### PR TITLE
Add jobs to harvest Cevi and Remmicom

### DIFF
--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201007-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201007-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201007-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201007-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/1cba3219-ca81-4058-b955-c13002b34613> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1cba3219-ca81-4058-b955-c13002b34613";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "151ee76c-8726-48f3-9d06-f04a66df4c19";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/586ba8bc-01ea-489d-ad4e-4c9af1a2b0ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "586ba8bc-01ea-489d-ad4e-4c9af1a2b0ca";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19>.
+
+  <http://redpencil.data.gift/id/task/98f74878-9e53-454f-9cdd-c939a581bb05> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "98f74878-9e53-454f-9cdd-c939a581bb05";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/1cba3219-ca81-4058-b955-c13002b34613>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/586ba8bc-01ea-489d-ad4e-4c9af1a2b0ca>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/929268ef-2420-4979-bff8-f1a41795750f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "929268ef-2420-4979-bff8-f1a41795750f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/bb/1273504c-5741-4057-b38b-dc4c025918eb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/929268ef-2420-4979-bff8-f1a41795750f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ed1f955-bb70-4416-bbe1-45293e4e7813> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ed1f955-bb70-4416-bbe1-45293e4e7813";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/bb/2385530b-e35b-49c8-b831-f3c20ed50f97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ed1f955-bb70-4416-bbe1-45293e4e7813>.
+    
+<http://data.lblod.info/id/remote-data-objects/31f37854-d883-401f-ae46-88ee410c7059> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31f37854-d883-401f-ae46-88ee410c7059";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/bb/541e6198-8cb9-43ed-a96c-0949da7105f8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31f37854-d883-401f-ae46-88ee410c7059>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fbf768a-1cdb-4db1-b878-015e5f0d839b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fbf768a-1cdb-4db1-b878-015e5f0d839b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/bb/55c10f05-c800-4c7f-98d0-e1ea90a76032/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fbf768a-1cdb-4db1-b878-015e5f0d839b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5f4b2cf-7262-4c70-a0c5-01d96748212c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5f4b2cf-7262-4c70-a0c5-01d96748212c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/bb/75283a49-2890-4cca-bce6-ad79486da2f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5f4b2cf-7262-4c70-a0c5-01d96748212c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b16c0db-2525-43b9-a71a-8227fa0f1f3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b16c0db-2525-43b9-a71a-8227fa0f1f3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/bb/83dba160-64af-4e94-bdbf-ece1f6309f3a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b16c0db-2525-43b9-a71a-8227fa0f1f3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/104000d5-cb0b-4240-9e6b-e031972c2334> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "104000d5-cb0b-4240-9e6b-e031972c2334";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/bb/93756059-70bf-4dd7-9091-ab9b24ec76db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/104000d5-cb0b-4240-9e6b-e031972c2334>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdd7bd91-87b7-437b-9a5e-dcd0e0e66c4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdd7bd91-87b7-437b-9a5e-dcd0e0e66c4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/bb/bd17fb0e-7b34-4ae0-9fd5-1b3b901b8da0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdd7bd91-87b7-437b-9a5e-dcd0e0e66c4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/da54ebdc-3c1e-4268-9ea3-9eb6c6110311> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da54ebdc-3c1e-4268-9ea3-9eb6c6110311";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/bb/c5876bfc-3a96-4206-8deb-4aa09a218c4c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da54ebdc-3c1e-4268-9ea3-9eb6c6110311>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d4f703b-6c9c-425d-b323-844b42a2d7bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d4f703b-6c9c-425d-b323-844b42a2d7bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/bb/dad15366-f981-4ca1-8bbd-736717cb6652/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d4f703b-6c9c-425d-b323-844b42a2d7bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/318cb47b-4954-48a6-9591-620c4685139f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "318cb47b-4954-48a6-9591-620c4685139f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/0fd90ee5-ec16-4a9c-be66-0b7f79d36491/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/318cb47b-4954-48a6-9591-620c4685139f>.
+    
+<http://data.lblod.info/id/remote-data-objects/11eb4eca-c5ba-4f75-84de-8af7f102cef7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11eb4eca-c5ba-4f75-84de-8af7f102cef7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/0fd90ee5-ec16-4a9c-be66-0b7f79d36491/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11eb4eca-c5ba-4f75-84de-8af7f102cef7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f116bec1-fd91-4f5b-bc6f-e18ef4a60772> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f116bec1-fd91-4f5b-bc6f-e18ef4a60772";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/0fd90ee5-ec16-4a9c-be66-0b7f79d36491/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f116bec1-fd91-4f5b-bc6f-e18ef4a60772>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ee27c9e-f4ad-4cca-b322-9df9485e0063> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ee27c9e-f4ad-4cca-b322-9df9485e0063";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/142b3f7c-1e95-4e41-9859-d9d8fffebe1f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ee27c9e-f4ad-4cca-b322-9df9485e0063>.
+    
+<http://data.lblod.info/id/remote-data-objects/eefe7db4-b62c-4b5c-b0c1-7f1f1548fd13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eefe7db4-b62c-4b5c-b0c1-7f1f1548fd13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/142b3f7c-1e95-4e41-9859-d9d8fffebe1f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eefe7db4-b62c-4b5c-b0c1-7f1f1548fd13>.
+    
+<http://data.lblod.info/id/remote-data-objects/80b7fed1-aca6-4a53-a1c2-006a82e2a140> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80b7fed1-aca6-4a53-a1c2-006a82e2a140";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/142b3f7c-1e95-4e41-9859-d9d8fffebe1f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80b7fed1-aca6-4a53-a1c2-006a82e2a140>.
+    
+<http://data.lblod.info/id/remote-data-objects/514268d8-382f-4172-9114-16a2af04cdaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "514268d8-382f-4172-9114-16a2af04cdaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/21a8551a-90c8-4872-89d6-15ae24ac4641/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/514268d8-382f-4172-9114-16a2af04cdaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4b0dff5-160a-4e52-a95a-9dac9cd075be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4b0dff5-160a-4e52-a95a-9dac9cd075be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/21a8551a-90c8-4872-89d6-15ae24ac4641/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4b0dff5-160a-4e52-a95a-9dac9cd075be>.
+    
+<http://data.lblod.info/id/remote-data-objects/55b343c4-511e-4b10-88f4-4c7f4d8d27f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55b343c4-511e-4b10-88f4-4c7f4d8d27f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/21a8551a-90c8-4872-89d6-15ae24ac4641/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55b343c4-511e-4b10-88f4-4c7f4d8d27f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3449750-240b-4b82-93b3-d94b53bc9d9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3449750-240b-4b82-93b3-d94b53bc9d9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/420dc530-d3e9-4d10-8667-6c3dfe4c6e3d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3449750-240b-4b82-93b3-d94b53bc9d9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/feba930d-a8b1-4956-ade4-71a42f2ef53a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "feba930d-a8b1-4956-ade4-71a42f2ef53a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/420dc530-d3e9-4d10-8667-6c3dfe4c6e3d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/feba930d-a8b1-4956-ade4-71a42f2ef53a>.
+    
+<http://data.lblod.info/id/remote-data-objects/773c8593-fe6b-433d-9974-4ac5f1e58d3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "773c8593-fe6b-433d-9974-4ac5f1e58d3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/420dc530-d3e9-4d10-8667-6c3dfe4c6e3d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/773c8593-fe6b-433d-9974-4ac5f1e58d3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4372aa7-2db4-4dd3-b91a-f51817907950> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4372aa7-2db4-4dd3-b91a-f51817907950";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/64dd7e16-8617-42aa-b7e7-6fb458f4a1dd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4372aa7-2db4-4dd3-b91a-f51817907950>.
+    
+<http://data.lblod.info/id/remote-data-objects/c27a0f67-5876-484d-957b-633d30fd4dac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c27a0f67-5876-484d-957b-633d30fd4dac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/64dd7e16-8617-42aa-b7e7-6fb458f4a1dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c27a0f67-5876-484d-957b-633d30fd4dac>.
+    
+<http://data.lblod.info/id/remote-data-objects/457e03a7-51ca-47d0-ac31-81e8c380330b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "457e03a7-51ca-47d0-ac31-81e8c380330b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/64dd7e16-8617-42aa-b7e7-6fb458f4a1dd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/457e03a7-51ca-47d0-ac31-81e8c380330b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d64319bd-41ea-4c45-9bba-06fc812657cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d64319bd-41ea-4c45-9bba-06fc812657cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/88d9f0f2-2d56-46e7-ad1a-336180a0753a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d64319bd-41ea-4c45-9bba-06fc812657cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/d906e70f-a582-4eb1-936b-c632b5dc8328> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d906e70f-a582-4eb1-936b-c632b5dc8328";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/88d9f0f2-2d56-46e7-ad1a-336180a0753a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d906e70f-a582-4eb1-936b-c632b5dc8328>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f460693-8081-449c-9444-2b6df5791a82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f460693-8081-449c-9444-2b6df5791a82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/88d9f0f2-2d56-46e7-ad1a-336180a0753a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f460693-8081-449c-9444-2b6df5791a82>.
+    
+<http://data.lblod.info/id/remote-data-objects/215c2e9a-960b-4558-932d-bc374df886ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "215c2e9a-960b-4558-932d-bc374df886ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/902d6a33-e7ef-4f27-b2fe-5d65cf15f442/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/215c2e9a-960b-4558-932d-bc374df886ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/eab33153-9ff8-4a08-af28-0611afefa625> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eab33153-9ff8-4a08-af28-0611afefa625";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/902d6a33-e7ef-4f27-b2fe-5d65cf15f442/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eab33153-9ff8-4a08-af28-0611afefa625>.
+    
+<http://data.lblod.info/id/remote-data-objects/92177133-0b18-46b4-a37c-0cabb4240e02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92177133-0b18-46b4-a37c-0cabb4240e02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/902d6a33-e7ef-4f27-b2fe-5d65cf15f442/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92177133-0b18-46b4-a37c-0cabb4240e02>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ba7c5e2-707e-4b23-b9ef-182cd9c88b6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ba7c5e2-707e-4b23-b9ef-182cd9c88b6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/a569c5c6-9802-4038-94db-14ae9b777e55/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ba7c5e2-707e-4b23-b9ef-182cd9c88b6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0a28e8d-452f-4939-b56a-f4788c53f1c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0a28e8d-452f-4939-b56a-f4788c53f1c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/a569c5c6-9802-4038-94db-14ae9b777e55/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0a28e8d-452f-4939-b56a-f4788c53f1c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b64b069-45ba-4edb-be5c-f866d713f20e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b64b069-45ba-4edb-be5c-f866d713f20e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/a569c5c6-9802-4038-94db-14ae9b777e55/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b64b069-45ba-4edb-be5c-f866d713f20e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccd9af73-5c85-44d9-84ea-79503f861b7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccd9af73-5c85-44d9-84ea-79503f861b7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/a8a24f23-5ba3-47a2-9696-aebf8e496fa1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccd9af73-5c85-44d9-84ea-79503f861b7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9159a8ac-9bb7-4869-845b-c7ecd95e785b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9159a8ac-9bb7-4869-845b-c7ecd95e785b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/a8a24f23-5ba3-47a2-9696-aebf8e496fa1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9159a8ac-9bb7-4869-845b-c7ecd95e785b>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcfd536c-cebf-49c6-b691-719d4c8b8a02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcfd536c-cebf-49c6-b691-719d4c8b8a02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/a8a24f23-5ba3-47a2-9696-aebf8e496fa1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcfd536c-cebf-49c6-b691-719d4c8b8a02>.
+    
+<http://data.lblod.info/id/remote-data-objects/304676d5-987d-46cd-add8-bbb6380d4b87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "304676d5-987d-46cd-add8-bbb6380d4b87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/c28b4d13-e2bc-43eb-96b0-fea8c8935c89/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/304676d5-987d-46cd-add8-bbb6380d4b87>.
+    
+<http://data.lblod.info/id/remote-data-objects/de56c1c5-a631-41e2-819b-927da2442f8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de56c1c5-a631-41e2-819b-927da2442f8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/c28b4d13-e2bc-43eb-96b0-fea8c8935c89/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de56c1c5-a631-41e2-819b-927da2442f8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b18970a4-8d10-48fc-b43c-6e3d565cbbed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b18970a4-8d10-48fc-b43c-6e3d565cbbed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/c28b4d13-e2bc-43eb-96b0-fea8c8935c89/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b18970a4-8d10-48fc-b43c-6e3d565cbbed>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f1ed9a1-04c1-4482-951b-92490fd487b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f1ed9a1-04c1-4482-951b-92490fd487b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/c32b982e-0e8e-4f56-a2d3-d40e457a7354/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f1ed9a1-04c1-4482-951b-92490fd487b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fb37c44-bc95-4f6b-9b27-7a2c82456f86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fb37c44-bc95-4f6b-9b27-7a2c82456f86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/c32b982e-0e8e-4f56-a2d3-d40e457a7354/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fb37c44-bc95-4f6b-9b27-7a2c82456f86>.
+    
+<http://data.lblod.info/id/remote-data-objects/e57a3011-29c9-4892-bf96-a1855b6727e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e57a3011-29c9-4892-bf96-a1855b6727e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/c32b982e-0e8e-4f56-a2d3-d40e457a7354/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e57a3011-29c9-4892-bf96-a1855b6727e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1284287e-d2b6-442e-9f87-6945881bfd95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1284287e-d2b6-442e-9f87-6945881bfd95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/ca9e2364-17c5-4dca-b7db-0ce6d0dbd488/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1284287e-d2b6-442e-9f87-6945881bfd95>.
+    
+<http://data.lblod.info/id/remote-data-objects/35d9f386-2723-4173-b1c8-981fe11682db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35d9f386-2723-4173-b1c8-981fe11682db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/ca9e2364-17c5-4dca-b7db-0ce6d0dbd488/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35d9f386-2723-4173-b1c8-981fe11682db>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab2d66bc-6a87-49dc-883b-31206e24f923> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab2d66bc-6a87-49dc-883b-31206e24f923";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/ca9e2364-17c5-4dca-b7db-0ce6d0dbd488/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab2d66bc-6a87-49dc-883b-31206e24f923>.
+    
+<http://data.lblod.info/id/remote-data-objects/57eee1be-3abf-43c0-bf0e-8d79d530dfcf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57eee1be-3abf-43c0-bf0e-8d79d530dfcf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/d1ffbfab-69bc-4c8b-b77f-475ed9be1ded/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57eee1be-3abf-43c0-bf0e-8d79d530dfcf>.
+    
+<http://data.lblod.info/id/remote-data-objects/121e4513-d323-453a-8424-99aa7b218213> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "121e4513-d323-453a-8424-99aa7b218213";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/d1ffbfab-69bc-4c8b-b77f-475ed9be1ded/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/121e4513-d323-453a-8424-99aa7b218213>.
+    
+<http://data.lblod.info/id/remote-data-objects/f20136f3-f847-497a-8d49-fc150e3dcef6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f20136f3-f847-497a-8d49-fc150e3dcef6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/d1ffbfab-69bc-4c8b-b77f-475ed9be1ded/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f20136f3-f847-497a-8d49-fc150e3dcef6>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c2b5a03-561d-407d-8d31-25286d68b98c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c2b5a03-561d-407d-8d31-25286d68b98c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/daa4e4da-1bc2-4f4e-8591-9b61cd75863c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/151ee76c-8726-48f3-9d06-f04a66df4c19> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c2b5a03-561d-407d-8d31-25286d68b98c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201009-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201009-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201009-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201009-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/934c7ec1-cc5b-411f-8d10-4daf1eba8427> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "934c7ec1-cc5b-411f-8d10-4daf1eba8427";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7d4545e7-d82f-45be-8ce8-4c5c42304c9d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/33f392c9-c830-470b-a8d2-9d8d22e99c17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "33f392c9-c830-470b-a8d2-9d8d22e99c17";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d>.
+
+  <http://redpencil.data.gift/id/task/b88243bf-b801-4940-82e4-0a23eb725ff2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b88243bf-b801-4940-82e4-0a23eb725ff2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/934c7ec1-cc5b-411f-8d10-4daf1eba8427>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/33f392c9-c830-470b-a8d2-9d8d22e99c17>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c6ea85e5-49cb-474d-93b5-bf6cf82eb197> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6ea85e5-49cb-474d-93b5-bf6cf82eb197";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/daa4e4da-1bc2-4f4e-8591-9b61cd75863c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6ea85e5-49cb-474d-93b5-bf6cf82eb197>.
+    
+<http://data.lblod.info/id/remote-data-objects/16ad4f8d-2bde-4093-8180-682acacfbe95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16ad4f8d-2bde-4093-8180-682acacfbe95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/daa4e4da-1bc2-4f4e-8591-9b61cd75863c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16ad4f8d-2bde-4093-8180-682acacfbe95>.
+    
+<http://data.lblod.info/id/remote-data-objects/c58141c4-1a65-491d-8c1f-b7740de3ece8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c58141c4-1a65-491d-8c1f-b7740de3ece8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/ea06cc79-b2a5-4a72-9178-37227cf2dde5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c58141c4-1a65-491d-8c1f-b7740de3ece8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c202d95c-1c58-4f76-baef-a304406c9383> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c202d95c-1c58-4f76-baef-a304406c9383";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/ea06cc79-b2a5-4a72-9178-37227cf2dde5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c202d95c-1c58-4f76-baef-a304406c9383>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c49d787-80ab-4954-b39d-f2323f4beacf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c49d787-80ab-4954-b39d-f2323f4beacf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/ea06cc79-b2a5-4a72-9178-37227cf2dde5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c49d787-80ab-4954-b39d-f2323f4beacf>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2064d5c-b2e8-4d01-9b0b-d4a8a87f3817> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2064d5c-b2e8-4d01-9b0b-d4a8a87f3817";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/f3184991-894d-4a4c-bf64-11b62a77eb26/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2064d5c-b2e8-4d01-9b0b-d4a8a87f3817>.
+    
+<http://data.lblod.info/id/remote-data-objects/c83068fc-da01-4fd9-bc5d-8630afdb3b3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c83068fc-da01-4fd9-bc5d-8630afdb3b3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/gr/f3184991-894d-4a4c-bf64-11b62a77eb26/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c83068fc-da01-4fd9-bc5d-8630afdb3b3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f193fdf-16b6-4926-8fa7-3f0fc35bcc1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f193fdf-16b6-4926-8fa7-3f0fc35bcc1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/0385bedf-8a7f-4193-836a-66ec3c76cfef/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f193fdf-16b6-4926-8fa7-3f0fc35bcc1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8cf2dac-aabc-4633-be47-8a699571399a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8cf2dac-aabc-4633-be47-8a699571399a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/0385bedf-8a7f-4193-836a-66ec3c76cfef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8cf2dac-aabc-4633-be47-8a699571399a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b92dddb-0505-4552-bcb1-8b0993e419c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b92dddb-0505-4552-bcb1-8b0993e419c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/04067a71-fd1b-4c1f-9651-ee7462015296/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b92dddb-0505-4552-bcb1-8b0993e419c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8fbf5b5-cbd0-4598-90cc-81f12488190b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8fbf5b5-cbd0-4598-90cc-81f12488190b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/04067a71-fd1b-4c1f-9651-ee7462015296/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8fbf5b5-cbd0-4598-90cc-81f12488190b>.
+    
+<http://data.lblod.info/id/remote-data-objects/34b28192-c3e9-427d-8ada-07cb4a1fe688> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34b28192-c3e9-427d-8ada-07cb4a1fe688";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/04067a71-fd1b-4c1f-9651-ee7462015296/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34b28192-c3e9-427d-8ada-07cb4a1fe688>.
+    
+<http://data.lblod.info/id/remote-data-objects/87a1cb8e-e8fc-4519-9de3-52a7d36612aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87a1cb8e-e8fc-4519-9de3-52a7d36612aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/251ffc3f-edc1-4846-ae99-0c0da6bb859e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87a1cb8e-e8fc-4519-9de3-52a7d36612aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ce0f69d-8db1-4e45-8ceb-eb56840dc6a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ce0f69d-8db1-4e45-8ceb-eb56840dc6a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/251ffc3f-edc1-4846-ae99-0c0da6bb859e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ce0f69d-8db1-4e45-8ceb-eb56840dc6a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/816b5d34-3dfd-437a-b0ff-9e5bf5f0f178> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "816b5d34-3dfd-437a-b0ff-9e5bf5f0f178";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/251ffc3f-edc1-4846-ae99-0c0da6bb859e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/816b5d34-3dfd-437a-b0ff-9e5bf5f0f178>.
+    
+<http://data.lblod.info/id/remote-data-objects/82eded41-4485-410a-a697-936df14748b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82eded41-4485-410a-a697-936df14748b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/4e49d5e2-a6a0-4574-bc0a-ea1a56718d67/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82eded41-4485-410a-a697-936df14748b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/90af77df-baf9-4290-904e-f2c8e03c0079> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90af77df-baf9-4290-904e-f2c8e03c0079";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/4e49d5e2-a6a0-4574-bc0a-ea1a56718d67/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90af77df-baf9-4290-904e-f2c8e03c0079>.
+    
+<http://data.lblod.info/id/remote-data-objects/38a34d0c-711e-418c-b0e9-33351860a7f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38a34d0c-711e-418c-b0e9-33351860a7f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/4e49d5e2-a6a0-4574-bc0a-ea1a56718d67/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38a34d0c-711e-418c-b0e9-33351860a7f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/20e127f4-c01b-46a0-8c96-29164f340b37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20e127f4-c01b-46a0-8c96-29164f340b37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/56177831-696d-4eaf-b66b-d76961384be8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20e127f4-c01b-46a0-8c96-29164f340b37>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9e7ef35-2cd8-43f2-8987-86f21a513bdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9e7ef35-2cd8-43f2-8987-86f21a513bdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/56177831-696d-4eaf-b66b-d76961384be8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9e7ef35-2cd8-43f2-8987-86f21a513bdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d3f2eb8-f4bc-4b61-9eb4-fee2fe9aa79b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d3f2eb8-f4bc-4b61-9eb4-fee2fe9aa79b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/56177831-696d-4eaf-b66b-d76961384be8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d3f2eb8-f4bc-4b61-9eb4-fee2fe9aa79b>.
+    
+<http://data.lblod.info/id/remote-data-objects/884b0c09-2030-42f4-9fe6-5b1284dc7eeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "884b0c09-2030-42f4-9fe6-5b1284dc7eeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/68a5b1f1-7495-4bc6-b60d-94c6a7a7d8ce/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/884b0c09-2030-42f4-9fe6-5b1284dc7eeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/f504c30f-7cb0-47d7-9046-70d3f97324ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f504c30f-7cb0-47d7-9046-70d3f97324ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/68a5b1f1-7495-4bc6-b60d-94c6a7a7d8ce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f504c30f-7cb0-47d7-9046-70d3f97324ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/08b9e4f3-ed69-4672-bf99-235c43533e59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08b9e4f3-ed69-4672-bf99-235c43533e59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/68a5b1f1-7495-4bc6-b60d-94c6a7a7d8ce/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08b9e4f3-ed69-4672-bf99-235c43533e59>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5853bee-5b5d-4558-9add-2e65dcc377f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5853bee-5b5d-4558-9add-2e65dcc377f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/94aec3a6-1941-4e38-99c3-aacb0401a091/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5853bee-5b5d-4558-9add-2e65dcc377f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a31319ff-3955-45bd-8ed0-99096994e225> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a31319ff-3955-45bd-8ed0-99096994e225";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/94aec3a6-1941-4e38-99c3-aacb0401a091/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a31319ff-3955-45bd-8ed0-99096994e225>.
+    
+<http://data.lblod.info/id/remote-data-objects/92d14c62-40d9-47f4-a42b-618bf54ca64c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92d14c62-40d9-47f4-a42b-618bf54ca64c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/94aec3a6-1941-4e38-99c3-aacb0401a091/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92d14c62-40d9-47f4-a42b-618bf54ca64c>.
+    
+<http://data.lblod.info/id/remote-data-objects/603f1316-2512-4f1b-8ac0-9c1161f17a3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "603f1316-2512-4f1b-8ac0-9c1161f17a3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/a039a9c8-b777-4661-b034-84247948d174/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/603f1316-2512-4f1b-8ac0-9c1161f17a3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e62907cf-83a4-4b1b-ad0f-bb799546cd29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e62907cf-83a4-4b1b-ad0f-bb799546cd29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/a039a9c8-b777-4661-b034-84247948d174/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e62907cf-83a4-4b1b-ad0f-bb799546cd29>.
+    
+<http://data.lblod.info/id/remote-data-objects/91bbae92-3fb4-43c8-a5a9-418559fe3929> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91bbae92-3fb4-43c8-a5a9-418559fe3929";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/a039a9c8-b777-4661-b034-84247948d174/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91bbae92-3fb4-43c8-a5a9-418559fe3929>.
+    
+<http://data.lblod.info/id/remote-data-objects/26585378-a275-46c8-948e-22891cc19c6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26585378-a275-46c8-948e-22891cc19c6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/ad064abf-e1bf-4ec3-b6d7-3d65610dd3c6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26585378-a275-46c8-948e-22891cc19c6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/16a307fd-57a2-457e-8856-ebd41576c7d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16a307fd-57a2-457e-8856-ebd41576c7d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/ad064abf-e1bf-4ec3-b6d7-3d65610dd3c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16a307fd-57a2-457e-8856-ebd41576c7d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/7918683b-95e2-4fa3-95ef-8c7201f7e8b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7918683b-95e2-4fa3-95ef-8c7201f7e8b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/ad064abf-e1bf-4ec3-b6d7-3d65610dd3c6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7918683b-95e2-4fa3-95ef-8c7201f7e8b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/ded9630d-9a2a-4613-b788-2602153a4fef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ded9630d-9a2a-4613-b788-2602153a4fef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/b3a349d5-ac94-457d-8f7c-d0ccb9e6509b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ded9630d-9a2a-4613-b788-2602153a4fef>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0c4a332-9576-4301-9629-2ca87ab0e8cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0c4a332-9576-4301-9629-2ca87ab0e8cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/b3a349d5-ac94-457d-8f7c-d0ccb9e6509b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0c4a332-9576-4301-9629-2ca87ab0e8cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/09851cd6-e77d-4502-98fd-e7615b1a072e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09851cd6-e77d-4502-98fd-e7615b1a072e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/b3a349d5-ac94-457d-8f7c-d0ccb9e6509b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09851cd6-e77d-4502-98fd-e7615b1a072e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5a2c25f-d062-4d57-9d70-f92fcc756940> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5a2c25f-d062-4d57-9d70-f92fcc756940";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/c92996b2-3b8e-4466-b41d-b029e11e8fdb/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5a2c25f-d062-4d57-9d70-f92fcc756940>.
+    
+<http://data.lblod.info/id/remote-data-objects/5115ed0e-96dc-4d46-9041-ee5b5261e913> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5115ed0e-96dc-4d46-9041-ee5b5261e913";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/c92996b2-3b8e-4466-b41d-b029e11e8fdb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5115ed0e-96dc-4d46-9041-ee5b5261e913>.
+    
+<http://data.lblod.info/id/remote-data-objects/22192c01-d8de-4713-b470-ff51c5bc4b0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22192c01-d8de-4713-b470-ff51c5bc4b0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/c92996b2-3b8e-4466-b41d-b029e11e8fdb/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22192c01-d8de-4713-b470-ff51c5bc4b0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/830075d6-1cdc-4bad-b29a-d1cce664e4df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "830075d6-1cdc-4bad-b29a-d1cce664e4df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/d4100735-838b-499a-adb6-8d09810ad24f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/830075d6-1cdc-4bad-b29a-d1cce664e4df>.
+    
+<http://data.lblod.info/id/remote-data-objects/9793f41e-f3a1-4ff0-8cbf-09d28b72a51c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9793f41e-f3a1-4ff0-8cbf-09d28b72a51c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/d4100735-838b-499a-adb6-8d09810ad24f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9793f41e-f3a1-4ff0-8cbf-09d28b72a51c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e1be89e-14c5-43bc-af72-d56e373abd5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e1be89e-14c5-43bc-af72-d56e373abd5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/d4100735-838b-499a-adb6-8d09810ad24f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e1be89e-14c5-43bc-af72-d56e373abd5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8174ebc-9aec-4ddc-b8d8-e78e1aad5893> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8174ebc-9aec-4ddc-b8d8-e78e1aad5893";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/e373fa5e-ace8-45b3-b7d0-49a5729f659d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8174ebc-9aec-4ddc-b8d8-e78e1aad5893>.
+    
+<http://data.lblod.info/id/remote-data-objects/592f261e-c539-4994-ad05-c6c2870b1654> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "592f261e-c539-4994-ad05-c6c2870b1654";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/e373fa5e-ace8-45b3-b7d0-49a5729f659d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/592f261e-c539-4994-ad05-c6c2870b1654>.
+    
+<http://data.lblod.info/id/remote-data-objects/68f9b63e-dbed-4d7e-b794-76bb7ed5fc39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68f9b63e-dbed-4d7e-b794-76bb7ed5fc39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/e373fa5e-ace8-45b3-b7d0-49a5729f659d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68f9b63e-dbed-4d7e-b794-76bb7ed5fc39>.
+    
+<http://data.lblod.info/id/remote-data-objects/a35784be-1c6b-479d-9483-c9e5e114c556> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a35784be-1c6b-479d-9483-c9e5e114c556";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/f3f13022-43ce-4f84-b218-8af0fe3a7337/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a35784be-1c6b-479d-9483-c9e5e114c556>.
+    
+<http://data.lblod.info/id/remote-data-objects/22bf528b-1964-44e4-8f6a-427d112bafb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22bf528b-1964-44e4-8f6a-427d112bafb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/f3f13022-43ce-4f84-b218-8af0fe3a7337/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22bf528b-1964-44e4-8f6a-427d112bafb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa72aa4f-89df-4018-8ebb-4f137c7bd545> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa72aa4f-89df-4018-8ebb-4f137c7bd545";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/rmw/f3f13022-43ce-4f84-b218-8af0fe3a7337/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa72aa4f-89df-4018-8ebb-4f137c7bd545>.
+    
+<http://data.lblod.info/id/remote-data-objects/abd0c563-2cec-4569-9b69-7bd7ad730c21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abd0c563-2cec-4569-9b69-7bd7ad730c21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/00b5e982-c5d3-4c86-a10d-826fbf416506/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abd0c563-2cec-4569-9b69-7bd7ad730c21>.
+    
+<http://data.lblod.info/id/remote-data-objects/030cc3f0-7003-4d8c-9aa7-4462284848dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "030cc3f0-7003-4d8c-9aa7-4462284848dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/048ec459-c5e9-4627-a9f2-2d50ad50f76c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d4545e7-d82f-45be-8ce8-4c5c42304c9d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/030cc3f0-7003-4d8c-9aa7-4462284848dc>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201010-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201010-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201010-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201010-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/181d2a35-343a-4e6e-bc62-548bbfdf72c5> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "181d2a35-343a-4e6e-bc62-548bbfdf72c5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "434e101f-68e7-422e-b47c-2953c9cb8c2c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/3c41d50a-a01d-4ad2-ae4f-4f260b8cc3f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3c41d50a-a01d-4ad2-ae4f-4f260b8cc3f1";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c>.
+
+  <http://redpencil.data.gift/id/task/44444a43-c5b4-454a-8b3c-d05434471a4c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "44444a43-c5b4-454a-8b3c-d05434471a4c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/181d2a35-343a-4e6e-bc62-548bbfdf72c5>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/3c41d50a-a01d-4ad2-ae4f-4f260b8cc3f1>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e3e04137-11c7-42d6-84c8-a6581c408164> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3e04137-11c7-42d6-84c8-a6581c408164";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/0a79d8b4-49a2-4b4e-8d66-5f125cff96fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3e04137-11c7-42d6-84c8-a6581c408164>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc027cf2-8c3a-48bd-9a25-7245925668db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc027cf2-8c3a-48bd-9a25-7245925668db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/0d001286-ad00-4c1c-95a7-dc4e1dca81ba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc027cf2-8c3a-48bd-9a25-7245925668db>.
+    
+<http://data.lblod.info/id/remote-data-objects/27311dae-5c11-431b-aea4-8d2aef824782> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27311dae-5c11-431b-aea4-8d2aef824782";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/0d20bcef-e918-4b43-b0d1-8659f89077ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27311dae-5c11-431b-aea4-8d2aef824782>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae976ae2-0233-4390-adbe-74cde2e6bdff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae976ae2-0233-4390-adbe-74cde2e6bdff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/11013673-1161-4b6c-adf4-690c86d39e06/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae976ae2-0233-4390-adbe-74cde2e6bdff>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ee811ae-a910-4ac7-9ca6-6a1b5a716722> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ee811ae-a910-4ac7-9ca6-6a1b5a716722";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/1434d593-001f-4def-9210-de6201de5344/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ee811ae-a910-4ac7-9ca6-6a1b5a716722>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0265263-14ec-4103-9a0a-4fe47be0dc48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0265263-14ec-4103-9a0a-4fe47be0dc48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/17eed764-c08c-4777-8eb6-79e23a29ac45/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0265263-14ec-4103-9a0a-4fe47be0dc48>.
+    
+<http://data.lblod.info/id/remote-data-objects/e469df54-57a8-4f5f-8ff0-95043636349b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e469df54-57a8-4f5f-8ff0-95043636349b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/185c4acc-9aa9-469a-a114-148069c0f2ca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e469df54-57a8-4f5f-8ff0-95043636349b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f14d5140-aab2-47b8-8926-22cf67c9a7e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f14d5140-aab2-47b8-8926-22cf67c9a7e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/201c3e5d-902c-4650-9a10-5ce8dab3a9f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f14d5140-aab2-47b8-8926-22cf67c9a7e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/5686f4a7-ab0b-4148-8f8e-385ac4500077> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5686f4a7-ab0b-4148-8f8e-385ac4500077";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/276d7070-3c89-4e13-8b57-835e3bc78426/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5686f4a7-ab0b-4148-8f8e-385ac4500077>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfeaa3fe-3184-4b0a-875b-390b440f2373> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfeaa3fe-3184-4b0a-875b-390b440f2373";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/27885291-5a7b-441e-98cb-a71b28cbcdcb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfeaa3fe-3184-4b0a-875b-390b440f2373>.
+    
+<http://data.lblod.info/id/remote-data-objects/20b529c3-5bc8-4075-98db-881dc624a3fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20b529c3-5bc8-4075-98db-881dc624a3fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/281cf67f-7a67-4af0-ad27-e98a83c1189e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20b529c3-5bc8-4075-98db-881dc624a3fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a3c60bf-3612-49c6-a6d6-d7e9217b7005> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a3c60bf-3612-49c6-a6d6-d7e9217b7005";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/345c770e-389f-4dd8-9b40-9c6f9c2ad276/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a3c60bf-3612-49c6-a6d6-d7e9217b7005>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e1d515a-8314-45fe-81fd-9b7c9f93845d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e1d515a-8314-45fe-81fd-9b7c9f93845d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/38e3da81-6677-48fc-84d0-5c205181c225/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e1d515a-8314-45fe-81fd-9b7c9f93845d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5620e208-506b-4dea-b05f-7c227103c0ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5620e208-506b-4dea-b05f-7c227103c0ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/38fd1190-306b-4c36-bcba-f67b10f6c998/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5620e208-506b-4dea-b05f-7c227103c0ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/08cb52c6-b354-4725-bd46-d3a35c9c0683> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08cb52c6-b354-4725-bd46-d3a35c9c0683";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/39e2f282-98c0-4d3f-afae-d47389b5d7a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08cb52c6-b354-4725-bd46-d3a35c9c0683>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e5d796e-773e-47b8-aed2-2df988de934c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e5d796e-773e-47b8-aed2-2df988de934c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/47c95526-b46d-47ff-aed7-a91b3da1fa59/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e5d796e-773e-47b8-aed2-2df988de934c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2d4258e-90d9-4c63-8fcd-83fe68f71414> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2d4258e-90d9-4c63-8fcd-83fe68f71414";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/4b57e184-4bc8-44e8-9fa7-834db843ec42/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2d4258e-90d9-4c63-8fcd-83fe68f71414>.
+    
+<http://data.lblod.info/id/remote-data-objects/7aee85be-7e7a-470e-b81e-5bd372c17f89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7aee85be-7e7a-470e-b81e-5bd372c17f89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/4b7ce396-3364-497d-a215-c4eee93b282a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7aee85be-7e7a-470e-b81e-5bd372c17f89>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd112be7-72c5-46f1-907d-69e59fa9d98d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd112be7-72c5-46f1-907d-69e59fa9d98d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/4cf0480c-10e9-42d5-8167-f0a20648181c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd112be7-72c5-46f1-907d-69e59fa9d98d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee5912bf-be16-4086-8123-65c066ad63de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee5912bf-be16-4086-8123-65c066ad63de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/6a03bcf1-7ddd-49a1-a604-1742e98d363f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee5912bf-be16-4086-8123-65c066ad63de>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc93dd56-4922-41d4-b9d7-79cd61a1c5d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc93dd56-4922-41d4-b9d7-79cd61a1c5d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/6eee26d1-3f71-4ca4-b4ee-7f4d461b4a0a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc93dd56-4922-41d4-b9d7-79cd61a1c5d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e8e665d-d6f3-4a95-a34e-5069beef36d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e8e665d-d6f3-4a95-a34e-5069beef36d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/6f3840e0-a683-459f-ae43-619954dcbd34/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e8e665d-d6f3-4a95-a34e-5069beef36d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/83dd2888-42dd-4c4c-ab87-89800fa4298e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83dd2888-42dd-4c4c-ab87-89800fa4298e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/76032e5d-d8e7-4774-91cd-7d913860c0e8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83dd2888-42dd-4c4c-ab87-89800fa4298e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4506d54b-b3cc-4d47-9f78-6cc572573822> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4506d54b-b3cc-4d47-9f78-6cc572573822";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/76c1b4ee-7517-42ad-8152-9362564d39ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4506d54b-b3cc-4d47-9f78-6cc572573822>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a6e208b-1746-45b8-bd6d-2bb297400ff1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a6e208b-1746-45b8-bd6d-2bb297400ff1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/792e0818-2aba-4fc6-98ac-5fc2db8657ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a6e208b-1746-45b8-bd6d-2bb297400ff1>.
+    
+<http://data.lblod.info/id/remote-data-objects/17c85aca-1531-4a11-b694-c3c5d163d503> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17c85aca-1531-4a11-b694-c3c5d163d503";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/79b91ed9-ad4d-4e92-82c5-56dc230f5df4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17c85aca-1531-4a11-b694-c3c5d163d503>.
+    
+<http://data.lblod.info/id/remote-data-objects/aae56f3f-4ae2-4bb0-85e3-451ebd760044> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aae56f3f-4ae2-4bb0-85e3-451ebd760044";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/7b2b29bf-5717-45a4-a5bf-790884bde971/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aae56f3f-4ae2-4bb0-85e3-451ebd760044>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2bccd10-e50b-4f77-9f54-474b0ef693cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2bccd10-e50b-4f77-9f54-474b0ef693cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/7ec4d6de-1583-4a29-977f-45eed679c0dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2bccd10-e50b-4f77-9f54-474b0ef693cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/23bb07b6-674f-44a6-ab50-18e23cea95c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23bb07b6-674f-44a6-ab50-18e23cea95c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/8403bd65-d72d-4f4a-a185-8c84304919e6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23bb07b6-674f-44a6-ab50-18e23cea95c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/11821f65-6ff8-40c8-b369-b080cfee1ca4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11821f65-6ff8-40c8-b369-b080cfee1ca4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/86d5c414-18d8-4f3f-8b2e-ec72418b01e5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11821f65-6ff8-40c8-b369-b080cfee1ca4>.
+    
+<http://data.lblod.info/id/remote-data-objects/df41dbb3-d3ec-4e20-b8e0-175b2f721821> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df41dbb3-d3ec-4e20-b8e0-175b2f721821";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/877ffb01-088f-4337-a8a1-36fd3ee3d9cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df41dbb3-d3ec-4e20-b8e0-175b2f721821>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9aa7c14-cf61-49f0-981f-2f80dd12a78d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9aa7c14-cf61-49f0-981f-2f80dd12a78d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/88dc7fde-def2-4936-b3ea-e20e0b1ee2c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9aa7c14-cf61-49f0-981f-2f80dd12a78d>.
+    
+<http://data.lblod.info/id/remote-data-objects/31410d0d-c701-4615-acb9-6a9a209b2162> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31410d0d-c701-4615-acb9-6a9a209b2162";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/89e16117-ccc6-402e-ba35-69dfc79df0f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31410d0d-c701-4615-acb9-6a9a209b2162>.
+    
+<http://data.lblod.info/id/remote-data-objects/315aba3e-ee81-47a9-a33b-86ec82f49d1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "315aba3e-ee81-47a9-a33b-86ec82f49d1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/8c6e477e-8974-42cb-8fb2-b596d1f90b90/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/315aba3e-ee81-47a9-a33b-86ec82f49d1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/670638fd-a564-44b8-94e5-6b34db8259b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "670638fd-a564-44b8-94e5-6b34db8259b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/8e1c880f-af1b-40bd-9bce-2b5cf937ea81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/670638fd-a564-44b8-94e5-6b34db8259b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/82509566-aee0-4ea9-916e-ffc415a2ff8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82509566-aee0-4ea9-916e-ffc415a2ff8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/92027cec-767e-4ac2-91cf-9a095b451f46/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82509566-aee0-4ea9-916e-ffc415a2ff8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff8748e0-7369-4fca-8e9d-8fbdd94063da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff8748e0-7369-4fca-8e9d-8fbdd94063da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/97a8f90f-b0eb-4392-973c-f9e81644a7f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff8748e0-7369-4fca-8e9d-8fbdd94063da>.
+    
+<http://data.lblod.info/id/remote-data-objects/55352a66-dc67-45ef-956c-2f63bcad80a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55352a66-dc67-45ef-956c-2f63bcad80a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/9be10e36-cc41-4e1f-8b16-c7cc37c3b9e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55352a66-dc67-45ef-956c-2f63bcad80a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ceb68c24-e433-416e-839d-394b065b6410> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ceb68c24-e433-416e-839d-394b065b6410";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/9e79e230-0d3a-4609-95d9-c2fa143f0456/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ceb68c24-e433-416e-839d-394b065b6410>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f26db5f-049e-44b0-93f7-fa7c5dcf6501> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f26db5f-049e-44b0-93f7-fa7c5dcf6501";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/9ed95ff3-eb4f-47c6-8117-2ae24a8e68f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f26db5f-049e-44b0-93f7-fa7c5dcf6501>.
+    
+<http://data.lblod.info/id/remote-data-objects/835a6f89-8ce4-4359-b30c-8199aa095942> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "835a6f89-8ce4-4359-b30c-8199aa095942";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/a21fd52a-d135-4b33-a136-0d88771da11b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/835a6f89-8ce4-4359-b30c-8199aa095942>.
+    
+<http://data.lblod.info/id/remote-data-objects/71c3fb4f-1240-480c-9ea7-6998c3f8a935> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71c3fb4f-1240-480c-9ea7-6998c3f8a935";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/a4b91ed7-4252-4512-999c-69716435cbab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71c3fb4f-1240-480c-9ea7-6998c3f8a935>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd6f510b-82f1-4981-b4e0-812c7d82757b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd6f510b-82f1-4981-b4e0-812c7d82757b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/a5e09f68-eaa0-402c-9432-ca3d2cdd827a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd6f510b-82f1-4981-b4e0-812c7d82757b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ae3b558-3a7f-4d47-90d4-a3905a2fdfd6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ae3b558-3a7f-4d47-90d4-a3905a2fdfd6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/a684b33d-dca6-43a1-a957-c8b7a4609957/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ae3b558-3a7f-4d47-90d4-a3905a2fdfd6>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b9bc527-c9dc-4f7f-8467-ec4538ecee51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b9bc527-c9dc-4f7f-8467-ec4538ecee51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/ad262b36-cfbe-452b-af19-eeb324a33922/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b9bc527-c9dc-4f7f-8467-ec4538ecee51>.
+    
+<http://data.lblod.info/id/remote-data-objects/41168fcd-17ca-4fbb-a61b-7de8bba00fb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41168fcd-17ca-4fbb-a61b-7de8bba00fb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/b23e1bf4-9846-4246-81a1-48c6599842c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41168fcd-17ca-4fbb-a61b-7de8bba00fb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/82d49037-3930-4a51-8bba-9c6f01aed1a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82d49037-3930-4a51-8bba-9c6f01aed1a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/b34030cd-5af1-422b-8200-4870024b35d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82d49037-3930-4a51-8bba-9c6f01aed1a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bc72946-9131-45a8-b0e3-edb1fba6c524> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bc72946-9131-45a8-b0e3-edb1fba6c524";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/be4f11c4-d1ab-495d-811d-83a4696844ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bc72946-9131-45a8-b0e3-edb1fba6c524>.
+    
+<http://data.lblod.info/id/remote-data-objects/b50b558b-1a8f-4822-8eff-3ea3284a0894> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b50b558b-1a8f-4822-8eff-3ea3284a0894";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/c187d824-2a61-4f4e-bc22-9964e293942f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b50b558b-1a8f-4822-8eff-3ea3284a0894>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a1ee543-9a43-434b-bb79-ca0bd10df7c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a1ee543-9a43-434b-bb79-ca0bd10df7c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/c4d79c65-40a0-463a-b50a-021cb0ad68fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/434e101f-68e7-422e-b47c-2953c9cb8c2c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a1ee543-9a43-434b-bb79-ca0bd10df7c9>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201011-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201011-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201011-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201011-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/cd50f55d-f1c9-4be9-a492-43e505aa03d8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cd50f55d-f1c9-4be9-a492-43e505aa03d8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8aeb8f76-3f9c-4276-887c-2ad565d264bc";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/43acd93a-064c-4386-b92b-ade772a1430a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "43acd93a-064c-4386-b92b-ade772a1430a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc>.
+
+  <http://redpencil.data.gift/id/task/7a0fccc2-034b-412b-9bcf-ba07ad54e9c1> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7a0fccc2-034b-412b-9bcf-ba07ad54e9c1";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/cd50f55d-f1c9-4be9-a492-43e505aa03d8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/43acd93a-064c-4386-b92b-ade772a1430a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/cda32bcc-998e-41fd-b858-1b77195791b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cda32bcc-998e-41fd-b858-1b77195791b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/c755f6b9-2e0e-4156-bfdf-173cc90239d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cda32bcc-998e-41fd-b858-1b77195791b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/330f3933-bf4a-4f2c-be51-59e5d0e1ebe6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "330f3933-bf4a-4f2c-be51-59e5d0e1ebe6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/c9480d70-dfcd-4f64-ae95-fa5354f57eb3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/330f3933-bf4a-4f2c-be51-59e5d0e1ebe6>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e24e2d2-3da8-49d5-9c8b-641a136860d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e24e2d2-3da8-49d5-9c8b-641a136860d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/cac1cf76-1d73-42ef-a250-8583a60e097a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e24e2d2-3da8-49d5-9c8b-641a136860d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d8fa400-c304-4dad-a967-2593ec069b42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d8fa400-c304-4dad-a967-2593ec069b42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/cd775eda-bb01-4033-953c-89fcd167abec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d8fa400-c304-4dad-a967-2593ec069b42>.
+    
+<http://data.lblod.info/id/remote-data-objects/bda13120-789d-47c9-aa7f-ea68f96ea1f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bda13120-789d-47c9-aa7f-ea68f96ea1f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/ce4d6c2f-ca9e-4d56-8e28-f098cf051329/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bda13120-789d-47c9-aa7f-ea68f96ea1f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfa2265e-1c04-436d-96ec-eeaa53cdc99b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfa2265e-1c04-436d-96ec-eeaa53cdc99b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/d44ed325-07e2-499e-987c-49a3301b5d4c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfa2265e-1c04-436d-96ec-eeaa53cdc99b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c6d47ca-3399-4337-983d-283f26bbb13d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c6d47ca-3399-4337-983d-283f26bbb13d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/d4cedaf6-e062-4a9c-ab1d-b291cb19bd8a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c6d47ca-3399-4337-983d-283f26bbb13d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c0919e2-0ead-43a4-a90f-05d4bd9b1d57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c0919e2-0ead-43a4-a90f-05d4bd9b1d57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/d6c52e51-1a7f-4b04-ba88-ceca92bdd1c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c0919e2-0ead-43a4-a90f-05d4bd9b1d57>.
+    
+<http://data.lblod.info/id/remote-data-objects/111507a3-fa88-4cd0-a74f-3f707393a8c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "111507a3-fa88-4cd0-a74f-3f707393a8c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/dcd4585f-df01-427e-b61a-21fc8fdc56f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/111507a3-fa88-4cd0-a74f-3f707393a8c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d86540ba-963a-4903-9999-9faa8b1f886a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d86540ba-963a-4903-9999-9faa8b1f886a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/dd1b2df2-f208-4e3e-ac7f-0f256172e4e6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d86540ba-963a-4903-9999-9faa8b1f886a>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbe6eae8-38e3-4c9e-a3db-083265aaf3da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbe6eae8-38e3-4c9e-a3db-083265aaf3da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/de97f0e3-5c42-48d8-80ab-b850074a8a81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbe6eae8-38e3-4c9e-a3db-083265aaf3da>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d7f9752-df8e-458b-ab4a-dfcf3649ad06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d7f9752-df8e-458b-ab4a-dfcf3649ad06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/dedebd75-3465-4532-8e84-928df24f3990/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d7f9752-df8e-458b-ab4a-dfcf3649ad06>.
+    
+<http://data.lblod.info/id/remote-data-objects/61df24de-e83b-49a3-842e-501e617d29db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61df24de-e83b-49a3-842e-501e617d29db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/e331c020-6edb-43df-a016-018484bd897d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61df24de-e83b-49a3-842e-501e617d29db>.
+    
+<http://data.lblod.info/id/remote-data-objects/722bf493-b657-44fd-b3fb-ab3539a75d3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "722bf493-b657-44fd-b3fb-ab3539a75d3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/ed82891b-ac57-4d6f-8509-fce62a51a7cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/722bf493-b657-44fd-b3fb-ab3539a75d3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/627ab16c-4e7e-482d-8495-2d126d807c0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "627ab16c-4e7e-482d-8495-2d126d807c0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/ee561855-4210-4d46-9af3-b0b743524db5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/627ab16c-4e7e-482d-8495-2d126d807c0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d65f9b7-8804-4395-8dd9-4c1c75e80abc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d65f9b7-8804-4395-8dd9-4c1c75e80abc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/f4968281-4923-4a3e-9df1-9309c4992d02/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d65f9b7-8804-4395-8dd9-4c1c75e80abc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4373472-8785-447d-af2e-d4ee0eaa7ab6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4373472-8785-447d-af2e-d4ee0eaa7ab6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/f654b4b0-c37f-4a18-9277-bb78d3e0e5b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4373472-8785-447d-af2e-d4ee0eaa7ab6>.
+    
+<http://data.lblod.info/id/remote-data-objects/84f7b0cf-c73d-4e19-b57b-7834bd4a8407> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84f7b0cf-c73d-4e19-b57b-7834bd4a8407";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/f8d723dd-6ab4-4a34-8bd9-dd7599345b2b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84f7b0cf-c73d-4e19-b57b-7834bd4a8407>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ada0c46-5eb0-4b63-809c-cdc56498b690> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ada0c46-5eb0-4b63-809c-cdc56498b690";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/fa684922-eaad-4c2c-9264-4f326caf9ade/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ada0c46-5eb0-4b63-809c-cdc56498b690>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffe959fa-8e37-4a08-b8e4-812ea916bee7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffe959fa-8e37-4a08-b8e4-812ea916bee7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/fadfb3d9-c034-45d4-8be0-07a7abd72c4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffe959fa-8e37-4a08-b8e4-812ea916bee7>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bea0de1-fa75-48ac-b417-b9ec775114ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bea0de1-fa75-48ac-b417-b9ec775114ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/fc66e2c4-3eb6-4475-aa21-46c74ca85db7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bea0de1-fa75-48ac-b417-b9ec775114ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/62dc5d24-8a10-484c-9aed-775b1aefd2ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62dc5d24-8a10-484c-9aed-775b1aefd2ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/fdb60d5d-9bcb-42d5-bf0f-dfb39779b3bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62dc5d24-8a10-484c-9aed-775b1aefd2ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0fd0f68-c31f-4c59-84df-9eb36ecc833b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0fd0f68-c31f-4c59-84df-9eb36ecc833b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/sc/fe0f3e10-f3c2-4dac-b2a4-d5feafca1130/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0fd0f68-c31f-4c59-84df-9eb36ecc833b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5794148-3226-4d50-b618-55fb1414b444> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5794148-3226-4d50-b618-55fb1414b444";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/01e703ef-4cd2-4721-819e-52eded51c2cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5794148-3226-4d50-b618-55fb1414b444>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc36dd57-bec0-47a7-85cd-670d4916bda1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc36dd57-bec0-47a7-85cd-670d4916bda1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/0b83bd38-8fae-421a-82cf-fd71112baf49/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc36dd57-bec0-47a7-85cd-670d4916bda1>.
+    
+<http://data.lblod.info/id/remote-data-objects/dca35fc9-b283-4910-a66a-60af9d227454> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dca35fc9-b283-4910-a66a-60af9d227454";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/0d38ffff-0c72-4207-990d-fefa62dffd79/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dca35fc9-b283-4910-a66a-60af9d227454>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd2a07c7-4700-4ebc-b800-87c43f176f64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd2a07c7-4700-4ebc-b800-87c43f176f64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/116d1e5d-a58b-4e81-850a-e1b001f5d478/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd2a07c7-4700-4ebc-b800-87c43f176f64>.
+    
+<http://data.lblod.info/id/remote-data-objects/4981e06f-45ee-440f-a61d-3584179eb244> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4981e06f-45ee-440f-a61d-3584179eb244";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/14b6a740-5f52-4619-8e43-52fe32486673/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4981e06f-45ee-440f-a61d-3584179eb244>.
+    
+<http://data.lblod.info/id/remote-data-objects/02443de3-8056-4f87-834c-d1ee15dfe48f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02443de3-8056-4f87-834c-d1ee15dfe48f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/14e4d7a9-f20e-40f7-9212-4c4682815c39/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02443de3-8056-4f87-834c-d1ee15dfe48f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d64857fd-0ad5-4b3f-944f-f2c932d9fa04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d64857fd-0ad5-4b3f-944f-f2c932d9fa04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/196e1e86-b155-4727-a42d-c55a05832a2b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d64857fd-0ad5-4b3f-944f-f2c932d9fa04>.
+    
+<http://data.lblod.info/id/remote-data-objects/a92e6acd-f531-4d9c-885d-a70d2f320e72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a92e6acd-f531-4d9c-885d-a70d2f320e72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/1e828e98-7edd-4e3c-8613-ac9171629bf9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a92e6acd-f531-4d9c-885d-a70d2f320e72>.
+    
+<http://data.lblod.info/id/remote-data-objects/2026d0b9-2712-4f2c-bf1d-b9088f03352e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2026d0b9-2712-4f2c-bf1d-b9088f03352e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/202674ec-c7ba-416d-95d6-c56ee5077d27/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2026d0b9-2712-4f2c-bf1d-b9088f03352e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fd229b8-2334-4fbc-9718-2622dd6a5e8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fd229b8-2334-4fbc-9718-2622dd6a5e8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/29fc6f74-d34c-4ec5-9fee-e0394992088b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fd229b8-2334-4fbc-9718-2622dd6a5e8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcf598d2-ebf2-43d4-828a-f3531235dbe7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcf598d2-ebf2-43d4-828a-f3531235dbe7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/2a759aba-1e2e-422b-9ae8-ba8a425629f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcf598d2-ebf2-43d4-828a-f3531235dbe7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6e855c3-c14d-46cc-ab13-5a44de7ec30a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6e855c3-c14d-46cc-ab13-5a44de7ec30a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/2e11264d-eb15-41b4-9656-6a0e90f0d86a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6e855c3-c14d-46cc-ab13-5a44de7ec30a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0caebaa-245f-4a80-b8ec-220b07637aa7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0caebaa-245f-4a80-b8ec-220b07637aa7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/2f4308a1-94f5-46b9-9d7e-f73ebc5770da/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0caebaa-245f-4a80-b8ec-220b07637aa7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4d76a82-fdef-4640-b85c-3046d8802c92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4d76a82-fdef-4640-b85c-3046d8802c92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/2ff134c6-c2d1-46bd-b164-6c0f1a7018df/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4d76a82-fdef-4640-b85c-3046d8802c92>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4c37a0b-6803-46b2-b750-0daa05cd043b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4c37a0b-6803-46b2-b750-0daa05cd043b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/31ea0824-3191-4a98-9c92-1117576e41d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4c37a0b-6803-46b2-b750-0daa05cd043b>.
+    
+<http://data.lblod.info/id/remote-data-objects/543d1103-a59d-4c1e-8315-72eb8b555266> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "543d1103-a59d-4c1e-8315-72eb8b555266";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/39e9234a-4af5-4fc2-a104-93854b9d5189/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/543d1103-a59d-4c1e-8315-72eb8b555266>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fe156a5-5dec-4c22-bf66-6a87129764d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fe156a5-5dec-4c22-bf66-6a87129764d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/3c060982-9028-43c2-b80b-f7e056cd3c76/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fe156a5-5dec-4c22-bf66-6a87129764d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8943a20-0b24-4ac6-b6e6-f83fc6837e96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8943a20-0b24-4ac6-b6e6-f83fc6837e96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/44d85e96-b59f-4a98-9f5e-c0f2478fc815/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8943a20-0b24-4ac6-b6e6-f83fc6837e96>.
+    
+<http://data.lblod.info/id/remote-data-objects/1475fc30-94dd-41e4-af57-f81ae2c1cdf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1475fc30-94dd-41e4-af57-f81ae2c1cdf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/47399ec4-4017-40ab-8a8e-4f827375b043/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1475fc30-94dd-41e4-af57-f81ae2c1cdf9>.
+    
+<http://data.lblod.info/id/remote-data-objects/51e994fa-83ee-49bc-ae29-38314d7a586d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51e994fa-83ee-49bc-ae29-38314d7a586d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/495ccd01-0f3c-4de4-8b08-26646c699155/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51e994fa-83ee-49bc-ae29-38314d7a586d>.
+    
+<http://data.lblod.info/id/remote-data-objects/62d476b5-dcab-46c6-a29f-e11bc279ce6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62d476b5-dcab-46c6-a29f-e11bc279ce6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/4c29bd80-43b1-4b80-ae67-cf220c93a315/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62d476b5-dcab-46c6-a29f-e11bc279ce6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/399b653b-1301-4ea4-a042-d5e3d5034bda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "399b653b-1301-4ea4-a042-d5e3d5034bda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/51c3f86c-880a-4c83-b919-ffcee888d534/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/399b653b-1301-4ea4-a042-d5e3d5034bda>.
+    
+<http://data.lblod.info/id/remote-data-objects/692e7c14-c98f-4ad1-943a-7465db472bc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "692e7c14-c98f-4ad1-943a-7465db472bc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/52837b48-f8a5-47e1-a9c5-6be46edecc4c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/692e7c14-c98f-4ad1-943a-7465db472bc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1d09344-e953-465a-8fde-7a41c0f47e22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1d09344-e953-465a-8fde-7a41c0f47e22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/54b87e3f-02dc-4309-9e3a-16f39b8e946a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1d09344-e953-465a-8fde-7a41c0f47e22>.
+    
+<http://data.lblod.info/id/remote-data-objects/4896e8b0-c7ae-40ae-be2e-e67b9c95ae05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4896e8b0-c7ae-40ae-be2e-e67b9c95ae05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/587c3d4c-07cf-41f6-a412-6d154d6a5f46/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4896e8b0-c7ae-40ae-be2e-e67b9c95ae05>.
+    
+<http://data.lblod.info/id/remote-data-objects/d53e3c4b-436d-4301-b288-ebce4b6c4c05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d53e3c4b-436d-4301-b288-ebce4b6c4c05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/58ea5924-672d-447b-a779-22267596edf4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d53e3c4b-436d-4301-b288-ebce4b6c4c05>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bbfd23b-a1cd-48a3-8878-7a57ac47d215> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bbfd23b-a1cd-48a3-8878-7a57ac47d215";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/58ec4a21-9fce-40e1-99df-028a636f1f0f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8aeb8f76-3f9c-4276-887c-2ad565d264bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bbfd23b-a1cd-48a3-8878-7a57ac47d215>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201012-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201012-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201012-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201012-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/abd5dcab-2c57-41bf-b5a2-865655816c7f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "abd5dcab-2c57-41bf-b5a2-865655816c7f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "17a8dbff-4463-472f-b6b1-c7fc554a857b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9481a899-c544-4d88-a057-dc50393f0a9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9481a899-c544-4d88-a057-dc50393f0a9b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b>.
+
+  <http://redpencil.data.gift/id/task/69743683-b3c1-4c1e-a561-af758bc5eb51> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "69743683-b3c1-4c1e-a561-af758bc5eb51";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/abd5dcab-2c57-41bf-b5a2-865655816c7f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9481a899-c544-4d88-a057-dc50393f0a9b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d1e89574-0d09-44ac-8a6b-2efee6205316> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1e89574-0d09-44ac-8a6b-2efee6205316";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/5fe3d844-e034-45c3-a383-0d1d0171ded4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1e89574-0d09-44ac-8a6b-2efee6205316>.
+    
+<http://data.lblod.info/id/remote-data-objects/898af363-df1f-473c-87ae-4da8d315651e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "898af363-df1f-473c-87ae-4da8d315651e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/6c403d78-4b07-4eb8-a2c6-eb4350fe5dc5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/898af363-df1f-473c-87ae-4da8d315651e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1c97b5b-6de9-47d7-aded-66c73d923be8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1c97b5b-6de9-47d7-aded-66c73d923be8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/6d7f449c-aa5b-4fdc-be2d-2ffa76262a9a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1c97b5b-6de9-47d7-aded-66c73d923be8>.
+    
+<http://data.lblod.info/id/remote-data-objects/75370e61-db6f-4981-b07f-670721684126> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75370e61-db6f-4981-b07f-670721684126";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/709fbcbe-9fb6-480b-94b1-9b74f1409531/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75370e61-db6f-4981-b07f-670721684126>.
+    
+<http://data.lblod.info/id/remote-data-objects/2809f6da-7ea8-4bc6-8ba8-4c4be8950d9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2809f6da-7ea8-4bc6-8ba8-4c4be8950d9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/7232703a-4223-4a38-83ad-dac0d135ed16/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2809f6da-7ea8-4bc6-8ba8-4c4be8950d9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f19e310-63df-4771-a106-7e22a9b59351> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f19e310-63df-4771-a106-7e22a9b59351";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/7639b1b7-ef7a-47b9-a4fe-adb47681b2f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f19e310-63df-4771-a106-7e22a9b59351>.
+    
+<http://data.lblod.info/id/remote-data-objects/ded1f453-e84f-400e-9ac7-d65f0ace2e3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ded1f453-e84f-400e-9ac7-d65f0ace2e3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/77711e73-a08b-42ec-8839-54b8024f0611/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ded1f453-e84f-400e-9ac7-d65f0ace2e3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc25a729-be72-4186-8cda-232fcda85e31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc25a729-be72-4186-8cda-232fcda85e31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/78a8be27-1bb1-4d6f-a371-ccb929ba0c4b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc25a729-be72-4186-8cda-232fcda85e31>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fe876e6-5f35-4b03-bbb6-621eb3f21303> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fe876e6-5f35-4b03-bbb6-621eb3f21303";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/81f07f9d-2ad1-4b20-8d4b-4b135dc002c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fe876e6-5f35-4b03-bbb6-621eb3f21303>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcd5e0e0-5f09-4589-a68b-0cd47f7b692e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcd5e0e0-5f09-4589-a68b-0cd47f7b692e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/87c365bd-e92d-466a-b0fb-d65a06c1ce1c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcd5e0e0-5f09-4589-a68b-0cd47f7b692e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c08a7694-41cf-4931-9078-1202fb2ceecd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c08a7694-41cf-4931-9078-1202fb2ceecd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/8856ab25-7c67-4af0-93ee-8194cba22886/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c08a7694-41cf-4931-9078-1202fb2ceecd>.
+    
+<http://data.lblod.info/id/remote-data-objects/461ecafc-3aed-4eeb-8462-1af3ee35481a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "461ecafc-3aed-4eeb-8462-1af3ee35481a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/8991ab27-7c29-4a7a-9c2b-53512683dc41/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/461ecafc-3aed-4eeb-8462-1af3ee35481a>.
+    
+<http://data.lblod.info/id/remote-data-objects/20fb9fd8-e5ff-46d3-beec-b94b12e41296> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20fb9fd8-e5ff-46d3-beec-b94b12e41296";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/8b8cbebe-1186-4c45-bcf4-389c817fc1b8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20fb9fd8-e5ff-46d3-beec-b94b12e41296>.
+    
+<http://data.lblod.info/id/remote-data-objects/64564513-ab8f-45db-a976-ac9030dddd8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64564513-ab8f-45db-a976-ac9030dddd8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/8c19f166-dd63-4f0c-993d-0b7069ef1542/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64564513-ab8f-45db-a976-ac9030dddd8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6e54ddf-7d08-4e36-aa0b-325bcfec9723> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6e54ddf-7d08-4e36-aa0b-325bcfec9723";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/91404eda-3ac4-4162-aab7-e7083123aa67/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6e54ddf-7d08-4e36-aa0b-325bcfec9723>.
+    
+<http://data.lblod.info/id/remote-data-objects/3921862a-1eba-430f-9e11-33199c1f1455> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3921862a-1eba-430f-9e11-33199c1f1455";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/9252344d-425b-432a-8d76-36d01e34d6ed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3921862a-1eba-430f-9e11-33199c1f1455>.
+    
+<http://data.lblod.info/id/remote-data-objects/47e40c15-91ef-4324-a3ed-7359cf6323a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47e40c15-91ef-4324-a3ed-7359cf6323a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/94b8daaf-632c-4b38-904f-4c486bb21e49/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47e40c15-91ef-4324-a3ed-7359cf6323a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/74cefe27-c629-41d6-b9e2-38ff7587e203> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74cefe27-c629-41d6-b9e2-38ff7587e203";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/99dfee78-4440-4530-8a63-6e49c40744ee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74cefe27-c629-41d6-b9e2-38ff7587e203>.
+    
+<http://data.lblod.info/id/remote-data-objects/e10871d4-9449-4118-a3ab-0ba47d19f6dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e10871d4-9449-4118-a3ab-0ba47d19f6dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/9f3dcc4c-3b3b-462f-a0d8-a4cc2931965a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e10871d4-9449-4118-a3ab-0ba47d19f6dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/07ae7110-a5db-4bc0-8b9a-bdbab2649bc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07ae7110-a5db-4bc0-8b9a-bdbab2649bc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/a024e67d-9b26-4bcf-90a8-f5ce3ec7d970/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07ae7110-a5db-4bc0-8b9a-bdbab2649bc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/08be5979-b1a0-45a2-8766-5ff5d76363f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08be5979-b1a0-45a2-8766-5ff5d76363f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/a8208152-2016-499f-ab75-b5bc22b1a0e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08be5979-b1a0-45a2-8766-5ff5d76363f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/824d4579-8779-4fcd-87d2-2206b55d469f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "824d4579-8779-4fcd-87d2-2206b55d469f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/a9be9803-7763-4866-907e-1f2413ba4ae3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/824d4579-8779-4fcd-87d2-2206b55d469f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d0ea01a-5f00-4564-95d6-93759c953b33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d0ea01a-5f00-4564-95d6-93759c953b33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/aa089651-eedc-4e75-8dac-b6d8991c8877/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d0ea01a-5f00-4564-95d6-93759c953b33>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1691b23-14d4-4e5e-a1a8-1098058fef03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1691b23-14d4-4e5e-a1a8-1098058fef03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/ac829291-26f3-4f90-b903-178968d12431/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1691b23-14d4-4e5e-a1a8-1098058fef03>.
+    
+<http://data.lblod.info/id/remote-data-objects/7255988a-fa37-4697-ab61-53910c8a7ec1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7255988a-fa37-4697-ab61-53910c8a7ec1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/ad4c2479-090c-484b-88d4-a8108dfa56a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7255988a-fa37-4697-ab61-53910c8a7ec1>.
+    
+<http://data.lblod.info/id/remote-data-objects/477b005e-f267-4b48-904d-711a61841a63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "477b005e-f267-4b48-904d-711a61841a63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/af7e7661-9c22-45a2-b421-bb39fc283fc2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/477b005e-f267-4b48-904d-711a61841a63>.
+    
+<http://data.lblod.info/id/remote-data-objects/a30848c8-7c7d-4326-a436-2440fbfffcf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a30848c8-7c7d-4326-a436-2440fbfffcf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/afca8bef-7008-4cfe-a379-f411fe406c97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a30848c8-7c7d-4326-a436-2440fbfffcf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/12b253bd-c113-4f3a-888f-f761748433a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12b253bd-c113-4f3a-888f-f761748433a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/b8086cea-d595-4d5e-9e4f-d810bb059976/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12b253bd-c113-4f3a-888f-f761748433a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/fce09d10-5662-4dcc-81f3-a9ecda3b89a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fce09d10-5662-4dcc-81f3-a9ecda3b89a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/b834b767-8169-4007-87b8-cf922aeaa947/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fce09d10-5662-4dcc-81f3-a9ecda3b89a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcff0ee6-09cd-4f54-beca-db3eac13c15a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcff0ee6-09cd-4f54-beca-db3eac13c15a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/bd61c195-5227-48f5-8f1b-a0098b3663d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcff0ee6-09cd-4f54-beca-db3eac13c15a>.
+    
+<http://data.lblod.info/id/remote-data-objects/81c5659e-9aec-4377-94c4-ca7589adcda8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81c5659e-9aec-4377-94c4-ca7589adcda8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/bdb484c1-9ba3-4d02-a636-d627bff59040/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81c5659e-9aec-4377-94c4-ca7589adcda8>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c1e3f0d-d681-4c06-9808-f32a522e6b22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c1e3f0d-d681-4c06-9808-f32a522e6b22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/cfd38dc4-d2a8-4d40-a99e-00a936d8cdb0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c1e3f0d-d681-4c06-9808-f32a522e6b22>.
+    
+<http://data.lblod.info/id/remote-data-objects/03bd9b56-b4ad-4933-8a9b-8f18ca94682b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03bd9b56-b4ad-4933-8a9b-8f18ca94682b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/d06c3339-703e-4d92-b05a-27bc9489f47d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03bd9b56-b4ad-4933-8a9b-8f18ca94682b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ba53aae-9294-4dca-aca3-e25fec0369eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ba53aae-9294-4dca-aca3-e25fec0369eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/d151bf85-963b-4e5e-990e-8d70c20ac7f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ba53aae-9294-4dca-aca3-e25fec0369eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ed95020-ef1d-49e6-b4a7-f1d5233e4a41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ed95020-ef1d-49e6-b4a7-f1d5233e4a41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/d8f35dc4-7b4d-4702-8e4d-6a2b5b29ddd4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ed95020-ef1d-49e6-b4a7-f1d5233e4a41>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b703df4-745f-4169-b276-ef750644d15a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b703df4-745f-4169-b276-ef750644d15a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/dd7682a2-0736-4d96-96e5-e95d81259f57/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b703df4-745f-4169-b276-ef750644d15a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7fab69a-a0b4-465d-9c72-18e7eb33fb37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7fab69a-a0b4-465d-9c72-18e7eb33fb37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/de526668-ddf3-455e-a411-05945b16c2e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7fab69a-a0b4-465d-9c72-18e7eb33fb37>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bf6a895-7fb3-402b-bc2a-5a6ec4069079> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bf6a895-7fb3-402b-bc2a-5a6ec4069079";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/deca1a83-8a3f-49b2-bbec-ca609e87dfd6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bf6a895-7fb3-402b-bc2a-5a6ec4069079>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd54d619-6f90-4509-9224-d989750fb980> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd54d619-6f90-4509-9224-d989750fb980";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/e2d12331-b9c5-437f-b4a8-1a59ddd9dfdd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd54d619-6f90-4509-9224-d989750fb980>.
+    
+<http://data.lblod.info/id/remote-data-objects/078b8667-2e34-4365-910b-3b74c2350650> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "078b8667-2e34-4365-910b-3b74c2350650";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/e527a0d1-398e-4b2b-90db-c3732718d8bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/078b8667-2e34-4365-910b-3b74c2350650>.
+    
+<http://data.lblod.info/id/remote-data-objects/e517a02d-5cad-41c5-adf0-ffddfaa75014> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e517a02d-5cad-41c5-adf0-ffddfaa75014";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/f3794c9e-d0be-43ed-9bc6-ed1a22e483c0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e517a02d-5cad-41c5-adf0-ffddfaa75014>.
+    
+<http://data.lblod.info/id/remote-data-objects/01ea4db4-0902-43d8-8686-bd853004f372> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01ea4db4-0902-43d8-8686-bd853004f372";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/f3afd81b-13d4-4f60-bffa-68d2eae39da3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01ea4db4-0902-43d8-8686-bd853004f372>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ba96ad7-31ca-4bd7-9543-62f40f12d339> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ba96ad7-31ca-4bd7-9543-62f40f12d339";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/f4ccbb7b-3c1c-4676-ab65-13d658cd1441/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ba96ad7-31ca-4bd7-9543-62f40f12d339>.
+    
+<http://data.lblod.info/id/remote-data-objects/f65219fa-16c2-4723-8feb-cf5cc316e5de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f65219fa-16c2-4723-8feb-cf5cc316e5de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/f5625d6e-1387-4731-ba86-a06397c97879/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f65219fa-16c2-4723-8feb-cf5cc316e5de>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8d0ccbd-5ff8-4420-b672-d09dc2ebb053> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8d0ccbd-5ff8-4420-b672-d09dc2ebb053";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/fd091842-50bf-441f-829d-fadce7c40462/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8d0ccbd-5ff8-4420-b672-d09dc2ebb053>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c0e76bb-3065-4186-8db8-7663c1d01d4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c0e76bb-3065-4186-8db8-7663c1d01d4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://alken.meetingburger.net/vabu/fe6db0f7-01c6-4860-8924-79eaf6e11d22/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c0e76bb-3065-4186-8db8-7663c1d01d4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e827f8f-9cef-4b36-8551-e48f2d73578b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e827f8f-9cef-4b36-8551-e48f2d73578b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/bb/6d9b178b-4357-461f-9559-fc04d0c74769/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e827f8f-9cef-4b36-8551-e48f2d73578b>.
+    
+<http://data.lblod.info/id/remote-data-objects/717d0ea2-960c-4ad1-bc8d-a51d9a84a52e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "717d0ea2-960c-4ad1-bc8d-a51d9a84a52e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/06c05583-d75a-44a9-b54b-6219870fe8ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/717d0ea2-960c-4ad1-bc8d-a51d9a84a52e>.
+    
+<http://data.lblod.info/id/remote-data-objects/158e5a4b-1e30-4f94-99cc-8f804577d60e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "158e5a4b-1e30-4f94-99cc-8f804577d60e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/094d6528-6a87-45ac-bba9-f6bd190603d9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/158e5a4b-1e30-4f94-99cc-8f804577d60e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1ac8f32-0e75-4dcd-aa1a-21426331d1db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1ac8f32-0e75-4dcd-aa1a-21426331d1db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/0d4f1977-45c3-4337-864b-b62ea5077838/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17a8dbff-4463-472f-b6b1-c7fc554a857b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1ac8f32-0e75-4dcd-aa1a-21426331d1db>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201014-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201014-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201014-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201014-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/1bcc5308-ee38-43e7-88e2-98764a9d2f03> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1bcc5308-ee38-43e7-88e2-98764a9d2f03";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ef502fdf-70dc-4e1e-bd6a-5bbeebb68950";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ce9ef101-80fb-485d-95a0-a6595b66db6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ce9ef101-80fb-485d-95a0-a6595b66db6e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950>.
+
+  <http://redpencil.data.gift/id/task/32fb8dd0-ad04-4d51-9189-1673fad5da88> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "32fb8dd0-ad04-4d51-9189-1673fad5da88";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/1bcc5308-ee38-43e7-88e2-98764a9d2f03>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ce9ef101-80fb-485d-95a0-a6595b66db6e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/08ad0c02-93f9-4afa-ae1e-ee89926de34e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08ad0c02-93f9-4afa-ae1e-ee89926de34e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/1081c6e7-7767-431f-94ab-64bf4cb23ae4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08ad0c02-93f9-4afa-ae1e-ee89926de34e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c7e9baa-df28-44e1-a982-84b2b0d3a50f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c7e9baa-df28-44e1-a982-84b2b0d3a50f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/12dc6238-25e8-4b0d-a728-4a61ab3ae0b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c7e9baa-df28-44e1-a982-84b2b0d3a50f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a15b8c8e-f106-44b4-bcf3-f4d9aeaa0d87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a15b8c8e-f106-44b4-bcf3-f4d9aeaa0d87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/13904a62-e07c-4d53-af89-405d9a5d854f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a15b8c8e-f106-44b4-bcf3-f4d9aeaa0d87>.
+    
+<http://data.lblod.info/id/remote-data-objects/b96b224c-3847-4f2f-9ef9-6ac9f67e3d22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b96b224c-3847-4f2f-9ef9-6ac9f67e3d22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/172bfd04-7f85-442c-91ca-991e87f4fc37/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b96b224c-3847-4f2f-9ef9-6ac9f67e3d22>.
+    
+<http://data.lblod.info/id/remote-data-objects/abe87378-660e-4878-a567-d84e93c0cb7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abe87378-660e-4878-a567-d84e93c0cb7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/222f157b-f0ae-40e3-8e79-a55fd721a3f6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abe87378-660e-4878-a567-d84e93c0cb7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/170faa88-c2c3-49ca-8761-b538ec12bbda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "170faa88-c2c3-49ca-8761-b538ec12bbda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/2262dfd5-34bf-4e92-9625-3d6eeb8865c0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/170faa88-c2c3-49ca-8761-b538ec12bbda>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d0e6418-c3bd-435c-bf88-413bbdf7d9ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d0e6418-c3bd-435c-bf88-413bbdf7d9ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/25a4c5bb-a289-4947-ab8a-26b8d7d23051/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d0e6418-c3bd-435c-bf88-413bbdf7d9ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/589dd5d1-2965-4821-959a-fcf31a92ff70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "589dd5d1-2965-4821-959a-fcf31a92ff70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/30beace0-8e63-450b-b00a-e405f5b69752/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/589dd5d1-2965-4821-959a-fcf31a92ff70>.
+    
+<http://data.lblod.info/id/remote-data-objects/863fa085-b0c7-48f9-a7b7-77cdb160814c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "863fa085-b0c7-48f9-a7b7-77cdb160814c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/35134fcd-7453-42dc-bd1d-633925a370e9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/863fa085-b0c7-48f9-a7b7-77cdb160814c>.
+    
+<http://data.lblod.info/id/remote-data-objects/12e2e4ac-3365-4d4d-a962-ef133910ddc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12e2e4ac-3365-4d4d-a962-ef133910ddc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/382ef55e-22d4-4b5e-9ddf-958d6f826293/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12e2e4ac-3365-4d4d-a962-ef133910ddc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/4681d726-66f0-4ea5-a602-ffbcfb9db512> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4681d726-66f0-4ea5-a602-ffbcfb9db512";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/3934fe86-98f0-4a69-a435-96ebf574c7e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4681d726-66f0-4ea5-a602-ffbcfb9db512>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdd44317-5082-431c-813b-18a6af33718d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdd44317-5082-431c-813b-18a6af33718d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/492c5dfb-4f41-40f3-b69e-72240397ed86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdd44317-5082-431c-813b-18a6af33718d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d3c5bc4-0cfb-4e09-bb0f-05b0b3487c7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d3c5bc4-0cfb-4e09-bb0f-05b0b3487c7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/4d884126-a2e2-4c5e-aa6c-97917948e163/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d3c5bc4-0cfb-4e09-bb0f-05b0b3487c7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c7976ef-bdf1-43a6-aaee-5285f9e07659> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c7976ef-bdf1-43a6-aaee-5285f9e07659";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/5252ba77-c679-4095-b795-0990c55891ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c7976ef-bdf1-43a6-aaee-5285f9e07659>.
+    
+<http://data.lblod.info/id/remote-data-objects/49a19c29-2778-4769-8b0b-34b23906acfc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49a19c29-2778-4769-8b0b-34b23906acfc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/531e0946-592f-476c-b9ce-56ea1e9b45c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49a19c29-2778-4769-8b0b-34b23906acfc>.
+    
+<http://data.lblod.info/id/remote-data-objects/a039b64a-f891-4764-b98f-e98225727fc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a039b64a-f891-4764-b98f-e98225727fc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/54cce0b7-c7dd-465d-8d0e-d570538ef49f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a039b64a-f891-4764-b98f-e98225727fc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e586e94c-e51a-4852-bb08-ae600b3eb59c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e586e94c-e51a-4852-bb08-ae600b3eb59c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/566c81b7-c756-4d8d-b0d3-ee54a3532d51/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e586e94c-e51a-4852-bb08-ae600b3eb59c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0308f785-b7eb-4754-a6c2-c5974c39cf65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0308f785-b7eb-4754-a6c2-c5974c39cf65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/58f83e18-fc0b-4b8d-b755-929095fc23ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0308f785-b7eb-4754-a6c2-c5974c39cf65>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0b7d2d9-1e5c-4b06-9db4-6ee1d3fb8e0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0b7d2d9-1e5c-4b06-9db4-6ee1d3fb8e0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/5d29d854-3adf-4c5c-93c3-cf7a9662cd54/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0b7d2d9-1e5c-4b06-9db4-6ee1d3fb8e0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5a7f4f3-0841-480d-81bf-0d57e7e66b75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5a7f4f3-0841-480d-81bf-0d57e7e66b75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/68142f7b-6d73-48eb-bd6d-5871671118b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5a7f4f3-0841-480d-81bf-0d57e7e66b75>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c9aecfb-0849-4192-bee3-aec6f3bbb2e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c9aecfb-0849-4192-bee3-aec6f3bbb2e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/6a5d06ae-d37e-4acd-8f3a-620b7d732ebd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c9aecfb-0849-4192-bee3-aec6f3bbb2e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bffa913-5c38-4892-9b17-4f9de9ce8ae1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bffa913-5c38-4892-9b17-4f9de9ce8ae1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/6bf37a57-4c68-47bd-91cb-1ad184f4dad9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bffa913-5c38-4892-9b17-4f9de9ce8ae1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3df1f59-bccd-42c8-94a1-675c346a1be8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3df1f59-bccd-42c8-94a1-675c346a1be8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/750ce1c7-7879-4178-b1a9-1993c363e3d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3df1f59-bccd-42c8-94a1-675c346a1be8>.
+    
+<http://data.lblod.info/id/remote-data-objects/44037b2b-828e-4ddd-9ec4-8974fe5d6833> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44037b2b-828e-4ddd-9ec4-8974fe5d6833";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/79b0e57b-00f7-4ed4-b953-b31c8c9eb19e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44037b2b-828e-4ddd-9ec4-8974fe5d6833>.
+    
+<http://data.lblod.info/id/remote-data-objects/5635d808-60f1-4c1b-ae6a-2cdc04ff76bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5635d808-60f1-4c1b-ae6a-2cdc04ff76bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/7be32151-a3a7-4959-9ef9-2509cf15f7f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5635d808-60f1-4c1b-ae6a-2cdc04ff76bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcfd080f-1dbf-43d4-86f6-a34a8b705733> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcfd080f-1dbf-43d4-86f6-a34a8b705733";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/7c1a672a-629e-4b15-bba1-deca7b2f1f86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcfd080f-1dbf-43d4-86f6-a34a8b705733>.
+    
+<http://data.lblod.info/id/remote-data-objects/7356ab76-f933-4d15-a791-02c4233c2170> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7356ab76-f933-4d15-a791-02c4233c2170";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/7c58b5ac-5b2c-4293-b687-6ae5e4a1ae7d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7356ab76-f933-4d15-a791-02c4233c2170>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f0815de-608d-4298-895c-4fef6ef466c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f0815de-608d-4298-895c-4fef6ef466c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/7deb3359-ed7b-4d5d-98e1-2f201346db23/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f0815de-608d-4298-895c-4fef6ef466c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/71d6c76d-ddbc-4476-b754-2ecf2664c8fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71d6c76d-ddbc-4476-b754-2ecf2664c8fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/7e3212fa-f893-4e66-979a-1795753eec44/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71d6c76d-ddbc-4476-b754-2ecf2664c8fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd286315-311c-410c-9ff8-885eae629202> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd286315-311c-410c-9ff8-885eae629202";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/7f4fa258-7099-432e-90fb-033660cafb01/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd286315-311c-410c-9ff8-885eae629202>.
+    
+<http://data.lblod.info/id/remote-data-objects/b65f2e67-3ada-4350-a2ba-4f4cb4f09801> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b65f2e67-3ada-4350-a2ba-4f4cb4f09801";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/84e69be9-29ee-4f95-8613-0333b9b61ca5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b65f2e67-3ada-4350-a2ba-4f4cb4f09801>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f43ff33-7907-4229-beb8-f416be13d76d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f43ff33-7907-4229-beb8-f416be13d76d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/8d309570-bb07-48a8-b891-951def62ff31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f43ff33-7907-4229-beb8-f416be13d76d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bab04f7-d952-41f4-9000-0ab27c8f1fb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bab04f7-d952-41f4-9000-0ab27c8f1fb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/8e86d8aa-e2a8-4ca3-b5ad-3bac16e7ebb9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bab04f7-d952-41f4-9000-0ab27c8f1fb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cf827b8-db25-449a-b30a-e816246d2194> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cf827b8-db25-449a-b30a-e816246d2194";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/90501a8d-caee-4ff1-a987-04d2fef21ed4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cf827b8-db25-449a-b30a-e816246d2194>.
+    
+<http://data.lblod.info/id/remote-data-objects/63feebcf-0817-40b7-bdcf-7684b9501c29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63feebcf-0817-40b7-bdcf-7684b9501c29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/923e697b-f93e-4877-90ef-7f48cae4e422/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63feebcf-0817-40b7-bdcf-7684b9501c29>.
+    
+<http://data.lblod.info/id/remote-data-objects/9164d84a-556d-4207-9145-b964d09e2ead> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9164d84a-556d-4207-9145-b964d09e2ead";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/93542d90-6523-4f6c-91b1-940f0c83d629/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9164d84a-556d-4207-9145-b964d09e2ead>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c48d6d0-c229-4172-88e5-23f6c7abe645> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c48d6d0-c229-4172-88e5-23f6c7abe645";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/936c71ce-ee12-4ae9-bc78-d0ea76ee6c26/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c48d6d0-c229-4172-88e5-23f6c7abe645>.
+    
+<http://data.lblod.info/id/remote-data-objects/b95136da-a33a-43f4-879f-7b49ceddc4e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b95136da-a33a-43f4-879f-7b49ceddc4e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/946d30d5-d1b0-4b68-a8b9-29b3c569f661/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b95136da-a33a-43f4-879f-7b49ceddc4e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e43af89-9b32-404f-a4f2-2ea712de7a86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e43af89-9b32-404f-a4f2-2ea712de7a86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/97dc0c72-62c2-4282-a4f4-a5442884e4d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e43af89-9b32-404f-a4f2-2ea712de7a86>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b62f250-8c24-4101-8166-7f031a5a76a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b62f250-8c24-4101-8166-7f031a5a76a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/9f8c6a0f-0eb7-4b57-96bf-4f73d096eec2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b62f250-8c24-4101-8166-7f031a5a76a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/441311c4-5d48-44be-acce-7a016d64508a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "441311c4-5d48-44be-acce-7a016d64508a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/a0fa7c33-2003-46f7-b97a-4f51e84558a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/441311c4-5d48-44be-acce-7a016d64508a>.
+    
+<http://data.lblod.info/id/remote-data-objects/53c52928-7f62-4404-9d76-d0a3848e499f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53c52928-7f62-4404-9d76-d0a3848e499f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/a2513f14-a6ff-4b33-8cb8-fefe3c13dc66/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53c52928-7f62-4404-9d76-d0a3848e499f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3e88bfc-138f-445a-8d60-ce2d103c1b36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3e88bfc-138f-445a-8d60-ce2d103c1b36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/a4eeff27-9f84-4b55-b14e-b0f990fb5126/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3e88bfc-138f-445a-8d60-ce2d103c1b36>.
+    
+<http://data.lblod.info/id/remote-data-objects/c643384a-0d27-4c2a-b027-8877e7ec48ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c643384a-0d27-4c2a-b027-8877e7ec48ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/ad91778a-8945-4d96-9c67-839c5953b683/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c643384a-0d27-4c2a-b027-8877e7ec48ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad691131-f9b6-4590-9b50-e37ed1e05c7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad691131-f9b6-4590-9b50-e37ed1e05c7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/ad9d8197-58c6-4bfa-b502-132b9cba6095/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad691131-f9b6-4590-9b50-e37ed1e05c7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a1585e3-61ce-4409-ac65-56a823151dc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a1585e3-61ce-4409-ac65-56a823151dc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/b27b3f7d-9786-4a12-b699-814605db7eb4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a1585e3-61ce-4409-ac65-56a823151dc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5396baa3-d1de-4d70-9d66-ffdf98088f5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5396baa3-d1de-4d70-9d66-ffdf98088f5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/ba9b92e7-ac37-4756-938f-834349a4d577/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5396baa3-d1de-4d70-9d66-ffdf98088f5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6d97cf4-a498-4160-afe8-bb8aabf4fc60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6d97cf4-a498-4160-afe8-bb8aabf4fc60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/bc87fb4e-6a96-4ff2-bd90-4eca7e383303/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6d97cf4-a498-4160-afe8-bb8aabf4fc60>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cff25bc-1c40-4816-b01c-ce96af754375> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cff25bc-1c40-4816-b01c-ce96af754375";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/ccf1f809-6afe-49bb-9276-1ef006cc1ad6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cff25bc-1c40-4816-b01c-ce96af754375>.
+    
+<http://data.lblod.info/id/remote-data-objects/77ffb813-64b4-4259-820e-8696a60b8108> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77ffb813-64b4-4259-820e-8696a60b8108";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/cdba9b27-ca93-418c-8ea7-f3d0c3a4ab12/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ef502fdf-70dc-4e1e-bd6a-5bbeebb68950> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77ffb813-64b4-4259-820e-8696a60b8108>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201015-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201015-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201015-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201015-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/726cc048-811f-4e27-abd7-8e31f634c787> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "726cc048-811f-4e27-abd7-8e31f634c787";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6e6843d7-402c-44d1-8b1c-29dd88e17e6d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e8d54724-a1e1-4ccb-bb18-0d69a03fe682> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e8d54724-a1e1-4ccb-bb18-0d69a03fe682";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d>.
+
+  <http://redpencil.data.gift/id/task/f128a7be-7aae-4ccc-a63f-0d9b256012f5> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f128a7be-7aae-4ccc-a63f-0d9b256012f5";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/726cc048-811f-4e27-abd7-8e31f634c787>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e8d54724-a1e1-4ccb-bb18-0d69a03fe682>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/afe43156-41f6-42ee-851b-781ee4463746> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afe43156-41f6-42ee-851b-781ee4463746";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/cf27cef2-095d-4d2a-a8f6-81f88ca7e6d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afe43156-41f6-42ee-851b-781ee4463746>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a2ae4b9-22f8-4a09-894e-d19b22bc2394> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a2ae4b9-22f8-4a09-894e-d19b22bc2394";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/d6982099-1b4d-4e87-9fa5-2a141c17b309/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a2ae4b9-22f8-4a09-894e-d19b22bc2394>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cdc710c-2037-4096-99e0-8fc645d97fb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cdc710c-2037-4096-99e0-8fc645d97fb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/de3f4c1a-13bd-4ff9-89f8-8e7d4c1405e6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cdc710c-2037-4096-99e0-8fc645d97fb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/740fab3c-fad1-427a-85d0-bb485fc0dac9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "740fab3c-fad1-427a-85d0-bb485fc0dac9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/df8374e6-92d4-4899-9272-3c88e3a1e46c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/740fab3c-fad1-427a-85d0-bb485fc0dac9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f789697c-bf2d-49c3-865a-07e3ff80c358> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f789697c-bf2d-49c3-865a-07e3ff80c358";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/e18ee0a8-447c-4dba-8bce-dfc470e6d591/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f789697c-bf2d-49c3-865a-07e3ff80c358>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ae970d0-1755-423c-bbf3-c07ef40ae9d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ae970d0-1755-423c-bbf3-c07ef40ae9d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/e5308ab2-bb33-471b-b278-423e03b7ed5b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ae970d0-1755-423c-bbf3-c07ef40ae9d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/086c9d7f-434a-4fe9-a001-1720ff70c31e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "086c9d7f-434a-4fe9-a001-1720ff70c31e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/e60366d5-b9e6-4271-a0c9-1b23ff9e0ecc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/086c9d7f-434a-4fe9-a001-1720ff70c31e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f028075-877d-4a3d-805a-b995ddc43741> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f028075-877d-4a3d-805a-b995ddc43741";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/e85a6427-b9a8-4f5a-8875-fe0a18c75bda/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f028075-877d-4a3d-805a-b995ddc43741>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8613132-ffa4-4665-bcce-f752e41d6ace> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8613132-ffa4-4665-bcce-f752e41d6ace";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/e89d676d-4678-4e1a-9dd5-96007f541470/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8613132-ffa4-4665-bcce-f752e41d6ace>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5c9e4ff-9dde-45e1-be13-74ba9bfc1078> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5c9e4ff-9dde-45e1-be13-74ba9bfc1078";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/e9395fca-972d-4833-96f1-720e11935da0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5c9e4ff-9dde-45e1-be13-74ba9bfc1078>.
+    
+<http://data.lblod.info/id/remote-data-objects/46c216f9-6f4f-4bc8-88a7-91ef4cdb0442> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46c216f9-6f4f-4bc8-88a7-91ef4cdb0442";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/e98d5fa2-406f-4533-98d4-a9251811a997/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46c216f9-6f4f-4bc8-88a7-91ef4cdb0442>.
+    
+<http://data.lblod.info/id/remote-data-objects/80ed1d67-57ad-4659-9a4e-4a907d59068a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80ed1d67-57ad-4659-9a4e-4a907d59068a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/ef0cf908-e166-46a4-971e-2a197bc0fb52/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80ed1d67-57ad-4659-9a4e-4a907d59068a>.
+    
+<http://data.lblod.info/id/remote-data-objects/10e6c346-8cd7-49e8-ae4d-5cce83ea0eda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10e6c346-8cd7-49e8-ae4d-5cce83ea0eda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/f60e86b6-9390-48dc-85fd-ef6f9f46d586/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10e6c346-8cd7-49e8-ae4d-5cce83ea0eda>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac27d2af-042f-4c18-96a7-6150f2fe1b22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac27d2af-042f-4c18-96a7-6150f2fe1b22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/cbs/ff304a02-eaeb-474e-9996-c5624674f851/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac27d2af-042f-4c18-96a7-6150f2fe1b22>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d801c41-0fe6-4b5b-a8b8-1f0f4d47d436> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d801c41-0fe6-4b5b-a8b8-1f0f4d47d436";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/04ad5eef-40ad-4fbf-ae92-51496711f722/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d801c41-0fe6-4b5b-a8b8-1f0f4d47d436>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b4b4978-9718-4175-8c04-6364b8a3a14a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b4b4978-9718-4175-8c04-6364b8a3a14a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/04ad5eef-40ad-4fbf-ae92-51496711f722/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b4b4978-9718-4175-8c04-6364b8a3a14a>.
+    
+<http://data.lblod.info/id/remote-data-objects/129d77ef-38e9-4960-b2ab-95657248503b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "129d77ef-38e9-4960-b2ab-95657248503b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/04ad5eef-40ad-4fbf-ae92-51496711f722/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/129d77ef-38e9-4960-b2ab-95657248503b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d360d758-9aa2-436a-8842-0d4b1aacd5e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d360d758-9aa2-436a-8842-0d4b1aacd5e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/2aa67226-fd1c-46cc-9c40-e5ee17e1d5d6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d360d758-9aa2-436a-8842-0d4b1aacd5e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/66562411-5fd8-4bb0-ab7d-592f46131aba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66562411-5fd8-4bb0-ab7d-592f46131aba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/2aa67226-fd1c-46cc-9c40-e5ee17e1d5d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66562411-5fd8-4bb0-ab7d-592f46131aba>.
+    
+<http://data.lblod.info/id/remote-data-objects/abebd6c3-387b-4d2b-bf68-c4cb0f834de1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abebd6c3-387b-4d2b-bf68-c4cb0f834de1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/2aa67226-fd1c-46cc-9c40-e5ee17e1d5d6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abebd6c3-387b-4d2b-bf68-c4cb0f834de1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d2f78c9-6644-44a5-b917-95c2cbae4cef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d2f78c9-6644-44a5-b917-95c2cbae4cef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/3635d5ea-767d-4e0c-ba6d-02f4e9caa423/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d2f78c9-6644-44a5-b917-95c2cbae4cef>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fd91f99-6071-410e-bd70-805162604890> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fd91f99-6071-410e-bd70-805162604890";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/3635d5ea-767d-4e0c-ba6d-02f4e9caa423/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fd91f99-6071-410e-bd70-805162604890>.
+    
+<http://data.lblod.info/id/remote-data-objects/850f797b-3c8d-4e23-b86b-def1193c4032> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "850f797b-3c8d-4e23-b86b-def1193c4032";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/3635d5ea-767d-4e0c-ba6d-02f4e9caa423/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/850f797b-3c8d-4e23-b86b-def1193c4032>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae7db401-4a34-48ca-bd74-b10fdbeaa4ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae7db401-4a34-48ca-bd74-b10fdbeaa4ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/455a5354-42d9-4ddc-95b0-b8600342a0d6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae7db401-4a34-48ca-bd74-b10fdbeaa4ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a016bf3-cb85-4ad6-9a6b-8c7ba782657e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a016bf3-cb85-4ad6-9a6b-8c7ba782657e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/455a5354-42d9-4ddc-95b0-b8600342a0d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a016bf3-cb85-4ad6-9a6b-8c7ba782657e>.
+    
+<http://data.lblod.info/id/remote-data-objects/47a56a54-2e14-4d4a-9dbd-b584d6852a9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47a56a54-2e14-4d4a-9dbd-b584d6852a9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/455a5354-42d9-4ddc-95b0-b8600342a0d6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47a56a54-2e14-4d4a-9dbd-b584d6852a9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/36bbd716-c885-4778-988f-1ba395623a4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36bbd716-c885-4778-988f-1ba395623a4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/4d8139d0-a842-4cf1-8799-315f73595865/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36bbd716-c885-4778-988f-1ba395623a4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/65798f1e-9a47-44fc-a0b9-b144f6c26e3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65798f1e-9a47-44fc-a0b9-b144f6c26e3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/4d8139d0-a842-4cf1-8799-315f73595865/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65798f1e-9a47-44fc-a0b9-b144f6c26e3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/48ef9f25-bf93-401f-a73b-aebf7b8c73ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48ef9f25-bf93-401f-a73b-aebf7b8c73ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/4d8139d0-a842-4cf1-8799-315f73595865/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48ef9f25-bf93-401f-a73b-aebf7b8c73ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe4eee4a-cfbe-407b-b002-012b8cfa1645> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe4eee4a-cfbe-407b-b002-012b8cfa1645";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/584377ff-75cf-4e8b-af4d-63acccb6bcf3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe4eee4a-cfbe-407b-b002-012b8cfa1645>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7c437fa-6156-433d-9266-3c1ba77cf406> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7c437fa-6156-433d-9266-3c1ba77cf406";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/584377ff-75cf-4e8b-af4d-63acccb6bcf3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7c437fa-6156-433d-9266-3c1ba77cf406>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c8311a0-93c9-4975-b871-928be46e4c29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c8311a0-93c9-4975-b871-928be46e4c29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/584377ff-75cf-4e8b-af4d-63acccb6bcf3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c8311a0-93c9-4975-b871-928be46e4c29>.
+    
+<http://data.lblod.info/id/remote-data-objects/dae50193-8626-4023-a4be-f1378d140dd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dae50193-8626-4023-a4be-f1378d140dd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/677a1dbe-230b-4dca-a88f-b31497d69b11/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dae50193-8626-4023-a4be-f1378d140dd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e8bfe05-7d7f-4ca8-8ec2-eb26d7bab7af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e8bfe05-7d7f-4ca8-8ec2-eb26d7bab7af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/677a1dbe-230b-4dca-a88f-b31497d69b11/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e8bfe05-7d7f-4ca8-8ec2-eb26d7bab7af>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd00ca3f-716c-4c5a-afd5-a2e8e411ec71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd00ca3f-716c-4c5a-afd5-a2e8e411ec71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/677a1dbe-230b-4dca-a88f-b31497d69b11/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd00ca3f-716c-4c5a-afd5-a2e8e411ec71>.
+    
+<http://data.lblod.info/id/remote-data-objects/2004ad5b-90bb-4150-81d0-00d15b241ef2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2004ad5b-90bb-4150-81d0-00d15b241ef2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/73f15417-240b-49cd-9d95-3f76b7443e0e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2004ad5b-90bb-4150-81d0-00d15b241ef2>.
+    
+<http://data.lblod.info/id/remote-data-objects/655485c3-57c5-4a25-b1d9-1455eff5fe31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "655485c3-57c5-4a25-b1d9-1455eff5fe31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/73f15417-240b-49cd-9d95-3f76b7443e0e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/655485c3-57c5-4a25-b1d9-1455eff5fe31>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f8d1427-e1da-4892-8d51-099d955c23bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f8d1427-e1da-4892-8d51-099d955c23bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/73f15417-240b-49cd-9d95-3f76b7443e0e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f8d1427-e1da-4892-8d51-099d955c23bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e689ef4-1d2e-4ccf-a8e2-5a177085f1bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e689ef4-1d2e-4ccf-a8e2-5a177085f1bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/7cff11fc-cb76-4777-a656-4bd81b1709c1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e689ef4-1d2e-4ccf-a8e2-5a177085f1bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/228a893f-f970-4f15-9c25-5eebaae9bf54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "228a893f-f970-4f15-9c25-5eebaae9bf54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/7cff11fc-cb76-4777-a656-4bd81b1709c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/228a893f-f970-4f15-9c25-5eebaae9bf54>.
+    
+<http://data.lblod.info/id/remote-data-objects/f53f7fe3-9210-4c91-9006-598c7d50b277> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f53f7fe3-9210-4c91-9006-598c7d50b277";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/7cff11fc-cb76-4777-a656-4bd81b1709c1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f53f7fe3-9210-4c91-9006-598c7d50b277>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4100da6-7681-4664-b693-f604ff39d0c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4100da6-7681-4664-b693-f604ff39d0c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/88289204-6694-4eda-8760-35014a3d61f0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4100da6-7681-4664-b693-f604ff39d0c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/57e9600c-9c5e-4096-8d45-e9de3263e0a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57e9600c-9c5e-4096-8d45-e9de3263e0a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/88289204-6694-4eda-8760-35014a3d61f0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57e9600c-9c5e-4096-8d45-e9de3263e0a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f61e4914-b08e-4515-8541-37f4e8b3b004> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f61e4914-b08e-4515-8541-37f4e8b3b004";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/88289204-6694-4eda-8760-35014a3d61f0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f61e4914-b08e-4515-8541-37f4e8b3b004>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb95a27e-42f4-470b-8a98-71e6bc9486be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb95a27e-42f4-470b-8a98-71e6bc9486be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/afe0ce4b-aa6b-4026-bfbe-f879202bea6f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb95a27e-42f4-470b-8a98-71e6bc9486be>.
+    
+<http://data.lblod.info/id/remote-data-objects/018bf657-2586-40e6-88f6-9c89b373f409> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "018bf657-2586-40e6-88f6-9c89b373f409";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/afe0ce4b-aa6b-4026-bfbe-f879202bea6f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/018bf657-2586-40e6-88f6-9c89b373f409>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5b9d4b3-d58d-4123-ae70-8244489e6a0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5b9d4b3-d58d-4123-ae70-8244489e6a0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/afe0ce4b-aa6b-4026-bfbe-f879202bea6f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5b9d4b3-d58d-4123-ae70-8244489e6a0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7c7a4a7-73cd-4efc-b672-a12b79094b00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7c7a4a7-73cd-4efc-b672-a12b79094b00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/b29d05fe-4aae-4d03-9073-0af5f31cf2b7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7c7a4a7-73cd-4efc-b672-a12b79094b00>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0df8f50-8992-436e-afb7-987a495701d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0df8f50-8992-436e-afb7-987a495701d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/b29d05fe-4aae-4d03-9073-0af5f31cf2b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0df8f50-8992-436e-afb7-987a495701d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a6d791c-bc68-4883-9b32-511948ee1bbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a6d791c-bc68-4883-9b32-511948ee1bbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/b29d05fe-4aae-4d03-9073-0af5f31cf2b7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6843d7-402c-44d1-8b1c-29dd88e17e6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a6d791c-bc68-4883-9b32-511948ee1bbf>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201016-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201016-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201016-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201016-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/4293cc6e-8f36-4c1e-af9f-0690bb3c9403> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4293cc6e-8f36-4c1e-af9f-0690bb3c9403";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "039c6c31-cbb3-49ae-a50a-8dec6c92053c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/1099ef61-0cfe-4ae5-a00d-dc3f45800e40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1099ef61-0cfe-4ae5-a00d-dc3f45800e40";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c>.
+
+  <http://redpencil.data.gift/id/task/51bb1169-b3c8-4be6-8445-8c74b9209c23> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "51bb1169-b3c8-4be6-8445-8c74b9209c23";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/4293cc6e-8f36-4c1e-af9f-0690bb3c9403>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/1099ef61-0cfe-4ae5-a00d-dc3f45800e40>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d48a79e2-513a-4bc7-a8e7-d27ab6c5e124> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d48a79e2-513a-4bc7-a8e7-d27ab6c5e124";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/d7423843-3149-45b0-aee8-6fb008da4a99/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d48a79e2-513a-4bc7-a8e7-d27ab6c5e124>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4c4cd01-af5a-4054-897c-e6c04d90550f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4c4cd01-af5a-4054-897c-e6c04d90550f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/d7423843-3149-45b0-aee8-6fb008da4a99/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4c4cd01-af5a-4054-897c-e6c04d90550f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddd489e8-a21a-4068-93ff-56ca43838f01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddd489e8-a21a-4068-93ff-56ca43838f01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/d7423843-3149-45b0-aee8-6fb008da4a99/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddd489e8-a21a-4068-93ff-56ca43838f01>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1a396a7-1f32-4f23-875f-9ac4fa16a1f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1a396a7-1f32-4f23-875f-9ac4fa16a1f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/f3cf0658-461b-4307-8860-9cf0e15bc243/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1a396a7-1f32-4f23-875f-9ac4fa16a1f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fb9205d-cae5-472d-87ce-9a5eb70d3695> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fb9205d-cae5-472d-87ce-9a5eb70d3695";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/f3cf0658-461b-4307-8860-9cf0e15bc243/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fb9205d-cae5-472d-87ce-9a5eb70d3695>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea25ee4e-adc0-4353-a458-abd385a8bf0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea25ee4e-adc0-4353-a458-abd385a8bf0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/fe4b0031-5466-486f-8eed-0c66101c3cf8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea25ee4e-adc0-4353-a458-abd385a8bf0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7b592ca-c754-4fae-83de-16c8fb46438d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7b592ca-c754-4fae-83de-16c8fb46438d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/fe4b0031-5466-486f-8eed-0c66101c3cf8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7b592ca-c754-4fae-83de-16c8fb46438d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7951d25-bfa2-4a9d-8971-8ab9ea8926bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7951d25-bfa2-4a9d-8971-8ab9ea8926bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/GR/fe4b0031-5466-486f-8eed-0c66101c3cf8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7951d25-bfa2-4a9d-8971-8ab9ea8926bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/161b03b3-11f7-450d-9435-3545f1e6a411> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "161b03b3-11f7-450d-9435-3545f1e6a411";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/07505171-fe08-4aae-8cda-a74a91393477/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/161b03b3-11f7-450d-9435-3545f1e6a411>.
+    
+<http://data.lblod.info/id/remote-data-objects/5528a6f4-f37c-4203-b701-52d751c62eaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5528a6f4-f37c-4203-b701-52d751c62eaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/07505171-fe08-4aae-8cda-a74a91393477/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5528a6f4-f37c-4203-b701-52d751c62eaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/77bb3751-7abd-436f-b6aa-958d5327eaf3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77bb3751-7abd-436f-b6aa-958d5327eaf3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/07505171-fe08-4aae-8cda-a74a91393477/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77bb3751-7abd-436f-b6aa-958d5327eaf3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a15929a4-4296-432c-bc01-319f5a6de3f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a15929a4-4296-432c-bc01-319f5a6de3f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/25ea5931-94d7-44e5-ae56-0d17e601e0c5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a15929a4-4296-432c-bc01-319f5a6de3f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/718d226a-327f-4f7c-b903-ec625d9b92b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "718d226a-327f-4f7c-b903-ec625d9b92b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/25ea5931-94d7-44e5-ae56-0d17e601e0c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/718d226a-327f-4f7c-b903-ec625d9b92b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b7db2b6-5d16-45ba-9a5f-5501cccadb85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b7db2b6-5d16-45ba-9a5f-5501cccadb85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/25ea5931-94d7-44e5-ae56-0d17e601e0c5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b7db2b6-5d16-45ba-9a5f-5501cccadb85>.
+    
+<http://data.lblod.info/id/remote-data-objects/2446b010-6fc8-42b8-ad0e-21c42ee6be1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2446b010-6fc8-42b8-ad0e-21c42ee6be1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/56d86068-4137-4c8b-9dff-9068389e9a35/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2446b010-6fc8-42b8-ad0e-21c42ee6be1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a435a8aa-aaaf-4394-a1ff-d6e4ab5738f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a435a8aa-aaaf-4394-a1ff-d6e4ab5738f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/56d86068-4137-4c8b-9dff-9068389e9a35/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a435a8aa-aaaf-4394-a1ff-d6e4ab5738f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/31f1c2ab-1123-4177-8b73-3369855bc658> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31f1c2ab-1123-4177-8b73-3369855bc658";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/56d86068-4137-4c8b-9dff-9068389e9a35/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31f1c2ab-1123-4177-8b73-3369855bc658>.
+    
+<http://data.lblod.info/id/remote-data-objects/40523736-eaeb-4343-bf90-48d576f089f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40523736-eaeb-4343-bf90-48d576f089f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/7de40993-592d-4b49-8098-b257adfb6e8e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40523736-eaeb-4343-bf90-48d576f089f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/16c05ddc-069e-4303-95f2-b6d4e691c588> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16c05ddc-069e-4303-95f2-b6d4e691c588";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/7de40993-592d-4b49-8098-b257adfb6e8e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16c05ddc-069e-4303-95f2-b6d4e691c588>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d32080d-9014-409a-9924-b4b3e81cbafa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d32080d-9014-409a-9924-b4b3e81cbafa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/7de40993-592d-4b49-8098-b257adfb6e8e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d32080d-9014-409a-9924-b4b3e81cbafa>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d73b8a4-5319-46e9-bf58-2a3000f523f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d73b8a4-5319-46e9-bf58-2a3000f523f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/84b43de0-d32e-42c9-92d5-1813ac5829ce/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d73b8a4-5319-46e9-bf58-2a3000f523f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/325c8ba0-878a-49a7-8fb0-ab313b564eaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "325c8ba0-878a-49a7-8fb0-ab313b564eaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/84b43de0-d32e-42c9-92d5-1813ac5829ce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/325c8ba0-878a-49a7-8fb0-ab313b564eaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fddb9dd-42ce-4f26-a0e0-f3c534c3ff9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fddb9dd-42ce-4f26-a0e0-f3c534c3ff9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/84b43de0-d32e-42c9-92d5-1813ac5829ce/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fddb9dd-42ce-4f26-a0e0-f3c534c3ff9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/816fe3c0-1621-4c42-b8ab-c5d54eb28d44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "816fe3c0-1621-4c42-b8ab-c5d54eb28d44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/b7f3f389-48a8-4afa-b09b-c8cec9e12889/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/816fe3c0-1621-4c42-b8ab-c5d54eb28d44>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fad662e-5b0e-402c-8cee-505e686088cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fad662e-5b0e-402c-8cee-505e686088cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/b7f3f389-48a8-4afa-b09b-c8cec9e12889/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fad662e-5b0e-402c-8cee-505e686088cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/69042847-8c77-46ff-8da2-e8048879c0b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69042847-8c77-46ff-8da2-e8048879c0b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/bc320ccc-97e8-437e-bc8e-049bbb4970a5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69042847-8c77-46ff-8da2-e8048879c0b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/1318a52d-e670-4136-b20f-ad94914b87f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1318a52d-e670-4136-b20f-ad94914b87f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/bc320ccc-97e8-437e-bc8e-049bbb4970a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1318a52d-e670-4136-b20f-ad94914b87f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9516b15d-fd23-4c8c-947b-37e2d6b17e93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9516b15d-fd23-4c8c-947b-37e2d6b17e93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/bc320ccc-97e8-437e-bc8e-049bbb4970a5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9516b15d-fd23-4c8c-947b-37e2d6b17e93>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7b88d2c-4aa4-4b34-8f35-447e4d80ff9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7b88d2c-4aa4-4b34-8f35-447e4d80ff9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/d10c09db-b5f1-4520-a677-9cf72992314f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7b88d2c-4aa4-4b34-8f35-447e4d80ff9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca28c2bf-0c46-4dde-bd76-eca00ea98183> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca28c2bf-0c46-4dde-bd76-eca00ea98183";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/d10c09db-b5f1-4520-a677-9cf72992314f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca28c2bf-0c46-4dde-bd76-eca00ea98183>.
+    
+<http://data.lblod.info/id/remote-data-objects/5657b3ba-d492-400d-b6fe-814da4383461> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5657b3ba-d492-400d-b6fe-814da4383461";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/d10c09db-b5f1-4520-a677-9cf72992314f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5657b3ba-d492-400d-b6fe-814da4383461>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d5f4e45-6ba2-4aed-8a7c-3f465e37ca90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d5f4e45-6ba2-4aed-8a7c-3f465e37ca90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/d3d443b1-8063-4ca2-8a08-14bf54eeed80/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d5f4e45-6ba2-4aed-8a7c-3f465e37ca90>.
+    
+<http://data.lblod.info/id/remote-data-objects/76e9e7ac-7795-483c-89b1-bb8df8639054> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76e9e7ac-7795-483c-89b1-bb8df8639054";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/d3d443b1-8063-4ca2-8a08-14bf54eeed80/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76e9e7ac-7795-483c-89b1-bb8df8639054>.
+    
+<http://data.lblod.info/id/remote-data-objects/be611007-9a3e-4f9f-860c-4c1ee25b4021> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be611007-9a3e-4f9f-860c-4c1ee25b4021";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/d3d443b1-8063-4ca2-8a08-14bf54eeed80/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be611007-9a3e-4f9f-860c-4c1ee25b4021>.
+    
+<http://data.lblod.info/id/remote-data-objects/8281399b-3989-4997-9d32-5644a5bc07d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8281399b-3989-4997-9d32-5644a5bc07d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/f0cc6f25-bf85-43a6-acb2-6dcb4e69b71c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8281399b-3989-4997-9d32-5644a5bc07d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d895f5a-d73e-48fb-810c-4c291256fb00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d895f5a-d73e-48fb-810c-4c291256fb00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/f0cc6f25-bf85-43a6-acb2-6dcb4e69b71c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d895f5a-d73e-48fb-810c-4c291256fb00>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c4e74a1-b0e8-42cc-b670-1fa4a0b86d59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c4e74a1-b0e8-42cc-b670-1fa4a0b86d59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/rmw/f0cc6f25-bf85-43a6-acb2-6dcb4e69b71c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c4e74a1-b0e8-42cc-b670-1fa4a0b86d59>.
+    
+<http://data.lblod.info/id/remote-data-objects/00fe5fb5-7110-48ab-aea3-d8980a5fe19a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00fe5fb5-7110-48ab-aea3-d8980a5fe19a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/0230fdc9-50d7-4d08-bdae-ab16f03a96c7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00fe5fb5-7110-48ab-aea3-d8980a5fe19a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cb8ff8d-6da0-468a-a641-381ff51c942e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cb8ff8d-6da0-468a-a641-381ff51c942e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/11539db1-6fee-421e-8cc0-8e5a8d53e2b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cb8ff8d-6da0-468a-a641-381ff51c942e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f56aa24-8b69-4177-afd9-99389a2aa891> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f56aa24-8b69-4177-afd9-99389a2aa891";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/121397d8-b381-4056-860a-c4569eef98fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f56aa24-8b69-4177-afd9-99389a2aa891>.
+    
+<http://data.lblod.info/id/remote-data-objects/84df0f10-b8fb-4971-81a9-ae71409b6775> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84df0f10-b8fb-4971-81a9-ae71409b6775";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/25ac0da6-9a40-413c-8fa5-ce3f41da3f53/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84df0f10-b8fb-4971-81a9-ae71409b6775>.
+    
+<http://data.lblod.info/id/remote-data-objects/e113c48b-c84c-42e1-bc16-983c86b0abb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e113c48b-c84c-42e1-bc16-983c86b0abb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/28691c49-353d-418e-9fce-a2d4fde1ab21/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e113c48b-c84c-42e1-bc16-983c86b0abb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbe185c7-5873-4eae-a762-cfcbf8434fd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbe185c7-5873-4eae-a762-cfcbf8434fd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/2d3baee4-3119-4d6f-9480-33fc68acf085/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbe185c7-5873-4eae-a762-cfcbf8434fd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/174a1636-a497-4cbb-9612-e29ced3b28bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "174a1636-a497-4cbb-9612-e29ced3b28bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/320c6d3a-5673-47ad-875b-2eac5616bd89/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/174a1636-a497-4cbb-9612-e29ced3b28bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f5735c1-8411-4e7f-9bda-937deb7e023c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f5735c1-8411-4e7f-9bda-937deb7e023c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/4285b45b-993e-4995-9e16-aec9968f090f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f5735c1-8411-4e7f-9bda-937deb7e023c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a032f59-d284-4d1b-a04e-c147ff356369> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a032f59-d284-4d1b-a04e-c147ff356369";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/4573f46d-b1de-4fc3-85cd-6e696cea6a84/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a032f59-d284-4d1b-a04e-c147ff356369>.
+    
+<http://data.lblod.info/id/remote-data-objects/1682b475-96cc-42bb-89de-8c70d81e4854> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1682b475-96cc-42bb-89de-8c70d81e4854";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/46193c5b-f7aa-4730-a119-5ed6444831d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1682b475-96cc-42bb-89de-8c70d81e4854>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ecb2f63-df6b-4616-b9ec-ab2ed41bf278> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ecb2f63-df6b-4616-b9ec-ab2ed41bf278";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/46460b64-b00b-48aa-bce7-08bc151c1724/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ecb2f63-df6b-4616-b9ec-ab2ed41bf278>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab5587aa-2c36-4d01-a10c-8d1f3d4b48e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab5587aa-2c36-4d01-a10c-8d1f3d4b48e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/498a0f51-bb7c-4b9e-8a0f-88db0ae4bd30/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab5587aa-2c36-4d01-a10c-8d1f3d4b48e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/317d3e55-bf0f-4225-9c22-df7c166f120a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "317d3e55-bf0f-4225-9c22-df7c166f120a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/4d3cfbec-972e-48e9-bff9-14acd3b8fcd2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/039c6c31-cbb3-49ae-a50a-8dec6c92053c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/317d3e55-bf0f-4225-9c22-df7c166f120a>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201017-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201017-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201017-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201017-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/620676f9-4572-4da6-82c5-bfdcc2ca0ab1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "620676f9-4572-4da6-82c5-bfdcc2ca0ab1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "da51782d-f606-4618-9df0-1a8b8dd6ad37";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4f8ea928-6433-4360-a45f-89db037ee478> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4f8ea928-6433-4360-a45f-89db037ee478";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37>.
+
+  <http://redpencil.data.gift/id/task/5a407127-428a-444f-b779-10781c1a1910> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5a407127-428a-444f-b779-10781c1a1910";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/620676f9-4572-4da6-82c5-bfdcc2ca0ab1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4f8ea928-6433-4360-a45f-89db037ee478>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/805e933c-88be-4846-92d2-c6fc94e99596> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "805e933c-88be-4846-92d2-c6fc94e99596";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/50685afc-bda3-41a1-8e13-43af2ff87eea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/805e933c-88be-4846-92d2-c6fc94e99596>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbaefe4f-5dba-498e-bb7f-dee87e4ff840> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbaefe4f-5dba-498e-bb7f-dee87e4ff840";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/5cfefe3d-215f-4400-b8ee-7f053466b3bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbaefe4f-5dba-498e-bb7f-dee87e4ff840>.
+    
+<http://data.lblod.info/id/remote-data-objects/057de74a-5247-4dca-91e1-fb9389e67061> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "057de74a-5247-4dca-91e1-fb9389e67061";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/5d80f0ec-bf29-4837-ae79-f1c73c854edc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/057de74a-5247-4dca-91e1-fb9389e67061>.
+    
+<http://data.lblod.info/id/remote-data-objects/6eb4ec4e-0fdd-47bb-89e2-2f9ebf6f9e30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6eb4ec4e-0fdd-47bb-89e2-2f9ebf6f9e30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/9d431f72-8b33-4a1e-9229-1cfa620a7a4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6eb4ec4e-0fdd-47bb-89e2-2f9ebf6f9e30>.
+    
+<http://data.lblod.info/id/remote-data-objects/46da4613-2f9e-428e-b206-89c6a1def9f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46da4613-2f9e-428e-b206-89c6a1def9f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/9dc9727b-bbd1-4323-be00-fdb941b15901/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46da4613-2f9e-428e-b206-89c6a1def9f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6fd25dd-5c98-4f8a-8820-0cc923a13a09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6fd25dd-5c98-4f8a-8820-0cc923a13a09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/a3cf5a27-c947-4756-846f-4d8f9fecd939/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6fd25dd-5c98-4f8a-8820-0cc923a13a09>.
+    
+<http://data.lblod.info/id/remote-data-objects/84092d0b-d8e8-4860-b74f-8e4a1dd95d5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84092d0b-d8e8-4860-b74f-8e4a1dd95d5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/a53a9898-e233-4247-aed6-a2628d9c9d24/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84092d0b-d8e8-4860-b74f-8e4a1dd95d5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a79a504d-82ce-4e1b-869f-7bcd26929bad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a79a504d-82ce-4e1b-869f-7bcd26929bad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/a9b01e06-2ae1-4d69-bdbd-6414bf7a568f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a79a504d-82ce-4e1b-869f-7bcd26929bad>.
+    
+<http://data.lblod.info/id/remote-data-objects/425d861b-1ccb-4309-8560-32847e1c572f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "425d861b-1ccb-4309-8560-32847e1c572f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/c67cdb7e-ca84-4786-8d63-aa17d5b6e21d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/425d861b-1ccb-4309-8560-32847e1c572f>.
+    
+<http://data.lblod.info/id/remote-data-objects/20171170-c2c0-489a-930a-3d2ef3fc2aaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20171170-c2c0-489a-930a-3d2ef3fc2aaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/d2dcd02f-c4a6-4f29-8a70-f8bb6d7154de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20171170-c2c0-489a-930a-3d2ef3fc2aaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f8b6be5-5a0c-41eb-bd75-dc2ca058a022> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f8b6be5-5a0c-41eb-bd75-dc2ca058a022";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/d929066f-0844-4971-8bcc-d097c5b4ac62/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f8b6be5-5a0c-41eb-bd75-dc2ca058a022>.
+    
+<http://data.lblod.info/id/remote-data-objects/27717f18-02b5-4acf-9a56-ae58e81bcad8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27717f18-02b5-4acf-9a56-ae58e81bcad8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/e4fb73a3-ccae-4a4a-bcf8-34990e70e10c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27717f18-02b5-4acf-9a56-ae58e81bcad8>.
+    
+<http://data.lblod.info/id/remote-data-objects/671c2b84-e3fd-4c0f-a60a-d62c69026030> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "671c2b84-e3fd-4c0f-a60a-d62c69026030";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/e56cdea1-e616-4ed5-a706-ec528c20951f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/671c2b84-e3fd-4c0f-a60a-d62c69026030>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff797cf4-fdb1-482f-9a81-d45f61a8a671> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff797cf4-fdb1-482f-9a81-d45f61a8a671";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/e832f3ad-16bd-4935-8b8d-bace7aabdd3d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff797cf4-fdb1-482f-9a81-d45f61a8a671>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a0890c0-9c2b-43bb-90d7-9be0c27b27d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a0890c0-9c2b-43bb-90d7-9be0c27b27d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/e963fe7d-005f-4441-9132-c91b8415cc21/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a0890c0-9c2b-43bb-90d7-9be0c27b27d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/50a63a06-124b-45f5-a02d-85b636074ac0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50a63a06-124b-45f5-a02d-85b636074ac0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/eaee2433-0615-4fea-a2a0-fc6fa1ace00b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50a63a06-124b-45f5-a02d-85b636074ac0>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb00ff70-c2c9-4b81-9d01-08e6199be06b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb00ff70-c2c9-4b81-9d01-08e6199be06b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/f55590e0-981d-411b-a56b-f28b4a972681/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb00ff70-c2c9-4b81-9d01-08e6199be06b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4655cf71-5844-4061-b8f7-cc4cba61d849> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4655cf71-5844-4061-b8f7-cc4cba61d849";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/f73562d8-3ea7-45e4-9efc-b04598f93918/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4655cf71-5844-4061-b8f7-cc4cba61d849>.
+    
+<http://data.lblod.info/id/remote-data-objects/61e91911-73d1-4325-8043-ffca155297f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61e91911-73d1-4325-8043-ffca155297f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/f9e8f527-39cf-42f1-8d2a-cc97695cfa6d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61e91911-73d1-4325-8043-ffca155297f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/34a7bdec-316a-499b-9c30-b8e555e461e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34a7bdec-316a-499b-9c30-b8e555e461e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/fdfe2cd7-616d-461a-9463-ff6d22a9cd49/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34a7bdec-316a-499b-9c30-b8e555e461e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/7332538a-3642-48e1-ae00-39f549e6b1b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7332538a-3642-48e1-ae00-39f549e6b1b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://asse.meetingburger.net/vabu/fdffc37c-7404-4a49-8e5b-f427afb7e7c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7332538a-3642-48e1-ae00-39f549e6b1b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b78ad8da-2ec9-441a-8877-5b95b893aa7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b78ad8da-2ec9-441a-8877-5b95b893aa7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/1fbaa9d3-00cc-4fd0-9828-a0bfeda35a02/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b78ad8da-2ec9-441a-8877-5b95b893aa7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fff4d61a-4829-4018-a87b-e5d2763911c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fff4d61a-4829-4018-a87b-e5d2763911c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/1fbaa9d3-00cc-4fd0-9828-a0bfeda35a02/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fff4d61a-4829-4018-a87b-e5d2763911c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f508cea5-3db8-41cb-9146-d9faa7ba184c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f508cea5-3db8-41cb-9146-d9faa7ba184c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/1fbaa9d3-00cc-4fd0-9828-a0bfeda35a02/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f508cea5-3db8-41cb-9146-d9faa7ba184c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0730be09-d66d-47de-8250-7258fb2b9bdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0730be09-d66d-47de-8250-7258fb2b9bdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/5cb16dee-8840-4ee0-8283-424e64909769/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0730be09-d66d-47de-8250-7258fb2b9bdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/2170019c-0aab-4631-abdc-b423f8edff20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2170019c-0aab-4631-abdc-b423f8edff20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/5cb16dee-8840-4ee0-8283-424e64909769/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2170019c-0aab-4631-abdc-b423f8edff20>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9f745e3-1025-428d-b737-46c6ae7e9fd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9f745e3-1025-428d-b737-46c6ae7e9fd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/5cb16dee-8840-4ee0-8283-424e64909769/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9f745e3-1025-428d-b737-46c6ae7e9fd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/81b12e11-932c-4371-9a79-e17b403e8fd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81b12e11-932c-4371-9a79-e17b403e8fd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/67910366-ff74-405c-901f-d973a57de6f6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81b12e11-932c-4371-9a79-e17b403e8fd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcd7ba11-50b2-4c08-8d24-194351898fa4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcd7ba11-50b2-4c08-8d24-194351898fa4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/67910366-ff74-405c-901f-d973a57de6f6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcd7ba11-50b2-4c08-8d24-194351898fa4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cf89eb4-f264-4e5a-936a-e1577f3790c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cf89eb4-f264-4e5a-936a-e1577f3790c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/67910366-ff74-405c-901f-d973a57de6f6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cf89eb4-f264-4e5a-936a-e1577f3790c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4443aaa6-b71a-4ab7-9ddc-7d4649719302> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4443aaa6-b71a-4ab7-9ddc-7d4649719302";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/78dec491-97d0-486b-b072-bbcf91e228c3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4443aaa6-b71a-4ab7-9ddc-7d4649719302>.
+    
+<http://data.lblod.info/id/remote-data-objects/0564ec78-8265-4a4c-8262-8ad68dc161eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0564ec78-8265-4a4c-8262-8ad68dc161eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/78dec491-97d0-486b-b072-bbcf91e228c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0564ec78-8265-4a4c-8262-8ad68dc161eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/71d9e362-80eb-4735-9d7a-d2df3fcbbad1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71d9e362-80eb-4735-9d7a-d2df3fcbbad1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/78dec491-97d0-486b-b072-bbcf91e228c3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71d9e362-80eb-4735-9d7a-d2df3fcbbad1>.
+    
+<http://data.lblod.info/id/remote-data-objects/4743bb8b-7b8b-4073-a479-9cd3a89d88a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4743bb8b-7b8b-4073-a479-9cd3a89d88a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/7c1ff9df-2fd6-4fc6-b1bc-11bdd270ad54/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4743bb8b-7b8b-4073-a479-9cd3a89d88a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/772a9752-885b-40ee-bde6-ac81cba298aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "772a9752-885b-40ee-bde6-ac81cba298aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/7c1ff9df-2fd6-4fc6-b1bc-11bdd270ad54/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/772a9752-885b-40ee-bde6-ac81cba298aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/16c2607e-174e-4fb2-9faa-1843f00c034e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16c2607e-174e-4fb2-9faa-1843f00c034e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/7c1ff9df-2fd6-4fc6-b1bc-11bdd270ad54/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16c2607e-174e-4fb2-9faa-1843f00c034e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ec32cd3-78f8-4946-bfeb-b1d5528d1f14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ec32cd3-78f8-4946-bfeb-b1d5528d1f14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/84350b3b-e369-44bd-a099-8114a8a86368/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ec32cd3-78f8-4946-bfeb-b1d5528d1f14>.
+    
+<http://data.lblod.info/id/remote-data-objects/b527a442-d207-49af-91d0-8e786ad0f7d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b527a442-d207-49af-91d0-8e786ad0f7d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/84350b3b-e369-44bd-a099-8114a8a86368/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b527a442-d207-49af-91d0-8e786ad0f7d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/22988c58-4a37-4a37-855d-11366dc8ee91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22988c58-4a37-4a37-855d-11366dc8ee91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/84350b3b-e369-44bd-a099-8114a8a86368/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22988c58-4a37-4a37-855d-11366dc8ee91>.
+    
+<http://data.lblod.info/id/remote-data-objects/022a17b7-6092-4e48-93ec-65d6aa21841f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "022a17b7-6092-4e48-93ec-65d6aa21841f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/85196e4a-e958-4d43-abad-783c08fcba9c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/022a17b7-6092-4e48-93ec-65d6aa21841f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4a6b975-3b2d-4167-a420-dbba008510a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4a6b975-3b2d-4167-a420-dbba008510a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/85196e4a-e958-4d43-abad-783c08fcba9c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4a6b975-3b2d-4167-a420-dbba008510a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/25f86651-58b9-48f0-8781-5c026bf4ea5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25f86651-58b9-48f0-8781-5c026bf4ea5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/9023675c-534f-47e4-9082-385902143c74/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25f86651-58b9-48f0-8781-5c026bf4ea5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/bace96d6-209b-4a9b-b701-94970ba59e35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bace96d6-209b-4a9b-b701-94970ba59e35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/9023675c-534f-47e4-9082-385902143c74/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bace96d6-209b-4a9b-b701-94970ba59e35>.
+    
+<http://data.lblod.info/id/remote-data-objects/30bbc23b-d87e-4c63-899f-18b399add739> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30bbc23b-d87e-4c63-899f-18b399add739";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/9023675c-534f-47e4-9082-385902143c74/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30bbc23b-d87e-4c63-899f-18b399add739>.
+    
+<http://data.lblod.info/id/remote-data-objects/4442c815-bb38-42bb-a3c7-70bce204672b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4442c815-bb38-42bb-a3c7-70bce204672b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/95759f88-d289-4688-9e59-85f6d76a8699/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4442c815-bb38-42bb-a3c7-70bce204672b>.
+    
+<http://data.lblod.info/id/remote-data-objects/74ce9d75-918d-42d9-92a1-7104a28d0e4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74ce9d75-918d-42d9-92a1-7104a28d0e4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/95759f88-d289-4688-9e59-85f6d76a8699/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74ce9d75-918d-42d9-92a1-7104a28d0e4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7449515-442e-46ac-b1bf-5eee83a808ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7449515-442e-46ac-b1bf-5eee83a808ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/95759f88-d289-4688-9e59-85f6d76a8699/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7449515-442e-46ac-b1bf-5eee83a808ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/eae65277-cece-4b49-ab85-8718a0718101> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eae65277-cece-4b49-ab85-8718a0718101";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/ac6599a9-1e7c-4f51-94de-b0065aa14a34/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eae65277-cece-4b49-ab85-8718a0718101>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d5524e9-f366-4bde-b3d7-54c0d2fb5cfc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d5524e9-f366-4bde-b3d7-54c0d2fb5cfc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/ac6599a9-1e7c-4f51-94de-b0065aa14a34/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d5524e9-f366-4bde-b3d7-54c0d2fb5cfc>.
+    
+<http://data.lblod.info/id/remote-data-objects/74e56f23-2cd1-4b65-b622-edcd1f77864e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74e56f23-2cd1-4b65-b622-edcd1f77864e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/ac6599a9-1e7c-4f51-94de-b0065aa14a34/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da51782d-f606-4618-9df0-1a8b8dd6ad37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74e56f23-2cd1-4b65-b622-edcd1f77864e>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201018-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201018-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201018-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201018-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/60165b2f-566d-42f4-a7c9-ed1241fb94ac> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "60165b2f-566d-42f4-a7c9-ed1241fb94ac";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b198698d-b6da-4eed-99d5-13e524827098";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e86cd1ad-5cdf-4332-b260-f553abe1ac35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e86cd1ad-5cdf-4332-b260-f553abe1ac35";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098>.
+
+  <http://redpencil.data.gift/id/task/9ccc87bb-08c1-4b0e-b90c-7dca3424598a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9ccc87bb-08c1-4b0e-b90c-7dca3424598a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/60165b2f-566d-42f4-a7c9-ed1241fb94ac>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e86cd1ad-5cdf-4332-b260-f553abe1ac35>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7770c014-db4c-4917-8817-ef51a60afef6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7770c014-db4c-4917-8817-ef51a60afef6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/b32712aa-4003-4f28-9642-0ab8ff42d8d5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7770c014-db4c-4917-8817-ef51a60afef6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d000b463-2810-494f-b4fe-9b5006deeb9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d000b463-2810-494f-b4fe-9b5006deeb9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/b32712aa-4003-4f28-9642-0ab8ff42d8d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d000b463-2810-494f-b4fe-9b5006deeb9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebf46142-1fbe-4667-8a9d-a48265927250> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebf46142-1fbe-4667-8a9d-a48265927250";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/b32712aa-4003-4f28-9642-0ab8ff42d8d5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebf46142-1fbe-4667-8a9d-a48265927250>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd1d5e6c-b023-40c8-bf3f-4bdfcae324ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd1d5e6c-b023-40c8-bf3f-4bdfcae324ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/b3dd9199-ec19-47f2-a31d-08cbe7ef43b3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd1d5e6c-b023-40c8-bf3f-4bdfcae324ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/b418c8ed-2e53-4609-a76f-2d7fa03a4ff1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b418c8ed-2e53-4609-a76f-2d7fa03a4ff1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/b3dd9199-ec19-47f2-a31d-08cbe7ef43b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b418c8ed-2e53-4609-a76f-2d7fa03a4ff1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad12efd0-43a5-4f7b-bb2f-5efe9207603b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad12efd0-43a5-4f7b-bb2f-5efe9207603b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/b3dd9199-ec19-47f2-a31d-08cbe7ef43b3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad12efd0-43a5-4f7b-bb2f-5efe9207603b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c21eb8e-626c-474c-be23-6edfa5915131> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c21eb8e-626c-474c-be23-6edfa5915131";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/d9e0a8b0-de60-4c37-bbdf-ce6fd7444c11/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c21eb8e-626c-474c-be23-6edfa5915131>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfbf8d52-abbf-4df9-b6e0-bcceeef68f83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfbf8d52-abbf-4df9-b6e0-bcceeef68f83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/d9e0a8b0-de60-4c37-bbdf-ce6fd7444c11/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfbf8d52-abbf-4df9-b6e0-bcceeef68f83>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0458ba2-782a-4069-82df-8b9625882397> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0458ba2-782a-4069-82df-8b9625882397";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/d9e0a8b0-de60-4c37-bbdf-ce6fd7444c11/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0458ba2-782a-4069-82df-8b9625882397>.
+    
+<http://data.lblod.info/id/remote-data-objects/567e0532-67c7-4551-a39a-ff76e98394e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "567e0532-67c7-4551-a39a-ff76e98394e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/dde77349-313c-49dc-a100-22214bbfb10a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/567e0532-67c7-4551-a39a-ff76e98394e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/cefe4888-4146-4553-bc28-e03c5420cb56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cefe4888-4146-4553-bc28-e03c5420cb56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/dde77349-313c-49dc-a100-22214bbfb10a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cefe4888-4146-4553-bc28-e03c5420cb56>.
+    
+<http://data.lblod.info/id/remote-data-objects/8908c57e-d392-4fbd-9d9a-e9582b40c634> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8908c57e-d392-4fbd-9d9a-e9582b40c634";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/ffc0ecc9-1dfa-436b-a72f-a49d3e158edc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8908c57e-d392-4fbd-9d9a-e9582b40c634>.
+    
+<http://data.lblod.info/id/remote-data-objects/558dfa97-ef20-424b-9c82-a4bd69b21e5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "558dfa97-ef20-424b-9c82-a4bd69b21e5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/ffc0ecc9-1dfa-436b-a72f-a49d3e158edc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/558dfa97-ef20-424b-9c82-a4bd69b21e5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fede959-6acd-4c52-9d96-96df87b57bdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fede959-6acd-4c52-9d96-96df87b57bdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/agb-rvb/ffc0ecc9-1dfa-436b-a72f-a49d3e158edc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fede959-6acd-4c52-9d96-96df87b57bdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3e342cb-504a-466c-89a7-42caf8d73af9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3e342cb-504a-466c-89a7-42caf8d73af9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/08985487-70d8-477c-9e62-32f6f36dba49/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3e342cb-504a-466c-89a7-42caf8d73af9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b25e9e4-d17c-46c2-9a47-418f188b8b4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b25e9e4-d17c-46c2-9a47-418f188b8b4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/0addd74b-841f-46e3-b00c-2db6a4cb0d6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b25e9e4-d17c-46c2-9a47-418f188b8b4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad3111f8-ca71-48d7-9c63-9487110dd2c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad3111f8-ca71-48d7-9c63-9487110dd2c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/0b10fbac-e30c-4433-aabe-b1b14ae1f734/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad3111f8-ca71-48d7-9c63-9487110dd2c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/88756e2a-c310-4b7d-a0db-1f894a7c672e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88756e2a-c310-4b7d-a0db-1f894a7c672e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/0be8885d-4afd-4765-9d33-8e1d348a43a0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88756e2a-c310-4b7d-a0db-1f894a7c672e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8804c45a-a38e-4471-a11d-ff7028e823ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8804c45a-a38e-4471-a11d-ff7028e823ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/0d8c4e22-dd46-4ba3-ae74-aea436506de4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8804c45a-a38e-4471-a11d-ff7028e823ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/cebc7a29-cfb8-49f4-9d6d-73b2e8b0a694> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cebc7a29-cfb8-49f4-9d6d-73b2e8b0a694";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/0dc9eef3-bc65-44bf-a32c-37a4a2150cb0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cebc7a29-cfb8-49f4-9d6d-73b2e8b0a694>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d3576d9-3b30-456e-8496-3d1f29aa8f54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d3576d9-3b30-456e-8496-3d1f29aa8f54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/12a7c7e2-4748-4b60-9212-a76bc97aab9d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d3576d9-3b30-456e-8496-3d1f29aa8f54>.
+    
+<http://data.lblod.info/id/remote-data-objects/371c56a5-ec79-47ac-bb0e-12904b67d10f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "371c56a5-ec79-47ac-bb0e-12904b67d10f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/174a0994-7fd0-4071-ba26-8c5f1f5526cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/371c56a5-ec79-47ac-bb0e-12904b67d10f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a8265f2-f585-414b-981c-5421c80e475d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a8265f2-f585-414b-981c-5421c80e475d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/1bf264c2-2c89-4211-8161-50454bb7fa5c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a8265f2-f585-414b-981c-5421c80e475d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4cda9ba-d095-4520-b7be-bb06b794a7ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4cda9ba-d095-4520-b7be-bb06b794a7ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/1f1758bf-d74f-415b-93f9-434a86fee160/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4cda9ba-d095-4520-b7be-bb06b794a7ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/7de7044c-23d9-49a1-9d3e-142035f25cb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7de7044c-23d9-49a1-9d3e-142035f25cb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/246f3b41-364e-47a5-8634-9d8f65743682/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7de7044c-23d9-49a1-9d3e-142035f25cb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a3be7c0-5f9a-4204-a565-7de4bcc4e696> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a3be7c0-5f9a-4204-a565-7de4bcc4e696";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/25e013dd-f492-41da-b300-c3cd8731dc8c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a3be7c0-5f9a-4204-a565-7de4bcc4e696>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd57c663-a388-4409-8954-9eda44402a90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd57c663-a388-4409-8954-9eda44402a90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/2a882157-af0a-4c67-bfb2-ab8de7605096/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd57c663-a388-4409-8954-9eda44402a90>.
+    
+<http://data.lblod.info/id/remote-data-objects/62fb3656-0b05-4a60-9759-cdda96516cd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62fb3656-0b05-4a60-9759-cdda96516cd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/2bdee247-b873-4d9c-aae1-e908875a252e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62fb3656-0b05-4a60-9759-cdda96516cd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac42e2f5-f13b-4ec8-9947-88dcc0308a4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac42e2f5-f13b-4ec8-9947-88dcc0308a4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/3431ef98-40d0-46e7-9634-f35967f3cfdf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac42e2f5-f13b-4ec8-9947-88dcc0308a4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6224d565-cfe3-45d9-8a4d-1ac3cab1dacd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6224d565-cfe3-45d9-8a4d-1ac3cab1dacd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/35f5cc79-8671-46c6-ba76-512de26e0dd5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6224d565-cfe3-45d9-8a4d-1ac3cab1dacd>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ad67602-f0bb-496b-9aa2-5fce12b7690a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ad67602-f0bb-496b-9aa2-5fce12b7690a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/365d92d3-e11c-43ac-a371-ef1582926eb7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ad67602-f0bb-496b-9aa2-5fce12b7690a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d0dca4e-e6a2-4e70-9887-8b48403e6ed2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d0dca4e-e6a2-4e70-9887-8b48403e6ed2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/365fda27-94bd-4332-907a-cb45498befe7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d0dca4e-e6a2-4e70-9887-8b48403e6ed2>.
+    
+<http://data.lblod.info/id/remote-data-objects/722ec412-e6ab-412f-bdfb-722b0b64ff1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "722ec412-e6ab-412f-bdfb-722b0b64ff1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/38a2699b-a849-494b-8595-57206d996f31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/722ec412-e6ab-412f-bdfb-722b0b64ff1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/75d884bd-932e-4cc9-9abb-88f1455590fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75d884bd-932e-4cc9-9abb-88f1455590fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/3958708b-77b7-472b-9fad-897d59f53cc1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75d884bd-932e-4cc9-9abb-88f1455590fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1915ee1-4c09-456d-9322-98f35837f773> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1915ee1-4c09-456d-9322-98f35837f773";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/3a5e4e7f-d992-4772-b460-7f7b62779dd2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1915ee1-4c09-456d-9322-98f35837f773>.
+    
+<http://data.lblod.info/id/remote-data-objects/bca15053-2810-4bdd-909e-805712ee582e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bca15053-2810-4bdd-909e-805712ee582e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/3e9b17df-9268-43d0-ab4c-d0015c2668f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bca15053-2810-4bdd-909e-805712ee582e>.
+    
+<http://data.lblod.info/id/remote-data-objects/efc412aa-245f-4d6c-88bf-f8216e6c7a29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efc412aa-245f-4d6c-88bf-f8216e6c7a29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/40264f9b-9823-4516-b203-e4da473b4a6d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efc412aa-245f-4d6c-88bf-f8216e6c7a29>.
+    
+<http://data.lblod.info/id/remote-data-objects/e455e45e-109d-4996-85d8-fd792e4a4587> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e455e45e-109d-4996-85d8-fd792e4a4587";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/4079f87f-da1f-4f4a-b26d-11f93e215df5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e455e45e-109d-4996-85d8-fd792e4a4587>.
+    
+<http://data.lblod.info/id/remote-data-objects/54a7039a-fbb7-40b2-aa9e-e39dd585aefd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54a7039a-fbb7-40b2-aa9e-e39dd585aefd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/4169764a-f882-4d0b-a06c-0efd9b88a260/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54a7039a-fbb7-40b2-aa9e-e39dd585aefd>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd6d5476-f030-4898-8fbe-4b4a901cf3ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd6d5476-f030-4898-8fbe-4b4a901cf3ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/4b8ef03b-a601-4062-8b46-5ba4a268feda/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd6d5476-f030-4898-8fbe-4b4a901cf3ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5c9a5d6-fd0a-41d8-93eb-ef0a12d107de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5c9a5d6-fd0a-41d8-93eb-ef0a12d107de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/50ceaa54-18d3-4cab-8ab8-ddd23e08a7b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5c9a5d6-fd0a-41d8-93eb-ef0a12d107de>.
+    
+<http://data.lblod.info/id/remote-data-objects/37a217a6-7d10-487d-ab5a-1216f869c7d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37a217a6-7d10-487d-ab5a-1216f869c7d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/50fef5cf-2b30-46ac-a213-92eee4d2037e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37a217a6-7d10-487d-ab5a-1216f869c7d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/04992cd7-946d-4be4-b970-6b065908c59f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04992cd7-946d-4be4-b970-6b065908c59f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/5be7dd31-badc-4e4a-b147-d047c43c967e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04992cd7-946d-4be4-b970-6b065908c59f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3232ba6-f11f-40ab-ab78-5450d1e93615> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3232ba6-f11f-40ab-ab78-5450d1e93615";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/5ca4179f-6132-4ffb-b8f0-efe541fb7387/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3232ba6-f11f-40ab-ab78-5450d1e93615>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1adb7fa-aea4-4356-9fd1-1f9fbae61a98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1adb7fa-aea4-4356-9fd1-1f9fbae61a98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/5dc8a2a2-8374-4f7d-a6ab-e40ef4f2f446/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1adb7fa-aea4-4356-9fd1-1f9fbae61a98>.
+    
+<http://data.lblod.info/id/remote-data-objects/16a81682-113b-49b9-9726-9f21ec7c6b05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16a81682-113b-49b9-9726-9f21ec7c6b05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/65ce7acc-e38e-4865-92c9-aae54af5f1f5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16a81682-113b-49b9-9726-9f21ec7c6b05>.
+    
+<http://data.lblod.info/id/remote-data-objects/20a649d6-6a85-4b67-8cca-5cf8fd6291bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20a649d6-6a85-4b67-8cca-5cf8fd6291bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/67b17385-044c-493d-941a-9e8407ed333a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20a649d6-6a85-4b67-8cca-5cf8fd6291bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/a73f7594-66d6-4fc1-8abe-ce0ccc01e19a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a73f7594-66d6-4fc1-8abe-ce0ccc01e19a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/69e351ed-d7a5-45ee-9faf-68db8fd44cf5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a73f7594-66d6-4fc1-8abe-ce0ccc01e19a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e275b02c-e091-4cf6-9ede-2db979e38e16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e275b02c-e091-4cf6-9ede-2db979e38e16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/741aa740-35a2-4534-8caa-929e44799a62/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e275b02c-e091-4cf6-9ede-2db979e38e16>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ebba3c8-025e-427b-8726-2443e205696e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ebba3c8-025e-427b-8726-2443e205696e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/766fee40-0711-4976-80c0-c648d2affe33/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b198698d-b6da-4eed-99d5-13e524827098> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ebba3c8-025e-427b-8726-2443e205696e>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201020-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201020-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201020-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201020-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/45cc311c-afac-4f42-9511-99c2b2b11d1c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "45cc311c-afac-4f42-9511-99c2b2b11d1c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "80fb74f4-02f1-4d59-80b4-3fe92822e7c0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d5b514db-6852-496c-ad2d-5b82917124d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d5b514db-6852-496c-ad2d-5b82917124d9";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0>.
+
+  <http://redpencil.data.gift/id/task/529f8595-7544-426e-be65-6ab3731f66de> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "529f8595-7544-426e-be65-6ab3731f66de";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/45cc311c-afac-4f42-9511-99c2b2b11d1c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d5b514db-6852-496c-ad2d-5b82917124d9>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/85c0be6c-bacd-4302-bfd8-f14d74167062> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85c0be6c-bacd-4302-bfd8-f14d74167062";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/77b3832d-063a-48c0-9ae9-3fd19532565c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85c0be6c-bacd-4302-bfd8-f14d74167062>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f58d18f-50d8-4214-8f4c-234f69c46908> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f58d18f-50d8-4214-8f4c-234f69c46908";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/79688d0d-8154-4afe-a281-65dd19715633/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f58d18f-50d8-4214-8f4c-234f69c46908>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2044f67-0360-497f-a8f8-7e0149546436> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2044f67-0360-497f-a8f8-7e0149546436";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/7b657cf1-eb9e-47a6-a5cd-fcaf46d0c64a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2044f67-0360-497f-a8f8-7e0149546436>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a7ce0b0-2ebe-47f7-b7bd-bc0acbe860c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a7ce0b0-2ebe-47f7-b7bd-bc0acbe860c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/7e1dfa0e-db4e-4a19-9da5-70ddf3525a31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a7ce0b0-2ebe-47f7-b7bd-bc0acbe860c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/5261aa3c-8786-4c02-8fcd-b8edae991507> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5261aa3c-8786-4c02-8fcd-b8edae991507";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/81347de0-d70d-4f8d-ab87-3e8392dd5bcd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5261aa3c-8786-4c02-8fcd-b8edae991507>.
+    
+<http://data.lblod.info/id/remote-data-objects/11d3bd1f-73a3-4d8a-b6bc-ddcf3a610662> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11d3bd1f-73a3-4d8a-b6bc-ddcf3a610662";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/81cea50e-0744-4db3-bd9b-9dfeb5aa27f5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11d3bd1f-73a3-4d8a-b6bc-ddcf3a610662>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2cde233-a336-41dd-974c-7a980212679d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2cde233-a336-41dd-974c-7a980212679d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/844e103d-e96d-4c04-8b38-bcfe0f39d377/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2cde233-a336-41dd-974c-7a980212679d>.
+    
+<http://data.lblod.info/id/remote-data-objects/31d3f386-df3f-4e75-a4c0-c7ab8501b253> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31d3f386-df3f-4e75-a4c0-c7ab8501b253";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/86fe61f3-9d42-4095-9a79-cd14c0919e83/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31d3f386-df3f-4e75-a4c0-c7ab8501b253>.
+    
+<http://data.lblod.info/id/remote-data-objects/386096ad-fa23-453f-a5fe-6396d389a639> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "386096ad-fa23-453f-a5fe-6396d389a639";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/873fa1b8-2be5-4426-8303-bfd84220937f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/386096ad-fa23-453f-a5fe-6396d389a639>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c1cfcaf-7246-499a-9273-40d9926301b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c1cfcaf-7246-499a-9273-40d9926301b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/914c7b2e-6838-41f8-b386-8b69992d69c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c1cfcaf-7246-499a-9273-40d9926301b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/54f61a9f-060b-45a3-9573-e8d19f4903bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54f61a9f-060b-45a3-9573-e8d19f4903bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/9ff20258-1f49-4f91-b32a-1a4c8b994488/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54f61a9f-060b-45a3-9573-e8d19f4903bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/a592d199-a005-49af-88d9-afd18662be43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a592d199-a005-49af-88d9-afd18662be43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/a09a0e7e-014c-478b-915b-b68ebcde4ee5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a592d199-a005-49af-88d9-afd18662be43>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c54328e-3651-4585-aaa0-5e0f8ea696a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c54328e-3651-4585-aaa0-5e0f8ea696a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/a3b3745a-285d-419e-a379-162c527ad25c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c54328e-3651-4585-aaa0-5e0f8ea696a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/826a8214-0fb4-4b41-b0a0-07845396fbab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "826a8214-0fb4-4b41-b0a0-07845396fbab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/aa306a19-c397-4083-9c5b-9615e483b018/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/826a8214-0fb4-4b41-b0a0-07845396fbab>.
+    
+<http://data.lblod.info/id/remote-data-objects/046d084e-1b9b-437f-adc4-1520092a81aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "046d084e-1b9b-437f-adc4-1520092a81aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/bacbc250-306e-422f-8e63-a3b1844f753d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/046d084e-1b9b-437f-adc4-1520092a81aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/2320d1c1-a82e-49cb-bc63-c0bdca44adeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2320d1c1-a82e-49cb-bc63-c0bdca44adeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/bb9dd3fd-0464-4cdf-b10a-5063b79195a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2320d1c1-a82e-49cb-bc63-c0bdca44adeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/34810634-8374-43af-805c-ac97e2c60e0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34810634-8374-43af-805c-ac97e2c60e0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/bddbe560-58d3-4f3b-a8c4-b188f7de6df1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34810634-8374-43af-805c-ac97e2c60e0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0b28b73-a27f-4c46-a3b3-655da43a166d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0b28b73-a27f-4c46-a3b3-655da43a166d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/c44664eb-c62e-4b0a-af12-2c8e1043f8ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0b28b73-a27f-4c46-a3b3-655da43a166d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2177e08-d98a-4011-ba7d-5ec069331d95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2177e08-d98a-4011-ba7d-5ec069331d95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/c63d219d-3c28-4b84-9c88-4bac1166e682/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2177e08-d98a-4011-ba7d-5ec069331d95>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5667087-8b1f-46f7-9088-168e57dba2fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5667087-8b1f-46f7-9088-168e57dba2fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/cb2bee4a-8789-4110-b111-f3c21ed41522/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5667087-8b1f-46f7-9088-168e57dba2fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccbeb12e-832a-40a7-91a2-cb36dafc674e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccbeb12e-832a-40a7-91a2-cb36dafc674e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/cc63211d-4ea2-45e4-bc91-2d6f5ae8a865/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccbeb12e-832a-40a7-91a2-cb36dafc674e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f92b4ce-8d96-4656-812e-1d7dfaeec1c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f92b4ce-8d96-4656-812e-1d7dfaeec1c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/cc91b42e-fd67-4a90-a768-980b1f02f957/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f92b4ce-8d96-4656-812e-1d7dfaeec1c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/04b06ee2-43d3-4506-a2e2-46ccc5c16821> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04b06ee2-43d3-4506-a2e2-46ccc5c16821";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/d3377838-8fdc-449d-94a6-bebde67bc342/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04b06ee2-43d3-4506-a2e2-46ccc5c16821>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f504e1c-0cf8-4f91-b843-00a398389dd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f504e1c-0cf8-4f91-b843-00a398389dd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/dbd44183-9c83-40d8-92ae-5b1a58e569bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f504e1c-0cf8-4f91-b843-00a398389dd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae8625ff-f2cd-4184-94e6-acfdaeeafe80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae8625ff-f2cd-4184-94e6-acfdaeeafe80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/e45d6184-f1f8-4cfe-9d4f-95f6e5eb6005/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae8625ff-f2cd-4184-94e6-acfdaeeafe80>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ca32b9f-3236-46d4-9956-444853ee8f4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ca32b9f-3236-46d4-9956-444853ee8f4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/ebfdace0-b50b-4366-ae1b-92715e789d46/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ca32b9f-3236-46d4-9956-444853ee8f4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7100d2c-5b27-4c34-b87c-588c02a3047c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7100d2c-5b27-4c34-b87c-588c02a3047c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/f0155d70-dc3f-41cd-a02d-e74a716f8dcb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7100d2c-5b27-4c34-b87c-588c02a3047c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2aaa3f9e-d233-4329-8727-310951b6cca3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2aaa3f9e-d233-4329-8727-310951b6cca3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/bb/f77cd996-a506-4955-96ae-7dcea043196a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2aaa3f9e-d233-4329-8727-310951b6cca3>.
+    
+<http://data.lblod.info/id/remote-data-objects/264bcf09-6d50-4578-9220-3df235de416e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "264bcf09-6d50-4578-9220-3df235de416e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/01b1a009-681e-4250-affc-d3d4ba01ebae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/264bcf09-6d50-4578-9220-3df235de416e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d130f05-5324-4d1f-a618-a8f0d06a5a04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d130f05-5324-4d1f-a618-a8f0d06a5a04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/0f55a4cc-9329-43b7-ae62-8d0cc2d1d2d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d130f05-5324-4d1f-a618-a8f0d06a5a04>.
+    
+<http://data.lblod.info/id/remote-data-objects/3426bc9b-67b0-4770-a478-e1fd972da519> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3426bc9b-67b0-4770-a478-e1fd972da519";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/10a7d2c3-6a4c-418b-9502-a7e93ed1628c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3426bc9b-67b0-4770-a478-e1fd972da519>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2a97cf4-545c-4811-9c2e-569e3c8b579c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2a97cf4-545c-4811-9c2e-569e3c8b579c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/12122e3c-24e1-42a7-97e2-4c5c8640d54c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2a97cf4-545c-4811-9c2e-569e3c8b579c>.
+    
+<http://data.lblod.info/id/remote-data-objects/af394db2-977f-46c0-9740-a4babf66ffad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af394db2-977f-46c0-9740-a4babf66ffad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/169f92ea-e7dd-4fc5-9c2b-966ff3421f28/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af394db2-977f-46c0-9740-a4babf66ffad>.
+    
+<http://data.lblod.info/id/remote-data-objects/699a4829-6bf1-48f5-850e-68ade69277df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "699a4829-6bf1-48f5-850e-68ade69277df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/176af73f-a258-40b7-b320-a4e5d0eaf7b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/699a4829-6bf1-48f5-850e-68ade69277df>.
+    
+<http://data.lblod.info/id/remote-data-objects/61242b6d-09a7-4928-884b-2251e6c539bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61242b6d-09a7-4928-884b-2251e6c539bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/1908a95b-49ce-48c6-8cc9-574b9a08d961/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61242b6d-09a7-4928-884b-2251e6c539bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc6cf06e-c801-43c7-b77a-11f1ed9e2b5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc6cf06e-c801-43c7-b77a-11f1ed9e2b5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/241e7a52-1ecb-415d-afe5-d24a512fb2cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc6cf06e-c801-43c7-b77a-11f1ed9e2b5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a83a8437-6de4-433e-bfa5-12dfa5b1dd4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a83a8437-6de4-433e-bfa5-12dfa5b1dd4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/2e92ad96-da04-48f9-b3c2-254160b96bb2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a83a8437-6de4-433e-bfa5-12dfa5b1dd4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8018f55c-65c1-4120-817d-fac582c42f24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8018f55c-65c1-4120-817d-fac582c42f24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/31d31cdf-a27f-4f14-838f-642e92e36aa9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8018f55c-65c1-4120-817d-fac582c42f24>.
+    
+<http://data.lblod.info/id/remote-data-objects/beafdd4c-0381-40b5-b1f7-16172b387d8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "beafdd4c-0381-40b5-b1f7-16172b387d8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/341accde-71b8-4cee-8d2d-6980b7b82c23/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/beafdd4c-0381-40b5-b1f7-16172b387d8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/93233a1d-0437-4619-a46a-79d863bca262> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93233a1d-0437-4619-a46a-79d863bca262";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/3647045c-854a-4f23-8867-3f9589f6a3ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93233a1d-0437-4619-a46a-79d863bca262>.
+    
+<http://data.lblod.info/id/remote-data-objects/42394e7e-a0d7-4c95-adbb-e4d3b6e2f306> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42394e7e-a0d7-4c95-adbb-e4d3b6e2f306";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/3c53212b-e4ac-4b87-8a22-c92b251dfda1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42394e7e-a0d7-4c95-adbb-e4d3b6e2f306>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bbe3486-3fe7-497f-81e1-3de5be9c86fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bbe3486-3fe7-497f-81e1-3de5be9c86fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/3ce44366-8253-4b12-9d8e-d60889372ca5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bbe3486-3fe7-497f-81e1-3de5be9c86fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcf9ad40-8a95-4a16-bb25-ae4d73e6cd1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcf9ad40-8a95-4a16-bb25-ae4d73e6cd1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/3d0e2be8-898f-4651-a29e-9be9f5f59911/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcf9ad40-8a95-4a16-bb25-ae4d73e6cd1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba573d69-6dac-43a7-9189-7c0ea2ac8bbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba573d69-6dac-43a7-9189-7c0ea2ac8bbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/46ef63e1-16fb-48f4-8b42-729ad0818306/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba573d69-6dac-43a7-9189-7c0ea2ac8bbb>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae849629-59b9-4f32-a683-081682a6fa1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae849629-59b9-4f32-a683-081682a6fa1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/4918e769-99cb-4b20-85d5-a72f962ff525/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae849629-59b9-4f32-a683-081682a6fa1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe65d558-5e37-4280-b58e-b0e5b53b0718> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe65d558-5e37-4280-b58e-b0e5b53b0718";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/4db90635-6923-485d-bacb-f68460949ea5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe65d558-5e37-4280-b58e-b0e5b53b0718>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5e23a37-83e6-4ba7-b633-f67e228515a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5e23a37-83e6-4ba7-b633-f67e228515a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/4e76808c-7a7c-4d37-81b8-cbea71eebdc1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5e23a37-83e6-4ba7-b633-f67e228515a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3b5eb76-15b8-4352-b8f8-1cca1f35c17c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3b5eb76-15b8-4352-b8f8-1cca1f35c17c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/57ee8930-fa16-494b-a37d-6512d98b3c7d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3b5eb76-15b8-4352-b8f8-1cca1f35c17c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa11badc-32e1-450a-b016-8786d0e7190b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa11badc-32e1-450a-b016-8786d0e7190b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/5a4c9d69-a177-466a-a45e-abc7bccd516e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa11badc-32e1-450a-b016-8786d0e7190b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b70cee40-ccb3-489c-8d3b-d103bc74df85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b70cee40-ccb3-489c-8d3b-d103bc74df85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/5a9cd5e1-5881-47b5-8647-f576a0495ef6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80fb74f4-02f1-4d59-80b4-3fe92822e7c0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b70cee40-ccb3-489c-8d3b-d103bc74df85>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201021-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201021-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201021-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201021-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/203d7807-6497-4b39-9d5a-cb37355b6823> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "203d7807-6497-4b39-9d5a-cb37355b6823";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "daf81a8a-33de-42f0-9551-a8420c40f383";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a26dee9b-83f1-40a4-98a5-87ac9a11dfb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a26dee9b-83f1-40a4-98a5-87ac9a11dfb8";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383>.
+
+  <http://redpencil.data.gift/id/task/3039181c-2ae7-4215-8f66-c294b7330292> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3039181c-2ae7-4215-8f66-c294b7330292";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/203d7807-6497-4b39-9d5a-cb37355b6823>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a26dee9b-83f1-40a4-98a5-87ac9a11dfb8>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a301333d-de42-424e-9b44-b7714823387c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a301333d-de42-424e-9b44-b7714823387c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/5b43a3bd-393c-48b3-98be-0c97bc4082f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a301333d-de42-424e-9b44-b7714823387c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ff730da-294c-4bd6-864e-de0d512a293f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ff730da-294c-4bd6-864e-de0d512a293f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/5c58c4ba-6912-4aa2-84c0-5fcb95e1f966/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ff730da-294c-4bd6-864e-de0d512a293f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bf36e90-5425-41d9-9faf-9501ff04807b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bf36e90-5425-41d9-9faf-9501ff04807b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/5f8cc8d1-33f4-437a-9ef3-47e104b51af1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bf36e90-5425-41d9-9faf-9501ff04807b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7103d018-90f2-4353-8f1d-bcbd25f24460> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7103d018-90f2-4353-8f1d-bcbd25f24460";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/6a282f26-b17d-4713-b57a-e55e17c6c578/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7103d018-90f2-4353-8f1d-bcbd25f24460>.
+    
+<http://data.lblod.info/id/remote-data-objects/911696b6-67c6-4264-9645-49b223a62e72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "911696b6-67c6-4264-9645-49b223a62e72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/7058d8fc-0863-4766-956a-7f63d088744f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/911696b6-67c6-4264-9645-49b223a62e72>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf1f4e92-1c91-434c-b333-d6176c72c630> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf1f4e92-1c91-434c-b333-d6176c72c630";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/710d4371-0e21-4cd9-b4ad-2a7552fdc5a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf1f4e92-1c91-434c-b333-d6176c72c630>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fdfe5e4-3ca9-4934-81cd-bf051e49beef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fdfe5e4-3ca9-4934-81cd-bf051e49beef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/7b1dca29-bada-4a0d-8ddd-d3710a6cfac8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fdfe5e4-3ca9-4934-81cd-bf051e49beef>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce9c266c-33dd-460a-920d-dc6ea2577535> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce9c266c-33dd-460a-920d-dc6ea2577535";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/81472aae-a225-4463-803c-487adb5a687e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce9c266c-33dd-460a-920d-dc6ea2577535>.
+    
+<http://data.lblod.info/id/remote-data-objects/060dbac7-091a-4173-adca-923fc4a91548> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "060dbac7-091a-4173-adca-923fc4a91548";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/8d7ceccc-282f-4c5c-bbdc-8e96e1466688/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/060dbac7-091a-4173-adca-923fc4a91548>.
+    
+<http://data.lblod.info/id/remote-data-objects/93e7d447-ed51-487f-bd9c-29beb1a7e77e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93e7d447-ed51-487f-bd9c-29beb1a7e77e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/92e1e34c-278d-42c3-a7eb-0da72a5ab095/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93e7d447-ed51-487f-bd9c-29beb1a7e77e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3d457ab-d311-45a1-9e6a-caae5bcdff74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3d457ab-d311-45a1-9e6a-caae5bcdff74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/931d3ca4-b2bb-4351-b7ce-f82696ce5ba1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3d457ab-d311-45a1-9e6a-caae5bcdff74>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c54b62a-b028-4d41-a44f-24c8907becf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c54b62a-b028-4d41-a44f-24c8907becf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/933358dc-8375-4c9d-81dd-4b13707e9a6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c54b62a-b028-4d41-a44f-24c8907becf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/936c9551-7c4d-458a-a299-93641ad669bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "936c9551-7c4d-458a-a299-93641ad669bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/947a9dfd-789f-491e-8bfe-b01fc5d75d7c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/936c9551-7c4d-458a-a299-93641ad669bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c20cc630-b06a-48d5-a263-0fafabb317ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c20cc630-b06a-48d5-a263-0fafabb317ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/94d51bf3-11ee-4130-b1e6-3a7b5b1e87ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c20cc630-b06a-48d5-a263-0fafabb317ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/89bd299a-3f93-467f-abd2-59738e50195d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89bd299a-3f93-467f-abd2-59738e50195d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/98a38941-5db9-4ccb-9d48-52b2de9a657d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89bd299a-3f93-467f-abd2-59738e50195d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdbc17e1-09dd-45b5-b73c-d4ba89ad3117> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdbc17e1-09dd-45b5-b73c-d4ba89ad3117";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/994c808c-6d80-4e58-9099-3a254d2ea7d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdbc17e1-09dd-45b5-b73c-d4ba89ad3117>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a2f67d8-e177-4123-abf2-6c512147d6a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a2f67d8-e177-4123-abf2-6c512147d6a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/9f897dc5-109d-46a9-a366-e311980366da/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a2f67d8-e177-4123-abf2-6c512147d6a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c370b6b1-aa22-43ee-b9b8-d180574b3f59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c370b6b1-aa22-43ee-b9b8-d180574b3f59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/a19ef333-d06c-492c-a273-6a82c282d65e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c370b6b1-aa22-43ee-b9b8-d180574b3f59>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cbabea4-097c-4306-908d-65d4eff81e1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cbabea4-097c-4306-908d-65d4eff81e1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/a30bf7ca-7a00-4655-b19b-c2218ce67306/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cbabea4-097c-4306-908d-65d4eff81e1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa37ab23-4a6b-4853-bd70-4116afb07de3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa37ab23-4a6b-4853-bd70-4116afb07de3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/a64e1a82-98b5-43c3-aa5b-0fe30b0c24ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa37ab23-4a6b-4853-bd70-4116afb07de3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e764b97d-8b8d-4d3a-ac19-9e8686aae46d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e764b97d-8b8d-4d3a-ac19-9e8686aae46d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/a7be9ac3-7672-4994-bdc4-d92ce30803b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e764b97d-8b8d-4d3a-ac19-9e8686aae46d>.
+    
+<http://data.lblod.info/id/remote-data-objects/701cc473-aa34-4011-b4b2-8c8a160db66b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "701cc473-aa34-4011-b4b2-8c8a160db66b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/adff21c4-cd19-422a-a422-0891adf5f85a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/701cc473-aa34-4011-b4b2-8c8a160db66b>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc269ea5-2093-434a-b0ed-adde56d7ea0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc269ea5-2093-434a-b0ed-adde56d7ea0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/ae46faa8-28ab-4b09-8071-b09edff398b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc269ea5-2093-434a-b0ed-adde56d7ea0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6cc7be8-5c87-49e9-a66d-023c39ee68b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6cc7be8-5c87-49e9-a66d-023c39ee68b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/b3001b44-f167-4e5f-98bb-cea5f11e81e6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6cc7be8-5c87-49e9-a66d-023c39ee68b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e69f9a5c-71a9-4d01-87f5-0f2ea989e8b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e69f9a5c-71a9-4d01-87f5-0f2ea989e8b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/b3c4c113-ea6b-4d9e-84a2-ef1474e8a189/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e69f9a5c-71a9-4d01-87f5-0f2ea989e8b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/4321a7e4-399a-4048-82ec-048c9274d457> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4321a7e4-399a-4048-82ec-048c9274d457";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/b800890f-a1a5-404e-b2ea-3c816cc690d8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4321a7e4-399a-4048-82ec-048c9274d457>.
+    
+<http://data.lblod.info/id/remote-data-objects/12c76586-6b34-40f4-b81e-289fe56fb5e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12c76586-6b34-40f4-b81e-289fe56fb5e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/bd9b8ae7-ed55-4048-9784-eaa96cbe0264/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12c76586-6b34-40f4-b81e-289fe56fb5e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f23e2c1-56c4-412a-90d4-b1a2916587cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f23e2c1-56c4-412a-90d4-b1a2916587cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/be754fe6-c790-4eca-9853-637f5c793e38/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f23e2c1-56c4-412a-90d4-b1a2916587cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3d6e83f-2b86-474f-96dc-0fad4d40c40e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3d6e83f-2b86-474f-96dc-0fad4d40c40e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/befb2f56-03e0-4753-9a16-8c7a29a79840/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3d6e83f-2b86-474f-96dc-0fad4d40c40e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1aff5c1-a6de-4ab6-8175-60b4e6cfe9af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1aff5c1-a6de-4ab6-8175-60b4e6cfe9af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/c26dd1ab-b6d2-41f4-bbbe-7a14b9e54ec3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1aff5c1-a6de-4ab6-8175-60b4e6cfe9af>.
+    
+<http://data.lblod.info/id/remote-data-objects/9942c72d-ff64-4708-bbee-3482757563f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9942c72d-ff64-4708-bbee-3482757563f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/c4dc4bd8-4e24-4628-a295-0b1bdd9859dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9942c72d-ff64-4708-bbee-3482757563f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2fda4b0-5b86-4639-9c47-bd9d3a84e7f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2fda4b0-5b86-4639-9c47-bd9d3a84e7f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/cd0d8ecd-8bdc-4bac-8cbc-7dc1f55c720b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2fda4b0-5b86-4639-9c47-bd9d3a84e7f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/51832a1b-24e1-4a55-86fc-f7c3e297c3c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51832a1b-24e1-4a55-86fc-f7c3e297c3c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/cd1e4605-afbd-4616-8ac9-fa5604b4b8e5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51832a1b-24e1-4a55-86fc-f7c3e297c3c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/93f44275-84aa-4b84-8523-098af5916b6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93f44275-84aa-4b84-8523-098af5916b6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/cd1e7d0d-7790-458c-9b46-8e78e4db3fa9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93f44275-84aa-4b84-8523-098af5916b6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7e825ad-d046-4911-97ae-b23019f3c09e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7e825ad-d046-4911-97ae-b23019f3c09e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/da0821cc-9bb5-4077-b6e5-a5cba594ddb7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7e825ad-d046-4911-97ae-b23019f3c09e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d85ba5f3-91d2-4a61-a05e-3a9023178a50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d85ba5f3-91d2-4a61-a05e-3a9023178a50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/dad2ceef-6ca7-4a61-beba-bcd92db53fcb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d85ba5f3-91d2-4a61-a05e-3a9023178a50>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5ed5b34-eace-4683-aea3-385f5062fd2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5ed5b34-eace-4683-aea3-385f5062fd2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/dc90935c-fa4e-4fe4-bb24-d5b05190cb0f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5ed5b34-eace-4683-aea3-385f5062fd2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b90ee7a-c00d-4b23-b80e-710595b0c029> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b90ee7a-c00d-4b23-b80e-710595b0c029";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/de891867-8ff8-4bdd-ab34-84cc81054dc7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b90ee7a-c00d-4b23-b80e-710595b0c029>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee7a9628-5945-4f9a-984b-24016c1dc7d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee7a9628-5945-4f9a-984b-24016c1dc7d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/e263c291-fadb-4d0c-8712-8939ec828863/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee7a9628-5945-4f9a-984b-24016c1dc7d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a426cebe-8dc7-4c12-b374-9e83c0b058d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a426cebe-8dc7-4c12-b374-9e83c0b058d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/e3f5c2a5-4913-4528-8835-eea4ba7303c2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a426cebe-8dc7-4c12-b374-9e83c0b058d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5f0159a-11a3-4e3b-b303-2f3fb98c474b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5f0159a-11a3-4e3b-b303-2f3fb98c474b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/eb0522e9-5ae4-4a47-94aa-790a9a15fc20/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5f0159a-11a3-4e3b-b303-2f3fb98c474b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2bf61ba-ef09-4991-98f6-97b9808df518> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2bf61ba-ef09-4991-98f6-97b9808df518";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/ec3e37a5-4bc2-4a00-a846-f50cb35bfc74/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2bf61ba-ef09-4991-98f6-97b9808df518>.
+    
+<http://data.lblod.info/id/remote-data-objects/30c12433-d4b3-4000-8d95-d4f4af8e654b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30c12433-d4b3-4000-8d95-d4f4af8e654b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/eff1bddd-70c7-4aa6-88fd-12e2fedf696d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30c12433-d4b3-4000-8d95-d4f4af8e654b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8fc4a4f-fad3-44eb-842d-bb0966cc2f41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8fc4a4f-fad3-44eb-842d-bb0966cc2f41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/f25f9d77-1b6d-428d-9896-8de905e312de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8fc4a4f-fad3-44eb-842d-bb0966cc2f41>.
+    
+<http://data.lblod.info/id/remote-data-objects/df498ffd-de56-4166-bba5-2e231c6ed0e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df498ffd-de56-4166-bba5-2e231c6ed0e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/f27d387a-604a-4cab-a6a1-f14f99c609a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df498ffd-de56-4166-bba5-2e231c6ed0e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fef3d3f-ad0f-4e7b-9a11-0804f4fc39d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fef3d3f-ad0f-4e7b-9a11-0804f4fc39d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/f2e42a21-71de-4461-be3c-8373e0e94b48/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fef3d3f-ad0f-4e7b-9a11-0804f4fc39d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/3525e881-0a0a-4e02-b20e-9e0896cf91a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3525e881-0a0a-4e02-b20e-9e0896cf91a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/f51d4910-b035-4fda-a14d-84ba62ff2672/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3525e881-0a0a-4e02-b20e-9e0896cf91a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/416deacb-d449-4ad7-be3d-35185382b916> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "416deacb-d449-4ad7-be3d-35185382b916";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/f6890a58-1c49-48e2-97f8-c59dad27785b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/416deacb-d449-4ad7-be3d-35185382b916>.
+    
+<http://data.lblod.info/id/remote-data-objects/18872b0c-8929-455a-9125-ad06ccc5c630> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18872b0c-8929-455a-9125-ad06ccc5c630";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/ff2870d5-f206-4044-8de9-eb67952b72bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18872b0c-8929-455a-9125-ad06ccc5c630>.
+    
+<http://data.lblod.info/id/remote-data-objects/2eed192c-af1b-453d-9d9c-4493f4f0cba8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2eed192c-af1b-453d-9d9c-4493f4f0cba8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/cbs/ff9c3ad2-e2a4-4138-a76c-dc3a59070ccc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/daf81a8a-33de-42f0-9551-a8420c40f383> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2eed192c-af1b-453d-9d9c-4493f4f0cba8>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201022-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201022-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201022-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201022-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f74a3fe2-3d3d-4982-820e-3c9ad0ce863a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f74a3fe2-3d3d-4982-820e-3c9ad0ce863a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "01953b7b-af36-4867-981a-18e85daa07f5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/fed9f1c3-57df-4782-9420-5d83db47b9e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fed9f1c3-57df-4782-9420-5d83db47b9e4";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5>.
+
+  <http://redpencil.data.gift/id/task/e15bee6a-6175-4114-82da-2dd64d6f79ca> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e15bee6a-6175-4114-82da-2dd64d6f79ca";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f74a3fe2-3d3d-4982-820e-3c9ad0ce863a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/fed9f1c3-57df-4782-9420-5d83db47b9e4>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/ca675335-7f8d-4032-be3d-bd4357f4c3e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca675335-7f8d-4032-be3d-bd4357f4c3e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/03d11c0f-b045-414b-a53d-3f096a162d9e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca675335-7f8d-4032-be3d-bd4357f4c3e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a4cc287-b5f7-4581-9b32-137ebd221e17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a4cc287-b5f7-4581-9b32-137ebd221e17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/03d11c0f-b045-414b-a53d-3f096a162d9e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a4cc287-b5f7-4581-9b32-137ebd221e17>.
+    
+<http://data.lblod.info/id/remote-data-objects/781b0301-bfe5-483e-99a4-b00b1f2fdc40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "781b0301-bfe5-483e-99a4-b00b1f2fdc40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/03d11c0f-b045-414b-a53d-3f096a162d9e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/781b0301-bfe5-483e-99a4-b00b1f2fdc40>.
+    
+<http://data.lblod.info/id/remote-data-objects/0df604d7-fc75-40a3-88d8-6eb62fe6d2fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0df604d7-fc75-40a3-88d8-6eb62fe6d2fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/15fc3ff8-c5c3-4134-a26a-12b9395d8ea2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0df604d7-fc75-40a3-88d8-6eb62fe6d2fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/a22b86e8-024a-487e-be24-cbde45b65b40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a22b86e8-024a-487e-be24-cbde45b65b40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/15fc3ff8-c5c3-4134-a26a-12b9395d8ea2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a22b86e8-024a-487e-be24-cbde45b65b40>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca495ac4-b742-488e-a90b-174dc398c041> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca495ac4-b742-488e-a90b-174dc398c041";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/15fc3ff8-c5c3-4134-a26a-12b9395d8ea2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca495ac4-b742-488e-a90b-174dc398c041>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f54e1b0-926a-4392-90d2-f9029d3254d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f54e1b0-926a-4392-90d2-f9029d3254d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/26a3ca8c-b3a4-4511-8a8d-404a13cebbfc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f54e1b0-926a-4392-90d2-f9029d3254d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/91af6955-cf4f-4278-98af-8187c7a55424> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91af6955-cf4f-4278-98af-8187c7a55424";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/26a3ca8c-b3a4-4511-8a8d-404a13cebbfc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91af6955-cf4f-4278-98af-8187c7a55424>.
+    
+<http://data.lblod.info/id/remote-data-objects/417bd556-b8c7-48f3-9294-2f8803d1b68b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "417bd556-b8c7-48f3-9294-2f8803d1b68b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/26a3ca8c-b3a4-4511-8a8d-404a13cebbfc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/417bd556-b8c7-48f3-9294-2f8803d1b68b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d8f6cc6-6419-426d-9b39-a04cb6199a8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d8f6cc6-6419-426d-9b39-a04cb6199a8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/52091482-acc3-4a14-9588-dba45e9892ac/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d8f6cc6-6419-426d-9b39-a04cb6199a8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3822c0f1-3fdd-4814-a503-f53bdcae09c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3822c0f1-3fdd-4814-a503-f53bdcae09c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/52091482-acc3-4a14-9588-dba45e9892ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3822c0f1-3fdd-4814-a503-f53bdcae09c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ce65f1b-f878-47b5-965d-57cd3998554e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ce65f1b-f878-47b5-965d-57cd3998554e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/52091482-acc3-4a14-9588-dba45e9892ac/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ce65f1b-f878-47b5-965d-57cd3998554e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed0f5746-aa3b-442f-8ebb-5bcc3444a0c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed0f5746-aa3b-442f-8ebb-5bcc3444a0c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/59287e2d-5e87-4fad-adf5-925388f38366/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed0f5746-aa3b-442f-8ebb-5bcc3444a0c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8b2f2a5-6af2-463b-87e0-fc5b219f2320> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8b2f2a5-6af2-463b-87e0-fc5b219f2320";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/59287e2d-5e87-4fad-adf5-925388f38366/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8b2f2a5-6af2-463b-87e0-fc5b219f2320>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d3ca801-06b7-432d-ac89-7b1aabe95052> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d3ca801-06b7-432d-ac89-7b1aabe95052";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/59287e2d-5e87-4fad-adf5-925388f38366/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d3ca801-06b7-432d-ac89-7b1aabe95052>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a0631a5-4abb-45c6-8d14-04252e1ac599> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a0631a5-4abb-45c6-8d14-04252e1ac599";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/5e072ba5-f1d4-4ab2-810e-f83094aeba68/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a0631a5-4abb-45c6-8d14-04252e1ac599>.
+    
+<http://data.lblod.info/id/remote-data-objects/86e9b631-08fe-4440-9895-d052a540cb44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86e9b631-08fe-4440-9895-d052a540cb44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/5e072ba5-f1d4-4ab2-810e-f83094aeba68/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86e9b631-08fe-4440-9895-d052a540cb44>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1108095-43be-4ed6-bd4c-e719227c6620> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1108095-43be-4ed6-bd4c-e719227c6620";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/5e072ba5-f1d4-4ab2-810e-f83094aeba68/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1108095-43be-4ed6-bd4c-e719227c6620>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7c9389d-2513-4209-b7fa-60a5043794b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7c9389d-2513-4209-b7fa-60a5043794b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/66b24b60-4334-41a0-851d-8eff176f7b4f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7c9389d-2513-4209-b7fa-60a5043794b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/de1c265c-3155-4c50-a047-c2336c639f4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de1c265c-3155-4c50-a047-c2336c639f4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/66b24b60-4334-41a0-851d-8eff176f7b4f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de1c265c-3155-4c50-a047-c2336c639f4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/908087d7-0401-4dac-9140-4d12c8666c23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "908087d7-0401-4dac-9140-4d12c8666c23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/66b24b60-4334-41a0-851d-8eff176f7b4f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/908087d7-0401-4dac-9140-4d12c8666c23>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f631418-1f6e-4ba6-bf58-84b2441df60c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f631418-1f6e-4ba6-bf58-84b2441df60c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/769fef9e-f8db-4eed-a89b-7fca69eece39/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f631418-1f6e-4ba6-bf58-84b2441df60c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c66b876-2d73-4f2b-a6c7-c06e1fda52c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c66b876-2d73-4f2b-a6c7-c06e1fda52c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/769fef9e-f8db-4eed-a89b-7fca69eece39/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c66b876-2d73-4f2b-a6c7-c06e1fda52c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/06ec7217-8e38-436e-ae7b-e6d79e6e6e25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06ec7217-8e38-436e-ae7b-e6d79e6e6e25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/769fef9e-f8db-4eed-a89b-7fca69eece39/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06ec7217-8e38-436e-ae7b-e6d79e6e6e25>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5935ae4-0d9f-4e6a-8deb-4ecc58e97e57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5935ae4-0d9f-4e6a-8deb-4ecc58e97e57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/7b8e2355-7105-4dc4-949c-03567e4c7fbc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5935ae4-0d9f-4e6a-8deb-4ecc58e97e57>.
+    
+<http://data.lblod.info/id/remote-data-objects/cde76abd-d992-4427-aa2d-c5a339ceaf53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cde76abd-d992-4427-aa2d-c5a339ceaf53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/7b8e2355-7105-4dc4-949c-03567e4c7fbc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cde76abd-d992-4427-aa2d-c5a339ceaf53>.
+    
+<http://data.lblod.info/id/remote-data-objects/661b38ea-b435-46ce-b138-68b85d0aeb4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "661b38ea-b435-46ce-b138-68b85d0aeb4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/7b8e2355-7105-4dc4-949c-03567e4c7fbc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/661b38ea-b435-46ce-b138-68b85d0aeb4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2e61f11-6f06-4159-b344-7eb5708b751a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2e61f11-6f06-4159-b344-7eb5708b751a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/7d055a34-1bfb-48f5-ae03-be8873c388d2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2e61f11-6f06-4159-b344-7eb5708b751a>.
+    
+<http://data.lblod.info/id/remote-data-objects/61674b3c-1f98-400c-a829-6129ad5541fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61674b3c-1f98-400c-a829-6129ad5541fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/7d055a34-1bfb-48f5-ae03-be8873c388d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61674b3c-1f98-400c-a829-6129ad5541fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f113f9d-a2da-4a3e-987c-19be8359fd12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f113f9d-a2da-4a3e-987c-19be8359fd12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/7d055a34-1bfb-48f5-ae03-be8873c388d2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f113f9d-a2da-4a3e-987c-19be8359fd12>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bafc23b-fc83-45d8-8407-5c8dc2e0162b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bafc23b-fc83-45d8-8407-5c8dc2e0162b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/84ffc764-efae-4c9c-b2d9-c277ef987531/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bafc23b-fc83-45d8-8407-5c8dc2e0162b>.
+    
+<http://data.lblod.info/id/remote-data-objects/12c8fd4a-070e-44ca-9dbb-eb7a1a5e8fda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12c8fd4a-070e-44ca-9dbb-eb7a1a5e8fda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/84ffc764-efae-4c9c-b2d9-c277ef987531/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12c8fd4a-070e-44ca-9dbb-eb7a1a5e8fda>.
+    
+<http://data.lblod.info/id/remote-data-objects/c37471d0-32e7-4710-9efa-638ac01152c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c37471d0-32e7-4710-9efa-638ac01152c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/c45e6ec5-6cf1-4002-8587-de5fd79d7ecf/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c37471d0-32e7-4710-9efa-638ac01152c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/563f7031-1437-47ae-827c-95f61ab19b70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "563f7031-1437-47ae-827c-95f61ab19b70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/c45e6ec5-6cf1-4002-8587-de5fd79d7ecf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/563f7031-1437-47ae-827c-95f61ab19b70>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0269615-b1cd-476b-83ec-a7bcbc53e82d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0269615-b1cd-476b-83ec-a7bcbc53e82d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/c45e6ec5-6cf1-4002-8587-de5fd79d7ecf/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0269615-b1cd-476b-83ec-a7bcbc53e82d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c007129-e5e4-406d-8be1-5cdfcd81494a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c007129-e5e4-406d-8be1-5cdfcd81494a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/c732e2f7-afeb-4ac0-87e7-f3902e3b124c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c007129-e5e4-406d-8be1-5cdfcd81494a>.
+    
+<http://data.lblod.info/id/remote-data-objects/385b62bb-315f-4963-b00a-84418a9ad892> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "385b62bb-315f-4963-b00a-84418a9ad892";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/c732e2f7-afeb-4ac0-87e7-f3902e3b124c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/385b62bb-315f-4963-b00a-84418a9ad892>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccd4c96b-94dd-4269-8775-63d61d4cb279> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccd4c96b-94dd-4269-8775-63d61d4cb279";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/c732e2f7-afeb-4ac0-87e7-f3902e3b124c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccd4c96b-94dd-4269-8775-63d61d4cb279>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a6dad4b-6274-463a-8af5-898f1e410178> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a6dad4b-6274-463a-8af5-898f1e410178";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/dc2fde6d-0cda-4374-93ce-cabd6ef49448/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a6dad4b-6274-463a-8af5-898f1e410178>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8f9eae4-d2fc-4b32-a1cc-04ba3d69ceb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8f9eae4-d2fc-4b32-a1cc-04ba3d69ceb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/dc2fde6d-0cda-4374-93ce-cabd6ef49448/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8f9eae4-d2fc-4b32-a1cc-04ba3d69ceb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/562671af-f162-47ed-8c54-99641feb5b0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "562671af-f162-47ed-8c54-99641feb5b0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/dc2fde6d-0cda-4374-93ce-cabd6ef49448/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/562671af-f162-47ed-8c54-99641feb5b0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca9fdec1-5953-4833-84f3-bffaf8cce96a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca9fdec1-5953-4833-84f3-bffaf8cce96a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/e87a03b9-ffb4-4d36-a964-91241bc771c4/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca9fdec1-5953-4833-84f3-bffaf8cce96a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2d84376-20e7-420f-84f6-18ac0d0a5246> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2d84376-20e7-420f-84f6-18ac0d0a5246";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/e87a03b9-ffb4-4d36-a964-91241bc771c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2d84376-20e7-420f-84f6-18ac0d0a5246>.
+    
+<http://data.lblod.info/id/remote-data-objects/9bf10da1-b914-4542-92c1-34aa030da53c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9bf10da1-b914-4542-92c1-34aa030da53c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/gr/e87a03b9-ffb4-4d36-a964-91241bc771c4/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9bf10da1-b914-4542-92c1-34aa030da53c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4df1a7ad-5564-4cc7-a26d-cfb69b423cc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4df1a7ad-5564-4cc7-a26d-cfb69b423cc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/03ffea8e-7d5f-44da-a0d6-d30ee4ab49ff/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4df1a7ad-5564-4cc7-a26d-cfb69b423cc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d3aa09d-8bda-4d11-a131-be32a39f3e41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d3aa09d-8bda-4d11-a131-be32a39f3e41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/03ffea8e-7d5f-44da-a0d6-d30ee4ab49ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d3aa09d-8bda-4d11-a131-be32a39f3e41>.
+    
+<http://data.lblod.info/id/remote-data-objects/442d6425-899d-47fa-9312-977b397db7e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "442d6425-899d-47fa-9312-977b397db7e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/03ffea8e-7d5f-44da-a0d6-d30ee4ab49ff/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/442d6425-899d-47fa-9312-977b397db7e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7a2aa19-af13-453e-9a23-dd17c3b72823> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7a2aa19-af13-453e-9a23-dd17c3b72823";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/12f8d964-649b-4693-b865-5729ca50f811/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7a2aa19-af13-453e-9a23-dd17c3b72823>.
+    
+<http://data.lblod.info/id/remote-data-objects/04d41300-25a6-438c-9e3c-2602a88011a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04d41300-25a6-438c-9e3c-2602a88011a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/12f8d964-649b-4693-b865-5729ca50f811/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04d41300-25a6-438c-9e3c-2602a88011a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/3076dca4-8e81-4a38-ac2e-736ec553a966> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3076dca4-8e81-4a38-ac2e-736ec553a966";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/12f8d964-649b-4693-b865-5729ca50f811/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01953b7b-af36-4867-981a-18e85daa07f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3076dca4-8e81-4a38-ac2e-736ec553a966>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201023-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201023-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201023-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201023-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2c04634e-7e9c-4dd2-8453-f3084d8eea1b> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2c04634e-7e9c-4dd2-8453-f3084d8eea1b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a072fcd0-e62a-4533-b547-6f35711fc669";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f43b13d8-609a-4db3-b410-40b57d158b24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f43b13d8-609a-4db3-b410-40b57d158b24";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669>.
+
+  <http://redpencil.data.gift/id/task/4e989bd1-c8c5-444b-a006-8a981f2dd0cb> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4e989bd1-c8c5-444b-a006-8a981f2dd0cb";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2c04634e-7e9c-4dd2-8453-f3084d8eea1b>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f43b13d8-609a-4db3-b410-40b57d158b24>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/52ec1086-b4b5-42e2-b116-b0df5fe545e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52ec1086-b4b5-42e2-b116-b0df5fe545e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/33555553-35a6-492e-8d5f-1113b03e5297/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52ec1086-b4b5-42e2-b116-b0df5fe545e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c04ad790-2f3a-4fed-8ab2-cedfcb0649fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c04ad790-2f3a-4fed-8ab2-cedfcb0649fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/33555553-35a6-492e-8d5f-1113b03e5297/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c04ad790-2f3a-4fed-8ab2-cedfcb0649fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/70355e50-54ab-4765-9bf1-89214a3a37a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70355e50-54ab-4765-9bf1-89214a3a37a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/33555553-35a6-492e-8d5f-1113b03e5297/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70355e50-54ab-4765-9bf1-89214a3a37a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/25a407b1-bb66-4f7a-af3e-1e55d9fba664> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25a407b1-bb66-4f7a-af3e-1e55d9fba664";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/54a7b49b-2487-4812-ada6-7d30d851c0f7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25a407b1-bb66-4f7a-af3e-1e55d9fba664>.
+    
+<http://data.lblod.info/id/remote-data-objects/c49a5388-77da-49c9-b4b3-b00e5a3fe555> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c49a5388-77da-49c9-b4b3-b00e5a3fe555";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/54a7b49b-2487-4812-ada6-7d30d851c0f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c49a5388-77da-49c9-b4b3-b00e5a3fe555>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a9870ef-53fb-4ace-8c04-d98958496b0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a9870ef-53fb-4ace-8c04-d98958496b0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/54a7b49b-2487-4812-ada6-7d30d851c0f7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a9870ef-53fb-4ace-8c04-d98958496b0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/58e218bf-2fa4-4df8-8c10-bc80b45c889e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58e218bf-2fa4-4df8-8c10-bc80b45c889e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/76c77db2-cd70-4c6c-8603-d4e9d09cb4e7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58e218bf-2fa4-4df8-8c10-bc80b45c889e>.
+    
+<http://data.lblod.info/id/remote-data-objects/93e1262d-ee5a-4153-8657-78ee7e681d40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93e1262d-ee5a-4153-8657-78ee7e681d40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/76c77db2-cd70-4c6c-8603-d4e9d09cb4e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93e1262d-ee5a-4153-8657-78ee7e681d40>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e73be68-2755-411a-96fc-e0e835e09f6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e73be68-2755-411a-96fc-e0e835e09f6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/76c77db2-cd70-4c6c-8603-d4e9d09cb4e7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e73be68-2755-411a-96fc-e0e835e09f6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9234d2a5-43f6-4f7b-bda1-54c6beead690> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9234d2a5-43f6-4f7b-bda1-54c6beead690";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/7b860208-a562-4137-a2a2-e94c29cd0eee/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9234d2a5-43f6-4f7b-bda1-54c6beead690>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3715677-4aa6-4a86-be2a-2c8d00d0c47f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3715677-4aa6-4a86-be2a-2c8d00d0c47f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/7b860208-a562-4137-a2a2-e94c29cd0eee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3715677-4aa6-4a86-be2a-2c8d00d0c47f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cfc6a49-2f9f-4fe8-8dec-03fe49958b79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cfc6a49-2f9f-4fe8-8dec-03fe49958b79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/7b860208-a562-4137-a2a2-e94c29cd0eee/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cfc6a49-2f9f-4fe8-8dec-03fe49958b79>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fa1f0de-bdf7-47f6-814c-46ac9e361aca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fa1f0de-bdf7-47f6-814c-46ac9e361aca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/7d363904-a2d7-466f-837d-94703ce414f3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fa1f0de-bdf7-47f6-814c-46ac9e361aca>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c3e6da7-4f4f-4607-b25b-09158f2d9e50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c3e6da7-4f4f-4607-b25b-09158f2d9e50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/7d363904-a2d7-466f-837d-94703ce414f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c3e6da7-4f4f-4607-b25b-09158f2d9e50>.
+    
+<http://data.lblod.info/id/remote-data-objects/95b1be95-a78c-431e-b701-3f32b9a8ca3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95b1be95-a78c-431e-b701-3f32b9a8ca3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/7d363904-a2d7-466f-837d-94703ce414f3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95b1be95-a78c-431e-b701-3f32b9a8ca3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a4a7f1f-d516-452e-a61c-884617a22955> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a4a7f1f-d516-452e-a61c-884617a22955";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/82141b5a-e942-4180-8589-7e279d5cc0a6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a4a7f1f-d516-452e-a61c-884617a22955>.
+    
+<http://data.lblod.info/id/remote-data-objects/0109eeb1-43bb-4fd7-a22c-af6582fdf402> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0109eeb1-43bb-4fd7-a22c-af6582fdf402";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/82141b5a-e942-4180-8589-7e279d5cc0a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0109eeb1-43bb-4fd7-a22c-af6582fdf402>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d719ca9-118d-45dd-ad23-569962c71bed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d719ca9-118d-45dd-ad23-569962c71bed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/82141b5a-e942-4180-8589-7e279d5cc0a6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d719ca9-118d-45dd-ad23-569962c71bed>.
+    
+<http://data.lblod.info/id/remote-data-objects/d274884b-bd63-4a30-80c0-129e15f3b8dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d274884b-bd63-4a30-80c0-129e15f3b8dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/865b7636-61d1-49aa-8475-8977021be3ff/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d274884b-bd63-4a30-80c0-129e15f3b8dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/73cc4ff2-c757-4564-892c-924b76f416cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73cc4ff2-c757-4564-892c-924b76f416cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/865b7636-61d1-49aa-8475-8977021be3ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73cc4ff2-c757-4564-892c-924b76f416cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/67383ba8-9474-4a3f-8044-5a3875eb940c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67383ba8-9474-4a3f-8044-5a3875eb940c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/865b7636-61d1-49aa-8475-8977021be3ff/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67383ba8-9474-4a3f-8044-5a3875eb940c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ff16bad-177f-439d-b79f-8aa8ba835b17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ff16bad-177f-439d-b79f-8aa8ba835b17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/a49d1b5e-8bdd-4729-aaca-12d031f6011d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ff16bad-177f-439d-b79f-8aa8ba835b17>.
+    
+<http://data.lblod.info/id/remote-data-objects/ede35d0b-e6e6-47d0-ae57-1c6d41244c6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ede35d0b-e6e6-47d0-ae57-1c6d41244c6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/a49d1b5e-8bdd-4729-aaca-12d031f6011d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ede35d0b-e6e6-47d0-ae57-1c6d41244c6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/94d2364b-3741-46eb-a918-be94d6ce68b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94d2364b-3741-46eb-a918-be94d6ce68b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/a49d1b5e-8bdd-4729-aaca-12d031f6011d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94d2364b-3741-46eb-a918-be94d6ce68b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/69efed12-c953-4767-8af3-ee63f19c6ffc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69efed12-c953-4767-8af3-ee63f19c6ffc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/b46e6ce3-fe42-484e-b575-962ca23d2d02/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69efed12-c953-4767-8af3-ee63f19c6ffc>.
+    
+<http://data.lblod.info/id/remote-data-objects/db2fe0dc-2e5d-4ebb-aa06-ec431c990e74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db2fe0dc-2e5d-4ebb-aa06-ec431c990e74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/b46e6ce3-fe42-484e-b575-962ca23d2d02/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db2fe0dc-2e5d-4ebb-aa06-ec431c990e74>.
+    
+<http://data.lblod.info/id/remote-data-objects/050f23ec-c189-4e41-ac53-e69754464845> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "050f23ec-c189-4e41-ac53-e69754464845";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/b46e6ce3-fe42-484e-b575-962ca23d2d02/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/050f23ec-c189-4e41-ac53-e69754464845>.
+    
+<http://data.lblod.info/id/remote-data-objects/86d7545c-575a-4ee0-bf82-48e0830fdee5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86d7545c-575a-4ee0-bf82-48e0830fdee5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/b47f9746-b6dc-4628-8815-65d0f297ffe7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86d7545c-575a-4ee0-bf82-48e0830fdee5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4346da8b-c4ee-4f14-8273-f2eed21c5efc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4346da8b-c4ee-4f14-8273-f2eed21c5efc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/b47f9746-b6dc-4628-8815-65d0f297ffe7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4346da8b-c4ee-4f14-8273-f2eed21c5efc>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f9a9234-a1f7-496f-9bca-867a852a1920> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f9a9234-a1f7-496f-9bca-867a852a1920";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/b47f9746-b6dc-4628-8815-65d0f297ffe7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f9a9234-a1f7-496f-9bca-867a852a1920>.
+    
+<http://data.lblod.info/id/remote-data-objects/f557a445-493d-498f-a8a5-2167c4628f98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f557a445-493d-498f-a8a5-2167c4628f98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/c9b86e56-6ff6-48bd-8530-c283c60f1550/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f557a445-493d-498f-a8a5-2167c4628f98>.
+    
+<http://data.lblod.info/id/remote-data-objects/b88e5288-a5a5-4f2e-b30b-8d0bb750255e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b88e5288-a5a5-4f2e-b30b-8d0bb750255e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/c9b86e56-6ff6-48bd-8530-c283c60f1550/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b88e5288-a5a5-4f2e-b30b-8d0bb750255e>.
+    
+<http://data.lblod.info/id/remote-data-objects/737aeafa-d2ae-4270-a553-07973cde72ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "737aeafa-d2ae-4270-a553-07973cde72ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/cf59c7a9-21f7-4033-b021-acf010af28bf/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/737aeafa-d2ae-4270-a553-07973cde72ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/621a7344-ef15-4ec7-bb1e-4482ca1b3c86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "621a7344-ef15-4ec7-bb1e-4482ca1b3c86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/cf59c7a9-21f7-4033-b021-acf010af28bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/621a7344-ef15-4ec7-bb1e-4482ca1b3c86>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd468d5d-9a91-474e-ba13-b45840cef328> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd468d5d-9a91-474e-ba13-b45840cef328";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/cf59c7a9-21f7-4033-b021-acf010af28bf/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd468d5d-9a91-474e-ba13-b45840cef328>.
+    
+<http://data.lblod.info/id/remote-data-objects/fda77dd0-6269-4be1-9581-241dfdd3bbff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fda77dd0-6269-4be1-9581-241dfdd3bbff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/eb92a3e1-948e-4c0f-a9ee-776aafcfa1fe/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fda77dd0-6269-4be1-9581-241dfdd3bbff>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef9e276c-747f-47d2-b8f2-cdf78299a599> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef9e276c-747f-47d2-b8f2-cdf78299a599";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/eb92a3e1-948e-4c0f-a9ee-776aafcfa1fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef9e276c-747f-47d2-b8f2-cdf78299a599>.
+    
+<http://data.lblod.info/id/remote-data-objects/41e5a5ae-474f-4e2c-ab05-b7215853c2ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41e5a5ae-474f-4e2c-ab05-b7215853c2ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/or/eb92a3e1-948e-4c0f-a9ee-776aafcfa1fe/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41e5a5ae-474f-4e2c-ab05-b7215853c2ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc26e14c-364c-4a03-8417-6e9163cbac3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc26e14c-364c-4a03-8417-6e9163cbac3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/0233040e-9f6d-4349-a266-7c1be0f077e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc26e14c-364c-4a03-8417-6e9163cbac3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/421a1a05-c0ca-4515-b1ce-d66f7a1a92b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "421a1a05-c0ca-4515-b1ce-d66f7a1a92b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/0252b0ca-6421-4e83-92f3-126c28b0b5ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/421a1a05-c0ca-4515-b1ce-d66f7a1a92b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1aa5d693-38a1-4e24-a3d6-1853ceb20f4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1aa5d693-38a1-4e24-a3d6-1853ceb20f4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/1116ed56-0d19-4e8e-961b-7a6dc39d58dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1aa5d693-38a1-4e24-a3d6-1853ceb20f4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/072ad6cf-6016-4b1e-9acf-fd4416d4361a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "072ad6cf-6016-4b1e-9acf-fd4416d4361a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/12751b9c-6159-4662-811f-f0e3d264a22e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/072ad6cf-6016-4b1e-9acf-fd4416d4361a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c78702e-69ea-41ab-9e31-539bfe73d10c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c78702e-69ea-41ab-9e31-539bfe73d10c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/140ae8eb-83e4-41af-a105-11e2e722a407/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c78702e-69ea-41ab-9e31-539bfe73d10c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8761e18-8472-4767-8f9f-b185b7113d13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8761e18-8472-4767-8f9f-b185b7113d13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/14a9555a-d260-4f48-87af-f8df9291411b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8761e18-8472-4767-8f9f-b185b7113d13>.
+    
+<http://data.lblod.info/id/remote-data-objects/27a472ad-a878-4cbd-8c9a-88fb9ec0159b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27a472ad-a878-4cbd-8c9a-88fb9ec0159b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/17c739fa-9271-416a-8431-df3a3ed72b45/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27a472ad-a878-4cbd-8c9a-88fb9ec0159b>.
+    
+<http://data.lblod.info/id/remote-data-objects/178bda40-1f10-4249-bf19-516a56adf9f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "178bda40-1f10-4249-bf19-516a56adf9f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/18ba6814-a834-47e0-863a-9166e5868bb5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/178bda40-1f10-4249-bf19-516a56adf9f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/742af740-c493-4462-8f52-fb4fe39f2444> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "742af740-c493-4462-8f52-fb4fe39f2444";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/1997861a-d01c-4e36-91a0-3df458f258fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/742af740-c493-4462-8f52-fb4fe39f2444>.
+    
+<http://data.lblod.info/id/remote-data-objects/00b88580-ea43-4360-90aa-e1500e160b59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00b88580-ea43-4360-90aa-e1500e160b59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/20d36362-aec9-4a77-9679-636a2481b2c0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00b88580-ea43-4360-90aa-e1500e160b59>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cea64e5-0b2d-45c6-b495-b2ed859825b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cea64e5-0b2d-45c6-b495-b2ed859825b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/24f88844-09ca-424f-8171-79ec74bfcf51/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cea64e5-0b2d-45c6-b495-b2ed859825b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4796d931-1480-4688-9813-0b5709b38b3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4796d931-1480-4688-9813-0b5709b38b3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/254bef69-6d98-4ab9-b53c-b98c7c9fc637/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a072fcd0-e62a-4533-b547-6f35711fc669> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4796d931-1480-4688-9813-0b5709b38b3b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201025-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201025-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201025-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201025-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/64a3dd47-2c94-452a-975e-f15960de99a8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "64a3dd47-2c94-452a-975e-f15960de99a8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5c98afe1-ee52-405d-a731-f9572466c23e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/5df06ef9-1f6c-457b-8571-2e0414ba8b8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5df06ef9-1f6c-457b-8571-2e0414ba8b8e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e>.
+
+  <http://redpencil.data.gift/id/task/681b42f7-3d99-4649-bda9-72aec6ce2eae> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "681b42f7-3d99-4649-bda9-72aec6ce2eae";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/64a3dd47-2c94-452a-975e-f15960de99a8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/5df06ef9-1f6c-457b-8571-2e0414ba8b8e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/cf95d266-f86b-4a3f-b7b9-f7ff32cb5cf3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf95d266-f86b-4a3f-b7b9-f7ff32cb5cf3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/25850f70-f56c-443c-8df5-65ba7a19d5be/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf95d266-f86b-4a3f-b7b9-f7ff32cb5cf3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0713e36-ea9a-4793-8556-9cc9126ea1e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0713e36-ea9a-4793-8556-9cc9126ea1e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/29ed53b8-008c-4095-9183-467b2d824b0f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0713e36-ea9a-4793-8556-9cc9126ea1e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/f127ea91-fe0a-4295-be8d-620e7b6efc7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f127ea91-fe0a-4295-be8d-620e7b6efc7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/2dfd8ae2-1e16-49b2-bc80-04c01caf20ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f127ea91-fe0a-4295-be8d-620e7b6efc7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ea826f9-6248-4959-ac84-078d7b8647eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ea826f9-6248-4959-ac84-078d7b8647eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/2f04bee3-2c03-49e1-b737-34eedc8ab180/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ea826f9-6248-4959-ac84-078d7b8647eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9ec8294-628a-49d4-ac6d-ce1684c38aa9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9ec8294-628a-49d4-ac6d-ce1684c38aa9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/2f455610-2609-42d3-b433-176d926bbc0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9ec8294-628a-49d4-ac6d-ce1684c38aa9>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fd517b9-ad1e-4a3d-851b-a234e152aa53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fd517b9-ad1e-4a3d-851b-a234e152aa53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/339c3d8f-bae0-4eb3-a42e-b0cdad359f08/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fd517b9-ad1e-4a3d-851b-a234e152aa53>.
+    
+<http://data.lblod.info/id/remote-data-objects/e48b8d2f-0838-4f65-8dfe-e057fa346383> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e48b8d2f-0838-4f65-8dfe-e057fa346383";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/3453c35b-fd9a-491d-a332-693a8b0df699/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e48b8d2f-0838-4f65-8dfe-e057fa346383>.
+    
+<http://data.lblod.info/id/remote-data-objects/11fb28fd-056e-479d-8134-f23fc581b700> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11fb28fd-056e-479d-8134-f23fc581b700";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/38f92aa0-c710-4044-b7ad-6b215489d150/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11fb28fd-056e-479d-8134-f23fc581b700>.
+    
+<http://data.lblod.info/id/remote-data-objects/01bc9a3b-12c9-4370-8b16-993327293d16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01bc9a3b-12c9-4370-8b16-993327293d16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/3988f88c-2520-49a7-b200-819d0d3c6881/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01bc9a3b-12c9-4370-8b16-993327293d16>.
+    
+<http://data.lblod.info/id/remote-data-objects/431479ae-aa74-42f6-aa9f-06b91120da29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "431479ae-aa74-42f6-aa9f-06b91120da29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/3a76366d-b110-4925-9812-6016e0f713eb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/431479ae-aa74-42f6-aa9f-06b91120da29>.
+    
+<http://data.lblod.info/id/remote-data-objects/672214b9-2db8-44ce-ae48-f38cbb56a82e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "672214b9-2db8-44ce-ae48-f38cbb56a82e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/45d9ac63-2bbf-4921-93c9-d091bb99145f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/672214b9-2db8-44ce-ae48-f38cbb56a82e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5179701c-71ac-49ba-9e5f-7e6363b2e677> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5179701c-71ac-49ba-9e5f-7e6363b2e677";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/512c78b2-544a-44bb-b007-f8cda04117d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5179701c-71ac-49ba-9e5f-7e6363b2e677>.
+    
+<http://data.lblod.info/id/remote-data-objects/e78d1a02-a9fd-4b38-a838-b3a91b994aae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e78d1a02-a9fd-4b38-a838-b3a91b994aae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/520bc234-f6c3-4b14-bd8d-7cf02bcd353e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e78d1a02-a9fd-4b38-a838-b3a91b994aae>.
+    
+<http://data.lblod.info/id/remote-data-objects/33ecd0c1-490e-4b8a-b755-1e3096432e08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33ecd0c1-490e-4b8a-b755-1e3096432e08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/53152de6-843c-4614-b0db-e1f9d3799f94/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33ecd0c1-490e-4b8a-b755-1e3096432e08>.
+    
+<http://data.lblod.info/id/remote-data-objects/8432b016-1374-4559-bf36-9069e94f6e59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8432b016-1374-4559-bf36-9069e94f6e59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/56b6db06-5cfe-47b0-829f-79ac8eb700cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8432b016-1374-4559-bf36-9069e94f6e59>.
+    
+<http://data.lblod.info/id/remote-data-objects/85aed648-d120-4932-9281-ec6858ca21dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85aed648-d120-4932-9281-ec6858ca21dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/602d292c-8a04-44b2-a03d-4f8ee3b65979/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85aed648-d120-4932-9281-ec6858ca21dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/76655251-072e-4ed5-af9d-039b5f21f61c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76655251-072e-4ed5-af9d-039b5f21f61c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/6245d1d3-04cf-4534-8ce0-c0d025a9135f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76655251-072e-4ed5-af9d-039b5f21f61c>.
+    
+<http://data.lblod.info/id/remote-data-objects/58f78d4c-6ca3-4ca3-a531-05e60c3fc8e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58f78d4c-6ca3-4ca3-a531-05e60c3fc8e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/625f9b25-1199-4de7-9b5c-24198f4a0862/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58f78d4c-6ca3-4ca3-a531-05e60c3fc8e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f93eb95-ecb4-446d-9f20-2ff0e8f1ef52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f93eb95-ecb4-446d-9f20-2ff0e8f1ef52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/6325d718-2067-40fc-a5ed-23dfa0d49ce0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f93eb95-ecb4-446d-9f20-2ff0e8f1ef52>.
+    
+<http://data.lblod.info/id/remote-data-objects/68eb287e-d79d-493d-91ec-7c79d4a319dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68eb287e-d79d-493d-91ec-7c79d4a319dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/65d544a1-eaee-4576-9906-19d84ff41c10/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68eb287e-d79d-493d-91ec-7c79d4a319dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/9eb54348-e2eb-4880-a4ab-599fa82e8f9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9eb54348-e2eb-4880-a4ab-599fa82e8f9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/66551b7e-5efa-46d6-8376-ebbb15a57722/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9eb54348-e2eb-4880-a4ab-599fa82e8f9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e354fd05-6f6c-4b9b-9ffb-56d28ce02fcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e354fd05-6f6c-4b9b-9ffb-56d28ce02fcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/67a622c3-1562-44a3-ba43-94d103c9c5ca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e354fd05-6f6c-4b9b-9ffb-56d28ce02fcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/854c2c90-3eaf-44c3-8a92-13034ab492cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "854c2c90-3eaf-44c3-8a92-13034ab492cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/681b03f0-cb55-49e0-8d70-58aa4bfc9e49/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/854c2c90-3eaf-44c3-8a92-13034ab492cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2850708-836c-4e72-8b27-3bfeea97795b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2850708-836c-4e72-8b27-3bfeea97795b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/6ca58f21-d2a7-4e71-bb35-aa25987469b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2850708-836c-4e72-8b27-3bfeea97795b>.
+    
+<http://data.lblod.info/id/remote-data-objects/eda5c9c6-1d28-4e48-a136-63124b977201> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eda5c9c6-1d28-4e48-a136-63124b977201";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/71938e90-e917-4184-b1b3-2692d5c9f9bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eda5c9c6-1d28-4e48-a136-63124b977201>.
+    
+<http://data.lblod.info/id/remote-data-objects/738fad38-dccf-488a-8b1d-352ea9457e3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "738fad38-dccf-488a-8b1d-352ea9457e3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/754c6fa7-4ec9-421c-837a-19d75256a29e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/738fad38-dccf-488a-8b1d-352ea9457e3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fcf51fd-d7c4-496e-8704-fb1c6719ad34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fcf51fd-d7c4-496e-8704-fb1c6719ad34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/77a5e788-ca3a-45e3-8b77-1f749be2766e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fcf51fd-d7c4-496e-8704-fb1c6719ad34>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0e7cac3-fec6-4bc1-8e64-1eb3d7018f12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0e7cac3-fec6-4bc1-8e64-1eb3d7018f12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/7873173e-09e2-451b-8e1f-67846f659122/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0e7cac3-fec6-4bc1-8e64-1eb3d7018f12>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ecebf0d-a167-4623-979e-0b7a7fcb22b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ecebf0d-a167-4623-979e-0b7a7fcb22b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/7f30cd4c-1922-40b3-a3c4-cff96595f5a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ecebf0d-a167-4623-979e-0b7a7fcb22b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5e2005a-993d-4a3e-9a1e-6e41749163b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5e2005a-993d-4a3e-9a1e-6e41749163b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/80a38f99-4aa4-42c5-a220-24608b859ff5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5e2005a-993d-4a3e-9a1e-6e41749163b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/664c3bf8-4b16-4082-8be2-371e86502139> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "664c3bf8-4b16-4082-8be2-371e86502139";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/83f978b6-5e5a-4844-ba72-ca9117575ef5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/664c3bf8-4b16-4082-8be2-371e86502139>.
+    
+<http://data.lblod.info/id/remote-data-objects/49d8e0de-db03-4373-a9a9-293f9de99fd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49d8e0de-db03-4373-a9a9-293f9de99fd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/85796764-51be-456d-86c6-7254b1330a06/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49d8e0de-db03-4373-a9a9-293f9de99fd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c16ff95f-6bd4-4d2f-aa8f-e777a04c9afe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c16ff95f-6bd4-4d2f-aa8f-e777a04c9afe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/8ca953fb-5b4e-4adf-a9aa-b46aea420874/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c16ff95f-6bd4-4d2f-aa8f-e777a04c9afe>.
+    
+<http://data.lblod.info/id/remote-data-objects/a06fcec0-6c8b-40ab-87ca-a281f37e20fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a06fcec0-6c8b-40ab-87ca-a281f37e20fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/8ce21993-d36a-4fce-aed8-7f7cd2af959d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a06fcec0-6c8b-40ab-87ca-a281f37e20fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d010e1e4-fa9a-4f6c-887c-fe5b2e406b02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d010e1e4-fa9a-4f6c-887c-fe5b2e406b02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/911771e6-0088-4205-ade3-d90c5963cc72/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d010e1e4-fa9a-4f6c-887c-fe5b2e406b02>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd24c165-bc3f-4b69-91fc-5c032f620e86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd24c165-bc3f-4b69-91fc-5c032f620e86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/96a44eea-1093-49b4-a584-49ffe3d5907e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd24c165-bc3f-4b69-91fc-5c032f620e86>.
+    
+<http://data.lblod.info/id/remote-data-objects/27d1bae6-a124-462b-863c-bb74c991b279> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27d1bae6-a124-462b-863c-bb74c991b279";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/976a1e18-c033-4284-a218-8536d0029a83/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27d1bae6-a124-462b-863c-bb74c991b279>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbda93bd-3b95-4cfa-8bd2-6411dc239a0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbda93bd-3b95-4cfa-8bd2-6411dc239a0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/977bbaf9-7fee-4520-811a-bb909af9f7a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbda93bd-3b95-4cfa-8bd2-6411dc239a0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce5f8599-cb9f-45ef-b099-f5c0c4231aac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce5f8599-cb9f-45ef-b099-f5c0c4231aac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/9e84feb8-d392-473b-83a1-fe4e332ba55d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce5f8599-cb9f-45ef-b099-f5c0c4231aac>.
+    
+<http://data.lblod.info/id/remote-data-objects/684259b1-747c-4dcf-8164-0f6445807cb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "684259b1-747c-4dcf-8164-0f6445807cb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/a7b97d3d-5dca-4434-ab66-1de821395243/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/684259b1-747c-4dcf-8164-0f6445807cb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9c87fb8-9b02-409a-b5c4-ff241ed12432> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9c87fb8-9b02-409a-b5c4-ff241ed12432";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/a988ef94-ee83-4356-92a8-3d0e290e6d50/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9c87fb8-9b02-409a-b5c4-ff241ed12432>.
+    
+<http://data.lblod.info/id/remote-data-objects/7320ad69-4709-4818-a343-4351ffa99386> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7320ad69-4709-4818-a343-4351ffa99386";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/ad8af1e6-e722-4b61-8c05-404641993072/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7320ad69-4709-4818-a343-4351ffa99386>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cebf8e4-bd47-4626-99f5-ca361404ef3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cebf8e4-bd47-4626-99f5-ca361404ef3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/b46f642a-d6ba-4496-b51f-549b2b9b0dd4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cebf8e4-bd47-4626-99f5-ca361404ef3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5dca2dae-a2be-4b00-acbf-995a24c0c515> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5dca2dae-a2be-4b00-acbf-995a24c0c515";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/b514f491-3522-4fdb-859a-adedbb10b037/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5dca2dae-a2be-4b00-acbf-995a24c0c515>.
+    
+<http://data.lblod.info/id/remote-data-objects/7aa271ea-0e9a-4144-aa31-eae58d6bd40a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7aa271ea-0e9a-4144-aa31-eae58d6bd40a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/b63ba4a4-6cdb-47dc-829b-820e0fce8896/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7aa271ea-0e9a-4144-aa31-eae58d6bd40a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d259fdaf-e4df-40df-91e4-26b739cd4c3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d259fdaf-e4df-40df-91e4-26b739cd4c3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/b77e6f69-8e67-4424-b41d-3def69f1d622/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d259fdaf-e4df-40df-91e4-26b739cd4c3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3477fc4-63bb-4c89-be86-4a386764a12e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3477fc4-63bb-4c89-be86-4a386764a12e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/ba1752c2-4981-4ffd-b34f-bb2d91be6cf2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3477fc4-63bb-4c89-be86-4a386764a12e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6364351-3d1f-4660-9e3c-ae95b33f084e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6364351-3d1f-4660-9e3c-ae95b33f084e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/c59244ff-ed9c-4352-8dee-b240c1c74336/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6364351-3d1f-4660-9e3c-ae95b33f084e>.
+    
+<http://data.lblod.info/id/remote-data-objects/29be9e74-6f7a-4ba1-956f-7b9929097826> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29be9e74-6f7a-4ba1-956f-7b9929097826";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/d2aab2ab-6ca3-4842-a91f-7d85689ae9b8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29be9e74-6f7a-4ba1-956f-7b9929097826>.
+    
+<http://data.lblod.info/id/remote-data-objects/5234749b-4da7-4c76-9dca-2ebf1f6b4866> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5234749b-4da7-4c76-9dca-2ebf1f6b4866";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/dc8b2836-7db3-420b-96d4-2e0e7a39c861/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c98afe1-ee52-405d-a731-f9572466c23e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5234749b-4da7-4c76-9dca-2ebf1f6b4866>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201026-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201026-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201026-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201026-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7c86098f-cbe8-4e62-bff2-57c96ba2abb8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7c86098f-cbe8-4e62-bff2-57c96ba2abb8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f51a8afd-d3f6-43b7-9874-5ab13fb23878> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f51a8afd-d3f6-43b7-9874-5ab13fb23878";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2>.
+
+  <http://redpencil.data.gift/id/task/94e7a0d2-0e85-4bf5-85bc-6ec863221a4a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "94e7a0d2-0e85-4bf5-85bc-6ec863221a4a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7c86098f-cbe8-4e62-bff2-57c96ba2abb8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f51a8afd-d3f6-43b7-9874-5ab13fb23878>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/ac1ef772-bd09-4f90-ab43-fa865992c7d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac1ef772-bd09-4f90-ab43-fa865992c7d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/e06d76ef-9753-4f50-ac86-d96c80903caa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac1ef772-bd09-4f90-ab43-fa865992c7d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c9009bc-3971-4b93-9838-ed5c8a951340> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c9009bc-3971-4b93-9838-ed5c8a951340";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/e464bfde-7ed9-4f9f-acc8-ad5ec20df294/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c9009bc-3971-4b93-9838-ed5c8a951340>.
+    
+<http://data.lblod.info/id/remote-data-objects/da572d0f-6dbd-4761-a98d-53a5594a0338> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da572d0f-6dbd-4761-a98d-53a5594a0338";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/e9586305-120c-4e52-95f0-b0152f9dc57a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da572d0f-6dbd-4761-a98d-53a5594a0338>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec1705dc-e672-4755-aa8e-469af0a408a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec1705dc-e672-4755-aa8e-469af0a408a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/eb372f0c-41fb-4748-ba7b-c3aa0390f621/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec1705dc-e672-4755-aa8e-469af0a408a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b7335b7-9145-439e-9fb0-ba2ff0c5cdd6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b7335b7-9145-439e-9fb0-ba2ff0c5cdd6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/f0065d94-6332-41bb-878a-afeb4b35b769/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b7335b7-9145-439e-9fb0-ba2ff0c5cdd6>.
+    
+<http://data.lblod.info/id/remote-data-objects/45c8b058-c570-45fe-860b-0e19544b3743> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45c8b058-c570-45fe-860b-0e19544b3743";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/f7966646-0f8d-49fe-a8b2-23e4ea0b2007/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45c8b058-c570-45fe-860b-0e19544b3743>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d34ac32-a63d-4d48-8bd1-2b86a77c2ca4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d34ac32-a63d-4d48-8bd1-2b86a77c2ca4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/f7d02ce0-5d7c-4233-a50d-5df70c6fab58/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d34ac32-a63d-4d48-8bd1-2b86a77c2ca4>.
+    
+<http://data.lblod.info/id/remote-data-objects/b94c843c-9560-46f8-90bd-bdae3112662f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b94c843c-9560-46f8-90bd-bdae3112662f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/f8226e3a-df3f-4593-99da-e02629f4936e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b94c843c-9560-46f8-90bd-bdae3112662f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bbd1f0e-0121-42c0-abf2-54848c0d7c55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bbd1f0e-0121-42c0-abf2-54848c0d7c55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://beersel.meetingburger.net/vabu/fcfdf5f0-e527-4a63-ae7c-352b7eb57498/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bbd1f0e-0121-42c0-abf2-54848c0d7c55>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b29852e-508f-483c-beb4-025cf703c5bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b29852e-508f-483c-beb4-025cf703c5bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/0099be02-2b94-4b4e-be68-12fe6d58c232/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b29852e-508f-483c-beb4-025cf703c5bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f1715b1-bdb1-415c-a13a-8cc788150591> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f1715b1-bdb1-415c-a13a-8cc788150591";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/0eb67c98-3df3-426d-aadb-907e8b360138/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f1715b1-bdb1-415c-a13a-8cc788150591>.
+    
+<http://data.lblod.info/id/remote-data-objects/23357538-186d-44e7-b9f8-46eef1d915f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23357538-186d-44e7-b9f8-46eef1d915f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/20a2a1e0-0b86-4f48-a79b-19a98900b790/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23357538-186d-44e7-b9f8-46eef1d915f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bc039d5-6313-457e-9ced-2e7f126c08dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bc039d5-6313-457e-9ced-2e7f126c08dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/31f79f6f-eef3-4a41-86bd-65bae9b05f45/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bc039d5-6313-457e-9ced-2e7f126c08dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c5f2623-ef6d-47b6-8d9b-1bb29098eaac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c5f2623-ef6d-47b6-8d9b-1bb29098eaac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/3b7f5956-bab8-4aa3-a529-a0ea5714b9d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c5f2623-ef6d-47b6-8d9b-1bb29098eaac>.
+    
+<http://data.lblod.info/id/remote-data-objects/cebcf759-8494-4735-ab4a-f03e4e470355> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cebcf759-8494-4735-ab4a-f03e4e470355";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/494ad594-9511-4ea6-935a-545c6ec5c1bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cebcf759-8494-4735-ab4a-f03e4e470355>.
+    
+<http://data.lblod.info/id/remote-data-objects/83fe79bf-cd3e-473f-9e19-e8f9ea7f4d99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83fe79bf-cd3e-473f-9e19-e8f9ea7f4d99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/4b54290e-f0fc-42f9-a1a1-c08794068244/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83fe79bf-cd3e-473f-9e19-e8f9ea7f4d99>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1a8219c-f077-41da-88eb-7a83a62a7d3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1a8219c-f077-41da-88eb-7a83a62a7d3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/64afb435-a9a8-4c6e-ba02-c63c8a28e962/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1a8219c-f077-41da-88eb-7a83a62a7d3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1650d2c-3786-48b1-a789-483fc1c175bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1650d2c-3786-48b1-a789-483fc1c175bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/79dd0fa8-bcd4-41e4-bf7d-95e48586f80b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1650d2c-3786-48b1-a789-483fc1c175bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e1031bb-6ba7-416f-be58-1377327faa22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e1031bb-6ba7-416f-be58-1377327faa22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/7e00c529-2268-4969-899e-e788931c9daa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e1031bb-6ba7-416f-be58-1377327faa22>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c0cc62e-3d46-40b7-a9ea-43b902fa587c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c0cc62e-3d46-40b7-a9ea-43b902fa587c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/82281524-4a38-44c8-89f4-9e2fceb126af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c0cc62e-3d46-40b7-a9ea-43b902fa587c>.
+    
+<http://data.lblod.info/id/remote-data-objects/aeb4a4bc-08f7-44db-9725-43d8054957cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aeb4a4bc-08f7-44db-9725-43d8054957cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/83a3a4d2-e0d3-42bc-8fdc-ee527698d4c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aeb4a4bc-08f7-44db-9725-43d8054957cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4ac9baa-b8c8-4588-8564-2b2d7236abf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4ac9baa-b8c8-4588-8564-2b2d7236abf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/846b301f-fb08-4745-8e2b-c7e5abded87b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4ac9baa-b8c8-4588-8564-2b2d7236abf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4c28228-ba08-42f2-a06c-707655c3add9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4c28228-ba08-42f2-a06c-707655c3add9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/89cfd2d6-3282-4fe7-bf62-78072affef8e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4c28228-ba08-42f2-a06c-707655c3add9>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cab7545-48b5-482a-a440-0a7806205416> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cab7545-48b5-482a-a440-0a7806205416";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/8c7a1067-7848-4337-a1ec-f62878f84142/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cab7545-48b5-482a-a440-0a7806205416>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7c15e5a-0284-423d-a083-3a858c77eafd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7c15e5a-0284-423d-a083-3a858c77eafd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/8f9999d4-bf51-4d07-8659-5226a7631307/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7c15e5a-0284-423d-a083-3a858c77eafd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d57ab72e-d87d-4eb8-9ed4-0a282fcf750f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d57ab72e-d87d-4eb8-9ed4-0a282fcf750f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/945bc05e-5699-4bee-9404-7b139d34330a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d57ab72e-d87d-4eb8-9ed4-0a282fcf750f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b21feb5-b5a9-4baa-a3f7-d0c9666b9034> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b21feb5-b5a9-4baa-a3f7-d0c9666b9034";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/ab5a4fbd-3a3a-4969-a60b-732c58a6f1e5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b21feb5-b5a9-4baa-a3f7-d0c9666b9034>.
+    
+<http://data.lblod.info/id/remote-data-objects/93e63d35-838c-4494-8951-39a917c32363> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93e63d35-838c-4494-8951-39a917c32363";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/b4e4934d-a923-4aa8-8bc4-fb651d2b0588/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93e63d35-838c-4494-8951-39a917c32363>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f7b7236-0630-4585-928d-ef449fd62176> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f7b7236-0630-4585-928d-ef449fd62176";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/b6320b6b-2655-4725-aeda-05a158855629/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f7b7236-0630-4585-928d-ef449fd62176>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b88e364-1b65-4537-a5da-f055caedad8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b88e364-1b65-4537-a5da-f055caedad8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/bb81f9ad-672c-4a32-8810-8b46310de63e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b88e364-1b65-4537-a5da-f055caedad8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b039dd69-47cc-4221-bdce-14e643e93b7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b039dd69-47cc-4221-bdce-14e643e93b7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/bbf17471-267c-4907-be75-f46a5676c8eb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b039dd69-47cc-4221-bdce-14e643e93b7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4085041c-8928-42e2-88f1-3d8c0c04c462> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4085041c-8928-42e2-88f1-3d8c0c04c462";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/c5b831b5-3199-480a-a625-928ebed4c0a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4085041c-8928-42e2-88f1-3d8c0c04c462>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d2df718-2b90-491c-9d8a-224776174576> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d2df718-2b90-491c-9d8a-224776174576";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/d22df275-d1b8-4197-8db3-b56fd995e90e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d2df718-2b90-491c-9d8a-224776174576>.
+    
+<http://data.lblod.info/id/remote-data-objects/80fd4957-0dfc-43f5-858e-a2b58fa6aa68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80fd4957-0dfc-43f5-858e-a2b58fa6aa68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/d3128e8c-5ca9-4697-b904-3a47f3287f4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80fd4957-0dfc-43f5-858e-a2b58fa6aa68>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca67c855-a822-4434-91b7-e911cdb61726> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca67c855-a822-4434-91b7-e911cdb61726";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/d575e0b5-752c-4f7b-a4ba-f5a1654d4d3b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca67c855-a822-4434-91b7-e911cdb61726>.
+    
+<http://data.lblod.info/id/remote-data-objects/1830be45-250e-4962-b4d1-a855ecdb8c88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1830be45-250e-4962-b4d1-a855ecdb8c88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/d83b8ff8-00ad-447d-908a-86ccbc7a8fe6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1830be45-250e-4962-b4d1-a855ecdb8c88>.
+    
+<http://data.lblod.info/id/remote-data-objects/342ba473-5bb6-4e33-b2c3-5b56c6c05005> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "342ba473-5bb6-4e33-b2c3-5b56c6c05005";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/f73380e0-ad5e-411a-a239-631a0a286ea9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/342ba473-5bb6-4e33-b2c3-5b56c6c05005>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b8feda5-6ccd-49fa-80a9-8110bfd33d49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b8feda5-6ccd-49fa-80a9-8110bfd33d49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/burg/f949fa8b-18b9-45a6-a0bb-99c07e48d80e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b8feda5-6ccd-49fa-80a9-8110bfd33d49>.
+    
+<http://data.lblod.info/id/remote-data-objects/481780ac-64d5-4a31-b306-4170b6f23bf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "481780ac-64d5-4a31-b306-4170b6f23bf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/08af9c7f-69f4-464d-9bbe-d6b66f5ec3c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/481780ac-64d5-4a31-b306-4170b6f23bf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/22fb7b7f-6062-4eb9-90ff-ecc52252df8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22fb7b7f-6062-4eb9-90ff-ecc52252df8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/0e2b0e52-0504-4fa0-8a5f-8f0e93512b44/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22fb7b7f-6062-4eb9-90ff-ecc52252df8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8e700c1-e633-40d9-8739-d454df25ee73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8e700c1-e633-40d9-8739-d454df25ee73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/0e87fdbb-9028-4473-8887-063d2cfc6af6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8e700c1-e633-40d9-8739-d454df25ee73>.
+    
+<http://data.lblod.info/id/remote-data-objects/1911bbd2-ee47-4aa7-9bb4-97820bba6917> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1911bbd2-ee47-4aa7-9bb4-97820bba6917";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/13ff2ef0-62f9-45a5-94c0-86cff003385d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1911bbd2-ee47-4aa7-9bb4-97820bba6917>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba268bfd-ede1-4ae2-90ee-cf8504ec881e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba268bfd-ede1-4ae2-90ee-cf8504ec881e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/184955a6-1bf3-435e-af0f-134476eacf67/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba268bfd-ede1-4ae2-90ee-cf8504ec881e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e62bed6-547e-4139-813f-a095fff14683> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e62bed6-547e-4139-813f-a095fff14683";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/187e0973-ae2c-4b72-a3f5-7f0f4b7d6ee9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e62bed6-547e-4139-813f-a095fff14683>.
+    
+<http://data.lblod.info/id/remote-data-objects/13a4cf2e-975c-4dc5-8ce9-de84a463aae8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13a4cf2e-975c-4dc5-8ce9-de84a463aae8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/194907c2-dcda-479a-90cf-d649e21e4fb1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13a4cf2e-975c-4dc5-8ce9-de84a463aae8>.
+    
+<http://data.lblod.info/id/remote-data-objects/55203b59-e21a-474e-b95d-40fae3357497> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55203b59-e21a-474e-b95d-40fae3357497";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/1b03098f-8b86-4cff-91ce-d12dc221d4fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55203b59-e21a-474e-b95d-40fae3357497>.
+    
+<http://data.lblod.info/id/remote-data-objects/689ed2b8-d732-4be5-9882-9a47812c6183> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "689ed2b8-d732-4be5-9882-9a47812c6183";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/1da79710-a76a-4478-bf60-f3f3e1dab1e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/689ed2b8-d732-4be5-9882-9a47812c6183>.
+    
+<http://data.lblod.info/id/remote-data-objects/512e9be8-94f9-4e0c-b4f3-1f7c74f686fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "512e9be8-94f9-4e0c-b4f3-1f7c74f686fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/1e3621a2-c02a-4d7a-b628-96a561d2eadc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/512e9be8-94f9-4e0c-b4f3-1f7c74f686fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/39d13807-f541-41d2-ae56-db2c9b2aba02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39d13807-f541-41d2-ae56-db2c9b2aba02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/21268541-dc67-4ecf-a539-5f5e0c8512e9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39d13807-f541-41d2-ae56-db2c9b2aba02>.
+    
+<http://data.lblod.info/id/remote-data-objects/163dbd62-425e-4855-b99a-14d3a968d8c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "163dbd62-425e-4855-b99a-14d3a968d8c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/2383d44f-144f-4b3c-b465-a52d51f1bb97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0302ea2-c9b9-4eb9-936a-2ea5bc286bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/163dbd62-425e-4855-b99a-14d3a968d8c8>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201027-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201027-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201027-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201027-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7c5bf076-07f0-433d-b15a-143f79a1c3d0> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7c5bf076-07f0-433d-b15a-143f79a1c3d0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2fcfcfda-cba8-4868-b567-1b14f215115d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/0ff262e6-cb12-4ec7-a2b7-9310015d53ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0ff262e6-cb12-4ec7-a2b7-9310015d53ea";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d>.
+
+  <http://redpencil.data.gift/id/task/9e9947a6-ba58-4bb7-9c2f-09fee7b7d403> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9e9947a6-ba58-4bb7-9c2f-09fee7b7d403";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7c5bf076-07f0-433d-b15a-143f79a1c3d0>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/0ff262e6-cb12-4ec7-a2b7-9310015d53ea>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4be23da1-c7fd-460f-b8a3-a7ad2eec60a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4be23da1-c7fd-460f-b8a3-a7ad2eec60a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/30fab48a-8bbf-4f6b-9319-485a95df1fb2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4be23da1-c7fd-460f-b8a3-a7ad2eec60a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/74f6e4a4-c6e0-4390-8d12-800fe553c561> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74f6e4a4-c6e0-4390-8d12-800fe553c561";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/33118171-f9b1-4ffb-857d-316db5bf101b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74f6e4a4-c6e0-4390-8d12-800fe553c561>.
+    
+<http://data.lblod.info/id/remote-data-objects/93b6ebee-2106-4579-a455-1dbc6c3cc75c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93b6ebee-2106-4579-a455-1dbc6c3cc75c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/33cb363b-db17-4d82-be63-6aeeda2607e4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93b6ebee-2106-4579-a455-1dbc6c3cc75c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8102a43b-9af8-4109-8609-b2160a273f37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8102a43b-9af8-4109-8609-b2160a273f37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/3e847eb7-3863-45f4-9552-20b747fd6f45/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8102a43b-9af8-4109-8609-b2160a273f37>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb632762-7d8b-4a51-a680-9b617dcc13db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb632762-7d8b-4a51-a680-9b617dcc13db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/411ebbfd-0a21-47d6-bdb7-626689c8c7f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb632762-7d8b-4a51-a680-9b617dcc13db>.
+    
+<http://data.lblod.info/id/remote-data-objects/7284d667-9d4e-4688-a5f1-d4c3dc03af24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7284d667-9d4e-4688-a5f1-d4c3dc03af24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/423d876b-e1a8-4abd-a557-000bf60d7ffb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7284d667-9d4e-4688-a5f1-d4c3dc03af24>.
+    
+<http://data.lblod.info/id/remote-data-objects/438d2dec-3878-4b06-89b9-658401566aee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "438d2dec-3878-4b06-89b9-658401566aee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/42507f00-ce45-4d45-9b31-a4f92e5c6fe2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/438d2dec-3878-4b06-89b9-658401566aee>.
+    
+<http://data.lblod.info/id/remote-data-objects/946716db-d0da-4e4b-bad3-8219c0874386> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "946716db-d0da-4e4b-bad3-8219c0874386";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/438544db-b98c-4272-aeb8-333f65f41ede/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/946716db-d0da-4e4b-bad3-8219c0874386>.
+    
+<http://data.lblod.info/id/remote-data-objects/398ca5ab-15a7-4b26-a3a4-1ae4d9fb5ac0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "398ca5ab-15a7-4b26-a3a4-1ae4d9fb5ac0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/46ed9b65-1d92-458e-8813-891b637180fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/398ca5ab-15a7-4b26-a3a4-1ae4d9fb5ac0>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b6fd721-5ef9-4abe-9f32-562e63f04a1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b6fd721-5ef9-4abe-9f32-562e63f04a1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/48e2f6b4-b62b-461f-95e1-ca9e63d78e8c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b6fd721-5ef9-4abe-9f32-562e63f04a1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/af8e6feb-0e25-45fe-b6c2-bb091f5f5b66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af8e6feb-0e25-45fe-b6c2-bb091f5f5b66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/4e1efade-a738-4e83-b238-9056be7686c7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af8e6feb-0e25-45fe-b6c2-bb091f5f5b66>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c01690c-92d3-4d74-aa34-cc0224321425> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c01690c-92d3-4d74-aa34-cc0224321425";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/52d6d2a1-6701-4ada-9bf9-cbd0951b56e2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c01690c-92d3-4d74-aa34-cc0224321425>.
+    
+<http://data.lblod.info/id/remote-data-objects/44e250a9-8cb5-4e02-8ad8-7862c42d4222> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44e250a9-8cb5-4e02-8ad8-7862c42d4222";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/553e668d-427a-46f5-8213-eda1ba6bd083/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44e250a9-8cb5-4e02-8ad8-7862c42d4222>.
+    
+<http://data.lblod.info/id/remote-data-objects/2111dc47-11a7-4f75-9dfc-cf78e7cf8013> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2111dc47-11a7-4f75-9dfc-cf78e7cf8013";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/5a1c462d-b19b-47b5-831b-e3693182c36f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2111dc47-11a7-4f75-9dfc-cf78e7cf8013>.
+    
+<http://data.lblod.info/id/remote-data-objects/f80dbd7b-36d7-42d9-8271-4d9d44e35b94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f80dbd7b-36d7-42d9-8271-4d9d44e35b94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/5d7a3c2c-264b-44c8-9043-a2fcf980386f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f80dbd7b-36d7-42d9-8271-4d9d44e35b94>.
+    
+<http://data.lblod.info/id/remote-data-objects/72299b49-c8c0-4d01-ad1a-fbfc71af6a36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72299b49-c8c0-4d01-ad1a-fbfc71af6a36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/5d87f009-2728-4a69-acce-58d8ab08bc3d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72299b49-c8c0-4d01-ad1a-fbfc71af6a36>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0397d5a-e847-4814-b25b-3572eb783533> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0397d5a-e847-4814-b25b-3572eb783533";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/5e3977c5-c5ef-44e2-acd2-6f9c77b1048f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0397d5a-e847-4814-b25b-3572eb783533>.
+    
+<http://data.lblod.info/id/remote-data-objects/043adb4c-cd06-4599-a722-42bc2ffc2ea4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "043adb4c-cd06-4599-a722-42bc2ffc2ea4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/63326991-2814-490e-947d-63fd49e506d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/043adb4c-cd06-4599-a722-42bc2ffc2ea4>.
+    
+<http://data.lblod.info/id/remote-data-objects/725bf9ed-f03a-4006-ab8d-421595b24708> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "725bf9ed-f03a-4006-ab8d-421595b24708";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/67abb1b0-4a73-4c8d-a51d-25a59f599ecb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/725bf9ed-f03a-4006-ab8d-421595b24708>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccc4e331-328c-4f9d-bde7-7617b2385bb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccc4e331-328c-4f9d-bde7-7617b2385bb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/68744200-2cd3-4a0e-a1a5-2aa263f76100/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccc4e331-328c-4f9d-bde7-7617b2385bb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/176efaa0-8331-4ef4-9704-6317a4d17b41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "176efaa0-8331-4ef4-9704-6317a4d17b41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/733caf98-0ca2-4b57-bb68-57d9ac864829/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/176efaa0-8331-4ef4-9704-6317a4d17b41>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d1cd64b-d6a3-475d-aee0-2e19fc310968> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d1cd64b-d6a3-475d-aee0-2e19fc310968";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/7619b06e-5d07-46f4-9232-435dc443f617/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d1cd64b-d6a3-475d-aee0-2e19fc310968>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bd0817d-90f5-435e-a3a7-ae868b30df70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bd0817d-90f5-435e-a3a7-ae868b30df70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/77b23894-c545-4b5d-885c-81b86df466c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bd0817d-90f5-435e-a3a7-ae868b30df70>.
+    
+<http://data.lblod.info/id/remote-data-objects/e627c564-f5f3-4e16-bbd3-8e8c8aa108f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e627c564-f5f3-4e16-bbd3-8e8c8aa108f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/78dade3a-c441-4aa0-ae85-423f0f47b683/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e627c564-f5f3-4e16-bbd3-8e8c8aa108f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d559914f-3908-4e67-b545-4fef682afb5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d559914f-3908-4e67-b545-4fef682afb5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/7a0e6855-c325-47ef-ab17-31f5f9a97f03/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d559914f-3908-4e67-b545-4fef682afb5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a775ed1-8aa8-47ce-a4e7-137c9d5f3297> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a775ed1-8aa8-47ce-a4e7-137c9d5f3297";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/7ab72048-fb33-4937-8d1c-3f94983b4f9c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a775ed1-8aa8-47ce-a4e7-137c9d5f3297>.
+    
+<http://data.lblod.info/id/remote-data-objects/783af1a2-c498-4761-a75c-1121ac76311f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "783af1a2-c498-4761-a75c-1121ac76311f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/7b1da96b-3e23-425e-ab48-e53328f855a2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/783af1a2-c498-4761-a75c-1121ac76311f>.
+    
+<http://data.lblod.info/id/remote-data-objects/477e0398-b417-4503-94bf-2b6f43adf030> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "477e0398-b417-4503-94bf-2b6f43adf030";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/809d2150-e438-4203-91eb-58958cfb345f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/477e0398-b417-4503-94bf-2b6f43adf030>.
+    
+<http://data.lblod.info/id/remote-data-objects/050ef821-a2f5-42ec-a62b-852eef2f6e4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "050ef821-a2f5-42ec-a62b-852eef2f6e4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/80f878ee-4cba-46d9-b40e-b295cc84e871/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/050ef821-a2f5-42ec-a62b-852eef2f6e4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f234ab77-614c-4a7b-b2c4-d5fa962ec86b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f234ab77-614c-4a7b-b2c4-d5fa962ec86b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/8da63038-883f-4380-866d-39e398f6140a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f234ab77-614c-4a7b-b2c4-d5fa962ec86b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d98a7c7a-e256-4e90-b29d-8f7c143732f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d98a7c7a-e256-4e90-b29d-8f7c143732f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/93a57112-9afc-4a77-bbae-fac44b3faf95/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d98a7c7a-e256-4e90-b29d-8f7c143732f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa7c5875-18d4-4f39-ab56-2cf4fcbc6144> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa7c5875-18d4-4f39-ab56-2cf4fcbc6144";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/976741ee-f994-438c-a4a5-17f97d61fc25/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa7c5875-18d4-4f39-ab56-2cf4fcbc6144>.
+    
+<http://data.lblod.info/id/remote-data-objects/d44f7366-8e02-43f5-9a7a-bed7caecb015> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d44f7366-8e02-43f5-9a7a-bed7caecb015";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/99af00a1-be12-45c7-a4ef-84ee01facb8a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d44f7366-8e02-43f5-9a7a-bed7caecb015>.
+    
+<http://data.lblod.info/id/remote-data-objects/90d90e26-afe2-45d1-aff7-85e9b8adc88d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90d90e26-afe2-45d1-aff7-85e9b8adc88d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/a267f91d-0d14-4ca1-ad6b-b76a9e6c7cca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90d90e26-afe2-45d1-aff7-85e9b8adc88d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e42afb8-c2d5-40e5-af30-087ed2c522a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e42afb8-c2d5-40e5-af30-087ed2c522a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/a57c1bc2-d360-4a5e-9220-c17e4264aa70/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e42afb8-c2d5-40e5-af30-087ed2c522a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbd6b10c-eebc-4a4e-8089-662f2c4e6eaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbd6b10c-eebc-4a4e-8089-662f2c4e6eaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/a76266d8-2038-412a-8fd2-40b16b37f89c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbd6b10c-eebc-4a4e-8089-662f2c4e6eaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/970ff7d1-7387-40ea-9ab0-621c247da9fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "970ff7d1-7387-40ea-9ab0-621c247da9fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/af33a388-ce00-4cc0-b1b3-22396b99bbc3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/970ff7d1-7387-40ea-9ab0-621c247da9fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/06fc5604-b3d8-49b2-8309-0dc7db251892> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06fc5604-b3d8-49b2-8309-0dc7db251892";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/b057e733-7a67-4cc5-9d34-45ba571aa788/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06fc5604-b3d8-49b2-8309-0dc7db251892>.
+    
+<http://data.lblod.info/id/remote-data-objects/0627f7cf-7574-44e0-b2c3-e6cd64f76021> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0627f7cf-7574-44e0-b2c3-e6cd64f76021";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/b5759297-c53f-481a-b48d-e6a9b2069e35/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0627f7cf-7574-44e0-b2c3-e6cd64f76021>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ebf96e4-de39-41b4-862f-80f39b11b0f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ebf96e4-de39-41b4-862f-80f39b11b0f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/c08b1594-d369-4909-8615-3b2aa32cd8bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ebf96e4-de39-41b4-862f-80f39b11b0f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca1bb4c1-03a6-4e58-a9ab-1a4fbdfcefe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca1bb4c1-03a6-4e58-a9ab-1a4fbdfcefe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/c44a5f4d-684d-438f-8ca7-d5b9ac19833c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca1bb4c1-03a6-4e58-a9ab-1a4fbdfcefe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a3a5a08-99ad-41fe-8a88-9926d794d6a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a3a5a08-99ad-41fe-8a88-9926d794d6a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/c61106fc-bacc-4dc9-9705-6970092a3670/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a3a5a08-99ad-41fe-8a88-9926d794d6a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab9ffe32-d2de-4101-ba32-4eaf486ae3a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab9ffe32-d2de-4101-ba32-4eaf486ae3a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/c8d2683d-6608-4e96-b95a-658ecb9400b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab9ffe32-d2de-4101-ba32-4eaf486ae3a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a94b79c-93df-4f56-8be1-fe0fac4ae936> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a94b79c-93df-4f56-8be1-fe0fac4ae936";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/c95ae851-f8a5-4790-8027-ccaa41540fda/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a94b79c-93df-4f56-8be1-fe0fac4ae936>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1098e78-b2fb-4424-a952-74cd7e22e3c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1098e78-b2fb-4424-a952-74cd7e22e3c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/cb851b4a-b606-432a-ab4c-edb144a0a7d9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1098e78-b2fb-4424-a952-74cd7e22e3c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e21977d8-36cc-43b0-b557-85aa07a18dde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e21977d8-36cc-43b0-b557-85aa07a18dde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/ce8b54d0-0ab8-4971-a06d-4b837caa0050/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e21977d8-36cc-43b0-b557-85aa07a18dde>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4d84e68-6a7d-44ad-a1c2-07e566ab5b2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4d84e68-6a7d-44ad-a1c2-07e566ab5b2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/cfbeb8ce-82a4-49f3-9b40-0af424c55518/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4d84e68-6a7d-44ad-a1c2-07e566ab5b2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c03674c-cf4c-4b19-bfaa-b4fd2b665cc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c03674c-cf4c-4b19-bfaa-b4fd2b665cc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/d1379d3c-8ef9-4b96-a99f-4c7882c3b919/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c03674c-cf4c-4b19-bfaa-b4fd2b665cc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/97931ab2-0105-4a12-b097-6aa756c7a5bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97931ab2-0105-4a12-b097-6aa756c7a5bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/d1bd38ed-1c13-452e-b5f1-526f85012051/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97931ab2-0105-4a12-b097-6aa756c7a5bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f764c256-392a-4cf7-80a6-46ccb566fe27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f764c256-392a-4cf7-80a6-46ccb566fe27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/d42db585-5fcd-41fb-9cda-b63bf6fb2cdf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2fcfcfda-cba8-4868-b567-1b14f215115d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f764c256-392a-4cf7-80a6-46ccb566fe27>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201028-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201028-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201028-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201028-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/4011545d-f22e-4c3b-89a2-ba1027cc5f4e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4011545d-f22e-4c3b-89a2-ba1027cc5f4e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "41b9466e-20f5-4da6-a33a-bc7b8ff17677";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9359974b-3eb1-4502-94ba-307115ae3609> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9359974b-3eb1-4502-94ba-307115ae3609";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677>.
+
+  <http://redpencil.data.gift/id/task/9120fb71-7d62-4f9b-a819-db7f5d35cdb9> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9120fb71-7d62-4f9b-a819-db7f5d35cdb9";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/4011545d-f22e-4c3b-89a2-ba1027cc5f4e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9359974b-3eb1-4502-94ba-307115ae3609>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4107586e-7ec1-4a3b-96f7-8664922d9b4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4107586e-7ec1-4a3b-96f7-8664922d9b4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/d613e3e8-6f13-4ed2-951a-5b7e364d66a2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4107586e-7ec1-4a3b-96f7-8664922d9b4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/084ced8b-f597-4964-bcde-e51a46758bf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "084ced8b-f597-4964-bcde-e51a46758bf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/d8bcb102-7634-4343-a06d-81d8f1f34d88/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/084ced8b-f597-4964-bcde-e51a46758bf9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1588a295-7396-4083-b202-8206a7c86c0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1588a295-7396-4083-b202-8206a7c86c0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/dac320fa-4022-4867-bcde-22f66fb15b26/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1588a295-7396-4083-b202-8206a7c86c0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd2f56b6-02ab-41c1-bcbb-9d6c673d8840> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd2f56b6-02ab-41c1-bcbb-9d6c673d8840";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/db93db43-b826-434e-b8cc-bdc51ea6b232/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd2f56b6-02ab-41c1-bcbb-9d6c673d8840>.
+    
+<http://data.lblod.info/id/remote-data-objects/29555f04-ebd1-40d4-b88f-848d0436c08f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29555f04-ebd1-40d4-b88f-848d0436c08f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/dd265a08-d576-42fc-9664-584db2607367/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29555f04-ebd1-40d4-b88f-848d0436c08f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e145ed77-8773-4491-85e0-25fe6f3ea396> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e145ed77-8773-4491-85e0-25fe6f3ea396";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/ddf5bfba-41b8-44d4-a6a6-5fdee1c7a1c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e145ed77-8773-4491-85e0-25fe6f3ea396>.
+    
+<http://data.lblod.info/id/remote-data-objects/61fc2052-1f84-46ea-8bc7-b0f6c4f94eaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61fc2052-1f84-46ea-8bc7-b0f6c4f94eaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/e04b4a8f-fd7f-4754-8764-aaaf9284c582/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61fc2052-1f84-46ea-8bc7-b0f6c4f94eaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/80820839-0644-421e-91c4-f56b51250024> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80820839-0644-421e-91c4-f56b51250024";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/e41c2f4f-6bd3-4589-bed9-2e9be5ad324c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80820839-0644-421e-91c4-f56b51250024>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8ee177d-5715-4760-8ebc-5bfb3a8d0088> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8ee177d-5715-4760-8ebc-5bfb3a8d0088";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/e4ea4c36-36a3-49c1-bbe9-22a7bdb9d10d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8ee177d-5715-4760-8ebc-5bfb3a8d0088>.
+    
+<http://data.lblod.info/id/remote-data-objects/2744f7c2-9d0b-4d6e-b509-9a93adb5591a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2744f7c2-9d0b-4d6e-b509-9a93adb5591a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/ec78a0dd-415c-41bb-bf8e-4edebc07e193/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2744f7c2-9d0b-4d6e-b509-9a93adb5591a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7503c600-9516-4bd1-aa7e-d84f439050a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7503c600-9516-4bd1-aa7e-d84f439050a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/f2a4ffeb-77eb-4da5-b244-e706783024e4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7503c600-9516-4bd1-aa7e-d84f439050a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b800179-44b5-4bb5-9d5f-ee1765aba8c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b800179-44b5-4bb5-9d5f-ee1765aba8c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/f4169232-b6d6-4efb-9c21-6a2080f86fc9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b800179-44b5-4bb5-9d5f-ee1765aba8c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/08a86e18-5629-47a5-af8f-f4d53723bc52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08a86e18-5629-47a5-af8f-f4d53723bc52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/fa2f9d04-985a-44b8-94f8-7ae505bf0de8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08a86e18-5629-47a5-af8f-f4d53723bc52>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3bf2a6b-865c-4991-a31f-c9009f2dee8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3bf2a6b-865c-4991-a31f-c9009f2dee8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/fc3eb67c-245f-4137-a537-d41793058529/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3bf2a6b-865c-4991-a31f-c9009f2dee8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/19c063f6-c0f3-433e-8ff4-b2efc0370994> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19c063f6-c0f3-433e-8ff4-b2efc0370994";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/cbs/ff4c4d03-2166-482d-88bd-df4610979fad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19c063f6-c0f3-433e-8ff4-b2efc0370994>.
+    
+<http://data.lblod.info/id/remote-data-objects/205ea775-67a0-4b90-ac9e-db6da68451ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "205ea775-67a0-4b90-ac9e-db6da68451ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/0793999e-7df0-4501-87ff-1b8cc6476849/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/205ea775-67a0-4b90-ac9e-db6da68451ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/dba25993-b75c-4759-88f2-1306267d4532> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dba25993-b75c-4759-88f2-1306267d4532";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/0793999e-7df0-4501-87ff-1b8cc6476849/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dba25993-b75c-4759-88f2-1306267d4532>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2483868-7100-47dc-a03f-1a396d18f727> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2483868-7100-47dc-a03f-1a396d18f727";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/119696b0-8fd5-495b-a391-e7bfe20c7fc2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2483868-7100-47dc-a03f-1a396d18f727>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bd3836b-c118-4eda-b427-9946d844a815> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bd3836b-c118-4eda-b427-9946d844a815";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/119696b0-8fd5-495b-a391-e7bfe20c7fc2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bd3836b-c118-4eda-b427-9946d844a815>.
+    
+<http://data.lblod.info/id/remote-data-objects/466a885d-43c8-4b16-b6a8-c96f9064b1c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "466a885d-43c8-4b16-b6a8-c96f9064b1c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/1365d009-dd62-493b-8465-174943e4b3d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/466a885d-43c8-4b16-b6a8-c96f9064b1c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcfb41e7-8fe5-4b05-967b-7db750959109> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcfb41e7-8fe5-4b05-967b-7db750959109";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/1365d009-dd62-493b-8465-174943e4b3d1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcfb41e7-8fe5-4b05-967b-7db750959109>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f1a87b8-4da0-49d4-858e-70e19ce09f0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f1a87b8-4da0-49d4-858e-70e19ce09f0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/24ca8ded-f576-4637-b8be-abb9dc61c201/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f1a87b8-4da0-49d4-858e-70e19ce09f0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/02b9e2ce-dce3-4807-a1cc-4464544c6057> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02b9e2ce-dce3-4807-a1cc-4464544c6057";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/24ca8ded-f576-4637-b8be-abb9dc61c201/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02b9e2ce-dce3-4807-a1cc-4464544c6057>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b7545e9-72cd-40d3-bc4e-6973c497d01a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b7545e9-72cd-40d3-bc4e-6973c497d01a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/3116c2d4-7f48-4fde-9c91-8ad48017146b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b7545e9-72cd-40d3-bc4e-6973c497d01a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d23f795-09d4-495b-9bf6-8eedd6b998e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d23f795-09d4-495b-9bf6-8eedd6b998e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/3116c2d4-7f48-4fde-9c91-8ad48017146b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d23f795-09d4-495b-9bf6-8eedd6b998e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0fea897-6407-43ab-8e41-7e2205318300> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0fea897-6407-43ab-8e41-7e2205318300";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/57144191-9d8a-4318-85eb-06577f8b9955/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0fea897-6407-43ab-8e41-7e2205318300>.
+    
+<http://data.lblod.info/id/remote-data-objects/61d00a75-f074-427b-8273-979d39d6ae36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61d00a75-f074-427b-8273-979d39d6ae36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/57144191-9d8a-4318-85eb-06577f8b9955/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61d00a75-f074-427b-8273-979d39d6ae36>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fecc85c-6e0f-4cf1-be8e-36aecc8697ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fecc85c-6e0f-4cf1-be8e-36aecc8697ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/8ee4e8e5-8d2b-4158-a1b2-54b6a2eba7b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fecc85c-6e0f-4cf1-be8e-36aecc8697ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/05cc845e-d0be-4b2e-b305-561723d7a09c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05cc845e-d0be-4b2e-b305-561723d7a09c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/8ee4e8e5-8d2b-4158-a1b2-54b6a2eba7b2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05cc845e-d0be-4b2e-b305-561723d7a09c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0bbdf2a-7dd4-4d60-8424-dad7444c1b69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0bbdf2a-7dd4-4d60-8424-dad7444c1b69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/9073bedf-8a76-4756-bafe-0db792fd8ca5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0bbdf2a-7dd4-4d60-8424-dad7444c1b69>.
+    
+<http://data.lblod.info/id/remote-data-objects/0194e8dc-2327-4e78-8b67-0c9fd8a48c21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0194e8dc-2327-4e78-8b67-0c9fd8a48c21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/9073bedf-8a76-4756-bafe-0db792fd8ca5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0194e8dc-2327-4e78-8b67-0c9fd8a48c21>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6f839fc-f159-409d-9e23-dba5bea29076> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6f839fc-f159-409d-9e23-dba5bea29076";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/93d1e665-8240-4911-92a5-c223cde9d808/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6f839fc-f159-409d-9e23-dba5bea29076>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd0fc28a-a386-414b-b065-74a89e7e1798> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd0fc28a-a386-414b-b065-74a89e7e1798";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/93d1e665-8240-4911-92a5-c223cde9d808/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd0fc28a-a386-414b-b065-74a89e7e1798>.
+    
+<http://data.lblod.info/id/remote-data-objects/871bbd4a-65d1-4a29-a6d6-f8cb6bc02f48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "871bbd4a-65d1-4a29-a6d6-f8cb6bc02f48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/9f5b325d-d1ab-4e26-a38b-01de71a9f327/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/871bbd4a-65d1-4a29-a6d6-f8cb6bc02f48>.
+    
+<http://data.lblod.info/id/remote-data-objects/22a3a8cc-5f22-44e7-9969-28b94128387a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22a3a8cc-5f22-44e7-9969-28b94128387a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/9f5b325d-d1ab-4e26-a38b-01de71a9f327/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22a3a8cc-5f22-44e7-9969-28b94128387a>.
+    
+<http://data.lblod.info/id/remote-data-objects/532f5b45-a207-40c6-9790-f029c44776ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "532f5b45-a207-40c6-9790-f029c44776ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/abde95d8-fec5-48f5-a825-b7ecb02c1eb1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/532f5b45-a207-40c6-9790-f029c44776ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c1d29b8-d3d6-47dd-b839-f221e1506dc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c1d29b8-d3d6-47dd-b839-f221e1506dc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/abde95d8-fec5-48f5-a825-b7ecb02c1eb1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c1d29b8-d3d6-47dd-b839-f221e1506dc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/43d58e37-a1f8-4437-a40b-89ad243757ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43d58e37-a1f8-4437-a40b-89ad243757ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/dd2c3b43-8d7d-42df-83a6-72185892d5cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43d58e37-a1f8-4437-a40b-89ad243757ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/9572b141-af0d-49d2-b240-e1ecc3bf8bb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9572b141-af0d-49d2-b240-e1ecc3bf8bb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/dd2c3b43-8d7d-42df-83a6-72185892d5cd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9572b141-af0d-49d2-b240-e1ecc3bf8bb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3aeaf1d-03c8-4b71-aaec-8e809c615725> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3aeaf1d-03c8-4b71-aaec-8e809c615725";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/e592de2d-428d-4519-964a-1f864220aa5b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3aeaf1d-03c8-4b71-aaec-8e809c615725>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8d53f36-ee3e-46bc-ab67-d20b47be31d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8d53f36-ee3e-46bc-ab67-d20b47be31d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/e592de2d-428d-4519-964a-1f864220aa5b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8d53f36-ee3e-46bc-ab67-d20b47be31d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/567083fd-e18a-4e7a-862a-a579b07238c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "567083fd-e18a-4e7a-862a-a579b07238c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/eab71b31-c296-4e9b-b404-b59891c38186/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/567083fd-e18a-4e7a-862a-a579b07238c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/2067f110-b999-48df-8292-2b5bd39dcd0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2067f110-b999-48df-8292-2b5bd39dcd0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/eab71b31-c296-4e9b-b404-b59891c38186/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2067f110-b999-48df-8292-2b5bd39dcd0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/38277b32-d508-44c7-af32-c6a01f6c6a67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38277b32-d508-44c7-af32-c6a01f6c6a67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/f78b30c6-89d3-489e-bf6b-6289e0bfafba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38277b32-d508-44c7-af32-c6a01f6c6a67>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ebb2240-7801-465c-8e1e-bda06397d12f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ebb2240-7801-465c-8e1e-bda06397d12f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/gr/f78b30c6-89d3-489e-bf6b-6289e0bfafba/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ebb2240-7801-465c-8e1e-bda06397d12f>.
+    
+<http://data.lblod.info/id/remote-data-objects/123aa46d-cb05-49ae-a222-9a36893679a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "123aa46d-cb05-49ae-a222-9a36893679a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/1436f01d-b5aa-42ae-84c3-28ba3e0f3b42/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/123aa46d-cb05-49ae-a222-9a36893679a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b8a8a8b-0d6b-4805-974a-dd7373f82fd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b8a8a8b-0d6b-4805-974a-dd7373f82fd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/1436f01d-b5aa-42ae-84c3-28ba3e0f3b42/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b8a8a8b-0d6b-4805-974a-dd7373f82fd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3854553-897f-4c13-ba5c-7d84c21cd4b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3854553-897f-4c13-ba5c-7d84c21cd4b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/257df18d-c3d5-4ed7-b761-acb31b2d4372/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3854553-897f-4c13-ba5c-7d84c21cd4b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc3560e1-6991-4a6a-99c4-f3e9873ead7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc3560e1-6991-4a6a-99c4-f3e9873ead7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/257df18d-c3d5-4ed7-b761-acb31b2d4372/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc3560e1-6991-4a6a-99c4-f3e9873ead7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/80ef3229-a15a-4eec-82ce-5c9611c624c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80ef3229-a15a-4eec-82ce-5c9611c624c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/38815a1e-fd47-4ba2-877a-d761f59bffbf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41b9466e-20f5-4da6-a33a-bc7b8ff17677> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80ef3229-a15a-4eec-82ce-5c9611c624c0>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201030-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201030-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201030-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201030-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a7d34841-354e-4eea-bc4a-9fcbdc2ee4f0> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a7d34841-354e-4eea-bc4a-9fcbdc2ee4f0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c12c98cc-2add-4af5-990c-3c1d7ce0321c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c269765a-1189-4808-946b-b0548b0a87a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c269765a-1189-4808-946b-b0548b0a87a2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c>.
+
+  <http://redpencil.data.gift/id/task/6a11c47b-8c5c-4fb3-9de0-b327c742be97> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6a11c47b-8c5c-4fb3-9de0-b327c742be97";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a7d34841-354e-4eea-bc4a-9fcbdc2ee4f0>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c269765a-1189-4808-946b-b0548b0a87a2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/1aacf3a6-1544-4094-b394-678c37b24d39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1aacf3a6-1544-4094-b394-678c37b24d39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/38815a1e-fd47-4ba2-877a-d761f59bffbf/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1aacf3a6-1544-4094-b394-678c37b24d39>.
+    
+<http://data.lblod.info/id/remote-data-objects/b49f88f8-6040-4b1c-8564-95cf7c954a3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b49f88f8-6040-4b1c-8564-95cf7c954a3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/3d8ad2fa-6a7c-4984-86c8-04c4683bd1b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b49f88f8-6040-4b1c-8564-95cf7c954a3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8328903b-cd88-4791-a8c5-65270967c3e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8328903b-cd88-4791-a8c5-65270967c3e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/3d8ad2fa-6a7c-4984-86c8-04c4683bd1b7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8328903b-cd88-4791-a8c5-65270967c3e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7760705-c26f-41c8-83e4-1dc83338854a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7760705-c26f-41c8-83e4-1dc83338854a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/6c374077-09b9-4cf6-b3f3-d1db08526644/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7760705-c26f-41c8-83e4-1dc83338854a>.
+    
+<http://data.lblod.info/id/remote-data-objects/13f8e4a0-f58f-4f29-8def-99ff35d5c134> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13f8e4a0-f58f-4f29-8def-99ff35d5c134";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/6c374077-09b9-4cf6-b3f3-d1db08526644/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13f8e4a0-f58f-4f29-8def-99ff35d5c134>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ec524b0-faa2-49fa-a9e5-43659ecd0f80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ec524b0-faa2-49fa-a9e5-43659ecd0f80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/6eba7308-89bf-4010-9984-86727bcfb3c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ec524b0-faa2-49fa-a9e5-43659ecd0f80>.
+    
+<http://data.lblod.info/id/remote-data-objects/08a6c42d-1f31-4cb8-8211-04ae943e7293> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08a6c42d-1f31-4cb8-8211-04ae943e7293";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/6eba7308-89bf-4010-9984-86727bcfb3c1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08a6c42d-1f31-4cb8-8211-04ae943e7293>.
+    
+<http://data.lblod.info/id/remote-data-objects/53aa46c4-35bc-491e-bc09-37d88b8c045a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53aa46c4-35bc-491e-bc09-37d88b8c045a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/9d20808b-b702-42f7-86df-81c1569f01b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53aa46c4-35bc-491e-bc09-37d88b8c045a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5582d7b7-f864-4b56-aea6-5efb17391925> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5582d7b7-f864-4b56-aea6-5efb17391925";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/9d20808b-b702-42f7-86df-81c1569f01b4/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5582d7b7-f864-4b56-aea6-5efb17391925>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bbc34ed-7998-4326-bcc0-0b5b3aa4c3a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bbc34ed-7998-4326-bcc0-0b5b3aa4c3a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/aa10f738-5937-4291-8965-f3ec74aa37f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bbc34ed-7998-4326-bcc0-0b5b3aa4c3a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a20aacb-9424-4166-8f52-d9e1bc55eab8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a20aacb-9424-4166-8f52-d9e1bc55eab8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/aa10f738-5937-4291-8965-f3ec74aa37f1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a20aacb-9424-4166-8f52-d9e1bc55eab8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c45d65e-49d8-4450-8b9d-173e53b2577d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c45d65e-49d8-4450-8b9d-173e53b2577d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/b5469097-0b94-4131-b704-85a1832a9e1f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c45d65e-49d8-4450-8b9d-173e53b2577d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f5da028-8892-44f4-b2d0-87e1dc61e28a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f5da028-8892-44f4-b2d0-87e1dc61e28a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/b5469097-0b94-4131-b704-85a1832a9e1f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f5da028-8892-44f4-b2d0-87e1dc61e28a>.
+    
+<http://data.lblod.info/id/remote-data-objects/06c9207d-5890-4fcf-a66f-62cea770ecb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06c9207d-5890-4fcf-a66f-62cea770ecb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/cd43881a-6090-4c43-9d9f-8f80a2a6167b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06c9207d-5890-4fcf-a66f-62cea770ecb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba116148-f465-4d7d-8e43-26bb5d186782> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba116148-f465-4d7d-8e43-26bb5d186782";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/cd43881a-6090-4c43-9d9f-8f80a2a6167b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba116148-f465-4d7d-8e43-26bb5d186782>.
+    
+<http://data.lblod.info/id/remote-data-objects/31280052-4d23-4093-aa83-7eaf1af00bd4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31280052-4d23-4093-aa83-7eaf1af00bd4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/ce780b8e-1018-40ec-b38d-9b8fdba2e8b1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31280052-4d23-4093-aa83-7eaf1af00bd4>.
+    
+<http://data.lblod.info/id/remote-data-objects/eaaef541-6ad0-47b7-9fa3-72cf5b853127> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eaaef541-6ad0-47b7-9fa3-72cf5b853127";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/ce780b8e-1018-40ec-b38d-9b8fdba2e8b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eaaef541-6ad0-47b7-9fa3-72cf5b853127>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cf525af-f4f9-4a5c-b7ab-61556577fbf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cf525af-f4f9-4a5c-b7ab-61556577fbf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/d7c6c4dc-3f0e-4bc1-a4c5-cc8813d7723e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cf525af-f4f9-4a5c-b7ab-61556577fbf9>.
+    
+<http://data.lblod.info/id/remote-data-objects/937e53c1-ecc4-4e84-8b0f-6652051cce68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "937e53c1-ecc4-4e84-8b0f-6652051cce68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/d7c6c4dc-3f0e-4bc1-a4c5-cc8813d7723e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/937e53c1-ecc4-4e84-8b0f-6652051cce68>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e27fd2a-fc49-478b-b1e2-eb2e23be57ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e27fd2a-fc49-478b-b1e2-eb2e23be57ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/e6a1feda-f66d-482c-bd1e-49794af9b572/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e27fd2a-fc49-478b-b1e2-eb2e23be57ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/0887946a-e40d-4b9e-b636-0cf986306c13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0887946a-e40d-4b9e-b636-0cf986306c13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rmw/e6a1feda-f66d-482c-bd1e-49794af9b572/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0887946a-e40d-4b9e-b636-0cf986306c13>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8f6ac3a-452d-476e-880a-7f72071cc518> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8f6ac3a-452d-476e-880a-7f72071cc518";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rvb/024c319d-cf01-4ec3-9215-9a5626e3699c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8f6ac3a-452d-476e-880a-7f72071cc518>.
+    
+<http://data.lblod.info/id/remote-data-objects/9573e1d4-43da-4f8a-8536-4252ce3dcc34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9573e1d4-43da-4f8a-8536-4252ce3dcc34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rvb/69238ab3-ca23-4bf9-9054-0acfa982f740/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9573e1d4-43da-4f8a-8536-4252ce3dcc34>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ca50bb1-a81a-4770-a7af-b29a48b413d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ca50bb1-a81a-4770-a7af-b29a48b413d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rvb/69baa71c-3d34-4dd4-a7c7-faedcaea7ce7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ca50bb1-a81a-4770-a7af-b29a48b413d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff41254a-22db-4dd6-94ef-13bfa2c68428> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff41254a-22db-4dd6-94ef-13bfa2c68428";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rvb/82d6a6f6-5574-4e2f-b97f-1f6def166c7c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff41254a-22db-4dd6-94ef-13bfa2c68428>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c4fbe76-bfe8-466e-8607-08854ed5c17f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c4fbe76-bfe8-466e-8607-08854ed5c17f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rvb/895ff61e-8ff8-4e86-9d9b-fae30e09d675/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c4fbe76-bfe8-466e-8607-08854ed5c17f>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc804879-6586-4408-8aa1-91696ec92f9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc804879-6586-4408-8aa1-91696ec92f9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/rvb/f12d8eff-4ef8-43a3-835c-64b06d7d602a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc804879-6586-4408-8aa1-91696ec92f9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b40c2638-dc37-41e8-a1e1-618438e6c424> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b40c2638-dc37-41e8-a1e1-618438e6c424";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/0f76c005-6717-4b41-9a7c-a96dd54f0b32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b40c2638-dc37-41e8-a1e1-618438e6c424>.
+    
+<http://data.lblod.info/id/remote-data-objects/3798a35e-2698-4e7c-aecd-639c4d24ead3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3798a35e-2698-4e7c-aecd-639c4d24ead3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/12de697d-64de-4d6c-9388-cc340c8d5771/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3798a35e-2698-4e7c-aecd-639c4d24ead3>.
+    
+<http://data.lblod.info/id/remote-data-objects/af162b00-86a8-4ce5-9474-1c56f5874cb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af162b00-86a8-4ce5-9474-1c56f5874cb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/155c4604-f7cf-4c3c-afa7-799151528974/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af162b00-86a8-4ce5-9474-1c56f5874cb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c704e68-3394-4bd9-9b58-f8010ca8c867> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c704e68-3394-4bd9-9b58-f8010ca8c867";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/15ed6af1-6461-4b84-a970-0d83c0662816/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c704e68-3394-4bd9-9b58-f8010ca8c867>.
+    
+<http://data.lblod.info/id/remote-data-objects/98f998b1-6bcd-4403-a7b9-84fe1e54512c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98f998b1-6bcd-4403-a7b9-84fe1e54512c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/16423955-de34-4aa2-9a5a-6631e4086620/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98f998b1-6bcd-4403-a7b9-84fe1e54512c>.
+    
+<http://data.lblod.info/id/remote-data-objects/93ee9ae6-2a9f-4f7a-bf46-5e2d18a8940f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93ee9ae6-2a9f-4f7a-bf46-5e2d18a8940f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/1650227f-6d04-43d4-af91-993893027602/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93ee9ae6-2a9f-4f7a-bf46-5e2d18a8940f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7f96efb-204a-4851-8ce7-235e3c5428be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7f96efb-204a-4851-8ce7-235e3c5428be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/1c4f40f1-b825-4a55-971b-1789f1c42937/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7f96efb-204a-4851-8ce7-235e3c5428be>.
+    
+<http://data.lblod.info/id/remote-data-objects/053b061e-b669-4105-b45c-8e80650a61dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "053b061e-b669-4105-b45c-8e80650a61dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/1e194f2c-d90e-46de-9b60-dfd7a75e683e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/053b061e-b669-4105-b45c-8e80650a61dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/67da6a63-b689-4986-a607-c767a633f5f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67da6a63-b689-4986-a607-c767a633f5f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/1e96934a-6383-4022-b35c-eda3926e2fd6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67da6a63-b689-4986-a607-c767a633f5f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/85ea8c21-4608-4659-b091-d9306de05db9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85ea8c21-4608-4659-b091-d9306de05db9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/21883863-0193-4bc5-9d4b-230758a7386d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85ea8c21-4608-4659-b091-d9306de05db9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5138f46e-ae9f-4990-9cd8-bb72fc6f94ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5138f46e-ae9f-4990-9cd8-bb72fc6f94ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/24e828c9-511d-40fc-9dcc-3dec07d4d68f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5138f46e-ae9f-4990-9cd8-bb72fc6f94ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/994bb842-6907-40a4-8672-4dd5d6fccce3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "994bb842-6907-40a4-8672-4dd5d6fccce3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/256d749f-a9cc-4d07-9607-d013e9ae3d4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/994bb842-6907-40a4-8672-4dd5d6fccce3>.
+    
+<http://data.lblod.info/id/remote-data-objects/882e91ea-7545-4fb5-8af7-d2fb3a44402f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "882e91ea-7545-4fb5-8af7-d2fb3a44402f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/28795412-7ef3-4a0c-814a-14ec8755e4b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/882e91ea-7545-4fb5-8af7-d2fb3a44402f>.
+    
+<http://data.lblod.info/id/remote-data-objects/983ff550-94fb-49f3-b85b-3fb8f59f4f73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "983ff550-94fb-49f3-b85b-3fb8f59f4f73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/28e704c1-a9d8-471a-9222-8d1b6ea5663f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/983ff550-94fb-49f3-b85b-3fb8f59f4f73>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d339c0a-814a-4178-88ab-bae8ad2602c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d339c0a-814a-4178-88ab-bae8ad2602c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/29f3134e-cde3-4738-a1ec-85a03784f7d9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d339c0a-814a-4178-88ab-bae8ad2602c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d24cd69e-92f0-4307-b32b-071e8b2875ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d24cd69e-92f0-4307-b32b-071e8b2875ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/2e3d462f-db3f-433f-a53e-8a8d035c9dce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d24cd69e-92f0-4307-b32b-071e8b2875ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/63083956-a4bc-410e-a953-858171edad6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63083956-a4bc-410e-a953-858171edad6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/2e7df3cf-3176-47a1-a68f-6112d34bc76f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63083956-a4bc-410e-a953-858171edad6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2777a6c-295c-4a45-82da-17a3d2682429> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2777a6c-295c-4a45-82da-17a3d2682429";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/317dfed6-a41d-4f36-962a-44590eb14a88/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2777a6c-295c-4a45-82da-17a3d2682429>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f77740a-a275-4931-a986-4a2a801dfc16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f77740a-a275-4931-a986-4a2a801dfc16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/32b5e8b8-baf1-4150-9300-65d432e8853a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f77740a-a275-4931-a986-4a2a801dfc16>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0ed8e2c-0e3a-4ec9-8e14-a5fa30622ad4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0ed8e2c-0e3a-4ec9-8e14-a5fa30622ad4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/344229f3-2e9b-4011-a651-09ba2bfebee5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0ed8e2c-0e3a-4ec9-8e14-a5fa30622ad4>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcb812b9-f25a-4d91-b864-366d9a366047> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcb812b9-f25a-4d91-b864-366d9a366047";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/346ba5ec-7b22-49b9-81e0-c6ec8e3f0193/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcb812b9-f25a-4d91-b864-366d9a366047>.
+    
+<http://data.lblod.info/id/remote-data-objects/72f03bdb-ad63-48c4-9dfa-642b396a453f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72f03bdb-ad63-48c4-9dfa-642b396a453f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/3538dcc2-cbc7-425b-b9fa-1a47f98ac9f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72f03bdb-ad63-48c4-9dfa-642b396a453f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9bde2c05-292d-48ec-9e1d-c8ba56981f75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9bde2c05-292d-48ec-9e1d-c8ba56981f75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/38787c96-bbba-4559-a604-26c87e2cd981/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c12c98cc-2add-4af5-990c-3c1d7ce0321c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9bde2c05-292d-48ec-9e1d-c8ba56981f75>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201031-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201031-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201031-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201031-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/547e8706-0aa2-4d14-a738-5bf63ed5b7ee> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "547e8706-0aa2-4d14-a738-5bf63ed5b7ee";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "38551991-e053-408a-a065-f296b6ab9fa4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d589fd7e-a6ae-4821-b00c-19f9d404a8eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d589fd7e-a6ae-4821-b00c-19f9d404a8eb";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4>.
+
+  <http://redpencil.data.gift/id/task/03c6b932-c01f-49f4-9ba5-89091b2d562c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "03c6b932-c01f-49f4-9ba5-89091b2d562c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/547e8706-0aa2-4d14-a738-5bf63ed5b7ee>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d589fd7e-a6ae-4821-b00c-19f9d404a8eb>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/6b6e8da2-cb8a-4965-ab34-c44b27dd1a1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b6e8da2-cb8a-4965-ab34-c44b27dd1a1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/3c207965-2cfd-4988-b088-1019c17605e6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b6e8da2-cb8a-4965-ab34-c44b27dd1a1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c1b3b12-8032-49c2-a229-cf368d4c49de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c1b3b12-8032-49c2-a229-cf368d4c49de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/46d2ddf6-631b-414f-a97f-74d8851c1cab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c1b3b12-8032-49c2-a229-cf368d4c49de>.
+    
+<http://data.lblod.info/id/remote-data-objects/230cef68-562c-49df-851b-5f43adb06808> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "230cef68-562c-49df-851b-5f43adb06808";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/4769a40d-9cef-4445-beef-60aaf8f9b219/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/230cef68-562c-49df-851b-5f43adb06808>.
+    
+<http://data.lblod.info/id/remote-data-objects/e568e40c-bc92-46ff-8aa3-2eae115f8265> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e568e40c-bc92-46ff-8aa3-2eae115f8265";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/483d54f8-1cfb-49b4-99a4-fbb55773bd2a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e568e40c-bc92-46ff-8aa3-2eae115f8265>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d5399f8-1bfe-4afa-8539-40d9ffe0ec4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d5399f8-1bfe-4afa-8539-40d9ffe0ec4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/4d416bae-4f47-4e5c-95d7-2332f02ce4d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d5399f8-1bfe-4afa-8539-40d9ffe0ec4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9083e7f0-46bb-4633-ac88-130ad41465ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9083e7f0-46bb-4633-ac88-130ad41465ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/51d443da-e1be-4501-8744-6d3bdbbe6374/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9083e7f0-46bb-4633-ac88-130ad41465ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f1b236f-6bcd-4fd7-8dd2-116b58795f89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f1b236f-6bcd-4fd7-8dd2-116b58795f89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/537b1d4b-aeec-4807-9c55-602581c6e29e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f1b236f-6bcd-4fd7-8dd2-116b58795f89>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a1a8a53-ff2f-4ae1-b788-2964dab28c09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a1a8a53-ff2f-4ae1-b788-2964dab28c09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/579ab832-8abb-4fb9-b21d-6d68e6385334/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a1a8a53-ff2f-4ae1-b788-2964dab28c09>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fb5b77e-1d85-4afb-a395-0958a4321b0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fb5b77e-1d85-4afb-a395-0958a4321b0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/5d7f392e-31ff-4cee-8376-4abefc7d08b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fb5b77e-1d85-4afb-a395-0958a4321b0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4b98273-f960-49c3-958b-9d8dbbfb3e1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4b98273-f960-49c3-958b-9d8dbbfb3e1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/5e084856-81d4-4b19-9abb-ee77b5168eeb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4b98273-f960-49c3-958b-9d8dbbfb3e1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3523d9ce-8db1-4b7c-abdb-43c5eebb8623> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3523d9ce-8db1-4b7c-abdb-43c5eebb8623";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/5fa19427-39cd-48f5-beb1-89ef64eac596/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3523d9ce-8db1-4b7c-abdb-43c5eebb8623>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ad21f4a-a305-412f-a5fc-6e3a3adead41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ad21f4a-a305-412f-a5fc-6e3a3adead41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/6529adc9-eade-4b88-b5e2-1c5057d78374/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ad21f4a-a305-412f-a5fc-6e3a3adead41>.
+    
+<http://data.lblod.info/id/remote-data-objects/48425778-1eed-47d2-95a6-b2a1c7d674ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48425778-1eed-47d2-95a6-b2a1c7d674ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/6ed0e7b4-3b79-4dba-acc7-6fa419427eca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48425778-1eed-47d2-95a6-b2a1c7d674ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/860bed06-446b-4e3a-bf98-09465a82fb5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "860bed06-446b-4e3a-bf98-09465a82fb5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/822705fb-66d0-4835-a93b-905010d45f85/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/860bed06-446b-4e3a-bf98-09465a82fb5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/02dd3c1b-337b-4d79-a831-514a288f30eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02dd3c1b-337b-4d79-a831-514a288f30eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/89bb3366-0686-4233-968b-4ba4a0d03e03/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02dd3c1b-337b-4d79-a831-514a288f30eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/f93d2150-6fc7-4190-b279-0eb27fd16413> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f93d2150-6fc7-4190-b279-0eb27fd16413";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/8bbd9552-03d6-4151-9c92-03b35f3e9ccb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f93d2150-6fc7-4190-b279-0eb27fd16413>.
+    
+<http://data.lblod.info/id/remote-data-objects/3087f95d-1664-4e05-8d89-8db41a178261> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3087f95d-1664-4e05-8d89-8db41a178261";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/8d8690fc-9130-46b2-bc98-b1b3056a51a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3087f95d-1664-4e05-8d89-8db41a178261>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2dc486b-5e79-4858-947e-ba37df2b09aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2dc486b-5e79-4858-947e-ba37df2b09aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/94cc9012-0852-4438-8a7a-7ac03c06e34f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2dc486b-5e79-4858-947e-ba37df2b09aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/e356df67-20a1-4716-9250-89b940e6ad76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e356df67-20a1-4716-9250-89b940e6ad76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/99136419-2390-4a48-80ce-e6fbeb2ed67d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e356df67-20a1-4716-9250-89b940e6ad76>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f80d415-d9bc-4058-bcde-8b1ea14ad401> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f80d415-d9bc-4058-bcde-8b1ea14ad401";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/99666965-b461-49f1-9920-3c3fda59eb7d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f80d415-d9bc-4058-bcde-8b1ea14ad401>.
+    
+<http://data.lblod.info/id/remote-data-objects/60f05bf6-13d9-4e1f-83d3-d5db8787b384> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60f05bf6-13d9-4e1f-83d3-d5db8787b384";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/9aa8a7c8-ebb5-4287-8fe3-b4d4db735415/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60f05bf6-13d9-4e1f-83d3-d5db8787b384>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea6b9165-7446-47c5-9e9e-a32117919fbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea6b9165-7446-47c5-9e9e-a32117919fbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/a0c63c1d-00c7-4263-b791-0144c7007500/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea6b9165-7446-47c5-9e9e-a32117919fbb>.
+    
+<http://data.lblod.info/id/remote-data-objects/708bce2c-1a53-4fff-a193-fbb661876379> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "708bce2c-1a53-4fff-a193-fbb661876379";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/a2432fd0-620e-4a33-9670-dc8cc982e11b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/708bce2c-1a53-4fff-a193-fbb661876379>.
+    
+<http://data.lblod.info/id/remote-data-objects/802052e9-e318-4dd3-8dce-7f5c7d52a688> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "802052e9-e318-4dd3-8dce-7f5c7d52a688";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/a286d608-8e07-4123-a71e-432c34e394b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/802052e9-e318-4dd3-8dce-7f5c7d52a688>.
+    
+<http://data.lblod.info/id/remote-data-objects/3faf7b82-f8cd-460e-98d4-3505509a552f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3faf7b82-f8cd-460e-98d4-3505509a552f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/a5a9db35-e27a-4fea-ac51-70b4fe847132/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3faf7b82-f8cd-460e-98d4-3505509a552f>.
+    
+<http://data.lblod.info/id/remote-data-objects/161919eb-c302-48dd-8dfe-38169fc0be67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "161919eb-c302-48dd-8dfe-38169fc0be67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/a8af576f-23f3-4564-9132-3a98880e6d54/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/161919eb-c302-48dd-8dfe-38169fc0be67>.
+    
+<http://data.lblod.info/id/remote-data-objects/83485f1d-29d3-4a19-8b3d-e7892791b061> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83485f1d-29d3-4a19-8b3d-e7892791b061";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/a977d767-f50a-4bbb-a7db-ec32a251ec23/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83485f1d-29d3-4a19-8b3d-e7892791b061>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fcbf3fd-3b78-47ff-ae25-62d4c03f30e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fcbf3fd-3b78-47ff-ae25-62d4c03f30e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/af440d4a-8f63-4db0-82a5-5b6e4886424f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fcbf3fd-3b78-47ff-ae25-62d4c03f30e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8ba0767-b695-4395-ac20-aea7e184964d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8ba0767-b695-4395-ac20-aea7e184964d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/b044f0e5-2e70-4d5d-b3d3-d49af975a703/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8ba0767-b695-4395-ac20-aea7e184964d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9afa5a6-40c8-4b2e-bc70-0a5f8161af8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9afa5a6-40c8-4b2e-bc70-0a5f8161af8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/b1335b3e-7ed3-4f17-88fe-2e9c053658c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9afa5a6-40c8-4b2e-bc70-0a5f8161af8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d44a4039-9d40-434c-b5e0-677003626d8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d44a4039-9d40-434c-b5e0-677003626d8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/be3850a6-d5a9-45b3-9668-e17967551b01/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d44a4039-9d40-434c-b5e0-677003626d8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea55e7fe-f697-4656-a5c7-a8df1d085a3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea55e7fe-f697-4656-a5c7-a8df1d085a3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/c22eea90-25c9-48eb-81d3-c5e8b37fbc0d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea55e7fe-f697-4656-a5c7-a8df1d085a3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d2a2b95-5717-495e-afb5-fc1c56c26639> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d2a2b95-5717-495e-afb5-fc1c56c26639";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/cdc1fe6e-ac2d-41aa-afb9-296e3a815580/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d2a2b95-5717-495e-afb5-fc1c56c26639>.
+    
+<http://data.lblod.info/id/remote-data-objects/9eb19a8e-c940-4f53-a6d6-aabc9a5bf935> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9eb19a8e-c940-4f53-a6d6-aabc9a5bf935";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/d237995b-3c84-44e8-bebd-4600ccafc7de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9eb19a8e-c940-4f53-a6d6-aabc9a5bf935>.
+    
+<http://data.lblod.info/id/remote-data-objects/a26b65f5-7814-4d03-8f62-4c75a1151ec7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a26b65f5-7814-4d03-8f62-4c75a1151ec7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/d62f72a5-7087-4678-bbb6-a7308cd4d96e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a26b65f5-7814-4d03-8f62-4c75a1151ec7>.
+    
+<http://data.lblod.info/id/remote-data-objects/de873623-c9e6-4d33-ba21-5dfc756e57da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de873623-c9e6-4d33-ba21-5dfc756e57da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/dc3a09f5-7b98-462e-991a-7a2b5391a2e9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de873623-c9e6-4d33-ba21-5dfc756e57da>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1d3c45c-ad36-475a-af8e-030fb3ab12ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1d3c45c-ad36-475a-af8e-030fb3ab12ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/deb03492-af6e-4e4f-ac79-2ee897b9c2e2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1d3c45c-ad36-475a-af8e-030fb3ab12ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ec46093-1ce4-4d53-823f-0e13019a6768> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ec46093-1ce4-4d53-823f-0e13019a6768";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/e0f3eb33-0d29-4a89-98d7-2082ab8752b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ec46093-1ce4-4d53-823f-0e13019a6768>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f869294-bc5f-4339-842a-b74d3f6c1cc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f869294-bc5f-4339-842a-b74d3f6c1cc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/e20f2c24-e5bd-4502-9d84-8592ed1d20ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f869294-bc5f-4339-842a-b74d3f6c1cc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7809ee4b-8e1d-4f96-be54-54da991d12ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7809ee4b-8e1d-4f96-be54-54da991d12ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/e49dcd48-84a2-4f33-88fc-02abb24205b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7809ee4b-8e1d-4f96-be54-54da991d12ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/5410e7a2-7225-4d15-bb76-853c15ffc59f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5410e7a2-7225-4d15-bb76-853c15ffc59f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/e7701e1a-029c-41b7-9b8d-366c2f7c7a6c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5410e7a2-7225-4d15-bb76-853c15ffc59f>.
+    
+<http://data.lblod.info/id/remote-data-objects/88863c68-566a-4007-a689-5aaf50c3c564> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88863c68-566a-4007-a689-5aaf50c3c564";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/e8e051a6-baac-47e5-9d2c-6ab0cab4414d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88863c68-566a-4007-a689-5aaf50c3c564>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcdb30ec-dead-4c48-b846-15792d2a5352> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcdb30ec-dead-4c48-b846-15792d2a5352";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/e9db7d09-fddd-4696-9835-0c248c2d95ed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcdb30ec-dead-4c48-b846-15792d2a5352>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebf8b118-f40d-4be1-b009-e21b81f751e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebf8b118-f40d-4be1-b009-e21b81f751e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/f07177b1-5897-4921-bda2-c772d252bbf0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebf8b118-f40d-4be1-b009-e21b81f751e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb093177-2554-42dc-bef5-17af349d0e6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb093177-2554-42dc-bef5-17af349d0e6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/f675b001-c0e8-4e7b-b45b-67f10b223a36/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb093177-2554-42dc-bef5-17af349d0e6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/61e026a9-0f38-4afd-97b9-ad0af5977302> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61e026a9-0f38-4afd-97b9-ad0af5977302";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/f8ec46c7-be00-4d68-b97e-c3ca2deb0238/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61e026a9-0f38-4afd-97b9-ad0af5977302>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6e94536-1f9b-49c1-bf54-487c2a640ea3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6e94536-1f9b-49c1-bf54-487c2a640ea3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://begijnendijk.meetingburger.net/vabu/f9d34709-e566-4143-9de0-397e17236850/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6e94536-1f9b-49c1-bf54-487c2a640ea3>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd883a21-6f93-4749-b957-f30abfb795b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd883a21-6f93-4749-b957-f30abfb795b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/0d5772ce-9955-4b8c-857d-e5aea15e57a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd883a21-6f93-4749-b957-f30abfb795b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e591deff-0711-4c40-acd8-730fb099b9e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e591deff-0711-4c40-acd8-730fb099b9e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/11acfe4e-504a-4495-83b2-ecf2a5af3e45/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e591deff-0711-4c40-acd8-730fb099b9e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/182eba8c-d79f-45be-8d76-460d50ced089> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "182eba8c-d79f-45be-8d76-460d50ced089";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/14eafda4-1330-4b9e-8722-52990b9f7bce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38551991-e053-408a-a065-f296b6ab9fa4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/182eba8c-d79f-45be-8d76-460d50ced089>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201032-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201032-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201032-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201032-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f1e5283e-7f76-43c6-af7f-bf1bb273a17c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f1e5283e-7f76-43c6-af7f-bf1bb273a17c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "346e96bb-e5e3-4f97-8048-be3f6966bad8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/2378788e-242b-4ba5-a7a6-c0631f1143d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2378788e-242b-4ba5-a7a6-c0631f1143d2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8>.
+
+  <http://redpencil.data.gift/id/task/3dbd25cd-ce78-449d-b812-e82d4633a8e6> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3dbd25cd-ce78-449d-b812-e82d4633a8e6";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f1e5283e-7f76-43c6-af7f-bf1bb273a17c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/2378788e-242b-4ba5-a7a6-c0631f1143d2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/9790d290-5ef9-4b64-a4ae-213cf34d6c79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9790d290-5ef9-4b64-a4ae-213cf34d6c79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/171ce3ff-89bc-420d-aaad-19977c88cae8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9790d290-5ef9-4b64-a4ae-213cf34d6c79>.
+    
+<http://data.lblod.info/id/remote-data-objects/b766928c-d401-4372-a626-712abf2529ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b766928c-d401-4372-a626-712abf2529ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/1c071897-191b-4f91-bc07-f4606a7ad37c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b766928c-d401-4372-a626-712abf2529ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e02e7ce-53a4-46b5-b91a-cba39d799848> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e02e7ce-53a4-46b5-b91a-cba39d799848";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/2d49404b-292a-41ed-9231-32a2c984710b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e02e7ce-53a4-46b5-b91a-cba39d799848>.
+    
+<http://data.lblod.info/id/remote-data-objects/57f7d3f2-13ad-4fed-8cdf-2c7487bab310> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57f7d3f2-13ad-4fed-8cdf-2c7487bab310";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/41dc466a-1e7f-44c2-8798-3e83232955f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57f7d3f2-13ad-4fed-8cdf-2c7487bab310>.
+    
+<http://data.lblod.info/id/remote-data-objects/e90d923e-b08c-4e78-932a-0e618cd0b2f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e90d923e-b08c-4e78-932a-0e618cd0b2f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/46221543-6e4e-4a72-8a79-16d58f40b3ca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e90d923e-b08c-4e78-932a-0e618cd0b2f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/61d75462-2768-4318-aaaf-3c1b83478d44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61d75462-2768-4318-aaaf-3c1b83478d44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/479bb0ca-7e6f-4a80-a3d2-20db13c4ba05/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61d75462-2768-4318-aaaf-3c1b83478d44>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3aef474-d31f-4bc5-b3da-f77a37450fa8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3aef474-d31f-4bc5-b3da-f77a37450fa8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/4a0fcbd5-6020-4166-bec0-e218890b64c2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3aef474-d31f-4bc5-b3da-f77a37450fa8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1883e764-2444-4acb-b7fd-3132c89c9eae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1883e764-2444-4acb-b7fd-3132c89c9eae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/4ca07dbd-3025-49c4-95a3-405522c3cd0d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1883e764-2444-4acb-b7fd-3132c89c9eae>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc6a60a8-19fd-4bab-8eda-14c91721fb69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc6a60a8-19fd-4bab-8eda-14c91721fb69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/4ca768fc-c126-4b3d-aa7c-2930c9462d01/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc6a60a8-19fd-4bab-8eda-14c91721fb69>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1933623-f626-4e55-b44c-85a524472f80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1933623-f626-4e55-b44c-85a524472f80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/4db64183-8885-4b17-93f4-bd5e565d2662/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1933623-f626-4e55-b44c-85a524472f80>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa3b5267-3c40-4070-a5b9-f4af6e7ba057> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa3b5267-3c40-4070-a5b9-f4af6e7ba057";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/5b9488a3-85c8-4a0f-be0b-29b80ceff025/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa3b5267-3c40-4070-a5b9-f4af6e7ba057>.
+    
+<http://data.lblod.info/id/remote-data-objects/11fa43b2-46fd-43e9-aecd-83b6fddd3d93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11fa43b2-46fd-43e9-aecd-83b6fddd3d93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/5c9d5b9d-fae9-479b-a63d-2a2dc801c00e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11fa43b2-46fd-43e9-aecd-83b6fddd3d93>.
+    
+<http://data.lblod.info/id/remote-data-objects/b56d07cd-7412-4534-9a73-9716370e61e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b56d07cd-7412-4534-9a73-9716370e61e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/64b647b4-52d2-4ce7-8d6a-d3b76e9cbc20/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b56d07cd-7412-4534-9a73-9716370e61e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/12ca3a68-cd61-42f3-b5a0-bca60792a5f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12ca3a68-cd61-42f3-b5a0-bca60792a5f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/6afae1ff-39f5-4f9f-82e6-3db13b6a1b10/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12ca3a68-cd61-42f3-b5a0-bca60792a5f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a15307b-dba3-40a7-b8a3-e998b8f58891> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a15307b-dba3-40a7-b8a3-e998b8f58891";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/6b793087-cb12-465a-be21-a2fabf888873/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a15307b-dba3-40a7-b8a3-e998b8f58891>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c093854-03bb-49df-9bb3-9b9c4fc7aaf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c093854-03bb-49df-9bb3-9b9c4fc7aaf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/6bc02433-64f6-4a3f-bc7c-265c7a77e99c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c093854-03bb-49df-9bb3-9b9c4fc7aaf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cf978e1-e3b2-4301-b019-3af8e6f281a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cf978e1-e3b2-4301-b019-3af8e6f281a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/6e79a007-8259-4a11-9e35-7e3fb04be282/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cf978e1-e3b2-4301-b019-3af8e6f281a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d17e8b85-4387-452d-8fae-feebfd03c536> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d17e8b85-4387-452d-8fae-feebfd03c536";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/760b6340-cfdc-44f9-b902-0e3e9b878f8a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d17e8b85-4387-452d-8fae-feebfd03c536>.
+    
+<http://data.lblod.info/id/remote-data-objects/204a34c0-7cb7-478f-a72c-0b0b9b62408a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "204a34c0-7cb7-478f-a72c-0b0b9b62408a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/77569dc9-0b9f-4133-811a-48f163cf5c4a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/204a34c0-7cb7-478f-a72c-0b0b9b62408a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bd1b584-9c16-471c-9a57-3725857da52c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bd1b584-9c16-471c-9a57-3725857da52c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/7a0fe3ca-0238-4652-91b7-e4a9137282a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bd1b584-9c16-471c-9a57-3725857da52c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5de93da2-8bb5-45cb-bc7d-8f9e21afa9e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5de93da2-8bb5-45cb-bc7d-8f9e21afa9e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/811caad2-6cd8-47bc-b6d7-27fb02decc81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5de93da2-8bb5-45cb-bc7d-8f9e21afa9e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e214b23-a143-4b7d-bbd8-5c7049dcf0d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e214b23-a143-4b7d-bbd8-5c7049dcf0d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/9243967f-7688-4125-bf39-61efc58bc2b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e214b23-a143-4b7d-bbd8-5c7049dcf0d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/073b2e7b-95a9-4374-8fec-cfec3418ad6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "073b2e7b-95a9-4374-8fec-cfec3418ad6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/962b30d0-8d88-41cb-8d73-68491e607b52/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/073b2e7b-95a9-4374-8fec-cfec3418ad6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/35705593-cac3-42c3-81d6-542be4068b98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35705593-cac3-42c3-81d6-542be4068b98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/a4af974d-08c9-4930-94ea-4b90f3b144cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35705593-cac3-42c3-81d6-542be4068b98>.
+    
+<http://data.lblod.info/id/remote-data-objects/6db31b52-3567-4f6f-b4e9-3496e209be4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6db31b52-3567-4f6f-b4e9-3496e209be4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/a621d59a-5246-443f-9fb8-b73c6d386230/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6db31b52-3567-4f6f-b4e9-3496e209be4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/18181176-54d5-4f0c-a85f-5d2e72bf0bd4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18181176-54d5-4f0c-a85f-5d2e72bf0bd4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/a86763ae-9a92-4d42-9493-68361cf87377/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18181176-54d5-4f0c-a85f-5d2e72bf0bd4>.
+    
+<http://data.lblod.info/id/remote-data-objects/29df78a5-096c-4932-8cd0-879d01a8175e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29df78a5-096c-4932-8cd0-879d01a8175e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/b4972717-a4b0-4a1d-bdbc-f1065c65d61b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29df78a5-096c-4932-8cd0-879d01a8175e>.
+    
+<http://data.lblod.info/id/remote-data-objects/98a7466c-d848-4ee9-b0f1-495209483344> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98a7466c-d848-4ee9-b0f1-495209483344";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/b524ffde-99d9-4b0d-8777-8d706751fc4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98a7466c-d848-4ee9-b0f1-495209483344>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d4e860c-edd2-4aea-a845-2534b1458318> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d4e860c-edd2-4aea-a845-2534b1458318";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/b84a3dcf-3145-4e23-84e5-94a0c814050e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d4e860c-edd2-4aea-a845-2534b1458318>.
+    
+<http://data.lblod.info/id/remote-data-objects/5dd1af32-39e9-4271-85d3-e3f05b2d80ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5dd1af32-39e9-4271-85d3-e3f05b2d80ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/b9c926f2-13eb-4461-ac98-7350d681e831/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5dd1af32-39e9-4271-85d3-e3f05b2d80ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e57222a-275f-4ece-92e0-13e6beb9f706> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e57222a-275f-4ece-92e0-13e6beb9f706";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/baeb8800-67f1-4b02-9b4c-0a1ec76935f5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e57222a-275f-4ece-92e0-13e6beb9f706>.
+    
+<http://data.lblod.info/id/remote-data-objects/7257f0ac-185d-42aa-a22c-c04c8e9b6cb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7257f0ac-185d-42aa-a22c-c04c8e9b6cb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/bcd6411b-d0ea-451d-8c24-80550e528be8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7257f0ac-185d-42aa-a22c-c04c8e9b6cb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/69438e97-4bfb-47e4-9b80-0d60e887fda0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69438e97-4bfb-47e4-9b80-0d60e887fda0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/c5ff6f7c-7cfb-44f1-b960-1c0fe27ac24e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69438e97-4bfb-47e4-9b80-0d60e887fda0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3978814-10ff-428f-b042-ff588003b9c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3978814-10ff-428f-b042-ff588003b9c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/cad9beb5-4c76-4f8e-8a4c-5622d40765d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3978814-10ff-428f-b042-ff588003b9c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b824151-ef11-45e3-98de-e3bd35621cc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b824151-ef11-45e3-98de-e3bd35621cc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/ce0c31d4-5201-495e-9d52-920de4463acd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b824151-ef11-45e3-98de-e3bd35621cc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca14767d-3b3c-4629-9cc9-8f1dd1337270> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca14767d-3b3c-4629-9cc9-8f1dd1337270";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/d11f8499-75be-46c2-a7de-ba1f01faf71f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca14767d-3b3c-4629-9cc9-8f1dd1337270>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f4f37e8-e15a-40fe-910c-7fb1aae48843> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f4f37e8-e15a-40fe-910c-7fb1aae48843";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/d3dbc8b0-5ddc-483d-841e-e99b5a134f72/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f4f37e8-e15a-40fe-910c-7fb1aae48843>.
+    
+<http://data.lblod.info/id/remote-data-objects/385c9b07-4e90-49ec-8f8c-7369bbda47b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "385c9b07-4e90-49ec-8f8c-7369bbda47b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/e13d71a9-3945-437a-957b-a897847527b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/385c9b07-4e90-49ec-8f8c-7369bbda47b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/67e069ab-a450-495e-819c-9ad23f784309> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67e069ab-a450-495e-819c-9ad23f784309";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/e61c2fcf-a26a-49ed-9b4c-f43ba54b4c6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67e069ab-a450-495e-819c-9ad23f784309>.
+    
+<http://data.lblod.info/id/remote-data-objects/f32117be-4acb-47ae-b5ef-cd4552d8cc97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f32117be-4acb-47ae-b5ef-cd4552d8cc97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/e782b82b-8375-46e5-aea0-2570c1e9385d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f32117be-4acb-47ae-b5ef-cd4552d8cc97>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5dca29f-e3b9-497c-8c69-742e4d297024> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5dca29f-e3b9-497c-8c69-742e4d297024";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/f05a154b-b26f-4a1c-a3b6-e1a41b46b128/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5dca29f-e3b9-497c-8c69-742e4d297024>.
+    
+<http://data.lblod.info/id/remote-data-objects/42fb287c-b5c3-48cd-88e8-6baf4da7024c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42fb287c-b5c3-48cd-88e8-6baf4da7024c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/f97f93fc-e0b2-4f38-b28d-22b704ae3ac9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42fb287c-b5c3-48cd-88e8-6baf4da7024c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e6d941e-e85c-432f-b65e-80059e72044e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e6d941e-e85c-432f-b65e-80059e72044e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/fa6ce3b9-5b8f-4310-af90-d1626d8c4458/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e6d941e-e85c-432f-b65e-80059e72044e>.
+    
+<http://data.lblod.info/id/remote-data-objects/51eae432-e1b8-4dd8-871c-3ac98c98adb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51eae432-e1b8-4dd8-871c-3ac98c98adb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/bb/ffaa037d-cf30-4027-a9a8-33b0466dc2cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51eae432-e1b8-4dd8-871c-3ac98c98adb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/6da4777e-a7a8-41cc-8eea-a6fa8e07fb53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6da4777e-a7a8-41cc-8eea-a6fa8e07fb53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/009dcbdd-ca7e-42a0-a8d7-c1dc607d5d7b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6da4777e-a7a8-41cc-8eea-a6fa8e07fb53>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8e35d3a-4fb1-4ad1-b8b8-1ac8d3038ae1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8e35d3a-4fb1-4ad1-b8b8-1ac8d3038ae1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/0a1966d8-a26e-4778-baa1-000d1eb5243a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8e35d3a-4fb1-4ad1-b8b8-1ac8d3038ae1>.
+    
+<http://data.lblod.info/id/remote-data-objects/620f62c1-331d-4f52-b3ea-6c780e2af6c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "620f62c1-331d-4f52-b3ea-6c780e2af6c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/18a222c2-6207-44a8-9080-cc96b716ef9b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/620f62c1-331d-4f52-b3ea-6c780e2af6c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1f39892-be25-43ee-a7bf-ce2377acfe78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1f39892-be25-43ee-a7bf-ce2377acfe78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/1ae52ec2-e3c3-43d5-aefb-50c042071f77/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1f39892-be25-43ee-a7bf-ce2377acfe78>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ef47893-293d-4ae8-9d50-7e5fed9c318a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ef47893-293d-4ae8-9d50-7e5fed9c318a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/1b75b2a9-ba4a-420f-9269-311373e0c342/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ef47893-293d-4ae8-9d50-7e5fed9c318a>.
+    
+<http://data.lblod.info/id/remote-data-objects/28e000fc-baa1-4693-ba22-ca3e3c79e18c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28e000fc-baa1-4693-ba22-ca3e3c79e18c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/248d5314-49ff-4f73-b9b3-3c0f81829602/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/346e96bb-e5e3-4f97-8048-be3f6966bad8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28e000fc-baa1-4693-ba22-ca3e3c79e18c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201033-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201033-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201033-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201033-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7967c66d-8341-4c0b-a6d3-0a3271a1c1d9> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7967c66d-8341-4c0b-a6d3-0a3271a1c1d9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c473dc9e-e57c-4bee-8c4d-11e1afd6eb81";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c56551a4-eb4e-4837-ac55-99559e99c9fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c56551a4-eb4e-4837-ac55-99559e99c9fe";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81>.
+
+  <http://redpencil.data.gift/id/task/c392980c-3ba8-4aed-b835-030bf363c332> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c392980c-3ba8-4aed-b835-030bf363c332";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7967c66d-8341-4c0b-a6d3-0a3271a1c1d9>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c56551a4-eb4e-4837-ac55-99559e99c9fe>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/851ad008-dec1-4090-bd6f-2df155b23e36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "851ad008-dec1-4090-bd6f-2df155b23e36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/249a0288-fcd3-4c56-bfde-ad6b4117a299/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/851ad008-dec1-4090-bd6f-2df155b23e36>.
+    
+<http://data.lblod.info/id/remote-data-objects/38be0b2b-e42e-4cdd-98d3-446699b88e97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38be0b2b-e42e-4cdd-98d3-446699b88e97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/24a3e846-dbe2-4afc-8611-5fdcd26aa996/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38be0b2b-e42e-4cdd-98d3-446699b88e97>.
+    
+<http://data.lblod.info/id/remote-data-objects/56a2b6c2-81d4-4668-a6df-5d914b135f46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56a2b6c2-81d4-4668-a6df-5d914b135f46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/293e19e6-81d1-405d-b2d7-e44d563c909b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56a2b6c2-81d4-4668-a6df-5d914b135f46>.
+    
+<http://data.lblod.info/id/remote-data-objects/f727a4af-9338-4190-a6af-56ae657338c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f727a4af-9338-4190-a6af-56ae657338c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/2a4c875e-4a8f-4e7b-b61f-3f966fc60587/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f727a4af-9338-4190-a6af-56ae657338c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/da03e5a7-d3d7-44df-8b10-90cddd4f405f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da03e5a7-d3d7-44df-8b10-90cddd4f405f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/2d67b8ac-e2a7-469a-b356-eb16a01d8085/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da03e5a7-d3d7-44df-8b10-90cddd4f405f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cc633ac-8bb9-4591-b825-ed1f01883ba6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cc633ac-8bb9-4591-b825-ed1f01883ba6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/2fbef560-cccc-4413-b7d8-f9523b950984/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cc633ac-8bb9-4591-b825-ed1f01883ba6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f88bbf3e-80ac-4e88-aa62-1303b3887fc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f88bbf3e-80ac-4e88-aa62-1303b3887fc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/3b60c695-6aac-4d40-87e0-af887064719a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f88bbf3e-80ac-4e88-aa62-1303b3887fc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/81bb5b3a-bc39-4fda-b0ee-f118c1f9a714> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81bb5b3a-bc39-4fda-b0ee-f118c1f9a714";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/43ad53a7-999c-447b-8690-205133c8a9b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81bb5b3a-bc39-4fda-b0ee-f118c1f9a714>.
+    
+<http://data.lblod.info/id/remote-data-objects/941f69e7-2232-4961-9122-32386777a87d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "941f69e7-2232-4961-9122-32386777a87d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/4628242d-6b8f-4b17-9c9d-1839f01fcef7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/941f69e7-2232-4961-9122-32386777a87d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b97d6981-3be7-4e51-839a-abdd5354b7c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b97d6981-3be7-4e51-839a-abdd5354b7c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/4c2bec9b-0622-46f8-8854-867fb0467714/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b97d6981-3be7-4e51-839a-abdd5354b7c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad8ddf9c-3b6d-4735-b71b-430412e4b14c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad8ddf9c-3b6d-4735-b71b-430412e4b14c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/4e1f6bfd-f01d-4dc5-860d-3d81e54aab1b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad8ddf9c-3b6d-4735-b71b-430412e4b14c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce900614-c9e2-4a84-a019-4604b9eaf634> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce900614-c9e2-4a84-a019-4604b9eaf634";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/4ee18483-50ef-4237-a6d9-b6bb0a9f75b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce900614-c9e2-4a84-a019-4604b9eaf634>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a93e56e-f44f-4b12-9a66-ca96126c2f2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a93e56e-f44f-4b12-9a66-ca96126c2f2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/4f727b4d-c15e-4738-a343-9766ebda4368/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a93e56e-f44f-4b12-9a66-ca96126c2f2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/888d4f2d-651e-4d9f-93ed-b921de86ec6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "888d4f2d-651e-4d9f-93ed-b921de86ec6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/549115e2-ec1d-4357-8ec1-5abd901707b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/888d4f2d-651e-4d9f-93ed-b921de86ec6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fab8d756-6794-4c55-bf2b-d399f726220e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fab8d756-6794-4c55-bf2b-d399f726220e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/58369880-a13d-41b8-9a34-6f31d85b786b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fab8d756-6794-4c55-bf2b-d399f726220e>.
+    
+<http://data.lblod.info/id/remote-data-objects/89feaa9f-4662-4882-8929-502d93b2c243> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89feaa9f-4662-4882-8929-502d93b2c243";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/586dbe44-21e1-471d-ba90-68b4db8217a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89feaa9f-4662-4882-8929-502d93b2c243>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b36d1d2-0d7f-44bf-9078-f6f14dcca1b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b36d1d2-0d7f-44bf-9078-f6f14dcca1b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/5fb0c417-964b-4d2a-800f-8222644f0179/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b36d1d2-0d7f-44bf-9078-f6f14dcca1b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a407808b-e86c-44db-a2fa-64c9311c2e3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a407808b-e86c-44db-a2fa-64c9311c2e3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/75406ade-982f-43d2-a33a-652d888aad98/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a407808b-e86c-44db-a2fa-64c9311c2e3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/89dd4e6d-f763-4f80-a25c-579587a8f0a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89dd4e6d-f763-4f80-a25c-579587a8f0a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/7dad995b-47df-42a0-ba83-69e861796561/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89dd4e6d-f763-4f80-a25c-579587a8f0a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d73f05b-eb23-41ed-9c2e-c931024c8e1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d73f05b-eb23-41ed-9c2e-c931024c8e1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/87a6ac94-3f88-4311-966e-e329b95c1e23/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d73f05b-eb23-41ed-9c2e-c931024c8e1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf8cb65d-8595-42c7-91b2-9905ae6b4fee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf8cb65d-8595-42c7-91b2-9905ae6b4fee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/8a68d8cb-33ab-47bc-bb70-e3a51e61ad30/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf8cb65d-8595-42c7-91b2-9905ae6b4fee>.
+    
+<http://data.lblod.info/id/remote-data-objects/b79a1bd2-6964-426a-ae47-b2ece8f105aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b79a1bd2-6964-426a-ae47-b2ece8f105aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/8d77b354-f5ab-4eee-afe7-45fcd12c109a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b79a1bd2-6964-426a-ae47-b2ece8f105aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/05d8df51-544b-4a41-b69f-f764785d301d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05d8df51-544b-4a41-b69f-f764785d301d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/9b724a9a-bdbd-40a1-8ca3-bebe6579e924/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05d8df51-544b-4a41-b69f-f764785d301d>.
+    
+<http://data.lblod.info/id/remote-data-objects/12fad894-13e6-4a4a-98c6-e0bf180f215d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12fad894-13e6-4a4a-98c6-e0bf180f215d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/a0615e7d-5844-4fe8-9ab3-f0d8fc17d098/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12fad894-13e6-4a4a-98c6-e0bf180f215d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c138ebda-145f-47a7-866c-1ebd12062509> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c138ebda-145f-47a7-866c-1ebd12062509";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/a2a65925-0ead-4f50-a1fb-9b0c6ea3d108/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c138ebda-145f-47a7-866c-1ebd12062509>.
+    
+<http://data.lblod.info/id/remote-data-objects/feda5320-8495-497e-8e12-51f54e9edf54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "feda5320-8495-497e-8e12-51f54e9edf54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/a6d92a2e-cbff-4245-8a26-4ac4160d0d4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/feda5320-8495-497e-8e12-51f54e9edf54>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7bb4c0a-1016-4274-9092-4903d8e17e11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7bb4c0a-1016-4274-9092-4903d8e17e11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/aa136637-0d93-4183-8ebd-0f28bb49d80f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7bb4c0a-1016-4274-9092-4903d8e17e11>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1152008-9ce1-4d2c-9264-8cb24d93a509> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1152008-9ce1-4d2c-9264-8cb24d93a509";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/ac141a82-1ef8-4ca7-a36c-f46fb17b46bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1152008-9ce1-4d2c-9264-8cb24d93a509>.
+    
+<http://data.lblod.info/id/remote-data-objects/44d80368-27c6-417d-86bf-e64b45d2a4cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44d80368-27c6-417d-86bf-e64b45d2a4cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/af47724a-1a95-42bd-a5d0-26b1476ca241/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44d80368-27c6-417d-86bf-e64b45d2a4cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/1014fd27-19df-4bb2-a30f-305ca3214807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1014fd27-19df-4bb2-a30f-305ca3214807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/b79c8f24-f768-454d-a6b5-d5002c5212bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1014fd27-19df-4bb2-a30f-305ca3214807>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee46d66d-8c5c-445b-840b-e7e434c83469> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee46d66d-8c5c-445b-840b-e7e434c83469";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/b911c811-0714-42da-83c0-ff33fdb79c97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee46d66d-8c5c-445b-840b-e7e434c83469>.
+    
+<http://data.lblod.info/id/remote-data-objects/493dfdd7-6248-4f67-a356-0ef2e392182b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "493dfdd7-6248-4f67-a356-0ef2e392182b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/baa22f44-96f0-4b48-8ad6-3a165305e31c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/493dfdd7-6248-4f67-a356-0ef2e392182b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2916398-a5fd-4c30-aae9-ad0b46ab2c9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2916398-a5fd-4c30-aae9-ad0b46ab2c9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/bc3c236b-fc13-43c0-819d-6bb0d8379cce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2916398-a5fd-4c30-aae9-ad0b46ab2c9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d647ea1f-5018-4e17-b07e-1a90b1a2b59b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d647ea1f-5018-4e17-b07e-1a90b1a2b59b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/bd3b6bb3-f5fd-4e7c-a7cc-82814f041c5c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d647ea1f-5018-4e17-b07e-1a90b1a2b59b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7edfae45-05de-4ecc-8132-56aaee52d490> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7edfae45-05de-4ecc-8132-56aaee52d490";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/c759d233-9269-4d70-8b98-2a301814e12c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7edfae45-05de-4ecc-8132-56aaee52d490>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f1baee9-d2c2-405e-89d5-782cd0fc0cc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f1baee9-d2c2-405e-89d5-782cd0fc0cc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/cb590371-e71c-4403-a30c-7ebf40126f42/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f1baee9-d2c2-405e-89d5-782cd0fc0cc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/af086cfa-c53e-4e11-9093-c1d454848ba1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af086cfa-c53e-4e11-9093-c1d454848ba1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/cb62d43d-1f84-422f-9e63-583939d5d8ba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af086cfa-c53e-4e11-9093-c1d454848ba1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f97f7458-4f3d-4c71-823c-f8a436fb082f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f97f7458-4f3d-4c71-823c-f8a436fb082f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/cfadda37-69c8-4f4d-91ca-ac8950b25ac3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f97f7458-4f3d-4c71-823c-f8a436fb082f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b7f4ec4-6a25-4c31-86b7-12b015c6c3d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b7f4ec4-6a25-4c31-86b7-12b015c6c3d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/d2170000-d2c2-4c45-9392-b1a52df7b8f8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b7f4ec4-6a25-4c31-86b7-12b015c6c3d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/23168593-513d-4d1d-9cdf-c03ec0dcd71b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23168593-513d-4d1d-9cdf-c03ec0dcd71b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/d2f460a9-b752-4bcd-9e14-c8ffbae65189/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23168593-513d-4d1d-9cdf-c03ec0dcd71b>.
+    
+<http://data.lblod.info/id/remote-data-objects/02851899-9bea-4cac-b169-07b895d82027> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02851899-9bea-4cac-b169-07b895d82027";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/d4249641-2c84-43a7-8e55-728c962847c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02851899-9bea-4cac-b169-07b895d82027>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4914052-2762-4179-a6ae-65f1eb7c61b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4914052-2762-4179-a6ae-65f1eb7c61b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/d6cf4ca2-5151-43fb-a254-bb8d5acd961d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4914052-2762-4179-a6ae-65f1eb7c61b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/707539e0-a227-46af-8269-1d19e09fc003> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "707539e0-a227-46af-8269-1d19e09fc003";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/d885e5ac-8ecb-4690-8278-feae9a1ee8d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/707539e0-a227-46af-8269-1d19e09fc003>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cc111c3-2900-4b0e-a082-b015dd4ff5e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cc111c3-2900-4b0e-a082-b015dd4ff5e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/ee532414-17de-4fda-83b9-3b397cacedec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cc111c3-2900-4b0e-a082-b015dd4ff5e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6b0a656-8ee0-4a77-81ac-b659123c8552> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6b0a656-8ee0-4a77-81ac-b659123c8552";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/f7f823a9-fbc0-4033-8407-ead9a81a1020/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6b0a656-8ee0-4a77-81ac-b659123c8552>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cf9fe97-fbc1-4169-8e88-464b76fd1752> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cf9fe97-fbc1-4169-8e88-464b76fd1752";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/f9d37c4d-c1e0-48c9-8bd2-09fdc4a3e7fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cf9fe97-fbc1-4169-8e88-464b76fd1752>.
+    
+<http://data.lblod.info/id/remote-data-objects/55d72f83-fc3e-413c-8451-972102a0f79e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55d72f83-fc3e-413c-8451-972102a0f79e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/cbs/fa435b49-944b-4b4a-be1a-bb99c69c4be4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55d72f83-fc3e-413c-8451-972102a0f79e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d9e5039-dee3-4dd2-a74f-d0f70154d03d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d9e5039-dee3-4dd2-a74f-d0f70154d03d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/028deaf1-2242-4b4f-b4c9-2a08f2ab3cb3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d9e5039-dee3-4dd2-a74f-d0f70154d03d>.
+    
+<http://data.lblod.info/id/remote-data-objects/048d6d99-40b7-4886-8c8a-374a1d6afbce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "048d6d99-40b7-4886-8c8a-374a1d6afbce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/028deaf1-2242-4b4f-b4c9-2a08f2ab3cb3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/048d6d99-40b7-4886-8c8a-374a1d6afbce>.
+    
+<http://data.lblod.info/id/remote-data-objects/475ae21b-ffe9-44b2-9661-0c5951782bd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "475ae21b-ffe9-44b2-9661-0c5951782bd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/028deaf1-2242-4b4f-b4c9-2a08f2ab3cb3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c473dc9e-e57c-4bee-8c4d-11e1afd6eb81> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/475ae21b-ffe9-44b2-9661-0c5951782bd9>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201034-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201034-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201034-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201034-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/740c696e-af0f-42e2-b2b4-533991993579> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "740c696e-af0f-42e2-b2b4-533991993579";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/8192d27b-b936-4041-a857-509345ca731d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8192d27b-b936-4041-a857-509345ca731d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57>.
+
+  <http://redpencil.data.gift/id/task/e0797c7d-b35b-441d-a73b-29c45a85aa0f> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e0797c7d-b35b-441d-a73b-29c45a85aa0f";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/740c696e-af0f-42e2-b2b4-533991993579>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/8192d27b-b936-4041-a857-509345ca731d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/f3488c9b-76d6-4c27-844e-b8fa8fb04a7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3488c9b-76d6-4c27-844e-b8fa8fb04a7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/06266258-5a94-478f-9895-394b3869505b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3488c9b-76d6-4c27-844e-b8fa8fb04a7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7299d5ad-930b-4389-84be-e8eee57db601> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7299d5ad-930b-4389-84be-e8eee57db601";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/06266258-5a94-478f-9895-394b3869505b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7299d5ad-930b-4389-84be-e8eee57db601>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d1445fe-8128-4946-95c5-7ac4ef72aa5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d1445fe-8128-4946-95c5-7ac4ef72aa5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/06266258-5a94-478f-9895-394b3869505b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d1445fe-8128-4946-95c5-7ac4ef72aa5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1c87d4c-d18c-41b6-b7fc-93aeea876c0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1c87d4c-d18c-41b6-b7fc-93aeea876c0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/1840683c-a049-4e33-803e-1f85e775703d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1c87d4c-d18c-41b6-b7fc-93aeea876c0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa2acdcb-7a82-4357-ada9-6b1cf9b13b3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa2acdcb-7a82-4357-ada9-6b1cf9b13b3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/1840683c-a049-4e33-803e-1f85e775703d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa2acdcb-7a82-4357-ada9-6b1cf9b13b3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/786494e5-ea39-4806-ba94-2e7f07655942> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "786494e5-ea39-4806-ba94-2e7f07655942";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/1840683c-a049-4e33-803e-1f85e775703d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/786494e5-ea39-4806-ba94-2e7f07655942>.
+    
+<http://data.lblod.info/id/remote-data-objects/97fd2d1a-b500-46e6-b65a-a44ee56db4e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97fd2d1a-b500-46e6-b65a-a44ee56db4e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/1b4292f0-d7e5-4de2-9adc-9b4c3d78504e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97fd2d1a-b500-46e6-b65a-a44ee56db4e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b5de9c7-4e2f-4e84-88e6-fadc7a519be4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b5de9c7-4e2f-4e84-88e6-fadc7a519be4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/1b4292f0-d7e5-4de2-9adc-9b4c3d78504e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b5de9c7-4e2f-4e84-88e6-fadc7a519be4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d7880a7-a009-4777-9fd8-5f39d487721a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d7880a7-a009-4777-9fd8-5f39d487721a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/1b4292f0-d7e5-4de2-9adc-9b4c3d78504e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d7880a7-a009-4777-9fd8-5f39d487721a>.
+    
+<http://data.lblod.info/id/remote-data-objects/747da16f-9a60-4c26-b020-98b76defcc81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "747da16f-9a60-4c26-b020-98b76defcc81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/1ba16e09-5fe9-459f-a579-26a9d5a378cc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/747da16f-9a60-4c26-b020-98b76defcc81>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b44b288-8dc2-45c6-bc98-9d05833fc92c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b44b288-8dc2-45c6-bc98-9d05833fc92c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/1ba16e09-5fe9-459f-a579-26a9d5a378cc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b44b288-8dc2-45c6-bc98-9d05833fc92c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2972a6ef-45fb-49ec-a212-781393d40510> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2972a6ef-45fb-49ec-a212-781393d40510";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/1ba16e09-5fe9-459f-a579-26a9d5a378cc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2972a6ef-45fb-49ec-a212-781393d40510>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b65661f-68ec-4999-a4b5-cad761154d63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b65661f-68ec-4999-a4b5-cad761154d63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/44fdb71d-a489-485b-834d-4be71f812acd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b65661f-68ec-4999-a4b5-cad761154d63>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c62ed9e-825b-4740-9f81-5642e76fda66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c62ed9e-825b-4740-9f81-5642e76fda66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/44fdb71d-a489-485b-834d-4be71f812acd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c62ed9e-825b-4740-9f81-5642e76fda66>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8425ae8-4378-497f-9468-dabc81df78a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8425ae8-4378-497f-9468-dabc81df78a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/44fdb71d-a489-485b-834d-4be71f812acd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8425ae8-4378-497f-9468-dabc81df78a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/62915582-6110-4586-8076-b4ad4b6ce5b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62915582-6110-4586-8076-b4ad4b6ce5b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/53450034-2117-4db6-8e9c-d30e46d4dfa1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62915582-6110-4586-8076-b4ad4b6ce5b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/98672506-19a2-44ac-ba1c-4ec58828f491> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98672506-19a2-44ac-ba1c-4ec58828f491";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/53450034-2117-4db6-8e9c-d30e46d4dfa1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98672506-19a2-44ac-ba1c-4ec58828f491>.
+    
+<http://data.lblod.info/id/remote-data-objects/97ebe783-5918-4615-8324-acc34bc55466> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97ebe783-5918-4615-8324-acc34bc55466";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/53450034-2117-4db6-8e9c-d30e46d4dfa1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97ebe783-5918-4615-8324-acc34bc55466>.
+    
+<http://data.lblod.info/id/remote-data-objects/95958e58-7133-4638-a307-0ffabbddcc8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95958e58-7133-4638-a307-0ffabbddcc8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/5b0c8790-d4b7-4583-9878-af4cdd78fa92/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95958e58-7133-4638-a307-0ffabbddcc8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2fd460a-c281-4f78-bf0d-80f752bc7e61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2fd460a-c281-4f78-bf0d-80f752bc7e61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/5b0c8790-d4b7-4583-9878-af4cdd78fa92/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2fd460a-c281-4f78-bf0d-80f752bc7e61>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3b591c3-d5ef-462f-b6cd-c9a72afceca7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3b591c3-d5ef-462f-b6cd-c9a72afceca7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/5e97e7a2-7d35-4479-a7a6-223c51beb28c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3b591c3-d5ef-462f-b6cd-c9a72afceca7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a883176a-358a-47ad-a12e-d24fd19af5cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a883176a-358a-47ad-a12e-d24fd19af5cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/5e97e7a2-7d35-4479-a7a6-223c51beb28c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a883176a-358a-47ad-a12e-d24fd19af5cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/1183418f-ed72-41a5-a892-17c0d017e02c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1183418f-ed72-41a5-a892-17c0d017e02c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/5e97e7a2-7d35-4479-a7a6-223c51beb28c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1183418f-ed72-41a5-a892-17c0d017e02c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e0e8bbd-b841-4ab9-82a3-7133ac279866> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e0e8bbd-b841-4ab9-82a3-7133ac279866";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/6aefbb1f-9b11-4947-bcb1-e46143cbce9b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e0e8bbd-b841-4ab9-82a3-7133ac279866>.
+    
+<http://data.lblod.info/id/remote-data-objects/330a2bcc-e6f3-46bf-82b6-f37efdbed839> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "330a2bcc-e6f3-46bf-82b6-f37efdbed839";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/6aefbb1f-9b11-4947-bcb1-e46143cbce9b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/330a2bcc-e6f3-46bf-82b6-f37efdbed839>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef76a37d-dfd4-4604-b2c1-12d7e17959fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef76a37d-dfd4-4604-b2c1-12d7e17959fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/6aefbb1f-9b11-4947-bcb1-e46143cbce9b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef76a37d-dfd4-4604-b2c1-12d7e17959fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f256400-2763-4bce-ab61-b722f0d3d1c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f256400-2763-4bce-ab61-b722f0d3d1c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/8cef5800-dae2-4743-8a59-2578620cd3c9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f256400-2763-4bce-ab61-b722f0d3d1c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/687b0eb9-c57d-48ef-b828-631692328a50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "687b0eb9-c57d-48ef-b828-631692328a50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/8cef5800-dae2-4743-8a59-2578620cd3c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/687b0eb9-c57d-48ef-b828-631692328a50>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9f891c9-b7a1-458d-b5f4-4ddea261480c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9f891c9-b7a1-458d-b5f4-4ddea261480c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/8cef5800-dae2-4743-8a59-2578620cd3c9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9f891c9-b7a1-458d-b5f4-4ddea261480c>.
+    
+<http://data.lblod.info/id/remote-data-objects/61ca6bea-67d4-4c70-a747-7d69bb5a8715> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61ca6bea-67d4-4c70-a747-7d69bb5a8715";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/a35add90-0eb1-4164-bb01-f5ecde89f654/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61ca6bea-67d4-4c70-a747-7d69bb5a8715>.
+    
+<http://data.lblod.info/id/remote-data-objects/040d0f92-22af-49c3-9484-d4b7a7b329a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "040d0f92-22af-49c3-9484-d4b7a7b329a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/a35add90-0eb1-4164-bb01-f5ecde89f654/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/040d0f92-22af-49c3-9484-d4b7a7b329a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d0dd40f-d28d-459a-ad5f-35d80355f3ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d0dd40f-d28d-459a-ad5f-35d80355f3ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/a35add90-0eb1-4164-bb01-f5ecde89f654/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d0dd40f-d28d-459a-ad5f-35d80355f3ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/282c3ebc-2306-4595-b2e1-b884363a7158> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "282c3ebc-2306-4595-b2e1-b884363a7158";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/ad6fd08e-97e0-4c84-8c0a-e24503bab67c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/282c3ebc-2306-4595-b2e1-b884363a7158>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4b1d3c9-4f6d-4aa7-a3a9-f286cdc1647b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4b1d3c9-4f6d-4aa7-a3a9-f286cdc1647b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/ad6fd08e-97e0-4c84-8c0a-e24503bab67c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4b1d3c9-4f6d-4aa7-a3a9-f286cdc1647b>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd33da32-0d5a-40c4-9d48-2cfb097d0fe2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd33da32-0d5a-40c4-9d48-2cfb097d0fe2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/ad6fd08e-97e0-4c84-8c0a-e24503bab67c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd33da32-0d5a-40c4-9d48-2cfb097d0fe2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1e11b77-6a74-4ba7-951b-75bce292d17f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1e11b77-6a74-4ba7-951b-75bce292d17f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/b76f11d7-6577-4eb5-b080-6988b96b49f9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1e11b77-6a74-4ba7-951b-75bce292d17f>.
+    
+<http://data.lblod.info/id/remote-data-objects/805ea50b-a686-4aad-b70f-2b472d86ddf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "805ea50b-a686-4aad-b70f-2b472d86ddf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/b76f11d7-6577-4eb5-b080-6988b96b49f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/805ea50b-a686-4aad-b70f-2b472d86ddf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7a4d72f-5fad-44ad-affc-dce193ffab09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7a4d72f-5fad-44ad-affc-dce193ffab09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/b76f11d7-6577-4eb5-b080-6988b96b49f9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7a4d72f-5fad-44ad-affc-dce193ffab09>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6983097-bbf6-46c6-9ae8-0c2f7e630586> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6983097-bbf6-46c6-9ae8-0c2f7e630586";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/dac494f1-4651-4f9e-bc39-b4f930c1758f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6983097-bbf6-46c6-9ae8-0c2f7e630586>.
+    
+<http://data.lblod.info/id/remote-data-objects/68ac0f7f-166d-4147-8435-c42d543b8a26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68ac0f7f-166d-4147-8435-c42d543b8a26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/dac494f1-4651-4f9e-bc39-b4f930c1758f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68ac0f7f-166d-4147-8435-c42d543b8a26>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3222df8-c75d-4b70-8292-f80a8a00bcef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3222df8-c75d-4b70-8292-f80a8a00bcef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/gr/dac494f1-4651-4f9e-bc39-b4f930c1758f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3222df8-c75d-4b70-8292-f80a8a00bcef>.
+    
+<http://data.lblod.info/id/remote-data-objects/f76c4c0b-1f41-4aac-bf63-a783cfbf94f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f76c4c0b-1f41-4aac-bf63-a783cfbf94f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/0aeb6992-b5be-4348-ad60-a551e196d2c5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f76c4c0b-1f41-4aac-bf63-a783cfbf94f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f774c5d2-7cb0-40f4-b908-bcb4e1234263> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f774c5d2-7cb0-40f4-b908-bcb4e1234263";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/0aeb6992-b5be-4348-ad60-a551e196d2c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f774c5d2-7cb0-40f4-b908-bcb4e1234263>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0f9a14a-2de5-45c5-aa44-ffcf7c085835> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0f9a14a-2de5-45c5-aa44-ffcf7c085835";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/0aeb6992-b5be-4348-ad60-a551e196d2c5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0f9a14a-2de5-45c5-aa44-ffcf7c085835>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2ca1d16-7fcf-4210-9dd8-29ecefa44eae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2ca1d16-7fcf-4210-9dd8-29ecefa44eae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/330dd44c-ddf0-4913-b2e1-c4c650d1b09c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2ca1d16-7fcf-4210-9dd8-29ecefa44eae>.
+    
+<http://data.lblod.info/id/remote-data-objects/468ef858-6540-4a3d-8e98-03e3a918a130> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "468ef858-6540-4a3d-8e98-03e3a918a130";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/330dd44c-ddf0-4913-b2e1-c4c650d1b09c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/468ef858-6540-4a3d-8e98-03e3a918a130>.
+    
+<http://data.lblod.info/id/remote-data-objects/acb288e1-48c3-4a5c-af9c-2bca6d8c43f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acb288e1-48c3-4a5c-af9c-2bca6d8c43f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/330dd44c-ddf0-4913-b2e1-c4c650d1b09c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acb288e1-48c3-4a5c-af9c-2bca6d8c43f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6384c115-629e-4dda-866a-3924c580f527> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6384c115-629e-4dda-866a-3924c580f527";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/3ccfc2d6-9f30-4886-bd1a-ba27d188fa08/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6384c115-629e-4dda-866a-3924c580f527>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7b76750-e380-46bd-9a04-15c2686eac51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7b76750-e380-46bd-9a04-15c2686eac51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/3ccfc2d6-9f30-4886-bd1a-ba27d188fa08/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7b76750-e380-46bd-9a04-15c2686eac51>.
+    
+<http://data.lblod.info/id/remote-data-objects/59f27915-c5df-416a-b54b-22221b60c227> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59f27915-c5df-416a-b54b-22221b60c227";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/3ccfc2d6-9f30-4886-bd1a-ba27d188fa08/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6e6a7ad8-a6b7-4558-96f0-d1e0140b7f57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59f27915-c5df-416a-b54b-22221b60c227>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201036-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201036-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201036-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201036-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3f45b58c-d4f3-48d8-a67a-e7b3b7c63aaf> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3f45b58c-d4f3-48d8-a67a-e7b3b7c63aaf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/3f1fabef-912f-4a66-b871-b567cfb2d2ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3f1fabef-912f-4a66-b871-b567cfb2d2ca";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc>.
+
+  <http://redpencil.data.gift/id/task/dcbf5215-8b7f-429f-95d2-a02e36be7314> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dcbf5215-8b7f-429f-95d2-a02e36be7314";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3f45b58c-d4f3-48d8-a67a-e7b3b7c63aaf>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/3f1fabef-912f-4a66-b871-b567cfb2d2ca>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5c10ad93-4cef-47bf-a024-6d24c4afd974> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c10ad93-4cef-47bf-a024-6d24c4afd974";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/3e0c8b90-0a71-4f01-9c71-95598fcf0870/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c10ad93-4cef-47bf-a024-6d24c4afd974>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd695951-ca4a-4e95-8192-8fc418a07cfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd695951-ca4a-4e95-8192-8fc418a07cfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/3e0c8b90-0a71-4f01-9c71-95598fcf0870/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd695951-ca4a-4e95-8192-8fc418a07cfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fda2c46-bf53-4a63-91ee-b5018fa60304> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fda2c46-bf53-4a63-91ee-b5018fa60304";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/3e0c8b90-0a71-4f01-9c71-95598fcf0870/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fda2c46-bf53-4a63-91ee-b5018fa60304>.
+    
+<http://data.lblod.info/id/remote-data-objects/66b9c536-ba14-4867-94e6-6de10c359e71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66b9c536-ba14-4867-94e6-6de10c359e71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/59a9eed7-e903-4e66-8842-d93a0fb668e9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66b9c536-ba14-4867-94e6-6de10c359e71>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb97ecc5-86d3-43e5-861e-454936474fe8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb97ecc5-86d3-43e5-861e-454936474fe8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/59a9eed7-e903-4e66-8842-d93a0fb668e9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb97ecc5-86d3-43e5-861e-454936474fe8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b14a21f8-4aa8-48e7-96c2-9fc08ca44e26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b14a21f8-4aa8-48e7-96c2-9fc08ca44e26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/59a9eed7-e903-4e66-8842-d93a0fb668e9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b14a21f8-4aa8-48e7-96c2-9fc08ca44e26>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2711d32-dd9e-4e5d-9d7a-9afd7b1e43d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2711d32-dd9e-4e5d-9d7a-9afd7b1e43d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/6667988f-fa6e-4b07-9c86-d283430ea789/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2711d32-dd9e-4e5d-9d7a-9afd7b1e43d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1bcebc7-7cea-4bbc-97a5-2d5f4eda767a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1bcebc7-7cea-4bbc-97a5-2d5f4eda767a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/6667988f-fa6e-4b07-9c86-d283430ea789/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1bcebc7-7cea-4bbc-97a5-2d5f4eda767a>.
+    
+<http://data.lblod.info/id/remote-data-objects/599d5d6e-163b-4e8b-963e-0c7ce04dfd39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "599d5d6e-163b-4e8b-963e-0c7ce04dfd39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/6667988f-fa6e-4b07-9c86-d283430ea789/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/599d5d6e-163b-4e8b-963e-0c7ce04dfd39>.
+    
+<http://data.lblod.info/id/remote-data-objects/00ef5a14-248b-49cb-845f-5ea147432583> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00ef5a14-248b-49cb-845f-5ea147432583";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/6f53fe0b-c162-4025-9251-f45125fce918/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00ef5a14-248b-49cb-845f-5ea147432583>.
+    
+<http://data.lblod.info/id/remote-data-objects/a199735a-f96e-4ad2-ad84-491923e3a944> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a199735a-f96e-4ad2-ad84-491923e3a944";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/6f53fe0b-c162-4025-9251-f45125fce918/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a199735a-f96e-4ad2-ad84-491923e3a944>.
+    
+<http://data.lblod.info/id/remote-data-objects/3857dfed-8b48-4315-b325-84a08610e8de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3857dfed-8b48-4315-b325-84a08610e8de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/797b5c88-c90a-4aae-9dca-d5b3a776b026/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3857dfed-8b48-4315-b325-84a08610e8de>.
+    
+<http://data.lblod.info/id/remote-data-objects/b58b6d2a-1c32-48eb-95f4-4a8b7d230428> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b58b6d2a-1c32-48eb-95f4-4a8b7d230428";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/797b5c88-c90a-4aae-9dca-d5b3a776b026/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b58b6d2a-1c32-48eb-95f4-4a8b7d230428>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac373b44-37fb-4acf-8bc5-ba11eea99150> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac373b44-37fb-4acf-8bc5-ba11eea99150";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/797b5c88-c90a-4aae-9dca-d5b3a776b026/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac373b44-37fb-4acf-8bc5-ba11eea99150>.
+    
+<http://data.lblod.info/id/remote-data-objects/731fb875-fb50-4c0d-b729-cdb4f46115d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "731fb875-fb50-4c0d-b729-cdb4f46115d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/b4282a56-f056-4bf5-a61f-59322c5fea41/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/731fb875-fb50-4c0d-b729-cdb4f46115d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b9c0a57-bc68-4297-8ebe-43db32310c97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b9c0a57-bc68-4297-8ebe-43db32310c97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/b4282a56-f056-4bf5-a61f-59322c5fea41/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b9c0a57-bc68-4297-8ebe-43db32310c97>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a911a3f-dfb1-4817-89c4-24098d9a7047> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a911a3f-dfb1-4817-89c4-24098d9a7047";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/b4282a56-f056-4bf5-a61f-59322c5fea41/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a911a3f-dfb1-4817-89c4-24098d9a7047>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e42a699-a941-40a0-aec0-a53ed7bba96d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e42a699-a941-40a0-aec0-a53ed7bba96d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/be1d2e53-9cc2-4dd9-8244-d7f3da383c6d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e42a699-a941-40a0-aec0-a53ed7bba96d>.
+    
+<http://data.lblod.info/id/remote-data-objects/2222ae91-1c9c-4c8d-b0d7-56fd0cdf04b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2222ae91-1c9c-4c8d-b0d7-56fd0cdf04b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/be1d2e53-9cc2-4dd9-8244-d7f3da383c6d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2222ae91-1c9c-4c8d-b0d7-56fd0cdf04b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb242e49-e72f-4b2d-8b2a-1dfe5956aa16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb242e49-e72f-4b2d-8b2a-1dfe5956aa16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/be1d2e53-9cc2-4dd9-8244-d7f3da383c6d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb242e49-e72f-4b2d-8b2a-1dfe5956aa16>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4275036-8ff3-41e9-a28a-9d6b3ed9f26b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4275036-8ff3-41e9-a28a-9d6b3ed9f26b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/beed1657-3adc-4e49-aaa9-5f51912e412e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4275036-8ff3-41e9-a28a-9d6b3ed9f26b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9d109a5-acba-4d6f-a935-1322ef9b120d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9d109a5-acba-4d6f-a935-1322ef9b120d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/beed1657-3adc-4e49-aaa9-5f51912e412e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9d109a5-acba-4d6f-a935-1322ef9b120d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd1f023a-0a0e-49c9-bd0c-2858807a5b44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd1f023a-0a0e-49c9-bd0c-2858807a5b44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/beed1657-3adc-4e49-aaa9-5f51912e412e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd1f023a-0a0e-49c9-bd0c-2858807a5b44>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0ed0051-2fde-4dbd-83f3-7f95cfe3346a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0ed0051-2fde-4dbd-83f3-7f95cfe3346a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/eeeb32a8-37de-43ae-89b7-8bfa18aa1614/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0ed0051-2fde-4dbd-83f3-7f95cfe3346a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef799b25-d99b-4a65-8f9c-4f17b1527ba6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef799b25-d99b-4a65-8f9c-4f17b1527ba6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/eeeb32a8-37de-43ae-89b7-8bfa18aa1614/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef799b25-d99b-4a65-8f9c-4f17b1527ba6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1feb30c-6b9f-4cd0-bd0f-45d3947d04fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1feb30c-6b9f-4cd0-bd0f-45d3947d04fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/eeeb32a8-37de-43ae-89b7-8bfa18aa1614/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1feb30c-6b9f-4cd0-bd0f-45d3947d04fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/417b78da-125c-4cbf-8097-d83b71b2e4cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "417b78da-125c-4cbf-8097-d83b71b2e4cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/fea82ee3-7e26-491a-a8e3-ac7dbff2dbdf/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/417b78da-125c-4cbf-8097-d83b71b2e4cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9ab6385-61a3-482b-8dd2-07b50a440cbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9ab6385-61a3-482b-8dd2-07b50a440cbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/fea82ee3-7e26-491a-a8e3-ac7dbff2dbdf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9ab6385-61a3-482b-8dd2-07b50a440cbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbc93356-c220-4d2b-81f6-4f3557325112> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbc93356-c220-4d2b-81f6-4f3557325112";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/fea82ee3-7e26-491a-a8e3-ac7dbff2dbdf/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbc93356-c220-4d2b-81f6-4f3557325112>.
+    
+<http://data.lblod.info/id/remote-data-objects/d49463b6-80a9-44ea-a325-b72cfc9a98ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d49463b6-80a9-44ea-a325-b72cfc9a98ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/ffd662e9-8c76-427a-bdc4-3b5094b6eddc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d49463b6-80a9-44ea-a325-b72cfc9a98ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d88f7ad-9cc1-4594-bb20-413c50bc251e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d88f7ad-9cc1-4594-bb20-413c50bc251e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/ffd662e9-8c76-427a-bdc4-3b5094b6eddc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d88f7ad-9cc1-4594-bb20-413c50bc251e>.
+    
+<http://data.lblod.info/id/remote-data-objects/855270df-9f9a-4497-9d8e-416f08b5cd6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "855270df-9f9a-4497-9d8e-416f08b5cd6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/rmw/ffd662e9-8c76-427a-bdc4-3b5094b6eddc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/855270df-9f9a-4497-9d8e-416f08b5cd6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f35f220d-d2cf-43fd-baed-5908c6a40e5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f35f220d-d2cf-43fd-baed-5908c6a40e5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/0470c5a0-a41d-4e46-be4f-7b6d9e334e84/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f35f220d-d2cf-43fd-baed-5908c6a40e5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9851e790-a928-487a-bc30-d4b5ccceb295> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9851e790-a928-487a-bc30-d4b5ccceb295";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/08a4e3d6-e164-41b1-ab66-167a6c80fe1a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9851e790-a928-487a-bc30-d4b5ccceb295>.
+    
+<http://data.lblod.info/id/remote-data-objects/a43f9456-7612-4b8f-8494-2c0a10f0c7c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a43f9456-7612-4b8f-8494-2c0a10f0c7c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/09ee567b-62ce-4603-9f40-f27a76960789/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a43f9456-7612-4b8f-8494-2c0a10f0c7c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7df2ff15-d096-4690-8b72-6f552e411c95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7df2ff15-d096-4690-8b72-6f552e411c95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/127006dd-ed0b-437a-80cd-d349caa99c77/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7df2ff15-d096-4690-8b72-6f552e411c95>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a03be1b-0682-42cb-89e4-b18aca10564f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a03be1b-0682-42cb-89e4-b18aca10564f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/142cd5df-a0c2-46fa-b07b-6192627acb08/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a03be1b-0682-42cb-89e4-b18aca10564f>.
+    
+<http://data.lblod.info/id/remote-data-objects/16fbfdc0-a798-440f-8055-a8392609a931> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16fbfdc0-a798-440f-8055-a8392609a931";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/1d7de2b1-6d42-4352-bdbf-23e14b7c3d3a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16fbfdc0-a798-440f-8055-a8392609a931>.
+    
+<http://data.lblod.info/id/remote-data-objects/bde0391d-e4e4-499d-b0d1-faac77437231> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bde0391d-e4e4-499d-b0d1-faac77437231";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/2482e140-d41d-4074-901a-7e82e9e1a9d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bde0391d-e4e4-499d-b0d1-faac77437231>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a4efb79-ffec-413e-957c-28d89069182b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a4efb79-ffec-413e-957c-28d89069182b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/2b782268-14a2-4940-8bce-1d7fa47a8407/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a4efb79-ffec-413e-957c-28d89069182b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fafbbf9-5ab6-45a3-9e81-8eda9b7a1acf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fafbbf9-5ab6-45a3-9e81-8eda9b7a1acf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/2d0f6c5f-98ef-453b-84af-52104d2ddde7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fafbbf9-5ab6-45a3-9e81-8eda9b7a1acf>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd9d7885-7e95-4c2c-850b-0d998a0adf9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd9d7885-7e95-4c2c-850b-0d998a0adf9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/361f94cd-53bd-49cf-9591-b34f48b98bda/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd9d7885-7e95-4c2c-850b-0d998a0adf9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/49e6cf13-dd4a-4906-9041-bb86da176319> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49e6cf13-dd4a-4906-9041-bb86da176319";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/38fa2f15-6cf4-4db9-8bb3-53c68409c732/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49e6cf13-dd4a-4906-9041-bb86da176319>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b6c2ff4-8fad-4320-96fe-46032ced66c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b6c2ff4-8fad-4320-96fe-46032ced66c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/3bb9aff8-575d-48d9-a7dc-dfbc3c6f3b1a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b6c2ff4-8fad-4320-96fe-46032ced66c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1f1e304-a561-4b27-b1c6-6de9b695a839> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1f1e304-a561-4b27-b1c6-6de9b695a839";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/3edf8f81-fe17-410b-bba2-437678874097/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1f1e304-a561-4b27-b1c6-6de9b695a839>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ef29070-99d8-436b-ae7e-f1f8ca604eac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ef29070-99d8-436b-ae7e-f1f8ca604eac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/48699024-1ce8-4497-ab20-8f852863dc81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ef29070-99d8-436b-ae7e-f1f8ca604eac>.
+    
+<http://data.lblod.info/id/remote-data-objects/54f2e1ae-d6e0-48ab-a590-9529753f1d6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54f2e1ae-d6e0-48ab-a590-9529753f1d6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/4e379646-3f94-4319-9f36-8a79c40d1752/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54f2e1ae-d6e0-48ab-a590-9529753f1d6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e644e0b4-a38a-46de-b5fe-a029795c1452> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e644e0b4-a38a-46de-b5fe-a029795c1452";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/4e6cb0eb-7540-455d-97fc-6494fd77ff46/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e644e0b4-a38a-46de-b5fe-a029795c1452>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c139104-4d04-4409-b7e6-fe400f305c9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c139104-4d04-4409-b7e6-fe400f305c9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/61782e57-a16d-40de-8107-f6ac22706123/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c139104-4d04-4409-b7e6-fe400f305c9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/db430541-6c24-44b5-bde8-1f4a5956ebd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db430541-6c24-44b5-bde8-1f4a5956ebd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/6a1d7bf7-cd83-458e-862d-43394850ed53/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b0f247fa-1b1e-4f7f-a20a-0d8fb1a871cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db430541-6c24-44b5-bde8-1f4a5956ebd2>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201037-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201037-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201037-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201037-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/83eab160-b994-4b6c-b7b8-8344a1116023> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "83eab160-b994-4b6c-b7b8-8344a1116023";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e28be4a8-d104-4116-89b7-b02479ad19b4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a7ef2291-8b9d-4e61-9473-4aca63bb402a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a7ef2291-8b9d-4e61-9473-4aca63bb402a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4>.
+
+  <http://redpencil.data.gift/id/task/fc8e0b54-df38-4f03-b9ac-ad3532971a53> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fc8e0b54-df38-4f03-b9ac-ad3532971a53";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/83eab160-b994-4b6c-b7b8-8344a1116023>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a7ef2291-8b9d-4e61-9473-4aca63bb402a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/8187619b-eaf5-4026-a113-581df3e4486c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8187619b-eaf5-4026-a113-581df3e4486c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/6c7e4c40-e341-45a4-b5ff-edb4001462e6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8187619b-eaf5-4026-a113-581df3e4486c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fafc6c7a-d4e7-4324-ba78-84198d3afaf0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fafc6c7a-d4e7-4324-ba78-84198d3afaf0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/71a98a44-98b1-48c8-8c93-78b5e855b831/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fafc6c7a-d4e7-4324-ba78-84198d3afaf0>.
+    
+<http://data.lblod.info/id/remote-data-objects/de93b6ed-6a58-45d4-8d81-6fecb239c53b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de93b6ed-6a58-45d4-8d81-6fecb239c53b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/84cdf747-1905-4407-93e0-12a4a1040489/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de93b6ed-6a58-45d4-8d81-6fecb239c53b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9844e657-55bb-469f-9763-50ac0f015315> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9844e657-55bb-469f-9763-50ac0f015315";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/84f5e07c-b9fc-4bba-b7ba-5129e868cb9e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9844e657-55bb-469f-9763-50ac0f015315>.
+    
+<http://data.lblod.info/id/remote-data-objects/420fe2f7-a16e-419b-9558-300b65b104d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "420fe2f7-a16e-419b-9558-300b65b104d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/8b25ce5f-945d-4f35-91b7-539203598462/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/420fe2f7-a16e-419b-9558-300b65b104d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f176a9e-7bc5-45af-ac82-204a9ce0c2fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f176a9e-7bc5-45af-ac82-204a9ce0c2fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/8e8f10a7-3b32-4296-afc4-705fea970879/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f176a9e-7bc5-45af-ac82-204a9ce0c2fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/85c422be-2380-4d5b-8536-72d1a5f00217> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85c422be-2380-4d5b-8536-72d1a5f00217";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/9590da13-3ccf-4099-bbc2-c20c2a61160f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85c422be-2380-4d5b-8536-72d1a5f00217>.
+    
+<http://data.lblod.info/id/remote-data-objects/24d32b96-6fac-4c7c-a808-fc26c9f5e761> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24d32b96-6fac-4c7c-a808-fc26c9f5e761";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/99231caf-4e4b-4240-bd7d-a75d343e23c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24d32b96-6fac-4c7c-a808-fc26c9f5e761>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b854d30-27cb-4dbc-ac9e-e57d5b4d7c65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b854d30-27cb-4dbc-ac9e-e57d5b4d7c65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/a4f43301-3b5a-4847-8593-510b1c36cebc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b854d30-27cb-4dbc-ac9e-e57d5b4d7c65>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4ad4e5c-ba84-4abe-ba1c-b763577ec223> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4ad4e5c-ba84-4abe-ba1c-b763577ec223";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/ae7cf756-0d33-4f07-a5d6-12fc999d4a20/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4ad4e5c-ba84-4abe-ba1c-b763577ec223>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bd58a96-fbd1-4bde-9606-cc22dbd2bdf0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bd58a96-fbd1-4bde-9606-cc22dbd2bdf0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/b1bd8534-405c-4428-888a-c730cb9318cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bd58a96-fbd1-4bde-9606-cc22dbd2bdf0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3165220-871f-4adb-9480-9b2ee891cb62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3165220-871f-4adb-9480-9b2ee891cb62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/b6d69874-1350-446e-b696-85a3f4fa6cbe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3165220-871f-4adb-9480-9b2ee891cb62>.
+    
+<http://data.lblod.info/id/remote-data-objects/be96646c-e278-4838-b9e3-ba3713cfa3b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be96646c-e278-4838-b9e3-ba3713cfa3b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/b7e18775-bb3f-4beb-949d-e45be30ef3de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be96646c-e278-4838-b9e3-ba3713cfa3b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/efa4dc07-2cbc-4edc-938f-a5b1c27f3a74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efa4dc07-2cbc-4edc-938f-a5b1c27f3a74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/b8f00987-7252-482e-8ce8-cee30ad22422/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efa4dc07-2cbc-4edc-938f-a5b1c27f3a74>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac655136-1f9b-4914-b8e3-9a550255b90b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac655136-1f9b-4914-b8e3-9a550255b90b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/b9661ffd-bf15-484e-a5a1-0f1903ae073e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac655136-1f9b-4914-b8e3-9a550255b90b>.
+    
+<http://data.lblod.info/id/remote-data-objects/81dc1da5-86cd-4800-bd24-c319cb706aff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81dc1da5-86cd-4800-bd24-c319cb706aff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/ba2752d0-c3ac-4480-aa71-4ff513791ae3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81dc1da5-86cd-4800-bd24-c319cb706aff>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e3ff34f-102b-4fac-a4a1-814141d02f04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e3ff34f-102b-4fac-a4a1-814141d02f04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/bcf1b7e9-fce1-4ee9-b71a-0eadc198593c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e3ff34f-102b-4fac-a4a1-814141d02f04>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d02011c-bff5-4b17-a98a-24418e237522> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d02011c-bff5-4b17-a98a-24418e237522";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/bddfe9e9-ebd6-4f5a-b7f6-d79b920b349d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d02011c-bff5-4b17-a98a-24418e237522>.
+    
+<http://data.lblod.info/id/remote-data-objects/75fee0be-b2c6-4eec-a70c-50066829d16b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75fee0be-b2c6-4eec-a70c-50066829d16b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/c0a6ad24-780c-432c-9d60-17db7831d57c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75fee0be-b2c6-4eec-a70c-50066829d16b>.
+    
+<http://data.lblod.info/id/remote-data-objects/001c7c21-80fb-451b-9e11-e54390c44cbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "001c7c21-80fb-451b-9e11-e54390c44cbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/cbd52c7e-9079-4ae2-b80e-7a0d0beda5ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/001c7c21-80fb-451b-9e11-e54390c44cbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6e4a77d-4738-4b29-b610-895e5d8681d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6e4a77d-4738-4b29-b610-895e5d8681d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/cca0c2ec-a650-4d51-8738-7885ae723399/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6e4a77d-4738-4b29-b610-895e5d8681d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fed805e-d810-4e5e-862e-8ef934479108> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fed805e-d810-4e5e-862e-8ef934479108";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/d8f07024-1db6-490c-a3bc-6c2517aa5996/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fed805e-d810-4e5e-862e-8ef934479108>.
+    
+<http://data.lblod.info/id/remote-data-objects/4db5cf8a-6524-48db-9b94-298524d44117> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4db5cf8a-6524-48db-9b94-298524d44117";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/d9547798-47b9-4493-b7df-2daa21b238d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4db5cf8a-6524-48db-9b94-298524d44117>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e37a143-0e5a-4392-ade1-9b196e8ee951> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e37a143-0e5a-4392-ade1-9b196e8ee951";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/e2249d42-f26e-4356-a7b9-529e9a916b3f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e37a143-0e5a-4392-ade1-9b196e8ee951>.
+    
+<http://data.lblod.info/id/remote-data-objects/995e956c-2f3d-4bae-9197-728bced972d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "995e956c-2f3d-4bae-9197-728bced972d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/e31e70f7-da3b-4dbc-b115-cebfaca895b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/995e956c-2f3d-4bae-9197-728bced972d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8263bb8c-6293-425b-8ee9-3b9f0aa1054a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8263bb8c-6293-425b-8ee9-3b9f0aa1054a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/e39e5972-fd1a-4a23-a530-d381c9859fb7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8263bb8c-6293-425b-8ee9-3b9f0aa1054a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e9bae56-9ebc-4b1a-8bfb-5e09b1f5a3f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e9bae56-9ebc-4b1a-8bfb-5e09b1f5a3f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/e7c4bdb8-fe74-4508-9ded-2d7a8699202a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e9bae56-9ebc-4b1a-8bfb-5e09b1f5a3f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fbdb022-9f9c-4ba2-9022-24385871840a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fbdb022-9f9c-4ba2-9022-24385871840a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/edacc568-e4c7-49cb-aceb-9c197731c0a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fbdb022-9f9c-4ba2-9022-24385871840a>.
+    
+<http://data.lblod.info/id/remote-data-objects/09289b1d-20f2-4c48-ab74-e0ccb1e28560> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09289b1d-20f2-4c48-ab74-e0ccb1e28560";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bekkevoort.meetingburger.net/vabu/f9ebefa5-ffa6-4406-9ff9-eecee212a02e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09289b1d-20f2-4c48-ab74-e0ccb1e28560>.
+    
+<http://data.lblod.info/id/remote-data-objects/e08fd688-7dc9-4dd2-880b-3f74578b2f83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e08fd688-7dc9-4dd2-880b-3f74578b2f83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/173d2e47-1ea5-45df-b286-2fd941f65b14/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e08fd688-7dc9-4dd2-880b-3f74578b2f83>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d818193-2b58-4f36-bbd9-a6c80e21b5cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d818193-2b58-4f36-bbd9-a6c80e21b5cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/1ca59eb4-4b6e-4455-b8d4-4d0d64582b61/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d818193-2b58-4f36-bbd9-a6c80e21b5cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cf85f08-ffaa-4d27-9030-d30109da97f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cf85f08-ffaa-4d27-9030-d30109da97f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/24e68fe0-1793-47cc-b55a-1335daf5c002/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cf85f08-ffaa-4d27-9030-d30109da97f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/31e3266f-9d17-44a2-85ad-8ac652fa7d1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31e3266f-9d17-44a2-85ad-8ac652fa7d1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/4ebaacd2-56f0-4cd2-bd71-9c5556c4bcbe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31e3266f-9d17-44a2-85ad-8ac652fa7d1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d6c3a53-599c-4bb4-8718-1f40d9494d7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d6c3a53-599c-4bb4-8718-1f40d9494d7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/4ee800c9-ed5f-47c8-a1b1-d5904f6b56f6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d6c3a53-599c-4bb4-8718-1f40d9494d7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0096622-a358-4c2d-a05b-a488d6a1d698> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0096622-a358-4c2d-a05b-a488d6a1d698";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/5c16d923-9fba-4bc1-8260-3e48e46a557b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0096622-a358-4c2d-a05b-a488d6a1d698>.
+    
+<http://data.lblod.info/id/remote-data-objects/63f347b8-241d-4665-a530-2651b7ab79a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63f347b8-241d-4665-a530-2651b7ab79a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/65520d93-6e79-4c0c-bbc8-137f2c503040/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63f347b8-241d-4665-a530-2651b7ab79a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f2c7017-43f2-4a44-b89b-f768c189cdcb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f2c7017-43f2-4a44-b89b-f768c189cdcb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/6cef1b23-da08-427c-bf5a-57614e6ae9ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f2c7017-43f2-4a44-b89b-f768c189cdcb>.
+    
+<http://data.lblod.info/id/remote-data-objects/26b0dcd1-33eb-45b3-9571-dd2302bf74d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26b0dcd1-33eb-45b3-9571-dd2302bf74d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/79aebf80-63e8-4898-8712-1a1641e1ad48/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26b0dcd1-33eb-45b3-9571-dd2302bf74d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/17f86b04-da0a-4a9b-981a-a1fdda15f56c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17f86b04-da0a-4a9b-981a-a1fdda15f56c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/86e41ef1-5cf8-4410-bca3-be9aecfaba16/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17f86b04-da0a-4a9b-981a-a1fdda15f56c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a29e50f1-4cfa-45c4-bfc0-d1ab073f4faa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a29e50f1-4cfa-45c4-bfc0-d1ab073f4faa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/92464248-66f5-4a53-bcd1-49da386bf3b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a29e50f1-4cfa-45c4-bfc0-d1ab073f4faa>.
+    
+<http://data.lblod.info/id/remote-data-objects/51eedb67-9b05-4f25-8e14-82762b999def> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51eedb67-9b05-4f25-8e14-82762b999def";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/95e56d3f-15a8-43ce-adbd-2a9f92a3c954/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51eedb67-9b05-4f25-8e14-82762b999def>.
+    
+<http://data.lblod.info/id/remote-data-objects/a13d0434-4969-42a4-a411-e62397633444> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a13d0434-4969-42a4-a411-e62397633444";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/977164a2-4769-45a9-ba87-c123d589895b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a13d0434-4969-42a4-a411-e62397633444>.
+    
+<http://data.lblod.info/id/remote-data-objects/96fab216-fff9-406b-976e-64ae3a137ff4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96fab216-fff9-406b-976e-64ae3a137ff4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/9ac442ae-3066-4ef6-90df-c9c6cd7d9247/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96fab216-fff9-406b-976e-64ae3a137ff4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b8878b7-da42-435c-aa82-ab76806f8621> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b8878b7-da42-435c-aa82-ab76806f8621";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/be0c318d-beb4-489b-9799-d492402b40f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b8878b7-da42-435c-aa82-ab76806f8621>.
+    
+<http://data.lblod.info/id/remote-data-objects/de040457-05cf-4ad6-b0e2-69df8c890d43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de040457-05cf-4ad6-b0e2-69df8c890d43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/bf94eac8-5c56-4c2c-8186-c1da7701d79c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de040457-05cf-4ad6-b0e2-69df8c890d43>.
+    
+<http://data.lblod.info/id/remote-data-objects/c741d356-e8d3-46e8-aaaa-8032ee8394be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c741d356-e8d3-46e8-aaaa-8032ee8394be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/c7af1dcf-4a23-4525-ae70-73795cc44cad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c741d356-e8d3-46e8-aaaa-8032ee8394be>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d002336-353e-437b-93e2-d8ca4fa7acaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d002336-353e-437b-93e2-d8ca4fa7acaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/cde56578-40ea-4543-a211-3f67f776de86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d002336-353e-437b-93e2-d8ca4fa7acaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb96d359-ab17-4a6e-8a60-389d9e42dc2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb96d359-ab17-4a6e-8a60-389d9e42dc2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/d2c0efef-e71b-47c6-b3b7-655e6c29a8f5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb96d359-ab17-4a6e-8a60-389d9e42dc2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b64c4ff-7ee9-45e8-a0f4-3b1d8be1c6f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b64c4ff-7ee9-45e8-a0f4-3b1d8be1c6f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/d3c37cda-4271-46e9-a2e6-daf1a65e8bb1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b64c4ff-7ee9-45e8-a0f4-3b1d8be1c6f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2db3badd-d9ea-4d84-8c26-dedc96c67845> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2db3badd-d9ea-4d84-8c26-dedc96c67845";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/e79b6df6-af2d-4a4b-8fa1-4c85180a049d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e28be4a8-d104-4116-89b7-b02479ad19b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2db3badd-d9ea-4d84-8c26-dedc96c67845>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201038-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201038-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201038-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201038-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/6d4413a7-a124-4f9a-a06a-e63d762e012c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6d4413a7-a124-4f9a-a06a-e63d762e012c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e0c815f7-8d2d-4d03-9672-34382d916210";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d60606f5-ea1c-4ccb-8c5d-33b273b44d8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d60606f5-ea1c-4ccb-8c5d-33b273b44d8f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210>.
+
+  <http://redpencil.data.gift/id/task/ae467fd3-4977-45d0-a0a2-c7b43610663a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ae467fd3-4977-45d0-a0a2-c7b43610663a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/6d4413a7-a124-4f9a-a06a-e63d762e012c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d60606f5-ea1c-4ccb-8c5d-33b273b44d8f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4cb5ee3c-945c-4660-af5c-dc3c286034ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cb5ee3c-945c-4660-af5c-dc3c286034ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/e8cd0bcf-a22f-4108-a225-bdb5d5cac12c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cb5ee3c-945c-4660-af5c-dc3c286034ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/73fb543a-3f54-4457-9e94-0cb6d9c206c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73fb543a-3f54-4457-9e94-0cb6d9c206c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/bb/f6859006-ad3d-4822-9269-1c2eba8ae6b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73fb543a-3f54-4457-9e94-0cb6d9c206c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d2372c0-fe4b-4c49-b179-ec6873f69486> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d2372c0-fe4b-4c49-b179-ec6873f69486";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/0110c442-e988-4483-a2c0-db50c734975e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d2372c0-fe4b-4c49-b179-ec6873f69486>.
+    
+<http://data.lblod.info/id/remote-data-objects/0166a023-e488-4430-a3ac-3316e7c2b2d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0166a023-e488-4430-a3ac-3316e7c2b2d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/05e0ad53-ba78-4113-814c-b3c6f0d56c84/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0166a023-e488-4430-a3ac-3316e7c2b2d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5517c5ab-01a3-469b-86ec-95fc6d9bd444> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5517c5ab-01a3-469b-86ec-95fc6d9bd444";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/08f3608d-3171-4166-9af2-fb34532018a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5517c5ab-01a3-469b-86ec-95fc6d9bd444>.
+    
+<http://data.lblod.info/id/remote-data-objects/05707e9d-0451-47a0-a18f-511d4ebd6359> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05707e9d-0451-47a0-a18f-511d4ebd6359";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/0bc44a23-cb7a-4a9f-8a76-310e6b9faa65/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05707e9d-0451-47a0-a18f-511d4ebd6359>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbf6945b-a544-4fd7-b173-3d19b91a40b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbf6945b-a544-4fd7-b173-3d19b91a40b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/0c7b6c6d-7c9f-4300-a269-ab17791ced0e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbf6945b-a544-4fd7-b173-3d19b91a40b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfc9974f-02de-4c56-9d9e-a99cb7855d8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfc9974f-02de-4c56-9d9e-a99cb7855d8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/0f106941-074f-4fdb-8db1-294088fa66dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfc9974f-02de-4c56-9d9e-a99cb7855d8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a71bd5c-15df-40ca-b369-782460e8d9e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a71bd5c-15df-40ca-b369-782460e8d9e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/1372f38e-2418-4cca-bbf7-5a578169a381/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a71bd5c-15df-40ca-b369-782460e8d9e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e093ef2-e8a3-42a9-aa0d-c5224f313fbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e093ef2-e8a3-42a9-aa0d-c5224f313fbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/19ca63b8-ae3f-4db8-bf34-2da48757d1d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e093ef2-e8a3-42a9-aa0d-c5224f313fbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef9f8c20-c451-4cfb-b3c4-30262d2fe5bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef9f8c20-c451-4cfb-b3c4-30262d2fe5bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/1ad24b25-c27a-47d7-9290-35c821f8a3a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef9f8c20-c451-4cfb-b3c4-30262d2fe5bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbe95322-3b25-476e-8b37-91ab55b93ddf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbe95322-3b25-476e-8b37-91ab55b93ddf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/200b051d-72a5-4e31-b8f9-d531a772e512/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbe95322-3b25-476e-8b37-91ab55b93ddf>.
+    
+<http://data.lblod.info/id/remote-data-objects/4adbcfc1-fd25-454d-8855-42b3909b15b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4adbcfc1-fd25-454d-8855-42b3909b15b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/26e6053b-dafd-4b16-9f16-bd98c976fbc3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4adbcfc1-fd25-454d-8855-42b3909b15b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcbc7d17-40dd-471c-b24f-3217711ed0d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcbc7d17-40dd-471c-b24f-3217711ed0d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/2d636d83-2f19-4857-8e8d-e7b6c6f1e9d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcbc7d17-40dd-471c-b24f-3217711ed0d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcbf898e-25e0-492d-ae52-9f57c6b9ac78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcbf898e-25e0-492d-ae52-9f57c6b9ac78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/2f65813d-ced2-44cd-819b-f07d987cddb3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcbf898e-25e0-492d-ae52-9f57c6b9ac78>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a99a01f-153b-45e9-90f8-6ac765cd5b5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a99a01f-153b-45e9-90f8-6ac765cd5b5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/3317884d-0283-4131-b704-91e2f2d3816f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a99a01f-153b-45e9-90f8-6ac765cd5b5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d21df35a-5836-4fbb-94b5-21237e7a4d84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d21df35a-5836-4fbb-94b5-21237e7a4d84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/338a4dfd-6703-4169-a943-8122b4475f4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d21df35a-5836-4fbb-94b5-21237e7a4d84>.
+    
+<http://data.lblod.info/id/remote-data-objects/145b192b-024c-4804-8362-33ed587d1c9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "145b192b-024c-4804-8362-33ed587d1c9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/3ad44391-b797-4618-b827-9e52188d688e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/145b192b-024c-4804-8362-33ed587d1c9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c47eb18e-1fc8-42e4-8848-e95cfa2524dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c47eb18e-1fc8-42e4-8848-e95cfa2524dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/414f6d73-5ec5-4093-82c3-8abb0f8b6c2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c47eb18e-1fc8-42e4-8848-e95cfa2524dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/33ba1f4e-b12b-4d17-a1b7-2902a7d70287> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33ba1f4e-b12b-4d17-a1b7-2902a7d70287";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/48b04632-d985-4a8c-9bb1-ad323b9fd4eb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33ba1f4e-b12b-4d17-a1b7-2902a7d70287>.
+    
+<http://data.lblod.info/id/remote-data-objects/d86cd309-50a0-4ea6-8b31-19b2303d500d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d86cd309-50a0-4ea6-8b31-19b2303d500d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/4a6ea594-6144-4cef-9172-e5bcf170b68c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d86cd309-50a0-4ea6-8b31-19b2303d500d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ebed4d6-0df8-435c-9a06-2b452a6d2d32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ebed4d6-0df8-435c-9a06-2b452a6d2d32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/4cc39380-9c90-4b99-a9a7-8044ad221cad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ebed4d6-0df8-435c-9a06-2b452a6d2d32>.
+    
+<http://data.lblod.info/id/remote-data-objects/7de100a8-3c3f-4ae5-8842-522d60dfd2fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7de100a8-3c3f-4ae5-8842-522d60dfd2fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/4e7d021f-db5d-40c9-ae1c-fe0f4eeb1f1f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7de100a8-3c3f-4ae5-8842-522d60dfd2fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c3a5d75-79aa-4105-af88-247895a20869> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c3a5d75-79aa-4105-af88-247895a20869";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/562cf6f3-72d9-4d11-8324-c3e3e4ae13a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c3a5d75-79aa-4105-af88-247895a20869>.
+    
+<http://data.lblod.info/id/remote-data-objects/8270f193-3f71-4d3f-9a3c-3811c1218adf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8270f193-3f71-4d3f-9a3c-3811c1218adf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/575f2a9c-d10d-4853-881b-e683b90de4b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8270f193-3f71-4d3f-9a3c-3811c1218adf>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8053403-c803-4214-aa45-868aabe486c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8053403-c803-4214-aa45-868aabe486c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/58178d9e-fd7a-4328-a9ec-5eef348fb1ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8053403-c803-4214-aa45-868aabe486c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/f95b6f45-30e1-469c-ace5-4581d981c5a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f95b6f45-30e1-469c-ace5-4581d981c5a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/58a94e70-0b74-44ab-9c4b-671e6cc857fb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f95b6f45-30e1-469c-ace5-4581d981c5a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f14e1a8-b653-482b-9ee5-25e5a25be61a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f14e1a8-b653-482b-9ee5-25e5a25be61a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/5dd8bb85-04da-4ef7-98e5-d683cea0a4eb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f14e1a8-b653-482b-9ee5-25e5a25be61a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bda666a8-43c6-494e-86d1-f4576d1e9fee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bda666a8-43c6-494e-86d1-f4576d1e9fee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/705dee29-243b-4b0f-b0b5-1f2e759eddb6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bda666a8-43c6-494e-86d1-f4576d1e9fee>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d9313ce-6f2c-40bb-85a6-364a761936d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d9313ce-6f2c-40bb-85a6-364a761936d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/72d2596a-258d-4f3e-b2aa-51a619410f99/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d9313ce-6f2c-40bb-85a6-364a761936d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ae6cc7b-c692-4087-8de7-cfd92dc67d2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ae6cc7b-c692-4087-8de7-cfd92dc67d2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/761548b5-0788-4ec9-bd92-3724a92ae9d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ae6cc7b-c692-4087-8de7-cfd92dc67d2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f45f3d1-2ccf-4e5b-b6f2-23e7b9a764fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f45f3d1-2ccf-4e5b-b6f2-23e7b9a764fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/7d1dd468-ff7a-43aa-8b83-360f4d660d67/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f45f3d1-2ccf-4e5b-b6f2-23e7b9a764fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c809cb3-8414-4d30-8123-a5c577d52e2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c809cb3-8414-4d30-8123-a5c577d52e2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/89731b23-fd63-4a08-8504-a64477d21c99/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c809cb3-8414-4d30-8123-a5c577d52e2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c1fa9e7-14a2-4f46-b153-dd5408f91626> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c1fa9e7-14a2-4f46-b153-dd5408f91626";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/8b755b4e-e3cf-45cb-bff1-69e4d642a5bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c1fa9e7-14a2-4f46-b153-dd5408f91626>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f3d8b16-4b01-49e7-acea-02e704e190a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f3d8b16-4b01-49e7-acea-02e704e190a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/93105888-7973-441b-a429-1896d4048425/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f3d8b16-4b01-49e7-acea-02e704e190a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/7643df75-d3c9-4219-96bd-a8fee5584ebf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7643df75-d3c9-4219-96bd-a8fee5584ebf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/936f6abf-4f82-4e5e-8aa0-7f9830790b41/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7643df75-d3c9-4219-96bd-a8fee5584ebf>.
+    
+<http://data.lblod.info/id/remote-data-objects/16b5df93-753d-4f45-8c97-a12243903735> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16b5df93-753d-4f45-8c97-a12243903735";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/953935b8-01b3-46c2-91f1-65233e509ca4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16b5df93-753d-4f45-8c97-a12243903735>.
+    
+<http://data.lblod.info/id/remote-data-objects/d213c787-199c-4cd4-bc7c-de31cb031cc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d213c787-199c-4cd4-bc7c-de31cb031cc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/98871ec3-8801-4aa6-b57e-05c23b5d4b78/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d213c787-199c-4cd4-bc7c-de31cb031cc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1efb70a7-16a7-403a-9e11-d6d35b715fe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1efb70a7-16a7-403a-9e11-d6d35b715fe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/99919046-6416-4536-b47b-ab9c60db14d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1efb70a7-16a7-403a-9e11-d6d35b715fe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/19720faf-e1e5-475e-8d23-e4846ea819aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19720faf-e1e5-475e-8d23-e4846ea819aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/99eac6e7-7b17-426b-a768-ebd747d43dfa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19720faf-e1e5-475e-8d23-e4846ea819aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/53fd2b28-387d-4f11-a007-0c9beaec2b23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53fd2b28-387d-4f11-a007-0c9beaec2b23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/9a1c0266-e0aa-4662-a225-8e9e3c912151/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53fd2b28-387d-4f11-a007-0c9beaec2b23>.
+    
+<http://data.lblod.info/id/remote-data-objects/1228775a-9bed-43e7-bfa1-98c46eb41e11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1228775a-9bed-43e7-bfa1-98c46eb41e11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/9ba471fd-8b40-455d-b4e9-766204c424db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1228775a-9bed-43e7-bfa1-98c46eb41e11>.
+    
+<http://data.lblod.info/id/remote-data-objects/cef9286e-5e4e-488f-9d6c-11b3853cba75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cef9286e-5e4e-488f-9d6c-11b3853cba75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/9d6af429-619a-432c-a69a-d9b17838757e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cef9286e-5e4e-488f-9d6c-11b3853cba75>.
+    
+<http://data.lblod.info/id/remote-data-objects/d240f4b1-6591-4569-8d4e-128feac1daa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d240f4b1-6591-4569-8d4e-128feac1daa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/a7927a21-a40d-4a58-945d-c4d518021208/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d240f4b1-6591-4569-8d4e-128feac1daa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8334794-a783-4e62-b4f6-6c762e0e4a8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8334794-a783-4e62-b4f6-6c762e0e4a8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/ad84e967-6f5a-4a5d-9392-4a8fa2d195d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8334794-a783-4e62-b4f6-6c762e0e4a8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b579af7-c025-4c3b-88f8-ef5fe87f21c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b579af7-c025-4c3b-88f8-ef5fe87f21c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/af7ed83b-f070-486c-ad97-21727807ae97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b579af7-c025-4c3b-88f8-ef5fe87f21c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a336c29-c83f-497f-bb01-6dd98b40ad30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a336c29-c83f-497f-bb01-6dd98b40ad30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/b49285ec-9564-42cb-bb92-a711d33a7746/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a336c29-c83f-497f-bb01-6dd98b40ad30>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c710407-cb5f-457d-bbee-f0b816d561fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c710407-cb5f-457d-bbee-f0b816d561fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/b5214ea8-af85-47d4-8a6d-7bbee6dce588/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c710407-cb5f-457d-bbee-f0b816d561fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc97d963-7a52-4a74-b03d-d2c8a7857a63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc97d963-7a52-4a74-b03d-d2c8a7857a63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/b6f4f0ee-36f1-4e5c-a5d0-f224f1b480d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc97d963-7a52-4a74-b03d-d2c8a7857a63>.
+    
+<http://data.lblod.info/id/remote-data-objects/34472902-6f56-459c-9f6c-3f879ed8a0b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34472902-6f56-459c-9f6c-3f879ed8a0b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/bba2c73d-0d3a-40d9-a14a-96d4ee4b56ba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c815f7-8d2d-4d03-9672-34382d916210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34472902-6f56-459c-9f6c-3f879ed8a0b3>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201039-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201039-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201039-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201039-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/80e502df-5954-4c37-bc3e-30c955a01bef> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "80e502df-5954-4c37-bc3e-30c955a01bef";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7ee3acb5-6084-43fb-8637-2ea7fcf641df";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/11c7a527-85f6-45f0-ab46-043689167a0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "11c7a527-85f6-45f0-ab46-043689167a0d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df>.
+
+  <http://redpencil.data.gift/id/task/f970d5ff-eaae-4864-b4a8-5de79a0a7174> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f970d5ff-eaae-4864-b4a8-5de79a0a7174";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/80e502df-5954-4c37-bc3e-30c955a01bef>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/11c7a527-85f6-45f0-ab46-043689167a0d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/15602ca4-83f6-4e78-ae22-e0103de2d991> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15602ca4-83f6-4e78-ae22-e0103de2d991";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/bc94b0a4-32e4-46b4-b5c3-023e90bda669/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15602ca4-83f6-4e78-ae22-e0103de2d991>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bf457fd-8d80-44b6-acc9-5ddabd85443d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bf457fd-8d80-44b6-acc9-5ddabd85443d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/c7a81bc5-c514-4a93-9eb5-871b8352bedd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bf457fd-8d80-44b6-acc9-5ddabd85443d>.
+    
+<http://data.lblod.info/id/remote-data-objects/87d257f3-0a68-44ba-bde5-77ea8dceee7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87d257f3-0a68-44ba-bde5-77ea8dceee7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/cc10a0d5-9d90-4de4-8b8b-d8b93c764a74/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87d257f3-0a68-44ba-bde5-77ea8dceee7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b4e8158-209b-4855-9cf7-c52d546075ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b4e8158-209b-4855-9cf7-c52d546075ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/ce36f5eb-1dfc-4f0d-8717-1f0b69e566df/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b4e8158-209b-4855-9cf7-c52d546075ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/f77af722-d8b6-4641-b754-83edf4b48e5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f77af722-d8b6-4641-b754-83edf4b48e5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/cfad0955-3a3a-4c96-82be-49cc88a1288c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f77af722-d8b6-4641-b754-83edf4b48e5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ca1087d-9e73-4692-8e2a-b90b9c55df48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ca1087d-9e73-4692-8e2a-b90b9c55df48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/d231494b-6fc6-4049-a11f-dd390b3b385f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ca1087d-9e73-4692-8e2a-b90b9c55df48>.
+    
+<http://data.lblod.info/id/remote-data-objects/aff91e93-3c56-4491-abf6-60d16c937bb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aff91e93-3c56-4491-abf6-60d16c937bb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/d2569b9a-8360-47ae-b61c-9b13649d9fb2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aff91e93-3c56-4491-abf6-60d16c937bb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/062378c7-dfd0-4a6a-ac8f-ac9b60b93141> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "062378c7-dfd0-4a6a-ac8f-ac9b60b93141";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/d3b73544-464f-4041-9c18-deabc0b08339/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/062378c7-dfd0-4a6a-ac8f-ac9b60b93141>.
+    
+<http://data.lblod.info/id/remote-data-objects/74c97280-d942-4160-a306-8e3d8bd542d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74c97280-d942-4160-a306-8e3d8bd542d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/d5c34214-c948-443f-b432-72ae75d6e825/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74c97280-d942-4160-a306-8e3d8bd542d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e30c23c-1a8c-48ad-ab2c-0ecf0544b828> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e30c23c-1a8c-48ad-ab2c-0ecf0544b828";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/d76fb9fc-56c4-491d-a6e7-6d8237da2688/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e30c23c-1a8c-48ad-ab2c-0ecf0544b828>.
+    
+<http://data.lblod.info/id/remote-data-objects/c989562b-f647-408e-ac30-bdd8e46f0109> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c989562b-f647-408e-ac30-bdd8e46f0109";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/dee67913-d016-45ce-9f71-2be70de26dc1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c989562b-f647-408e-ac30-bdd8e46f0109>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb4fe6a3-1547-437d-ac15-5817c907dae4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb4fe6a3-1547-437d-ac15-5817c907dae4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/e0762b2f-aeec-4bd7-ba9b-60377069b397/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb4fe6a3-1547-437d-ac15-5817c907dae4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c0a0299-4707-486d-92a7-369326b8c699> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c0a0299-4707-486d-92a7-369326b8c699";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/e0f55d79-f1d0-4f29-8129-5f5d45aff6e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c0a0299-4707-486d-92a7-369326b8c699>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e60a24e-b551-4b55-a6b1-df6f4f4d8fed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e60a24e-b551-4b55-a6b1-df6f4f4d8fed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/e3958cdd-826f-44ed-9205-8a42925738d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e60a24e-b551-4b55-a6b1-df6f4f4d8fed>.
+    
+<http://data.lblod.info/id/remote-data-objects/364518ae-c0a9-45d2-be19-f6dba4de0116> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "364518ae-c0a9-45d2-be19-f6dba4de0116";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/e8c7222a-94e9-4274-ae86-2e9d3e5c4f98/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/364518ae-c0a9-45d2-be19-f6dba4de0116>.
+    
+<http://data.lblod.info/id/remote-data-objects/304afcd7-408e-47ae-8789-84321b07c9ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "304afcd7-408e-47ae-8789-84321b07c9ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/ea9ba567-43bc-4db1-bafe-5a3321af2dc2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/304afcd7-408e-47ae-8789-84321b07c9ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5162cf2-1152-4f2f-8dad-7f5e29e9ef77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5162cf2-1152-4f2f-8dad-7f5e29e9ef77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/ef46ad24-73a8-4315-953a-374da97e571a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5162cf2-1152-4f2f-8dad-7f5e29e9ef77>.
+    
+<http://data.lblod.info/id/remote-data-objects/0119ed9e-0d28-4d0b-918c-5b19b38cb5c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0119ed9e-0d28-4d0b-918c-5b19b38cb5c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/f252f2c0-c9a0-4525-8390-359574f098b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0119ed9e-0d28-4d0b-918c-5b19b38cb5c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b005382-2274-4477-ae97-50ac0edfb0b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b005382-2274-4477-ae97-50ac0edfb0b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/f311b614-0efd-4cab-9adf-85e450d390e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b005382-2274-4477-ae97-50ac0edfb0b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd8a4a55-f2b9-464c-bae2-31805e6534c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd8a4a55-f2b9-464c-bae2-31805e6534c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/cbs/f67b94fe-71cc-4296-8e00-c3fbae4195c2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd8a4a55-f2b9-464c-bae2-31805e6534c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/79cf8f48-dd70-46f6-8077-17305784d6d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79cf8f48-dd70-46f6-8077-17305784d6d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/13b4ff9c-e2e5-42fd-9a62-bf582fd3680f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79cf8f48-dd70-46f6-8077-17305784d6d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd0d2bd4-52de-4b3b-ad34-6c1414975ebf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd0d2bd4-52de-4b3b-ad34-6c1414975ebf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/13b4ff9c-e2e5-42fd-9a62-bf582fd3680f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd0d2bd4-52de-4b3b-ad34-6c1414975ebf>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0692218-c27b-4186-8a6c-8c68713170f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0692218-c27b-4186-8a6c-8c68713170f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/13b4ff9c-e2e5-42fd-9a62-bf582fd3680f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0692218-c27b-4186-8a6c-8c68713170f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d154094-176f-4617-916d-56a6200b0bb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d154094-176f-4617-916d-56a6200b0bb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/159a251b-20de-4afe-84ad-9357577a2e1c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d154094-176f-4617-916d-56a6200b0bb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/9590ac94-6412-4659-8bc7-698163b6ba53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9590ac94-6412-4659-8bc7-698163b6ba53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/159a251b-20de-4afe-84ad-9357577a2e1c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9590ac94-6412-4659-8bc7-698163b6ba53>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d7cb012-2e74-4d03-8232-a61bbf97af75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d7cb012-2e74-4d03-8232-a61bbf97af75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/159a251b-20de-4afe-84ad-9357577a2e1c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d7cb012-2e74-4d03-8232-a61bbf97af75>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc41192b-0c9e-4045-9342-65b1c52a3a0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc41192b-0c9e-4045-9342-65b1c52a3a0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/4f506a01-963f-4962-b25c-d2c4bde97f3f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc41192b-0c9e-4045-9342-65b1c52a3a0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/79be782f-ec1e-46b2-b245-e870f331fdd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79be782f-ec1e-46b2-b245-e870f331fdd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/4f506a01-963f-4962-b25c-d2c4bde97f3f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79be782f-ec1e-46b2-b245-e870f331fdd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/57a1e712-b58c-446b-86d0-1352cdd2a009> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57a1e712-b58c-446b-86d0-1352cdd2a009";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/4f506a01-963f-4962-b25c-d2c4bde97f3f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57a1e712-b58c-446b-86d0-1352cdd2a009>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ee3e391-c5bc-43e3-8636-e2a6f3fa17e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ee3e391-c5bc-43e3-8636-e2a6f3fa17e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/5366d682-3321-46a2-b265-34b66bf1287a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ee3e391-c5bc-43e3-8636-e2a6f3fa17e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ddf7195-2e5d-4ebb-b3f5-8963bc7bea7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ddf7195-2e5d-4ebb-b3f5-8963bc7bea7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/5366d682-3321-46a2-b265-34b66bf1287a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ddf7195-2e5d-4ebb-b3f5-8963bc7bea7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8dad9fa5-8f67-4066-b01f-63fccfc82beb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8dad9fa5-8f67-4066-b01f-63fccfc82beb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/5366d682-3321-46a2-b265-34b66bf1287a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8dad9fa5-8f67-4066-b01f-63fccfc82beb>.
+    
+<http://data.lblod.info/id/remote-data-objects/35701dd4-fb88-442e-b35f-79c8aa39fcd6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35701dd4-fb88-442e-b35f-79c8aa39fcd6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/57410df2-21f6-4e6e-a77f-3ce4ec2b4212/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35701dd4-fb88-442e-b35f-79c8aa39fcd6>.
+    
+<http://data.lblod.info/id/remote-data-objects/aca4f547-024a-4e0f-ac29-89f01710d153> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aca4f547-024a-4e0f-ac29-89f01710d153";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/57410df2-21f6-4e6e-a77f-3ce4ec2b4212/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aca4f547-024a-4e0f-ac29-89f01710d153>.
+    
+<http://data.lblod.info/id/remote-data-objects/95fd3a42-7602-4e2e-81a0-b855eea439be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95fd3a42-7602-4e2e-81a0-b855eea439be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/57410df2-21f6-4e6e-a77f-3ce4ec2b4212/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95fd3a42-7602-4e2e-81a0-b855eea439be>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf49a937-f55a-44b2-8233-94546b6ad333> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf49a937-f55a-44b2-8233-94546b6ad333";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/5f228298-b068-4709-bd83-6676b91d22ac/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf49a937-f55a-44b2-8233-94546b6ad333>.
+    
+<http://data.lblod.info/id/remote-data-objects/34e92291-de2d-414c-ac39-d5c763e113a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34e92291-de2d-414c-ac39-d5c763e113a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/5f228298-b068-4709-bd83-6676b91d22ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34e92291-de2d-414c-ac39-d5c763e113a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/30e686be-38c8-44cc-9791-b904a5f7a7d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30e686be-38c8-44cc-9791-b904a5f7a7d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/5f228298-b068-4709-bd83-6676b91d22ac/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30e686be-38c8-44cc-9791-b904a5f7a7d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f1d195c-871a-4427-bcb7-f46b20288cde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f1d195c-871a-4427-bcb7-f46b20288cde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/703331db-092b-41dc-8308-a2f421f8cc1c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f1d195c-871a-4427-bcb7-f46b20288cde>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4bb4456-158c-402d-ab8a-2e00d857dd8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4bb4456-158c-402d-ab8a-2e00d857dd8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/703331db-092b-41dc-8308-a2f421f8cc1c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4bb4456-158c-402d-ab8a-2e00d857dd8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a449572-6a6b-42ab-bc0a-9e4d3046e6d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a449572-6a6b-42ab-bc0a-9e4d3046e6d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/703331db-092b-41dc-8308-a2f421f8cc1c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a449572-6a6b-42ab-bc0a-9e4d3046e6d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5fecf26-c630-43eb-adb8-ccd4d7f01ea4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5fecf26-c630-43eb-adb8-ccd4d7f01ea4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/7ea7ef94-314c-4754-b69d-095926a03ff2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5fecf26-c630-43eb-adb8-ccd4d7f01ea4>.
+    
+<http://data.lblod.info/id/remote-data-objects/aada0cc4-4bde-4736-9d27-c7bc30cd0d0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aada0cc4-4bde-4736-9d27-c7bc30cd0d0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/7ea7ef94-314c-4754-b69d-095926a03ff2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aada0cc4-4bde-4736-9d27-c7bc30cd0d0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5c7c4b9-9534-4adb-aaac-d51495e99ee7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5c7c4b9-9534-4adb-aaac-d51495e99ee7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/7ea7ef94-314c-4754-b69d-095926a03ff2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5c7c4b9-9534-4adb-aaac-d51495e99ee7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4005bc6-9798-4abb-b438-c21480a9fbd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4005bc6-9798-4abb-b438-c21480a9fbd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/906e9f60-8350-4ca1-9e88-9302dd6ae34e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4005bc6-9798-4abb-b438-c21480a9fbd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/99992ecd-534f-439a-babb-4a3f7c5e513e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99992ecd-534f-439a-babb-4a3f7c5e513e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/906e9f60-8350-4ca1-9e88-9302dd6ae34e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99992ecd-534f-439a-babb-4a3f7c5e513e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b2eff6b-d02b-4479-bd60-5fe9d678f45d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b2eff6b-d02b-4479-bd60-5fe9d678f45d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/9345ee0e-63e4-493f-9556-806924a72c38/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b2eff6b-d02b-4479-bd60-5fe9d678f45d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e4dca63-2eae-4148-b1b6-86ba4486d6cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e4dca63-2eae-4148-b1b6-86ba4486d6cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/9345ee0e-63e4-493f-9556-806924a72c38/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e4dca63-2eae-4148-b1b6-86ba4486d6cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/47300304-ea1a-4b33-b25f-8f333ca778d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47300304-ea1a-4b33-b25f-8f333ca778d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/9345ee0e-63e4-493f-9556-806924a72c38/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47300304-ea1a-4b33-b25f-8f333ca778d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8862182b-3b86-4065-a5f2-1d0b41302c7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8862182b-3b86-4065-a5f2-1d0b41302c7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/c6efa432-cd0b-4eec-8b1d-ca009b270868/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ee3acb5-6084-43fb-8637-2ea7fcf641df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8862182b-3b86-4065-a5f2-1d0b41302c7d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201041-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201041-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201041-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201041-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/afc96de5-619d-4544-b4b1-e03c6ee322de> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "afc96de5-619d-4544-b4b1-e03c6ee322de";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dd9afe75-949a-48ca-b937-00f7b7dfd222";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/26203d23-3a4d-4525-9577-36e9481c94da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "26203d23-3a4d-4525-9577-36e9481c94da";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222>.
+
+  <http://redpencil.data.gift/id/task/563abc99-9832-4703-8709-e20ffdb30236> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "563abc99-9832-4703-8709-e20ffdb30236";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/afc96de5-619d-4544-b4b1-e03c6ee322de>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/26203d23-3a4d-4525-9577-36e9481c94da>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/63a30e3e-65c7-48ad-993b-32b00dcf8c27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63a30e3e-65c7-48ad-993b-32b00dcf8c27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/c6efa432-cd0b-4eec-8b1d-ca009b270868/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63a30e3e-65c7-48ad-993b-32b00dcf8c27>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf0718b4-a59c-4dc0-9536-7ea7a2d282b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf0718b4-a59c-4dc0-9536-7ea7a2d282b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/c6efa432-cd0b-4eec-8b1d-ca009b270868/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf0718b4-a59c-4dc0-9536-7ea7a2d282b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/249dad4d-d079-444e-8649-49dfd23c4f23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "249dad4d-d079-444e-8649-49dfd23c4f23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/dc64b782-2068-4007-8d69-cbaa941a8e8e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/249dad4d-d079-444e-8649-49dfd23c4f23>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4ee829f-da4a-4b71-a119-f0892d6afa42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4ee829f-da4a-4b71-a119-f0892d6afa42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/dc64b782-2068-4007-8d69-cbaa941a8e8e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4ee829f-da4a-4b71-a119-f0892d6afa42>.
+    
+<http://data.lblod.info/id/remote-data-objects/00ad39ee-7d0c-47ce-b8fa-764ef558a56a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00ad39ee-7d0c-47ce-b8fa-764ef558a56a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/dc64b782-2068-4007-8d69-cbaa941a8e8e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00ad39ee-7d0c-47ce-b8fa-764ef558a56a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7d140e0-3cc4-4ea5-8ad0-9482bec76303> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7d140e0-3cc4-4ea5-8ad0-9482bec76303";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/e06e6ecf-1e60-4706-aadd-20914c1ba284/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7d140e0-3cc4-4ea5-8ad0-9482bec76303>.
+    
+<http://data.lblod.info/id/remote-data-objects/48ede63a-a3d3-4048-9dd5-fde547b7f8b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48ede63a-a3d3-4048-9dd5-fde547b7f8b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/e06e6ecf-1e60-4706-aadd-20914c1ba284/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48ede63a-a3d3-4048-9dd5-fde547b7f8b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/76a8fc7c-4781-463b-b69d-9abab7b79b6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76a8fc7c-4781-463b-b69d-9abab7b79b6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/e06e6ecf-1e60-4706-aadd-20914c1ba284/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76a8fc7c-4781-463b-b69d-9abab7b79b6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbb757b2-7741-4bff-8bf4-932a29c6a07b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbb757b2-7741-4bff-8bf4-932a29c6a07b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/e6ff13dc-c78e-4e99-87ed-83d0547f843f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbb757b2-7741-4bff-8bf4-932a29c6a07b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec487221-2f71-4785-b79d-19d0d2145ef5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec487221-2f71-4785-b79d-19d0d2145ef5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/e6ff13dc-c78e-4e99-87ed-83d0547f843f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec487221-2f71-4785-b79d-19d0d2145ef5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c51ea67b-b3de-4792-b65a-a20fd696310b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c51ea67b-b3de-4792-b65a-a20fd696310b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/e6ff13dc-c78e-4e99-87ed-83d0547f843f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c51ea67b-b3de-4792-b65a-a20fd696310b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f96d762-1247-4ee9-968a-2154853c72f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f96d762-1247-4ee9-968a-2154853c72f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/f72f72e4-62ae-4cf9-a85c-cda5c2fd3ab4/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f96d762-1247-4ee9-968a-2154853c72f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea077cf0-f2d3-471d-bfeb-d297119ef794> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea077cf0-f2d3-471d-bfeb-d297119ef794";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/f72f72e4-62ae-4cf9-a85c-cda5c2fd3ab4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea077cf0-f2d3-471d-bfeb-d297119ef794>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cb47cd0-0fd9-47e5-99cb-cd8293a11ade> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cb47cd0-0fd9-47e5-99cb-cd8293a11ade";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/gr/f72f72e4-62ae-4cf9-a85c-cda5c2fd3ab4/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cb47cd0-0fd9-47e5-99cb-cd8293a11ade>.
+    
+<http://data.lblod.info/id/remote-data-objects/100d6af5-d376-4bb2-8855-6e1387400236> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "100d6af5-d376-4bb2-8855-6e1387400236";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/042bd5d9-6eda-4d2f-a49d-7bdd9ec9cc1d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/100d6af5-d376-4bb2-8855-6e1387400236>.
+    
+<http://data.lblod.info/id/remote-data-objects/e68a9192-f234-48b8-ad71-b7e9c591c39a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e68a9192-f234-48b8-ad71-b7e9c591c39a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/042bd5d9-6eda-4d2f-a49d-7bdd9ec9cc1d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e68a9192-f234-48b8-ad71-b7e9c591c39a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c32c5862-7545-4393-b4db-7c7c26ed5222> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c32c5862-7545-4393-b4db-7c7c26ed5222";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/042bd5d9-6eda-4d2f-a49d-7bdd9ec9cc1d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c32c5862-7545-4393-b4db-7c7c26ed5222>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbafd8f5-397c-4636-a1e8-c6bb1631be31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbafd8f5-397c-4636-a1e8-c6bb1631be31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/2c8bbf30-552a-4f9f-a91b-05e6b899dc6a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbafd8f5-397c-4636-a1e8-c6bb1631be31>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9e36a05-1077-42b7-99f2-040c6243f3d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9e36a05-1077-42b7-99f2-040c6243f3d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/2c8bbf30-552a-4f9f-a91b-05e6b899dc6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9e36a05-1077-42b7-99f2-040c6243f3d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b5cccd8-e592-4c97-9e99-4a6cc8872e47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b5cccd8-e592-4c97-9e99-4a6cc8872e47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/2c8bbf30-552a-4f9f-a91b-05e6b899dc6a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b5cccd8-e592-4c97-9e99-4a6cc8872e47>.
+    
+<http://data.lblod.info/id/remote-data-objects/241622b2-952d-46d1-ba65-ea3bd9d5b4ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "241622b2-952d-46d1-ba65-ea3bd9d5b4ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/482f0641-5951-447b-9303-33f9bacca0b9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/241622b2-952d-46d1-ba65-ea3bd9d5b4ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcc2cd75-25f0-4de9-8ea5-7b98d67faea9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcc2cd75-25f0-4de9-8ea5-7b98d67faea9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/482f0641-5951-447b-9303-33f9bacca0b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcc2cd75-25f0-4de9-8ea5-7b98d67faea9>.
+    
+<http://data.lblod.info/id/remote-data-objects/45487be5-8dea-4ac4-b308-c9bd0c5c6c4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45487be5-8dea-4ac4-b308-c9bd0c5c6c4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/482f0641-5951-447b-9303-33f9bacca0b9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45487be5-8dea-4ac4-b308-c9bd0c5c6c4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d96da51-da28-4e86-a6f1-e55b0800726d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d96da51-da28-4e86-a6f1-e55b0800726d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/4dfbfed5-414e-4c73-86dc-e9e18affed4f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d96da51-da28-4e86-a6f1-e55b0800726d>.
+    
+<http://data.lblod.info/id/remote-data-objects/721e9ae9-995e-4d01-8ce4-cdec8bcf34e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "721e9ae9-995e-4d01-8ce4-cdec8bcf34e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/4dfbfed5-414e-4c73-86dc-e9e18affed4f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/721e9ae9-995e-4d01-8ce4-cdec8bcf34e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf54c30d-49dc-4bd3-8b72-b74b2c8c5b75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf54c30d-49dc-4bd3-8b72-b74b2c8c5b75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/4dfbfed5-414e-4c73-86dc-e9e18affed4f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf54c30d-49dc-4bd3-8b72-b74b2c8c5b75>.
+    
+<http://data.lblod.info/id/remote-data-objects/e915f9b2-38fe-41ae-9fe3-15c62d9ec388> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e915f9b2-38fe-41ae-9fe3-15c62d9ec388";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/652a2766-b53b-454e-a189-a694d5c76f70/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e915f9b2-38fe-41ae-9fe3-15c62d9ec388>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f954520-2d04-4da3-9cb9-5947cf53a60b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f954520-2d04-4da3-9cb9-5947cf53a60b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/652a2766-b53b-454e-a189-a694d5c76f70/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f954520-2d04-4da3-9cb9-5947cf53a60b>.
+    
+<http://data.lblod.info/id/remote-data-objects/09de1253-e65c-401a-8122-80cc639c3c7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09de1253-e65c-401a-8122-80cc639c3c7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/652a2766-b53b-454e-a189-a694d5c76f70/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09de1253-e65c-401a-8122-80cc639c3c7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b71b6527-7483-4326-be3e-aa4abcc6149a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b71b6527-7483-4326-be3e-aa4abcc6149a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/6fa20dfa-0d20-4dc9-958d-8a1e09deb345/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b71b6527-7483-4326-be3e-aa4abcc6149a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c03e350f-d279-495f-9e04-e5ce3b10f565> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c03e350f-d279-495f-9e04-e5ce3b10f565";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/6fa20dfa-0d20-4dc9-958d-8a1e09deb345/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c03e350f-d279-495f-9e04-e5ce3b10f565>.
+    
+<http://data.lblod.info/id/remote-data-objects/64a1dc19-04e1-4e31-bb8b-f1a2f92cd3b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64a1dc19-04e1-4e31-bb8b-f1a2f92cd3b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/6fa20dfa-0d20-4dc9-958d-8a1e09deb345/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64a1dc19-04e1-4e31-bb8b-f1a2f92cd3b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4af5b29-051c-4c29-96b2-29b8eb8c5836> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4af5b29-051c-4c29-96b2-29b8eb8c5836";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/734668d8-2d83-4d8f-8f4b-46856dd972d1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4af5b29-051c-4c29-96b2-29b8eb8c5836>.
+    
+<http://data.lblod.info/id/remote-data-objects/d78ced8f-1002-41c9-af74-268e7bc7a32e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d78ced8f-1002-41c9-af74-268e7bc7a32e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/734668d8-2d83-4d8f-8f4b-46856dd972d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d78ced8f-1002-41c9-af74-268e7bc7a32e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4563da0-dd88-47e6-abe9-61097671f165> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4563da0-dd88-47e6-abe9-61097671f165";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/734668d8-2d83-4d8f-8f4b-46856dd972d1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4563da0-dd88-47e6-abe9-61097671f165>.
+    
+<http://data.lblod.info/id/remote-data-objects/b024432a-cd50-4a5e-a8e8-e8d765b5979f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b024432a-cd50-4a5e-a8e8-e8d765b5979f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/898a03ab-5525-4034-ba6f-a6df9684ede9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b024432a-cd50-4a5e-a8e8-e8d765b5979f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5069c134-1441-4644-bf38-0917dcd6384d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5069c134-1441-4644-bf38-0917dcd6384d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/898a03ab-5525-4034-ba6f-a6df9684ede9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5069c134-1441-4644-bf38-0917dcd6384d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbf099bf-36d2-4418-9a41-d8d131e8e6f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbf099bf-36d2-4418-9a41-d8d131e8e6f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/898a03ab-5525-4034-ba6f-a6df9684ede9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbf099bf-36d2-4418-9a41-d8d131e8e6f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/53849861-eae2-4430-bdf8-85efe7483a4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53849861-eae2-4430-bdf8-85efe7483a4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/ab70c38c-ec1a-4ab7-af50-10528ae14996/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53849861-eae2-4430-bdf8-85efe7483a4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ffe1c9e-a35e-4c2c-bae8-25ecdb8a983c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ffe1c9e-a35e-4c2c-bae8-25ecdb8a983c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/ab70c38c-ec1a-4ab7-af50-10528ae14996/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ffe1c9e-a35e-4c2c-bae8-25ecdb8a983c>.
+    
+<http://data.lblod.info/id/remote-data-objects/26956228-958d-4625-8127-101fe50ea8dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26956228-958d-4625-8127-101fe50ea8dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/ab70c38c-ec1a-4ab7-af50-10528ae14996/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26956228-958d-4625-8127-101fe50ea8dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/19a578fb-51f8-400e-9c6e-20d54df175e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19a578fb-51f8-400e-9c6e-20d54df175e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/b98fadaa-6292-4365-acc4-8443b17f2a54/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19a578fb-51f8-400e-9c6e-20d54df175e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1f3b8fa-4a53-4335-9aae-aede74253e2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1f3b8fa-4a53-4335-9aae-aede74253e2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/b98fadaa-6292-4365-acc4-8443b17f2a54/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1f3b8fa-4a53-4335-9aae-aede74253e2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bf166dd-b001-4d47-b7df-c055dc64fbfb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bf166dd-b001-4d47-b7df-c055dc64fbfb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/b98fadaa-6292-4365-acc4-8443b17f2a54/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bf166dd-b001-4d47-b7df-c055dc64fbfb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d886e897-130e-44ce-8812-2e0798f1520e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d886e897-130e-44ce-8812-2e0798f1520e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/cccfcff1-0b90-4964-a561-29211c78be95/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d886e897-130e-44ce-8812-2e0798f1520e>.
+    
+<http://data.lblod.info/id/remote-data-objects/da51d985-717e-44bd-b295-1828943a0a8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da51d985-717e-44bd-b295-1828943a0a8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/cccfcff1-0b90-4964-a561-29211c78be95/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da51d985-717e-44bd-b295-1828943a0a8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/66c448b9-382c-448a-b686-1f86abd89de6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66c448b9-382c-448a-b686-1f86abd89de6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/d0939c93-58d7-453c-9f02-3384fb57f3da/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66c448b9-382c-448a-b686-1f86abd89de6>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c73a2ab-7a37-4656-99d6-c7484ed807e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c73a2ab-7a37-4656-99d6-c7484ed807e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/d0939c93-58d7-453c-9f02-3384fb57f3da/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c73a2ab-7a37-4656-99d6-c7484ed807e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/92287e91-0c26-47e9-b62e-a68b3624f8c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92287e91-0c26-47e9-b62e-a68b3624f8c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/d0939c93-58d7-453c-9f02-3384fb57f3da/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92287e91-0c26-47e9-b62e-a68b3624f8c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec2efea2-5871-428f-b8fe-6923dbcdc7ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec2efea2-5871-428f-b8fe-6923dbcdc7ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/e5981750-f9ef-464f-97cb-b1b83e6f96e1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd9afe75-949a-48ca-b937-00f7b7dfd222> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec2efea2-5871-428f-b8fe-6923dbcdc7ef>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201042-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201042-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201042-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201042-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/88e0fc70-2a54-4116-86c3-e4cbfbbb5926> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "88e0fc70-2a54-4116-86c3-e4cbfbbb5926";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/960810fc-58dd-4837-a376-c6d304cc0fa9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "960810fc-58dd-4837-a376-c6d304cc0fa9";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a>.
+
+  <http://redpencil.data.gift/id/task/52e84e3b-f8a1-4d05-b3a0-800b9b15cf52> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "52e84e3b-f8a1-4d05-b3a0-800b9b15cf52";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/88e0fc70-2a54-4116-86c3-e4cbfbbb5926>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/960810fc-58dd-4837-a376-c6d304cc0fa9>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d0c89419-dc04-4381-8bf9-3e3d54ca508a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0c89419-dc04-4381-8bf9-3e3d54ca508a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/e5981750-f9ef-464f-97cb-b1b83e6f96e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0c89419-dc04-4381-8bf9-3e3d54ca508a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a48f10d3-432f-4387-9a37-d2a38ce0d3a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a48f10d3-432f-4387-9a37-d2a38ce0d3a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/e5981750-f9ef-464f-97cb-b1b83e6f96e1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a48f10d3-432f-4387-9a37-d2a38ce0d3a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/11eba413-3459-4f19-8e64-b54770bb2a98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11eba413-3459-4f19-8e64-b54770bb2a98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/ed5e1d97-4528-4264-a3e2-aa3d17b25528/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11eba413-3459-4f19-8e64-b54770bb2a98>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3f38bcf-f288-4985-befe-bf603928ab7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3f38bcf-f288-4985-befe-bf603928ab7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/ed5e1d97-4528-4264-a3e2-aa3d17b25528/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3f38bcf-f288-4985-befe-bf603928ab7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/623dcf79-8df1-45f0-bf82-09b726c2936e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "623dcf79-8df1-45f0-bf82-09b726c2936e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/rmw/ed5e1d97-4528-4264-a3e2-aa3d17b25528/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/623dcf79-8df1-45f0-bf82-09b726c2936e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b081545d-5497-4da3-b51f-27fadf743833> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b081545d-5497-4da3-b51f-27fadf743833";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/039dd992-48c3-4a1a-bcba-1633a58b6d69/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b081545d-5497-4da3-b51f-27fadf743833>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd2bbc81-4f43-4e9e-b666-4b9db436d106> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd2bbc81-4f43-4e9e-b666-4b9db436d106";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/074edce9-7d0b-4152-aaf1-ea8d479eef07/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd2bbc81-4f43-4e9e-b666-4b9db436d106>.
+    
+<http://data.lblod.info/id/remote-data-objects/53c3b57f-e0d1-4c2c-9944-f1c673a1314d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53c3b57f-e0d1-4c2c-9944-f1c673a1314d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/217ac420-9dea-44a8-8e6d-050e39ee26e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53c3b57f-e0d1-4c2c-9944-f1c673a1314d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb56ffc0-b768-47f6-b287-a5b275116b77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb56ffc0-b768-47f6-b287-a5b275116b77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/225cefb8-5bc9-438b-ac32-7ed5814faeca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb56ffc0-b768-47f6-b287-a5b275116b77>.
+    
+<http://data.lblod.info/id/remote-data-objects/0779608a-d544-428e-be15-12c31c41816a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0779608a-d544-428e-be15-12c31c41816a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/2329a760-c851-44e2-acdb-f6e6fbb62b14/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0779608a-d544-428e-be15-12c31c41816a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e14fa91-db08-4e7f-bae1-ee1c04bfec97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e14fa91-db08-4e7f-bae1-ee1c04bfec97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/34062dde-1bb1-483d-9d41-2fa30560449b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e14fa91-db08-4e7f-bae1-ee1c04bfec97>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe7c9086-2b34-4824-bf75-81bd4eab31ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe7c9086-2b34-4824-bf75-81bd4eab31ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/3aa804d4-9d53-4912-a53e-8795f514dcc0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe7c9086-2b34-4824-bf75-81bd4eab31ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/ead36a6f-bfea-4764-9242-aa111b3de4f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ead36a6f-bfea-4764-9242-aa111b3de4f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/3afa9db3-67d1-4851-9772-e19dba003236/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ead36a6f-bfea-4764-9242-aa111b3de4f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/18d4906f-6ebe-40f1-94bc-11084a77592c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18d4906f-6ebe-40f1-94bc-11084a77592c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/3d66aa26-76e3-4857-ada0-75ccf99ccb47/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18d4906f-6ebe-40f1-94bc-11084a77592c>.
+    
+<http://data.lblod.info/id/remote-data-objects/54b86a97-9965-4999-96e3-0d12f8de2def> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54b86a97-9965-4999-96e3-0d12f8de2def";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/40d2941f-1d9b-4e17-91a1-3fcdafd7929c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54b86a97-9965-4999-96e3-0d12f8de2def>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c3b876d-6deb-45d9-82be-3524cf949136> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c3b876d-6deb-45d9-82be-3524cf949136";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/45625114-02d5-4a08-aad2-345ff2b506ca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c3b876d-6deb-45d9-82be-3524cf949136>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e5008a0-70a1-4a23-b0a5-9a8bc0a3a963> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e5008a0-70a1-4a23-b0a5-9a8bc0a3a963";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/4ab2f309-3e13-41a4-bd0c-198d9da7c027/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e5008a0-70a1-4a23-b0a5-9a8bc0a3a963>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f3a6806-e416-4693-9f31-ec37f75865bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f3a6806-e416-4693-9f31-ec37f75865bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/4cccd4bd-6c7a-47b3-b26c-fd427b83bdc1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f3a6806-e416-4693-9f31-ec37f75865bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/1557e1b8-82d8-45a6-8426-a329b515090b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1557e1b8-82d8-45a6-8426-a329b515090b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/512eb43f-8fc3-4390-8f65-83ea9f6bfe62/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1557e1b8-82d8-45a6-8426-a329b515090b>.
+    
+<http://data.lblod.info/id/remote-data-objects/452a79dc-de19-4718-befb-a1eea0ebd7e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "452a79dc-de19-4718-befb-a1eea0ebd7e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/524e7ccb-8fde-462f-9427-921a1d57731a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/452a79dc-de19-4718-befb-a1eea0ebd7e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bc7f4e0-f8fa-482c-9538-e3a848dd22de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bc7f4e0-f8fa-482c-9538-e3a848dd22de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/53e239b0-6423-4e38-8776-ed99828d09d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bc7f4e0-f8fa-482c-9538-e3a848dd22de>.
+    
+<http://data.lblod.info/id/remote-data-objects/01b0180b-0b35-4544-8651-4bdb14705806> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01b0180b-0b35-4544-8651-4bdb14705806";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/5655e5e2-49db-41ea-9a90-04e2943a2eb5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01b0180b-0b35-4544-8651-4bdb14705806>.
+    
+<http://data.lblod.info/id/remote-data-objects/aec6dc12-a02a-4e3b-b3b3-db71e24d9750> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aec6dc12-a02a-4e3b-b3b3-db71e24d9750";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/5ee4360e-6cd5-4c41-94b5-0b4ee0c37bec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aec6dc12-a02a-4e3b-b3b3-db71e24d9750>.
+    
+<http://data.lblod.info/id/remote-data-objects/c38f2a2a-23e9-41ca-991b-2aa351f8964c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c38f2a2a-23e9-41ca-991b-2aa351f8964c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/64d44be8-8bfb-467f-a375-7dc279c36263/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c38f2a2a-23e9-41ca-991b-2aa351f8964c>.
+    
+<http://data.lblod.info/id/remote-data-objects/05211ea5-5ee0-4968-bbd2-a704d3ce37aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05211ea5-5ee0-4968-bbd2-a704d3ce37aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/67135925-9e69-4e1a-8384-fc38d4ef163b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05211ea5-5ee0-4968-bbd2-a704d3ce37aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/782ddc6e-586b-43c4-b8f6-e2100f7f62ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "782ddc6e-586b-43c4-b8f6-e2100f7f62ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/743e4f3e-2c18-45a4-b318-fa88539859fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/782ddc6e-586b-43c4-b8f6-e2100f7f62ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/0de51999-03e2-43ac-93c7-292e86375a25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0de51999-03e2-43ac-93c7-292e86375a25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/747ac720-6718-4a5a-9d44-09a99a60c513/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0de51999-03e2-43ac-93c7-292e86375a25>.
+    
+<http://data.lblod.info/id/remote-data-objects/96b42f66-186c-4911-ac5a-1b6b18786591> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96b42f66-186c-4911-ac5a-1b6b18786591";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/75863605-eb89-4c30-a3d9-0194413c0a18/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96b42f66-186c-4911-ac5a-1b6b18786591>.
+    
+<http://data.lblod.info/id/remote-data-objects/745b5d04-b68f-4624-848d-661c0873ad5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "745b5d04-b68f-4624-848d-661c0873ad5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/774e0426-68e1-4207-95b7-203fbd77f751/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/745b5d04-b68f-4624-848d-661c0873ad5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d628bb2-832f-4153-94b9-ef4a07e89a5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d628bb2-832f-4153-94b9-ef4a07e89a5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/7bfb137c-c675-454f-aa18-9b84e1a1fbbd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d628bb2-832f-4153-94b9-ef4a07e89a5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/57a5787b-3439-41ca-b985-6ce4f9687266> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57a5787b-3439-41ca-b985-6ce4f9687266";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/816ea510-6515-4552-a4d2-e62dbd5d1834/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57a5787b-3439-41ca-b985-6ce4f9687266>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c0e417a-3eeb-4404-9b69-d5b9743dacda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c0e417a-3eeb-4404-9b69-d5b9743dacda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/82c4d51b-04d3-4b12-8d26-ade98e27fde5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c0e417a-3eeb-4404-9b69-d5b9743dacda>.
+    
+<http://data.lblod.info/id/remote-data-objects/29ed10bf-f90e-4191-b922-ececb5140ef1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29ed10bf-f90e-4191-b922-ececb5140ef1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/84153504-8697-44b8-8964-e1c5cbe0446e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29ed10bf-f90e-4191-b922-ececb5140ef1>.
+    
+<http://data.lblod.info/id/remote-data-objects/85dea287-0fdd-41e3-879b-1b73979dc529> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85dea287-0fdd-41e3-879b-1b73979dc529";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/89d7782b-860f-470b-a938-c681b9b7f1f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85dea287-0fdd-41e3-879b-1b73979dc529>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc092634-f81e-4e04-bcce-27e1b9d2553d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc092634-f81e-4e04-bcce-27e1b9d2553d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/8fdb0d06-04bc-4085-967c-906bfd0eb24d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc092634-f81e-4e04-bcce-27e1b9d2553d>.
+    
+<http://data.lblod.info/id/remote-data-objects/74cad180-d7b7-4dc1-9353-9514d6f0a43b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74cad180-d7b7-4dc1-9353-9514d6f0a43b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/92bae7fd-8237-4d82-afff-4da1fc6dd11f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74cad180-d7b7-4dc1-9353-9514d6f0a43b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6a5f35a-392a-4880-9ee7-f807be9bd7f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6a5f35a-392a-4880-9ee7-f807be9bd7f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/932c6ea9-9e4d-4065-874f-acb40c03c26f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6a5f35a-392a-4880-9ee7-f807be9bd7f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6ece78b-a97a-4227-87ea-78fb563ce029> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6ece78b-a97a-4227-87ea-78fb563ce029";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/9521ea5d-18dc-4331-ae16-86dce7e452d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6ece78b-a97a-4227-87ea-78fb563ce029>.
+    
+<http://data.lblod.info/id/remote-data-objects/278f3625-3cb4-4b22-81a1-e8c0b7622955> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "278f3625-3cb4-4b22-81a1-e8c0b7622955";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/95765083-3665-4569-997c-1218d615fe65/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/278f3625-3cb4-4b22-81a1-e8c0b7622955>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd7a937d-eb98-471f-806d-d058f8680dfd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd7a937d-eb98-471f-806d-d058f8680dfd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/9d1dc45b-18ad-4d79-94eb-889b97ced415/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd7a937d-eb98-471f-806d-d058f8680dfd>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0c4af1c-a951-42c1-8f0b-402067d3b9d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0c4af1c-a951-42c1-8f0b-402067d3b9d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/9e096840-3900-439c-b2a4-3f859553976a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0c4af1c-a951-42c1-8f0b-402067d3b9d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f49dd1d-541b-4f20-aa78-045f36228ffd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f49dd1d-541b-4f20-aa78-045f36228ffd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/a497d049-556d-4185-922d-392253212cf1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f49dd1d-541b-4f20-aa78-045f36228ffd>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cdd5a69-6feb-44ff-a262-26aeab466d6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cdd5a69-6feb-44ff-a262-26aeab466d6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/afbe0035-9f3b-4925-b089-9959d02abc2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cdd5a69-6feb-44ff-a262-26aeab466d6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fdabb66-13c1-471b-a1ee-af5b5c030306> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fdabb66-13c1-471b-a1ee-af5b5c030306";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/b1ed75a0-02d9-4d63-bbb6-ec029bae1ebb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fdabb66-13c1-471b-a1ee-af5b5c030306>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9a2ff37-c4fb-416e-8057-064a47f13d41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9a2ff37-c4fb-416e-8057-064a47f13d41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/b34be270-82f5-44a6-9205-dd57d6bd43aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9a2ff37-c4fb-416e-8057-064a47f13d41>.
+    
+<http://data.lblod.info/id/remote-data-objects/89a4e623-d12f-44d9-afec-bbdb6f789084> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89a4e623-d12f-44d9-afec-bbdb6f789084";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/b508774a-6c70-4c50-b8af-93c23a4b91f5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89a4e623-d12f-44d9-afec-bbdb6f789084>.
+    
+<http://data.lblod.info/id/remote-data-objects/735fd314-5490-41ff-9146-2362f860b938> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "735fd314-5490-41ff-9146-2362f860b938";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/b60ad25a-38a4-43c4-abe2-5f8050defb93/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/735fd314-5490-41ff-9146-2362f860b938>.
+    
+<http://data.lblod.info/id/remote-data-objects/f06fc0d2-deb4-4abc-bdc0-8eeb46b3714e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f06fc0d2-deb4-4abc-bdc0-8eeb46b3714e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/b8c6f9bb-222e-4b43-acb7-aadd42ecea43/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f06fc0d2-deb4-4abc-bdc0-8eeb46b3714e>.
+    
+<http://data.lblod.info/id/remote-data-objects/25c83c0c-f839-4820-b76b-ea6cb8a37ea2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25c83c0c-f839-4820-b76b-ea6cb8a37ea2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/bb8d7b4e-d66b-4a05-96de-ba25d0e9f6b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25c83c0c-f839-4820-b76b-ea6cb8a37ea2>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba62ab2e-eae1-445b-ab9f-46c28081fb01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba62ab2e-eae1-445b-ab9f-46c28081fb01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/bdb08d96-31b4-46b3-a51e-8116f768a192/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4c6b0f07-9b47-4386-a2e4-a4c4dc3ce98a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba62ab2e-eae1-445b-ab9f-46c28081fb01>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201043-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201043-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201043-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201043-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/94f570b6-9e7b-4aa4-a29f-123cf85b8aba> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "94f570b6-9e7b-4aa4-a29f-123cf85b8aba";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dc296ba6-318f-436c-8793-f1aad20173c1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d5a8333e-196f-469a-912a-fbbe319f9171> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d5a8333e-196f-469a-912a-fbbe319f9171";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1>.
+
+  <http://redpencil.data.gift/id/task/e07fcb5b-08bd-44e8-bb6f-144ec0dec966> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e07fcb5b-08bd-44e8-bb6f-144ec0dec966";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/94f570b6-9e7b-4aa4-a29f-123cf85b8aba>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d5a8333e-196f-469a-912a-fbbe319f9171>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/1653a193-1840-4f83-ac86-d0e192ae4a23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1653a193-1840-4f83-ac86-d0e192ae4a23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/bfe1c924-77ed-40b6-aab1-576f5f55bae2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1653a193-1840-4f83-ac86-d0e192ae4a23>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b9ef00f-a666-4ad4-b71a-fcb6e1d53311> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b9ef00f-a666-4ad4-b71a-fcb6e1d53311";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/c66f080e-ff7a-4fea-a310-d388780b00f8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b9ef00f-a666-4ad4-b71a-fcb6e1d53311>.
+    
+<http://data.lblod.info/id/remote-data-objects/80e71b95-c07a-4d98-b0b4-5698ea8943cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80e71b95-c07a-4d98-b0b4-5698ea8943cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/c87429bb-938a-447b-bbd4-965e03c3187a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80e71b95-c07a-4d98-b0b4-5698ea8943cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/5222c9c5-0ca1-412a-b7fa-da2afe675bd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5222c9c5-0ca1-412a-b7fa-da2afe675bd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/ca4c7650-d930-4213-aaec-149bbc6894e5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5222c9c5-0ca1-412a-b7fa-da2afe675bd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/958ed98a-dd95-4a1b-9799-150c2c8dd6c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "958ed98a-dd95-4a1b-9799-150c2c8dd6c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/d31b4e08-c696-43d7-86a1-faf2bba7dd2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/958ed98a-dd95-4a1b-9799-150c2c8dd6c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/95e049b3-7a3c-410a-9863-6a110aa307e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95e049b3-7a3c-410a-9863-6a110aa307e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/d4c0123f-4a69-44c3-99d9-645fb5894867/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95e049b3-7a3c-410a-9863-6a110aa307e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/20e4371d-2a87-4929-8b47-b30bd5450ad6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20e4371d-2a87-4929-8b47-b30bd5450ad6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/d6c279ba-a100-49a1-9c4e-e690ae3471af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20e4371d-2a87-4929-8b47-b30bd5450ad6>.
+    
+<http://data.lblod.info/id/remote-data-objects/19aa7a54-9747-4f6c-bba5-5a46d2f8c583> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19aa7a54-9747-4f6c-bba5-5a46d2f8c583";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/db844e63-464c-4e33-bb45-fb51cc441173/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19aa7a54-9747-4f6c-bba5-5a46d2f8c583>.
+    
+<http://data.lblod.info/id/remote-data-objects/942dc09c-2449-4f8a-ac39-b8d87ca5b121> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "942dc09c-2449-4f8a-ac39-b8d87ca5b121";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/dc9d7461-437c-4480-ab5a-87b560224285/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/942dc09c-2449-4f8a-ac39-b8d87ca5b121>.
+    
+<http://data.lblod.info/id/remote-data-objects/11591551-82fa-4a66-aa60-92417d0c7bb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11591551-82fa-4a66-aa60-92417d0c7bb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/e1ec99b6-bfbd-4747-8440-3c34ad825d17/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11591551-82fa-4a66-aa60-92417d0c7bb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/254334f8-8cb6-4c2f-b17d-2b7ac3a96ccd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "254334f8-8cb6-4c2f-b17d-2b7ac3a96ccd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/e406224c-1bdb-486c-bf5d-56e206a335ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/254334f8-8cb6-4c2f-b17d-2b7ac3a96ccd>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ea13245-33f6-47ab-b84c-96a64267306f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ea13245-33f6-47ab-b84c-96a64267306f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/f0ed5cb6-e249-42c1-abc9-4d35fdd652f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ea13245-33f6-47ab-b84c-96a64267306f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1b9c407-6d03-4c28-84bc-8d01b2c33e80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1b9c407-6d03-4c28-84bc-8d01b2c33e80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/f2f6ecb8-d44f-4d5c-9679-b25338e3cfa6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1b9c407-6d03-4c28-84bc-8d01b2c33e80>.
+    
+<http://data.lblod.info/id/remote-data-objects/c30bcd36-f126-4acc-ba68-f29bfddb19f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c30bcd36-f126-4acc-ba68-f29bfddb19f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/f58c27ca-374b-4bca-8ee7-1872af71aec6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c30bcd36-f126-4acc-ba68-f29bfddb19f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ddfa76c-39ee-4903-ba92-91baa2a23f3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ddfa76c-39ee-4903-ba92-91baa2a23f3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/f5fc7d4c-57b4-4ded-9050-82e0ee0d04b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ddfa76c-39ee-4903-ba92-91baa2a23f3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2e3f2df-a579-4c23-8007-54c949d67c82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2e3f2df-a579-4c23-8007-54c949d67c82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/f80fa79b-3556-4ca6-bcf0-ebea9a718d66/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2e3f2df-a579-4c23-8007-54c949d67c82>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9eb87a8-4820-4a9d-8867-f529a5f70f2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9eb87a8-4820-4a9d-8867-f529a5f70f2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://bertem.meetingburger.net/vabu/fdd45be5-fbb7-48c6-8aab-96fc51b7b80f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9eb87a8-4820-4a9d-8867-f529a5f70f2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca00b5af-135b-4959-9303-5239162ad95c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca00b5af-135b-4959-9303-5239162ad95c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/1fdcedde-84ff-49e4-9130-bab8bb41cdc0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca00b5af-135b-4959-9303-5239162ad95c>.
+    
+<http://data.lblod.info/id/remote-data-objects/177ae0f1-3a83-4df0-aa5b-4e13d8a36ac5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "177ae0f1-3a83-4df0-aa5b-4e13d8a36ac5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/27e914ab-2345-460a-a1e7-9aa1e24bdfd7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/177ae0f1-3a83-4df0-aa5b-4e13d8a36ac5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5d547aa-dbee-4592-bf3e-e642a97e2ae3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5d547aa-dbee-4592-bf3e-e642a97e2ae3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/35c198af-cebe-40d4-b06f-6320ff989238/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5d547aa-dbee-4592-bf3e-e642a97e2ae3>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ba0b2d4-44c9-47f3-ac60-b0e17e2a0e2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ba0b2d4-44c9-47f3-ac60-b0e17e2a0e2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/39c6b170-462c-4c07-84fc-fd50bf9d3ec8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ba0b2d4-44c9-47f3-ac60-b0e17e2a0e2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/15f392ed-4eba-487f-b02e-5b615b61ba4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15f392ed-4eba-487f-b02e-5b615b61ba4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/3f35029c-66bf-4d2f-9679-c8144387a057/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15f392ed-4eba-487f-b02e-5b615b61ba4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/071784c5-8914-4d50-b239-9335f8c612e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "071784c5-8914-4d50-b239-9335f8c612e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/43993de4-0171-491b-bdc9-a341905aeb50/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/071784c5-8914-4d50-b239-9335f8c612e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/5676ae83-8ae1-487a-8199-14a16461f361> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5676ae83-8ae1-487a-8199-14a16461f361";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/485a403c-c89b-4a41-b2d8-4fddbe62478b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5676ae83-8ae1-487a-8199-14a16461f361>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebdff495-c996-46f1-b4d9-2828f0d7e6af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebdff495-c996-46f1-b4d9-2828f0d7e6af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/5b9254a8-3a34-447a-bba9-5d28977479cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebdff495-c996-46f1-b4d9-2828f0d7e6af>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9323df2-b37f-4715-859d-1dd4a521a0f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9323df2-b37f-4715-859d-1dd4a521a0f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/8be8857f-519b-420e-a548-77aee7c35f27/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9323df2-b37f-4715-859d-1dd4a521a0f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/98e3bada-3f2d-4578-9768-e56f4051fa66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98e3bada-3f2d-4578-9768-e56f4051fa66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/91c5662b-448e-4372-bea0-b476a3dddbac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98e3bada-3f2d-4578-9768-e56f4051fa66>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd7d9f5f-e43b-4f24-a90e-06759b666465> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd7d9f5f-e43b-4f24-a90e-06759b666465";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/947efae6-e3cd-47ca-9498-8482f16d09b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd7d9f5f-e43b-4f24-a90e-06759b666465>.
+    
+<http://data.lblod.info/id/remote-data-objects/91850aa4-04e7-40e9-aa8d-b7c3fcb80ddc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91850aa4-04e7-40e9-aa8d-b7c3fcb80ddc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/a8b44118-b9e6-4cc8-9f99-e674fe6b87a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91850aa4-04e7-40e9-aa8d-b7c3fcb80ddc>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d77f8af-be32-4dfb-9f72-cc78b6543bcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d77f8af-be32-4dfb-9f72-cc78b6543bcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/b03ab885-4b3c-4f06-831e-9898e9a84f2b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d77f8af-be32-4dfb-9f72-cc78b6543bcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8b2f4ed-7a4b-4691-862d-002237e95547> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8b2f4ed-7a4b-4691-862d-002237e95547";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/b5442eea-2efd-4543-b141-c6c564255b28/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8b2f4ed-7a4b-4691-862d-002237e95547>.
+    
+<http://data.lblod.info/id/remote-data-objects/255f8ee4-2dcc-4ba2-977c-5d665895a8c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "255f8ee4-2dcc-4ba2-977c-5d665895a8c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/d21745c7-448a-4cdf-b5a9-87b78f295697/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/255f8ee4-2dcc-4ba2-977c-5d665895a8c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/558a25bd-f0ca-437e-889a-c76f444c9dcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "558a25bd-f0ca-437e-889a-c76f444c9dcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/eb5e50b9-5d6d-414c-8c48-c9a1456a248a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/558a25bd-f0ca-437e-889a-c76f444c9dcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/b79bdb7c-e5a9-4e01-8f59-2095cae1f44b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b79bdb7c-e5a9-4e01-8f59-2095cae1f44b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/f3820161-696d-42ff-b251-a7abaf505e0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b79bdb7c-e5a9-4e01-8f59-2095cae1f44b>.
+    
+<http://data.lblod.info/id/remote-data-objects/342dfbaf-2e62-4e01-b4ca-b9591bcaaaf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "342dfbaf-2e62-4e01-b4ca-b9591bcaaaf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/f878828f-8d8b-4e89-822d-7a851e1ff08f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/342dfbaf-2e62-4e01-b4ca-b9591bcaaaf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/065e0377-eacd-4992-95f2-407220c685b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "065e0377-eacd-4992-95f2-407220c685b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/bb/fd19de06-9237-4c0a-9448-642ea6a90e10/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/065e0377-eacd-4992-95f2-407220c685b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd1218e5-ad0f-4448-829b-64dbbab69b10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd1218e5-ad0f-4448-829b-64dbbab69b10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/06109c8e-e311-4a3e-a398-c87f2c84397e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd1218e5-ad0f-4448-829b-64dbbab69b10>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9d72c9c-2947-4650-8342-c7c30f6bfc4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9d72c9c-2947-4650-8342-c7c30f6bfc4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/084efadb-d565-460b-bdf6-3193a7716648/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9d72c9c-2947-4650-8342-c7c30f6bfc4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/78736d92-6b4a-4970-971e-64a1625e8eee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78736d92-6b4a-4970-971e-64a1625e8eee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/08973324-9f9c-40ce-a3e8-21c1ff06d7d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78736d92-6b4a-4970-971e-64a1625e8eee>.
+    
+<http://data.lblod.info/id/remote-data-objects/4209bc71-43a3-4e81-b0f7-3bef6fd9760b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4209bc71-43a3-4e81-b0f7-3bef6fd9760b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/0b779cf0-f4b8-4279-805b-3729b6586477/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4209bc71-43a3-4e81-b0f7-3bef6fd9760b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2518b302-4d30-496a-9c36-b00f1c9e25d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2518b302-4d30-496a-9c36-b00f1c9e25d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/10ba46f9-1a35-4cf4-a4ce-90826beac783/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2518b302-4d30-496a-9c36-b00f1c9e25d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fb0877f-476a-4f08-9640-c7a6138bd1a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fb0877f-476a-4f08-9640-c7a6138bd1a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/11c0333b-3251-4594-8fcc-a879cb8a1fcd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fb0877f-476a-4f08-9640-c7a6138bd1a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/76194da1-8a4d-4c14-9f68-f1217966507c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76194da1-8a4d-4c14-9f68-f1217966507c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/15c6e036-5bde-420c-92dd-28f01150d5a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76194da1-8a4d-4c14-9f68-f1217966507c>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc0cba1c-94c5-43b1-91a0-556ec0046730> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc0cba1c-94c5-43b1-91a0-556ec0046730";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/188f455f-0623-4784-818c-e06337a966b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc0cba1c-94c5-43b1-91a0-556ec0046730>.
+    
+<http://data.lblod.info/id/remote-data-objects/5773564b-a1c9-466b-bb89-b225e166ce2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5773564b-a1c9-466b-bb89-b225e166ce2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/1b3f2803-3c89-4252-ac8b-574b979b0efc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5773564b-a1c9-466b-bb89-b225e166ce2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ebb64ac-1cb7-42e3-a8b7-e679dbbd8474> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ebb64ac-1cb7-42e3-a8b7-e679dbbd8474";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/1bde3d75-4a7f-4832-a26c-521f9734a4d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ebb64ac-1cb7-42e3-a8b7-e679dbbd8474>.
+    
+<http://data.lblod.info/id/remote-data-objects/e74f28d0-f250-4c41-9c14-10f5c3a07ee6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e74f28d0-f250-4c41-9c14-10f5c3a07ee6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/1cac54f4-5cf4-44c0-9275-4fbc39c7d3c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e74f28d0-f250-4c41-9c14-10f5c3a07ee6>.
+    
+<http://data.lblod.info/id/remote-data-objects/96704430-9c3b-438a-aba7-b35a14c32c70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96704430-9c3b-438a-aba7-b35a14c32c70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/21d4126b-5e1a-4f96-8fd5-56fcab696a93/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96704430-9c3b-438a-aba7-b35a14c32c70>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf209379-a956-40dd-a9ad-389fabfad093> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf209379-a956-40dd-a9ad-389fabfad093";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/28311f66-b4db-470d-ba19-ef341726f8f5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf209379-a956-40dd-a9ad-389fabfad093>.
+    
+<http://data.lblod.info/id/remote-data-objects/31e853d8-eb2e-4ba7-879c-54b99cbb984d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31e853d8-eb2e-4ba7-879c-54b99cbb984d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/3109d039-cbe1-4a54-8041-347d0089dc3a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc296ba6-318f-436c-8793-f1aad20173c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31e853d8-eb2e-4ba7-879c-54b99cbb984d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201044-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201044-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201044-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201044-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/86c206a2-af41-4522-90ef-fcf5857fc68d> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "86c206a2-af41-4522-90ef-fcf5857fc68d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5294cdec-f180-4cf5-b5d4-b3fb143d4095";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e6d1c1b0-1f5a-4ef6-92b7-228fdce6a130> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e6d1c1b0-1f5a-4ef6-92b7-228fdce6a130";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095>.
+
+  <http://redpencil.data.gift/id/task/1e9afd28-bd74-4e1e-84b2-78118f823987> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1e9afd28-bd74-4e1e-84b2-78118f823987";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/86c206a2-af41-4522-90ef-fcf5857fc68d>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e6d1c1b0-1f5a-4ef6-92b7-228fdce6a130>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/733899a3-2996-42d9-a821-7c90f5f5cf65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "733899a3-2996-42d9-a821-7c90f5f5cf65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/35ba505c-8208-43fd-83cd-43f91032e70b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/733899a3-2996-42d9-a821-7c90f5f5cf65>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4223a73-f903-43d4-b08e-25efdc433ad3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4223a73-f903-43d4-b08e-25efdc433ad3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/36688a76-b196-4fbb-b395-a651b216128a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4223a73-f903-43d4-b08e-25efdc433ad3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0ac8ca7-af14-47b4-bd89-63f9a88d33d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0ac8ca7-af14-47b4-bd89-63f9a88d33d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/368751b8-b6dc-42c7-a6b2-ec7bd1087ec3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0ac8ca7-af14-47b4-bd89-63f9a88d33d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd2e77e2-1511-40eb-9c96-c164bcb5e10f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd2e77e2-1511-40eb-9c96-c164bcb5e10f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/37916133-5dcb-45f8-a798-497123a2129b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd2e77e2-1511-40eb-9c96-c164bcb5e10f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f8fb9d4-fb13-457a-b424-bb9c9fb84f77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f8fb9d4-fb13-457a-b424-bb9c9fb84f77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/39a1deae-4fe8-493a-a7cb-753cf9ddb7ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f8fb9d4-fb13-457a-b424-bb9c9fb84f77>.
+    
+<http://data.lblod.info/id/remote-data-objects/20ee7469-6659-418d-9c38-9f5fc6155c88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20ee7469-6659-418d-9c38-9f5fc6155c88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/3ab3fb83-4d85-4bec-ba21-5c5a28291a35/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20ee7469-6659-418d-9c38-9f5fc6155c88>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8fbe5b3-c7f8-4f4c-8c54-e698c783482e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8fbe5b3-c7f8-4f4c-8c54-e698c783482e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/3cfafa61-f6be-438a-b11f-0f60d8573890/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8fbe5b3-c7f8-4f4c-8c54-e698c783482e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad6a7101-9d7a-4979-a74c-b98fa9f70cc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad6a7101-9d7a-4979-a74c-b98fa9f70cc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/3f8d35e9-096e-48db-aa4c-dd4d3f849146/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad6a7101-9d7a-4979-a74c-b98fa9f70cc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/77bdbcd7-1c26-41f3-a92e-625d565fe524> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77bdbcd7-1c26-41f3-a92e-625d565fe524";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/44025014-3f13-4553-a056-f75f3f157f3d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77bdbcd7-1c26-41f3-a92e-625d565fe524>.
+    
+<http://data.lblod.info/id/remote-data-objects/b55069df-d135-4672-b353-550586b085f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b55069df-d135-4672-b353-550586b085f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/4666fa8a-ccda-4abc-9142-64a1e5aaf461/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b55069df-d135-4672-b353-550586b085f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f0ddb9d-9925-4d30-be2d-7fc7e242446f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f0ddb9d-9925-4d30-be2d-7fc7e242446f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/519df9a2-83ac-4c09-a315-dcc1571e1894/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f0ddb9d-9925-4d30-be2d-7fc7e242446f>.
+    
+<http://data.lblod.info/id/remote-data-objects/db006d5d-c21a-4e5e-a4ef-42227602d8e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db006d5d-c21a-4e5e-a4ef-42227602d8e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/593864b3-82db-4060-9229-b988714bb385/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db006d5d-c21a-4e5e-a4ef-42227602d8e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/601f0095-08ea-4886-88ee-404d6cf1a0e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "601f0095-08ea-4886-88ee-404d6cf1a0e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/5fe78b37-8dbe-49ee-82c9-88b22d3e4333/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/601f0095-08ea-4886-88ee-404d6cf1a0e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9de9d98-02d7-4042-8af2-6fb685840e14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9de9d98-02d7-4042-8af2-6fb685840e14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/6246d548-28d4-4626-bfd3-b5688d1f76a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9de9d98-02d7-4042-8af2-6fb685840e14>.
+    
+<http://data.lblod.info/id/remote-data-objects/b63b46d5-331c-483e-9141-c7133998baf7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b63b46d5-331c-483e-9141-c7133998baf7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/65b2c877-ee6f-41f5-94b3-6a08e12889d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b63b46d5-331c-483e-9141-c7133998baf7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1cc2baa-7804-4461-9854-b4a6181672c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1cc2baa-7804-4461-9854-b4a6181672c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/6df94b9d-6a42-43af-9918-b566caa57b3f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1cc2baa-7804-4461-9854-b4a6181672c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d176f076-572e-4bfc-88d6-98fc5d17b4c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d176f076-572e-4bfc-88d6-98fc5d17b4c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/7163ef1f-f056-476b-ac0f-a8a20ebf84b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d176f076-572e-4bfc-88d6-98fc5d17b4c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/124c3d23-773b-41d3-8650-ce4428e0b312> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "124c3d23-773b-41d3-8650-ce4428e0b312";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/72ce4770-c3ac-4290-8fcd-0369d45c2869/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/124c3d23-773b-41d3-8650-ce4428e0b312>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cd3aef7-521a-443e-8e71-9026563f7823> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cd3aef7-521a-443e-8e71-9026563f7823";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/73d81b6d-cd66-4ca5-8c20-f9f022366e74/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cd3aef7-521a-443e-8e71-9026563f7823>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bed77c6-e10f-443e-9668-5116251e1818> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bed77c6-e10f-443e-9668-5116251e1818";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/759f8b17-2c28-4330-ae4e-bc28695f0452/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bed77c6-e10f-443e-9668-5116251e1818>.
+    
+<http://data.lblod.info/id/remote-data-objects/161a4302-6c02-48dc-8491-1b3422e1620a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "161a4302-6c02-48dc-8491-1b3422e1620a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/7717bad4-c5ca-4127-b22e-8b5fb2a5c5f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/161a4302-6c02-48dc-8491-1b3422e1620a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3e33c1d-7aec-42a0-837e-cb233ea94763> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3e33c1d-7aec-42a0-837e-cb233ea94763";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/7bbe40e4-5ef7-4a70-9595-2b2f5c5fe175/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3e33c1d-7aec-42a0-837e-cb233ea94763>.
+    
+<http://data.lblod.info/id/remote-data-objects/61509dab-5574-4749-8fb3-0ac4050c3577> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61509dab-5574-4749-8fb3-0ac4050c3577";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/807a0f0c-bc4a-4f1f-90e1-f134e086279c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61509dab-5574-4749-8fb3-0ac4050c3577>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4f5b991-9550-4202-a96c-b754b280c09b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4f5b991-9550-4202-a96c-b754b280c09b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/81a8ca4c-df07-4c13-b6ef-dcd8ca3184e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4f5b991-9550-4202-a96c-b754b280c09b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3c8f03c-3bf3-4fed-ba7b-b91e2283a2b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3c8f03c-3bf3-4fed-ba7b-b91e2283a2b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/835b0caf-7988-49c2-a9eb-9914d9029c6f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3c8f03c-3bf3-4fed-ba7b-b91e2283a2b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/898e59aa-de24-45ae-8fa1-e33d0d4a1e6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "898e59aa-de24-45ae-8fa1-e33d0d4a1e6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/8d1d93bd-775f-45a8-8053-8feca09b4598/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/898e59aa-de24-45ae-8fa1-e33d0d4a1e6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f7e0620-31b7-4cb0-a374-76cdc8c119ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f7e0620-31b7-4cb0-a374-76cdc8c119ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/8ec1987c-a648-45ae-8367-02175c5fe4d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f7e0620-31b7-4cb0-a374-76cdc8c119ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f250d10-fb0a-457c-9c49-8cb70c3764b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f250d10-fb0a-457c-9c49-8cb70c3764b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/8ff66d41-d472-4de7-af76-64c7a6d58ffa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f250d10-fb0a-457c-9c49-8cb70c3764b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/64377272-02dd-490c-88c2-87ae7026ad5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64377272-02dd-490c-88c2-87ae7026ad5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/9af75c8f-6261-4d6b-bc5f-094e52702f9c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64377272-02dd-490c-88c2-87ae7026ad5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/90bc79b4-d97a-4d6a-8789-fae104192d0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90bc79b4-d97a-4d6a-8789-fae104192d0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/9fd0468e-d867-4c3e-8453-b8c1c7de4fdf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90bc79b4-d97a-4d6a-8789-fae104192d0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b197d618-cf3a-47b6-9234-1c166e7d2518> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b197d618-cf3a-47b6-9234-1c166e7d2518";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/a01375c9-91c7-4a9b-a9c8-9f1af603d2fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b197d618-cf3a-47b6-9234-1c166e7d2518>.
+    
+<http://data.lblod.info/id/remote-data-objects/d764757b-820f-4b79-bf3e-b13d6c9827c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d764757b-820f-4b79-bf3e-b13d6c9827c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/a7557720-adbf-4f63-ac19-b251b793c334/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d764757b-820f-4b79-bf3e-b13d6c9827c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd1692df-8db8-4f5e-8035-ab62678eaf12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd1692df-8db8-4f5e-8035-ab62678eaf12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/acdca5d4-85aa-4a94-aedf-9e5b1488212d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd1692df-8db8-4f5e-8035-ab62678eaf12>.
+    
+<http://data.lblod.info/id/remote-data-objects/9aae93a0-e8d9-46d5-b5d1-9c146720353a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9aae93a0-e8d9-46d5-b5d1-9c146720353a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/af6cba84-b216-43e6-9581-76b535e62d41/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9aae93a0-e8d9-46d5-b5d1-9c146720353a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a1edee0-310b-436b-af43-939151a2e7d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a1edee0-310b-436b-af43-939151a2e7d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/b26b4223-ca28-4e8a-9b87-212dec85abf0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a1edee0-310b-436b-af43-939151a2e7d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/44c2d3b6-71f9-49bc-bb24-e4be19e80468> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44c2d3b6-71f9-49bc-bb24-e4be19e80468";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/b2fb27c5-b081-40f0-aa26-2422cc65d147/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44c2d3b6-71f9-49bc-bb24-e4be19e80468>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9cbf237-5b33-47d7-8b89-5d1d30fa7a4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9cbf237-5b33-47d7-8b89-5d1d30fa7a4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/b798f552-39c3-4c9d-8d2a-ad0c2de22452/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9cbf237-5b33-47d7-8b89-5d1d30fa7a4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/54ac1298-1607-4e50-834c-befee3fbc794> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54ac1298-1607-4e50-834c-befee3fbc794";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/b9c796d0-211a-4f87-9317-829e58290425/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54ac1298-1607-4e50-834c-befee3fbc794>.
+    
+<http://data.lblod.info/id/remote-data-objects/f56b3738-23ac-45b0-ae49-4791b09dfccc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f56b3738-23ac-45b0-ae49-4791b09dfccc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/c3a2311f-36b4-4d27-b3e1-f4b32c976647/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f56b3738-23ac-45b0-ae49-4791b09dfccc>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1ada2dd-6e4f-4e2c-b1b6-be153abbc939> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1ada2dd-6e4f-4e2c-b1b6-be153abbc939";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/c6815a06-e505-4c52-ac90-e3954f6e58bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1ada2dd-6e4f-4e2c-b1b6-be153abbc939>.
+    
+<http://data.lblod.info/id/remote-data-objects/c647aaee-c211-4e4c-9b13-e22060b8183f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c647aaee-c211-4e4c-9b13-e22060b8183f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/c86217fb-496c-497b-82a0-f22224eb0b4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c647aaee-c211-4e4c-9b13-e22060b8183f>.
+    
+<http://data.lblod.info/id/remote-data-objects/83c676cd-deae-4f6f-b1a0-ab770e026a61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83c676cd-deae-4f6f-b1a0-ab770e026a61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/cad7322f-0743-4bd1-b512-7bdadf87214d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83c676cd-deae-4f6f-b1a0-ab770e026a61>.
+    
+<http://data.lblod.info/id/remote-data-objects/63f8e3b2-d29f-4830-996c-da5210db5b13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63f8e3b2-d29f-4830-996c-da5210db5b13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/d6054d33-256d-4034-9c40-6104bd437b5a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63f8e3b2-d29f-4830-996c-da5210db5b13>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc936665-ccec-4a78-ac15-e649e82bf7e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc936665-ccec-4a78-ac15-e649e82bf7e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/d709237b-b30b-4857-8dfb-dd0f35853a17/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc936665-ccec-4a78-ac15-e649e82bf7e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6760491b-0770-4859-aa03-c67bbe96912c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6760491b-0770-4859-aa03-c67bbe96912c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/da797d83-c4a2-4b87-baaa-6e870db05d4b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6760491b-0770-4859-aa03-c67bbe96912c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e41ee0b4-4929-4af4-8986-1bfa484d76b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e41ee0b4-4929-4af4-8986-1bfa484d76b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/e07b5c48-d2e5-40e1-8cce-428a02b5e8fb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e41ee0b4-4929-4af4-8986-1bfa484d76b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/732365b4-e4ef-48b4-b3a1-78372d47f86c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "732365b4-e4ef-48b4-b3a1-78372d47f86c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/e5a29310-b9a5-4e98-aade-3b5b4c51f2ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/732365b4-e4ef-48b4-b3a1-78372d47f86c>.
+    
+<http://data.lblod.info/id/remote-data-objects/848df569-dca2-4c8a-a3bd-078aae340128> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "848df569-dca2-4c8a-a3bd-078aae340128";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/e5b7e370-d057-4ebc-9f5c-55d502aad831/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/848df569-dca2-4c8a-a3bd-078aae340128>.
+    
+<http://data.lblod.info/id/remote-data-objects/5219c9f2-6493-4b68-bf7e-a06aba46e062> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5219c9f2-6493-4b68-bf7e-a06aba46e062";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/e63cf584-2725-42b6-aed6-e2be2ae33a04/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5219c9f2-6493-4b68-bf7e-a06aba46e062>.
+    
+<http://data.lblod.info/id/remote-data-objects/cca726e1-5f95-4a5c-9df3-8fb102bda924> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cca726e1-5f95-4a5c-9df3-8fb102bda924";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/e9c94a16-a93c-47ce-a9e2-cf15dfe87317/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5294cdec-f180-4cf5-b5d4-b3fb143d4095> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cca726e1-5f95-4a5c-9df3-8fb102bda924>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201045-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201045-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201045-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201045-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d5a6f895-d891-4f3e-bfc9-7d5022dd53e7> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d5a6f895-d891-4f3e-bfc9-7d5022dd53e7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c6daa504-cf77-4b8a-a9f4-814cb382422a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/17c37869-ecd6-4b99-a8e2-498847bd348b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "17c37869-ecd6-4b99-a8e2-498847bd348b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a>.
+
+  <http://redpencil.data.gift/id/task/02f53c18-d1a3-4614-accd-c1334ce820bf> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "02f53c18-d1a3-4614-accd-c1334ce820bf";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d5a6f895-d891-4f3e-bfc9-7d5022dd53e7>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/17c37869-ecd6-4b99-a8e2-498847bd348b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e6eb2388-a8e9-4478-abb6-1b005d44729d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6eb2388-a8e9-4478-abb6-1b005d44729d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/ed8fe4de-c0dd-470e-b319-4880203802f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6eb2388-a8e9-4478-abb6-1b005d44729d>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf278e71-b8f4-44a8-a2e3-1532226a7e5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf278e71-b8f4-44a8-a2e3-1532226a7e5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/f4472be9-1fa8-4e54-b96b-75b8917cf3a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf278e71-b8f4-44a8-a2e3-1532226a7e5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b08e107b-3a41-460a-8691-a33e84a3c7b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b08e107b-3a41-460a-8691-a33e84a3c7b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/cbs/f81443a7-a099-49c3-812f-5aa8422f64cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b08e107b-3a41-460a-8691-a33e84a3c7b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5d32e32-6723-452e-a346-124436f35fb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5d32e32-6723-452e-a346-124436f35fb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/08d98b83-3d10-467b-8f28-89e948a96809/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5d32e32-6723-452e-a346-124436f35fb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f4b5018-889c-4ee0-9137-2721dc5a402b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f4b5018-889c-4ee0-9137-2721dc5a402b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/08d98b83-3d10-467b-8f28-89e948a96809/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f4b5018-889c-4ee0-9137-2721dc5a402b>.
+    
+<http://data.lblod.info/id/remote-data-objects/475c467e-dd2b-446b-a0f0-f727ed909ef1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "475c467e-dd2b-446b-a0f0-f727ed909ef1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/08d98b83-3d10-467b-8f28-89e948a96809/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/475c467e-dd2b-446b-a0f0-f727ed909ef1>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a708bc1-edbd-4cac-a084-d97497ac7cc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a708bc1-edbd-4cac-a084-d97497ac7cc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/38a2dccc-1695-49d5-99a6-992777c36ad5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a708bc1-edbd-4cac-a084-d97497ac7cc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/abf7cf46-a6ef-4e0f-bebc-7611b8258047> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abf7cf46-a6ef-4e0f-bebc-7611b8258047";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/38a2dccc-1695-49d5-99a6-992777c36ad5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abf7cf46-a6ef-4e0f-bebc-7611b8258047>.
+    
+<http://data.lblod.info/id/remote-data-objects/35d5af76-c298-462d-a99a-9c5559420c9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35d5af76-c298-462d-a99a-9c5559420c9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/38a2dccc-1695-49d5-99a6-992777c36ad5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35d5af76-c298-462d-a99a-9c5559420c9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2f34b3b-d7a4-4e2c-8691-cdb6a5e0221c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2f34b3b-d7a4-4e2c-8691-cdb6a5e0221c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/5c44be3e-00df-4936-a6ae-5dcc90056a32/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2f34b3b-d7a4-4e2c-8691-cdb6a5e0221c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a37da248-da78-4da8-b0df-3e00f23f6089> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a37da248-da78-4da8-b0df-3e00f23f6089";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/5c44be3e-00df-4936-a6ae-5dcc90056a32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a37da248-da78-4da8-b0df-3e00f23f6089>.
+    
+<http://data.lblod.info/id/remote-data-objects/203aee8d-ed14-41e7-a9ce-da08a8f677f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "203aee8d-ed14-41e7-a9ce-da08a8f677f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/5c44be3e-00df-4936-a6ae-5dcc90056a32/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/203aee8d-ed14-41e7-a9ce-da08a8f677f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/256e10e8-835b-488a-8afe-ae999a5bc177> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "256e10e8-835b-488a-8afe-ae999a5bc177";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/6e446f2a-201b-4695-bdd1-501e9865b39b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/256e10e8-835b-488a-8afe-ae999a5bc177>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e6135aa-fda0-4fe5-b8a4-e2e97f3ec302> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e6135aa-fda0-4fe5-b8a4-e2e97f3ec302";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/6e446f2a-201b-4695-bdd1-501e9865b39b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e6135aa-fda0-4fe5-b8a4-e2e97f3ec302>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3b4bb43-bc11-40d6-aee7-66f1ae219541> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3b4bb43-bc11-40d6-aee7-66f1ae219541";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/6e446f2a-201b-4695-bdd1-501e9865b39b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3b4bb43-bc11-40d6-aee7-66f1ae219541>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccf5c2d0-6c17-4fc6-a8ba-1483248533e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccf5c2d0-6c17-4fc6-a8ba-1483248533e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/77db17ca-3320-4498-9a8b-d875fb8448ee/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccf5c2d0-6c17-4fc6-a8ba-1483248533e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ca0b904-2898-4689-b68c-420431d1c6ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ca0b904-2898-4689-b68c-420431d1c6ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/77db17ca-3320-4498-9a8b-d875fb8448ee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ca0b904-2898-4689-b68c-420431d1c6ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/d70fa2db-f1be-4930-9d51-7c8839453e30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d70fa2db-f1be-4930-9d51-7c8839453e30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/77db17ca-3320-4498-9a8b-d875fb8448ee/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d70fa2db-f1be-4930-9d51-7c8839453e30>.
+    
+<http://data.lblod.info/id/remote-data-objects/572f5f31-b2dc-4d02-8c16-eb0cc94a2c47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "572f5f31-b2dc-4d02-8c16-eb0cc94a2c47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/8136ccab-266f-416d-9d20-8a86b4b2ee91/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/572f5f31-b2dc-4d02-8c16-eb0cc94a2c47>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3051d72-2fd9-41e0-a8ac-e4f3e8482285> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3051d72-2fd9-41e0-a8ac-e4f3e8482285";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/8136ccab-266f-416d-9d20-8a86b4b2ee91/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3051d72-2fd9-41e0-a8ac-e4f3e8482285>.
+    
+<http://data.lblod.info/id/remote-data-objects/0127b78b-0c33-4f1e-99ea-158bdadf6e9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0127b78b-0c33-4f1e-99ea-158bdadf6e9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/8136ccab-266f-416d-9d20-8a86b4b2ee91/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0127b78b-0c33-4f1e-99ea-158bdadf6e9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc114f67-1f82-4574-918a-a27ebcc22338> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc114f67-1f82-4574-918a-a27ebcc22338";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/9c0c56cd-a752-4396-b460-46f2cb36917b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc114f67-1f82-4574-918a-a27ebcc22338>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3de2169-727d-4dfd-8d94-8f4c8b70e98c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3de2169-727d-4dfd-8d94-8f4c8b70e98c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/9c0c56cd-a752-4396-b460-46f2cb36917b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3de2169-727d-4dfd-8d94-8f4c8b70e98c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f37fd0f-f123-4088-848e-173509ffc9f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f37fd0f-f123-4088-848e-173509ffc9f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/9c0c56cd-a752-4396-b460-46f2cb36917b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f37fd0f-f123-4088-848e-173509ffc9f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c12a0af-6617-4034-bf1b-7f3d1db325ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c12a0af-6617-4034-bf1b-7f3d1db325ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/9eb93a27-cec9-4b3f-9805-02593542e60d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c12a0af-6617-4034-bf1b-7f3d1db325ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/f78d1d81-b4cf-4177-bb5e-eb3f0ad57ffd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f78d1d81-b4cf-4177-bb5e-eb3f0ad57ffd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/9eb93a27-cec9-4b3f-9805-02593542e60d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f78d1d81-b4cf-4177-bb5e-eb3f0ad57ffd>.
+    
+<http://data.lblod.info/id/remote-data-objects/59079990-a32d-469c-9280-141f722118fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59079990-a32d-469c-9280-141f722118fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/9eb93a27-cec9-4b3f-9805-02593542e60d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59079990-a32d-469c-9280-141f722118fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c64539b-e893-46c8-b174-ba575179beba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c64539b-e893-46c8-b174-ba575179beba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/a38805ce-1ef2-44a3-b6cb-914b515241bd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c64539b-e893-46c8-b174-ba575179beba>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cc661f0-0058-4130-a1c1-6e0b7ecfe7f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cc661f0-0058-4130-a1c1-6e0b7ecfe7f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/a38805ce-1ef2-44a3-b6cb-914b515241bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cc661f0-0058-4130-a1c1-6e0b7ecfe7f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d487a5b-d6d8-4775-bbef-54883ad4afd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d487a5b-d6d8-4775-bbef-54883ad4afd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/a38805ce-1ef2-44a3-b6cb-914b515241bd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d487a5b-d6d8-4775-bbef-54883ad4afd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/6de88932-586c-4525-a8c4-9aa389a90e33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6de88932-586c-4525-a8c4-9aa389a90e33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/afa21272-61de-4981-8414-dd25dfeab718/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6de88932-586c-4525-a8c4-9aa389a90e33>.
+    
+<http://data.lblod.info/id/remote-data-objects/c442a719-7eda-4c1f-92ae-4a8b162dd8c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c442a719-7eda-4c1f-92ae-4a8b162dd8c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/afa21272-61de-4981-8414-dd25dfeab718/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c442a719-7eda-4c1f-92ae-4a8b162dd8c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/90a6bbed-be32-49c5-8bd8-58bcc273535c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90a6bbed-be32-49c5-8bd8-58bcc273535c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/afa21272-61de-4981-8414-dd25dfeab718/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90a6bbed-be32-49c5-8bd8-58bcc273535c>.
+    
+<http://data.lblod.info/id/remote-data-objects/778ab07d-2066-4236-97ff-ef77bc60065c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "778ab07d-2066-4236-97ff-ef77bc60065c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/ca8fa438-aa7a-4701-8a5a-316ee12f8ed7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/778ab07d-2066-4236-97ff-ef77bc60065c>.
+    
+<http://data.lblod.info/id/remote-data-objects/08b2acdf-0b1e-4550-aa30-92689f37f181> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08b2acdf-0b1e-4550-aa30-92689f37f181";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/ca8fa438-aa7a-4701-8a5a-316ee12f8ed7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08b2acdf-0b1e-4550-aa30-92689f37f181>.
+    
+<http://data.lblod.info/id/remote-data-objects/394bc260-d3fe-4b17-9b42-1efbbe1a6488> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "394bc260-d3fe-4b17-9b42-1efbbe1a6488";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/ca8fa438-aa7a-4701-8a5a-316ee12f8ed7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/394bc260-d3fe-4b17-9b42-1efbbe1a6488>.
+    
+<http://data.lblod.info/id/remote-data-objects/17cddc10-3320-420d-8fd1-c6b1c034e5fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17cddc10-3320-420d-8fd1-c6b1c034e5fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/cc034f28-92bd-47dd-9d05-902c6ac06598/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17cddc10-3320-420d-8fd1-c6b1c034e5fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/6486136c-f57f-4aa5-9415-3294035f1e35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6486136c-f57f-4aa5-9415-3294035f1e35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/cc034f28-92bd-47dd-9d05-902c6ac06598/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6486136c-f57f-4aa5-9415-3294035f1e35>.
+    
+<http://data.lblod.info/id/remote-data-objects/4387e885-ba75-4d28-a135-a5970d7eebf4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4387e885-ba75-4d28-a135-a5970d7eebf4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/dcc7ab83-0f8c-4b6b-8012-755c0089342f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4387e885-ba75-4d28-a135-a5970d7eebf4>.
+    
+<http://data.lblod.info/id/remote-data-objects/68915c0e-a44b-48da-9b48-768d386a71b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68915c0e-a44b-48da-9b48-768d386a71b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/dcc7ab83-0f8c-4b6b-8012-755c0089342f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68915c0e-a44b-48da-9b48-768d386a71b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b738279a-8870-45b0-bf68-cb8d260307a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b738279a-8870-45b0-bf68-cb8d260307a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/dcc7ab83-0f8c-4b6b-8012-755c0089342f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b738279a-8870-45b0-bf68-cb8d260307a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/83c3fbb0-778b-4684-9d55-a5e7105873fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83c3fbb0-778b-4684-9d55-a5e7105873fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/f3d639db-abdc-4fa7-a9bb-2632b85cb15c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83c3fbb0-778b-4684-9d55-a5e7105873fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/353600d3-2cef-415a-9ea3-4d8fe11b3746> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "353600d3-2cef-415a-9ea3-4d8fe11b3746";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/f3d639db-abdc-4fa7-a9bb-2632b85cb15c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/353600d3-2cef-415a-9ea3-4d8fe11b3746>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c814db4-34aa-41c7-a9e3-cbc2101d08ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c814db4-34aa-41c7-a9e3-cbc2101d08ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/f3d639db-abdc-4fa7-a9bb-2632b85cb15c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c814db4-34aa-41c7-a9e3-cbc2101d08ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e24258d-8b3d-4bb6-8a89-48e1062eec42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e24258d-8b3d-4bb6-8a89-48e1062eec42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/facc2fee-1b1f-426f-87b4-88292cd3d2e3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e24258d-8b3d-4bb6-8a89-48e1062eec42>.
+    
+<http://data.lblod.info/id/remote-data-objects/14478915-2c91-4c44-8c89-4710b0b4789b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14478915-2c91-4c44-8c89-4710b0b4789b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/facc2fee-1b1f-426f-87b4-88292cd3d2e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14478915-2c91-4c44-8c89-4710b0b4789b>.
+    
+<http://data.lblod.info/id/remote-data-objects/471d030a-43ef-49f8-8646-ed41ad232359> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "471d030a-43ef-49f8-8646-ed41ad232359";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/gr/facc2fee-1b1f-426f-87b4-88292cd3d2e3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/471d030a-43ef-49f8-8646-ed41ad232359>.
+    
+<http://data.lblod.info/id/remote-data-objects/0955bb7a-af8a-4735-9ba3-503f2780e3a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0955bb7a-af8a-4735-9ba3-503f2780e3a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/0591f369-0c50-443b-9a24-06be893343ae/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0955bb7a-af8a-4735-9ba3-503f2780e3a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/27be7eeb-6e13-4517-b13b-d3410dc73843> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27be7eeb-6e13-4517-b13b-d3410dc73843";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/0591f369-0c50-443b-9a24-06be893343ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27be7eeb-6e13-4517-b13b-d3410dc73843>.
+    
+<http://data.lblod.info/id/remote-data-objects/1dd09e55-c94d-4dbe-8a8a-536c473edc9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1dd09e55-c94d-4dbe-8a8a-536c473edc9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/0591f369-0c50-443b-9a24-06be893343ae/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6daa504-cf77-4b8a-a9f4-814cb382422a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1dd09e55-c94d-4dbe-8a8a-536c473edc9d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201047-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201047-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201047-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201047-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a9d99081-3062-42b4-b6ac-c1a0231d9c7e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a9d99081-3062-42b4-b6ac-c1a0231d9c7e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5c1755e0-aff2-4634-a57e-0f25967a5efc";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4d51d4fd-8c56-4e2a-8dd4-e0e6a242335d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4d51d4fd-8c56-4e2a-8dd4-e0e6a242335d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc>.
+
+  <http://redpencil.data.gift/id/task/20ed1f8b-5b28-401c-b99f-6edc704263cc> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "20ed1f8b-5b28-401c-b99f-6edc704263cc";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a9d99081-3062-42b4-b6ac-c1a0231d9c7e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4d51d4fd-8c56-4e2a-8dd4-e0e6a242335d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/65c1d951-a9d6-4bca-ac96-1e551e31fbf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65c1d951-a9d6-4bca-ac96-1e551e31fbf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/0de5a1e1-77be-4e87-aa96-5269953bf4d0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65c1d951-a9d6-4bca-ac96-1e551e31fbf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/abd15d2b-d3b7-40cd-89c5-4c811b63166f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abd15d2b-d3b7-40cd-89c5-4c811b63166f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/0de5a1e1-77be-4e87-aa96-5269953bf4d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abd15d2b-d3b7-40cd-89c5-4c811b63166f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e6fda9d-b609-466c-8a3c-8b0f1c84a70f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e6fda9d-b609-466c-8a3c-8b0f1c84a70f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/0de5a1e1-77be-4e87-aa96-5269953bf4d0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e6fda9d-b609-466c-8a3c-8b0f1c84a70f>.
+    
+<http://data.lblod.info/id/remote-data-objects/16a5b33a-6647-4c91-9898-174bbbf143b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16a5b33a-6647-4c91-9898-174bbbf143b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/320d4401-5de1-4fcb-b5df-dd1e66907f31/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16a5b33a-6647-4c91-9898-174bbbf143b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/293b995c-5304-4f1e-a3cf-f9ba15dec41a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "293b995c-5304-4f1e-a3cf-f9ba15dec41a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/320d4401-5de1-4fcb-b5df-dd1e66907f31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/293b995c-5304-4f1e-a3cf-f9ba15dec41a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ef557a7-68c7-4e9d-91c6-42bdd3776686> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ef557a7-68c7-4e9d-91c6-42bdd3776686";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/56267732-f06b-490d-9478-aaf41d20f2c4/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ef557a7-68c7-4e9d-91c6-42bdd3776686>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8b9a1af-db24-4b3c-972b-91d2d045781f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8b9a1af-db24-4b3c-972b-91d2d045781f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/56267732-f06b-490d-9478-aaf41d20f2c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8b9a1af-db24-4b3c-972b-91d2d045781f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ca41ccd-55c9-4720-9f56-60fe1e7c2387> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ca41ccd-55c9-4720-9f56-60fe1e7c2387";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/56267732-f06b-490d-9478-aaf41d20f2c4/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ca41ccd-55c9-4720-9f56-60fe1e7c2387>.
+    
+<http://data.lblod.info/id/remote-data-objects/0524eaaf-76a3-4dac-a51c-4fc9be40b569> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0524eaaf-76a3-4dac-a51c-4fc9be40b569";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/63ca87a2-e660-4325-b337-2e7cc5fb38fe/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0524eaaf-76a3-4dac-a51c-4fc9be40b569>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa7de39f-c884-45ef-ae39-8a60fca48c05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa7de39f-c884-45ef-ae39-8a60fca48c05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/63ca87a2-e660-4325-b337-2e7cc5fb38fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa7de39f-c884-45ef-ae39-8a60fca48c05>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae14fc96-2336-455b-bb96-51a596847156> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae14fc96-2336-455b-bb96-51a596847156";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/63ca87a2-e660-4325-b337-2e7cc5fb38fe/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae14fc96-2336-455b-bb96-51a596847156>.
+    
+<http://data.lblod.info/id/remote-data-objects/92dc5d2e-7133-47fb-9ddd-b5b061908bfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92dc5d2e-7133-47fb-9ddd-b5b061908bfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/862cefaf-4fa8-4478-9e1a-27cfcf5c8800/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92dc5d2e-7133-47fb-9ddd-b5b061908bfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a512459-bb78-4d4f-918c-4baae9eba2e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a512459-bb78-4d4f-918c-4baae9eba2e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/862cefaf-4fa8-4478-9e1a-27cfcf5c8800/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a512459-bb78-4d4f-918c-4baae9eba2e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd922fd0-63c2-4d54-ba63-85b826bf2652> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd922fd0-63c2-4d54-ba63-85b826bf2652";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/862cefaf-4fa8-4478-9e1a-27cfcf5c8800/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd922fd0-63c2-4d54-ba63-85b826bf2652>.
+    
+<http://data.lblod.info/id/remote-data-objects/96019dd2-8644-46d4-8f3c-272ffeb8d417> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96019dd2-8644-46d4-8f3c-272ffeb8d417";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/b818df3b-4a73-4ac0-994e-88e068bb4168/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96019dd2-8644-46d4-8f3c-272ffeb8d417>.
+    
+<http://data.lblod.info/id/remote-data-objects/57f60393-d6ca-451e-a02d-6235fb988f13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57f60393-d6ca-451e-a02d-6235fb988f13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/b818df3b-4a73-4ac0-994e-88e068bb4168/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57f60393-d6ca-451e-a02d-6235fb988f13>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf1a7596-6dd9-4b44-8134-bbc0aafd8730> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf1a7596-6dd9-4b44-8134-bbc0aafd8730";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/b818df3b-4a73-4ac0-994e-88e068bb4168/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf1a7596-6dd9-4b44-8134-bbc0aafd8730>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff8360fe-a9bd-4d64-b62e-0dc1afebf01a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff8360fe-a9bd-4d64-b62e-0dc1afebf01a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/d0d3863c-bbd4-4aa5-8826-3e30c7f852a7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff8360fe-a9bd-4d64-b62e-0dc1afebf01a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9bf80e01-7661-4e99-831c-14d7fc020f96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9bf80e01-7661-4e99-831c-14d7fc020f96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/d0d3863c-bbd4-4aa5-8826-3e30c7f852a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9bf80e01-7661-4e99-831c-14d7fc020f96>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfebc9aa-8913-4849-876b-d7db25a5e6b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfebc9aa-8913-4849-876b-d7db25a5e6b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/d0d3863c-bbd4-4aa5-8826-3e30c7f852a7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfebc9aa-8913-4849-876b-d7db25a5e6b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/86b737fb-4d86-4e9c-8d90-fd8c7a0b0a25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86b737fb-4d86-4e9c-8d90-fd8c7a0b0a25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/e38458c6-c6c3-4981-b82f-661bd333d91d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86b737fb-4d86-4e9c-8d90-fd8c7a0b0a25>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c05aecb-8e07-4c21-b09c-e4a5986e9faf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c05aecb-8e07-4c21-b09c-e4a5986e9faf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/e38458c6-c6c3-4981-b82f-661bd333d91d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c05aecb-8e07-4c21-b09c-e4a5986e9faf>.
+    
+<http://data.lblod.info/id/remote-data-objects/660b180a-9fb2-4621-85f5-24387a3754da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "660b180a-9fb2-4621-85f5-24387a3754da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/e38458c6-c6c3-4981-b82f-661bd333d91d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/660b180a-9fb2-4621-85f5-24387a3754da>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a8bd355-312f-4fe6-a6fc-bae72e4af104> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a8bd355-312f-4fe6-a6fc-bae72e4af104";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/e4871a01-134a-40f0-818d-e0f63fbba65c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a8bd355-312f-4fe6-a6fc-bae72e4af104>.
+    
+<http://data.lblod.info/id/remote-data-objects/22173a0c-0e11-46a4-b13d-bd130828a94d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22173a0c-0e11-46a4-b13d-bd130828a94d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/e4871a01-134a-40f0-818d-e0f63fbba65c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22173a0c-0e11-46a4-b13d-bd130828a94d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1d3d54b-82b4-4b63-b29f-39044df1dd81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1d3d54b-82b4-4b63-b29f-39044df1dd81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/e4871a01-134a-40f0-818d-e0f63fbba65c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1d3d54b-82b4-4b63-b29f-39044df1dd81>.
+    
+<http://data.lblod.info/id/remote-data-objects/85a88a23-d2d4-4c76-b1c9-2aa45192fd35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85a88a23-d2d4-4c76-b1c9-2aa45192fd35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/e4a6834d-34b8-4190-aea4-7ab5248078b7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85a88a23-d2d4-4c76-b1c9-2aa45192fd35>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e4cf131-6eb1-48d7-9d7a-432c6dd43e3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e4cf131-6eb1-48d7-9d7a-432c6dd43e3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/e4a6834d-34b8-4190-aea4-7ab5248078b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e4cf131-6eb1-48d7-9d7a-432c6dd43e3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2910147-8843-4e7f-afb3-1245735b648c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2910147-8843-4e7f-afb3-1245735b648c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/e4a6834d-34b8-4190-aea4-7ab5248078b7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2910147-8843-4e7f-afb3-1245735b648c>.
+    
+<http://data.lblod.info/id/remote-data-objects/be157fec-a985-411a-8840-a1bcbc6f264d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be157fec-a985-411a-8840-a1bcbc6f264d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/ed303ed4-8698-421f-8740-91be8df72980/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be157fec-a985-411a-8840-a1bcbc6f264d>.
+    
+<http://data.lblod.info/id/remote-data-objects/22a40928-9272-4b7b-a009-6a2c9127f11f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22a40928-9272-4b7b-a009-6a2c9127f11f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/ed303ed4-8698-421f-8740-91be8df72980/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22a40928-9272-4b7b-a009-6a2c9127f11f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d54845a-4a26-462a-81b0-d7e05708908d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d54845a-4a26-462a-81b0-d7e05708908d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/rmw/ed303ed4-8698-421f-8740-91be8df72980/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d54845a-4a26-462a-81b0-d7e05708908d>.
+    
+<http://data.lblod.info/id/remote-data-objects/86a4fc8b-f3dd-4adc-84ec-989f6ee72adc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86a4fc8b-f3dd-4adc-84ec-989f6ee72adc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/086e6d31-7c1a-47a2-8373-0af0bf1779bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86a4fc8b-f3dd-4adc-84ec-989f6ee72adc>.
+    
+<http://data.lblod.info/id/remote-data-objects/619613ec-218b-482b-a677-3816a195ecc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "619613ec-218b-482b-a677-3816a195ecc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/0bc61a50-f7d9-4d8d-a2aa-4160678df987/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/619613ec-218b-482b-a677-3816a195ecc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3dc81d0-20dd-45be-a14d-78f2533b3d23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3dc81d0-20dd-45be-a14d-78f2533b3d23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/0ebdd651-b681-434a-9d12-0123a8ac1c79/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3dc81d0-20dd-45be-a14d-78f2533b3d23>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff43979d-65c4-470b-95b2-172d4ee76126> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff43979d-65c4-470b-95b2-172d4ee76126";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/10f89893-b99b-48dc-976c-727d72cce610/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff43979d-65c4-470b-95b2-172d4ee76126>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7fbd568-5868-45fe-b72b-0873e457ca17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7fbd568-5868-45fe-b72b-0873e457ca17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/1817344d-bae0-400c-9124-2c2eb8683205/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7fbd568-5868-45fe-b72b-0873e457ca17>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8b28431-b644-4d3e-8014-48869cdbe1cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8b28431-b644-4d3e-8014-48869cdbe1cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/1a171fe4-2bd0-49d8-a5bc-fcda55aeeb1c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8b28431-b644-4d3e-8014-48869cdbe1cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e3aa873-5f89-420e-9ad2-a6b3486ff432> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e3aa873-5f89-420e-9ad2-a6b3486ff432";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/22445302-7f62-4928-9af9-8fd68f6e7b5d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e3aa873-5f89-420e-9ad2-a6b3486ff432>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2ba84ca-1f23-4af4-b1a2-fdd98bad4cf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2ba84ca-1f23-4af4-b1a2-fdd98bad4cf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/229ffb9c-e224-44a3-b905-200373838b86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2ba84ca-1f23-4af4-b1a2-fdd98bad4cf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bfcfb5d-8746-4205-99a1-ce35f51a22d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bfcfb5d-8746-4205-99a1-ce35f51a22d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/232d7eb0-368f-41c8-863f-35c1f17105c7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bfcfb5d-8746-4205-99a1-ce35f51a22d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ae499d3-570d-4a56-b10a-4fe2d2db624a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ae499d3-570d-4a56-b10a-4fe2d2db624a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/35b737d7-2bdb-4b92-94ac-197491448109/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ae499d3-570d-4a56-b10a-4fe2d2db624a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3034b55b-b233-41ad-8008-28e56b61c4c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3034b55b-b233-41ad-8008-28e56b61c4c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/3f40dc4c-b70d-47c7-8e31-a4844d5ed95f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3034b55b-b233-41ad-8008-28e56b61c4c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c5e009e-11d6-4354-8174-ab95dd334d8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c5e009e-11d6-4354-8174-ab95dd334d8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/4054573b-b720-450c-a794-a06d4af9946a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c5e009e-11d6-4354-8174-ab95dd334d8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/29b70b41-bf1c-4b26-887c-0513f62adce3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29b70b41-bf1c-4b26-887c-0513f62adce3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/469f05bf-cdd7-4f16-bf8a-65e6f90c1d1a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29b70b41-bf1c-4b26-887c-0513f62adce3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0790895-b049-4864-a0ad-395d2992d222> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0790895-b049-4864-a0ad-395d2992d222";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/5764f3a5-24f3-453f-a64c-874ae5f69dd1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0790895-b049-4864-a0ad-395d2992d222>.
+    
+<http://data.lblod.info/id/remote-data-objects/78cad9e0-56dd-4cf8-8347-c8cb5ab0d0f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78cad9e0-56dd-4cf8-8347-c8cb5ab0d0f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/57aa58a6-5308-49a6-ba3f-372d7952121f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78cad9e0-56dd-4cf8-8347-c8cb5ab0d0f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/676ba3d3-1015-4f6e-bcbb-5890b68a21d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "676ba3d3-1015-4f6e-bcbb-5890b68a21d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/5a7c42b3-a036-45df-90a1-aa5c993b3f95/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/676ba3d3-1015-4f6e-bcbb-5890b68a21d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b197358-40e3-4060-8a00-f08d747ee777> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b197358-40e3-4060-8a00-f08d747ee777";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/5b84f116-f68d-4b2b-b655-689bd201fa32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b197358-40e3-4060-8a00-f08d747ee777>.
+    
+<http://data.lblod.info/id/remote-data-objects/bee403ce-6e8d-4369-a5c5-6726b57dce79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bee403ce-6e8d-4369-a5c5-6726b57dce79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/64b9f79f-2482-49d9-afc1-dbbd46c070b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c1755e0-aff2-4634-a57e-0f25967a5efc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bee403ce-6e8d-4369-a5c5-6726b57dce79>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201048-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201048-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201048-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201048-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/83deed93-4913-4bb4-be91-ee824cc5e4c3> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "83deed93-4913-4bb4-be91-ee824cc5e4c3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1221361a-c7d8-48f4-9294-5c578b51f6e8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6fb875f7-721c-4683-909c-98e82a842e71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6fb875f7-721c-4683-909c-98e82a842e71";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8>.
+
+  <http://redpencil.data.gift/id/task/78886931-02d0-4720-9996-8fd080778a6a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "78886931-02d0-4720-9996-8fd080778a6a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/83deed93-4913-4bb4-be91-ee824cc5e4c3>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6fb875f7-721c-4683-909c-98e82a842e71>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a9ef3bf5-b28e-4429-96c7-87448e25103b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9ef3bf5-b28e-4429-96c7-87448e25103b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/68c03118-2bb6-437f-8f39-a7c5a7e863a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9ef3bf5-b28e-4429-96c7-87448e25103b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9320813d-cfbf-4d43-a7c4-741d5fd30a3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9320813d-cfbf-4d43-a7c4-741d5fd30a3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/699020e8-7766-45b6-986a-c1c1294a28a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9320813d-cfbf-4d43-a7c4-741d5fd30a3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1485076-1d5e-4c95-ad7b-55b6ad2254fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1485076-1d5e-4c95-ad7b-55b6ad2254fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/77dd1ef7-b8ca-4fd2-98e6-fc512915e230/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1485076-1d5e-4c95-ad7b-55b6ad2254fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/61e52d19-13e9-47f6-847b-20ce06c382b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61e52d19-13e9-47f6-847b-20ce06c382b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/7f0d7efc-c9c6-441f-93e3-c9f38122b371/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61e52d19-13e9-47f6-847b-20ce06c382b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/86d6d782-5088-40f3-a447-485ab0412771> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86d6d782-5088-40f3-a447-485ab0412771";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/93e24362-9ac6-4bf8-bb85-f512ec0e00aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86d6d782-5088-40f3-a447-485ab0412771>.
+    
+<http://data.lblod.info/id/remote-data-objects/71ab9fcf-dfb0-4566-91ae-a7cfd87a2c6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71ab9fcf-dfb0-4566-91ae-a7cfd87a2c6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/9f883ec0-8c5a-4d90-929d-0e17ce2af9b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71ab9fcf-dfb0-4566-91ae-a7cfd87a2c6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/01c7f16e-52ec-46b0-9a27-295a17530a7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01c7f16e-52ec-46b0-9a27-295a17530a7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/a730cb73-50cd-43fa-b633-a03403159aeb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01c7f16e-52ec-46b0-9a27-295a17530a7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/497457ed-c125-4131-9a0b-0da7e0c1c699> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "497457ed-c125-4131-9a0b-0da7e0c1c699";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/aadf4ef0-559a-431d-b013-9f7581608d75/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/497457ed-c125-4131-9a0b-0da7e0c1c699>.
+    
+<http://data.lblod.info/id/remote-data-objects/cee62735-a363-4272-b66a-23bd88be8474> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cee62735-a363-4272-b66a-23bd88be8474";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/b1ee3a90-59ff-4e8a-ad6c-b12230047d06/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cee62735-a363-4272-b66a-23bd88be8474>.
+    
+<http://data.lblod.info/id/remote-data-objects/b90d150b-14e8-4267-9aef-72a1e6078f97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b90d150b-14e8-4267-9aef-72a1e6078f97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/b860ce39-b8f6-4947-988c-9645d8d40832/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b90d150b-14e8-4267-9aef-72a1e6078f97>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d0b5fa0-30ac-4a49-bd57-a1b284c776a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d0b5fa0-30ac-4a49-bd57-a1b284c776a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/bdadc241-4233-4836-930e-695a70d8c04d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d0b5fa0-30ac-4a49-bd57-a1b284c776a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/95715e70-6878-42bb-82ac-6e9cc4bd74bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95715e70-6878-42bb-82ac-6e9cc4bd74bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/c102f854-d8da-42ee-9609-bcbd69b46327/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95715e70-6878-42bb-82ac-6e9cc4bd74bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/253691a3-011e-4a47-8288-9eba2c174d3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "253691a3-011e-4a47-8288-9eba2c174d3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/c24f68f5-b672-40a0-b0df-ff78ae2a97a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/253691a3-011e-4a47-8288-9eba2c174d3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/dba37b24-1341-4c11-b1cf-95e5ceecaca8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dba37b24-1341-4c11-b1cf-95e5ceecaca8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/c9c75676-4556-46e5-b772-28361195b4b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dba37b24-1341-4c11-b1cf-95e5ceecaca8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fe909d8-32b0-49b0-9d36-eb00ffba6114> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fe909d8-32b0-49b0-9d36-eb00ffba6114";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/d3bc41a3-e9e9-4dea-890b-a2ce1a0d6c58/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fe909d8-32b0-49b0-9d36-eb00ffba6114>.
+    
+<http://data.lblod.info/id/remote-data-objects/8640b077-c3b3-4767-8293-b80cb4951473> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8640b077-c3b3-4767-8293-b80cb4951473";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/e6e79ba5-7b20-4cf0-894c-51ece60b8a2a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8640b077-c3b3-4767-8293-b80cb4951473>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c6252ee-bcc6-49a3-a571-8a3097f853ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c6252ee-bcc6-49a3-a571-8a3097f853ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/ed4a951b-af8b-42f1-a01f-14317e1a655e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c6252ee-bcc6-49a3-a571-8a3097f853ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/68964a92-d143-43b0-af18-def2cdfe2519> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68964a92-d143-43b0-af18-def2cdfe2519";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/f02d1fa5-1365-4f1b-8efd-73054a6eda75/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68964a92-d143-43b0-af18-def2cdfe2519>.
+    
+<http://data.lblod.info/id/remote-data-objects/db9955bc-8e67-47a2-8cdb-56992b3be47c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db9955bc-8e67-47a2-8cdb-56992b3be47c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/f21c34aa-333f-4dd3-bfad-ab3f9ced5ce3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db9955bc-8e67-47a2-8cdb-56992b3be47c>.
+    
+<http://data.lblod.info/id/remote-data-objects/78dab445-2282-4577-a04a-738b047983c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78dab445-2282-4577-a04a-738b047983c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/fa6ef2d8-4f81-4517-9b50-474e67634ffe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78dab445-2282-4577-a04a-738b047983c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e7a3b0e-4bca-48be-b8dc-f3b3e43062e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e7a3b0e-4bca-48be-b8dc-f3b3e43062e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boechout.meetingburger.net/vabu/fd8f8978-228a-4680-85b2-88013ef946d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e7a3b0e-4bca-48be-b8dc-f3b3e43062e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5f02b7e-e3fb-49db-a53f-d9f19942a4a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5f02b7e-e3fb-49db-a53f-d9f19942a4a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/0e523b1e-92e4-4dd4-a32b-c2620b4dba08/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5f02b7e-e3fb-49db-a53f-d9f19942a4a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/51d2b05a-b180-420e-a6c5-112e4677ea38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51d2b05a-b180-420e-a6c5-112e4677ea38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/206ba2fd-39cf-423f-9f8d-5d0c6aae9fac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51d2b05a-b180-420e-a6c5-112e4677ea38>.
+    
+<http://data.lblod.info/id/remote-data-objects/19efdc72-cb62-484b-a1e2-f6570cb4f12a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19efdc72-cb62-484b-a1e2-f6570cb4f12a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/2341ad38-56e2-45ed-a5dd-10e314f0a885/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19efdc72-cb62-484b-a1e2-f6570cb4f12a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5b6c51e-018c-4905-bb89-ad649113254b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5b6c51e-018c-4905-bb89-ad649113254b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/2b9fa058-7a3a-447e-ba0b-3aa7619a491e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5b6c51e-018c-4905-bb89-ad649113254b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bfb8f54-5af5-46e8-bd3f-600612e40eb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bfb8f54-5af5-46e8-bd3f-600612e40eb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/3cc771a8-9a29-416a-95e8-4a6164b3a2b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bfb8f54-5af5-46e8-bd3f-600612e40eb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b550052-ce8d-464d-b9a5-c5bdd636e3fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b550052-ce8d-464d-b9a5-c5bdd636e3fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/4d8e0110-f814-4379-858b-129c0b6fad88/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b550052-ce8d-464d-b9a5-c5bdd636e3fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/9317abc4-df9c-4928-8012-2f002196dcb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9317abc4-df9c-4928-8012-2f002196dcb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/4df855e3-ffb2-4e9f-8b75-9ade93389df3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9317abc4-df9c-4928-8012-2f002196dcb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ca3e6a1-3b67-4edf-adbf-abd270d26d37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ca3e6a1-3b67-4edf-adbf-abd270d26d37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/66f47973-b57d-44c8-8df0-1dcd9186df83/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ca3e6a1-3b67-4edf-adbf-abd270d26d37>.
+    
+<http://data.lblod.info/id/remote-data-objects/bad8281c-2542-43b9-a2f8-5645dec30029> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bad8281c-2542-43b9-a2f8-5645dec30029";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/6cc31b9e-2d80-4417-8009-3ce94eb28788/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bad8281c-2542-43b9-a2f8-5645dec30029>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e727737-e1f0-4c9e-bb23-e7451ea3cc09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e727737-e1f0-4c9e-bb23-e7451ea3cc09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/6cd25028-4b6a-4a7c-8161-8043180e7f5a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e727737-e1f0-4c9e-bb23-e7451ea3cc09>.
+    
+<http://data.lblod.info/id/remote-data-objects/acea2865-c7ec-4f33-b55c-8218573c780c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acea2865-c7ec-4f33-b55c-8218573c780c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/7c10e896-3fb6-4932-9dce-f9ae9d7d8e00/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acea2865-c7ec-4f33-b55c-8218573c780c>.
+    
+<http://data.lblod.info/id/remote-data-objects/77fdaf7a-f155-4d60-9441-a6c5399e2c56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77fdaf7a-f155-4d60-9441-a6c5399e2c56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/7f1029cd-69bc-4cd5-b7e8-548d86af550b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77fdaf7a-f155-4d60-9441-a6c5399e2c56>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4d57697-55ef-4d7b-8eb4-26f1f38dcf60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4d57697-55ef-4d7b-8eb4-26f1f38dcf60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/b828270f-568e-43d5-8609-022acf0daf2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4d57697-55ef-4d7b-8eb4-26f1f38dcf60>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0f895ea-98f6-424f-93ce-e023bf58d595> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0f895ea-98f6-424f-93ce-e023bf58d595";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/ba1b6077-cb39-4204-9943-a88e2d0be78c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0f895ea-98f6-424f-93ce-e023bf58d595>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c7ac78b-e7f4-46f7-8091-ef0022c67e24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c7ac78b-e7f4-46f7-8091-ef0022c67e24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/ba9518e3-3288-45a4-8e34-c7a0348d7f4d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c7ac78b-e7f4-46f7-8091-ef0022c67e24>.
+    
+<http://data.lblod.info/id/remote-data-objects/19d9b426-ecbe-4755-b418-327376a0ae5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19d9b426-ecbe-4755-b418-327376a0ae5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/c48c8d33-672c-410b-a2a8-002249fd889e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19d9b426-ecbe-4755-b418-327376a0ae5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0b1f2d1-e925-4d6a-92d7-7bf8e9e7eab0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0b1f2d1-e925-4d6a-92d7-7bf8e9e7eab0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/cda4c23a-5aa3-4d85-9404-74a5fdfcba65/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0b1f2d1-e925-4d6a-92d7-7bf8e9e7eab0>.
+    
+<http://data.lblod.info/id/remote-data-objects/63307ba1-b3cd-4331-a84f-85b88d9755fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63307ba1-b3cd-4331-a84f-85b88d9755fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/cf7d8057-950d-4543-9fed-452cf932c033/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63307ba1-b3cd-4331-a84f-85b88d9755fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/dedf5ff1-d851-4975-aed3-9dad2e67d584> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dedf5ff1-d851-4975-aed3-9dad2e67d584";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/d09d59e9-7cd9-47c3-a142-2af80debd95a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dedf5ff1-d851-4975-aed3-9dad2e67d584>.
+    
+<http://data.lblod.info/id/remote-data-objects/b814e69a-3851-416d-b968-485f45c50a1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b814e69a-3851-416d-b968-485f45c50a1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/d2bc735f-8b76-4c7b-b292-3021ddf29186/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b814e69a-3851-416d-b968-485f45c50a1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/44528e9a-2728-4290-97aa-49f302381c08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44528e9a-2728-4290-97aa-49f302381c08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/d989a958-47ec-4d5d-9155-a59f489d154d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44528e9a-2728-4290-97aa-49f302381c08>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c3ade89-e6ba-4eb4-93af-7fac9351375c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c3ade89-e6ba-4eb4-93af-7fac9351375c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/e54c960b-42ab-4f8e-8906-458bc415908f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c3ade89-e6ba-4eb4-93af-7fac9351375c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac548606-d37c-49e8-8d4d-e5d88b579329> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac548606-d37c-49e8-8d4d-e5d88b579329";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/ed5337a4-5cb9-4a96-9e04-1764b752cf88/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac548606-d37c-49e8-8d4d-e5d88b579329>.
+    
+<http://data.lblod.info/id/remote-data-objects/61b5523a-650f-49fc-8982-ef1b31c552f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61b5523a-650f-49fc-8982-ef1b31c552f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/bb/f85c1bcd-3c0d-4add-bb49-68a097f4fa35/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61b5523a-650f-49fc-8982-ef1b31c552f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/5982d5b2-26d4-49b7-9c6a-e1afb33f2c59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5982d5b2-26d4-49b7-9c6a-e1afb33f2c59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/02465d97-8c1e-4622-86e0-60a1e1afd577/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5982d5b2-26d4-49b7-9c6a-e1afb33f2c59>.
+    
+<http://data.lblod.info/id/remote-data-objects/afd1954b-16ee-444a-99ed-045c878d06dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afd1954b-16ee-444a-99ed-045c878d06dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/05bdc3e7-5d32-4d6e-9006-0e3f26d65957/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afd1954b-16ee-444a-99ed-045c878d06dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/0341bf3d-df55-40fd-a1a6-98662962cdf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0341bf3d-df55-40fd-a1a6-98662962cdf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/061aca70-5548-4eeb-afdf-61e749db1a9b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0341bf3d-df55-40fd-a1a6-98662962cdf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/65974ec0-3764-428e-b90b-a45f052cb5b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65974ec0-3764-428e-b90b-a45f052cb5b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/06b1f387-ec5f-4d51-aec2-b39d5bc805f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65974ec0-3764-428e-b90b-a45f052cb5b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a81e758-d07c-46b6-acbc-c463591ee536> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a81e758-d07c-46b6-acbc-c463591ee536";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/1642a656-0bd5-4ee9-9c74-71b275233ebf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1221361a-c7d8-48f4-9294-5c578b51f6e8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a81e758-d07c-46b6-acbc-c463591ee536>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201049-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201049-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201049-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201049-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7fe28428-5581-4c8c-a40f-7d0ecf9cab0c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7fe28428-5581-4c8c-a40f-7d0ecf9cab0c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "be5ba0c6-6120-43a2-a4b3-76c479835a93";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ab8331d7-4146-4e77-a3c7-16098f552088> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ab8331d7-4146-4e77-a3c7-16098f552088";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93>.
+
+  <http://redpencil.data.gift/id/task/fe791e7a-d913-4a6d-b899-57ab81d7fb7b> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fe791e7a-d913-4a6d-b899-57ab81d7fb7b";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7fe28428-5581-4c8c-a40f-7d0ecf9cab0c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ab8331d7-4146-4e77-a3c7-16098f552088>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/337f5c52-458c-42ef-847a-36f967baa21a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "337f5c52-458c-42ef-847a-36f967baa21a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/177f6777-3bd3-4162-b41d-cea554798f09/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/337f5c52-458c-42ef-847a-36f967baa21a>.
+    
+<http://data.lblod.info/id/remote-data-objects/011dc38e-8695-4773-8da8-b22eb23544ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "011dc38e-8695-4773-8da8-b22eb23544ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/24f361cf-1757-4530-b0f2-6eed0aa88c0c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/011dc38e-8695-4773-8da8-b22eb23544ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/82bd5a8c-4920-4893-a38e-25132fcc3e72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82bd5a8c-4920-4893-a38e-25132fcc3e72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/2687b123-e99d-4f5b-8603-ed7a2388be7c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82bd5a8c-4920-4893-a38e-25132fcc3e72>.
+    
+<http://data.lblod.info/id/remote-data-objects/37acf420-f8d8-446b-8003-254f5635e3ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37acf420-f8d8-446b-8003-254f5635e3ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/346b1062-77be-4766-85e9-6d7b03fec0bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37acf420-f8d8-446b-8003-254f5635e3ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/e086e36a-a00e-409b-82ae-4e335b557753> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e086e36a-a00e-409b-82ae-4e335b557753";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/364edbbf-0cef-4860-a196-ad492267be2a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e086e36a-a00e-409b-82ae-4e335b557753>.
+    
+<http://data.lblod.info/id/remote-data-objects/adab2cde-0e59-4f87-a48e-1447b54975b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "adab2cde-0e59-4f87-a48e-1447b54975b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/380aef09-1724-4643-a320-d3e4668cb918/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/adab2cde-0e59-4f87-a48e-1447b54975b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d577562-c0bf-4e86-ba69-38b98a96d637> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d577562-c0bf-4e86-ba69-38b98a96d637";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/48c34707-adf0-46b1-8834-635d68f8c584/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d577562-c0bf-4e86-ba69-38b98a96d637>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6ecef6e-d0c7-4714-871c-1e24bf344261> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6ecef6e-d0c7-4714-871c-1e24bf344261";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/4bddb6ab-0c5f-4e45-a152-90aebd7f040f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6ecef6e-d0c7-4714-871c-1e24bf344261>.
+    
+<http://data.lblod.info/id/remote-data-objects/162834c5-e4e9-4e95-aca8-ec7556fd6499> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "162834c5-e4e9-4e95-aca8-ec7556fd6499";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/5ae3f535-6da0-44c4-bc94-7f4655a9c8b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/162834c5-e4e9-4e95-aca8-ec7556fd6499>.
+    
+<http://data.lblod.info/id/remote-data-objects/7abf3ae5-cd68-4dde-b6c8-3473e4a3bc4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7abf3ae5-cd68-4dde-b6c8-3473e4a3bc4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/6c58ce2f-1c2f-48eb-87f7-ec29883dde6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7abf3ae5-cd68-4dde-b6c8-3473e4a3bc4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f75a882b-3121-490b-aa27-565966d4084f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f75a882b-3121-490b-aa27-565966d4084f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/6d065a12-689c-47a0-8332-5bfa492d5325/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f75a882b-3121-490b-aa27-565966d4084f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a51a3638-bfdc-4649-9d31-d4aacec4038b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a51a3638-bfdc-4649-9d31-d4aacec4038b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/72b3d2d6-ba3c-4a4e-88b8-7e580d93d793/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a51a3638-bfdc-4649-9d31-d4aacec4038b>.
+    
+<http://data.lblod.info/id/remote-data-objects/52a136c4-f51e-4833-8b72-28d6f3468345> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52a136c4-f51e-4833-8b72-28d6f3468345";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/76dff283-0856-4fc0-bf9a-06b5a72a6f0e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52a136c4-f51e-4833-8b72-28d6f3468345>.
+    
+<http://data.lblod.info/id/remote-data-objects/c08d671e-cc18-4bf5-a2a2-b01b4e220163> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c08d671e-cc18-4bf5-a2a2-b01b4e220163";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/81a456e2-4a88-45c1-a8da-8e511dba445c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c08d671e-cc18-4bf5-a2a2-b01b4e220163>.
+    
+<http://data.lblod.info/id/remote-data-objects/787e5ee1-786f-4d2d-b300-859b651583d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "787e5ee1-786f-4d2d-b300-859b651583d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/85462d0d-231d-468e-91e1-71ed6d3d34a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/787e5ee1-786f-4d2d-b300-859b651583d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee80ee03-f453-487c-8e6a-a93fb63dba52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee80ee03-f453-487c-8e6a-a93fb63dba52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/86fd2b70-a087-4a64-8e76-9144abd639f8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee80ee03-f453-487c-8e6a-a93fb63dba52>.
+    
+<http://data.lblod.info/id/remote-data-objects/e36dd452-12e7-4a67-a471-441d28cbba94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e36dd452-12e7-4a67-a471-441d28cbba94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/8baad3ef-c539-40fb-b392-42328b6edc88/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e36dd452-12e7-4a67-a471-441d28cbba94>.
+    
+<http://data.lblod.info/id/remote-data-objects/725fdde8-2038-48f8-8c44-5a6176d769ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "725fdde8-2038-48f8-8c44-5a6176d769ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/9d25ac04-bb56-4a09-ba55-d1bd612230ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/725fdde8-2038-48f8-8c44-5a6176d769ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfc4661a-f127-40ee-a044-e2dd1a26ce79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfc4661a-f127-40ee-a044-e2dd1a26ce79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/9da00287-d3dc-47d5-a5cd-972c2edc2e7f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfc4661a-f127-40ee-a044-e2dd1a26ce79>.
+    
+<http://data.lblod.info/id/remote-data-objects/3778ca8d-6999-4f28-97d2-a9a9dee7dd81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3778ca8d-6999-4f28-97d2-a9a9dee7dd81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/a60ec933-63f1-40a9-9970-452c0696099f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3778ca8d-6999-4f28-97d2-a9a9dee7dd81>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb592d03-868e-4293-901c-0ccc59395dc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb592d03-868e-4293-901c-0ccc59395dc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/a8a02f7d-e377-4282-94ab-e6b394bb1abe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb592d03-868e-4293-901c-0ccc59395dc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/38ff42a2-6560-4907-ac32-0f87b0108815> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38ff42a2-6560-4907-ac32-0f87b0108815";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/b45ab013-6dcf-4b66-895d-f4648c5ae6ce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38ff42a2-6560-4907-ac32-0f87b0108815>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ca3e78f-3e3e-46df-9882-9efcd8be7634> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ca3e78f-3e3e-46df-9882-9efcd8be7634";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/b5353aa4-131f-492e-97d9-50851b74b426/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ca3e78f-3e3e-46df-9882-9efcd8be7634>.
+    
+<http://data.lblod.info/id/remote-data-objects/80513f29-3203-4bea-9014-29ce902c490e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80513f29-3203-4bea-9014-29ce902c490e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/c1b8c152-cfe2-4d6e-b9f9-c9a1365ef1a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80513f29-3203-4bea-9014-29ce902c490e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec588386-fbd8-4be7-ae2d-6cde55443f52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec588386-fbd8-4be7-ae2d-6cde55443f52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/c1f9607c-c39d-4dc0-b49e-e4f0c4d0a1e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec588386-fbd8-4be7-ae2d-6cde55443f52>.
+    
+<http://data.lblod.info/id/remote-data-objects/40837048-0cae-45c1-af8c-f224ca925e88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40837048-0cae-45c1-af8c-f224ca925e88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/c4af6750-faac-4310-9521-8e546294b396/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40837048-0cae-45c1-af8c-f224ca925e88>.
+    
+<http://data.lblod.info/id/remote-data-objects/924f7c2a-53c9-4ed5-a7d8-977f6518867a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "924f7c2a-53c9-4ed5-a7d8-977f6518867a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/c85bbdee-e691-4ad4-83da-1fee0b3ffb24/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/924f7c2a-53c9-4ed5-a7d8-977f6518867a>.
+    
+<http://data.lblod.info/id/remote-data-objects/89890937-1030-4881-b214-8ea9728d6165> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89890937-1030-4881-b214-8ea9728d6165";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/d20de1f5-7a4a-4bae-84d9-019569f2d192/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89890937-1030-4881-b214-8ea9728d6165>.
+    
+<http://data.lblod.info/id/remote-data-objects/0755db5b-4213-4a4a-81be-292e73bda500> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0755db5b-4213-4a4a-81be-292e73bda500";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/d21c678c-7562-49db-b70f-6d0ce9508706/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0755db5b-4213-4a4a-81be-292e73bda500>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5292f83-bd1e-4a00-ace2-5a247ab8faed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5292f83-bd1e-4a00-ace2-5a247ab8faed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/e0ca3545-a6fb-4071-bd06-514dd7b24189/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5292f83-bd1e-4a00-ace2-5a247ab8faed>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1370c2d-f67c-4d91-8610-4b28e4d792d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1370c2d-f67c-4d91-8610-4b28e4d792d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/e30b2662-1f53-4b0b-b7c8-73446ee4807e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1370c2d-f67c-4d91-8610-4b28e4d792d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2886eb3e-aa60-461a-b16a-cfdd6dafb6de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2886eb3e-aa60-461a-b16a-cfdd6dafb6de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/ec956eeb-48a4-4483-8d2d-5c7d4627849c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2886eb3e-aa60-461a-b16a-cfdd6dafb6de>.
+    
+<http://data.lblod.info/id/remote-data-objects/7141b244-2102-4e10-aa37-9cb08d94e18f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7141b244-2102-4e10-aa37-9cb08d94e18f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/edbf541b-8998-49e8-9a02-392bfb2affe6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7141b244-2102-4e10-aa37-9cb08d94e18f>.
+    
+<http://data.lblod.info/id/remote-data-objects/873a6a41-3c5c-4f68-b008-53c9d3d88ce0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "873a6a41-3c5c-4f68-b008-53c9d3d88ce0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/edfe4b8a-58c0-46c6-a211-c6b365053b8b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/873a6a41-3c5c-4f68-b008-53c9d3d88ce0>.
+    
+<http://data.lblod.info/id/remote-data-objects/12abd362-c1d2-41ec-8462-40fa0076965e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12abd362-c1d2-41ec-8462-40fa0076965e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/f39839e7-5e2b-46c5-83a0-0ed603b17f36/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12abd362-c1d2-41ec-8462-40fa0076965e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3563a934-b2cd-4fc0-a295-01bf85261a83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3563a934-b2cd-4fc0-a295-01bf85261a83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/f691df8e-26d2-4882-91ba-39014e71aa0c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3563a934-b2cd-4fc0-a295-01bf85261a83>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc8d062c-51a8-4b0a-ac4d-5b1f9e83c43f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc8d062c-51a8-4b0a-ac4d-5b1f9e83c43f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/cbs/f7a083e0-1576-4995-9465-7717f64ed002/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc8d062c-51a8-4b0a-ac4d-5b1f9e83c43f>.
+    
+<http://data.lblod.info/id/remote-data-objects/82807794-1faa-454d-b4c4-338989c2db3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82807794-1faa-454d-b4c4-338989c2db3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/214bbaec-a624-46c2-acdb-8d4424424b5e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82807794-1faa-454d-b4c4-338989c2db3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bf6761f-c44c-4bd7-a590-432bd7c7cf92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bf6761f-c44c-4bd7-a590-432bd7c7cf92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/214bbaec-a624-46c2-acdb-8d4424424b5e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bf6761f-c44c-4bd7-a590-432bd7c7cf92>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0e7f975-94cc-47ce-87e7-4865e0bc3530> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0e7f975-94cc-47ce-87e7-4865e0bc3530";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/214bbaec-a624-46c2-acdb-8d4424424b5e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0e7f975-94cc-47ce-87e7-4865e0bc3530>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f003c44-cfb3-4121-bf6b-6a0fe37abe3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f003c44-cfb3-4121-bf6b-6a0fe37abe3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/224da62b-5eba-431d-8344-e79e1f946b1f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f003c44-cfb3-4121-bf6b-6a0fe37abe3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/31ef9da5-472a-4b2b-87e6-51caa913e0e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31ef9da5-472a-4b2b-87e6-51caa913e0e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/29c38cf3-6da9-4fa4-81ff-2d8942f34609/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31ef9da5-472a-4b2b-87e6-51caa913e0e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba3b4165-bbda-4da5-8d6e-f9223fa4fb2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba3b4165-bbda-4da5-8d6e-f9223fa4fb2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/2f4e2941-f766-4157-8af3-f5a30fe5e60b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba3b4165-bbda-4da5-8d6e-f9223fa4fb2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d80dc36c-05ec-4411-8056-eb1ac4289e3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d80dc36c-05ec-4411-8056-eb1ac4289e3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/2f4e2941-f766-4157-8af3-f5a30fe5e60b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d80dc36c-05ec-4411-8056-eb1ac4289e3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/defde379-fbcb-4fa2-a0c3-b3b5ce641b6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "defde379-fbcb-4fa2-a0c3-b3b5ce641b6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/2f4e2941-f766-4157-8af3-f5a30fe5e60b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/defde379-fbcb-4fa2-a0c3-b3b5ce641b6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/279c2892-822e-4593-811d-327a770e6fec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "279c2892-822e-4593-811d-327a770e6fec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/32bb8c21-5e12-4fc3-91f2-d06b9dcb00f4/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/279c2892-822e-4593-811d-327a770e6fec>.
+    
+<http://data.lblod.info/id/remote-data-objects/24dd6700-1ba3-4191-8c0c-6a562ed6c0c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24dd6700-1ba3-4191-8c0c-6a562ed6c0c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/32bb8c21-5e12-4fc3-91f2-d06b9dcb00f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24dd6700-1ba3-4191-8c0c-6a562ed6c0c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/964efd6e-590b-4261-b7c8-ba623d9ba8ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "964efd6e-590b-4261-b7c8-ba623d9ba8ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/32bb8c21-5e12-4fc3-91f2-d06b9dcb00f4/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/964efd6e-590b-4261-b7c8-ba623d9ba8ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/475e88b7-c585-4646-ac9f-b029a38214a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "475e88b7-c585-4646-ac9f-b029a38214a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/39c84468-4b61-4d4a-acfb-0a0af0637a22/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/475e88b7-c585-4646-ac9f-b029a38214a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/64a00957-b51c-4f79-bbc4-fe7d9c6d8788> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64a00957-b51c-4f79-bbc4-fe7d9c6d8788";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/39c84468-4b61-4d4a-acfb-0a0af0637a22/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/be5ba0c6-6120-43a2-a4b3-76c479835a93> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64a00957-b51c-4f79-bbc4-fe7d9c6d8788>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201050-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201050-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201050-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201050-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b59f7d2d-7bf7-4a6e-b71c-fecae9e21235> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b59f7d2d-7bf7-4a6e-b71c-fecae9e21235";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d68fcc30-5540-4607-9124-02b92eb6c544";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c62b9138-f580-49bb-b1bd-31bb5e5a911b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c62b9138-f580-49bb-b1bd-31bb5e5a911b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544>.
+
+  <http://redpencil.data.gift/id/task/32ff7477-d846-42e2-b32a-6f9fcf591a04> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "32ff7477-d846-42e2-b32a-6f9fcf591a04";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b59f7d2d-7bf7-4a6e-b71c-fecae9e21235>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c62b9138-f580-49bb-b1bd-31bb5e5a911b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/243b4f03-0ea9-404a-b7cf-1eb96127d867> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "243b4f03-0ea9-404a-b7cf-1eb96127d867";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/39c84468-4b61-4d4a-acfb-0a0af0637a22/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/243b4f03-0ea9-404a-b7cf-1eb96127d867>.
+    
+<http://data.lblod.info/id/remote-data-objects/f20a913c-718c-4b8f-ac37-4cbdad88373d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f20a913c-718c-4b8f-ac37-4cbdad88373d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/46b37211-b6d9-4b33-a8b4-685fc92dc53e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f20a913c-718c-4b8f-ac37-4cbdad88373d>.
+    
+<http://data.lblod.info/id/remote-data-objects/53c79f67-e768-470c-8a0e-2a899c5fc632> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53c79f67-e768-470c-8a0e-2a899c5fc632";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/46b37211-b6d9-4b33-a8b4-685fc92dc53e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53c79f67-e768-470c-8a0e-2a899c5fc632>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d5404e5-8a88-4828-8502-0282f9cfc3d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d5404e5-8a88-4828-8502-0282f9cfc3d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/46b37211-b6d9-4b33-a8b4-685fc92dc53e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d5404e5-8a88-4828-8502-0282f9cfc3d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/b23574ac-cdd6-4514-86ee-6f204a048289> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b23574ac-cdd6-4514-86ee-6f204a048289";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/58f6ec28-d4af-44bd-a18c-280520859c5e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b23574ac-cdd6-4514-86ee-6f204a048289>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0d238ed-5fb8-4a3b-90ed-3d6f8b375518> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0d238ed-5fb8-4a3b-90ed-3d6f8b375518";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/58f6ec28-d4af-44bd-a18c-280520859c5e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0d238ed-5fb8-4a3b-90ed-3d6f8b375518>.
+    
+<http://data.lblod.info/id/remote-data-objects/1773bc88-00aa-4052-9815-d265eeb69b0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1773bc88-00aa-4052-9815-d265eeb69b0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/94c2b955-fce8-4eb0-9816-ec538bf6d26c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1773bc88-00aa-4052-9815-d265eeb69b0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8fcba70-86c2-4dcf-904e-998279449ed4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8fcba70-86c2-4dcf-904e-998279449ed4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/94c2b955-fce8-4eb0-9816-ec538bf6d26c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8fcba70-86c2-4dcf-904e-998279449ed4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b353344-0788-4805-b537-011aa678c009> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b353344-0788-4805-b537-011aa678c009";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/94c2b955-fce8-4eb0-9816-ec538bf6d26c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b353344-0788-4805-b537-011aa678c009>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccd19660-a225-401c-8d98-9eadd185156f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccd19660-a225-401c-8d98-9eadd185156f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/a97d914d-6886-4fc6-b78a-b65c3bc23eee/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccd19660-a225-401c-8d98-9eadd185156f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bb214fb-2b79-4c8c-9484-4a641f3270c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bb214fb-2b79-4c8c-9484-4a641f3270c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/d4505a76-335a-4d87-b83a-98daf8af7f95/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bb214fb-2b79-4c8c-9484-4a641f3270c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7b16a8d-2dc8-4d4e-88b0-96c762f79747> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7b16a8d-2dc8-4d4e-88b0-96c762f79747";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/d4505a76-335a-4d87-b83a-98daf8af7f95/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7b16a8d-2dc8-4d4e-88b0-96c762f79747>.
+    
+<http://data.lblod.info/id/remote-data-objects/edec0067-eee1-420f-a475-18924559c160> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edec0067-eee1-420f-a475-18924559c160";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/dd38347e-ff43-4f5e-ae54-c5bff6a74737/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edec0067-eee1-420f-a475-18924559c160>.
+    
+<http://data.lblod.info/id/remote-data-objects/78ee4c8d-cf87-4067-bced-41ea51c6778b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78ee4c8d-cf87-4067-bced-41ea51c6778b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/dd38347e-ff43-4f5e-ae54-c5bff6a74737/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78ee4c8d-cf87-4067-bced-41ea51c6778b>.
+    
+<http://data.lblod.info/id/remote-data-objects/981fd4f9-8f36-4ba4-ab82-74fd63646290> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "981fd4f9-8f36-4ba4-ab82-74fd63646290";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/dd38347e-ff43-4f5e-ae54-c5bff6a74737/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/981fd4f9-8f36-4ba4-ab82-74fd63646290>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fc054bc-3132-421f-ab56-fd7689f85675> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fc054bc-3132-421f-ab56-fd7689f85675";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/df647c82-0f9f-47a7-9ac4-c763ea2a98b5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fc054bc-3132-421f-ab56-fd7689f85675>.
+    
+<http://data.lblod.info/id/remote-data-objects/85ffa5ff-73d9-48f8-a975-d6caf40d0ed0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85ffa5ff-73d9-48f8-a975-d6caf40d0ed0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/df647c82-0f9f-47a7-9ac4-c763ea2a98b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85ffa5ff-73d9-48f8-a975-d6caf40d0ed0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b5f0d15-7498-460e-a08b-82c3543f8a44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b5f0d15-7498-460e-a08b-82c3543f8a44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/e949e526-01e4-4047-92de-56a2eb16a0e2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b5f0d15-7498-460e-a08b-82c3543f8a44>.
+    
+<http://data.lblod.info/id/remote-data-objects/37132aae-5c36-4742-a240-158f4a5b7f8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37132aae-5c36-4742-a240-158f4a5b7f8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/e949e526-01e4-4047-92de-56a2eb16a0e2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37132aae-5c36-4742-a240-158f4a5b7f8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1761b36-a9ca-4c4c-ad9c-9e5232b5df7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1761b36-a9ca-4c4c-ad9c-9e5232b5df7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/e949e526-01e4-4047-92de-56a2eb16a0e2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1761b36-a9ca-4c4c-ad9c-9e5232b5df7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/880fa0a5-8761-402e-9824-b99d2722100c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "880fa0a5-8761-402e-9824-b99d2722100c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/f908885b-ea8a-4584-bbca-231894698212/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/880fa0a5-8761-402e-9824-b99d2722100c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f07d436-c0b4-4a36-943a-b88c32bf4dba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f07d436-c0b4-4a36-943a-b88c32bf4dba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/gr/fd859936-dbbf-4015-8c8e-898cc24f0ffc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f07d436-c0b4-4a36-943a-b88c32bf4dba>.
+    
+<http://data.lblod.info/id/remote-data-objects/94b2fdee-0b5a-49a8-b3f9-57aeab67f44e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94b2fdee-0b5a-49a8-b3f9-57aeab67f44e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/00131fb9-6416-48d3-bf06-4739c14ad681/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94b2fdee-0b5a-49a8-b3f9-57aeab67f44e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1baaf410-518c-4563-ad38-791008e10d9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1baaf410-518c-4563-ad38-791008e10d9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/00131fb9-6416-48d3-bf06-4739c14ad681/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1baaf410-518c-4563-ad38-791008e10d9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a2ddeb5-a202-46dd-8438-163648db9eaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a2ddeb5-a202-46dd-8438-163648db9eaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/00131fb9-6416-48d3-bf06-4739c14ad681/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a2ddeb5-a202-46dd-8438-163648db9eaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc196eb6-573f-4ddc-8afb-3effec38e255> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc196eb6-573f-4ddc-8afb-3effec38e255";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/2aec8ad1-34f2-478b-bbea-c26f6eaef9e9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc196eb6-573f-4ddc-8afb-3effec38e255>.
+    
+<http://data.lblod.info/id/remote-data-objects/633fce8e-8376-452f-abf8-1bc6afc34d30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "633fce8e-8376-452f-abf8-1bc6afc34d30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/2aec8ad1-34f2-478b-bbea-c26f6eaef9e9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/633fce8e-8376-452f-abf8-1bc6afc34d30>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2373382-f8fa-44fd-bd1c-72ac2de79099> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2373382-f8fa-44fd-bd1c-72ac2de79099";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/2aec8ad1-34f2-478b-bbea-c26f6eaef9e9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2373382-f8fa-44fd-bd1c-72ac2de79099>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb672899-a79a-497b-8dab-eac2b9eb8323> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb672899-a79a-497b-8dab-eac2b9eb8323";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/34902531-2879-4b0f-8a32-5270510d12c6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb672899-a79a-497b-8dab-eac2b9eb8323>.
+    
+<http://data.lblod.info/id/remote-data-objects/b856f59f-ad33-4491-b0d9-cab7e7f837e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b856f59f-ad33-4491-b0d9-cab7e7f837e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/34902531-2879-4b0f-8a32-5270510d12c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b856f59f-ad33-4491-b0d9-cab7e7f837e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/83adf235-2664-4eaa-925f-71f5a890273d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83adf235-2664-4eaa-925f-71f5a890273d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/34902531-2879-4b0f-8a32-5270510d12c6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83adf235-2664-4eaa-925f-71f5a890273d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0f4af79-dbc1-4466-b834-76554bd9a9e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0f4af79-dbc1-4466-b834-76554bd9a9e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/36d5fa10-741d-4907-a0e9-57f859ebe939/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0f4af79-dbc1-4466-b834-76554bd9a9e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ab270a7-3858-4890-9c25-4068fdd3be0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ab270a7-3858-4890-9c25-4068fdd3be0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/36d5fa10-741d-4907-a0e9-57f859ebe939/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ab270a7-3858-4890-9c25-4068fdd3be0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c29aecf9-e998-4b57-b308-df76622d7683> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c29aecf9-e998-4b57-b308-df76622d7683";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/36d5fa10-741d-4907-a0e9-57f859ebe939/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c29aecf9-e998-4b57-b308-df76622d7683>.
+    
+<http://data.lblod.info/id/remote-data-objects/10c0a06e-f9d4-47ed-b984-0e42c66e0b49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10c0a06e-f9d4-47ed-b984-0e42c66e0b49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/61ad3018-56c3-4c3c-ae19-433700b5bc1a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10c0a06e-f9d4-47ed-b984-0e42c66e0b49>.
+    
+<http://data.lblod.info/id/remote-data-objects/a76daa92-948f-4b43-9e8e-664b355a7d89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a76daa92-948f-4b43-9e8e-664b355a7d89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/61ad3018-56c3-4c3c-ae19-433700b5bc1a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a76daa92-948f-4b43-9e8e-664b355a7d89>.
+    
+<http://data.lblod.info/id/remote-data-objects/6312005b-315b-4f66-821e-2e0eb3698323> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6312005b-315b-4f66-821e-2e0eb3698323";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/61ad3018-56c3-4c3c-ae19-433700b5bc1a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6312005b-315b-4f66-821e-2e0eb3698323>.
+    
+<http://data.lblod.info/id/remote-data-objects/df2f83e0-4e0b-4ca5-9183-d24f7be5d9a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df2f83e0-4e0b-4ca5-9183-d24f7be5d9a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/72e1e02a-3193-4a5f-a3b3-97212008d895/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df2f83e0-4e0b-4ca5-9183-d24f7be5d9a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/096fea46-1fb0-4581-99ec-e0b960e34804> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "096fea46-1fb0-4581-99ec-e0b960e34804";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/72e1e02a-3193-4a5f-a3b3-97212008d895/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/096fea46-1fb0-4581-99ec-e0b960e34804>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb6ff728-0108-42b5-8025-0c26485543cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb6ff728-0108-42b5-8025-0c26485543cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/9870d506-6a0c-4540-bfe5-0e0167432164/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb6ff728-0108-42b5-8025-0c26485543cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3842925-5de0-4671-8839-f710e1aa814b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3842925-5de0-4671-8839-f710e1aa814b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/9870d506-6a0c-4540-bfe5-0e0167432164/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3842925-5de0-4671-8839-f710e1aa814b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb7a59f6-0c7b-45a4-9b58-ca1f33c71d0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb7a59f6-0c7b-45a4-9b58-ca1f33c71d0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/9870d506-6a0c-4540-bfe5-0e0167432164/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb7a59f6-0c7b-45a4-9b58-ca1f33c71d0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8390bcf-deac-4785-89f2-6424e4069dcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8390bcf-deac-4785-89f2-6424e4069dcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/9e4108c4-5544-4999-bbe8-b2b7ceb15e57/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8390bcf-deac-4785-89f2-6424e4069dcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b98c455-159c-4edb-812c-b7e85af7d365> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b98c455-159c-4edb-812c-b7e85af7d365";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/9e4108c4-5544-4999-bbe8-b2b7ceb15e57/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b98c455-159c-4edb-812c-b7e85af7d365>.
+    
+<http://data.lblod.info/id/remote-data-objects/6132d370-f243-4bef-a389-682aa471b252> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6132d370-f243-4bef-a389-682aa471b252";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/9e4108c4-5544-4999-bbe8-b2b7ceb15e57/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6132d370-f243-4bef-a389-682aa471b252>.
+    
+<http://data.lblod.info/id/remote-data-objects/2aa258c7-60ae-4cdc-8015-b46ffdbf98b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2aa258c7-60ae-4cdc-8015-b46ffdbf98b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/d344cb9a-cd44-450e-b592-771e23c0d0ad/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2aa258c7-60ae-4cdc-8015-b46ffdbf98b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1aee7d5-d085-4fdc-8bf3-9d5f64c7939e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1aee7d5-d085-4fdc-8bf3-9d5f64c7939e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/d344cb9a-cd44-450e-b592-771e23c0d0ad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1aee7d5-d085-4fdc-8bf3-9d5f64c7939e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea451bd1-51ab-4e32-be92-67966597bb2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea451bd1-51ab-4e32-be92-67966597bb2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/e6ec7208-7ce0-47b3-8355-37cf54862d5c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea451bd1-51ab-4e32-be92-67966597bb2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/152d85a9-49b7-4013-8491-6254142a0888> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "152d85a9-49b7-4013-8491-6254142a0888";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/e6ec7208-7ce0-47b3-8355-37cf54862d5c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/152d85a9-49b7-4013-8491-6254142a0888>.
+    
+<http://data.lblod.info/id/remote-data-objects/17d13ad4-ab88-4a96-b5d3-f0304e2735a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17d13ad4-ab88-4a96-b5d3-f0304e2735a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/fba36ad8-1a34-4c51-9e4d-c945f247070d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d68fcc30-5540-4607-9124-02b92eb6c544> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17d13ad4-ab88-4a96-b5d3-f0304e2735a3>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201052-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201052-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201052-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201052-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/cc02bdc7-7764-4a99-b225-5bf5504493f1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cc02bdc7-7764-4a99-b225-5bf5504493f1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "609a990f-dde2-4ebd-a6b7-d22ab5ba4c53";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/908cd008-16a7-46da-8266-4928a4245cfb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "908cd008-16a7-46da-8266-4928a4245cfb";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53>.
+
+  <http://redpencil.data.gift/id/task/5359c978-b36a-4911-b8fa-ad025a781ba8> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5359c978-b36a-4911-b8fa-ad025a781ba8";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/cc02bdc7-7764-4a99-b225-5bf5504493f1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/908cd008-16a7-46da-8266-4928a4245cfb>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/f36b1d50-c7c4-4fab-8526-c28166d459b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f36b1d50-c7c4-4fab-8526-c28166d459b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/fba36ad8-1a34-4c51-9e4d-c945f247070d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f36b1d50-c7c4-4fab-8526-c28166d459b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9a6eb84-a12f-409d-8a5a-356ab178c85c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9a6eb84-a12f-409d-8a5a-356ab178c85c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/rmw/fba36ad8-1a34-4c51-9e4d-c945f247070d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9a6eb84-a12f-409d-8a5a-356ab178c85c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fbdcd7f-a029-4859-bce4-57b4fea1e1c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fbdcd7f-a029-4859-bce4-57b4fea1e1c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/0072efc9-9638-4f18-9b86-0bd132a227c7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fbdcd7f-a029-4859-bce4-57b4fea1e1c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1d1fcc5-516f-4911-8262-6b7594c7db4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1d1fcc5-516f-4911-8262-6b7594c7db4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/0256d1b5-8029-46d7-a1bd-964ebde45248/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1d1fcc5-516f-4911-8262-6b7594c7db4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcb83b2c-5c1c-4727-967e-fef54db8bcb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcb83b2c-5c1c-4727-967e-fef54db8bcb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/08562b0b-6312-4784-a504-fcd92163014d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcb83b2c-5c1c-4727-967e-fef54db8bcb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7d9074a-a7a4-4807-b2dc-1b79cb829e91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7d9074a-a7a4-4807-b2dc-1b79cb829e91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/13098c14-7c7d-48cb-af72-9e60a991db9a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7d9074a-a7a4-4807-b2dc-1b79cb829e91>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3bdfaba-7e51-433a-b2b3-72525cb1a826> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3bdfaba-7e51-433a-b2b3-72525cb1a826";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/1bfec4bf-2053-42ba-b443-d9934055681f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3bdfaba-7e51-433a-b2b3-72525cb1a826>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0eaa3be-7828-4bd4-9b86-51edb8c50285> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0eaa3be-7828-4bd4-9b86-51edb8c50285";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/2882f1f6-c52f-40b1-bf76-82b4909ef304/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0eaa3be-7828-4bd4-9b86-51edb8c50285>.
+    
+<http://data.lblod.info/id/remote-data-objects/56767de4-56a9-49cd-976e-0880f2c85194> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56767de4-56a9-49cd-976e-0880f2c85194";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/2a207903-ae3e-4212-bf5b-68e2efde63af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56767de4-56a9-49cd-976e-0880f2c85194>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbcc0d06-110d-4a71-a801-43cd9ff5cc18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbcc0d06-110d-4a71-a801-43cd9ff5cc18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/2bcaa08d-51a6-44b4-8e3a-c0dc7cdad1b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbcc0d06-110d-4a71-a801-43cd9ff5cc18>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c562bf8-7b75-4dd0-be17-e86807b6f983> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c562bf8-7b75-4dd0-be17-e86807b6f983";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/3e2a15fd-c979-43ea-95cf-d1001fe621b8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c562bf8-7b75-4dd0-be17-e86807b6f983>.
+    
+<http://data.lblod.info/id/remote-data-objects/57ddd5a2-14b2-4b22-811e-ad8d21178d40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57ddd5a2-14b2-4b22-811e-ad8d21178d40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/4fe1d6ee-225a-41fe-9c2d-350deb0ed734/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57ddd5a2-14b2-4b22-811e-ad8d21178d40>.
+    
+<http://data.lblod.info/id/remote-data-objects/95f30297-4907-42e1-a7c5-773f9085b5a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95f30297-4907-42e1-a7c5-773f9085b5a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/53c394eb-bf73-4919-9e23-88307d655b6f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95f30297-4907-42e1-a7c5-773f9085b5a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/9075c864-b51a-4fc5-988b-3fc7e22fdf99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9075c864-b51a-4fc5-988b-3fc7e22fdf99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/569e7f73-2c1a-4594-b112-ec3449b6a0a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9075c864-b51a-4fc5-988b-3fc7e22fdf99>.
+    
+<http://data.lblod.info/id/remote-data-objects/d845b95d-f181-4bb1-8d2e-3bf71f9b62b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d845b95d-f181-4bb1-8d2e-3bf71f9b62b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/5eef4da2-dabf-47d9-9739-ff6d7509d5af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d845b95d-f181-4bb1-8d2e-3bf71f9b62b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e2c6b69-552c-4df9-858c-f599472768b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e2c6b69-552c-4df9-858c-f599472768b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/6702cf4d-d3fc-45ea-98ff-a18acd398d7c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e2c6b69-552c-4df9-858c-f599472768b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7156e9a-a5ef-4575-bb6a-93d17d60db32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7156e9a-a5ef-4575-bb6a-93d17d60db32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/6faf9723-44c9-4471-be97-d0df83b10388/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7156e9a-a5ef-4575-bb6a-93d17d60db32>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6fd9b1e-c205-4291-907d-c968d982aa2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6fd9b1e-c205-4291-907d-c968d982aa2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/6fb6ae42-2a67-4c8c-bdd6-a89658cb0d01/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6fd9b1e-c205-4291-907d-c968d982aa2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3a0e054-2e77-42e6-8ebc-e60a7681201b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3a0e054-2e77-42e6-8ebc-e60a7681201b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/722c443c-59e9-4c04-94cd-3b1384b3ff78/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3a0e054-2e77-42e6-8ebc-e60a7681201b>.
+    
+<http://data.lblod.info/id/remote-data-objects/35d76172-967c-4cf3-85b0-2be391955536> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35d76172-967c-4cf3-85b0-2be391955536";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/7dcb99d0-b315-41f1-80cc-4cb4fd2b7104/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35d76172-967c-4cf3-85b0-2be391955536>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a024702-5b12-4207-b903-c76719b99a34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a024702-5b12-4207-b903-c76719b99a34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/7ee9370d-c442-47a4-a696-1a4c36c48165/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a024702-5b12-4207-b903-c76719b99a34>.
+    
+<http://data.lblod.info/id/remote-data-objects/f05dbe01-8db7-4ac5-98e9-2dcd83f96455> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f05dbe01-8db7-4ac5-98e9-2dcd83f96455";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/89c6e028-cc5d-4156-8990-1e818ce83241/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f05dbe01-8db7-4ac5-98e9-2dcd83f96455>.
+    
+<http://data.lblod.info/id/remote-data-objects/eaf08d9c-5609-43a0-bf81-e0ff48a5a316> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eaf08d9c-5609-43a0-bf81-e0ff48a5a316";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/8fef8798-91a4-4e3f-8dea-1682a49a7549/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eaf08d9c-5609-43a0-bf81-e0ff48a5a316>.
+    
+<http://data.lblod.info/id/remote-data-objects/65784de2-c020-450e-a095-86280b5fd2f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65784de2-c020-450e-a095-86280b5fd2f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/96427a22-e680-402f-a08c-a4db3d30daef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65784de2-c020-450e-a095-86280b5fd2f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fd5867a-42de-4c91-8fd4-3e4b64827329> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fd5867a-42de-4c91-8fd4-3e4b64827329";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/9ec3a313-a735-47c1-9c11-5567cfb134bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fd5867a-42de-4c91-8fd4-3e4b64827329>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a08934b-f07a-4175-8dd1-3665cd0e0904> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a08934b-f07a-4175-8dd1-3665cd0e0904";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/9eff855b-ad64-46d8-a98a-7e7ed372e4f6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a08934b-f07a-4175-8dd1-3665cd0e0904>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fc5a184-30b9-43f0-bf47-9f0bc4b467f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fc5a184-30b9-43f0-bf47-9f0bc4b467f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/9f9f8b5d-7912-4b94-a2b4-5bf62bf1de32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fc5a184-30b9-43f0-bf47-9f0bc4b467f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ef30b3c-cd67-4a42-b48b-2aac7abf2131> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ef30b3c-cd67-4a42-b48b-2aac7abf2131";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/ab83741e-a811-49bc-8c55-3fdfcb370bff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ef30b3c-cd67-4a42-b48b-2aac7abf2131>.
+    
+<http://data.lblod.info/id/remote-data-objects/d048222b-68ad-4eba-8526-e5ea040bca48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d048222b-68ad-4eba-8526-e5ea040bca48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/ad038535-9834-4830-9ef5-4e2c407c26e2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d048222b-68ad-4eba-8526-e5ea040bca48>.
+    
+<http://data.lblod.info/id/remote-data-objects/3940ab18-f64c-4195-919b-9c3951e8379b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3940ab18-f64c-4195-919b-9c3951e8379b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/af9023fc-9059-4c97-b2b7-56e1097074cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3940ab18-f64c-4195-919b-9c3951e8379b>.
+    
+<http://data.lblod.info/id/remote-data-objects/06e20199-7e91-412b-aa2f-d584ff970142> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06e20199-7e91-412b-aa2f-d584ff970142";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/b3699ed5-86b0-4bbb-9039-e30e2e1f7a2d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06e20199-7e91-412b-aa2f-d584ff970142>.
+    
+<http://data.lblod.info/id/remote-data-objects/84fc966d-6ef5-4954-9990-65dbffe64599> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84fc966d-6ef5-4954-9990-65dbffe64599";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/bf7a8899-d3d1-464e-a523-9923c843eeb3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84fc966d-6ef5-4954-9990-65dbffe64599>.
+    
+<http://data.lblod.info/id/remote-data-objects/7757a96a-6c17-4cdb-903f-780969fc2d34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7757a96a-6c17-4cdb-903f-780969fc2d34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/c854ff1b-a6db-4b52-9bc6-0f94475a1795/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7757a96a-6c17-4cdb-903f-780969fc2d34>.
+    
+<http://data.lblod.info/id/remote-data-objects/0261169b-c532-4d51-9b0d-7c780b1c0c54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0261169b-c532-4d51-9b0d-7c780b1c0c54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/cb02e64d-e253-4055-a41b-48e32540f1dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0261169b-c532-4d51-9b0d-7c780b1c0c54>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b4b773a-0898-47d6-8906-b5b6d064fc2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b4b773a-0898-47d6-8906-b5b6d064fc2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/d7948fc5-02c7-407a-8089-0247acd6627a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b4b773a-0898-47d6-8906-b5b6d064fc2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/69a8e06e-de69-4338-9b76-557763d838a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69a8e06e-de69-4338-9b76-557763d838a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/d7e8cbda-d29a-400a-8af9-d07750a6df82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69a8e06e-de69-4338-9b76-557763d838a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/9044e058-69d1-418c-b379-12e5fcfd2cd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9044e058-69d1-418c-b379-12e5fcfd2cd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/dc5d1401-67f0-4fe7-bd3f-432e3d06a014/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9044e058-69d1-418c-b379-12e5fcfd2cd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a9887ba-af25-4361-8b32-f6e62b72ac6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a9887ba-af25-4361-8b32-f6e62b72ac6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/ddbc26f7-2c26-42a2-ab43-f5fa586be680/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a9887ba-af25-4361-8b32-f6e62b72ac6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/75b85d1d-e2c8-4c44-a782-cc24c7c65f22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75b85d1d-e2c8-4c44-a782-cc24c7c65f22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/def20b08-88c1-4893-80ca-a01c4d9d8e14/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75b85d1d-e2c8-4c44-a782-cc24c7c65f22>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cbdaa4a-f3ad-4ece-b3d3-635fe86379ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cbdaa4a-f3ad-4ece-b3d3-635fe86379ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/ee6db718-9662-49d9-9670-17edeae08b85/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cbdaa4a-f3ad-4ece-b3d3-635fe86379ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bb7f17a-0232-4cc0-9251-b96423dba942> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bb7f17a-0232-4cc0-9251-b96423dba942";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/f0d89403-2a16-4045-ab83-8bc798f11502/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bb7f17a-0232-4cc0-9251-b96423dba942>.
+    
+<http://data.lblod.info/id/remote-data-objects/30d51bbc-f85e-4148-8f2f-7e0bb9a14b72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30d51bbc-f85e-4148-8f2f-7e0bb9a14b72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/fa29ddd9-4028-40a3-9ae7-faa78f2591db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30d51bbc-f85e-4148-8f2f-7e0bb9a14b72>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab75bc64-782f-4203-b049-2ef952e4f961> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab75bc64-782f-4203-b049-2ef952e4f961";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boortmeerbeek.meetingburger.net/vabu/fd5eb2f4-afba-4f58-ac36-9a961cba18bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab75bc64-782f-4203-b049-2ef952e4f961>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f7f5e15-9add-4fd2-88c8-8a91881033c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f7f5e15-9add-4fd2-88c8-8a91881033c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/bb/077d60e3-a85f-4294-ba12-95b657cd5093/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f7f5e15-9add-4fd2-88c8-8a91881033c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/6647e1b0-9afb-492d-87c5-8cc455e23a67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6647e1b0-9afb-492d-87c5-8cc455e23a67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/bb/0dff1450-857c-4b53-b7ef-38992e48d6fb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6647e1b0-9afb-492d-87c5-8cc455e23a67>.
+    
+<http://data.lblod.info/id/remote-data-objects/92b63dd5-fbf6-46a1-b591-ef8f1141e553> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92b63dd5-fbf6-46a1-b591-ef8f1141e553";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/bb/184ff078-0a67-4996-8a42-623bb661f499/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92b63dd5-fbf6-46a1-b591-ef8f1141e553>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0006e49-3dec-4cf5-946f-c68d4d4a0842> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0006e49-3dec-4cf5-946f-c68d4d4a0842";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/bb/6c48880b-1dcb-4bf8-8b18-1b176ca7e087/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0006e49-3dec-4cf5-946f-c68d4d4a0842>.
+    
+<http://data.lblod.info/id/remote-data-objects/7867e74a-94f6-49bc-b276-ed3e346f79fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7867e74a-94f6-49bc-b276-ed3e346f79fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/bb/80ddd8f2-b5be-4aa7-a626-9fd75d9b5779/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7867e74a-94f6-49bc-b276-ed3e346f79fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d08457b8-b214-44db-bd7d-611cfcad459a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d08457b8-b214-44db-bd7d-611cfcad459a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/0579168f-eaaa-4d0b-9fdf-04cefc189cc5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d08457b8-b214-44db-bd7d-611cfcad459a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1233ed20-e883-4e04-878c-2ce0184b2d74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1233ed20-e883-4e04-878c-2ce0184b2d74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/0b067e8d-6117-4a9a-a403-b65d5fb37577/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/609a990f-dde2-4ebd-a6b7-d22ab5ba4c53> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1233ed20-e883-4e04-878c-2ce0184b2d74>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201053-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201053-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201053-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201053-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2e75abc9-99d5-4b8d-abf1-9ab25d44a197> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2e75abc9-99d5-4b8d-abf1-9ab25d44a197";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7f034e36-1b7b-4fce-9904-2df70da45354";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/5a5857f0-59ac-4a7e-b449-d8a8133267c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5a5857f0-59ac-4a7e-b449-d8a8133267c4";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354>.
+
+  <http://redpencil.data.gift/id/task/7801d824-0551-414c-8d52-98ab86c177f7> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7801d824-0551-414c-8d52-98ab86c177f7";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2e75abc9-99d5-4b8d-abf1-9ab25d44a197>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/5a5857f0-59ac-4a7e-b449-d8a8133267c4>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/aaa4027a-1e48-4f97-bd81-1e9238024327> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aaa4027a-1e48-4f97-bd81-1e9238024327";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/0c88caff-6257-4d85-b060-96069d9f1edc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aaa4027a-1e48-4f97-bd81-1e9238024327>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed943cbe-44aa-4483-90cd-643538d22730> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed943cbe-44aa-4483-90cd-643538d22730";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/1125826a-0517-4d2f-aa67-e0c8e5f2378d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed943cbe-44aa-4483-90cd-643538d22730>.
+    
+<http://data.lblod.info/id/remote-data-objects/0522e63f-6c48-445f-8482-ffbe03069b54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0522e63f-6c48-445f-8482-ffbe03069b54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/138c0c4a-b671-47be-8651-b48ddd94cbd2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0522e63f-6c48-445f-8482-ffbe03069b54>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7b81f8d-90c4-41dc-8f75-6f42a7cd14bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7b81f8d-90c4-41dc-8f75-6f42a7cd14bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/13d2a0fb-2715-4fed-9ffe-4da05ab0f1c7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7b81f8d-90c4-41dc-8f75-6f42a7cd14bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/2576f95e-4dc9-441f-93e6-e8cf0b84dcec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2576f95e-4dc9-441f-93e6-e8cf0b84dcec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/259f2118-e857-4aff-a63d-5eecadccc914/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2576f95e-4dc9-441f-93e6-e8cf0b84dcec>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b384014-b803-49dd-bca9-1b3ee386422b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b384014-b803-49dd-bca9-1b3ee386422b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/30f7de49-ea4f-4e61-a1b9-9c448b27ddb7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b384014-b803-49dd-bca9-1b3ee386422b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e5793a8-587d-450d-9241-580c4716f0cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e5793a8-587d-450d-9241-580c4716f0cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/32dfff96-70dc-4a2d-84d4-53b4196f94fb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e5793a8-587d-450d-9241-580c4716f0cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/203ad99b-37cd-475f-8de7-31aaa09a4445> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "203ad99b-37cd-475f-8de7-31aaa09a4445";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/3374b65e-ddf4-4915-8898-42981eaef3e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/203ad99b-37cd-475f-8de7-31aaa09a4445>.
+    
+<http://data.lblod.info/id/remote-data-objects/7db9f6e0-d08a-49c2-ab9e-a81406145a1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7db9f6e0-d08a-49c2-ab9e-a81406145a1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/33a5a9f1-7a85-4ec8-876d-2931fb1e4d5b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7db9f6e0-d08a-49c2-ab9e-a81406145a1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9ade046-0bb1-4e97-b591-39ce28d4df9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9ade046-0bb1-4e97-b591-39ce28d4df9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/3f141992-8206-4d56-a25f-3c563db9db97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9ade046-0bb1-4e97-b591-39ce28d4df9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8dae2190-5bc0-4077-8109-1d58077b115d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8dae2190-5bc0-4077-8109-1d58077b115d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/416aaafb-11b3-4c4d-be68-3930f64df579/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8dae2190-5bc0-4077-8109-1d58077b115d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6534d4e9-ff0f-4c8c-87cf-3747c24e4d80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6534d4e9-ff0f-4c8c-87cf-3747c24e4d80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/45426abd-bf86-455a-87b6-b5d5ee842234/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6534d4e9-ff0f-4c8c-87cf-3747c24e4d80>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d3baf93-dd08-44a5-8a8f-5eb0a688386e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d3baf93-dd08-44a5-8a8f-5eb0a688386e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/481e7418-b137-423c-98a5-0f8a2026b053/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d3baf93-dd08-44a5-8a8f-5eb0a688386e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a5fe204-65bd-49d1-b74e-07e5d6a93fb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a5fe204-65bd-49d1-b74e-07e5d6a93fb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/4b33193c-06bf-406e-ae8c-f2fede62d7e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a5fe204-65bd-49d1-b74e-07e5d6a93fb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b653c2ab-efe6-4179-8179-e698f2c16cbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b653c2ab-efe6-4179-8179-e698f2c16cbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/610aedd6-da1e-4d65-be2c-5704816f847c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b653c2ab-efe6-4179-8179-e698f2c16cbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/edcd8c64-74ef-4598-ad8c-661f44c46f02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edcd8c64-74ef-4598-ad8c-661f44c46f02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/62a934c6-44ea-442f-a731-05126ebd8b43/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edcd8c64-74ef-4598-ad8c-661f44c46f02>.
+    
+<http://data.lblod.info/id/remote-data-objects/4447bef9-27bf-4588-b285-e00edb85e0ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4447bef9-27bf-4588-b285-e00edb85e0ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/62f4c4ba-2cd4-4393-9d38-a7c957abf5c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4447bef9-27bf-4588-b285-e00edb85e0ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/6116d17f-9bfd-4dd9-a638-2cd669f9701f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6116d17f-9bfd-4dd9-a638-2cd669f9701f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/632d5a90-4fa3-4993-9e0f-fe027ad30602/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6116d17f-9bfd-4dd9-a638-2cd669f9701f>.
+    
+<http://data.lblod.info/id/remote-data-objects/533a732e-3f66-443a-90a0-8cfd797c8235> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "533a732e-3f66-443a-90a0-8cfd797c8235";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/6f841122-b4da-4785-9eb8-a9a805eabb7e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/533a732e-3f66-443a-90a0-8cfd797c8235>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2959755-2f4f-49d3-ad15-9f7c68ea8676> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2959755-2f4f-49d3-ad15-9f7c68ea8676";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/70e5f5a0-86ae-4b6a-b5f0-a69078ada876/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2959755-2f4f-49d3-ad15-9f7c68ea8676>.
+    
+<http://data.lblod.info/id/remote-data-objects/63f64a3f-3c88-4381-9200-ca4e902a8092> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63f64a3f-3c88-4381-9200-ca4e902a8092";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/77da6d40-e0b8-42ef-beee-af68e51bb4c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63f64a3f-3c88-4381-9200-ca4e902a8092>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fa878d9-48a8-44d4-8b38-89d8ca1519fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fa878d9-48a8-44d4-8b38-89d8ca1519fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/87cd581d-aa83-4aac-a142-ea3e20cfd869/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fa878d9-48a8-44d4-8b38-89d8ca1519fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bf26b57-543a-49df-8a26-e75321e1a036> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bf26b57-543a-49df-8a26-e75321e1a036";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/8935e688-8715-451c-9a9b-cd03882b7e41/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bf26b57-543a-49df-8a26-e75321e1a036>.
+    
+<http://data.lblod.info/id/remote-data-objects/99286c6d-590f-463f-8ca4-febd752e0e4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99286c6d-590f-463f-8ca4-febd752e0e4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/94e2b567-b329-4695-a5c7-ddf84a2a5644/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99286c6d-590f-463f-8ca4-febd752e0e4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d2b8b40-3bf5-4099-8cb5-6b19f0d41ccf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d2b8b40-3bf5-4099-8cb5-6b19f0d41ccf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/9676f593-1659-4b1d-9791-26de41f9bef4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d2b8b40-3bf5-4099-8cb5-6b19f0d41ccf>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bbd6b14-8c8d-4232-9236-f9bf5f3443ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bbd6b14-8c8d-4232-9236-f9bf5f3443ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/976fd681-5a35-40de-91f3-74e1a9f83766/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bbd6b14-8c8d-4232-9236-f9bf5f3443ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/1edae892-5f67-49f3-9654-e82a7b6438e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1edae892-5f67-49f3-9654-e82a7b6438e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/9aca97f6-3f26-411c-8739-533c04d85742/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1edae892-5f67-49f3-9654-e82a7b6438e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/559da0d7-6720-4c9b-a42f-ff3234a43da5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "559da0d7-6720-4c9b-a42f-ff3234a43da5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/9b93c10f-5c7f-48d0-85a3-6d34e27af10e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/559da0d7-6720-4c9b-a42f-ff3234a43da5>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd29ac5f-4808-4b86-84e8-f229637fa8ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd29ac5f-4808-4b86-84e8-f229637fa8ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/9c4847a2-c8b6-4f10-a1de-0b09fe06f282/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd29ac5f-4808-4b86-84e8-f229637fa8ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/303fe49c-bc2b-48c4-9cfa-1a7cd2694e81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "303fe49c-bc2b-48c4-9cfa-1a7cd2694e81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/a638ae78-bae3-43e0-ab08-d2866c3503c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/303fe49c-bc2b-48c4-9cfa-1a7cd2694e81>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6951080-4d9f-4a74-8e15-3df98e947c95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6951080-4d9f-4a74-8e15-3df98e947c95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/acbd53e8-64cb-45b6-82ee-ae043102f27b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6951080-4d9f-4a74-8e15-3df98e947c95>.
+    
+<http://data.lblod.info/id/remote-data-objects/68e70187-c044-495d-bed7-7480e4505215> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68e70187-c044-495d-bed7-7480e4505215";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/caf91374-7444-4990-a501-051573010bae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68e70187-c044-495d-bed7-7480e4505215>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce5bb292-5ce1-40b7-8a61-9b7a3b82a8c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce5bb292-5ce1-40b7-8a61-9b7a3b82a8c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/cc5b812f-d58a-4eef-8877-4d6bf7c78abd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce5bb292-5ce1-40b7-8a61-9b7a3b82a8c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/b948339b-9fa8-435e-ad56-f7b105f7e6ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b948339b-9fa8-435e-ad56-f7b105f7e6ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/cc7e43ec-7d29-4baa-a8b4-d07507c87d6b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b948339b-9fa8-435e-ad56-f7b105f7e6ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/a952c892-ee46-4d55-a85f-81a0984e133f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a952c892-ee46-4d55-a85f-81a0984e133f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/db85c786-e331-44b6-a782-6cf5881b9205/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a952c892-ee46-4d55-a85f-81a0984e133f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8890744-8e1f-40bc-b6b9-8abc4edb82f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8890744-8e1f-40bc-b6b9-8abc4edb82f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/e32eb813-fde1-4fe2-a55c-a4ac5f00a4a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8890744-8e1f-40bc-b6b9-8abc4edb82f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/b714e05f-35dd-4230-b7f4-beea3538ffdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b714e05f-35dd-4230-b7f4-beea3538ffdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/e5cc5d5e-3249-4a76-95d1-34f4459f6ae2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b714e05f-35dd-4230-b7f4-beea3538ffdf>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9b3e62c-e6b7-48d5-a51b-9599a77b7c6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9b3e62c-e6b7-48d5-a51b-9599a77b7c6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/e860f02c-59e1-495d-b1a3-03ebc90496b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9b3e62c-e6b7-48d5-a51b-9599a77b7c6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c8dfcd1-8280-488a-b9cf-acd74076854c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c8dfcd1-8280-488a-b9cf-acd74076854c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/f46f9152-7178-42c2-980a-4bb971008f83/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c8dfcd1-8280-488a-b9cf-acd74076854c>.
+    
+<http://data.lblod.info/id/remote-data-objects/bba986c5-765b-4ddd-bc6c-da701b9a7fb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bba986c5-765b-4ddd-bc6c-da701b9a7fb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/cbs/f5a9b64f-ffeb-4873-a672-0f4f228f60c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bba986c5-765b-4ddd-bc6c-da701b9a7fb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/217692d9-4f20-4d64-a189-778cb6d0b964> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "217692d9-4f20-4d64-a189-778cb6d0b964";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/0d700756-e1e0-4174-9af4-9063e6356ee1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/217692d9-4f20-4d64-a189-778cb6d0b964>.
+    
+<http://data.lblod.info/id/remote-data-objects/13ba8949-f502-4b2a-90b8-067c989510c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13ba8949-f502-4b2a-90b8-067c989510c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/0d700756-e1e0-4174-9af4-9063e6356ee1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13ba8949-f502-4b2a-90b8-067c989510c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/db428268-9589-4c40-9838-f5298168d216> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db428268-9589-4c40-9838-f5298168d216";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/0d700756-e1e0-4174-9af4-9063e6356ee1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db428268-9589-4c40-9838-f5298168d216>.
+    
+<http://data.lblod.info/id/remote-data-objects/85eb39ba-45ff-4c80-9142-ff42a28427d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85eb39ba-45ff-4c80-9142-ff42a28427d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/190efe10-da8b-4a26-bbf5-bc75f724c081/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85eb39ba-45ff-4c80-9142-ff42a28427d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4f49617-3925-4b55-83d3-d1b9bc955799> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4f49617-3925-4b55-83d3-d1b9bc955799";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/190efe10-da8b-4a26-bbf5-bc75f724c081/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4f49617-3925-4b55-83d3-d1b9bc955799>.
+    
+<http://data.lblod.info/id/remote-data-objects/2905bd99-7a5c-4495-b24f-c935a5bd5e67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2905bd99-7a5c-4495-b24f-c935a5bd5e67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/190efe10-da8b-4a26-bbf5-bc75f724c081/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2905bd99-7a5c-4495-b24f-c935a5bd5e67>.
+    
+<http://data.lblod.info/id/remote-data-objects/9af60d2b-7239-4bb4-93e9-8fbc68a32eb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9af60d2b-7239-4bb4-93e9-8fbc68a32eb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/2532ef44-b494-437a-ad7f-5cee03c88c5e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9af60d2b-7239-4bb4-93e9-8fbc68a32eb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ebecb26-a484-4560-8a77-545c78c76bc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ebecb26-a484-4560-8a77-545c78c76bc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/2532ef44-b494-437a-ad7f-5cee03c88c5e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ebecb26-a484-4560-8a77-545c78c76bc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/376c085e-bd5d-4e6f-80bd-a36e71f23a23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "376c085e-bd5d-4e6f-80bd-a36e71f23a23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/2532ef44-b494-437a-ad7f-5cee03c88c5e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/376c085e-bd5d-4e6f-80bd-a36e71f23a23>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b007fa4-2ea5-4c2c-a7a4-3b4e631a00c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b007fa4-2ea5-4c2c-a7a4-3b4e631a00c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/2b363edd-4f6f-4072-a510-c24dc21eb09c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7f034e36-1b7b-4fce-9904-2df70da45354> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b007fa4-2ea5-4c2c-a7a4-3b4e631a00c6>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201054-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201054-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201054-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201054-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/53d73577-3462-459e-b74f-b6c32a4f5bb3> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "53d73577-3462-459e-b74f-b6c32a4f5bb3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b9a326ef-8f83-482a-b596-bd993c9d1147";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6db5edde-b9b2-41a6-9bde-c5ad2836ec26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6db5edde-b9b2-41a6-9bde-c5ad2836ec26";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147>.
+
+  <http://redpencil.data.gift/id/task/de50df16-aca8-426c-844f-bc11578e6ac6> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "de50df16-aca8-426c-844f-bc11578e6ac6";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/53d73577-3462-459e-b74f-b6c32a4f5bb3>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6db5edde-b9b2-41a6-9bde-c5ad2836ec26>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a715ffc3-4802-4b9b-9faa-ae611fbd7bb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a715ffc3-4802-4b9b-9faa-ae611fbd7bb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/2b363edd-4f6f-4072-a510-c24dc21eb09c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a715ffc3-4802-4b9b-9faa-ae611fbd7bb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2f4e231-1b3e-485b-8f4b-6930eefcfb85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2f4e231-1b3e-485b-8f4b-6930eefcfb85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/2b363edd-4f6f-4072-a510-c24dc21eb09c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2f4e231-1b3e-485b-8f4b-6930eefcfb85>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e9e62e0-7b08-4b3e-bccc-381fad5e31df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e9e62e0-7b08-4b3e-bccc-381fad5e31df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/33e76369-c9f0-4b2e-9215-d3d6fe28ac8d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e9e62e0-7b08-4b3e-bccc-381fad5e31df>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d2fea86-2cde-494e-85ed-f77b29f40f60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d2fea86-2cde-494e-85ed-f77b29f40f60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/33e76369-c9f0-4b2e-9215-d3d6fe28ac8d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d2fea86-2cde-494e-85ed-f77b29f40f60>.
+    
+<http://data.lblod.info/id/remote-data-objects/47c61e81-124a-4eb0-a089-72dccc31318a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47c61e81-124a-4eb0-a089-72dccc31318a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/33e76369-c9f0-4b2e-9215-d3d6fe28ac8d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47c61e81-124a-4eb0-a089-72dccc31318a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5d3a023-89aa-4333-a5e4-7e3c213e13da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5d3a023-89aa-4333-a5e4-7e3c213e13da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/6bca63c0-fc8f-4141-bc92-33da9af4ae30/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5d3a023-89aa-4333-a5e4-7e3c213e13da>.
+    
+<http://data.lblod.info/id/remote-data-objects/26c5dfe0-ee1d-44f9-a00c-b4d09ecb2896> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26c5dfe0-ee1d-44f9-a00c-b4d09ecb2896";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/6bca63c0-fc8f-4141-bc92-33da9af4ae30/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26c5dfe0-ee1d-44f9-a00c-b4d09ecb2896>.
+    
+<http://data.lblod.info/id/remote-data-objects/a72ae935-ce36-4a3d-92cf-228915af991e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a72ae935-ce36-4a3d-92cf-228915af991e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/6bca63c0-fc8f-4141-bc92-33da9af4ae30/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a72ae935-ce36-4a3d-92cf-228915af991e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8e58f09-7b7c-4af0-8751-b0f0ec38b1c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8e58f09-7b7c-4af0-8751-b0f0ec38b1c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/876277d1-c0e2-484d-819a-6dd2e951a548/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8e58f09-7b7c-4af0-8751-b0f0ec38b1c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/405697f3-c7d6-4755-908e-34a23bb650bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "405697f3-c7d6-4755-908e-34a23bb650bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/876277d1-c0e2-484d-819a-6dd2e951a548/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/405697f3-c7d6-4755-908e-34a23bb650bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/76ba4fec-2c36-465e-aaab-f0149d4e7312> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76ba4fec-2c36-465e-aaab-f0149d4e7312";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/876277d1-c0e2-484d-819a-6dd2e951a548/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76ba4fec-2c36-465e-aaab-f0149d4e7312>.
+    
+<http://data.lblod.info/id/remote-data-objects/86fc7004-943f-4c66-87e0-d96d39d91c57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86fc7004-943f-4c66-87e0-d96d39d91c57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/abc20c28-a46c-4e2d-a099-2c87b0ce2d7c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86fc7004-943f-4c66-87e0-d96d39d91c57>.
+    
+<http://data.lblod.info/id/remote-data-objects/596559f2-e404-4763-a4aa-7232e8dddb38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "596559f2-e404-4763-a4aa-7232e8dddb38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/abc20c28-a46c-4e2d-a099-2c87b0ce2d7c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/596559f2-e404-4763-a4aa-7232e8dddb38>.
+    
+<http://data.lblod.info/id/remote-data-objects/1aa5b8c3-d007-44ad-b883-866ee983a086> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1aa5b8c3-d007-44ad-b883-866ee983a086";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/ba72d7a9-beb1-4e2b-b8b7-460ff0e8d802/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1aa5b8c3-d007-44ad-b883-866ee983a086>.
+    
+<http://data.lblod.info/id/remote-data-objects/687c2ab9-1409-40ed-9d47-e9a6a79d4961> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "687c2ab9-1409-40ed-9d47-e9a6a79d4961";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/ba72d7a9-beb1-4e2b-b8b7-460ff0e8d802/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/687c2ab9-1409-40ed-9d47-e9a6a79d4961>.
+    
+<http://data.lblod.info/id/remote-data-objects/c585ccd1-6f0a-4e02-8433-41ad5cad9ae9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c585ccd1-6f0a-4e02-8433-41ad5cad9ae9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/ba72d7a9-beb1-4e2b-b8b7-460ff0e8d802/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c585ccd1-6f0a-4e02-8433-41ad5cad9ae9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d6a843e-9557-441a-9d57-62bc064d1a7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d6a843e-9557-441a-9d57-62bc064d1a7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/f4b85bd4-cea4-43fe-bad7-66f6f949d475/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d6a843e-9557-441a-9d57-62bc064d1a7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1860bdd0-51ab-406f-b7a9-555ffe784243> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1860bdd0-51ab-406f-b7a9-555ffe784243";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/f4b85bd4-cea4-43fe-bad7-66f6f949d475/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1860bdd0-51ab-406f-b7a9-555ffe784243>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd312e0a-77a2-42ea-a5d8-25c0b2ec8046> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd312e0a-77a2-42ea-a5d8-25c0b2ec8046";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/gr/f4b85bd4-cea4-43fe-bad7-66f6f949d475/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd312e0a-77a2-42ea-a5d8-25c0b2ec8046>.
+    
+<http://data.lblod.info/id/remote-data-objects/64dd90ba-c9db-412c-9988-0503b1b38195> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64dd90ba-c9db-412c-9988-0503b1b38195";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/0f03586d-fc5f-4d6e-944e-c7ca418ece2a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64dd90ba-c9db-412c-9988-0503b1b38195>.
+    
+<http://data.lblod.info/id/remote-data-objects/62a87f5d-5900-4d0e-815d-b039769ae2b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62a87f5d-5900-4d0e-815d-b039769ae2b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/0f03586d-fc5f-4d6e-944e-c7ca418ece2a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62a87f5d-5900-4d0e-815d-b039769ae2b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8c8ce73-fb2b-4961-a085-163c7f0dd741> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8c8ce73-fb2b-4961-a085-163c7f0dd741";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/0f03586d-fc5f-4d6e-944e-c7ca418ece2a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8c8ce73-fb2b-4961-a085-163c7f0dd741>.
+    
+<http://data.lblod.info/id/remote-data-objects/72fafafe-d070-4614-bb9f-ff75883a8d38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72fafafe-d070-4614-bb9f-ff75883a8d38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/15ff293c-80fd-46d4-8401-6a91ee15c2f9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72fafafe-d070-4614-bb9f-ff75883a8d38>.
+    
+<http://data.lblod.info/id/remote-data-objects/42a308cc-f36b-40ee-a074-8005cf0e93a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42a308cc-f36b-40ee-a074-8005cf0e93a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/15ff293c-80fd-46d4-8401-6a91ee15c2f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42a308cc-f36b-40ee-a074-8005cf0e93a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c30e4e3-b3e4-4b8e-a5e0-a77cb02677ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c30e4e3-b3e4-4b8e-a5e0-a77cb02677ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/15ff293c-80fd-46d4-8401-6a91ee15c2f9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c30e4e3-b3e4-4b8e-a5e0-a77cb02677ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/11cca739-54ee-4acf-b7e4-8b67908fde57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11cca739-54ee-4acf-b7e4-8b67908fde57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/19f9e4f5-69e4-46fe-b396-9dff5eed36f2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11cca739-54ee-4acf-b7e4-8b67908fde57>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc08cc5d-7f55-43ea-a076-3a16b3ce688a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc08cc5d-7f55-43ea-a076-3a16b3ce688a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/19f9e4f5-69e4-46fe-b396-9dff5eed36f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc08cc5d-7f55-43ea-a076-3a16b3ce688a>.
+    
+<http://data.lblod.info/id/remote-data-objects/62b025c5-a9be-4533-b885-78a36a685e5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62b025c5-a9be-4533-b885-78a36a685e5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/19f9e4f5-69e4-46fe-b396-9dff5eed36f2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62b025c5-a9be-4533-b885-78a36a685e5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc3954a3-d559-4a4b-ac00-030dba3b6d17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc3954a3-d559-4a4b-ac00-030dba3b6d17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/3704e8ac-5d43-479e-8095-71b8c7e82dad/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc3954a3-d559-4a4b-ac00-030dba3b6d17>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d44f410-b656-4592-a579-f145e4cf5e4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d44f410-b656-4592-a579-f145e4cf5e4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/3704e8ac-5d43-479e-8095-71b8c7e82dad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d44f410-b656-4592-a579-f145e4cf5e4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/de141ec6-e5e9-48b9-a773-41d2a08d2870> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de141ec6-e5e9-48b9-a773-41d2a08d2870";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/4331304c-1146-4de3-8dfa-ce14165befa8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de141ec6-e5e9-48b9-a773-41d2a08d2870>.
+    
+<http://data.lblod.info/id/remote-data-objects/f256e856-d060-4b76-a578-0973aa850f0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f256e856-d060-4b76-a578-0973aa850f0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/4331304c-1146-4de3-8dfa-ce14165befa8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f256e856-d060-4b76-a578-0973aa850f0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ef244bf-e5a2-482c-943d-02f0886e9794> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ef244bf-e5a2-482c-943d-02f0886e9794";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/4331304c-1146-4de3-8dfa-ce14165befa8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ef244bf-e5a2-482c-943d-02f0886e9794>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d355825-99d2-464e-b87f-bf822c0207f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d355825-99d2-464e-b87f-bf822c0207f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/4a67e065-8514-4d63-aef6-161ce6584ba2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d355825-99d2-464e-b87f-bf822c0207f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a970c136-79d0-475b-bac5-3f14c27804a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a970c136-79d0-475b-bac5-3f14c27804a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/4a67e065-8514-4d63-aef6-161ce6584ba2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a970c136-79d0-475b-bac5-3f14c27804a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8914581-3769-4c47-b20d-2fd26c9c2570> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8914581-3769-4c47-b20d-2fd26c9c2570";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/4a67e065-8514-4d63-aef6-161ce6584ba2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8914581-3769-4c47-b20d-2fd26c9c2570>.
+    
+<http://data.lblod.info/id/remote-data-objects/a94ccdca-b154-430f-8c8e-444805c79c25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a94ccdca-b154-430f-8c8e-444805c79c25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/7fa2f6c0-b343-451b-8c50-8f64d8a71dc8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a94ccdca-b154-430f-8c8e-444805c79c25>.
+    
+<http://data.lblod.info/id/remote-data-objects/79b62414-955a-43aa-825c-b1e534c89a96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79b62414-955a-43aa-825c-b1e534c89a96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/7fa2f6c0-b343-451b-8c50-8f64d8a71dc8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79b62414-955a-43aa-825c-b1e534c89a96>.
+    
+<http://data.lblod.info/id/remote-data-objects/e526864b-bb35-4bde-8f28-0b44d1bc6487> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e526864b-bb35-4bde-8f28-0b44d1bc6487";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/7fa2f6c0-b343-451b-8c50-8f64d8a71dc8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e526864b-bb35-4bde-8f28-0b44d1bc6487>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c427e28-5c66-4040-b592-8638ebb64bf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c427e28-5c66-4040-b592-8638ebb64bf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/ab4cf56b-ad04-4143-b48a-5c07788bcece/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c427e28-5c66-4040-b592-8638ebb64bf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/15ea0a82-c315-4159-a9cf-3d3aec8d95dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15ea0a82-c315-4159-a9cf-3d3aec8d95dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/ab4cf56b-ad04-4143-b48a-5c07788bcece/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15ea0a82-c315-4159-a9cf-3d3aec8d95dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/70758a83-6723-4441-a614-b21b1f2ca106> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70758a83-6723-4441-a614-b21b1f2ca106";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/ab4cf56b-ad04-4143-b48a-5c07788bcece/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70758a83-6723-4441-a614-b21b1f2ca106>.
+    
+<http://data.lblod.info/id/remote-data-objects/3aecb5f8-f163-4cb7-b8a4-351d7f8d3d8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3aecb5f8-f163-4cb7-b8a4-351d7f8d3d8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/b35094d4-250e-49bd-be69-ac8a1257dcb1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3aecb5f8-f163-4cb7-b8a4-351d7f8d3d8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/29779222-efb7-4893-9322-3ff9df0a1d76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29779222-efb7-4893-9322-3ff9df0a1d76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/b35094d4-250e-49bd-be69-ac8a1257dcb1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29779222-efb7-4893-9322-3ff9df0a1d76>.
+    
+<http://data.lblod.info/id/remote-data-objects/101fd9f7-b4bd-4076-bb8b-0918492100d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "101fd9f7-b4bd-4076-bb8b-0918492100d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/cdf0f071-4cdf-4e64-8a30-2ce71b849ba6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/101fd9f7-b4bd-4076-bb8b-0918492100d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7046dba-dab0-488d-a6f1-634725156f93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7046dba-dab0-488d-a6f1-634725156f93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/cdf0f071-4cdf-4e64-8a30-2ce71b849ba6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7046dba-dab0-488d-a6f1-634725156f93>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fec8c8c-81c5-4c48-9b79-6e63cd0d2520> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fec8c8c-81c5-4c48-9b79-6e63cd0d2520";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/rmw/cdf0f071-4cdf-4e64-8a30-2ce71b849ba6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fec8c8c-81c5-4c48-9b79-6e63cd0d2520>.
+    
+<http://data.lblod.info/id/remote-data-objects/473a1ee6-c887-487d-8804-14bf04f298e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "473a1ee6-c887-487d-8804-14bf04f298e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/02860d88-7888-4d3f-850e-b96003022e98/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/473a1ee6-c887-487d-8804-14bf04f298e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e460d551-8949-4128-9895-9337ee1ee7f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e460d551-8949-4128-9895-9337ee1ee7f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/044746f0-498b-417a-b0be-071957c377ad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e460d551-8949-4128-9895-9337ee1ee7f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/36f4fa47-c9c8-40f0-bd1c-8e43d985515e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36f4fa47-c9c8-40f0-bd1c-8e43d985515e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/07d23c58-a5cb-4d00-9956-3205fe0b3ff0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9a326ef-8f83-482a-b596-bd993c9d1147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36f4fa47-c9c8-40f0-bd1c-8e43d985515e>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201055-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201055-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201055-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201055-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/6d5b2915-8c27-4c2a-b885-13ccfbaaadf1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6d5b2915-8c27-4c2a-b885-13ccfbaaadf1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bf005a7b-8fd6-475c-b762-19d3f797d8b0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9e7b3265-ff47-469c-bc8d-e870f10fa789> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9e7b3265-ff47-469c-bc8d-e870f10fa789";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0>.
+
+  <http://redpencil.data.gift/id/task/fc17045c-303d-45a1-8ff2-d3249e103fbf> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fc17045c-303d-45a1-8ff2-d3249e103fbf";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/6d5b2915-8c27-4c2a-b885-13ccfbaaadf1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9e7b3265-ff47-469c-bc8d-e870f10fa789>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a8d76541-c903-464b-8e71-b4f471fb17ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8d76541-c903-464b-8e71-b4f471fb17ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/0ace79d7-2cf9-499a-b990-1109c446a009/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8d76541-c903-464b-8e71-b4f471fb17ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/558a75c6-4d99-4b01-b2d3-0c8b46602fb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "558a75c6-4d99-4b01-b2d3-0c8b46602fb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/0eca7d07-13e6-4ee4-a46b-cb754bd05f85/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/558a75c6-4d99-4b01-b2d3-0c8b46602fb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d38e0c6-5cba-4b4b-b2af-3e25c8d5b77c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d38e0c6-5cba-4b4b-b2af-3e25c8d5b77c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/1261336d-c817-4a54-b723-3950291fb8b8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d38e0c6-5cba-4b4b-b2af-3e25c8d5b77c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e029b9b-0b1f-41a8-985d-92689b1a4675> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e029b9b-0b1f-41a8-985d-92689b1a4675";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/1469ede2-9fe0-4b17-9b06-49c037ce432c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e029b9b-0b1f-41a8-985d-92689b1a4675>.
+    
+<http://data.lblod.info/id/remote-data-objects/23c85728-0813-4afb-9921-85317e9b5671> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23c85728-0813-4afb-9921-85317e9b5671";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/14f36e99-c7aa-4038-8e36-a42474ae9461/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23c85728-0813-4afb-9921-85317e9b5671>.
+    
+<http://data.lblod.info/id/remote-data-objects/109561f9-2235-414c-a29e-1041cb7a0911> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "109561f9-2235-414c-a29e-1041cb7a0911";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/195e065c-c6ba-45ba-97e6-aad6fa78288f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/109561f9-2235-414c-a29e-1041cb7a0911>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa600ece-b330-4f0a-87b5-878c991c3a70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa600ece-b330-4f0a-87b5-878c991c3a70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/316ed479-d2fe-4419-8dbd-cc3499355ed9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa600ece-b330-4f0a-87b5-878c991c3a70>.
+    
+<http://data.lblod.info/id/remote-data-objects/fea34902-ee31-4f21-bb59-48de6d27d82a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fea34902-ee31-4f21-bb59-48de6d27d82a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/36f827d9-9409-4801-8b7a-36ccba1f892d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fea34902-ee31-4f21-bb59-48de6d27d82a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c97a7d9-4556-4483-bbe1-64153ad7c80e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c97a7d9-4556-4483-bbe1-64153ad7c80e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/3f7a2ed7-3672-45a2-893a-c01f947b416a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c97a7d9-4556-4483-bbe1-64153ad7c80e>.
+    
+<http://data.lblod.info/id/remote-data-objects/deeaefa5-3286-4e0a-9410-908b30c8b9e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "deeaefa5-3286-4e0a-9410-908b30c8b9e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/41946990-5812-49a6-97ba-de11f2fc7d98/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/deeaefa5-3286-4e0a-9410-908b30c8b9e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2860b94d-e790-49c5-92fb-387376797191> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2860b94d-e790-49c5-92fb-387376797191";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/42abd021-a6cb-452a-9261-59f1841f16f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2860b94d-e790-49c5-92fb-387376797191>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5ea417e-65e9-4b68-89e4-582164ec23a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5ea417e-65e9-4b68-89e4-582164ec23a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/46aee339-0098-4766-aa0a-837f52a2aebe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5ea417e-65e9-4b68-89e4-582164ec23a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/626388c7-2761-4cf6-ab63-5c3217cd3c61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "626388c7-2761-4cf6-ab63-5c3217cd3c61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/56561b73-bf8a-422c-af25-e4632566f5db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/626388c7-2761-4cf6-ab63-5c3217cd3c61>.
+    
+<http://data.lblod.info/id/remote-data-objects/aff7bc92-d3ca-4b82-87b8-16adfb15d4aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aff7bc92-d3ca-4b82-87b8-16adfb15d4aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/5aebd81e-4d2c-4719-b708-447553c35419/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aff7bc92-d3ca-4b82-87b8-16adfb15d4aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/932a4eb1-7700-4452-a9b2-3303128b6692> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "932a4eb1-7700-4452-a9b2-3303128b6692";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/6b92c747-7a58-48ff-a219-6350c8164685/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/932a4eb1-7700-4452-a9b2-3303128b6692>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fafe16a-c4e9-48bf-8107-b21bfb856777> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fafe16a-c4e9-48bf-8107-b21bfb856777";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/6e1ba7c0-f11e-44c2-8eb1-57a376fff2a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fafe16a-c4e9-48bf-8107-b21bfb856777>.
+    
+<http://data.lblod.info/id/remote-data-objects/77ffd2ec-79f2-4678-8219-338a9efb29cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77ffd2ec-79f2-4678-8219-338a9efb29cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/790587f6-5682-40d2-965e-f91a1dcdba9e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77ffd2ec-79f2-4678-8219-338a9efb29cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fafb340-0456-495d-b8b9-a6073a66faaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fafb340-0456-495d-b8b9-a6073a66faaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/7f58ee16-aef6-4fd9-88a4-b716b079a6e4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fafb340-0456-495d-b8b9-a6073a66faaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/c726e37d-61ff-4ad2-ab1e-7fbcfe565f2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c726e37d-61ff-4ad2-ab1e-7fbcfe565f2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/918dd204-2eab-461b-a9a8-b5d434883bcc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c726e37d-61ff-4ad2-ab1e-7fbcfe565f2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fee5aa65-b50e-4c31-9be2-709f8bcb46c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fee5aa65-b50e-4c31-9be2-709f8bcb46c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/97b55a21-830d-4e18-9df3-6e4b30baf1b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fee5aa65-b50e-4c31-9be2-709f8bcb46c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/d52d8464-6974-45a2-8439-b39353ef5044> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d52d8464-6974-45a2-8439-b39353ef5044";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/a98abdc4-940d-4b4e-b578-f72d3c548ad8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d52d8464-6974-45a2-8439-b39353ef5044>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b893499-08c5-447d-b6f2-d6c4777b049c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b893499-08c5-447d-b6f2-d6c4777b049c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/b6561175-6201-4538-b587-395f7b988218/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b893499-08c5-447d-b6f2-d6c4777b049c>.
+    
+<http://data.lblod.info/id/remote-data-objects/dff5caa7-e40c-4ff9-83ec-255f64103579> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dff5caa7-e40c-4ff9-83ec-255f64103579";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/c35e6bf9-4d2c-4020-9b0e-cb6d6832ae29/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dff5caa7-e40c-4ff9-83ec-255f64103579>.
+    
+<http://data.lblod.info/id/remote-data-objects/aabf2aff-571b-48a0-90a8-c09ff82b01d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aabf2aff-571b-48a0-90a8-c09ff82b01d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/db173dd4-c4d5-483f-855d-19c2504caad6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aabf2aff-571b-48a0-90a8-c09ff82b01d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffd46f2f-6a8e-43a6-af47-7e5cb2f9ca8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffd46f2f-6a8e-43a6-af47-7e5cb2f9ca8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/e256bd53-8f68-454b-b79b-a61abd804b82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffd46f2f-6a8e-43a6-af47-7e5cb2f9ca8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/71bae141-0743-4838-9a0c-eec752c75da7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71bae141-0743-4838-9a0c-eec752c75da7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/ea8b36a9-d470-48b3-be1a-47fa630519ba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71bae141-0743-4838-9a0c-eec752c75da7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d306ae1e-b0e7-4333-81de-2d2f58514f0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d306ae1e-b0e7-4333-81de-2d2f58514f0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/ef3fed43-1e2b-489f-b0f1-5996356fbd92/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d306ae1e-b0e7-4333-81de-2d2f58514f0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee7c3d87-d526-4a12-87e0-9a0224368884> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee7c3d87-d526-4a12-87e0-9a0224368884";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/f58e5a02-89a9-43ef-8068-d19b3b66ac13/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee7c3d87-d526-4a12-87e0-9a0224368884>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ac7d34b-8b4b-47ef-9746-08fdbbc65e04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ac7d34b-8b4b-47ef-9746-08fdbbc65e04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/f98bae46-b95d-4327-befe-e4a5c31d6dec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ac7d34b-8b4b-47ef-9746-08fdbbc65e04>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a51afc1-d302-4908-bf50-eb208d6df17b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a51afc1-d302-4908-bf50-eb208d6df17b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://boutersem.meetingburger.net/vb/ffa32594-655c-45e9-b628-1c44fa9a13e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a51afc1-d302-4908-bf50-eb208d6df17b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3207db7e-2fa2-4064-b309-bba3d26109e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3207db7e-2fa2-4064-b309-bba3d26109e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/agbrvb/3761f2af-31a2-47bf-8a09-a1dd101cc669/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3207db7e-2fa2-4064-b309-bba3d26109e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c170822d-9bea-43f6-9f75-9c6460ab1522> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c170822d-9bea-43f6-9f75-9c6460ab1522";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/agbrvb/9bfc2afa-7441-4a94-a9dc-aa71fc5295b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c170822d-9bea-43f6-9f75-9c6460ab1522>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8932ace-bdb6-4573-848d-8660b61395df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8932ace-bdb6-4573-848d-8660b61395df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/agbrvb/e2393fad-cadd-4322-bfe2-d32bc438f468/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8932ace-bdb6-4573-848d-8660b61395df>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6aa4ee2-6715-4cf1-b9b9-bfa2a74cfbe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6aa4ee2-6715-4cf1-b9b9-bfa2a74cfbe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/062fea56-e29d-4494-a128-55f6cbb79a15/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6aa4ee2-6715-4cf1-b9b9-bfa2a74cfbe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/cafa4ea5-22a4-4d27-b9ea-26713f44ca49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cafa4ea5-22a4-4d27-b9ea-26713f44ca49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/070aad75-bb43-4498-856b-e612509ed914/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cafa4ea5-22a4-4d27-b9ea-26713f44ca49>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c5bd228-0692-428a-ae92-ba4729cc69ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c5bd228-0692-428a-ae92-ba4729cc69ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/07bb3e91-ec6c-4d5b-b70b-e054d580f4db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c5bd228-0692-428a-ae92-ba4729cc69ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b36d903-baf9-4d60-9caf-38e79c8b37e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b36d903-baf9-4d60-9caf-38e79c8b37e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/09c08d3d-43a1-4039-badd-7dcca9f6bcb6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b36d903-baf9-4d60-9caf-38e79c8b37e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbfa51fe-b4b1-46bc-adcb-46e774c827ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbfa51fe-b4b1-46bc-adcb-46e774c827ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/0a0fe484-29a6-4439-be04-0004e96eb920/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbfa51fe-b4b1-46bc-adcb-46e774c827ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/65a2850e-06db-486d-8852-61a8df0317b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65a2850e-06db-486d-8852-61a8df0317b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/0d8c6056-dd18-45b0-83a4-5d797c50425c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65a2850e-06db-486d-8852-61a8df0317b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6904fe7-5766-40fb-bd95-b8478be339f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6904fe7-5766-40fb-bd95-b8478be339f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/11482f5f-7097-427a-ae15-ad30343c3a7b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6904fe7-5766-40fb-bd95-b8478be339f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c4ade28-2d8c-4f8e-abcb-57a9e61d310a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c4ade28-2d8c-4f8e-abcb-57a9e61d310a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/18569bf8-e71c-4a23-89e6-357132c45146/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c4ade28-2d8c-4f8e-abcb-57a9e61d310a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5989b672-2607-40fb-9359-df354445c7be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5989b672-2607-40fb-9359-df354445c7be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/18e34f23-b37a-4f5d-9983-5bbd38a8d4c2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5989b672-2607-40fb-9359-df354445c7be>.
+    
+<http://data.lblod.info/id/remote-data-objects/6502c5a4-f5b6-4d2d-9879-8a73eb02a078> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6502c5a4-f5b6-4d2d-9879-8a73eb02a078";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/1995a1ca-aa5e-4e2a-a7c9-491bf55bcf04/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6502c5a4-f5b6-4d2d-9879-8a73eb02a078>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c346103-f595-47f2-9bd6-bfc4964695d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c346103-f595-47f2-9bd6-bfc4964695d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/1ec90fc0-e891-4754-a2b0-817e92036103/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c346103-f595-47f2-9bd6-bfc4964695d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6a22584-aa15-489d-b2bf-95a8391b05b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6a22584-aa15-489d-b2bf-95a8391b05b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/2a5477e9-5af7-4c4e-adad-3eea1773603a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6a22584-aa15-489d-b2bf-95a8391b05b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/82ecda16-7e9b-4cfb-86d8-551378f97993> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82ecda16-7e9b-4cfb-86d8-551378f97993";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/2e0f3beb-946a-41d9-b924-8077b090f3e4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82ecda16-7e9b-4cfb-86d8-551378f97993>.
+    
+<http://data.lblod.info/id/remote-data-objects/48dd395e-62d6-4fdb-94b4-ab61b3e89cd4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48dd395e-62d6-4fdb-94b4-ab61b3e89cd4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/2e3c4165-0801-4538-8fc2-5e6fd0bd73d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48dd395e-62d6-4fdb-94b4-ab61b3e89cd4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebad6bc4-de38-4f88-b7c7-bf0f4a0654ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebad6bc4-de38-4f88-b7c7-bf0f4a0654ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/31cea62c-1c61-4787-8bb7-5ff5e0273935/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebad6bc4-de38-4f88-b7c7-bf0f4a0654ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/797a94d6-69d8-4e03-8e86-8de0a6bc47b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "797a94d6-69d8-4e03-8e86-8de0a6bc47b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/336dc41e-dfab-48bd-a1fc-669b88d89bfd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/797a94d6-69d8-4e03-8e86-8de0a6bc47b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/925ea27f-90f7-4bdc-acce-57de6e7600d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "925ea27f-90f7-4bdc-acce-57de6e7600d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/34f4f9e8-780d-44fe-929f-750cc5d7e0fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf005a7b-8fd6-475c-b762-19d3f797d8b0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/925ea27f-90f7-4bdc-acce-57de6e7600d0>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201057-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201057-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201057-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201057-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/ce8b41c0-8dfa-41d0-845e-07a362546e6a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ce8b41c0-8dfa-41d0-845e-07a362546e6a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "638dd9d0-ce55-4538-a40e-82ba65dd0b21";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/077fd596-a16c-4c0e-a1a8-0a9a4af8a0f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "077fd596-a16c-4c0e-a1a8-0a9a4af8a0f7";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21>.
+
+  <http://redpencil.data.gift/id/task/42159b56-2e85-4efd-9787-aa80ed468bff> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "42159b56-2e85-4efd-9787-aa80ed468bff";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/ce8b41c0-8dfa-41d0-845e-07a362546e6a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/077fd596-a16c-4c0e-a1a8-0a9a4af8a0f7>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4edb778e-9b73-4740-9512-631b43c55582> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4edb778e-9b73-4740-9512-631b43c55582";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/3cbb63f3-9e01-4d94-a4be-d727b14fdffd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4edb778e-9b73-4740-9512-631b43c55582>.
+    
+<http://data.lblod.info/id/remote-data-objects/d67d74dc-6c35-4ae5-a83e-3b64ae8de70d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d67d74dc-6c35-4ae5-a83e-3b64ae8de70d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/41c18fc2-1919-4198-b154-c2c1967ff3d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d67d74dc-6c35-4ae5-a83e-3b64ae8de70d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e79fcf10-ee41-4089-be3f-d1735b3ac0f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e79fcf10-ee41-4089-be3f-d1735b3ac0f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/46f1eb44-be66-4a97-b67e-8373113d2a05/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e79fcf10-ee41-4089-be3f-d1735b3ac0f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a34081c0-7773-489f-a93e-6edba8755d23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a34081c0-7773-489f-a93e-6edba8755d23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/48d7560f-7885-41d1-96d5-223262b0bb56/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a34081c0-7773-489f-a93e-6edba8755d23>.
+    
+<http://data.lblod.info/id/remote-data-objects/25978887-83bb-4064-a3e4-69cdff43e0a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25978887-83bb-4064-a3e4-69cdff43e0a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/4bf80403-0f71-499e-a571-57a81aaf8176/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25978887-83bb-4064-a3e4-69cdff43e0a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9e9f622-7770-4ce5-ad91-c8f8cdb0fd33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9e9f622-7770-4ce5-ad91-c8f8cdb0fd33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/4d9f83c0-17b3-4c30-b94e-daa78b05518b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9e9f622-7770-4ce5-ad91-c8f8cdb0fd33>.
+    
+<http://data.lblod.info/id/remote-data-objects/36f5afe0-06b5-4c38-bf18-305b58d5b909> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36f5afe0-06b5-4c38-bf18-305b58d5b909";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/58bb7a1d-6dbf-4e8b-aa70-1813e9584866/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36f5afe0-06b5-4c38-bf18-305b58d5b909>.
+    
+<http://data.lblod.info/id/remote-data-objects/251224b1-9dee-4bc5-a7ca-6d93dff621ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "251224b1-9dee-4bc5-a7ca-6d93dff621ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/6150b94f-6a44-449e-bf7d-5276ba0f6bbd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/251224b1-9dee-4bc5-a7ca-6d93dff621ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/a64c642f-40fe-47e4-bfe0-8ca005d7bf2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a64c642f-40fe-47e4-bfe0-8ca005d7bf2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/62b9c951-1e52-46a6-bee8-4ce940bba99e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a64c642f-40fe-47e4-bfe0-8ca005d7bf2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/28fa54c3-7561-448d-9b42-3b9c4b641901> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28fa54c3-7561-448d-9b42-3b9c4b641901";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/62c68d2e-e22e-4a5c-af29-fa67e30f418c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28fa54c3-7561-448d-9b42-3b9c4b641901>.
+    
+<http://data.lblod.info/id/remote-data-objects/daec63b7-d873-49ad-a065-a85c98c3fc14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "daec63b7-d873-49ad-a065-a85c98c3fc14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/64d93090-5583-4bb6-a83b-f3021fe01d0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/daec63b7-d873-49ad-a065-a85c98c3fc14>.
+    
+<http://data.lblod.info/id/remote-data-objects/771fdc44-1caa-4e20-9257-879ff71a8130> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "771fdc44-1caa-4e20-9257-879ff71a8130";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/69aca8f7-00a0-4f43-9140-f456b84ecfad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/771fdc44-1caa-4e20-9257-879ff71a8130>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d876e5b-7f40-4e6e-8fda-7c696b571af2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d876e5b-7f40-4e6e-8fda-7c696b571af2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/6e2d321e-0a06-4f49-9836-6a63a4e96faa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d876e5b-7f40-4e6e-8fda-7c696b571af2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b03a6b65-da82-43ed-98ce-3ec672419be6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b03a6b65-da82-43ed-98ce-3ec672419be6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/7198c9a2-759c-4aa2-985f-be964988cb7a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b03a6b65-da82-43ed-98ce-3ec672419be6>.
+    
+<http://data.lblod.info/id/remote-data-objects/16c9d4cf-fd75-4326-8d00-a75f2ba05dc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16c9d4cf-fd75-4326-8d00-a75f2ba05dc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/76a4ec6b-6e3f-4f6d-b59c-8e2b3adb0abb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16c9d4cf-fd75-4326-8d00-a75f2ba05dc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d856c67a-4f94-4f2d-a7ea-8697f4315f09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d856c67a-4f94-4f2d-a7ea-8697f4315f09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/80d83ccf-7b2a-41a9-901e-ec0c5a2b0646/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d856c67a-4f94-4f2d-a7ea-8697f4315f09>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8c0e45c-3638-4c34-a256-8b29f9c990b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8c0e45c-3638-4c34-a256-8b29f9c990b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/825d8418-146e-41bf-987f-1a7aa7ab1635/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8c0e45c-3638-4c34-a256-8b29f9c990b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/56daf18d-7960-4201-b73e-64d7d5e9abc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56daf18d-7960-4201-b73e-64d7d5e9abc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/82d71518-4d63-4e3e-9bb7-3f246e92af86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56daf18d-7960-4201-b73e-64d7d5e9abc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7f61616-9494-46b9-834d-985599a13796> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7f61616-9494-46b9-834d-985599a13796";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/85e25ef3-212d-48ff-9a8a-2151993ae53e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7f61616-9494-46b9-834d-985599a13796>.
+    
+<http://data.lblod.info/id/remote-data-objects/baae7d19-46a0-4479-8a9e-0e8455427184> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "baae7d19-46a0-4479-8a9e-0e8455427184";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/898cb13b-12c9-4679-990c-a621810a5e89/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/baae7d19-46a0-4479-8a9e-0e8455427184>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1c5f945-1e64-4e69-a529-c60aefb1ad68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1c5f945-1e64-4e69-a529-c60aefb1ad68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/8b17fdbd-bdb6-4c62-9701-8d5a9d36c0ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1c5f945-1e64-4e69-a529-c60aefb1ad68>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6299ab2-7b46-4f78-8ae1-8de35955734a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6299ab2-7b46-4f78-8ae1-8de35955734a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/8b3fa4da-153e-4de0-809d-34cd28c3aceb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6299ab2-7b46-4f78-8ae1-8de35955734a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f00d8df5-6234-425f-9088-b9267f86d40c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f00d8df5-6234-425f-9088-b9267f86d40c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/8c9b7420-bb28-4ccb-b7c8-0b4fd54ae2a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f00d8df5-6234-425f-9088-b9267f86d40c>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdccc523-ab35-46ce-94dd-ede8db880738> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdccc523-ab35-46ce-94dd-ede8db880738";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/8ec25b50-6db2-48b5-8f03-1168d5d46ccf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdccc523-ab35-46ce-94dd-ede8db880738>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a390752-ea28-482c-a41d-c57660e3dbfe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a390752-ea28-482c-a41d-c57660e3dbfe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/903af251-32f0-418c-8142-49995a413a6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a390752-ea28-482c-a41d-c57660e3dbfe>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0a637cc-94c6-4c32-99b5-83df49cc452f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0a637cc-94c6-4c32-99b5-83df49cc452f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/9539fb8c-fc5e-4f92-b0d0-2c1845cb90f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0a637cc-94c6-4c32-99b5-83df49cc452f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c989d52-634c-4470-8992-023b39394e44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c989d52-634c-4470-8992-023b39394e44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/98b1af05-65d0-4aaf-a5c3-d6697c6bb397/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c989d52-634c-4470-8992-023b39394e44>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccab31af-cc1c-4fc1-9b72-eed5d0c7f06c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccab31af-cc1c-4fc1-9b72-eed5d0c7f06c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/995a37d7-85c3-4f5d-afef-f028b0b36599/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccab31af-cc1c-4fc1-9b72-eed5d0c7f06c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f681fc6-d733-4ade-819a-5a9f34b9b909> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f681fc6-d733-4ade-819a-5a9f34b9b909";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/9c3835ca-9fa4-4513-bbb4-977839d41125/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f681fc6-d733-4ade-819a-5a9f34b9b909>.
+    
+<http://data.lblod.info/id/remote-data-objects/aaf60445-e6f4-476c-a21b-fb7e36325cac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aaf60445-e6f4-476c-a21b-fb7e36325cac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/9fcf2f08-b045-4534-85df-895f7535e378/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aaf60445-e6f4-476c-a21b-fb7e36325cac>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c0d7132-4989-470c-b3db-88579e08f88f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c0d7132-4989-470c-b3db-88579e08f88f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/a07772a0-0dff-4c67-9ef7-d3984cf30a7d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c0d7132-4989-470c-b3db-88579e08f88f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ed0589b-4d32-4af4-a67c-329f2aa8bc76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ed0589b-4d32-4af4-a67c-329f2aa8bc76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/a7817bcd-aaef-4b7a-9809-e36a861221f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ed0589b-4d32-4af4-a67c-329f2aa8bc76>.
+    
+<http://data.lblod.info/id/remote-data-objects/312df250-4b98-4840-a3ea-f2d2b66da725> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "312df250-4b98-4840-a3ea-f2d2b66da725";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/a84ed908-4425-440f-876c-35c4c8408593/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/312df250-4b98-4840-a3ea-f2d2b66da725>.
+    
+<http://data.lblod.info/id/remote-data-objects/11e653f0-5d82-4a78-baef-190f65b148b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11e653f0-5d82-4a78-baef-190f65b148b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/baea5a0b-2cb9-4485-9ea7-23d71b93d5a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11e653f0-5d82-4a78-baef-190f65b148b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e1cc346-e666-4494-a3ab-44e5c71e2600> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e1cc346-e666-4494-a3ab-44e5c71e2600";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/beb97038-fb2f-4e14-bc8e-30bf1ca601eb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e1cc346-e666-4494-a3ab-44e5c71e2600>.
+    
+<http://data.lblod.info/id/remote-data-objects/3366cfda-6006-47d4-b8d2-a5a5a84719b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3366cfda-6006-47d4-b8d2-a5a5a84719b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/beeee569-d80e-4b2d-826f-aeea4345e148/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3366cfda-6006-47d4-b8d2-a5a5a84719b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b4ca9aa-f26a-4b94-a873-bc187d3954f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b4ca9aa-f26a-4b94-a873-bc187d3954f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/c825c491-64fb-4812-a47c-8def8118268a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b4ca9aa-f26a-4b94-a873-bc187d3954f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fd698a9-178b-4140-b0c0-be68d3893a16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fd698a9-178b-4140-b0c0-be68d3893a16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/cb2e18ab-969c-41bd-a79b-1a4a41992f9a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fd698a9-178b-4140-b0c0-be68d3893a16>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3133489-d9fb-49f0-aa94-e3512a972502> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3133489-d9fb-49f0-aa94-e3512a972502";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/cd11e7d3-d1c0-4276-85a2-c97d1e87dd0d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3133489-d9fb-49f0-aa94-e3512a972502>.
+    
+<http://data.lblod.info/id/remote-data-objects/b899f2b9-b4fb-4c8b-9bf3-05c4a00676c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b899f2b9-b4fb-4c8b-9bf3-05c4a00676c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/ce1c4cd9-ef7d-409c-9083-e215c47496d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b899f2b9-b4fb-4c8b-9bf3-05c4a00676c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/93a5b158-9a0c-4b8d-9283-4748485491df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93a5b158-9a0c-4b8d-9283-4748485491df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/cfc144d2-391e-4553-b565-a99e81ac9b61/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93a5b158-9a0c-4b8d-9283-4748485491df>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5649990-b594-4b7b-8dad-e2e82345c50e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5649990-b594-4b7b-8dad-e2e82345c50e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/d102ce81-726a-4f6f-8f19-0c07777074fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5649990-b594-4b7b-8dad-e2e82345c50e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2df558c9-22b7-4f89-b73d-d7b0b04448b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2df558c9-22b7-4f89-b73d-d7b0b04448b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/dd4405d7-6649-4e3a-a19b-cb30d69095bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2df558c9-22b7-4f89-b73d-d7b0b04448b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5e3084d-13d7-4529-bf13-d074aab6c992> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5e3084d-13d7-4529-bf13-d074aab6c992";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/de92fe55-14d2-4025-aa65-a05fc46539ee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5e3084d-13d7-4529-bf13-d074aab6c992>.
+    
+<http://data.lblod.info/id/remote-data-objects/e41869c3-3292-4414-ae62-def39b832e3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e41869c3-3292-4414-ae62-def39b832e3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/ebdcdabe-b897-40d7-b614-8557373d45af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e41869c3-3292-4414-ae62-def39b832e3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd796736-e975-4c3d-a0a6-a7cd2ad99be3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd796736-e975-4c3d-a0a6-a7cd2ad99be3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/eeede0e8-bf6f-4504-90c5-e7281a39e2cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd796736-e975-4c3d-a0a6-a7cd2ad99be3>.
+    
+<http://data.lblod.info/id/remote-data-objects/66f3f23d-edff-46cc-8c95-4d61805a7336> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66f3f23d-edff-46cc-8c95-4d61805a7336";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/fa97d3e3-1b73-4ae2-be40-8b9eabbcd461/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66f3f23d-edff-46cc-8c95-4d61805a7336>.
+    
+<http://data.lblod.info/id/remote-data-objects/d44a6e12-944c-4e44-a526-6f4b9bcc6931> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d44a6e12-944c-4e44-a526-6f4b9bcc6931";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/fb87ef4b-0d84-4de9-9331-a88f267fec00/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d44a6e12-944c-4e44-a526-6f4b9bcc6931>.
+    
+<http://data.lblod.info/id/remote-data-objects/095fc28c-9467-4f51-9c2c-c702121879b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "095fc28c-9467-4f51-9c2c-c702121879b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/burg/fe17d927-984a-460d-bb69-f8f157e577a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/095fc28c-9467-4f51-9c2c-c702121879b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/80b78522-9586-47b3-a992-c7967919266d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80b78522-9586-47b3-a992-c7967919266d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/03eb2201-d9e3-450e-bf35-95d4cc805052/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/638dd9d0-ce55-4538-a40e-82ba65dd0b21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80b78522-9586-47b3-a992-c7967919266d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201058-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201058-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201058-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201058-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/53a108b5-ae5b-4363-aec6-1e99be77009c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "53a108b5-ae5b-4363-aec6-1e99be77009c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5bac7dd3-2516-4f87-8c52-f72017dbfbd4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/5eada23b-96be-489b-a84f-89d829a8d315> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5eada23b-96be-489b-a84f-89d829a8d315";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4>.
+
+  <http://redpencil.data.gift/id/task/c2f0e547-8141-44b3-a463-b05af608cf42> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c2f0e547-8141-44b3-a463-b05af608cf42";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/53a108b5-ae5b-4363-aec6-1e99be77009c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/5eada23b-96be-489b-a84f-89d829a8d315>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/094522fa-5a47-4265-b00b-133d7333282f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "094522fa-5a47-4265-b00b-133d7333282f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/0638c600-5ca5-47d7-b43a-17d322ee8a98/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/094522fa-5a47-4265-b00b-133d7333282f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0e441cf-5f8d-4d10-8021-6864fc8ca88a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0e441cf-5f8d-4d10-8021-6864fc8ca88a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/0dc30291-232a-4138-888e-ba8204c9a095/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0e441cf-5f8d-4d10-8021-6864fc8ca88a>.
+    
+<http://data.lblod.info/id/remote-data-objects/79de2d70-4917-410c-9ed8-41150b2495a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79de2d70-4917-410c-9ed8-41150b2495a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/13e97a5d-7a51-4249-a1fd-aa09af131606/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79de2d70-4917-410c-9ed8-41150b2495a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/df8a291d-d114-42a1-86ff-9cbfcdee00a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df8a291d-d114-42a1-86ff-9cbfcdee00a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/16cf57d6-9d20-4a68-a429-fe718cb49737/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df8a291d-d114-42a1-86ff-9cbfcdee00a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b211aa01-8efc-4515-9f1d-0cea494bd7b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b211aa01-8efc-4515-9f1d-0cea494bd7b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/1a8eae7d-2a29-4daa-9a0d-22f5e52b7794/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b211aa01-8efc-4515-9f1d-0cea494bd7b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/8360f920-a48f-4a91-894d-249ee7b5e1d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8360f920-a48f-4a91-894d-249ee7b5e1d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/1e506dfa-1842-453d-beee-60a02db71bc9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8360f920-a48f-4a91-894d-249ee7b5e1d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/deb3cd2f-6213-4ef2-b257-17f925b228de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "deb3cd2f-6213-4ef2-b257-17f925b228de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/229a857b-389e-4e0b-8bd6-a99ca64b2df4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/deb3cd2f-6213-4ef2-b257-17f925b228de>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1c4cb89-df79-4831-9e90-db97269d5b9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1c4cb89-df79-4831-9e90-db97269d5b9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/23e62585-982b-463e-9561-ae3156f0f039/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1c4cb89-df79-4831-9e90-db97269d5b9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfaf9dd9-2f16-497c-809d-c7d0d7541271> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfaf9dd9-2f16-497c-809d-c7d0d7541271";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/251fae20-274a-4ce9-999d-568910d3a1e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfaf9dd9-2f16-497c-809d-c7d0d7541271>.
+    
+<http://data.lblod.info/id/remote-data-objects/15debd5f-171d-41be-9a8f-b32f3b347c84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15debd5f-171d-41be-9a8f-b32f3b347c84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/252b2cf5-d33e-4413-ae71-0884e984c98e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15debd5f-171d-41be-9a8f-b32f3b347c84>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb23f6e6-7cf0-4395-939e-6c5761944920> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb23f6e6-7cf0-4395-939e-6c5761944920";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/270c0dcd-315a-4aa9-9809-a746a4f9a909/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb23f6e6-7cf0-4395-939e-6c5761944920>.
+    
+<http://data.lblod.info/id/remote-data-objects/fff06d83-2aa3-40e5-9111-c4144c5f90e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fff06d83-2aa3-40e5-9111-c4144c5f90e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/2a1d4ba5-88d4-4211-a3a3-1ffec12a6c28/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fff06d83-2aa3-40e5-9111-c4144c5f90e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc84b76c-7012-496e-b06e-4e027580117c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc84b76c-7012-496e-b06e-4e027580117c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/2c0d2413-71d9-4a01-9010-6e6feb7dc099/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc84b76c-7012-496e-b06e-4e027580117c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b45c943e-0349-45b1-8ac8-84984f23c109> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b45c943e-0349-45b1-8ac8-84984f23c109";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/2eb78925-7260-43a4-9210-3327a6da2249/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b45c943e-0349-45b1-8ac8-84984f23c109>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4214309-904c-42e4-acec-9566e4c45573> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4214309-904c-42e4-acec-9566e4c45573";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/32627a26-990c-49a8-9e88-d714ad07d33a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4214309-904c-42e4-acec-9566e4c45573>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb0fa09c-b1b6-480f-84ac-8766ad4ab94a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb0fa09c-b1b6-480f-84ac-8766ad4ab94a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/33d46e6b-2bd9-4197-bc90-11709e7579dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb0fa09c-b1b6-480f-84ac-8766ad4ab94a>.
+    
+<http://data.lblod.info/id/remote-data-objects/97df3973-89d5-4c8f-ab56-d77de9aff747> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97df3973-89d5-4c8f-ab56-d77de9aff747";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/34e08b7b-8a2c-471c-92b7-8a6053f1cd6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97df3973-89d5-4c8f-ab56-d77de9aff747>.
+    
+<http://data.lblod.info/id/remote-data-objects/8322dc62-a374-4375-a1b4-2fa43d37d5d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8322dc62-a374-4375-a1b4-2fa43d37d5d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/35c93e46-bfea-446b-b40c-673b5847d136/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8322dc62-a374-4375-a1b4-2fa43d37d5d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e835ce3b-b0e6-40cd-99ca-9af76022e212> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e835ce3b-b0e6-40cd-99ca-9af76022e212";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/365dab4b-ce45-476b-9ff9-cdfb4478ea69/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e835ce3b-b0e6-40cd-99ca-9af76022e212>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9cfee4d-3e0c-46e2-bf90-369c7af30372> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9cfee4d-3e0c-46e2-bf90-369c7af30372";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/383fcd35-6844-4e73-8ab3-77fb71330b88/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9cfee4d-3e0c-46e2-bf90-369c7af30372>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5c2ae96-e0ee-41b7-88a6-8b6cea640110> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5c2ae96-e0ee-41b7-88a6-8b6cea640110";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/3f4e0f1c-99b5-41e7-9715-d01715f76b8c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5c2ae96-e0ee-41b7-88a6-8b6cea640110>.
+    
+<http://data.lblod.info/id/remote-data-objects/84e1ed49-f7f3-47bd-a439-26f1c12161ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84e1ed49-f7f3-47bd-a439-26f1c12161ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/42e69102-a610-4a93-9050-9da933048f92/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84e1ed49-f7f3-47bd-a439-26f1c12161ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5e727cb-9a9f-45c5-9d76-9fb647dfc0a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5e727cb-9a9f-45c5-9d76-9fb647dfc0a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/43d15876-8ef3-4d4c-a250-f5573b7c84b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5e727cb-9a9f-45c5-9d76-9fb647dfc0a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf9fb2bf-e80a-4408-a3c1-3764548869cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf9fb2bf-e80a-4408-a3c1-3764548869cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/5240916c-e095-4807-9153-d04fa5bcf588/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf9fb2bf-e80a-4408-a3c1-3764548869cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/1011872c-2ae6-4112-b28a-f7183f5b0cf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1011872c-2ae6-4112-b28a-f7183f5b0cf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/53b09a63-93dc-443b-8659-1b04a9079f1b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1011872c-2ae6-4112-b28a-f7183f5b0cf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/03de5213-752a-434b-b061-945b0967cff1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03de5213-752a-434b-b061-945b0967cff1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/551760e2-0830-42e2-a5ab-4743919237ba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03de5213-752a-434b-b061-945b0967cff1>.
+    
+<http://data.lblod.info/id/remote-data-objects/febe2237-469d-477e-a056-7ad6abffdee8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "febe2237-469d-477e-a056-7ad6abffdee8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/56172f91-2c70-450a-99e6-37632f5741a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/febe2237-469d-477e-a056-7ad6abffdee8>.
+    
+<http://data.lblod.info/id/remote-data-objects/41284fbe-3026-4ce6-bbbf-dc26d9ab7cc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41284fbe-3026-4ce6-bbbf-dc26d9ab7cc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/59b2e3a2-ece9-4908-948e-cdebeaa9122c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41284fbe-3026-4ce6-bbbf-dc26d9ab7cc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec48f4bc-2f98-4a8c-8421-4787726fd370> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec48f4bc-2f98-4a8c-8421-4787726fd370";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/5a4b1c91-1455-45d9-9133-26415a2e23c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec48f4bc-2f98-4a8c-8421-4787726fd370>.
+    
+<http://data.lblod.info/id/remote-data-objects/645f7759-c416-443f-a2e0-ebe33ba105eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "645f7759-c416-443f-a2e0-ebe33ba105eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/5f6a60c1-89fa-4a40-8e98-1e2021d1dd4d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/645f7759-c416-443f-a2e0-ebe33ba105eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/b03563a9-171a-4043-b593-28ea1b4ff088> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b03563a9-171a-4043-b593-28ea1b4ff088";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/61ed0b4a-1d31-4472-a443-6840cfa60a34/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b03563a9-171a-4043-b593-28ea1b4ff088>.
+    
+<http://data.lblod.info/id/remote-data-objects/30ae42e2-db61-4b95-823e-bbdab6f06fac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30ae42e2-db61-4b95-823e-bbdab6f06fac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/634b1ca5-1f99-4b51-976f-3bc0d7ee20d8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30ae42e2-db61-4b95-823e-bbdab6f06fac>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5e19fab-04d5-406e-85e7-362b842203f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5e19fab-04d5-406e-85e7-362b842203f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/6644b98b-7481-4fc2-8e20-4cce30aeb7f0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5e19fab-04d5-406e-85e7-362b842203f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6892687-0b5c-455c-ad67-df15c8aa8f4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6892687-0b5c-455c-ad67-df15c8aa8f4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/6d8e3fae-a037-4d75-a532-75e5b10692ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6892687-0b5c-455c-ad67-df15c8aa8f4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2be61792-fba0-4ace-a044-58b61337760c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2be61792-fba0-4ace-a044-58b61337760c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/6e7d9210-41c8-4e95-99cb-a67be6a17fb7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2be61792-fba0-4ace-a044-58b61337760c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3736f2f7-b5ec-42d1-80b7-090f5f35e37d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3736f2f7-b5ec-42d1-80b7-090f5f35e37d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/730608c9-bda2-4511-a1a8-409aefeec3d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3736f2f7-b5ec-42d1-80b7-090f5f35e37d>.
+    
+<http://data.lblod.info/id/remote-data-objects/55e8bdea-ec8e-4766-9cf5-05a5b375f92a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55e8bdea-ec8e-4766-9cf5-05a5b375f92a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/755235e4-21ab-44e4-8e2b-d379e5aaaec2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55e8bdea-ec8e-4766-9cf5-05a5b375f92a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a79b8447-3be9-4528-a196-eaf3cc80ae4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a79b8447-3be9-4528-a196-eaf3cc80ae4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/7b62a655-0994-4788-aa70-3a4c49bd229e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a79b8447-3be9-4528-a196-eaf3cc80ae4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/50a085c7-404f-4b51-8cd9-3291aa50b58e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50a085c7-404f-4b51-8cd9-3291aa50b58e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/7f0e9520-903e-4acb-951a-ec4785753601/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50a085c7-404f-4b51-8cd9-3291aa50b58e>.
+    
+<http://data.lblod.info/id/remote-data-objects/716bccf0-c452-4868-8861-5c611526f89f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "716bccf0-c452-4868-8861-5c611526f89f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/7ffa3cf9-f6c5-4ec7-bf26-b11473aa34db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/716bccf0-c452-4868-8861-5c611526f89f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e0ecdff-ce0e-4823-abe9-3af2c485a193> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e0ecdff-ce0e-4823-abe9-3af2c485a193";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/81f2d06f-6a00-434c-8355-c747131a1460/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e0ecdff-ce0e-4823-abe9-3af2c485a193>.
+    
+<http://data.lblod.info/id/remote-data-objects/dab06f60-ec22-49f0-9434-ec971aff958e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dab06f60-ec22-49f0-9434-ec971aff958e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/8cf05aa9-d60c-4791-94a8-5996a7e5ff26/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dab06f60-ec22-49f0-9434-ec971aff958e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fede4555-f24a-4078-aed9-10a63a45ce5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fede4555-f24a-4078-aed9-10a63a45ce5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/919e0fe7-5a42-4d6d-9894-548ed10c5c5c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fede4555-f24a-4078-aed9-10a63a45ce5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/64b5cffd-a9e3-4fbd-9ab8-65319acd2b72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64b5cffd-a9e3-4fbd-9ab8-65319acd2b72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/9318648d-0bb1-4ad5-94e5-bf0296c8a529/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64b5cffd-a9e3-4fbd-9ab8-65319acd2b72>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb33dba4-ea3e-4d53-842a-7d4277d50c16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb33dba4-ea3e-4d53-842a-7d4277d50c16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/94705a7c-eefa-4a0e-a252-dbf4e50aa3e8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb33dba4-ea3e-4d53-842a-7d4277d50c16>.
+    
+<http://data.lblod.info/id/remote-data-objects/49a36828-578c-4e18-849a-8ea1e463c3be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49a36828-578c-4e18-849a-8ea1e463c3be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/9521ddc1-0b7e-4c4a-9e20-50d043824413/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49a36828-578c-4e18-849a-8ea1e463c3be>.
+    
+<http://data.lblod.info/id/remote-data-objects/19c74b5d-d1ec-4ff5-a218-389401cfe357> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19c74b5d-d1ec-4ff5-a218-389401cfe357";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/9e769a02-6363-4db4-abff-f12e7ac903d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19c74b5d-d1ec-4ff5-a218-389401cfe357>.
+    
+<http://data.lblod.info/id/remote-data-objects/50e72465-7293-4d1d-a4aa-9cb95ddbbf5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50e72465-7293-4d1d-a4aa-9cb95ddbbf5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/a07bdf33-32e0-4566-aad9-250cadebf63a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50e72465-7293-4d1d-a4aa-9cb95ddbbf5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a176bae9-906a-4aca-9e25-2f40e9183428> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a176bae9-906a-4aca-9e25-2f40e9183428";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/a337e776-436e-4c51-8ce9-b41dbcbf4923/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a176bae9-906a-4aca-9e25-2f40e9183428>.
+    
+<http://data.lblod.info/id/remote-data-objects/1595cd72-f23b-4ad6-af32-f92d40bf56d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1595cd72-f23b-4ad6-af32-f92d40bf56d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/ba9de4c7-cabb-4874-88a9-663dfa2786b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5bac7dd3-2516-4f87-8c52-f72017dbfbd4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1595cd72-f23b-4ad6-af32-f92d40bf56d2>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201059-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201059-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201059-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201059-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/590a30f5-24d4-492b-a63d-055255f69722> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "590a30f5-24d4-492b-a63d-055255f69722";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "14bb187d-e8e5-42da-a1d7-9b8aedb9b274";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/5085b58f-4633-455d-b272-17c3433364f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5085b58f-4633-455d-b272-17c3433364f6";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274>.
+
+  <http://redpencil.data.gift/id/task/92b96f3d-f418-4089-9f31-e30ec8fa2d55> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "92b96f3d-f418-4089-9f31-e30ec8fa2d55";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/590a30f5-24d4-492b-a63d-055255f69722>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/5085b58f-4633-455d-b272-17c3433364f6>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7a7b9755-197a-4de2-821d-b3055f4f6ce8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a7b9755-197a-4de2-821d-b3055f4f6ce8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/bbb3cefb-6ceb-4006-872c-08cf7b800ea1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a7b9755-197a-4de2-821d-b3055f4f6ce8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b19f08d2-536f-441f-91cb-3b70eb0b36fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b19f08d2-536f-441f-91cb-3b70eb0b36fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/bbf629e1-ad81-49fc-9d06-50893cef395c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b19f08d2-536f-441f-91cb-3b70eb0b36fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a164369-e2e0-4706-a1f3-810419d61b34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a164369-e2e0-4706-a1f3-810419d61b34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/c2c34a80-1dcb-4d19-9fd2-3ca873bca453/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a164369-e2e0-4706-a1f3-810419d61b34>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dff9250-c10a-41cf-83a5-dd361254b504> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dff9250-c10a-41cf-83a5-dd361254b504";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/cb7af250-fd5d-4cd0-b449-b58d5696d005/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dff9250-c10a-41cf-83a5-dd361254b504>.
+    
+<http://data.lblod.info/id/remote-data-objects/f48a84bf-ee05-4f93-9b59-b1411bd4145e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f48a84bf-ee05-4f93-9b59-b1411bd4145e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/d5f3c84d-7f47-4411-9f81-a7616dc81feb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f48a84bf-ee05-4f93-9b59-b1411bd4145e>.
+    
+<http://data.lblod.info/id/remote-data-objects/010f312c-527e-4ee0-82d7-508ed206e4e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "010f312c-527e-4ee0-82d7-508ed206e4e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/dae1883f-e820-4b60-b9bf-324a1226d205/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/010f312c-527e-4ee0-82d7-508ed206e4e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/52b20a1b-c027-4579-8a71-533306fdaedd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52b20a1b-c027-4579-8a71-533306fdaedd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/dd69d5a4-310a-4753-a21e-83ef0a568f03/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52b20a1b-c027-4579-8a71-533306fdaedd>.
+    
+<http://data.lblod.info/id/remote-data-objects/54e2e226-647a-48be-85b1-5c8cead4348d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54e2e226-647a-48be-85b1-5c8cead4348d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/e8ec2d81-3a21-4b68-9240-f94b89c1bc33/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54e2e226-647a-48be-85b1-5c8cead4348d>.
+    
+<http://data.lblod.info/id/remote-data-objects/caddcfbd-b0af-4cca-996d-90a9a74719fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "caddcfbd-b0af-4cca-996d-90a9a74719fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/eb931fc0-ee87-45de-81e6-eb0f4f94e44e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/caddcfbd-b0af-4cca-996d-90a9a74719fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2f859fe-4a23-4b4e-a3f1-1ce17023d9e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2f859fe-4a23-4b4e-a3f1-1ce17023d9e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/ec1ab149-dda8-4bce-8294-e77a3fe7b312/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2f859fe-4a23-4b4e-a3f1-1ce17023d9e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/95751ba0-917f-4ca6-9b49-fa4073bb2903> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95751ba0-917f-4ca6-9b49-fa4073bb2903";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/f1d4c87d-cf97-4b6c-8a5a-207ddcf0f69f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95751ba0-917f-4ca6-9b49-fa4073bb2903>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5b82e75-7d74-4959-b5dd-bf37431545a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5b82e75-7d74-4959-b5dd-bf37431545a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/f1f3b7d6-32ee-44b4-af83-2903fb5a352f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5b82e75-7d74-4959-b5dd-bf37431545a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0fe52e7-e14d-434c-b702-5b108cea8d2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0fe52e7-e14d-434c-b702-5b108cea8d2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/f5d3330c-73b9-4beb-8208-5947eb89706a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0fe52e7-e14d-434c-b702-5b108cea8d2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/695d78f2-a800-4927-a2e5-a579baff3e3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "695d78f2-a800-4927-a2e5-a579baff3e3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/f85f4322-efed-4b31-a68e-f76ab7ca5011/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/695d78f2-a800-4927-a2e5-a579baff3e3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9a2a1d5-3d9c-43f9-936b-b1f59fd8a9fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9a2a1d5-3d9c-43f9-936b-b1f59fd8a9fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/fa7ef5de-0649-4e9c-9fc5-8682d1256da3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9a2a1d5-3d9c-43f9-936b-b1f59fd8a9fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdc44139-807b-41c9-b318-f035b0bcebf7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdc44139-807b-41c9-b318-f035b0bcebf7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/fb00b64c-2641-469a-afff-231badf50dd7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdc44139-807b-41c9-b318-f035b0bcebf7>.
+    
+<http://data.lblod.info/id/remote-data-objects/65d711b8-c321-4490-8cd8-85f9bea7caff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65d711b8-c321-4490-8cd8-85f9bea7caff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/fcce784a-52c6-4c1f-ae87-f1af7fbd016e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65d711b8-c321-4490-8cd8-85f9bea7caff>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8fa362d-7f85-43f2-a50c-19ec6e556755> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8fa362d-7f85-43f2-a50c-19ec6e556755";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/cbs/fdfe5ea6-088c-4e32-a72b-d8add25225e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8fa362d-7f85-43f2-a50c-19ec6e556755>.
+    
+<http://data.lblod.info/id/remote-data-objects/125a95e3-f895-4843-a115-de249cbc20ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "125a95e3-f895-4843-a115-de249cbc20ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/1ae72b92-183e-424c-89c7-d805f1122cc7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/125a95e3-f895-4843-a115-de249cbc20ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1c5c196-da2a-4f16-b598-185326d14081> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1c5c196-da2a-4f16-b598-185326d14081";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/1ae72b92-183e-424c-89c7-d805f1122cc7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1c5c196-da2a-4f16-b598-185326d14081>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a3cfc59-f829-42c4-809f-f30d1f77f2c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a3cfc59-f829-42c4-809f-f30d1f77f2c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/1ae72b92-183e-424c-89c7-d805f1122cc7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a3cfc59-f829-42c4-809f-f30d1f77f2c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1127e328-01f0-445b-b38a-5089a705fe62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1127e328-01f0-445b-b38a-5089a705fe62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/29d7fed9-3bb9-41a1-9eaa-7bf73c9d975a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1127e328-01f0-445b-b38a-5089a705fe62>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3af23fc-e3ca-4f43-a68c-355242a6b0ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3af23fc-e3ca-4f43-a68c-355242a6b0ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/29d7fed9-3bb9-41a1-9eaa-7bf73c9d975a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3af23fc-e3ca-4f43-a68c-355242a6b0ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/b35abec3-7342-48e6-9476-ccef473d9936> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b35abec3-7342-48e6-9476-ccef473d9936";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/29d7fed9-3bb9-41a1-9eaa-7bf73c9d975a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b35abec3-7342-48e6-9476-ccef473d9936>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3dc96e6-1702-4c3c-bee7-738b7c06781f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3dc96e6-1702-4c3c-bee7-738b7c06781f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/4d39624c-8459-4d1a-bbf7-7cf1b428915e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3dc96e6-1702-4c3c-bee7-738b7c06781f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dc50d2e-73c6-4186-bdfe-767adba8b860> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dc50d2e-73c6-4186-bdfe-767adba8b860";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/4d39624c-8459-4d1a-bbf7-7cf1b428915e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dc50d2e-73c6-4186-bdfe-767adba8b860>.
+    
+<http://data.lblod.info/id/remote-data-objects/1472e1f1-c06e-4385-95ef-5b4a0728c9ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1472e1f1-c06e-4385-95ef-5b4a0728c9ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/4d39624c-8459-4d1a-bbf7-7cf1b428915e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1472e1f1-c06e-4385-95ef-5b4a0728c9ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b99fcda-0beb-4090-86a3-13485f462948> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b99fcda-0beb-4090-86a3-13485f462948";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/53532da3-f9af-4c58-8ace-35b84ec60984/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b99fcda-0beb-4090-86a3-13485f462948>.
+    
+<http://data.lblod.info/id/remote-data-objects/922fca2c-80e1-4d11-9843-dfa595020f70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "922fca2c-80e1-4d11-9843-dfa595020f70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/53532da3-f9af-4c58-8ace-35b84ec60984/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/922fca2c-80e1-4d11-9843-dfa595020f70>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf5a3be5-0dad-47b2-83ec-37a554cd9839> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf5a3be5-0dad-47b2-83ec-37a554cd9839";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/53532da3-f9af-4c58-8ace-35b84ec60984/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf5a3be5-0dad-47b2-83ec-37a554cd9839>.
+    
+<http://data.lblod.info/id/remote-data-objects/671c0abd-69f0-4369-81a5-705c88aed9bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "671c0abd-69f0-4369-81a5-705c88aed9bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/56214609-ba38-46af-9dfc-0db7eea93662/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/671c0abd-69f0-4369-81a5-705c88aed9bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ed70b39-fe00-4b6a-9243-01123261ef76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ed70b39-fe00-4b6a-9243-01123261ef76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/56214609-ba38-46af-9dfc-0db7eea93662/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ed70b39-fe00-4b6a-9243-01123261ef76>.
+    
+<http://data.lblod.info/id/remote-data-objects/789ceee4-4b0f-4756-8b48-6018d1731ac5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "789ceee4-4b0f-4756-8b48-6018d1731ac5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/56214609-ba38-46af-9dfc-0db7eea93662/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/789ceee4-4b0f-4756-8b48-6018d1731ac5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ac5bf64-0846-43e1-a738-03e38c8d2c40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ac5bf64-0846-43e1-a738-03e38c8d2c40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/5f03e587-4e54-4e6e-8b2a-1bdb358ef70a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ac5bf64-0846-43e1-a738-03e38c8d2c40>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf7bfb82-69d9-4b5d-9fab-968bc32011da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf7bfb82-69d9-4b5d-9fab-968bc32011da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/5f03e587-4e54-4e6e-8b2a-1bdb358ef70a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf7bfb82-69d9-4b5d-9fab-968bc32011da>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb84e870-a1f7-4724-9a6a-792c33571e88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb84e870-a1f7-4724-9a6a-792c33571e88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/5f03e587-4e54-4e6e-8b2a-1bdb358ef70a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb84e870-a1f7-4724-9a6a-792c33571e88>.
+    
+<http://data.lblod.info/id/remote-data-objects/54af52a9-5de8-41ff-8c76-ebfaabb8bc58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54af52a9-5de8-41ff-8c76-ebfaabb8bc58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/62991a24-4aaf-453d-b2fd-3bf11ce659f1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54af52a9-5de8-41ff-8c76-ebfaabb8bc58>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1304db9-11da-4c0c-8206-fe1a716deee6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1304db9-11da-4c0c-8206-fe1a716deee6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/62991a24-4aaf-453d-b2fd-3bf11ce659f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1304db9-11da-4c0c-8206-fe1a716deee6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c821764-295e-4079-b0b7-2e71f701df5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c821764-295e-4079-b0b7-2e71f701df5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/62991a24-4aaf-453d-b2fd-3bf11ce659f1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c821764-295e-4079-b0b7-2e71f701df5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/07a0eb33-5e91-49f6-9078-f4f91947ae77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07a0eb33-5e91-49f6-9078-f4f91947ae77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/7c52a54c-d214-4055-b15d-fb4ed47788da/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07a0eb33-5e91-49f6-9078-f4f91947ae77>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9826de3-d542-4d73-bfff-00890fcaca48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9826de3-d542-4d73-bfff-00890fcaca48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/7c52a54c-d214-4055-b15d-fb4ed47788da/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9826de3-d542-4d73-bfff-00890fcaca48>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ee9a8d1-f121-497a-b087-81f97028f116> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ee9a8d1-f121-497a-b087-81f97028f116";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/7c52a54c-d214-4055-b15d-fb4ed47788da/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ee9a8d1-f121-497a-b087-81f97028f116>.
+    
+<http://data.lblod.info/id/remote-data-objects/60a754b2-da0a-42d6-a58f-6111cea5db08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60a754b2-da0a-42d6-a58f-6111cea5db08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/81ffb86e-722c-4bcd-9c8d-4e6e578f8f4c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60a754b2-da0a-42d6-a58f-6111cea5db08>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc8a0edf-a3da-4fad-97a6-9cf96013b059> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc8a0edf-a3da-4fad-97a6-9cf96013b059";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/81ffb86e-722c-4bcd-9c8d-4e6e578f8f4c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc8a0edf-a3da-4fad-97a6-9cf96013b059>.
+    
+<http://data.lblod.info/id/remote-data-objects/1750299d-93b8-4f7c-bf85-d93cb8825a78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1750299d-93b8-4f7c-bf85-d93cb8825a78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/81ffb86e-722c-4bcd-9c8d-4e6e578f8f4c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1750299d-93b8-4f7c-bf85-d93cb8825a78>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d69f599-141d-4279-8e7f-5987f19ea768> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d69f599-141d-4279-8e7f-5987f19ea768";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/8ca4e9c6-c676-42a1-98bc-3f3aeb4fb071/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d69f599-141d-4279-8e7f-5987f19ea768>.
+    
+<http://data.lblod.info/id/remote-data-objects/71b3d89d-2e10-44d2-9f12-da7a95822807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71b3d89d-2e10-44d2-9f12-da7a95822807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/8ca4e9c6-c676-42a1-98bc-3f3aeb4fb071/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71b3d89d-2e10-44d2-9f12-da7a95822807>.
+    
+<http://data.lblod.info/id/remote-data-objects/96a3b28d-ed16-4b5b-8f11-0a3a44cd0ccd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96a3b28d-ed16-4b5b-8f11-0a3a44cd0ccd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/8ca4e9c6-c676-42a1-98bc-3f3aeb4fb071/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96a3b28d-ed16-4b5b-8f11-0a3a44cd0ccd>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcfb8d9f-139c-437a-9efd-d5ad7d1e0cdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcfb8d9f-139c-437a-9efd-d5ad7d1e0cdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/99304b46-8275-4ad6-aec4-eb07e0b50b60/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcfb8d9f-139c-437a-9efd-d5ad7d1e0cdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/39330106-c4af-4921-982e-d602ca4e8cf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39330106-c4af-4921-982e-d602ca4e8cf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/99304b46-8275-4ad6-aec4-eb07e0b50b60/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:10:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14bb187d-e8e5-42da-a1d7-9b8aedb9b274> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39330106-c4af-4921-982e-d602ca4e8cf9>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201100-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201100-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201100-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201100-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/cf229ab4-2ade-4b46-8e3e-029971761168> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cf229ab4-2ade-4b46-8e3e-029971761168";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "aab9505e-07b7-4dca-ab2e-89eeb175ccec";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f012f393-ce1c-44b4-ac22-2ccd1979c0f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f012f393-ce1c-44b4-ac22-2ccd1979c0f1";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec>.
+
+  <http://redpencil.data.gift/id/task/450eca27-7e3c-4627-afce-09e0570c69bb> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "450eca27-7e3c-4627-afce-09e0570c69bb";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/cf229ab4-2ade-4b46-8e3e-029971761168>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f012f393-ce1c-44b4-ac22-2ccd1979c0f1>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/cbe674dd-a767-4eec-9ccb-1786c1ba95d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbe674dd-a767-4eec-9ccb-1786c1ba95d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/99304b46-8275-4ad6-aec4-eb07e0b50b60/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbe674dd-a767-4eec-9ccb-1786c1ba95d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b4628a4-ef32-4553-b363-6340c09aba7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b4628a4-ef32-4553-b363-6340c09aba7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/999d209d-ade8-4789-aea2-acb862279846/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b4628a4-ef32-4553-b363-6340c09aba7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f291881-8bc4-4325-890b-825a67206c96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f291881-8bc4-4325-890b-825a67206c96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/999d209d-ade8-4789-aea2-acb862279846/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f291881-8bc4-4325-890b-825a67206c96>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b82ac3a-7d02-4b75-adb7-afb170183874> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b82ac3a-7d02-4b75-adb7-afb170183874";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/999d209d-ade8-4789-aea2-acb862279846/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b82ac3a-7d02-4b75-adb7-afb170183874>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b2dfb26-b881-4fd7-901e-26cfd690acfd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b2dfb26-b881-4fd7-901e-26cfd690acfd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/badc6cdb-c6d2-479f-83d6-fa2f82b54236/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b2dfb26-b881-4fd7-901e-26cfd690acfd>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f3cb66b-16a7-4c27-afd5-65074b161277> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f3cb66b-16a7-4c27-afd5-65074b161277";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/badc6cdb-c6d2-479f-83d6-fa2f82b54236/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f3cb66b-16a7-4c27-afd5-65074b161277>.
+    
+<http://data.lblod.info/id/remote-data-objects/dab8f46c-8a0a-4e42-aa39-ec865c83c71c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dab8f46c-8a0a-4e42-aa39-ec865c83c71c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/badc6cdb-c6d2-479f-83d6-fa2f82b54236/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dab8f46c-8a0a-4e42-aa39-ec865c83c71c>.
+    
+<http://data.lblod.info/id/remote-data-objects/80f116ec-cad9-4096-9d8a-750a6db2bfa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80f116ec-cad9-4096-9d8a-750a6db2bfa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/cd4fa87b-3b88-4d3d-9f60-c85db4b81698/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80f116ec-cad9-4096-9d8a-750a6db2bfa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a68daa64-0cda-4c64-86c7-fc9edd8a0f58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a68daa64-0cda-4c64-86c7-fc9edd8a0f58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/cd4fa87b-3b88-4d3d-9f60-c85db4b81698/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a68daa64-0cda-4c64-86c7-fc9edd8a0f58>.
+    
+<http://data.lblod.info/id/remote-data-objects/36f9c611-60df-473e-97c9-9508476a88c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36f9c611-60df-473e-97c9-9508476a88c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/cd4fa87b-3b88-4d3d-9f60-c85db4b81698/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36f9c611-60df-473e-97c9-9508476a88c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/17a173f7-1b1b-4e8f-ad05-58d3a2aa9b0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17a173f7-1b1b-4e8f-ad05-58d3a2aa9b0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/edca4251-60ff-4847-85c6-7344d8b55c64/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17a173f7-1b1b-4e8f-ad05-58d3a2aa9b0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3daf204c-b3ac-47f9-a079-c3ee2cda1c31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3daf204c-b3ac-47f9-a079-c3ee2cda1c31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/gr/edca4251-60ff-4847-85c6-7344d8b55c64/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3daf204c-b3ac-47f9-a079-c3ee2cda1c31>.
+    
+<http://data.lblod.info/id/remote-data-objects/95d7306d-b111-4d0a-bbf6-89bdad036e09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95d7306d-b111-4d0a-bbf6-89bdad036e09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/0e50fc82-a1bb-4f18-8c50-5a650c68d506/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95d7306d-b111-4d0a-bbf6-89bdad036e09>.
+    
+<http://data.lblod.info/id/remote-data-objects/9173e1d3-124a-4299-9808-dc28b4d46a3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9173e1d3-124a-4299-9808-dc28b4d46a3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/0e50fc82-a1bb-4f18-8c50-5a650c68d506/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9173e1d3-124a-4299-9808-dc28b4d46a3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f9bbcf4-a2cd-4090-9b44-316306f1485b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f9bbcf4-a2cd-4090-9b44-316306f1485b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/0e50fc82-a1bb-4f18-8c50-5a650c68d506/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f9bbcf4-a2cd-4090-9b44-316306f1485b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffc680da-9005-4e9e-9a85-ccc1c809b83f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffc680da-9005-4e9e-9a85-ccc1c809b83f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/0ff8a8dc-fc1b-4fa3-920b-abb504300ac8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffc680da-9005-4e9e-9a85-ccc1c809b83f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cbd591f-1517-4f42-b2a8-9de4dea128e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cbd591f-1517-4f42-b2a8-9de4dea128e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/0ff8a8dc-fc1b-4fa3-920b-abb504300ac8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cbd591f-1517-4f42-b2a8-9de4dea128e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea4d327e-c673-498c-ac3d-bc41f4ecfb09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea4d327e-c673-498c-ac3d-bc41f4ecfb09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/0ff8a8dc-fc1b-4fa3-920b-abb504300ac8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea4d327e-c673-498c-ac3d-bc41f4ecfb09>.
+    
+<http://data.lblod.info/id/remote-data-objects/76dd0735-fbb6-4db7-9e37-3a6ee6303fa2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76dd0735-fbb6-4db7-9e37-3a6ee6303fa2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/368e8e00-468a-4feb-a8a0-743d1946578f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76dd0735-fbb6-4db7-9e37-3a6ee6303fa2>.
+    
+<http://data.lblod.info/id/remote-data-objects/7eaa8386-0ae5-4ee5-a7b4-cb222da78cd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7eaa8386-0ae5-4ee5-a7b4-cb222da78cd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/368e8e00-468a-4feb-a8a0-743d1946578f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7eaa8386-0ae5-4ee5-a7b4-cb222da78cd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf8d57d1-dca3-415a-a15f-88bda528206e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf8d57d1-dca3-415a-a15f-88bda528206e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/368e8e00-468a-4feb-a8a0-743d1946578f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf8d57d1-dca3-415a-a15f-88bda528206e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d446753-7159-434c-bc13-770e5bf17c19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d446753-7159-434c-bc13-770e5bf17c19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/40546718-a95c-4f28-bb0c-994462190012/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d446753-7159-434c-bc13-770e5bf17c19>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fadb29d-aaf5-4d86-bd29-c42ef7645e94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fadb29d-aaf5-4d86-bd29-c42ef7645e94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/40546718-a95c-4f28-bb0c-994462190012/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fadb29d-aaf5-4d86-bd29-c42ef7645e94>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7c963d4-0879-4707-a7fd-4d36819be572> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7c963d4-0879-4707-a7fd-4d36819be572";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/40546718-a95c-4f28-bb0c-994462190012/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7c963d4-0879-4707-a7fd-4d36819be572>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf9bc2ee-4db9-4eed-a416-a0e4b022745e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf9bc2ee-4db9-4eed-a416-a0e4b022745e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/780bffc1-90aa-4771-9ffe-b004133492f2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf9bc2ee-4db9-4eed-a416-a0e4b022745e>.
+    
+<http://data.lblod.info/id/remote-data-objects/55b38ebc-e148-48f9-a6ad-6d713d943a7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55b38ebc-e148-48f9-a6ad-6d713d943a7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/780bffc1-90aa-4771-9ffe-b004133492f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55b38ebc-e148-48f9-a6ad-6d713d943a7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cfb8691-7fa1-4fb9-882b-7f97c0e98ca6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cfb8691-7fa1-4fb9-882b-7f97c0e98ca6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/780bffc1-90aa-4771-9ffe-b004133492f2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cfb8691-7fa1-4fb9-882b-7f97c0e98ca6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d21e70af-abfc-401e-8504-77fff92bc448> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d21e70af-abfc-401e-8504-77fff92bc448";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/7af9a052-6dc2-4caf-bcc8-ed33d6ede372/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d21e70af-abfc-401e-8504-77fff92bc448>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8b72981-e21e-4c0e-adf7-aeb4761fa328> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8b72981-e21e-4c0e-adf7-aeb4761fa328";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/7af9a052-6dc2-4caf-bcc8-ed33d6ede372/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8b72981-e21e-4c0e-adf7-aeb4761fa328>.
+    
+<http://data.lblod.info/id/remote-data-objects/48759c97-ad98-4a60-bfb7-ec4db3df58c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48759c97-ad98-4a60-bfb7-ec4db3df58c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/7af9a052-6dc2-4caf-bcc8-ed33d6ede372/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48759c97-ad98-4a60-bfb7-ec4db3df58c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/345fdd8d-b273-4c8d-97ef-a88ba6dec87c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "345fdd8d-b273-4c8d-97ef-a88ba6dec87c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/7df62329-cfaf-4201-8407-089f458d4b6b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/345fdd8d-b273-4c8d-97ef-a88ba6dec87c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ee03974-7f8d-4009-bcfd-b89ad603acdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ee03974-7f8d-4009-bcfd-b89ad603acdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/7df62329-cfaf-4201-8407-089f458d4b6b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ee03974-7f8d-4009-bcfd-b89ad603acdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ffb9070-59c7-4177-a148-e6c3ce221b73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ffb9070-59c7-4177-a148-e6c3ce221b73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/7df62329-cfaf-4201-8407-089f458d4b6b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ffb9070-59c7-4177-a148-e6c3ce221b73>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2a777c5-7f44-44ca-8b53-eb71ab6d9a67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2a777c5-7f44-44ca-8b53-eb71ab6d9a67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/82597b01-b9ea-4273-80c1-f7ae7e702e8a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2a777c5-7f44-44ca-8b53-eb71ab6d9a67>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b733645-d225-46c3-b144-635d12eb11a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b733645-d225-46c3-b144-635d12eb11a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/82597b01-b9ea-4273-80c1-f7ae7e702e8a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b733645-d225-46c3-b144-635d12eb11a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/882f1446-e19d-4293-8f1a-822627db122b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "882f1446-e19d-4293-8f1a-822627db122b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/82597b01-b9ea-4273-80c1-f7ae7e702e8a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/882f1446-e19d-4293-8f1a-822627db122b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bfeb0ad-8a3c-4ac6-b4b9-5552e837a2bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bfeb0ad-8a3c-4ac6-b4b9-5552e837a2bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/95403060-0463-41a0-b1a6-104c48bac448/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bfeb0ad-8a3c-4ac6-b4b9-5552e837a2bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d5a0bfd-7cee-48c7-9f41-00b8a9879f88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d5a0bfd-7cee-48c7-9f41-00b8a9879f88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/95403060-0463-41a0-b1a6-104c48bac448/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d5a0bfd-7cee-48c7-9f41-00b8a9879f88>.
+    
+<http://data.lblod.info/id/remote-data-objects/55a29ffc-b519-4c1c-8614-248e8230b61d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55a29ffc-b519-4c1c-8614-248e8230b61d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/95403060-0463-41a0-b1a6-104c48bac448/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55a29ffc-b519-4c1c-8614-248e8230b61d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f67ab84-f279-48bc-9d9a-0b86bcbc5a28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f67ab84-f279-48bc-9d9a-0b86bcbc5a28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/95b5c26f-4240-4763-80a9-2f2b59353aec/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f67ab84-f279-48bc-9d9a-0b86bcbc5a28>.
+    
+<http://data.lblod.info/id/remote-data-objects/7686a0a3-9ef8-4d82-8cce-e676ef9f6f2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7686a0a3-9ef8-4d82-8cce-e676ef9f6f2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/95b5c26f-4240-4763-80a9-2f2b59353aec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7686a0a3-9ef8-4d82-8cce-e676ef9f6f2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1bb4e6d-3d44-4b5f-a3fd-6217a82e7aab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1bb4e6d-3d44-4b5f-a3fd-6217a82e7aab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/95b5c26f-4240-4763-80a9-2f2b59353aec/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1bb4e6d-3d44-4b5f-a3fd-6217a82e7aab>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d474ac1-60c7-4c3b-8342-153774767847> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d474ac1-60c7-4c3b-8342-153774767847";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/9fa53718-3291-4b69-964f-c6450f44bb97/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d474ac1-60c7-4c3b-8342-153774767847>.
+    
+<http://data.lblod.info/id/remote-data-objects/67a761d2-bc4a-481a-bfd6-9be6a63200d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67a761d2-bc4a-481a-bfd6-9be6a63200d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/9fa53718-3291-4b69-964f-c6450f44bb97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67a761d2-bc4a-481a-bfd6-9be6a63200d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/613441fa-9071-48d8-b3c2-594824b3225b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "613441fa-9071-48d8-b3c2-594824b3225b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/9fa53718-3291-4b69-964f-c6450f44bb97/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/613441fa-9071-48d8-b3c2-594824b3225b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5b99168-7c0b-452a-97dd-cfefbef6242e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5b99168-7c0b-452a-97dd-cfefbef6242e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/a330ed81-2507-479e-a06e-890f64826793/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5b99168-7c0b-452a-97dd-cfefbef6242e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2236d975-04c6-41d8-a414-9f18cb7f61dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2236d975-04c6-41d8-a414-9f18cb7f61dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/a330ed81-2507-479e-a06e-890f64826793/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2236d975-04c6-41d8-a414-9f18cb7f61dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/38bc3d47-10b3-4c09-ac52-62856b4702d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38bc3d47-10b3-4c09-ac52-62856b4702d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/a330ed81-2507-479e-a06e-890f64826793/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38bc3d47-10b3-4c09-ac52-62856b4702d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/6279b512-7a7a-49bd-ba16-a6cbb17f6daa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6279b512-7a7a-49bd-ba16-a6cbb17f6daa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/a9ad7309-058d-4aaf-98de-ae95b0db91ac/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6279b512-7a7a-49bd-ba16-a6cbb17f6daa>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b98e4be-fda8-4968-a9aa-7b8056058ff7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b98e4be-fda8-4968-a9aa-7b8056058ff7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/a9ad7309-058d-4aaf-98de-ae95b0db91ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aab9505e-07b7-4dca-ab2e-89eeb175ccec> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b98e4be-fda8-4968-a9aa-7b8056058ff7>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201101-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201101-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201101-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201101-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b8df0bc1-e946-4df2-9a9c-1d5dd4f6c2ba> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b8df0bc1-e946-4df2-9a9c-1d5dd4f6c2ba";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4efc555d-c7da-452d-b148-e3b497a87fdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4efc555d-c7da-452d-b148-e3b497a87fdd";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70>.
+
+  <http://redpencil.data.gift/id/task/c5716e3e-73c9-4ca9-91ca-cb343e56ebc1> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c5716e3e-73c9-4ca9-91ca-cb343e56ebc1";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b8df0bc1-e946-4df2-9a9c-1d5dd4f6c2ba>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4efc555d-c7da-452d-b148-e3b497a87fdd>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e029fc05-0640-4372-91e3-84395e298d5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e029fc05-0640-4372-91e3-84395e298d5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/a9ad7309-058d-4aaf-98de-ae95b0db91ac/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e029fc05-0640-4372-91e3-84395e298d5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c7d8f55-6000-4ddc-97bc-69acc8f0f10b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c7d8f55-6000-4ddc-97bc-69acc8f0f10b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/b43f087b-3253-4f69-a89f-436dbe8a4a5a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c7d8f55-6000-4ddc-97bc-69acc8f0f10b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e70029e2-b55b-4f65-ac79-5c381258cd80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e70029e2-b55b-4f65-ac79-5c381258cd80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/b43f087b-3253-4f69-a89f-436dbe8a4a5a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e70029e2-b55b-4f65-ac79-5c381258cd80>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1df8991-8b82-41ee-a573-14e7cfefeccd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1df8991-8b82-41ee-a573-14e7cfefeccd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/eb115eab-8d8f-47e5-8179-0def39e6e90e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1df8991-8b82-41ee-a573-14e7cfefeccd>.
+    
+<http://data.lblod.info/id/remote-data-objects/71f9cc20-df66-4d90-918e-0e68b4561fd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71f9cc20-df66-4d90-918e-0e68b4561fd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/eb115eab-8d8f-47e5-8179-0def39e6e90e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71f9cc20-df66-4d90-918e-0e68b4561fd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c0c5aa2-f122-454d-b36d-e817eadeaf00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c0c5aa2-f122-454d-b36d-e817eadeaf00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/f3ce60cd-4540-4c14-9759-8821d4e2c671/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c0c5aa2-f122-454d-b36d-e817eadeaf00>.
+    
+<http://data.lblod.info/id/remote-data-objects/950ecdda-1d74-4f36-b3bf-540d1baeab0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "950ecdda-1d74-4f36-b3bf-540d1baeab0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/f3ce60cd-4540-4c14-9759-8821d4e2c671/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/950ecdda-1d74-4f36-b3bf-540d1baeab0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d14a4800-be40-497f-93a6-7896b21c0a92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d14a4800-be40-497f-93a6-7896b21c0a92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/rmw/f3ce60cd-4540-4c14-9759-8821d4e2c671/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d14a4800-be40-497f-93a6-7896b21c0a92>.
+    
+<http://data.lblod.info/id/remote-data-objects/105693a3-2bd3-46d9-8d57-428e95957f1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "105693a3-2bd3-46d9-8d57-428e95957f1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/004d11c2-9ccf-44bb-8299-a60cb3c81f38/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/105693a3-2bd3-46d9-8d57-428e95957f1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2bfbfa1-db40-4cc2-83ab-cb6f9bfd7f19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2bfbfa1-db40-4cc2-83ab-cb6f9bfd7f19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/0108adf7-2ca9-4d2a-8ef8-c1674a455ef8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2bfbfa1-db40-4cc2-83ab-cb6f9bfd7f19>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5c877f5-8d65-41de-86c3-08c0ddf6269f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5c877f5-8d65-41de-86c3-08c0ddf6269f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/025c74c3-4e8b-49cc-bd5c-6b240d74535a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5c877f5-8d65-41de-86c3-08c0ddf6269f>.
+    
+<http://data.lblod.info/id/remote-data-objects/18be799c-7163-4306-949f-ab734bb1f3f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18be799c-7163-4306-949f-ab734bb1f3f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/05ebfdd2-2211-47f1-ba94-94483f5a5dfe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18be799c-7163-4306-949f-ab734bb1f3f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c9f7537-1b26-47af-b46f-741ce2247da8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c9f7537-1b26-47af-b46f-741ce2247da8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/0b2e4384-fb3f-4391-82d8-a1f5b817e495/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c9f7537-1b26-47af-b46f-741ce2247da8>.
+    
+<http://data.lblod.info/id/remote-data-objects/61aa68ef-a75a-4f90-af11-11249f390364> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61aa68ef-a75a-4f90-af11-11249f390364";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/0becf759-38ab-487a-97a7-2aeaed295d62/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61aa68ef-a75a-4f90-af11-11249f390364>.
+    
+<http://data.lblod.info/id/remote-data-objects/f346f017-4e4f-4221-bdb5-acf9589501e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f346f017-4e4f-4221-bdb5-acf9589501e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/0ec05fbe-962d-4a84-bf67-2e6aec0082bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f346f017-4e4f-4221-bdb5-acf9589501e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/11fa2b38-7fdb-44bf-bb48-563410961f37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11fa2b38-7fdb-44bf-bb48-563410961f37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/129abf0d-c712-4bc3-81bd-3f5415753906/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11fa2b38-7fdb-44bf-bb48-563410961f37>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9de4b9a-740c-4218-9dee-cb16ec1c5161> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9de4b9a-740c-4218-9dee-cb16ec1c5161";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/16d7aa12-5766-46a4-bcf5-daff712837ce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9de4b9a-740c-4218-9dee-cb16ec1c5161>.
+    
+<http://data.lblod.info/id/remote-data-objects/af9fd2f0-de26-42ae-9492-8dfc90b977c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af9fd2f0-de26-42ae-9492-8dfc90b977c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/2250ef58-e79b-4593-aae8-feaf26fbd8d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af9fd2f0-de26-42ae-9492-8dfc90b977c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e30dac5-feaf-45d3-8b88-ab15068449f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e30dac5-feaf-45d3-8b88-ab15068449f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/22701ffd-0c37-44fb-a343-f3295d08f1de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e30dac5-feaf-45d3-8b88-ab15068449f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe928da5-0bdd-4cdb-94d5-7e04f8fb1d71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe928da5-0bdd-4cdb-94d5-7e04f8fb1d71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/2380b861-75fd-43db-89c6-2eca8727a684/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe928da5-0bdd-4cdb-94d5-7e04f8fb1d71>.
+    
+<http://data.lblod.info/id/remote-data-objects/931a2925-3602-4917-a7b9-57b06cc68600> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "931a2925-3602-4917-a7b9-57b06cc68600";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/2515d1ab-68d5-4cd1-811f-7c4d906d27a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/931a2925-3602-4917-a7b9-57b06cc68600>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc467aca-7fad-489d-af59-a32c16aae818> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc467aca-7fad-489d-af59-a32c16aae818";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/255692cf-9320-460a-a468-f5901ffa08b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc467aca-7fad-489d-af59-a32c16aae818>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f50242c-485d-45d6-a191-5342754470c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f50242c-485d-45d6-a191-5342754470c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/31a6a537-b3f6-43b3-820a-d03ae84dfb8d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f50242c-485d-45d6-a191-5342754470c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a24656a-349b-45c8-aa25-7db92a32b356> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a24656a-349b-45c8-aa25-7db92a32b356";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/31e50633-b9d7-4241-b782-0c423e538a3e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a24656a-349b-45c8-aa25-7db92a32b356>.
+    
+<http://data.lblod.info/id/remote-data-objects/a841c2de-a769-47ac-803c-94d4fc0bdc77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a841c2de-a769-47ac-803c-94d4fc0bdc77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/334ddb54-4971-4c2e-9b33-3b5667f26276/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a841c2de-a769-47ac-803c-94d4fc0bdc77>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6affa17-bbad-4ca7-bf46-fcc0f5ccaa61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6affa17-bbad-4ca7-bf46-fcc0f5ccaa61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/34b25224-572c-4ebf-a96b-2c594d3d3817/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6affa17-bbad-4ca7-bf46-fcc0f5ccaa61>.
+    
+<http://data.lblod.info/id/remote-data-objects/71093b51-0b4c-4063-a43e-488f2043b88f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71093b51-0b4c-4063-a43e-488f2043b88f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/3c5a1704-0a29-4348-b248-96f882113784/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71093b51-0b4c-4063-a43e-488f2043b88f>.
+    
+<http://data.lblod.info/id/remote-data-objects/13b9cdb0-8082-48e0-bf72-c87acb5c2e9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13b9cdb0-8082-48e0-bf72-c87acb5c2e9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/435d16e7-5554-4af3-96ec-71f52d3b9a1f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13b9cdb0-8082-48e0-bf72-c87acb5c2e9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc9b15c3-ef96-425f-bf06-3107ae6040ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc9b15c3-ef96-425f-bf06-3107ae6040ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/467500c7-9fef-49dd-92d1-863f07ca6ef7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc9b15c3-ef96-425f-bf06-3107ae6040ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c7ba313-db63-4621-a163-393a03cbd660> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c7ba313-db63-4621-a163-393a03cbd660";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/473528e8-ddac-429f-8d13-18172111478f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c7ba313-db63-4621-a163-393a03cbd660>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd778cfa-ab10-45e7-9327-75441c0e760b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd778cfa-ab10-45e7-9327-75441c0e760b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/495e9b6d-4678-4cc1-9e20-637e2eb1a120/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd778cfa-ab10-45e7-9327-75441c0e760b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b61c13a-35f1-4ff0-bcc0-773d4286d283> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b61c13a-35f1-4ff0-bcc0-773d4286d283";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/4f19773c-b60f-4e2a-833b-8f6550136a85/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b61c13a-35f1-4ff0-bcc0-773d4286d283>.
+    
+<http://data.lblod.info/id/remote-data-objects/66436b30-3a63-47c0-acd0-498970f515fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66436b30-3a63-47c0-acd0-498970f515fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/50771b6d-b984-43e9-af5d-68de257a7f12/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66436b30-3a63-47c0-acd0-498970f515fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/7472e333-010e-4cfd-b31c-1093a3cd317a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7472e333-010e-4cfd-b31c-1093a3cd317a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/567c00c9-d918-4291-afe8-7e07a93b3764/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7472e333-010e-4cfd-b31c-1093a3cd317a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6412d718-d9a5-412f-a894-126eaa561a88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6412d718-d9a5-412f-a894-126eaa561a88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/5c3d34ec-aa1f-43bb-9027-e44f298c40fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6412d718-d9a5-412f-a894-126eaa561a88>.
+    
+<http://data.lblod.info/id/remote-data-objects/da712f7e-8b43-4b46-a17b-4b8aeb70fd64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da712f7e-8b43-4b46-a17b-4b8aeb70fd64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/6207e656-9f8b-405a-b9ac-f8a8e72eb03d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da712f7e-8b43-4b46-a17b-4b8aeb70fd64>.
+    
+<http://data.lblod.info/id/remote-data-objects/1856790c-107b-4f8e-a3e6-aa99c9a16885> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1856790c-107b-4f8e-a3e6-aa99c9a16885";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/641eaf86-13fc-4822-8094-5062f06cae18/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1856790c-107b-4f8e-a3e6-aa99c9a16885>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4184687-69f6-4daa-9a1b-133a3462ae1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4184687-69f6-4daa-9a1b-133a3462ae1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/6884959d-d9d0-4604-b25c-669852976976/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4184687-69f6-4daa-9a1b-133a3462ae1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/afd575b7-0e1a-4b88-aee8-40972594f03a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afd575b7-0e1a-4b88-aee8-40972594f03a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/68d21e3b-0c9f-40e4-854f-b8a292eac422/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afd575b7-0e1a-4b88-aee8-40972594f03a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec8ec184-d93c-46bd-a32a-592d6cec3ffe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec8ec184-d93c-46bd-a32a-592d6cec3ffe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/6af7511a-662e-4c41-97e9-774333fa8fcd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec8ec184-d93c-46bd-a32a-592d6cec3ffe>.
+    
+<http://data.lblod.info/id/remote-data-objects/0578fe23-805a-4e01-94bb-69ee4609b3f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0578fe23-805a-4e01-94bb-69ee4609b3f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/6bb6bfe4-a907-4bdf-9296-7fd0f3625770/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0578fe23-805a-4e01-94bb-69ee4609b3f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c85c19ad-1e18-4d95-8154-43d72f275780> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c85c19ad-1e18-4d95-8154-43d72f275780";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/72000881-2754-40ad-aff0-4cfdd591d4b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c85c19ad-1e18-4d95-8154-43d72f275780>.
+    
+<http://data.lblod.info/id/remote-data-objects/93beefea-b3c8-4b3d-ae81-b2ef303a9fa1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93beefea-b3c8-4b3d-ae81-b2ef303a9fa1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/753622c8-b470-453c-b23b-e6b6843eb56d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93beefea-b3c8-4b3d-ae81-b2ef303a9fa1>.
+    
+<http://data.lblod.info/id/remote-data-objects/cce9f869-5f8a-439c-b243-9de05a19654c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cce9f869-5f8a-439c-b243-9de05a19654c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/7906a51a-9808-488e-9904-796ff2ab3b91/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cce9f869-5f8a-439c-b243-9de05a19654c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d8c8ec2-4836-4ccd-a06a-b8692b7daec5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d8c8ec2-4836-4ccd-a06a-b8692b7daec5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/8a725700-62e4-402e-97c3-290e90c32b59/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d8c8ec2-4836-4ccd-a06a-b8692b7daec5>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0e79d67-1c62-46c3-83d7-5052e8416a63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0e79d67-1c62-46c3-83d7-5052e8416a63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/95a35fd3-aefd-458e-8973-8270bffae138/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0e79d67-1c62-46c3-83d7-5052e8416a63>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9847696-0932-4f52-84e4-12466af8533a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9847696-0932-4f52-84e4-12466af8533a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/97c2e7ac-8b44-4a9b-81b7-b074579a983b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9847696-0932-4f52-84e4-12466af8533a>.
+    
+<http://data.lblod.info/id/remote-data-objects/10c54951-5414-4a65-879e-88be4d1bfc73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10c54951-5414-4a65-879e-88be4d1bfc73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/991a1c04-97ae-4602-b06b-dc0b097dba4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10c54951-5414-4a65-879e-88be4d1bfc73>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fcd74dd-aae0-4a19-b413-efc4e6459652> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fcd74dd-aae0-4a19-b413-efc4e6459652";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/9f166c89-fa43-4d6f-9270-e8f58b339f2a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fcd74dd-aae0-4a19-b413-efc4e6459652>.
+    
+<http://data.lblod.info/id/remote-data-objects/fad5ee15-d112-4f1a-a180-90e12b44dda3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fad5ee15-d112-4f1a-a180-90e12b44dda3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/a1433b43-ee03-4e88-9081-16cdf5ff9707/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ea5c3bf-b8e1-4e7f-b4b6-2861c70a2a70> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fad5ee15-d112-4f1a-a180-90e12b44dda3>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201103-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201103-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201103-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201103-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/ef7fce74-da9c-4b48-8ed9-0d61a6ea94c9> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ef7fce74-da9c-4b48-8ed9-0d61a6ea94c9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a478711d-2ac6-41c3-810d-979c7dfebc16";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/1a3f859d-a456-4466-ae4f-9113c11c2f7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1a3f859d-a456-4466-ae4f-9113c11c2f7c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16>.
+
+  <http://redpencil.data.gift/id/task/cdb0349d-fe9a-4bc8-b303-b9c769234f4d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cdb0349d-fe9a-4bc8-b303-b9c769234f4d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/ef7fce74-da9c-4b48-8ed9-0d61a6ea94c9>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/1a3f859d-a456-4466-ae4f-9113c11c2f7c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c9cae11b-f855-4eb8-ac43-07810641d19a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9cae11b-f855-4eb8-ac43-07810641d19a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/a2698eb9-8167-4e0e-b232-427a4a87f947/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9cae11b-f855-4eb8-ac43-07810641d19a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c754fb7-7f45-4473-b541-a896bf165aa5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c754fb7-7f45-4473-b541-a896bf165aa5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/a525778e-94c0-48f0-9ff2-ec6f68f5e118/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c754fb7-7f45-4473-b541-a896bf165aa5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c026af5a-bd43-4160-85fb-52919f58997e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c026af5a-bd43-4160-85fb-52919f58997e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/ae159e40-079e-4fff-a27a-b6987e298967/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c026af5a-bd43-4160-85fb-52919f58997e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a348aee9-da7f-4c49-905a-e107e13d47c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a348aee9-da7f-4c49-905a-e107e13d47c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/b0911e82-5d36-4d1c-b451-e2843a7c1e9c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a348aee9-da7f-4c49-905a-e107e13d47c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e497a72-e007-4163-819b-6cd59640f9d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e497a72-e007-4163-819b-6cd59640f9d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/b6a33dd9-e462-4960-9283-2604637b5ddd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e497a72-e007-4163-819b-6cd59640f9d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c0274b1-5952-4c0c-8ff7-41f7c5277c4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c0274b1-5952-4c0c-8ff7-41f7c5277c4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/b890db58-a787-4aa5-8c96-8c70be3b76dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c0274b1-5952-4c0c-8ff7-41f7c5277c4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/249f9a98-a3e7-4bcb-a367-a78b24d9d128> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "249f9a98-a3e7-4bcb-a367-a78b24d9d128";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/bd5e54da-b0f3-48dd-9478-f55e98400f6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/249f9a98-a3e7-4bcb-a367-a78b24d9d128>.
+    
+<http://data.lblod.info/id/remote-data-objects/554a67e3-2d8e-4764-895b-dca14485fd39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "554a67e3-2d8e-4764-895b-dca14485fd39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/bd6fba20-3e30-4a6a-862a-7638ed60b005/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/554a67e3-2d8e-4764-895b-dca14485fd39>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bd65f0e-159b-4717-8ea0-2291631d93dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bd65f0e-159b-4717-8ea0-2291631d93dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/be2e7a32-c757-4dc9-acc2-48b319e55512/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bd65f0e-159b-4717-8ea0-2291631d93dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c63daf0-7357-4743-8c20-9cede073f747> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c63daf0-7357-4743-8c20-9cede073f747";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/bec4c911-0ff5-4071-bf5f-eec587e41a32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c63daf0-7357-4743-8c20-9cede073f747>.
+    
+<http://data.lblod.info/id/remote-data-objects/95866c27-4e6c-4796-89b2-e077f26e548a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95866c27-4e6c-4796-89b2-e077f26e548a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/c03a6478-6493-46e3-9129-5e400702e7d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95866c27-4e6c-4796-89b2-e077f26e548a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e5a9636-3f80-428f-8231-85b2e63c313d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e5a9636-3f80-428f-8231-85b2e63c313d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/c7223225-0934-44a7-be25-15555c2f3c10/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e5a9636-3f80-428f-8231-85b2e63c313d>.
+    
+<http://data.lblod.info/id/remote-data-objects/570a6ef1-8ea2-4585-bec0-db2f51e43399> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "570a6ef1-8ea2-4585-bec0-db2f51e43399";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/c98efc75-7659-4607-b0ad-ac8ae6dec698/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/570a6ef1-8ea2-4585-bec0-db2f51e43399>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8e2277a-61ad-4731-a9c0-9eb15df0b29a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8e2277a-61ad-4731-a9c0-9eb15df0b29a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/d5e9c194-33bb-4871-92a1-e4d8a76e8eb5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8e2277a-61ad-4731-a9c0-9eb15df0b29a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9322e57-500b-45a0-b9ce-03be3218cc5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9322e57-500b-45a0-b9ce-03be3218cc5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/dcaa72b6-7094-46ca-a90e-debeee60a624/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9322e57-500b-45a0-b9ce-03be3218cc5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/af847026-d5e6-46c6-9abb-123895aa92d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af847026-d5e6-46c6-9abb-123895aa92d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/e1207333-98ee-45f3-8cf7-62267cc495ba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af847026-d5e6-46c6-9abb-123895aa92d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c5511fb-8888-44b1-91fa-b943a6985532> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c5511fb-8888-44b1-91fa-b943a6985532";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/e192a30f-b423-470e-be65-df43a571fff0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c5511fb-8888-44b1-91fa-b943a6985532>.
+    
+<http://data.lblod.info/id/remote-data-objects/06e7d98c-ec34-408a-a364-0815c194214f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06e7d98c-ec34-408a-a364-0815c194214f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/e6322f1a-30e8-41c1-96c1-3f2f5fdb9575/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06e7d98c-ec34-408a-a364-0815c194214f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1eb6165-b1b0-46c4-9ed2-a867ec39eb63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1eb6165-b1b0-46c4-9ed2-a867ec39eb63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/e6acbee5-3fdc-46ff-b07a-c9af518c7245/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1eb6165-b1b0-46c4-9ed2-a867ec39eb63>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d38d300-ed12-4cf1-a48a-0adefa5453d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d38d300-ed12-4cf1-a48a-0adefa5453d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/ef79e447-5d1e-4945-8421-3f9f76dc5d73/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d38d300-ed12-4cf1-a48a-0adefa5453d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6332d073-fe39-4d90-a239-ca5898031c9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6332d073-fe39-4d90-a239-ca5898031c9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/fb1358ee-bf86-4e86-a4e2-00996423e862/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6332d073-fe39-4d90-a239-ca5898031c9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/29763f15-91a5-4583-a250-caf2fbfeedc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29763f15-91a5-4583-a250-caf2fbfeedc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/fbb8cd29-6c15-48d0-b345-5ef3ebe13b31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29763f15-91a5-4583-a250-caf2fbfeedc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4c7efbd-0646-457e-8723-715e91e65757> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4c7efbd-0646-457e-8723-715e91e65757";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://brasschaat.meetingburger.net/vabu/ff73388e-dde7-4885-b8b1-25d9640a603d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4c7efbd-0646-457e-8723-715e91e65757>.
+    
+<http://data.lblod.info/id/remote-data-objects/a540696c-cc48-440d-b637-d5b6b3fcfcda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a540696c-cc48-440d-b637-d5b6b3fcfcda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/00552ea6-d61c-486c-a59f-9a35d5768a9b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a540696c-cc48-440d-b637-d5b6b3fcfcda>.
+    
+<http://data.lblod.info/id/remote-data-objects/d12232aa-472b-45f3-82cc-fb627fd1154c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d12232aa-472b-45f3-82cc-fb627fd1154c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/00aeaeba-cc9d-46e6-9127-17e4ca15ae81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d12232aa-472b-45f3-82cc-fb627fd1154c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9718c501-22b4-47bc-9b0f-755d8185cb1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9718c501-22b4-47bc-9b0f-755d8185cb1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/04e90e0f-40a3-4a9a-b41a-90de28339e55/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9718c501-22b4-47bc-9b0f-755d8185cb1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5984fabd-9c50-4f13-9b10-9b7ae7c941b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5984fabd-9c50-4f13-9b10-9b7ae7c941b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/096e0bf6-e7e1-4eef-a21e-69c570755b38/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5984fabd-9c50-4f13-9b10-9b7ae7c941b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/03857498-f200-4dff-82a4-4e0a27511a36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03857498-f200-4dff-82a4-4e0a27511a36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/0bfc1a18-b6ad-400d-9ede-134a74a2a811/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03857498-f200-4dff-82a4-4e0a27511a36>.
+    
+<http://data.lblod.info/id/remote-data-objects/220a7e55-633f-4ee2-991b-a061d006941b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "220a7e55-633f-4ee2-991b-a061d006941b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/123600db-a76d-47ba-af3d-1688c16debaf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/220a7e55-633f-4ee2-991b-a061d006941b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b053ab6d-0cd2-4a85-bad7-c4dd835bc610> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b053ab6d-0cd2-4a85-bad7-c4dd835bc610";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/1ad08b1c-663e-4baf-8471-59d149abaf0f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b053ab6d-0cd2-4a85-bad7-c4dd835bc610>.
+    
+<http://data.lblod.info/id/remote-data-objects/58b27120-9f76-4c1c-bbcc-02e056a89e54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58b27120-9f76-4c1c-bbcc-02e056a89e54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/1c0973c2-05f6-4dc1-aa6a-888710866e15/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58b27120-9f76-4c1c-bbcc-02e056a89e54>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae88bfd8-ee85-4ef6-9d59-a1f2240bbfc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae88bfd8-ee85-4ef6-9d59-a1f2240bbfc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/21b1e36e-033a-4355-bff2-c79d59f59f7b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae88bfd8-ee85-4ef6-9d59-a1f2240bbfc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e799ea79-5839-4476-87e4-30fa4decf594> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e799ea79-5839-4476-87e4-30fa4decf594";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/239a212d-9e87-431f-bc5b-2e02ea611e7e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e799ea79-5839-4476-87e4-30fa4decf594>.
+    
+<http://data.lblod.info/id/remote-data-objects/1da6b9ff-3d7e-4abe-b6fe-0255de4ec86d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1da6b9ff-3d7e-4abe-b6fe-0255de4ec86d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/2c6d4d14-6a7e-4f72-a226-ec6c89f9317b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1da6b9ff-3d7e-4abe-b6fe-0255de4ec86d>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc79e64c-3192-4dfc-9430-169ad47e3842> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc79e64c-3192-4dfc-9430-169ad47e3842";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/37cfbd9a-65e7-4b8b-b747-aae8a272fc6f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc79e64c-3192-4dfc-9430-169ad47e3842>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d42de47-4dbc-4d6f-89fa-425058477db5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d42de47-4dbc-4d6f-89fa-425058477db5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/40379ee7-7032-4301-ac95-77e7bb63a110/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d42de47-4dbc-4d6f-89fa-425058477db5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ca754ff-a346-4cf0-bfa1-44feb8f4313e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ca754ff-a346-4cf0-bfa1-44feb8f4313e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/4068b227-98df-44f7-b595-0abc2f9c80cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ca754ff-a346-4cf0-bfa1-44feb8f4313e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b02a3066-65d4-4fb1-806f-6324f623651e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b02a3066-65d4-4fb1-806f-6324f623651e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/5063042d-845a-4f17-9edc-85981ef73043/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b02a3066-65d4-4fb1-806f-6324f623651e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a07aaa2-79b4-4755-b963-6d7a69942e41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a07aaa2-79b4-4755-b963-6d7a69942e41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/50a97810-496d-49d6-9688-8d620c38926a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a07aaa2-79b4-4755-b963-6d7a69942e41>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8d90227-6a50-4c77-a02c-aa10549b922c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8d90227-6a50-4c77-a02c-aa10549b922c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/5300025b-d993-4bf4-9419-8c72b21e977e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8d90227-6a50-4c77-a02c-aa10549b922c>.
+    
+<http://data.lblod.info/id/remote-data-objects/26b41abb-07a5-4d2e-aa5f-d6ef2d334e1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26b41abb-07a5-4d2e-aa5f-d6ef2d334e1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/5562bea1-a8e4-4117-b628-58e9694ab9b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26b41abb-07a5-4d2e-aa5f-d6ef2d334e1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/267150d2-6466-4345-9287-aea5cacc0d48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "267150d2-6466-4345-9287-aea5cacc0d48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/63f7fc17-749b-49a0-aa48-302d52d1a7d9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/267150d2-6466-4345-9287-aea5cacc0d48>.
+    
+<http://data.lblod.info/id/remote-data-objects/5642124f-cf44-4ae4-89d4-6d6aa5872a70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5642124f-cf44-4ae4-89d4-6d6aa5872a70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/649dd7cd-fe6e-47eb-899c-0431abe3e2b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5642124f-cf44-4ae4-89d4-6d6aa5872a70>.
+    
+<http://data.lblod.info/id/remote-data-objects/329ebac4-0217-40b4-89dd-e4cfa9b2922f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "329ebac4-0217-40b4-89dd-e4cfa9b2922f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/745192a3-20ce-4556-9553-ddacdbfdc1e4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/329ebac4-0217-40b4-89dd-e4cfa9b2922f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b7d2521-067a-4365-95a7-06a43c1879ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b7d2521-067a-4365-95a7-06a43c1879ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/7678cb9d-c1af-4c3a-83ac-c9f00487ca8d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b7d2521-067a-4365-95a7-06a43c1879ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd43ab97-2c19-4f1f-b8a0-801cc1c2e064> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd43ab97-2c19-4f1f-b8a0-801cc1c2e064";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/8d6eee44-caf0-406a-9a5a-05642600a494/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd43ab97-2c19-4f1f-b8a0-801cc1c2e064>.
+    
+<http://data.lblod.info/id/remote-data-objects/934d8e91-529a-406a-a9d2-1a769f5bbbc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "934d8e91-529a-406a-a9d2-1a769f5bbbc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/8fff84d1-f6e8-442c-aaa5-74151f039b76/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/934d8e91-529a-406a-a9d2-1a769f5bbbc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b842ca8-4bcb-4558-8a8d-c3907ca02599> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b842ca8-4bcb-4558-8a8d-c3907ca02599";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/909d5571-f769-4a1c-bf30-cf2f40b69e0e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b842ca8-4bcb-4558-8a8d-c3907ca02599>.
+    
+<http://data.lblod.info/id/remote-data-objects/f890a05a-e8b6-429c-9c6b-ba349f979d63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f890a05a-e8b6-429c-9c6b-ba349f979d63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/940d7970-1142-4f3c-a981-105ab1cbede0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f890a05a-e8b6-429c-9c6b-ba349f979d63>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a29deba-f002-4225-b778-fc9138729332> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a29deba-f002-4225-b778-fc9138729332";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/97dd9f1a-93e3-432a-9a5a-cd34bfd31d94/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a478711d-2ac6-41c3-810d-979c7dfebc16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a29deba-f002-4225-b778-fc9138729332>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201104-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201104-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201104-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201104-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/98c6506c-14e7-4da5-a46f-733b17cf90a8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "98c6506c-14e7-4da5-a46f-733b17cf90a8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "58d9f22d-3db5-49d4-9ae0-f8e292739666";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6233511b-63df-4156-b7cf-fbc7cd90b185> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6233511b-63df-4156-b7cf-fbc7cd90b185";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666>.
+
+  <http://redpencil.data.gift/id/task/68f79a93-1bb4-49bf-b41a-1fe652021a11> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "68f79a93-1bb4-49bf-b41a-1fe652021a11";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/98c6506c-14e7-4da5-a46f-733b17cf90a8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6233511b-63df-4156-b7cf-fbc7cd90b185>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7b05bce2-2d46-4607-be14-135fc091b185> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b05bce2-2d46-4607-be14-135fc091b185";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/9a5a1a48-8a2a-437f-8032-c05549ad95c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b05bce2-2d46-4607-be14-135fc091b185>.
+    
+<http://data.lblod.info/id/remote-data-objects/42edec4a-a4e2-4161-91bd-905fbb043f8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42edec4a-a4e2-4161-91bd-905fbb043f8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/a9e041af-91ce-48db-9cad-6403bb440e13/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42edec4a-a4e2-4161-91bd-905fbb043f8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2ec982a-1e74-46e9-bf88-f5201f6eaa30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2ec982a-1e74-46e9-bf88-f5201f6eaa30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/aa292728-7992-464c-af17-f9f356e77d20/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2ec982a-1e74-46e9-bf88-f5201f6eaa30>.
+    
+<http://data.lblod.info/id/remote-data-objects/908b1945-6800-46a6-bc62-0aa07929313d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "908b1945-6800-46a6-bc62-0aa07929313d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/afbb0c40-f0af-4ad2-ab39-069fc5a27105/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/908b1945-6800-46a6-bc62-0aa07929313d>.
+    
+<http://data.lblod.info/id/remote-data-objects/510309e6-41f0-4a2d-aa5b-6ee3f2b28b6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "510309e6-41f0-4a2d-aa5b-6ee3f2b28b6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/c143765c-e58d-4ebd-9088-1aa5e13d5395/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/510309e6-41f0-4a2d-aa5b-6ee3f2b28b6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/be84be8d-5f8a-463c-a098-b0aec86325f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be84be8d-5f8a-463c-a098-b0aec86325f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/c4306d04-d10d-4679-957f-e4f496ccaecd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be84be8d-5f8a-463c-a098-b0aec86325f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/eae6a476-9cc4-4e44-9d9f-6e2a2febe906> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eae6a476-9cc4-4e44-9d9f-6e2a2febe906";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/d96effaf-7f61-4e48-ae61-9d9997b763d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eae6a476-9cc4-4e44-9d9f-6e2a2febe906>.
+    
+<http://data.lblod.info/id/remote-data-objects/941341aa-a450-4ad9-a4f3-f4e80975d85a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "941341aa-a450-4ad9-a4f3-f4e80975d85a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/e69bc07c-6565-4d04-9de5-0883d1777516/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/941341aa-a450-4ad9-a4f3-f4e80975d85a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d97c1de7-f4af-4e38-ada6-f5ac7a714dab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d97c1de7-f4af-4e38-ada6-f5ac7a714dab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/ea933953-6b5f-49ef-b0d1-32143aa0b309/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d97c1de7-f4af-4e38-ada6-f5ac7a714dab>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad9abd6a-30f4-44e8-90f6-36ff5177f095> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad9abd6a-30f4-44e8-90f6-36ff5177f095";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/eafb3706-15aa-4f0d-a786-c78bf42fc2e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad9abd6a-30f4-44e8-90f6-36ff5177f095>.
+    
+<http://data.lblod.info/id/remote-data-objects/685ecdd9-0528-4b33-8602-b0886c7dfae3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "685ecdd9-0528-4b33-8602-b0886c7dfae3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/f07c7d7d-665e-4027-85a6-3cbadf68b896/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/685ecdd9-0528-4b33-8602-b0886c7dfae3>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d6d5a46-aecc-42ae-895a-0e2d62608e45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d6d5a46-aecc-42ae-895a-0e2d62608e45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/f22a42d9-e363-4c0f-9363-c8a3b62dbb18/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d6d5a46-aecc-42ae-895a-0e2d62608e45>.
+    
+<http://data.lblod.info/id/remote-data-objects/98e847b2-d5f9-455f-bca8-3a8839207654> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98e847b2-d5f9-455f-bca8-3a8839207654";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/fac0f6a0-988a-4fa8-8307-4af2628934fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98e847b2-d5f9-455f-bca8-3a8839207654>.
+    
+<http://data.lblod.info/id/remote-data-objects/b103adf4-c343-44cc-b5fa-8849c8d895c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b103adf4-c343-44cc-b5fa-8849c8d895c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/bb/faf3c580-0125-4065-aaf0-4bb75baad096/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b103adf4-c343-44cc-b5fa-8849c8d895c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7428eac-e88b-4bd7-af6f-3c3ec42ad17e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7428eac-e88b-4bd7-af6f-3c3ec42ad17e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/02450cfa-3f69-4784-ba96-975975347afe/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7428eac-e88b-4bd7-af6f-3c3ec42ad17e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9669338-70c3-4b26-8fa8-6d50b25a345a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9669338-70c3-4b26-8fa8-6d50b25a345a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/02450cfa-3f69-4784-ba96-975975347afe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9669338-70c3-4b26-8fa8-6d50b25a345a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d2a599e-055f-46d2-8888-1988377d2e3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d2a599e-055f-46d2-8888-1988377d2e3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/02450cfa-3f69-4784-ba96-975975347afe/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d2a599e-055f-46d2-8888-1988377d2e3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/78456379-3130-4caa-b330-26cbcfbf13e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78456379-3130-4caa-b330-26cbcfbf13e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/04b62ac6-dd0a-44c4-a2d9-7a033fe9d606/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78456379-3130-4caa-b330-26cbcfbf13e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e76446c6-86e4-4178-b4e9-e003e290d40a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e76446c6-86e4-4178-b4e9-e003e290d40a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/04b62ac6-dd0a-44c4-a2d9-7a033fe9d606/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e76446c6-86e4-4178-b4e9-e003e290d40a>.
+    
+<http://data.lblod.info/id/remote-data-objects/10fbc644-a54a-443f-8b74-c04f9966d4b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10fbc644-a54a-443f-8b74-c04f9966d4b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/04b62ac6-dd0a-44c4-a2d9-7a033fe9d606/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10fbc644-a54a-443f-8b74-c04f9966d4b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d3bd66e-c726-4ed1-ad85-9d3f8fef14dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d3bd66e-c726-4ed1-ad85-9d3f8fef14dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/0cb20641-7b1d-4e7e-8838-b037335918af/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d3bd66e-c726-4ed1-ad85-9d3f8fef14dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d0ac7eb-af46-445c-beb1-3b391b678df8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d0ac7eb-af46-445c-beb1-3b391b678df8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/0cb20641-7b1d-4e7e-8838-b037335918af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d0ac7eb-af46-445c-beb1-3b391b678df8>.
+    
+<http://data.lblod.info/id/remote-data-objects/81f0a7f4-c054-4c4d-b2d6-a6961acc5516> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81f0a7f4-c054-4c4d-b2d6-a6961acc5516";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/0cb20641-7b1d-4e7e-8838-b037335918af/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81f0a7f4-c054-4c4d-b2d6-a6961acc5516>.
+    
+<http://data.lblod.info/id/remote-data-objects/9031cef4-4353-4fa0-966f-1e8358e51131> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9031cef4-4353-4fa0-966f-1e8358e51131";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/0cda8b88-9c87-4406-a381-82a06bcf10e5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9031cef4-4353-4fa0-966f-1e8358e51131>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbdc891f-1be0-4e5e-a05b-340315dc13c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbdc891f-1be0-4e5e-a05b-340315dc13c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/0cda8b88-9c87-4406-a381-82a06bcf10e5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbdc891f-1be0-4e5e-a05b-340315dc13c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa3b6ef4-4d8f-488b-9118-7204df9a518a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa3b6ef4-4d8f-488b-9118-7204df9a518a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/0cda8b88-9c87-4406-a381-82a06bcf10e5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa3b6ef4-4d8f-488b-9118-7204df9a518a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec9ea824-c18d-4a2f-8bc0-22cdece4fcb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec9ea824-c18d-4a2f-8bc0-22cdece4fcb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/0d44a743-1b00-4fb3-822d-51731eeacee2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec9ea824-c18d-4a2f-8bc0-22cdece4fcb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/46b57d60-3b36-4c3f-ba1f-376e426700c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46b57d60-3b36-4c3f-ba1f-376e426700c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/0d44a743-1b00-4fb3-822d-51731eeacee2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46b57d60-3b36-4c3f-ba1f-376e426700c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/83bceec6-4171-470d-9379-2ee86222957d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83bceec6-4171-470d-9379-2ee86222957d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/0d44a743-1b00-4fb3-822d-51731eeacee2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83bceec6-4171-470d-9379-2ee86222957d>.
+    
+<http://data.lblod.info/id/remote-data-objects/867bf7e9-b82c-4588-be8c-04a7d7cd9cde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "867bf7e9-b82c-4588-be8c-04a7d7cd9cde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/1a9c8796-144e-4d03-aa10-471883591c8c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/867bf7e9-b82c-4588-be8c-04a7d7cd9cde>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab2fe906-6dee-4d02-803f-1c262dbf2c9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab2fe906-6dee-4d02-803f-1c262dbf2c9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/1a9c8796-144e-4d03-aa10-471883591c8c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab2fe906-6dee-4d02-803f-1c262dbf2c9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c485a298-6076-4fcc-86c9-2c0f9a7c04bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c485a298-6076-4fcc-86c9-2c0f9a7c04bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/1a9c8796-144e-4d03-aa10-471883591c8c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c485a298-6076-4fcc-86c9-2c0f9a7c04bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2a9a48c-b116-425e-bec8-c3385bf98115> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2a9a48c-b116-425e-bec8-c3385bf98115";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/25604fc4-3417-4f8f-b275-87c0a54537ed/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2a9a48c-b116-425e-bec8-c3385bf98115>.
+    
+<http://data.lblod.info/id/remote-data-objects/cda49814-4a57-4124-96ee-47b51ea502df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cda49814-4a57-4124-96ee-47b51ea502df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/25604fc4-3417-4f8f-b275-87c0a54537ed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cda49814-4a57-4124-96ee-47b51ea502df>.
+    
+<http://data.lblod.info/id/remote-data-objects/a033a273-8463-4dec-814b-0d6fbf65d91b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a033a273-8463-4dec-814b-0d6fbf65d91b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/25604fc4-3417-4f8f-b275-87c0a54537ed/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a033a273-8463-4dec-814b-0d6fbf65d91b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0734013-b6ae-4d29-8c53-99979d37eb13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0734013-b6ae-4d29-8c53-99979d37eb13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/25e139b5-1caa-4e82-b23a-ff365122d9e0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0734013-b6ae-4d29-8c53-99979d37eb13>.
+    
+<http://data.lblod.info/id/remote-data-objects/88f527e2-02ee-4cf4-8c83-f59701061f31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88f527e2-02ee-4cf4-8c83-f59701061f31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/25e139b5-1caa-4e82-b23a-ff365122d9e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88f527e2-02ee-4cf4-8c83-f59701061f31>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbf6df00-525c-4089-b7fe-435e20ae395e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbf6df00-525c-4089-b7fe-435e20ae395e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/25e139b5-1caa-4e82-b23a-ff365122d9e0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbf6df00-525c-4089-b7fe-435e20ae395e>.
+    
+<http://data.lblod.info/id/remote-data-objects/be986ef7-134c-40e5-83e6-132beb1b8069> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be986ef7-134c-40e5-83e6-132beb1b8069";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/26919bd4-9790-4bb4-9f53-56c802bdca06/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be986ef7-134c-40e5-83e6-132beb1b8069>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fe5fd13-daa1-48b0-9b16-6ce76636108e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fe5fd13-daa1-48b0-9b16-6ce76636108e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/26919bd4-9790-4bb4-9f53-56c802bdca06/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fe5fd13-daa1-48b0-9b16-6ce76636108e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ea5b2f8-fcab-486b-beab-b6b45db0d1c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ea5b2f8-fcab-486b-beab-b6b45db0d1c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/26919bd4-9790-4bb4-9f53-56c802bdca06/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ea5b2f8-fcab-486b-beab-b6b45db0d1c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e03142c9-a7ec-466c-9cf2-85f688e9744b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e03142c9-a7ec-466c-9cf2-85f688e9744b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/26f0a6e0-1a84-4463-a5aa-45663a70651d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e03142c9-a7ec-466c-9cf2-85f688e9744b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ccccaf8-2720-4c91-accf-a045a0a5c628> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ccccaf8-2720-4c91-accf-a045a0a5c628";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/26f0a6e0-1a84-4463-a5aa-45663a70651d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ccccaf8-2720-4c91-accf-a045a0a5c628>.
+    
+<http://data.lblod.info/id/remote-data-objects/1df2c046-5e07-4c50-b607-c461b5421ecb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1df2c046-5e07-4c50-b607-c461b5421ecb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/26f0a6e0-1a84-4463-a5aa-45663a70651d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1df2c046-5e07-4c50-b607-c461b5421ecb>.
+    
+<http://data.lblod.info/id/remote-data-objects/131533b1-8358-4c81-8189-bc2ea200e74a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "131533b1-8358-4c81-8189-bc2ea200e74a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/2ededde6-5c60-4c3d-9654-1d4eb9050c71/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/131533b1-8358-4c81-8189-bc2ea200e74a>.
+    
+<http://data.lblod.info/id/remote-data-objects/15cf2ae1-3528-4717-9e9b-cf52413c3f13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15cf2ae1-3528-4717-9e9b-cf52413c3f13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/2ededde6-5c60-4c3d-9654-1d4eb9050c71/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15cf2ae1-3528-4717-9e9b-cf52413c3f13>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c555f63-ac6c-455f-a10e-6b461a8009a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c555f63-ac6c-455f-a10e-6b461a8009a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/2ededde6-5c60-4c3d-9654-1d4eb9050c71/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c555f63-ac6c-455f-a10e-6b461a8009a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7b0b845-c7a7-4882-a1f2-5dc4a00cbf5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7b0b845-c7a7-4882-a1f2-5dc4a00cbf5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/3442e0a5-5f20-4376-bbf7-2c752f5e1154/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7b0b845-c7a7-4882-a1f2-5dc4a00cbf5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6819d9c-4236-4400-bb92-102d9c5b0b03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6819d9c-4236-4400-bb92-102d9c5b0b03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/3442e0a5-5f20-4376-bbf7-2c752f5e1154/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6819d9c-4236-4400-bb92-102d9c5b0b03>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a588f24-3061-44dd-8b50-a8d4fe05cf09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a588f24-3061-44dd-8b50-a8d4fe05cf09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/3442e0a5-5f20-4376-bbf7-2c752f5e1154/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58d9f22d-3db5-49d4-9ae0-f8e292739666> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a588f24-3061-44dd-8b50-a8d4fe05cf09>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201105-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201105-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201105-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201105-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b252e54b-4d6e-4e35-a932-3d4427c60027> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b252e54b-4d6e-4e35-a932-3d4427c60027";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a63f3215-2dcc-43b2-baae-ac97f3cb2936> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a63f3215-2dcc-43b2-baae-ac97f3cb2936";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63>.
+
+  <http://redpencil.data.gift/id/task/48846692-f1e6-4a33-97f3-f2957435fa04> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "48846692-f1e6-4a33-97f3-f2957435fa04";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b252e54b-4d6e-4e35-a932-3d4427c60027>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a63f3215-2dcc-43b2-baae-ac97f3cb2936>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/127b3865-2445-4ec5-be0b-7d350456f6ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "127b3865-2445-4ec5-be0b-7d350456f6ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/3447c083-3e6a-4755-bcdd-b2a40c0b9e91/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/127b3865-2445-4ec5-be0b-7d350456f6ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/c308dd1f-4b5b-4eae-be78-381b29ef553c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c308dd1f-4b5b-4eae-be78-381b29ef553c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/3447c083-3e6a-4755-bcdd-b2a40c0b9e91/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c308dd1f-4b5b-4eae-be78-381b29ef553c>.
+    
+<http://data.lblod.info/id/remote-data-objects/41369abd-a6b1-490d-9914-9a75f7889dc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41369abd-a6b1-490d-9914-9a75f7889dc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/3447c083-3e6a-4755-bcdd-b2a40c0b9e91/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41369abd-a6b1-490d-9914-9a75f7889dc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0752caa4-88dc-4f51-aac6-2c644d93d89b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0752caa4-88dc-4f51-aac6-2c644d93d89b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/3f94f696-c0eb-4e53-adcb-3d98705d90cb/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0752caa4-88dc-4f51-aac6-2c644d93d89b>.
+    
+<http://data.lblod.info/id/remote-data-objects/49616c5f-e2c4-4e20-a806-1e7930ae3829> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49616c5f-e2c4-4e20-a806-1e7930ae3829";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/3f94f696-c0eb-4e53-adcb-3d98705d90cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49616c5f-e2c4-4e20-a806-1e7930ae3829>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7160d0e-7120-47ce-a8a8-5041064f6cf0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7160d0e-7120-47ce-a8a8-5041064f6cf0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/3f94f696-c0eb-4e53-adcb-3d98705d90cb/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7160d0e-7120-47ce-a8a8-5041064f6cf0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1ecc687-4477-4592-b1a8-712f751171d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1ecc687-4477-4592-b1a8-712f751171d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/400568c6-282c-4d69-b74d-73697ab831fa/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1ecc687-4477-4592-b1a8-712f751171d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5399dc4-0bff-45e4-8ef1-0f27af2277f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5399dc4-0bff-45e4-8ef1-0f27af2277f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/400568c6-282c-4d69-b74d-73697ab831fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5399dc4-0bff-45e4-8ef1-0f27af2277f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5bf583e-82c1-4d77-9f7c-29e276c786d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5bf583e-82c1-4d77-9f7c-29e276c786d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/400568c6-282c-4d69-b74d-73697ab831fa/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5bf583e-82c1-4d77-9f7c-29e276c786d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dd60c87-ebe0-4e7b-87d4-e9acb8d73cb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dd60c87-ebe0-4e7b-87d4-e9acb8d73cb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/44a65789-e62b-49bc-8d73-a2befa1a0550/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dd60c87-ebe0-4e7b-87d4-e9acb8d73cb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3365e473-ec8f-4d79-b103-48c39966910c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3365e473-ec8f-4d79-b103-48c39966910c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/44a65789-e62b-49bc-8d73-a2befa1a0550/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3365e473-ec8f-4d79-b103-48c39966910c>.
+    
+<http://data.lblod.info/id/remote-data-objects/94e34031-cf5d-46ea-a3b3-acb2df244f99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94e34031-cf5d-46ea-a3b3-acb2df244f99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/44a65789-e62b-49bc-8d73-a2befa1a0550/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94e34031-cf5d-46ea-a3b3-acb2df244f99>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb911bcf-4efb-43bc-ab64-6ba607fcec02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb911bcf-4efb-43bc-ab64-6ba607fcec02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/4bab8205-a009-418e-9589-6bc01aaab8f8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb911bcf-4efb-43bc-ab64-6ba607fcec02>.
+    
+<http://data.lblod.info/id/remote-data-objects/867445ab-abca-4739-a165-fa77102a1b8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "867445ab-abca-4739-a165-fa77102a1b8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/4bab8205-a009-418e-9589-6bc01aaab8f8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/867445ab-abca-4739-a165-fa77102a1b8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c83f903-8ca3-491f-8caf-e631c1db7102> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c83f903-8ca3-491f-8caf-e631c1db7102";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/4bab8205-a009-418e-9589-6bc01aaab8f8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c83f903-8ca3-491f-8caf-e631c1db7102>.
+    
+<http://data.lblod.info/id/remote-data-objects/42e91ea0-d0bd-4b05-8c45-3fbca8165cd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42e91ea0-d0bd-4b05-8c45-3fbca8165cd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/50240214-f0d4-4d9f-8d19-cf2f865945d1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42e91ea0-d0bd-4b05-8c45-3fbca8165cd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b9da3b4-7c25-4bca-8f80-0dddf1c3b63b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b9da3b4-7c25-4bca-8f80-0dddf1c3b63b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/50240214-f0d4-4d9f-8d19-cf2f865945d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b9da3b4-7c25-4bca-8f80-0dddf1c3b63b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b444313-8e51-43a7-89d8-8285d5ec7dbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b444313-8e51-43a7-89d8-8285d5ec7dbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/50240214-f0d4-4d9f-8d19-cf2f865945d1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b444313-8e51-43a7-89d8-8285d5ec7dbb>.
+    
+<http://data.lblod.info/id/remote-data-objects/11c9ed93-e5b5-4878-965a-493a17fcd401> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11c9ed93-e5b5-4878-965a-493a17fcd401";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/50ae3600-4ceb-44e5-bafa-a5d3a3697000/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11c9ed93-e5b5-4878-965a-493a17fcd401>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b7ea643-a31b-422e-9cd5-366fd83d713c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b7ea643-a31b-422e-9cd5-366fd83d713c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/50ae3600-4ceb-44e5-bafa-a5d3a3697000/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b7ea643-a31b-422e-9cd5-366fd83d713c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cb029d7-2ee0-4dd8-a40c-079914f18d07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cb029d7-2ee0-4dd8-a40c-079914f18d07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/50ae3600-4ceb-44e5-bafa-a5d3a3697000/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cb029d7-2ee0-4dd8-a40c-079914f18d07>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cf7b71a-f39c-4e27-92e8-662165bf1fe5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cf7b71a-f39c-4e27-92e8-662165bf1fe5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/5194476a-33dd-416c-af65-935be6ea1dd0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cf7b71a-f39c-4e27-92e8-662165bf1fe5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f08c995-6096-497a-a1ef-0506dfca9729> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f08c995-6096-497a-a1ef-0506dfca9729";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/5194476a-33dd-416c-af65-935be6ea1dd0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f08c995-6096-497a-a1ef-0506dfca9729>.
+    
+<http://data.lblod.info/id/remote-data-objects/90d2bf29-cec6-47d0-b291-be4945725ac3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90d2bf29-cec6-47d0-b291-be4945725ac3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/5194476a-33dd-416c-af65-935be6ea1dd0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90d2bf29-cec6-47d0-b291-be4945725ac3>.
+    
+<http://data.lblod.info/id/remote-data-objects/32875832-3c07-4ca7-b3fc-0aba7d98f6fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32875832-3c07-4ca7-b3fc-0aba7d98f6fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/5abffdb4-fd38-41c1-bd06-1197e9b0ebe8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32875832-3c07-4ca7-b3fc-0aba7d98f6fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/184e3d4f-a8bd-4a9a-b29d-b1e69b93d34a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "184e3d4f-a8bd-4a9a-b29d-b1e69b93d34a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/5abffdb4-fd38-41c1-bd06-1197e9b0ebe8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/184e3d4f-a8bd-4a9a-b29d-b1e69b93d34a>.
+    
+<http://data.lblod.info/id/remote-data-objects/aebeee31-54b6-4149-8220-2c41c1910a9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aebeee31-54b6-4149-8220-2c41c1910a9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/5abffdb4-fd38-41c1-bd06-1197e9b0ebe8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aebeee31-54b6-4149-8220-2c41c1910a9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3e944ab-c8d9-4131-8f76-7fb5a6623bee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3e944ab-c8d9-4131-8f76-7fb5a6623bee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/5ac552c9-6c2a-4e49-9856-bb9731bae5a1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3e944ab-c8d9-4131-8f76-7fb5a6623bee>.
+    
+<http://data.lblod.info/id/remote-data-objects/3828e1f3-4aea-4a12-b00b-cffd778ab15a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3828e1f3-4aea-4a12-b00b-cffd778ab15a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/5ac552c9-6c2a-4e49-9856-bb9731bae5a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3828e1f3-4aea-4a12-b00b-cffd778ab15a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f6147fc-3e47-4377-9a5b-389c16adceb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f6147fc-3e47-4377-9a5b-389c16adceb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/5ac552c9-6c2a-4e49-9856-bb9731bae5a1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f6147fc-3e47-4377-9a5b-389c16adceb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdeaf41a-c45c-4245-9d02-92655f711ebc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdeaf41a-c45c-4245-9d02-92655f711ebc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/5cc90c4d-7e32-4e45-8ca4-21619280a13d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdeaf41a-c45c-4245-9d02-92655f711ebc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f06ca744-464f-4197-82c5-104f3f07f2c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f06ca744-464f-4197-82c5-104f3f07f2c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/5cc90c4d-7e32-4e45-8ca4-21619280a13d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f06ca744-464f-4197-82c5-104f3f07f2c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/371bcc45-8f75-48c5-8638-d956689e9871> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "371bcc45-8f75-48c5-8638-d956689e9871";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/5cc90c4d-7e32-4e45-8ca4-21619280a13d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/371bcc45-8f75-48c5-8638-d956689e9871>.
+    
+<http://data.lblod.info/id/remote-data-objects/649db228-7113-41aa-8fd2-38075be0b954> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "649db228-7113-41aa-8fd2-38075be0b954";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/621ca408-6b71-42b0-beb6-6bf1607b722d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/649db228-7113-41aa-8fd2-38075be0b954>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd281b1e-4a67-47ad-b519-9b67526d8a8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd281b1e-4a67-47ad-b519-9b67526d8a8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/621ca408-6b71-42b0-beb6-6bf1607b722d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd281b1e-4a67-47ad-b519-9b67526d8a8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d71bc7cc-f305-45ef-ae75-1c5055d1a5fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d71bc7cc-f305-45ef-ae75-1c5055d1a5fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/621ca408-6b71-42b0-beb6-6bf1607b722d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d71bc7cc-f305-45ef-ae75-1c5055d1a5fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d9d6e9b-237f-4ad8-9e9c-16939cedf960> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d9d6e9b-237f-4ad8-9e9c-16939cedf960";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6396027d-33c7-4705-939e-7eb670c58444/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d9d6e9b-237f-4ad8-9e9c-16939cedf960>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e741c0d-ca53-4238-81a0-fbabe649e067> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e741c0d-ca53-4238-81a0-fbabe649e067";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6396027d-33c7-4705-939e-7eb670c58444/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e741c0d-ca53-4238-81a0-fbabe649e067>.
+    
+<http://data.lblod.info/id/remote-data-objects/89dbf8c5-f0e0-46d0-a71c-936d87aca77c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89dbf8c5-f0e0-46d0-a71c-936d87aca77c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6396027d-33c7-4705-939e-7eb670c58444/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89dbf8c5-f0e0-46d0-a71c-936d87aca77c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c908eca2-0f4c-44db-b4e2-22d475e5d293> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c908eca2-0f4c-44db-b4e2-22d475e5d293";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6401a573-edca-4360-b1ce-17cc7920c881/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c908eca2-0f4c-44db-b4e2-22d475e5d293>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f410e34-03d7-4414-8353-8771cbcdb875> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f410e34-03d7-4414-8353-8771cbcdb875";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6401a573-edca-4360-b1ce-17cc7920c881/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f410e34-03d7-4414-8353-8771cbcdb875>.
+    
+<http://data.lblod.info/id/remote-data-objects/846ae8ed-bc2c-4f06-98d3-bd4f85327429> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "846ae8ed-bc2c-4f06-98d3-bd4f85327429";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6401a573-edca-4360-b1ce-17cc7920c881/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/846ae8ed-bc2c-4f06-98d3-bd4f85327429>.
+    
+<http://data.lblod.info/id/remote-data-objects/46968928-e1e5-4ced-aef9-147f7a0d2188> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46968928-e1e5-4ced-aef9-147f7a0d2188";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/68fcf67d-810a-4645-88f7-748928901b3e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46968928-e1e5-4ced-aef9-147f7a0d2188>.
+    
+<http://data.lblod.info/id/remote-data-objects/81d259ee-ca17-4635-a2bf-7d7e952dd9b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81d259ee-ca17-4635-a2bf-7d7e952dd9b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/68fcf67d-810a-4645-88f7-748928901b3e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81d259ee-ca17-4635-a2bf-7d7e952dd9b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/80f799bf-23f5-4dec-af37-e129646840fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80f799bf-23f5-4dec-af37-e129646840fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/68fcf67d-810a-4645-88f7-748928901b3e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80f799bf-23f5-4dec-af37-e129646840fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/20eff388-02a2-41e2-b29f-bcb0fd371da9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20eff388-02a2-41e2-b29f-bcb0fd371da9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6c49ade5-a53e-4be8-a3d2-9d3566bc81d8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20eff388-02a2-41e2-b29f-bcb0fd371da9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6d0c5c4-7f53-4511-8165-6d9253519283> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6d0c5c4-7f53-4511-8165-6d9253519283";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6c49ade5-a53e-4be8-a3d2-9d3566bc81d8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6d0c5c4-7f53-4511-8165-6d9253519283>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a73ed6e-ea45-4808-8a52-f5fe373ecdf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a73ed6e-ea45-4808-8a52-f5fe373ecdf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6c49ade5-a53e-4be8-a3d2-9d3566bc81d8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a73ed6e-ea45-4808-8a52-f5fe373ecdf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/146d7414-9f02-4749-87e5-93fcbf86d6dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "146d7414-9f02-4749-87e5-93fcbf86d6dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6ce5439b-7bda-497d-a882-b4bc0ceb8625/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/146d7414-9f02-4749-87e5-93fcbf86d6dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0cc08e0-24fb-4022-9258-4d2a4b17f425> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0cc08e0-24fb-4022-9258-4d2a4b17f425";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6ce5439b-7bda-497d-a882-b4bc0ceb8625/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4f3b5fb0-32fe-4bdc-9914-cafc97bd9f63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0cc08e0-24fb-4022-9258-4d2a4b17f425>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201106-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201106-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201106-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201106-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2e675913-4092-4a7e-8b5a-8ab9f38b54c6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2e675913-4092-4a7e-8b5a-8ab9f38b54c6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ba934c50-a114-4247-b1b1-7eeff4e19e13";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f8f5bc0b-5f0a-4bf9-a076-9af3dda13bc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f8f5bc0b-5f0a-4bf9-a076-9af3dda13bc6";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13>.
+
+  <http://redpencil.data.gift/id/task/bc4c8809-7618-43e3-9748-127a23f5870b> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bc4c8809-7618-43e3-9748-127a23f5870b";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2e675913-4092-4a7e-8b5a-8ab9f38b54c6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f8f5bc0b-5f0a-4bf9-a076-9af3dda13bc6>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/899e08a6-d4c5-4323-95a9-cb957e417ede> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "899e08a6-d4c5-4323-95a9-cb957e417ede";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6ce5439b-7bda-497d-a882-b4bc0ceb8625/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/899e08a6-d4c5-4323-95a9-cb957e417ede>.
+    
+<http://data.lblod.info/id/remote-data-objects/7adaf8c3-4314-4efb-b5d1-6efd88d6b03e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7adaf8c3-4314-4efb-b5d1-6efd88d6b03e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6d0b7964-318e-4dcb-b7a3-ab794b4f88ff/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7adaf8c3-4314-4efb-b5d1-6efd88d6b03e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5490a19-936d-485f-a201-5fe4fcb10adf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5490a19-936d-485f-a201-5fe4fcb10adf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6d0b7964-318e-4dcb-b7a3-ab794b4f88ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5490a19-936d-485f-a201-5fe4fcb10adf>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a47001a-604a-4682-b06b-580f6cc58b67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a47001a-604a-4682-b06b-580f6cc58b67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6d0b7964-318e-4dcb-b7a3-ab794b4f88ff/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a47001a-604a-4682-b06b-580f6cc58b67>.
+    
+<http://data.lblod.info/id/remote-data-objects/39c931dc-4db6-4f0d-b709-957c1c1cbb1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39c931dc-4db6-4f0d-b709-957c1c1cbb1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6f05ef27-1f84-4490-bc35-5c7bb284f3a8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39c931dc-4db6-4f0d-b709-957c1c1cbb1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/96ecb547-a613-4ea8-a806-76f89514666a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96ecb547-a613-4ea8-a806-76f89514666a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6f05ef27-1f84-4490-bc35-5c7bb284f3a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96ecb547-a613-4ea8-a806-76f89514666a>.
+    
+<http://data.lblod.info/id/remote-data-objects/33a7da25-ad91-4fd4-9614-3a25fae370c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33a7da25-ad91-4fd4-9614-3a25fae370c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/6f05ef27-1f84-4490-bc35-5c7bb284f3a8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33a7da25-ad91-4fd4-9614-3a25fae370c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b4394ba-6257-4ff4-a548-4455d7b990e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b4394ba-6257-4ff4-a548-4455d7b990e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/71b4740c-a607-44de-afed-7687d467960d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b4394ba-6257-4ff4-a548-4455d7b990e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a712172a-4818-44a2-a330-2878a6eb226b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a712172a-4818-44a2-a330-2878a6eb226b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/71b4740c-a607-44de-afed-7687d467960d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a712172a-4818-44a2-a330-2878a6eb226b>.
+    
+<http://data.lblod.info/id/remote-data-objects/52bb2166-e69b-4ad2-a408-7c47eba7f081> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52bb2166-e69b-4ad2-a408-7c47eba7f081";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/71b4740c-a607-44de-afed-7687d467960d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52bb2166-e69b-4ad2-a408-7c47eba7f081>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9c75a56-0835-405b-9212-1c7d9b6cba0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9c75a56-0835-405b-9212-1c7d9b6cba0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/7381c86a-2510-444a-a9f1-fb0530824e85/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9c75a56-0835-405b-9212-1c7d9b6cba0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a9ce18b-91e4-4b30-95b8-67709f672172> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a9ce18b-91e4-4b30-95b8-67709f672172";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/7381c86a-2510-444a-a9f1-fb0530824e85/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a9ce18b-91e4-4b30-95b8-67709f672172>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f8250f2-74e9-4361-a279-20b74d9ad4d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f8250f2-74e9-4361-a279-20b74d9ad4d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/7381c86a-2510-444a-a9f1-fb0530824e85/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f8250f2-74e9-4361-a279-20b74d9ad4d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/09a567de-a98a-488e-9947-e6c06ffd6632> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09a567de-a98a-488e-9947-e6c06ffd6632";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/78347fb0-b871-46ae-973d-ba4552ae4a52/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09a567de-a98a-488e-9947-e6c06ffd6632>.
+    
+<http://data.lblod.info/id/remote-data-objects/6457c588-957d-4f53-b235-2dd83759f6e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6457c588-957d-4f53-b235-2dd83759f6e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/78347fb0-b871-46ae-973d-ba4552ae4a52/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6457c588-957d-4f53-b235-2dd83759f6e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc2d4ced-ed88-44dd-94d6-4d920a2c4333> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc2d4ced-ed88-44dd-94d6-4d920a2c4333";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/78347fb0-b871-46ae-973d-ba4552ae4a52/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc2d4ced-ed88-44dd-94d6-4d920a2c4333>.
+    
+<http://data.lblod.info/id/remote-data-objects/661efc6a-3bba-4c56-bc00-4a3afbe68f3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "661efc6a-3bba-4c56-bc00-4a3afbe68f3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/7926fc77-ea6d-48f9-957c-3b352991a933/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/661efc6a-3bba-4c56-bc00-4a3afbe68f3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bee50d7a-3cc8-4696-a332-c27cb4f81769> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bee50d7a-3cc8-4696-a332-c27cb4f81769";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/7926fc77-ea6d-48f9-957c-3b352991a933/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bee50d7a-3cc8-4696-a332-c27cb4f81769>.
+    
+<http://data.lblod.info/id/remote-data-objects/403ff5c0-7287-4c04-9b2a-3089e45a1902> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "403ff5c0-7287-4c04-9b2a-3089e45a1902";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/7926fc77-ea6d-48f9-957c-3b352991a933/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/403ff5c0-7287-4c04-9b2a-3089e45a1902>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f4a17b0-a5fc-45dc-9ecf-dac3226a7edc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f4a17b0-a5fc-45dc-9ecf-dac3226a7edc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/7af50827-1226-4ddb-85a2-702eaa538d62/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f4a17b0-a5fc-45dc-9ecf-dac3226a7edc>.
+    
+<http://data.lblod.info/id/remote-data-objects/a41d5f78-91a5-47fe-b472-ca9d4fb3940b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a41d5f78-91a5-47fe-b472-ca9d4fb3940b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/7af50827-1226-4ddb-85a2-702eaa538d62/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a41d5f78-91a5-47fe-b472-ca9d4fb3940b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d27c69c-cdad-4eca-b5c6-07fee46dfce6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d27c69c-cdad-4eca-b5c6-07fee46dfce6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/7af50827-1226-4ddb-85a2-702eaa538d62/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d27c69c-cdad-4eca-b5c6-07fee46dfce6>.
+    
+<http://data.lblod.info/id/remote-data-objects/686df2f1-ceff-4562-bf88-558b0ba21bf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "686df2f1-ceff-4562-bf88-558b0ba21bf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/7f42ee4b-14ee-4d19-b766-88c6ed5c1c84/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/686df2f1-ceff-4562-bf88-558b0ba21bf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/9da4615e-960b-4474-b2b2-ad63b75ebf06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9da4615e-960b-4474-b2b2-ad63b75ebf06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/7f42ee4b-14ee-4d19-b766-88c6ed5c1c84/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9da4615e-960b-4474-b2b2-ad63b75ebf06>.
+    
+<http://data.lblod.info/id/remote-data-objects/a55c2e71-846f-438a-8f31-3060ea66950e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a55c2e71-846f-438a-8f31-3060ea66950e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/7f42ee4b-14ee-4d19-b766-88c6ed5c1c84/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a55c2e71-846f-438a-8f31-3060ea66950e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d8f80ea-bc28-450e-94bf-e7de944bce0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d8f80ea-bc28-450e-94bf-e7de944bce0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/806d372e-6624-403a-b5bc-05efb7ad34c6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d8f80ea-bc28-450e-94bf-e7de944bce0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/500f285b-f300-4f49-80a9-6eb897fa792a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "500f285b-f300-4f49-80a9-6eb897fa792a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/806d372e-6624-403a-b5bc-05efb7ad34c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/500f285b-f300-4f49-80a9-6eb897fa792a>.
+    
+<http://data.lblod.info/id/remote-data-objects/73f4f208-f143-437a-85e4-08c0a9348163> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73f4f208-f143-437a-85e4-08c0a9348163";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/806d372e-6624-403a-b5bc-05efb7ad34c6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73f4f208-f143-437a-85e4-08c0a9348163>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fd1ee36-7935-4cd4-8023-271e09957f1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fd1ee36-7935-4cd4-8023-271e09957f1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/8431d7b2-e786-49fb-9ff1-6cbd1eeef24c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fd1ee36-7935-4cd4-8023-271e09957f1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6db6678-c1e5-48e3-9978-3cc23b6a4e7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6db6678-c1e5-48e3-9978-3cc23b6a4e7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/8431d7b2-e786-49fb-9ff1-6cbd1eeef24c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6db6678-c1e5-48e3-9978-3cc23b6a4e7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/89abb255-be69-4a0d-8af1-199fb70d2f43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89abb255-be69-4a0d-8af1-199fb70d2f43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/8431d7b2-e786-49fb-9ff1-6cbd1eeef24c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89abb255-be69-4a0d-8af1-199fb70d2f43>.
+    
+<http://data.lblod.info/id/remote-data-objects/07b34b56-f271-43c2-a14c-adc1d05f5bdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07b34b56-f271-43c2-a14c-adc1d05f5bdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/849f3ed2-3b1e-4751-8528-e79bdaae2384/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07b34b56-f271-43c2-a14c-adc1d05f5bdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/01dfa52f-a18d-4003-8530-eadf8360102d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01dfa52f-a18d-4003-8530-eadf8360102d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/849f3ed2-3b1e-4751-8528-e79bdaae2384/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01dfa52f-a18d-4003-8530-eadf8360102d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ab1af3d-15bb-4d95-a088-0a307c6b2ff8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ab1af3d-15bb-4d95-a088-0a307c6b2ff8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/849f3ed2-3b1e-4751-8528-e79bdaae2384/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ab1af3d-15bb-4d95-a088-0a307c6b2ff8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3c01e24-2aaa-4f6c-8a82-ff1b4ea24607> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3c01e24-2aaa-4f6c-8a82-ff1b4ea24607";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/8569072c-b56a-4877-9130-55f16cff4cd1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3c01e24-2aaa-4f6c-8a82-ff1b4ea24607>.
+    
+<http://data.lblod.info/id/remote-data-objects/a33e28f6-c853-4e2e-be20-a7283dbc2509> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a33e28f6-c853-4e2e-be20-a7283dbc2509";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/8569072c-b56a-4877-9130-55f16cff4cd1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a33e28f6-c853-4e2e-be20-a7283dbc2509>.
+    
+<http://data.lblod.info/id/remote-data-objects/74c62b36-d4f5-46b7-833e-8fdf1b73a103> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74c62b36-d4f5-46b7-833e-8fdf1b73a103";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/88356929-0b4b-4417-8ede-eb2e7c8ac437/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74c62b36-d4f5-46b7-833e-8fdf1b73a103>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba26d5e4-a3a5-41d4-bc06-28a2d6098232> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba26d5e4-a3a5-41d4-bc06-28a2d6098232";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/88356929-0b4b-4417-8ede-eb2e7c8ac437/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba26d5e4-a3a5-41d4-bc06-28a2d6098232>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2d2452d-542c-4bb5-92da-8b8aa465053e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2d2452d-542c-4bb5-92da-8b8aa465053e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/88356929-0b4b-4417-8ede-eb2e7c8ac437/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2d2452d-542c-4bb5-92da-8b8aa465053e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3f38da2-b88b-4878-8a41-2ed8ef8d9af4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3f38da2-b88b-4878-8a41-2ed8ef8d9af4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/97a07b44-5d6f-48d2-8186-2cee257c99d3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3f38da2-b88b-4878-8a41-2ed8ef8d9af4>.
+    
+<http://data.lblod.info/id/remote-data-objects/895ae9f9-81e7-4130-9505-a09899175b26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "895ae9f9-81e7-4130-9505-a09899175b26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/97a07b44-5d6f-48d2-8186-2cee257c99d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/895ae9f9-81e7-4130-9505-a09899175b26>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b1cc75c-bb41-4722-97ed-6166a2d0cec7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b1cc75c-bb41-4722-97ed-6166a2d0cec7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/97a07b44-5d6f-48d2-8186-2cee257c99d3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b1cc75c-bb41-4722-97ed-6166a2d0cec7>.
+    
+<http://data.lblod.info/id/remote-data-objects/421f4bb5-612c-400e-851a-c7aade9165b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "421f4bb5-612c-400e-851a-c7aade9165b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/9f323c05-9d9e-461b-9fc0-6a375998732f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/421f4bb5-612c-400e-851a-c7aade9165b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/62290f63-4a4d-43a1-8faa-7ae1fed28139> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62290f63-4a4d-43a1-8faa-7ae1fed28139";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/9f323c05-9d9e-461b-9fc0-6a375998732f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62290f63-4a4d-43a1-8faa-7ae1fed28139>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1adaa3a-1594-4482-b03a-0553e10f12af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1adaa3a-1594-4482-b03a-0553e10f12af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/9f323c05-9d9e-461b-9fc0-6a375998732f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1adaa3a-1594-4482-b03a-0553e10f12af>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6636ff5-ee10-4c87-9f41-3f4fc92d01a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6636ff5-ee10-4c87-9f41-3f4fc92d01a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/9fa1ad8d-bacc-45e0-b693-2aaa90da9670/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6636ff5-ee10-4c87-9f41-3f4fc92d01a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ced5509d-d0a0-48d8-a096-02b05ddd90be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ced5509d-d0a0-48d8-a096-02b05ddd90be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/9fa1ad8d-bacc-45e0-b693-2aaa90da9670/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ced5509d-d0a0-48d8-a096-02b05ddd90be>.
+    
+<http://data.lblod.info/id/remote-data-objects/11a03848-b351-4943-93f8-a232f2e64e94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11a03848-b351-4943-93f8-a232f2e64e94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/9fa1ad8d-bacc-45e0-b693-2aaa90da9670/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11a03848-b351-4943-93f8-a232f2e64e94>.
+    
+<http://data.lblod.info/id/remote-data-objects/821c38b9-3a8f-43bc-ad31-df07f1242d2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "821c38b9-3a8f-43bc-ad31-df07f1242d2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/a2c25b08-c172-46bd-84b5-20a82a9cf998/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/821c38b9-3a8f-43bc-ad31-df07f1242d2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fecf459d-a4fa-4697-990a-40fdac1162dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fecf459d-a4fa-4697-990a-40fdac1162dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/a2c25b08-c172-46bd-84b5-20a82a9cf998/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba934c50-a114-4247-b1b1-7eeff4e19e13> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fecf459d-a4fa-4697-990a-40fdac1162dd>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201108-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201108-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201108-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201108-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/24ae5044-3c23-4c89-b5aa-fa6f74f7ba3f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "24ae5044-3c23-4c89-b5aa-fa6f74f7ba3f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cee24ecf-7971-45ba-b03c-5e627281bf31";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/bdda9cb0-c572-4ee6-a58c-fb68a48e9bda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bdda9cb0-c572-4ee6-a58c-fb68a48e9bda";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31>.
+
+  <http://redpencil.data.gift/id/task/57fdca15-6888-4654-a472-ca14fda344ff> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "57fdca15-6888-4654-a472-ca14fda344ff";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/24ae5044-3c23-4c89-b5aa-fa6f74f7ba3f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/bdda9cb0-c572-4ee6-a58c-fb68a48e9bda>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d0132ce8-a301-434e-acbb-fbe049179ca1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0132ce8-a301-434e-acbb-fbe049179ca1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/a2c25b08-c172-46bd-84b5-20a82a9cf998/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0132ce8-a301-434e-acbb-fbe049179ca1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e64b92d7-7fec-469b-91d2-f72fb7af8429> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e64b92d7-7fec-469b-91d2-f72fb7af8429";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/a74f5334-a6a6-4b4e-8960-6036538bf640/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e64b92d7-7fec-469b-91d2-f72fb7af8429>.
+    
+<http://data.lblod.info/id/remote-data-objects/035dbf8d-e9a9-4d55-98aa-b63ba315c063> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "035dbf8d-e9a9-4d55-98aa-b63ba315c063";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/a74f5334-a6a6-4b4e-8960-6036538bf640/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/035dbf8d-e9a9-4d55-98aa-b63ba315c063>.
+    
+<http://data.lblod.info/id/remote-data-objects/df88e203-fb16-4063-b015-8027f316604f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df88e203-fb16-4063-b015-8027f316604f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/a74f5334-a6a6-4b4e-8960-6036538bf640/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df88e203-fb16-4063-b015-8027f316604f>.
+    
+<http://data.lblod.info/id/remote-data-objects/87f04606-7759-4842-89dc-6f5b05d32069> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87f04606-7759-4842-89dc-6f5b05d32069";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/abcda2b2-4016-4fd5-95cc-2260c7e40a85/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87f04606-7759-4842-89dc-6f5b05d32069>.
+    
+<http://data.lblod.info/id/remote-data-objects/48123fcf-7564-4690-9b4f-3ca249c0784e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48123fcf-7564-4690-9b4f-3ca249c0784e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/abcda2b2-4016-4fd5-95cc-2260c7e40a85/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48123fcf-7564-4690-9b4f-3ca249c0784e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fea8143-6485-4e06-ab7e-5ad117d06d32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fea8143-6485-4e06-ab7e-5ad117d06d32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/abcda2b2-4016-4fd5-95cc-2260c7e40a85/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fea8143-6485-4e06-ab7e-5ad117d06d32>.
+    
+<http://data.lblod.info/id/remote-data-objects/a397a83e-b957-4d24-8792-a13f3b2be553> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a397a83e-b957-4d24-8792-a13f3b2be553";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/ac5d4a2c-8771-4c1e-bb63-f78adddb76d2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a397a83e-b957-4d24-8792-a13f3b2be553>.
+    
+<http://data.lblod.info/id/remote-data-objects/8de3aba8-315d-4bae-a36b-3796906678da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8de3aba8-315d-4bae-a36b-3796906678da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/ac5d4a2c-8771-4c1e-bb63-f78adddb76d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8de3aba8-315d-4bae-a36b-3796906678da>.
+    
+<http://data.lblod.info/id/remote-data-objects/7de207b8-7745-4700-9363-cced8de67371> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7de207b8-7745-4700-9363-cced8de67371";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/ac5d4a2c-8771-4c1e-bb63-f78adddb76d2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7de207b8-7745-4700-9363-cced8de67371>.
+    
+<http://data.lblod.info/id/remote-data-objects/3785540c-53ec-4aac-adbb-d72d80223d00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3785540c-53ec-4aac-adbb-d72d80223d00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/ac6686fb-bc5a-4e84-9c48-cad18db9ac34/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3785540c-53ec-4aac-adbb-d72d80223d00>.
+    
+<http://data.lblod.info/id/remote-data-objects/edb83664-3472-4f48-8c84-5fa21a023fca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edb83664-3472-4f48-8c84-5fa21a023fca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/ac6686fb-bc5a-4e84-9c48-cad18db9ac34/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edb83664-3472-4f48-8c84-5fa21a023fca>.
+    
+<http://data.lblod.info/id/remote-data-objects/6df163da-5a95-41a8-b6f8-e967e23eca1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6df163da-5a95-41a8-b6f8-e967e23eca1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/ac6686fb-bc5a-4e84-9c48-cad18db9ac34/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6df163da-5a95-41a8-b6f8-e967e23eca1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/157dc275-d5a1-4b22-8390-7a31f898f0c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "157dc275-d5a1-4b22-8390-7a31f898f0c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/b7dc59c0-2472-4d22-a836-d55ff44bb7ee/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/157dc275-d5a1-4b22-8390-7a31f898f0c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3a658d2-7c76-48bb-908e-5f4f3aa5de77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3a658d2-7c76-48bb-908e-5f4f3aa5de77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/b7dc59c0-2472-4d22-a836-d55ff44bb7ee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3a658d2-7c76-48bb-908e-5f4f3aa5de77>.
+    
+<http://data.lblod.info/id/remote-data-objects/926943c0-a134-4621-9175-dacb20d76a61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "926943c0-a134-4621-9175-dacb20d76a61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/b7dc59c0-2472-4d22-a836-d55ff44bb7ee/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/926943c0-a134-4621-9175-dacb20d76a61>.
+    
+<http://data.lblod.info/id/remote-data-objects/73b2cbbb-70bf-43b5-b08c-913c4ae8e09e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73b2cbbb-70bf-43b5-b08c-913c4ae8e09e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/ba7e9e5a-f7b7-4071-97da-d4a7e65a558b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73b2cbbb-70bf-43b5-b08c-913c4ae8e09e>.
+    
+<http://data.lblod.info/id/remote-data-objects/47f0de8d-ab90-4e21-982a-430d1ba7a962> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47f0de8d-ab90-4e21-982a-430d1ba7a962";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/ba7e9e5a-f7b7-4071-97da-d4a7e65a558b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47f0de8d-ab90-4e21-982a-430d1ba7a962>.
+    
+<http://data.lblod.info/id/remote-data-objects/f69e66e1-36b3-40e5-9fb7-c3511c5c1206> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f69e66e1-36b3-40e5-9fb7-c3511c5c1206";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/ba7e9e5a-f7b7-4071-97da-d4a7e65a558b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f69e66e1-36b3-40e5-9fb7-c3511c5c1206>.
+    
+<http://data.lblod.info/id/remote-data-objects/99a0db29-7170-407c-b9e9-ecf0326c52b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99a0db29-7170-407c-b9e9-ecf0326c52b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/bcc8d331-123c-439e-a74c-42605f247887/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99a0db29-7170-407c-b9e9-ecf0326c52b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/bde3510d-9fc0-40f8-9669-53cc558e1fdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bde3510d-9fc0-40f8-9669-53cc558e1fdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/bcc8d331-123c-439e-a74c-42605f247887/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bde3510d-9fc0-40f8-9669-53cc558e1fdf>.
+    
+<http://data.lblod.info/id/remote-data-objects/718c00c9-62bd-4041-bb68-5570abc5f4ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "718c00c9-62bd-4041-bb68-5570abc5f4ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/bcc8d331-123c-439e-a74c-42605f247887/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/718c00c9-62bd-4041-bb68-5570abc5f4ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/cab640e0-28fd-45b7-b136-837e91651cbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cab640e0-28fd-45b7-b136-837e91651cbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/bdc64773-c2a4-4238-8ce3-f3cddd986c6e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cab640e0-28fd-45b7-b136-837e91651cbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c3deca3-04de-4fe9-9c40-5d443ad4fea0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c3deca3-04de-4fe9-9c40-5d443ad4fea0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/bdc64773-c2a4-4238-8ce3-f3cddd986c6e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c3deca3-04de-4fe9-9c40-5d443ad4fea0>.
+    
+<http://data.lblod.info/id/remote-data-objects/dac4c2ed-afe7-41a7-b175-a5482cfef007> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dac4c2ed-afe7-41a7-b175-a5482cfef007";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/bdc64773-c2a4-4238-8ce3-f3cddd986c6e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dac4c2ed-afe7-41a7-b175-a5482cfef007>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1c4d837-1a76-4662-b636-cb21ccf2bc56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1c4d837-1a76-4662-b636-cb21ccf2bc56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/bf17f618-e2d1-4d21-a7ca-f349fd271c0e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1c4d837-1a76-4662-b636-cb21ccf2bc56>.
+    
+<http://data.lblod.info/id/remote-data-objects/e39c9c35-c0d9-4e8f-8f5d-35cb9abffbbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e39c9c35-c0d9-4e8f-8f5d-35cb9abffbbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/bf17f618-e2d1-4d21-a7ca-f349fd271c0e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e39c9c35-c0d9-4e8f-8f5d-35cb9abffbbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a00a095-d39f-496d-9ebb-6c85a009c61f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a00a095-d39f-496d-9ebb-6c85a009c61f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/bf17f618-e2d1-4d21-a7ca-f349fd271c0e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a00a095-d39f-496d-9ebb-6c85a009c61f>.
+    
+<http://data.lblod.info/id/remote-data-objects/67eed05e-10c2-4573-bc0a-db50fa0157a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67eed05e-10c2-4573-bc0a-db50fa0157a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/c495978f-1c11-46a8-8fb9-7448ef9443f4/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67eed05e-10c2-4573-bc0a-db50fa0157a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/10f73f05-ea1d-4b14-9069-162f4c99a3ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10f73f05-ea1d-4b14-9069-162f4c99a3ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/c495978f-1c11-46a8-8fb9-7448ef9443f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10f73f05-ea1d-4b14-9069-162f4c99a3ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/916e7608-ce8c-4290-900f-199ae5f6f725> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "916e7608-ce8c-4290-900f-199ae5f6f725";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/c495978f-1c11-46a8-8fb9-7448ef9443f4/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/916e7608-ce8c-4290-900f-199ae5f6f725>.
+    
+<http://data.lblod.info/id/remote-data-objects/c347ac9e-6b08-4ea6-b55a-c015b84c2cc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c347ac9e-6b08-4ea6-b55a-c015b84c2cc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/c58621c4-2d41-4180-9095-28b01a672200/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c347ac9e-6b08-4ea6-b55a-c015b84c2cc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d9a8ee3-2cd4-4d4c-9787-6e3dc60018f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d9a8ee3-2cd4-4d4c-9787-6e3dc60018f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/c58621c4-2d41-4180-9095-28b01a672200/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d9a8ee3-2cd4-4d4c-9787-6e3dc60018f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1e7e7e6-61f6-4128-a545-8ac07eb20d68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1e7e7e6-61f6-4128-a545-8ac07eb20d68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/c58621c4-2d41-4180-9095-28b01a672200/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1e7e7e6-61f6-4128-a545-8ac07eb20d68>.
+    
+<http://data.lblod.info/id/remote-data-objects/6959dcdd-24a2-4671-881e-b3c2c87d6fd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6959dcdd-24a2-4671-881e-b3c2c87d6fd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/cebb8b49-bc64-4da6-bcb2-fd34144e2725/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6959dcdd-24a2-4671-881e-b3c2c87d6fd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a250f21-c1ba-4392-8fea-2b413c30ca5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a250f21-c1ba-4392-8fea-2b413c30ca5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/cebb8b49-bc64-4da6-bcb2-fd34144e2725/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a250f21-c1ba-4392-8fea-2b413c30ca5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f07c1ee9-75a7-4815-8f50-c6823b74d183> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f07c1ee9-75a7-4815-8f50-c6823b74d183";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/cebb8b49-bc64-4da6-bcb2-fd34144e2725/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f07c1ee9-75a7-4815-8f50-c6823b74d183>.
+    
+<http://data.lblod.info/id/remote-data-objects/f10a7238-3c31-4d5d-8536-58c8a13aabc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f10a7238-3c31-4d5d-8536-58c8a13aabc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/cf90d564-3f71-4262-ad6b-01565357c748/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f10a7238-3c31-4d5d-8536-58c8a13aabc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/655ed994-2442-448d-bf5c-6bc040b47f48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "655ed994-2442-448d-bf5c-6bc040b47f48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/cf90d564-3f71-4262-ad6b-01565357c748/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/655ed994-2442-448d-bf5c-6bc040b47f48>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae2abb9f-ab90-4274-8c09-524c3f6ed71f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae2abb9f-ab90-4274-8c09-524c3f6ed71f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/cf90d564-3f71-4262-ad6b-01565357c748/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae2abb9f-ab90-4274-8c09-524c3f6ed71f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e11051bb-ec0b-4ccb-85b3-03fc51d6af74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e11051bb-ec0b-4ccb-85b3-03fc51d6af74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/d15174bc-ad66-4412-a062-c715a4a30a2c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e11051bb-ec0b-4ccb-85b3-03fc51d6af74>.
+    
+<http://data.lblod.info/id/remote-data-objects/18d05593-2206-45b6-9f56-c51b045a4667> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18d05593-2206-45b6-9f56-c51b045a4667";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/d15174bc-ad66-4412-a062-c715a4a30a2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18d05593-2206-45b6-9f56-c51b045a4667>.
+    
+<http://data.lblod.info/id/remote-data-objects/04f5c5fe-50bf-4ebf-8b68-00ffba507927> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04f5c5fe-50bf-4ebf-8b68-00ffba507927";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/d15174bc-ad66-4412-a062-c715a4a30a2c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04f5c5fe-50bf-4ebf-8b68-00ffba507927>.
+    
+<http://data.lblod.info/id/remote-data-objects/acf7bf49-6a44-4f9b-8197-5a4172ec4a12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acf7bf49-6a44-4f9b-8197-5a4172ec4a12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/d2493ff9-f177-47e3-928c-1717f3c8fc4e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acf7bf49-6a44-4f9b-8197-5a4172ec4a12>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fd5fa62-ec61-4177-b681-5a112b357722> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fd5fa62-ec61-4177-b681-5a112b357722";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/d2493ff9-f177-47e3-928c-1717f3c8fc4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fd5fa62-ec61-4177-b681-5a112b357722>.
+    
+<http://data.lblod.info/id/remote-data-objects/c70e0170-271d-486a-887d-b6d045b4261d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c70e0170-271d-486a-887d-b6d045b4261d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/d2493ff9-f177-47e3-928c-1717f3c8fc4e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c70e0170-271d-486a-887d-b6d045b4261d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1f6edbc-0688-4bc9-a8bc-92d4ed4fc0b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1f6edbc-0688-4bc9-a8bc-92d4ed4fc0b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/d547d144-624c-4e85-8614-5160c5722c9f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1f6edbc-0688-4bc9-a8bc-92d4ed4fc0b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd586262-24cb-493e-8598-9930ed5bff19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd586262-24cb-493e-8598-9930ed5bff19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/d547d144-624c-4e85-8614-5160c5722c9f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd586262-24cb-493e-8598-9930ed5bff19>.
+    
+<http://data.lblod.info/id/remote-data-objects/faba500b-2bce-42a7-bf82-a79f9a6646c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "faba500b-2bce-42a7-bf82-a79f9a6646c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/d547d144-624c-4e85-8614-5160c5722c9f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/faba500b-2bce-42a7-bf82-a79f9a6646c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/8018a93f-1c1a-4ee0-93e6-a9117333d156> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8018a93f-1c1a-4ee0-93e6-a9117333d156";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/dbe10126-be16-40c0-a3ea-371958f3ebf7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cee24ecf-7971-45ba-b03c-5e627281bf31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8018a93f-1c1a-4ee0-93e6-a9117333d156>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201109-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201109-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201109-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201109-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/08282c24-dda9-4444-be9d-6f9ea67da21d> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "08282c24-dda9-4444-be9d-6f9ea67da21d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "731a6745-94b9-4b24-b8c5-4cbb85e38a1f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/df434a7e-ac83-4ab5-9e84-f5dacbf50d3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "df434a7e-ac83-4ab5-9e84-f5dacbf50d3d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f>.
+
+  <http://redpencil.data.gift/id/task/56836bdf-3ce3-4b7f-8fd8-a5fe58124c5c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "56836bdf-3ce3-4b7f-8fd8-a5fe58124c5c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/08282c24-dda9-4444-be9d-6f9ea67da21d>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/df434a7e-ac83-4ab5-9e84-f5dacbf50d3d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a78961fa-7266-4ac6-bd96-04056bfd8fea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a78961fa-7266-4ac6-bd96-04056bfd8fea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/dbe10126-be16-40c0-a3ea-371958f3ebf7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a78961fa-7266-4ac6-bd96-04056bfd8fea>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e0a4c1e-e488-4fd6-8ea8-51190a2aed03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e0a4c1e-e488-4fd6-8ea8-51190a2aed03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/dbe10126-be16-40c0-a3ea-371958f3ebf7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e0a4c1e-e488-4fd6-8ea8-51190a2aed03>.
+    
+<http://data.lblod.info/id/remote-data-objects/62f21ddf-6008-45d5-bab0-8550f38aa319> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62f21ddf-6008-45d5-bab0-8550f38aa319";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/e071597d-2917-470a-8058-8923dc6aeeea/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62f21ddf-6008-45d5-bab0-8550f38aa319>.
+    
+<http://data.lblod.info/id/remote-data-objects/fae13383-8efa-4cef-9059-dbe92e30143d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fae13383-8efa-4cef-9059-dbe92e30143d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/e071597d-2917-470a-8058-8923dc6aeeea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fae13383-8efa-4cef-9059-dbe92e30143d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d77b931-10af-4d52-ae65-f0c544ae63ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d77b931-10af-4d52-ae65-f0c544ae63ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/e071597d-2917-470a-8058-8923dc6aeeea/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d77b931-10af-4d52-ae65-f0c544ae63ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/8196d611-fb09-4365-8a1f-e782ea97a274> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8196d611-fb09-4365-8a1f-e782ea97a274";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/e0732e5e-a77a-41f6-a120-93e642f3f565/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8196d611-fb09-4365-8a1f-e782ea97a274>.
+    
+<http://data.lblod.info/id/remote-data-objects/c56ec088-f0e8-44da-ae36-cd241f11d382> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c56ec088-f0e8-44da-ae36-cd241f11d382";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/e0732e5e-a77a-41f6-a120-93e642f3f565/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c56ec088-f0e8-44da-ae36-cd241f11d382>.
+    
+<http://data.lblod.info/id/remote-data-objects/40cea8cd-7b0f-444d-9e32-06fd247da20c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40cea8cd-7b0f-444d-9e32-06fd247da20c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/e0732e5e-a77a-41f6-a120-93e642f3f565/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40cea8cd-7b0f-444d-9e32-06fd247da20c>.
+    
+<http://data.lblod.info/id/remote-data-objects/85c09358-a2a0-4cc5-bbfa-615023228e71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85c09358-a2a0-4cc5-bbfa-615023228e71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/e0e56b00-4f45-4485-b9e2-5bfb57736d34/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85c09358-a2a0-4cc5-bbfa-615023228e71>.
+    
+<http://data.lblod.info/id/remote-data-objects/5980afb1-eda1-4ff5-a189-7c2e3ceee831> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5980afb1-eda1-4ff5-a189-7c2e3ceee831";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/e0e56b00-4f45-4485-b9e2-5bfb57736d34/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5980afb1-eda1-4ff5-a189-7c2e3ceee831>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6921c7a-4e74-4eaa-bf53-cf909f7b858f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6921c7a-4e74-4eaa-bf53-cf909f7b858f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/e0e56b00-4f45-4485-b9e2-5bfb57736d34/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6921c7a-4e74-4eaa-bf53-cf909f7b858f>.
+    
+<http://data.lblod.info/id/remote-data-objects/907de6c1-fc4a-4b57-b83b-03601bb90a47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "907de6c1-fc4a-4b57-b83b-03601bb90a47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/eef688ec-82aa-4063-9b4d-3fa5d88a6c6a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/907de6c1-fc4a-4b57-b83b-03601bb90a47>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c268f1e-4cdc-4980-b718-dd4b4115c979> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c268f1e-4cdc-4980-b718-dd4b4115c979";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/eef688ec-82aa-4063-9b4d-3fa5d88a6c6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c268f1e-4cdc-4980-b718-dd4b4115c979>.
+    
+<http://data.lblod.info/id/remote-data-objects/2313644a-d82e-46a9-9fb3-66a9de259dc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2313644a-d82e-46a9-9fb3-66a9de259dc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/eef688ec-82aa-4063-9b4d-3fa5d88a6c6a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2313644a-d82e-46a9-9fb3-66a9de259dc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0073302-b132-40b4-9f62-bd924bc0d717> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0073302-b132-40b4-9f62-bd924bc0d717";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/fcb40294-ad31-4016-bac3-2f7ddc4be177/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0073302-b132-40b4-9f62-bd924bc0d717>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d0f5788-b28e-45c7-a6d8-6f461ac00e9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d0f5788-b28e-45c7-a6d8-6f461ac00e9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/fcb40294-ad31-4016-bac3-2f7ddc4be177/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d0f5788-b28e-45c7-a6d8-6f461ac00e9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc63ebd6-6df6-4506-bad1-5ff8ef351bc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc63ebd6-6df6-4506-bad1-5ff8ef351bc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/cbs/fcb40294-ad31-4016-bac3-2f7ddc4be177/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc63ebd6-6df6-4506-bad1-5ff8ef351bc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9ac4461-a095-416a-8b70-cc0c19c8dc25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9ac4461-a095-416a-8b70-cc0c19c8dc25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/16b46818-249e-4165-a834-2be5852fa6ed/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9ac4461-a095-416a-8b70-cc0c19c8dc25>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4b25e4f-470a-4774-b3f4-ebadce3c7b97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4b25e4f-470a-4774-b3f4-ebadce3c7b97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/16b46818-249e-4165-a834-2be5852fa6ed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4b25e4f-470a-4774-b3f4-ebadce3c7b97>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c83b467-6261-4692-b383-6d6b3f9efb52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c83b467-6261-4692-b383-6d6b3f9efb52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/16b46818-249e-4165-a834-2be5852fa6ed/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c83b467-6261-4692-b383-6d6b3f9efb52>.
+    
+<http://data.lblod.info/id/remote-data-objects/124b5abd-a320-4381-9875-429fad2311ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "124b5abd-a320-4381-9875-429fad2311ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/3a4ac10a-a3f9-4667-a058-107afc56da70/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/124b5abd-a320-4381-9875-429fad2311ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2408eae-de6c-47da-a3fa-f17fc3f69983> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2408eae-de6c-47da-a3fa-f17fc3f69983";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/3a4ac10a-a3f9-4667-a058-107afc56da70/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2408eae-de6c-47da-a3fa-f17fc3f69983>.
+    
+<http://data.lblod.info/id/remote-data-objects/67234b7d-e2df-4e3b-9dec-9b9516cbeecb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67234b7d-e2df-4e3b-9dec-9b9516cbeecb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/3a4ac10a-a3f9-4667-a058-107afc56da70/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67234b7d-e2df-4e3b-9dec-9b9516cbeecb>.
+    
+<http://data.lblod.info/id/remote-data-objects/74827976-0575-4363-ba7a-c13c3194b1f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74827976-0575-4363-ba7a-c13c3194b1f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/479c6553-16b3-4f43-95ad-671a5446f067/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74827976-0575-4363-ba7a-c13c3194b1f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a7ee14f-f63d-4839-9990-6c604275aab1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a7ee14f-f63d-4839-9990-6c604275aab1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/479c6553-16b3-4f43-95ad-671a5446f067/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a7ee14f-f63d-4839-9990-6c604275aab1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f03d2b27-07e6-467c-abf4-202c08625066> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f03d2b27-07e6-467c-abf4-202c08625066";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/479c6553-16b3-4f43-95ad-671a5446f067/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f03d2b27-07e6-467c-abf4-202c08625066>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0912cb2-0d23-4e5a-bdff-23e40733c16a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0912cb2-0d23-4e5a-bdff-23e40733c16a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/4f079408-e5d9-41b8-887c-ba586d18b7b0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0912cb2-0d23-4e5a-bdff-23e40733c16a>.
+    
+<http://data.lblod.info/id/remote-data-objects/70ffbd94-0ef5-4a2d-9001-1f7b03d0c4f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70ffbd94-0ef5-4a2d-9001-1f7b03d0c4f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/4f079408-e5d9-41b8-887c-ba586d18b7b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70ffbd94-0ef5-4a2d-9001-1f7b03d0c4f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/35aa67e1-0c77-4230-943b-37e7c3ea2972> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35aa67e1-0c77-4230-943b-37e7c3ea2972";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/65915ae1-0c45-4eed-bbd6-9548db0a2521/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35aa67e1-0c77-4230-943b-37e7c3ea2972>.
+    
+<http://data.lblod.info/id/remote-data-objects/19006518-0aea-413a-9d3d-a0f91936cded> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19006518-0aea-413a-9d3d-a0f91936cded";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/65915ae1-0c45-4eed-bbd6-9548db0a2521/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19006518-0aea-413a-9d3d-a0f91936cded>.
+    
+<http://data.lblod.info/id/remote-data-objects/92d573a5-ef49-46df-99c3-ad717538e42e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92d573a5-ef49-46df-99c3-ad717538e42e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/65915ae1-0c45-4eed-bbd6-9548db0a2521/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92d573a5-ef49-46df-99c3-ad717538e42e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fdad8e4-32ff-4bea-bf36-55b005584f38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fdad8e4-32ff-4bea-bf36-55b005584f38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/723e47d4-c2bc-47ea-8d1b-c0414b41a5ec/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fdad8e4-32ff-4bea-bf36-55b005584f38>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bc73cc9-9434-4b13-81d1-2ec801c171e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bc73cc9-9434-4b13-81d1-2ec801c171e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/723e47d4-c2bc-47ea-8d1b-c0414b41a5ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bc73cc9-9434-4b13-81d1-2ec801c171e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/59572e1e-2563-49d1-ad95-bd85baa386fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59572e1e-2563-49d1-ad95-bd85baa386fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/723e47d4-c2bc-47ea-8d1b-c0414b41a5ec/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59572e1e-2563-49d1-ad95-bd85baa386fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/42e2419d-9156-42b7-9832-79e159ea2a03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42e2419d-9156-42b7-9832-79e159ea2a03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/81cd8199-6aab-46cb-9dbf-261835293d86/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42e2419d-9156-42b7-9832-79e159ea2a03>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2d363d0-e78a-45bf-8d1f-165bd42a6a70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2d363d0-e78a-45bf-8d1f-165bd42a6a70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/81cd8199-6aab-46cb-9dbf-261835293d86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2d363d0-e78a-45bf-8d1f-165bd42a6a70>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc7d3bc2-80b0-4a2c-97b1-f6bfc9e353e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc7d3bc2-80b0-4a2c-97b1-f6bfc9e353e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/81cd8199-6aab-46cb-9dbf-261835293d86/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc7d3bc2-80b0-4a2c-97b1-f6bfc9e353e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ef4f500-718c-48d0-bda6-09cdcc4b358e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ef4f500-718c-48d0-bda6-09cdcc4b358e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/9b675d2c-7512-4b64-a7a2-809aac788368/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ef4f500-718c-48d0-bda6-09cdcc4b358e>.
+    
+<http://data.lblod.info/id/remote-data-objects/44857a9d-c0cc-4e97-9904-564505b10977> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44857a9d-c0cc-4e97-9904-564505b10977";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/9b675d2c-7512-4b64-a7a2-809aac788368/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44857a9d-c0cc-4e97-9904-564505b10977>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd2ae3b9-07b1-4f5a-83cd-744ec08012fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd2ae3b9-07b1-4f5a-83cd-744ec08012fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/9b675d2c-7512-4b64-a7a2-809aac788368/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd2ae3b9-07b1-4f5a-83cd-744ec08012fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0ba1bce-228b-4f39-a586-7a0ed24f62e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0ba1bce-228b-4f39-a586-7a0ed24f62e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/9cd24597-9293-46eb-93c2-894f359a2930/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0ba1bce-228b-4f39-a586-7a0ed24f62e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6767067b-84f6-4daa-8aae-ef50252a2b84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6767067b-84f6-4daa-8aae-ef50252a2b84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/9cd24597-9293-46eb-93c2-894f359a2930/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6767067b-84f6-4daa-8aae-ef50252a2b84>.
+    
+<http://data.lblod.info/id/remote-data-objects/9275b657-e3a0-47a7-9930-92b9fcd0d9c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9275b657-e3a0-47a7-9930-92b9fcd0d9c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/9cd24597-9293-46eb-93c2-894f359a2930/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9275b657-e3a0-47a7-9930-92b9fcd0d9c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/62453e41-0197-4a39-9ddd-0584c632f01d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62453e41-0197-4a39-9ddd-0584c632f01d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/a8f6d2bd-ac6a-46da-91a9-a6dd6ae1d0db/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62453e41-0197-4a39-9ddd-0584c632f01d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab6f952b-ddb5-4df1-bd48-213d22dd5ace> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab6f952b-ddb5-4df1-bd48-213d22dd5ace";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/a8f6d2bd-ac6a-46da-91a9-a6dd6ae1d0db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab6f952b-ddb5-4df1-bd48-213d22dd5ace>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1241cc7-ee48-4787-84d3-917c761cf5a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1241cc7-ee48-4787-84d3-917c761cf5a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/a8f6d2bd-ac6a-46da-91a9-a6dd6ae1d0db/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1241cc7-ee48-4787-84d3-917c761cf5a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf5e1cc2-2f32-4a4d-a857-bc47e918a453> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf5e1cc2-2f32-4a4d-a857-bc47e918a453";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/b9f9f4d7-1598-4cca-87d0-ab3a098387b6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf5e1cc2-2f32-4a4d-a857-bc47e918a453>.
+    
+<http://data.lblod.info/id/remote-data-objects/9de6ecb5-f16e-47e4-a700-9bf3a0151932> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9de6ecb5-f16e-47e4-a700-9bf3a0151932";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/b9f9f4d7-1598-4cca-87d0-ab3a098387b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9de6ecb5-f16e-47e4-a700-9bf3a0151932>.
+    
+<http://data.lblod.info/id/remote-data-objects/33af23e8-e38f-485a-8e77-5e0240d2fe52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33af23e8-e38f-485a-8e77-5e0240d2fe52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/b9f9f4d7-1598-4cca-87d0-ab3a098387b6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33af23e8-e38f-485a-8e77-5e0240d2fe52>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7c98524-cfc7-4561-9ecb-b6f80b70309d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7c98524-cfc7-4561-9ecb-b6f80b70309d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/ccb551e8-0adb-4839-b715-f8a0194ccd39/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/731a6745-94b9-4b24-b8c5-4cbb85e38a1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7c98524-cfc7-4561-9ecb-b6f80b70309d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201110-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201110-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201110-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201110-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/dd438e80-ffaf-43e4-b323-9de7818698c9> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dd438e80-ffaf-43e4-b323-9de7818698c9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e789bf6c-7299-4a78-88cf-e7c205c4abe7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/82df9b62-4d0f-4bbc-8957-0791ecd7df41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "82df9b62-4d0f-4bbc-8957-0791ecd7df41";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7>.
+
+  <http://redpencil.data.gift/id/task/41411dac-c137-42de-86ef-922809498e66> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "41411dac-c137-42de-86ef-922809498e66";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/dd438e80-ffaf-43e4-b323-9de7818698c9>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/82df9b62-4d0f-4bbc-8957-0791ecd7df41>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/238ec619-08eb-4807-bd7f-61ff516ef99a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "238ec619-08eb-4807-bd7f-61ff516ef99a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/ccb551e8-0adb-4839-b715-f8a0194ccd39/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/238ec619-08eb-4807-bd7f-61ff516ef99a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e85eef5-497f-46df-8c99-580417b5fd6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e85eef5-497f-46df-8c99-580417b5fd6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/ccb551e8-0adb-4839-b715-f8a0194ccd39/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e85eef5-497f-46df-8c99-580417b5fd6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c164d8a-04ea-4b4c-8d24-fc9cb6cdc536> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c164d8a-04ea-4b4c-8d24-fc9cb6cdc536";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/e17e6256-bfb8-4e82-90b0-fda1d6a998f3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c164d8a-04ea-4b4c-8d24-fc9cb6cdc536>.
+    
+<http://data.lblod.info/id/remote-data-objects/615223e0-0b97-4c27-8b5b-6229e89930bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "615223e0-0b97-4c27-8b5b-6229e89930bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/e17e6256-bfb8-4e82-90b0-fda1d6a998f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/615223e0-0b97-4c27-8b5b-6229e89930bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/87b44606-807f-4eef-b0d1-7c119af09c8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87b44606-807f-4eef-b0d1-7c119af09c8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/e17e6256-bfb8-4e82-90b0-fda1d6a998f3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87b44606-807f-4eef-b0d1-7c119af09c8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6dbb5be-dca9-4572-8059-f0800a001931> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6dbb5be-dca9-4572-8059-f0800a001931";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/e69142d2-ae25-4441-b012-34fea21e74db/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6dbb5be-dca9-4572-8059-f0800a001931>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bb81efd-a2cb-43c0-b17b-9ab67f00266c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bb81efd-a2cb-43c0-b17b-9ab67f00266c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/e69142d2-ae25-4441-b012-34fea21e74db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bb81efd-a2cb-43c0-b17b-9ab67f00266c>.
+    
+<http://data.lblod.info/id/remote-data-objects/82290e39-d90c-4b6b-b9dc-cd8422113d88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82290e39-d90c-4b6b-b9dc-cd8422113d88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/e69142d2-ae25-4441-b012-34fea21e74db/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82290e39-d90c-4b6b-b9dc-cd8422113d88>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ab77e51-0250-48a0-8f17-a9df7efef55b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ab77e51-0250-48a0-8f17-a9df7efef55b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/fcd8c8d5-1434-4f31-bac3-02d7a449d6ff/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ab77e51-0250-48a0-8f17-a9df7efef55b>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdd9937a-314a-4a82-b4e8-51ee8f04248b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdd9937a-314a-4a82-b4e8-51ee8f04248b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/fcd8c8d5-1434-4f31-bac3-02d7a449d6ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdd9937a-314a-4a82-b4e8-51ee8f04248b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d33af91-3d2b-4e7e-bfcf-7c9ff7905302> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d33af91-3d2b-4e7e-bfcf-7c9ff7905302";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/gr/fcd8c8d5-1434-4f31-bac3-02d7a449d6ff/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d33af91-3d2b-4e7e-bfcf-7c9ff7905302>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1c80e40-f319-4d2a-87fc-4e417322d2ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1c80e40-f319-4d2a-87fc-4e417322d2ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/0bc3647b-3a32-4b25-aace-6411115687f2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1c80e40-f319-4d2a-87fc-4e417322d2ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/d98c6e23-8bdb-41a5-8511-da56a0bf7de2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d98c6e23-8bdb-41a5-8511-da56a0bf7de2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/0bc3647b-3a32-4b25-aace-6411115687f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d98c6e23-8bdb-41a5-8511-da56a0bf7de2>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fd118d1-c550-42ac-9275-d881f703f35b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fd118d1-c550-42ac-9275-d881f703f35b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/0bc3647b-3a32-4b25-aace-6411115687f2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fd118d1-c550-42ac-9275-d881f703f35b>.
+    
+<http://data.lblod.info/id/remote-data-objects/bed82917-6184-4a97-a62b-b9264a7741f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bed82917-6184-4a97-a62b-b9264a7741f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/3ba0eee9-3f84-4010-b10e-68811abc1a51/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bed82917-6184-4a97-a62b-b9264a7741f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c161fd4-7d9f-4a69-b6de-052e9c6af030> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c161fd4-7d9f-4a69-b6de-052e9c6af030";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/3ba0eee9-3f84-4010-b10e-68811abc1a51/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c161fd4-7d9f-4a69-b6de-052e9c6af030>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0063945-176c-416f-bfa5-4f9f2f062807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0063945-176c-416f-bfa5-4f9f2f062807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/3ba0eee9-3f84-4010-b10e-68811abc1a51/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0063945-176c-416f-bfa5-4f9f2f062807>.
+    
+<http://data.lblod.info/id/remote-data-objects/eab88384-eff9-4267-b425-b203a946a414> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eab88384-eff9-4267-b425-b203a946a414";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/3d2c4745-bcf8-4998-9004-838562229fed/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eab88384-eff9-4267-b425-b203a946a414>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fb19044-8269-46aa-adb2-d6a97e4d5874> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fb19044-8269-46aa-adb2-d6a97e4d5874";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/3d2c4745-bcf8-4998-9004-838562229fed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fb19044-8269-46aa-adb2-d6a97e4d5874>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1feb3d9-931a-4acd-8176-acecefddb3d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1feb3d9-931a-4acd-8176-acecefddb3d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/3d2c4745-bcf8-4998-9004-838562229fed/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1feb3d9-931a-4acd-8176-acecefddb3d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/474caa0a-97da-4a3b-a48c-e6459b28d89d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "474caa0a-97da-4a3b-a48c-e6459b28d89d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/40307be8-66fb-46db-8c70-80537237231b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/474caa0a-97da-4a3b-a48c-e6459b28d89d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed3afc73-0b1f-4688-8286-f5b0d3e0289f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed3afc73-0b1f-4688-8286-f5b0d3e0289f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/40307be8-66fb-46db-8c70-80537237231b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed3afc73-0b1f-4688-8286-f5b0d3e0289f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c4fe039-4ace-4d66-bb89-73ab30277ccb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c4fe039-4ace-4d66-bb89-73ab30277ccb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/40307be8-66fb-46db-8c70-80537237231b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c4fe039-4ace-4d66-bb89-73ab30277ccb>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a74dceb-c2af-4fe2-a415-034cd668270f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a74dceb-c2af-4fe2-a415-034cd668270f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/498b9476-ac54-4f5a-8988-15faaf0b24f8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a74dceb-c2af-4fe2-a415-034cd668270f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca63f208-81af-405c-989e-c7e30f4844bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca63f208-81af-405c-989e-c7e30f4844bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/498b9476-ac54-4f5a-8988-15faaf0b24f8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca63f208-81af-405c-989e-c7e30f4844bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/66c29749-3387-4678-b02d-36f957f8026b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66c29749-3387-4678-b02d-36f957f8026b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/498b9476-ac54-4f5a-8988-15faaf0b24f8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66c29749-3387-4678-b02d-36f957f8026b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a117451-ff4a-4384-9d5d-0463698bf4a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a117451-ff4a-4384-9d5d-0463698bf4a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/4a6fd262-74e7-46f0-936d-ab59e062d9f8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a117451-ff4a-4384-9d5d-0463698bf4a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1edd989-05fd-4483-a7c9-3f363c121112> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1edd989-05fd-4483-a7c9-3f363c121112";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/4a6fd262-74e7-46f0-936d-ab59e062d9f8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1edd989-05fd-4483-a7c9-3f363c121112>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bd92dea-cafa-44b9-a67e-91db2160ff28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bd92dea-cafa-44b9-a67e-91db2160ff28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/4a6fd262-74e7-46f0-936d-ab59e062d9f8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bd92dea-cafa-44b9-a67e-91db2160ff28>.
+    
+<http://data.lblod.info/id/remote-data-objects/af5d8f19-0438-40a0-b206-aa4f487a09af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af5d8f19-0438-40a0-b206-aa4f487a09af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/53d960a5-ffe7-4a74-90c3-4e085a6d8cdf/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af5d8f19-0438-40a0-b206-aa4f487a09af>.
+    
+<http://data.lblod.info/id/remote-data-objects/d58628b9-918d-4908-9c66-e057fe036ef6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d58628b9-918d-4908-9c66-e057fe036ef6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/53d960a5-ffe7-4a74-90c3-4e085a6d8cdf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d58628b9-918d-4908-9c66-e057fe036ef6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1361da02-d26d-4c5d-b291-f5aa6f0575f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1361da02-d26d-4c5d-b291-f5aa6f0575f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/5d07d571-ba7b-4cad-8c84-2fdad276a2e6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1361da02-d26d-4c5d-b291-f5aa6f0575f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb4f2c21-48d9-4842-8dfe-a75d8f9fea2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb4f2c21-48d9-4842-8dfe-a75d8f9fea2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/5d07d571-ba7b-4cad-8c84-2fdad276a2e6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb4f2c21-48d9-4842-8dfe-a75d8f9fea2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d69e7810-7a3e-457f-97b0-2443268c246c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d69e7810-7a3e-457f-97b0-2443268c246c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/5d07d571-ba7b-4cad-8c84-2fdad276a2e6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d69e7810-7a3e-457f-97b0-2443268c246c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea169af0-6fe0-4ada-8e52-6276c53ef9d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea169af0-6fe0-4ada-8e52-6276c53ef9d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/627f9068-1022-492e-9333-69aeb6d92454/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea169af0-6fe0-4ada-8e52-6276c53ef9d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f6d05c6-b2f3-48fb-aee9-0fab5072ca8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f6d05c6-b2f3-48fb-aee9-0fab5072ca8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/627f9068-1022-492e-9333-69aeb6d92454/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f6d05c6-b2f3-48fb-aee9-0fab5072ca8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b3574bd-be32-419a-901f-9b4c8092bcb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b3574bd-be32-419a-901f-9b4c8092bcb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/627f9068-1022-492e-9333-69aeb6d92454/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b3574bd-be32-419a-901f-9b4c8092bcb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1d41503-f942-42a2-bb20-844392159909> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1d41503-f942-42a2-bb20-844392159909";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/9884c096-50b1-49f8-b8f0-b8a0a7e79e69/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1d41503-f942-42a2-bb20-844392159909>.
+    
+<http://data.lblod.info/id/remote-data-objects/22fb424f-1c26-47f5-82b1-b1b4e770e6f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22fb424f-1c26-47f5-82b1-b1b4e770e6f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/9884c096-50b1-49f8-b8f0-b8a0a7e79e69/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22fb424f-1c26-47f5-82b1-b1b4e770e6f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e832cda3-34a3-4679-acdd-9e26108b480b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e832cda3-34a3-4679-acdd-9e26108b480b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/9884c096-50b1-49f8-b8f0-b8a0a7e79e69/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e832cda3-34a3-4679-acdd-9e26108b480b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5a70fbb-039c-4b51-8357-3061eaf65594> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5a70fbb-039c-4b51-8357-3061eaf65594";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/9f1b9c09-c9fb-4a0b-a830-b8b880a1207b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5a70fbb-039c-4b51-8357-3061eaf65594>.
+    
+<http://data.lblod.info/id/remote-data-objects/01f18821-b38c-4281-96d8-d37f909f0812> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01f18821-b38c-4281-96d8-d37f909f0812";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/9f1b9c09-c9fb-4a0b-a830-b8b880a1207b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01f18821-b38c-4281-96d8-d37f909f0812>.
+    
+<http://data.lblod.info/id/remote-data-objects/608512c6-8421-4b25-b333-9e860fa1448b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "608512c6-8421-4b25-b333-9e860fa1448b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/9f1b9c09-c9fb-4a0b-a830-b8b880a1207b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/608512c6-8421-4b25-b333-9e860fa1448b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e1b0702-045f-4ab8-a841-d1cd123c7fbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e1b0702-045f-4ab8-a841-d1cd123c7fbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/a96e35bf-128d-44da-b815-8df0be0f5953/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e1b0702-045f-4ab8-a841-d1cd123c7fbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/070fd9a9-d636-4f9f-b1f5-b5892fa5a189> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "070fd9a9-d636-4f9f-b1f5-b5892fa5a189";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/a96e35bf-128d-44da-b815-8df0be0f5953/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/070fd9a9-d636-4f9f-b1f5-b5892fa5a189>.
+    
+<http://data.lblod.info/id/remote-data-objects/9226516b-dcae-43c2-bf2b-51b22a3ac73c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9226516b-dcae-43c2-bf2b-51b22a3ac73c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/a96e35bf-128d-44da-b815-8df0be0f5953/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9226516b-dcae-43c2-bf2b-51b22a3ac73c>.
+    
+<http://data.lblod.info/id/remote-data-objects/669ff76d-5f43-47a9-b6b2-9999ba414a47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "669ff76d-5f43-47a9-b6b2-9999ba414a47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/bbb6f26d-583d-433c-838e-7eac84406ed9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/669ff76d-5f43-47a9-b6b2-9999ba414a47>.
+    
+<http://data.lblod.info/id/remote-data-objects/081e19fa-0ebd-4b4f-b081-11df9fdd5d33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "081e19fa-0ebd-4b4f-b081-11df9fdd5d33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/bbb6f26d-583d-433c-838e-7eac84406ed9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/081e19fa-0ebd-4b4f-b081-11df9fdd5d33>.
+    
+<http://data.lblod.info/id/remote-data-objects/2979e63e-17b9-471d-ba8c-1bdeeb301a64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2979e63e-17b9-471d-ba8c-1bdeeb301a64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/bbb6f26d-583d-433c-838e-7eac84406ed9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2979e63e-17b9-471d-ba8c-1bdeeb301a64>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f300845-cdd8-49a7-b2c0-a47420c615f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f300845-cdd8-49a7-b2c0-a47420c615f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/c30cb762-b35f-412f-bdb9-38d57fa859ec/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e789bf6c-7299-4a78-88cf-e7c205c4abe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f300845-cdd8-49a7-b2c0-a47420c615f0>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201111-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201111-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201111-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201111-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7054851c-f217-47a6-8c1f-e4cbddaed365> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7054851c-f217-47a6-8c1f-e4cbddaed365";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e69b5865-9aa0-43f2-9530-47b3ae5ccab7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/1fc1041c-56a3-4aa9-bf5a-e7912b42a630> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1fc1041c-56a3-4aa9-bf5a-e7912b42a630";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7>.
+
+  <http://redpencil.data.gift/id/task/7e94d92c-f158-4ed9-98b2-ed85c891ed17> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7e94d92c-f158-4ed9-98b2-ed85c891ed17";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7054851c-f217-47a6-8c1f-e4cbddaed365>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/1fc1041c-56a3-4aa9-bf5a-e7912b42a630>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/f45e94e9-5fc4-4a0f-949e-85fb453bec31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f45e94e9-5fc4-4a0f-949e-85fb453bec31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/c30cb762-b35f-412f-bdb9-38d57fa859ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f45e94e9-5fc4-4a0f-949e-85fb453bec31>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed646ea8-e43b-49e0-b034-1fd9fa8c27d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed646ea8-e43b-49e0-b034-1fd9fa8c27d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/c30cb762-b35f-412f-bdb9-38d57fa859ec/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed646ea8-e43b-49e0-b034-1fd9fa8c27d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/14904145-3a5b-46ad-bde7-216a69dd1e9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14904145-3a5b-46ad-bde7-216a69dd1e9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/dad8e38f-cbf9-4209-95a6-663fdce7ad5c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14904145-3a5b-46ad-bde7-216a69dd1e9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/72d722b2-00a7-4899-b500-f7eefdd7efeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72d722b2-00a7-4899-b500-f7eefdd7efeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/dad8e38f-cbf9-4209-95a6-663fdce7ad5c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72d722b2-00a7-4899-b500-f7eefdd7efeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/494f30a2-6b82-41a0-b3ac-eff8782b537a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "494f30a2-6b82-41a0-b3ac-eff8782b537a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/or/dad8e38f-cbf9-4209-95a6-663fdce7ad5c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/494f30a2-6b82-41a0-b3ac-eff8782b537a>.
+    
+<http://data.lblod.info/id/remote-data-objects/60bd8d84-80db-4930-aae6-d9f9e88bb364> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60bd8d84-80db-4930-aae6-d9f9e88bb364";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/093cf31d-36fb-4e8f-a0d3-73f210a53b61/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60bd8d84-80db-4930-aae6-d9f9e88bb364>.
+    
+<http://data.lblod.info/id/remote-data-objects/22c1cb47-86a1-4c19-b805-88452dabf696> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22c1cb47-86a1-4c19-b805-88452dabf696";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/093cf31d-36fb-4e8f-a0d3-73f210a53b61/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22c1cb47-86a1-4c19-b805-88452dabf696>.
+    
+<http://data.lblod.info/id/remote-data-objects/909d9817-91ae-4a84-b4b0-0194a576f868> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "909d9817-91ae-4a84-b4b0-0194a576f868";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/093cf31d-36fb-4e8f-a0d3-73f210a53b61/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/909d9817-91ae-4a84-b4b0-0194a576f868>.
+    
+<http://data.lblod.info/id/remote-data-objects/25ef5545-b44d-4f00-9476-3640ac45d5f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25ef5545-b44d-4f00-9476-3640ac45d5f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/0e798719-d46f-482b-9d15-ed860158ea84/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25ef5545-b44d-4f00-9476-3640ac45d5f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/258f21e2-45f8-4770-92a4-fd8f7fee0b4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "258f21e2-45f8-4770-92a4-fd8f7fee0b4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/0e798719-d46f-482b-9d15-ed860158ea84/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/258f21e2-45f8-4770-92a4-fd8f7fee0b4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9525cc8f-6ba7-46a7-9c13-17147c5b14e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9525cc8f-6ba7-46a7-9c13-17147c5b14e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/0e798719-d46f-482b-9d15-ed860158ea84/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9525cc8f-6ba7-46a7-9c13-17147c5b14e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b36bffce-f604-489f-967b-719878594dd6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b36bffce-f604-489f-967b-719878594dd6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/10a90fdc-377a-471e-874c-a642c0484933/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b36bffce-f604-489f-967b-719878594dd6>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf28b298-22b7-40ab-9d21-ee879ded3075> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf28b298-22b7-40ab-9d21-ee879ded3075";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/10a90fdc-377a-471e-874c-a642c0484933/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf28b298-22b7-40ab-9d21-ee879ded3075>.
+    
+<http://data.lblod.info/id/remote-data-objects/3532bae4-1924-41ec-b76b-2cdb8ff5e377> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3532bae4-1924-41ec-b76b-2cdb8ff5e377";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/10a90fdc-377a-471e-874c-a642c0484933/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3532bae4-1924-41ec-b76b-2cdb8ff5e377>.
+    
+<http://data.lblod.info/id/remote-data-objects/19b16cb1-9ef5-4d7f-af98-6b11bcbc3131> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19b16cb1-9ef5-4d7f-af98-6b11bcbc3131";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/1400687d-0cf8-4e73-812b-71a3a779b5e0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19b16cb1-9ef5-4d7f-af98-6b11bcbc3131>.
+    
+<http://data.lblod.info/id/remote-data-objects/7430fd92-2b71-4fb4-bec7-6cb3a400dd27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7430fd92-2b71-4fb4-bec7-6cb3a400dd27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/1400687d-0cf8-4e73-812b-71a3a779b5e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7430fd92-2b71-4fb4-bec7-6cb3a400dd27>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cc9d756-e319-47c1-b94c-d2057a441adf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cc9d756-e319-47c1-b94c-d2057a441adf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/1400687d-0cf8-4e73-812b-71a3a779b5e0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cc9d756-e319-47c1-b94c-d2057a441adf>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f6ff624-e1a5-4ce9-8d81-4ca415043d11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f6ff624-e1a5-4ce9-8d81-4ca415043d11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/18552c7b-52f9-4951-92a2-ba56d1d20d6e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f6ff624-e1a5-4ce9-8d81-4ca415043d11>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbacc5d6-8baa-41e7-98b5-1a2d5430d7a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbacc5d6-8baa-41e7-98b5-1a2d5430d7a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/18552c7b-52f9-4951-92a2-ba56d1d20d6e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbacc5d6-8baa-41e7-98b5-1a2d5430d7a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbcb44e9-8e2b-4afb-b616-2559c4227b7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbcb44e9-8e2b-4afb-b616-2559c4227b7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/18552c7b-52f9-4951-92a2-ba56d1d20d6e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbcb44e9-8e2b-4afb-b616-2559c4227b7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c0d521e-24b6-4870-a445-fb3359e11ddf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c0d521e-24b6-4870-a445-fb3359e11ddf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/1d92dce3-cbae-4006-9aaf-d1a7720596c8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c0d521e-24b6-4870-a445-fb3359e11ddf>.
+    
+<http://data.lblod.info/id/remote-data-objects/87a96bbc-4c80-4b5f-bf52-53d32eab4236> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87a96bbc-4c80-4b5f-bf52-53d32eab4236";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/1d92dce3-cbae-4006-9aaf-d1a7720596c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87a96bbc-4c80-4b5f-bf52-53d32eab4236>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7b9821a-7cb7-477a-aa4f-b07844101cb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7b9821a-7cb7-477a-aa4f-b07844101cb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/1d92dce3-cbae-4006-9aaf-d1a7720596c8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7b9821a-7cb7-477a-aa4f-b07844101cb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7449d6a-0351-472d-b87f-e826d3c944a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7449d6a-0351-472d-b87f-e826d3c944a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/1fecd17a-b625-4570-8581-cb49b2f9876c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7449d6a-0351-472d-b87f-e826d3c944a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d84b894d-3ea6-412e-be15-11b1d996d782> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d84b894d-3ea6-412e-be15-11b1d996d782";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/1fecd17a-b625-4570-8581-cb49b2f9876c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d84b894d-3ea6-412e-be15-11b1d996d782>.
+    
+<http://data.lblod.info/id/remote-data-objects/91af866e-9473-4de9-9a02-2de9f9768ad5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91af866e-9473-4de9-9a02-2de9f9768ad5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/1fecd17a-b625-4570-8581-cb49b2f9876c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91af866e-9473-4de9-9a02-2de9f9768ad5>.
+    
+<http://data.lblod.info/id/remote-data-objects/88a53647-cffa-47e0-9088-ec33cd396cc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88a53647-cffa-47e0-9088-ec33cd396cc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/275e173b-a56b-4cf3-96e0-788a9bbf980a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88a53647-cffa-47e0-9088-ec33cd396cc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6717fe7-9e4b-4c33-a082-7d95d60110fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6717fe7-9e4b-4c33-a082-7d95d60110fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/275e173b-a56b-4cf3-96e0-788a9bbf980a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6717fe7-9e4b-4c33-a082-7d95d60110fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dee6231-7631-424d-994c-4875df4b0cc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dee6231-7631-424d-994c-4875df4b0cc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/275e173b-a56b-4cf3-96e0-788a9bbf980a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dee6231-7631-424d-994c-4875df4b0cc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/0de340c2-2667-4655-8b6c-40054966a456> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0de340c2-2667-4655-8b6c-40054966a456";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/298714a4-28e6-4328-ab32-33f608d962fd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0de340c2-2667-4655-8b6c-40054966a456>.
+    
+<http://data.lblod.info/id/remote-data-objects/af7b474a-105a-4cef-aadf-73b86da26e07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af7b474a-105a-4cef-aadf-73b86da26e07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/298714a4-28e6-4328-ab32-33f608d962fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af7b474a-105a-4cef-aadf-73b86da26e07>.
+    
+<http://data.lblod.info/id/remote-data-objects/78fcc7ae-05ee-4933-8efd-3ab205d7468a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78fcc7ae-05ee-4933-8efd-3ab205d7468a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/298714a4-28e6-4328-ab32-33f608d962fd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78fcc7ae-05ee-4933-8efd-3ab205d7468a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc41ed5e-cfab-43aa-ab2c-6e61eca52726> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc41ed5e-cfab-43aa-ab2c-6e61eca52726";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/29cc629a-eb7f-4cc0-8d3d-2fa01467db36/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc41ed5e-cfab-43aa-ab2c-6e61eca52726>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a32ae04-1071-4443-a470-632f3f2c0e80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a32ae04-1071-4443-a470-632f3f2c0e80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/29cc629a-eb7f-4cc0-8d3d-2fa01467db36/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a32ae04-1071-4443-a470-632f3f2c0e80>.
+    
+<http://data.lblod.info/id/remote-data-objects/5186eafd-2a6b-4123-9946-79ddff20a87f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5186eafd-2a6b-4123-9946-79ddff20a87f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/29cc629a-eb7f-4cc0-8d3d-2fa01467db36/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5186eafd-2a6b-4123-9946-79ddff20a87f>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd0e7c75-c68e-4ff4-90a2-f659bad8384a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd0e7c75-c68e-4ff4-90a2-f659bad8384a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/2cea1de3-aeea-43f1-8ba3-4720f7754022/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd0e7c75-c68e-4ff4-90a2-f659bad8384a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7433fb9-da5f-451d-80c4-cb6db67d1817> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7433fb9-da5f-451d-80c4-cb6db67d1817";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/2cea1de3-aeea-43f1-8ba3-4720f7754022/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7433fb9-da5f-451d-80c4-cb6db67d1817>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4e179cc-1b99-4df0-825b-c514927603d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4e179cc-1b99-4df0-825b-c514927603d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/2cea1de3-aeea-43f1-8ba3-4720f7754022/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4e179cc-1b99-4df0-825b-c514927603d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c0ba400-4435-48c8-b067-ad0135bb59eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c0ba400-4435-48c8-b067-ad0135bb59eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/2dce41e6-ddc3-4f92-a1bf-2672af51a005/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c0ba400-4435-48c8-b067-ad0135bb59eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/29571632-c4cf-4b2d-afae-463d786d6f05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29571632-c4cf-4b2d-afae-463d786d6f05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/2dce41e6-ddc3-4f92-a1bf-2672af51a005/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29571632-c4cf-4b2d-afae-463d786d6f05>.
+    
+<http://data.lblod.info/id/remote-data-objects/7089c030-8be3-4d74-abce-7b587958bc7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7089c030-8be3-4d74-abce-7b587958bc7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/2dce41e6-ddc3-4f92-a1bf-2672af51a005/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7089c030-8be3-4d74-abce-7b587958bc7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/82678c96-4a2c-4b4e-b187-0e8de9a1ed5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82678c96-4a2c-4b4e-b187-0e8de9a1ed5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/2f3de152-b99b-40b0-871e-fa259e02a528/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82678c96-4a2c-4b4e-b187-0e8de9a1ed5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/556db24e-c8c7-47e5-97e9-c702ede87fd4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "556db24e-c8c7-47e5-97e9-c702ede87fd4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/2f3de152-b99b-40b0-871e-fa259e02a528/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/556db24e-c8c7-47e5-97e9-c702ede87fd4>.
+    
+<http://data.lblod.info/id/remote-data-objects/49c5be00-567f-4fbd-b623-dc3cffb72b00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49c5be00-567f-4fbd-b623-dc3cffb72b00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/2f3de152-b99b-40b0-871e-fa259e02a528/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49c5be00-567f-4fbd-b623-dc3cffb72b00>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd32a085-cf72-4968-921c-b40025e31ae4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd32a085-cf72-4968-921c-b40025e31ae4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/30f41658-de25-492e-8410-8732bc2e8126/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd32a085-cf72-4968-921c-b40025e31ae4>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d69630f-aa6b-4f86-8cb4-38c2749d1eee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d69630f-aa6b-4f86-8cb4-38c2749d1eee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/30f41658-de25-492e-8410-8732bc2e8126/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d69630f-aa6b-4f86-8cb4-38c2749d1eee>.
+    
+<http://data.lblod.info/id/remote-data-objects/53309684-9aad-4128-8fa3-6677b71c760c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53309684-9aad-4128-8fa3-6677b71c760c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/30f41658-de25-492e-8410-8732bc2e8126/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53309684-9aad-4128-8fa3-6677b71c760c>.
+    
+<http://data.lblod.info/id/remote-data-objects/54d23cba-ab4e-4dc4-b44b-875fc026c1bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54d23cba-ab4e-4dc4-b44b-875fc026c1bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3277a686-192f-492c-9e1a-d70e1604fbe5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54d23cba-ab4e-4dc4-b44b-875fc026c1bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f19702f-a88f-4ad5-8f5c-d6eda2a034c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f19702f-a88f-4ad5-8f5c-d6eda2a034c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3277a686-192f-492c-9e1a-d70e1604fbe5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f19702f-a88f-4ad5-8f5c-d6eda2a034c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c19c8c8-278d-4d20-99de-550d0d9089c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c19c8c8-278d-4d20-99de-550d0d9089c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3277a686-192f-492c-9e1a-d70e1604fbe5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e69b5865-9aa0-43f2-9530-47b3ae5ccab7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c19c8c8-278d-4d20-99de-550d0d9089c5>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201113-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201113-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201113-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201113-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3f09fb5b-b033-41f3-b18a-6460d948a97e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3f09fb5b-b033-41f3-b18a-6460d948a97e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7b9844e0-a321-49da-abb2-12d031fe2043";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/29594cb7-197d-4836-9332-d702d78f7d34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "29594cb7-197d-4836-9332-d702d78f7d34";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043>.
+
+  <http://redpencil.data.gift/id/task/f700a5e7-7e13-4971-9f8c-e0f7f2fdc3b3> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f700a5e7-7e13-4971-9f8c-e0f7f2fdc3b3";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3f09fb5b-b033-41f3-b18a-6460d948a97e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/29594cb7-197d-4836-9332-d702d78f7d34>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/267ac3a9-df8e-451b-ad4c-de132743727c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "267ac3a9-df8e-451b-ad4c-de132743727c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/37028d6a-14b4-40f0-bd74-3f5fb633163f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/267ac3a9-df8e-451b-ad4c-de132743727c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a1161e9-c3d3-4145-849d-7d081cf83602> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a1161e9-c3d3-4145-849d-7d081cf83602";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/37028d6a-14b4-40f0-bd74-3f5fb633163f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a1161e9-c3d3-4145-849d-7d081cf83602>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b876d72-2640-4268-a7e2-2154f004e20e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b876d72-2640-4268-a7e2-2154f004e20e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/37028d6a-14b4-40f0-bd74-3f5fb633163f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b876d72-2640-4268-a7e2-2154f004e20e>.
+    
+<http://data.lblod.info/id/remote-data-objects/78aaa256-f716-486c-9f1a-76c36ec5e973> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78aaa256-f716-486c-9f1a-76c36ec5e973";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3915e0da-4a8e-4ff5-9cbb-a4aaf1122e1c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78aaa256-f716-486c-9f1a-76c36ec5e973>.
+    
+<http://data.lblod.info/id/remote-data-objects/f114e124-871a-45df-bfc0-e5c83a126497> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f114e124-871a-45df-bfc0-e5c83a126497";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3915e0da-4a8e-4ff5-9cbb-a4aaf1122e1c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f114e124-871a-45df-bfc0-e5c83a126497>.
+    
+<http://data.lblod.info/id/remote-data-objects/47ada6a5-314f-40ec-a6f3-e6bea44cf66d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47ada6a5-314f-40ec-a6f3-e6bea44cf66d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3915e0da-4a8e-4ff5-9cbb-a4aaf1122e1c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47ada6a5-314f-40ec-a6f3-e6bea44cf66d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4f3039a-12bc-40ee-a6e1-0d6b3ff917c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4f3039a-12bc-40ee-a6e1-0d6b3ff917c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3d69e52f-2e56-4108-9a3c-8c1c2e36a557/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4f3039a-12bc-40ee-a6e1-0d6b3ff917c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/50ed2ea7-00c4-4451-b984-bd0db5578d87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50ed2ea7-00c4-4451-b984-bd0db5578d87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3d69e52f-2e56-4108-9a3c-8c1c2e36a557/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50ed2ea7-00c4-4451-b984-bd0db5578d87>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c3071f4-b200-412a-a7fe-3f5f235a177a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c3071f4-b200-412a-a7fe-3f5f235a177a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3d69e52f-2e56-4108-9a3c-8c1c2e36a557/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c3071f4-b200-412a-a7fe-3f5f235a177a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a707b429-b948-4768-ba28-80d105af5b4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a707b429-b948-4768-ba28-80d105af5b4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3d79cc4c-b340-475e-aa06-7ed4bcb69adc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a707b429-b948-4768-ba28-80d105af5b4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/09808b13-d360-42f1-8b68-71b796256744> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09808b13-d360-42f1-8b68-71b796256744";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3d79cc4c-b340-475e-aa06-7ed4bcb69adc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09808b13-d360-42f1-8b68-71b796256744>.
+    
+<http://data.lblod.info/id/remote-data-objects/a36760ff-932f-411c-a7d2-71e2dde4a515> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a36760ff-932f-411c-a7d2-71e2dde4a515";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3d79cc4c-b340-475e-aa06-7ed4bcb69adc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a36760ff-932f-411c-a7d2-71e2dde4a515>.
+    
+<http://data.lblod.info/id/remote-data-objects/a96c8b07-31e5-4451-8c6d-d46cd02071a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a96c8b07-31e5-4451-8c6d-d46cd02071a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3da89e33-cca3-4a21-897b-8213a9353649/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a96c8b07-31e5-4451-8c6d-d46cd02071a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e6bf730-7b74-4816-a287-5bf17782adc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e6bf730-7b74-4816-a287-5bf17782adc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3da89e33-cca3-4a21-897b-8213a9353649/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e6bf730-7b74-4816-a287-5bf17782adc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ca4dd82-7e14-4672-b7ed-569fdbf03561> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ca4dd82-7e14-4672-b7ed-569fdbf03561";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3da89e33-cca3-4a21-897b-8213a9353649/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ca4dd82-7e14-4672-b7ed-569fdbf03561>.
+    
+<http://data.lblod.info/id/remote-data-objects/65a9ae05-b17f-41d0-808e-ba7650a50014> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65a9ae05-b17f-41d0-808e-ba7650a50014";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3f89a135-f44a-4d02-819b-2e0dc6754c29/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65a9ae05-b17f-41d0-808e-ba7650a50014>.
+    
+<http://data.lblod.info/id/remote-data-objects/b964b542-4fdd-4c94-8d52-dd42d793cd7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b964b542-4fdd-4c94-8d52-dd42d793cd7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3f89a135-f44a-4d02-819b-2e0dc6754c29/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b964b542-4fdd-4c94-8d52-dd42d793cd7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f43867c-2db7-4be2-b612-77395486af9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f43867c-2db7-4be2-b612-77395486af9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/3f89a135-f44a-4d02-819b-2e0dc6754c29/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f43867c-2db7-4be2-b612-77395486af9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/dce47582-6a99-4dad-bba6-73edda6c74ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dce47582-6a99-4dad-bba6-73edda6c74ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/41b3944e-725c-4065-b3a7-1cd2715dd664/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dce47582-6a99-4dad-bba6-73edda6c74ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b258240-5a16-487c-bae2-f83e5783c634> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b258240-5a16-487c-bae2-f83e5783c634";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/41b3944e-725c-4065-b3a7-1cd2715dd664/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b258240-5a16-487c-bae2-f83e5783c634>.
+    
+<http://data.lblod.info/id/remote-data-objects/92526414-a2c9-41cd-ad94-64c7f70b6c93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92526414-a2c9-41cd-ad94-64c7f70b6c93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/41b3944e-725c-4065-b3a7-1cd2715dd664/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92526414-a2c9-41cd-ad94-64c7f70b6c93>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ba94176-4d12-4abc-8e08-c48a8639eddd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ba94176-4d12-4abc-8e08-c48a8639eddd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/4c23f5a0-d79c-4689-b410-ce4a974d3203/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ba94176-4d12-4abc-8e08-c48a8639eddd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6d37bb8-f15e-4c6c-9e9a-4c35ec7cb846> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6d37bb8-f15e-4c6c-9e9a-4c35ec7cb846";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/4c23f5a0-d79c-4689-b410-ce4a974d3203/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6d37bb8-f15e-4c6c-9e9a-4c35ec7cb846>.
+    
+<http://data.lblod.info/id/remote-data-objects/47eb1665-177f-494c-9585-e6bd9d37deac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47eb1665-177f-494c-9585-e6bd9d37deac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/4c23f5a0-d79c-4689-b410-ce4a974d3203/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47eb1665-177f-494c-9585-e6bd9d37deac>.
+    
+<http://data.lblod.info/id/remote-data-objects/8dab6213-ed11-4869-8ec4-6ab95b841108> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8dab6213-ed11-4869-8ec4-6ab95b841108";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/4c7b9378-c305-4295-b02d-9f65f301f10e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8dab6213-ed11-4869-8ec4-6ab95b841108>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1fbb208-64cb-4a7d-b8d7-b1b86ea0f11a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1fbb208-64cb-4a7d-b8d7-b1b86ea0f11a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/4c7b9378-c305-4295-b02d-9f65f301f10e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1fbb208-64cb-4a7d-b8d7-b1b86ea0f11a>.
+    
+<http://data.lblod.info/id/remote-data-objects/eef1dfda-496b-4b74-a3ce-76f1f720146e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eef1dfda-496b-4b74-a3ce-76f1f720146e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/4c7b9378-c305-4295-b02d-9f65f301f10e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eef1dfda-496b-4b74-a3ce-76f1f720146e>.
+    
+<http://data.lblod.info/id/remote-data-objects/93cc8ef0-bbbb-46c0-a7b4-6d16ab66f495> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93cc8ef0-bbbb-46c0-a7b4-6d16ab66f495";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/4d7a5c43-edf9-4058-8a01-aa5d9583266e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93cc8ef0-bbbb-46c0-a7b4-6d16ab66f495>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e28ecd3-18fb-43ad-9373-4778a41716b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e28ecd3-18fb-43ad-9373-4778a41716b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/4d7a5c43-edf9-4058-8a01-aa5d9583266e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e28ecd3-18fb-43ad-9373-4778a41716b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/78a7ef0a-fc32-4bdf-a8e1-595c65a91b81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78a7ef0a-fc32-4bdf-a8e1-595c65a91b81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/4d7a5c43-edf9-4058-8a01-aa5d9583266e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78a7ef0a-fc32-4bdf-a8e1-595c65a91b81>.
+    
+<http://data.lblod.info/id/remote-data-objects/625872b9-3bd8-4384-aad2-a8212111e8e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "625872b9-3bd8-4384-aad2-a8212111e8e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/541c42c7-fc89-41b7-8616-2a3b330f73ae/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/625872b9-3bd8-4384-aad2-a8212111e8e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f23349d0-8832-4130-a432-a5d6b94e82b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f23349d0-8832-4130-a432-a5d6b94e82b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/541c42c7-fc89-41b7-8616-2a3b330f73ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f23349d0-8832-4130-a432-a5d6b94e82b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/5de304d9-def2-4111-bb12-b2b7b1bbe46d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5de304d9-def2-4111-bb12-b2b7b1bbe46d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/541c42c7-fc89-41b7-8616-2a3b330f73ae/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5de304d9-def2-4111-bb12-b2b7b1bbe46d>.
+    
+<http://data.lblod.info/id/remote-data-objects/72bbc12a-28b2-4403-afc8-046bfb4bf4aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72bbc12a-28b2-4403-afc8-046bfb4bf4aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/58aeee0a-4e11-4277-851e-7603fc465433/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72bbc12a-28b2-4403-afc8-046bfb4bf4aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/17ebabde-6970-4ad8-ad8e-4e5cb218aa4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17ebabde-6970-4ad8-ad8e-4e5cb218aa4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/58aeee0a-4e11-4277-851e-7603fc465433/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17ebabde-6970-4ad8-ad8e-4e5cb218aa4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/df392b73-64a4-4283-9902-ed0c61a213b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df392b73-64a4-4283-9902-ed0c61a213b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/58aeee0a-4e11-4277-851e-7603fc465433/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df392b73-64a4-4283-9902-ed0c61a213b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/53b24a06-c97c-471f-bfbb-4a114e02efcf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53b24a06-c97c-471f-bfbb-4a114e02efcf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/5ba8c06d-02aa-40e6-9cec-fe0528ca46a4/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53b24a06-c97c-471f-bfbb-4a114e02efcf>.
+    
+<http://data.lblod.info/id/remote-data-objects/86150cb5-eede-4f13-a1b9-f077e0a5aaf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86150cb5-eede-4f13-a1b9-f077e0a5aaf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/5ba8c06d-02aa-40e6-9cec-fe0528ca46a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86150cb5-eede-4f13-a1b9-f077e0a5aaf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd071fea-693d-4fbb-861a-63e06c035e6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd071fea-693d-4fbb-861a-63e06c035e6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/5ba8c06d-02aa-40e6-9cec-fe0528ca46a4/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd071fea-693d-4fbb-861a-63e06c035e6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/65e68e82-ca35-4af7-b511-945adccfc7a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65e68e82-ca35-4af7-b511-945adccfc7a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/628a1aa8-36de-4bda-85c4-2d1a241d7f6a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65e68e82-ca35-4af7-b511-945adccfc7a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/4345dfbf-a052-4a8e-8900-95c9904c6523> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4345dfbf-a052-4a8e-8900-95c9904c6523";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/628a1aa8-36de-4bda-85c4-2d1a241d7f6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4345dfbf-a052-4a8e-8900-95c9904c6523>.
+    
+<http://data.lblod.info/id/remote-data-objects/6883c5cf-308f-4b5c-b369-1cbaff3d0ba8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6883c5cf-308f-4b5c-b369-1cbaff3d0ba8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/628a1aa8-36de-4bda-85c4-2d1a241d7f6a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6883c5cf-308f-4b5c-b369-1cbaff3d0ba8>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd527741-ad87-438c-bc75-6891c1e05270> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd527741-ad87-438c-bc75-6891c1e05270";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/6afaec34-8437-41c0-b245-9f2dde0b6ed4/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd527741-ad87-438c-bc75-6891c1e05270>.
+    
+<http://data.lblod.info/id/remote-data-objects/def80ca6-7364-4566-b3a4-618c153b0ebf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "def80ca6-7364-4566-b3a4-618c153b0ebf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/6afaec34-8437-41c0-b245-9f2dde0b6ed4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/def80ca6-7364-4566-b3a4-618c153b0ebf>.
+    
+<http://data.lblod.info/id/remote-data-objects/73567bfc-bd0c-43f3-8cce-83a17827cd52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73567bfc-bd0c-43f3-8cce-83a17827cd52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/6afaec34-8437-41c0-b245-9f2dde0b6ed4/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73567bfc-bd0c-43f3-8cce-83a17827cd52>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c9f2246-3767-41a3-ad8b-c1c2ab1688ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c9f2246-3767-41a3-ad8b-c1c2ab1688ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/6ee5cf78-72ae-40c3-9e36-e4fc5a4fce44/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c9f2246-3767-41a3-ad8b-c1c2ab1688ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9d07179-c621-444d-8578-cd7f3166694c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9d07179-c621-444d-8578-cd7f3166694c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/6ee5cf78-72ae-40c3-9e36-e4fc5a4fce44/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9d07179-c621-444d-8578-cd7f3166694c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f00f2bd-1b64-4fad-ae18-308260456b08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f00f2bd-1b64-4fad-ae18-308260456b08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/6ee5cf78-72ae-40c3-9e36-e4fc5a4fce44/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f00f2bd-1b64-4fad-ae18-308260456b08>.
+    
+<http://data.lblod.info/id/remote-data-objects/25ab093f-73b5-4983-b0c9-4d521a990ab8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25ab093f-73b5-4983-b0c9-4d521a990ab8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/6ef9dfdf-7b03-46f1-b9ae-81eb9b05293d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25ab093f-73b5-4983-b0c9-4d521a990ab8>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe18fa41-2a19-4ce6-b6bb-1300c3208a85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe18fa41-2a19-4ce6-b6bb-1300c3208a85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/6ef9dfdf-7b03-46f1-b9ae-81eb9b05293d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7b9844e0-a321-49da-abb2-12d031fe2043> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe18fa41-2a19-4ce6-b6bb-1300c3208a85>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201114-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201114-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201114-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201114-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/0a6d6c22-4881-4c78-8a7c-cb64b32403b0> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0a6d6c22-4881-4c78-8a7c-cb64b32403b0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "781d0135-8826-49e7-ace9-8b847a104731";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e6a7f9ee-997a-48e5-9ba1-92617bbffb93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e6a7f9ee-997a-48e5-9ba1-92617bbffb93";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731>.
+
+  <http://redpencil.data.gift/id/task/1cb5b3a4-d07f-4f01-828e-1fe17f17d378> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1cb5b3a4-d07f-4f01-828e-1fe17f17d378";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/0a6d6c22-4881-4c78-8a7c-cb64b32403b0>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e6a7f9ee-997a-48e5-9ba1-92617bbffb93>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/277e6d80-270b-49d6-9d8e-8590cee5ddde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "277e6d80-270b-49d6-9d8e-8590cee5ddde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/6ef9dfdf-7b03-46f1-b9ae-81eb9b05293d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/277e6d80-270b-49d6-9d8e-8590cee5ddde>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6a54ea2-466f-416a-8701-48e05e5c658b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6a54ea2-466f-416a-8701-48e05e5c658b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/754dc624-65a7-4f8d-8fb6-023722f7e3c6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6a54ea2-466f-416a-8701-48e05e5c658b>.
+    
+<http://data.lblod.info/id/remote-data-objects/657de771-d0bf-4aa4-89e2-9b917a1bbf72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "657de771-d0bf-4aa4-89e2-9b917a1bbf72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/754dc624-65a7-4f8d-8fb6-023722f7e3c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/657de771-d0bf-4aa4-89e2-9b917a1bbf72>.
+    
+<http://data.lblod.info/id/remote-data-objects/2959116e-299e-4f70-9dee-07273393678b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2959116e-299e-4f70-9dee-07273393678b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/754dc624-65a7-4f8d-8fb6-023722f7e3c6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2959116e-299e-4f70-9dee-07273393678b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a007e536-0766-4785-bbec-a4616f0769a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a007e536-0766-4785-bbec-a4616f0769a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/794da7ff-29a7-47a7-b9f8-a92bd59b98ce/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a007e536-0766-4785-bbec-a4616f0769a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c5b9e35-c9e8-4bd7-b436-71e62d0f8a2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c5b9e35-c9e8-4bd7-b436-71e62d0f8a2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/794da7ff-29a7-47a7-b9f8-a92bd59b98ce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c5b9e35-c9e8-4bd7-b436-71e62d0f8a2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c01d739c-a636-42d6-9a4e-c90d00734982> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c01d739c-a636-42d6-9a4e-c90d00734982";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/794da7ff-29a7-47a7-b9f8-a92bd59b98ce/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c01d739c-a636-42d6-9a4e-c90d00734982>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d81ca6e-5c66-4f9c-96dc-96b55d8814a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d81ca6e-5c66-4f9c-96dc-96b55d8814a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/8584b83d-7f3f-4133-8af6-7b836953d600/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d81ca6e-5c66-4f9c-96dc-96b55d8814a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f783341a-291a-45a6-a8b1-98b60d61229b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f783341a-291a-45a6-a8b1-98b60d61229b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/8584b83d-7f3f-4133-8af6-7b836953d600/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f783341a-291a-45a6-a8b1-98b60d61229b>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb9b86b7-15b7-4ebf-bca0-8cc19b8b09e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb9b86b7-15b7-4ebf-bca0-8cc19b8b09e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/8584b83d-7f3f-4133-8af6-7b836953d600/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb9b86b7-15b7-4ebf-bca0-8cc19b8b09e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a3887ea-13b3-415b-a056-e1f8c297a8bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a3887ea-13b3-415b-a056-e1f8c297a8bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/87584034-c462-45b3-a88a-89090cda879e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a3887ea-13b3-415b-a056-e1f8c297a8bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/e734ccb2-f30e-4639-b414-8e83cf00902a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e734ccb2-f30e-4639-b414-8e83cf00902a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/87584034-c462-45b3-a88a-89090cda879e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e734ccb2-f30e-4639-b414-8e83cf00902a>.
+    
+<http://data.lblod.info/id/remote-data-objects/409df3d3-8395-40c5-97e0-654ad05f9d8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "409df3d3-8395-40c5-97e0-654ad05f9d8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/87584034-c462-45b3-a88a-89090cda879e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/409df3d3-8395-40c5-97e0-654ad05f9d8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/54e25c93-0770-4fff-8a38-0d1e5c820f1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54e25c93-0770-4fff-8a38-0d1e5c820f1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/87a2eb96-ce2b-4720-8196-c40bbce9ae5f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54e25c93-0770-4fff-8a38-0d1e5c820f1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/06143ecb-8ae3-4087-a6bb-9605d58c55e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06143ecb-8ae3-4087-a6bb-9605d58c55e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/87a2eb96-ce2b-4720-8196-c40bbce9ae5f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06143ecb-8ae3-4087-a6bb-9605d58c55e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1f95108-8f5f-4848-83eb-7769ab45e2fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1f95108-8f5f-4848-83eb-7769ab45e2fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/87a2eb96-ce2b-4720-8196-c40bbce9ae5f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1f95108-8f5f-4848-83eb-7769ab45e2fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/31d14caf-476b-4992-b531-7033754077db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31d14caf-476b-4992-b531-7033754077db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/88bba830-2949-4a53-9389-cfc62569f9c0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31d14caf-476b-4992-b531-7033754077db>.
+    
+<http://data.lblod.info/id/remote-data-objects/2aaac22d-b757-4eb4-9361-a5298be65d76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2aaac22d-b757-4eb4-9361-a5298be65d76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/88bba830-2949-4a53-9389-cfc62569f9c0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2aaac22d-b757-4eb4-9361-a5298be65d76>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbfe853c-2454-4a6f-a020-0577593aab02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbfe853c-2454-4a6f-a020-0577593aab02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/88bba830-2949-4a53-9389-cfc62569f9c0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbfe853c-2454-4a6f-a020-0577593aab02>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcd081ce-0915-45e8-8b5e-05a623025b05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcd081ce-0915-45e8-8b5e-05a623025b05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/89216842-5d30-4bda-bf8e-1c4156983663/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcd081ce-0915-45e8-8b5e-05a623025b05>.
+    
+<http://data.lblod.info/id/remote-data-objects/bea1e068-d0d7-4946-af91-90e6be24f9b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bea1e068-d0d7-4946-af91-90e6be24f9b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/89216842-5d30-4bda-bf8e-1c4156983663/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bea1e068-d0d7-4946-af91-90e6be24f9b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/90d56132-f4ec-48fa-9384-780e1c8ad338> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90d56132-f4ec-48fa-9384-780e1c8ad338";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/89216842-5d30-4bda-bf8e-1c4156983663/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90d56132-f4ec-48fa-9384-780e1c8ad338>.
+    
+<http://data.lblod.info/id/remote-data-objects/717c3ca6-7853-4435-84b7-094386f62b28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "717c3ca6-7853-4435-84b7-094386f62b28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/8af0dfcf-81dc-4958-9e70-d20e5d90cd01/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/717c3ca6-7853-4435-84b7-094386f62b28>.
+    
+<http://data.lblod.info/id/remote-data-objects/68945290-0680-429a-b5c3-327a784f81a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68945290-0680-429a-b5c3-327a784f81a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/8af0dfcf-81dc-4958-9e70-d20e5d90cd01/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68945290-0680-429a-b5c3-327a784f81a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a4a05a5-9fe2-4e2b-a684-984c3c7527be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a4a05a5-9fe2-4e2b-a684-984c3c7527be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/8af0dfcf-81dc-4958-9e70-d20e5d90cd01/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a4a05a5-9fe2-4e2b-a684-984c3c7527be>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac1e3b4d-b362-4ec7-914c-60c8b318e937> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac1e3b4d-b362-4ec7-914c-60c8b318e937";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/a114ce1c-412e-404e-8ad5-cbf3e906f689/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac1e3b4d-b362-4ec7-914c-60c8b318e937>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f47af20-f01e-4a30-89ce-a984bc14b202> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f47af20-f01e-4a30-89ce-a984bc14b202";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/a114ce1c-412e-404e-8ad5-cbf3e906f689/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f47af20-f01e-4a30-89ce-a984bc14b202>.
+    
+<http://data.lblod.info/id/remote-data-objects/829bed2b-9af4-4ebe-86d0-b14ba78908fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "829bed2b-9af4-4ebe-86d0-b14ba78908fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/a114ce1c-412e-404e-8ad5-cbf3e906f689/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/829bed2b-9af4-4ebe-86d0-b14ba78908fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed84c221-d4af-4f8a-a550-457f37779526> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed84c221-d4af-4f8a-a550-457f37779526";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/a1512f32-3c0b-4848-b488-558f5d0d8b0b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed84c221-d4af-4f8a-a550-457f37779526>.
+    
+<http://data.lblod.info/id/remote-data-objects/cba149bc-350f-4de2-94a5-d86efc440b89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cba149bc-350f-4de2-94a5-d86efc440b89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/a1512f32-3c0b-4848-b488-558f5d0d8b0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cba149bc-350f-4de2-94a5-d86efc440b89>.
+    
+<http://data.lblod.info/id/remote-data-objects/19c2038b-7b6c-454d-8fac-3e84d82c2936> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19c2038b-7b6c-454d-8fac-3e84d82c2936";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/a1512f32-3c0b-4848-b488-558f5d0d8b0b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19c2038b-7b6c-454d-8fac-3e84d82c2936>.
+    
+<http://data.lblod.info/id/remote-data-objects/883a3a84-b51f-4552-bb51-f095e7e9dccb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "883a3a84-b51f-4552-bb51-f095e7e9dccb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/a17f3be3-8ba6-449a-becf-5a4b60d02bee/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/883a3a84-b51f-4552-bb51-f095e7e9dccb>.
+    
+<http://data.lblod.info/id/remote-data-objects/b58068c9-a5be-4faf-a9f0-40dbfb926aac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b58068c9-a5be-4faf-a9f0-40dbfb926aac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/a17f3be3-8ba6-449a-becf-5a4b60d02bee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b58068c9-a5be-4faf-a9f0-40dbfb926aac>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cc32207-1a23-4ac5-bc03-e77764dfabe1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cc32207-1a23-4ac5-bc03-e77764dfabe1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/a17f3be3-8ba6-449a-becf-5a4b60d02bee/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cc32207-1a23-4ac5-bc03-e77764dfabe1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec6ae2f4-cf42-459b-92d7-e03e7f222829> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec6ae2f4-cf42-459b-92d7-e03e7f222829";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/a4c97670-0b61-4b91-a3e8-1b596eb6933c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec6ae2f4-cf42-459b-92d7-e03e7f222829>.
+    
+<http://data.lblod.info/id/remote-data-objects/15cac603-6361-4a22-93f6-3546358a51a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15cac603-6361-4a22-93f6-3546358a51a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/a4c97670-0b61-4b91-a3e8-1b596eb6933c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15cac603-6361-4a22-93f6-3546358a51a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/52854fb3-36b5-4778-a009-4b888bdb199a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52854fb3-36b5-4778-a009-4b888bdb199a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/a4c97670-0b61-4b91-a3e8-1b596eb6933c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52854fb3-36b5-4778-a009-4b888bdb199a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e54fffb7-5f25-4adb-89b2-2fceef24eb52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e54fffb7-5f25-4adb-89b2-2fceef24eb52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/a5324498-37d4-4a54-adca-1f4c2207f335/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e54fffb7-5f25-4adb-89b2-2fceef24eb52>.
+    
+<http://data.lblod.info/id/remote-data-objects/a790c25b-9d1b-4261-82db-bb11308b2812> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a790c25b-9d1b-4261-82db-bb11308b2812";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/a5324498-37d4-4a54-adca-1f4c2207f335/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a790c25b-9d1b-4261-82db-bb11308b2812>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1c1bc8e-6941-4686-b25d-a0bd462a06aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1c1bc8e-6941-4686-b25d-a0bd462a06aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/a5324498-37d4-4a54-adca-1f4c2207f335/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1c1bc8e-6941-4686-b25d-a0bd462a06aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b0210de-9c9d-4ac2-b7a8-b9ea6fcddddf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b0210de-9c9d-4ac2-b7a8-b9ea6fcddddf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/b252933a-fc8b-4858-8c08-c582195fd534/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b0210de-9c9d-4ac2-b7a8-b9ea6fcddddf>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e0cd48d-27f2-4317-8b9b-c3570888e4ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e0cd48d-27f2-4317-8b9b-c3570888e4ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/b252933a-fc8b-4858-8c08-c582195fd534/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e0cd48d-27f2-4317-8b9b-c3570888e4ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/557e7502-b024-4dd7-8241-8e5c4a929e11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "557e7502-b024-4dd7-8241-8e5c4a929e11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/b252933a-fc8b-4858-8c08-c582195fd534/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/557e7502-b024-4dd7-8241-8e5c4a929e11>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c81544e-466c-4a8d-b12c-1e71824c6161> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c81544e-466c-4a8d-b12c-1e71824c6161";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/b3605aae-2acc-437e-be69-c83900173fce/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c81544e-466c-4a8d-b12c-1e71824c6161>.
+    
+<http://data.lblod.info/id/remote-data-objects/722f7312-584a-4b51-813e-81fe7fc1236e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "722f7312-584a-4b51-813e-81fe7fc1236e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/b3605aae-2acc-437e-be69-c83900173fce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/722f7312-584a-4b51-813e-81fe7fc1236e>.
+    
+<http://data.lblod.info/id/remote-data-objects/142d6c41-a2a3-46e7-8407-af7b1a03e7f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "142d6c41-a2a3-46e7-8407-af7b1a03e7f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/b3605aae-2acc-437e-be69-c83900173fce/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/142d6c41-a2a3-46e7-8407-af7b1a03e7f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/92cce665-27c6-4e8b-b674-a988f7076caa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92cce665-27c6-4e8b-b674-a988f7076caa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/b83d1615-9662-4611-be3f-d4d0c84e0386/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92cce665-27c6-4e8b-b674-a988f7076caa>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6352ec3-3f94-4a97-89c1-f01bbd36605f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6352ec3-3f94-4a97-89c1-f01bbd36605f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/b83d1615-9662-4611-be3f-d4d0c84e0386/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6352ec3-3f94-4a97-89c1-f01bbd36605f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a4b9d21-fd48-4ba2-a529-80f5c5052824> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a4b9d21-fd48-4ba2-a529-80f5c5052824";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/b83d1615-9662-4611-be3f-d4d0c84e0386/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a4b9d21-fd48-4ba2-a529-80f5c5052824>.
+    
+<http://data.lblod.info/id/remote-data-objects/e487f454-45c4-4d9f-80c5-328dfc8ebbc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e487f454-45c4-4d9f-80c5-328dfc8ebbc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/ba328a45-c562-4784-b88d-26a44f27003b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/781d0135-8826-49e7-ace9-8b847a104731> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e487f454-45c4-4d9f-80c5-328dfc8ebbc7>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201115-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201115-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201115-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201115-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/605b25da-4e7c-4f11-997d-e7a0b80b5bf5> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "605b25da-4e7c-4f11-997d-e7a0b80b5bf5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f2b432fb-1e77-4d19-9524-77e6bb5d93c9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a25282b2-f6ba-4cd3-9e6f-78e0f390b8ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a25282b2-f6ba-4cd3-9e6f-78e0f390b8ef";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9>.
+
+  <http://redpencil.data.gift/id/task/92c153ef-8d2a-4529-bdbd-18655b97ab29> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "92c153ef-8d2a-4529-bdbd-18655b97ab29";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/605b25da-4e7c-4f11-997d-e7a0b80b5bf5>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a25282b2-f6ba-4cd3-9e6f-78e0f390b8ef>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b6f679d4-c962-4158-a78d-b76e88b3e22b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6f679d4-c962-4158-a78d-b76e88b3e22b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/ba328a45-c562-4784-b88d-26a44f27003b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6f679d4-c962-4158-a78d-b76e88b3e22b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff60cb8c-972d-4123-ab96-f92794d9f8cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff60cb8c-972d-4123-ab96-f92794d9f8cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/bf5cb907-7e0f-48f3-aecc-b7c06da64ccf/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff60cb8c-972d-4123-ab96-f92794d9f8cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd742034-199f-4072-82f5-a203c978fabf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd742034-199f-4072-82f5-a203c978fabf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/bf5cb907-7e0f-48f3-aecc-b7c06da64ccf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd742034-199f-4072-82f5-a203c978fabf>.
+    
+<http://data.lblod.info/id/remote-data-objects/d07dc64f-7552-4297-bea4-810b729f0d06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d07dc64f-7552-4297-bea4-810b729f0d06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/bf5cb907-7e0f-48f3-aecc-b7c06da64ccf/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d07dc64f-7552-4297-bea4-810b729f0d06>.
+    
+<http://data.lblod.info/id/remote-data-objects/a052c26b-15ad-4d2b-8f98-936713dafe0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a052c26b-15ad-4d2b-8f98-936713dafe0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/bfadb24a-372a-473f-80e7-8bfa039c8666/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a052c26b-15ad-4d2b-8f98-936713dafe0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/377e8b4f-9232-44c4-9240-1ad5dee5a86b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "377e8b4f-9232-44c4-9240-1ad5dee5a86b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/bfadb24a-372a-473f-80e7-8bfa039c8666/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/377e8b4f-9232-44c4-9240-1ad5dee5a86b>.
+    
+<http://data.lblod.info/id/remote-data-objects/09e835b3-88e8-432b-878a-a8313d27b17d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09e835b3-88e8-432b-878a-a8313d27b17d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/bfadb24a-372a-473f-80e7-8bfa039c8666/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09e835b3-88e8-432b-878a-a8313d27b17d>.
+    
+<http://data.lblod.info/id/remote-data-objects/12e9bcfb-6fc7-4f24-9e3b-0ae1458eca04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12e9bcfb-6fc7-4f24-9e3b-0ae1458eca04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/c1193960-43ac-4553-ac2a-de101dfc4354/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12e9bcfb-6fc7-4f24-9e3b-0ae1458eca04>.
+    
+<http://data.lblod.info/id/remote-data-objects/513ade5e-a3c5-49e8-90b5-5e2c2ed4a814> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "513ade5e-a3c5-49e8-90b5-5e2c2ed4a814";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/c1193960-43ac-4553-ac2a-de101dfc4354/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/513ade5e-a3c5-49e8-90b5-5e2c2ed4a814>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0393f7e-e9bc-49aa-b570-d76d7b04f27e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0393f7e-e9bc-49aa-b570-d76d7b04f27e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/c1193960-43ac-4553-ac2a-de101dfc4354/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0393f7e-e9bc-49aa-b570-d76d7b04f27e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4030858d-666e-4bde-9815-18f59a81be61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4030858d-666e-4bde-9815-18f59a81be61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/c4e4109c-3e44-42cd-af5f-81b548b90991/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4030858d-666e-4bde-9815-18f59a81be61>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb9be5cf-36f8-40b8-922f-693bdad8a61f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb9be5cf-36f8-40b8-922f-693bdad8a61f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/c4e4109c-3e44-42cd-af5f-81b548b90991/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb9be5cf-36f8-40b8-922f-693bdad8a61f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6903ad4d-d600-493f-b865-b374f851801c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6903ad4d-d600-493f-b865-b374f851801c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/c4e4109c-3e44-42cd-af5f-81b548b90991/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6903ad4d-d600-493f-b865-b374f851801c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f97a2ba-4ea5-492d-8eea-b1009afa1a23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f97a2ba-4ea5-492d-8eea-b1009afa1a23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/c9258cbe-a0e8-4bf7-ad29-9fc1b1203920/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f97a2ba-4ea5-492d-8eea-b1009afa1a23>.
+    
+<http://data.lblod.info/id/remote-data-objects/593e8ca7-7bf1-4006-a62e-1349bc064a03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "593e8ca7-7bf1-4006-a62e-1349bc064a03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/c9258cbe-a0e8-4bf7-ad29-9fc1b1203920/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/593e8ca7-7bf1-4006-a62e-1349bc064a03>.
+    
+<http://data.lblod.info/id/remote-data-objects/45f88e3f-db6d-4960-83ae-b08604ef26ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45f88e3f-db6d-4960-83ae-b08604ef26ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/c9258cbe-a0e8-4bf7-ad29-9fc1b1203920/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45f88e3f-db6d-4960-83ae-b08604ef26ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2b8797c-d931-45cb-8d5d-752065bc5886> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2b8797c-d931-45cb-8d5d-752065bc5886";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/c98ba626-c89c-44f4-87f4-9a21981d94a4/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2b8797c-d931-45cb-8d5d-752065bc5886>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dc0736f-a8ac-424b-b65d-d705fb6533b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dc0736f-a8ac-424b-b65d-d705fb6533b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/c98ba626-c89c-44f4-87f4-9a21981d94a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dc0736f-a8ac-424b-b65d-d705fb6533b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/90ff8e41-ba54-4e3f-9fef-8d4abb308520> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90ff8e41-ba54-4e3f-9fef-8d4abb308520";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/c98ba626-c89c-44f4-87f4-9a21981d94a4/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90ff8e41-ba54-4e3f-9fef-8d4abb308520>.
+    
+<http://data.lblod.info/id/remote-data-objects/9656763e-1689-4235-87d9-50e77edf3da7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9656763e-1689-4235-87d9-50e77edf3da7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/d7f11114-95d5-4cd0-9bf2-8757b7c9e726/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9656763e-1689-4235-87d9-50e77edf3da7>.
+    
+<http://data.lblod.info/id/remote-data-objects/3468949c-7e6a-4c50-8285-b27b8260eae8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3468949c-7e6a-4c50-8285-b27b8260eae8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/d7f11114-95d5-4cd0-9bf2-8757b7c9e726/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3468949c-7e6a-4c50-8285-b27b8260eae8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5325f68a-3031-41d8-bd70-9938ebaf0bb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5325f68a-3031-41d8-bd70-9938ebaf0bb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/d7f11114-95d5-4cd0-9bf2-8757b7c9e726/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5325f68a-3031-41d8-bd70-9938ebaf0bb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f3f172f-864a-498a-af3c-18d0fa60a475> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f3f172f-864a-498a-af3c-18d0fa60a475";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/da437ecf-7aff-4686-9970-4daba763fa2d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f3f172f-864a-498a-af3c-18d0fa60a475>.
+    
+<http://data.lblod.info/id/remote-data-objects/a142452a-eb16-477b-8a35-8095d71b4704> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a142452a-eb16-477b-8a35-8095d71b4704";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/da437ecf-7aff-4686-9970-4daba763fa2d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a142452a-eb16-477b-8a35-8095d71b4704>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb4bdae3-8f8b-4de1-aefa-0d07c281716d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb4bdae3-8f8b-4de1-aefa-0d07c281716d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/da437ecf-7aff-4686-9970-4daba763fa2d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb4bdae3-8f8b-4de1-aefa-0d07c281716d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8aa3a0c6-6792-4525-a76c-af276c0f2027> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8aa3a0c6-6792-4525-a76c-af276c0f2027";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/e522ad5f-6329-40e2-9bf7-f2b7f16a2594/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8aa3a0c6-6792-4525-a76c-af276c0f2027>.
+    
+<http://data.lblod.info/id/remote-data-objects/bae63e1a-3710-47ef-8b07-2b29f255a114> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bae63e1a-3710-47ef-8b07-2b29f255a114";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/e522ad5f-6329-40e2-9bf7-f2b7f16a2594/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bae63e1a-3710-47ef-8b07-2b29f255a114>.
+    
+<http://data.lblod.info/id/remote-data-objects/42f82921-b62a-41f2-b2d0-5dd8134e0b24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42f82921-b62a-41f2-b2d0-5dd8134e0b24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/e522ad5f-6329-40e2-9bf7-f2b7f16a2594/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42f82921-b62a-41f2-b2d0-5dd8134e0b24>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b0ece67-0994-43fe-b71e-1ae5589e5f7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b0ece67-0994-43fe-b71e-1ae5589e5f7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/ea15e8b8-79a2-4cde-91f7-d9f798990777/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b0ece67-0994-43fe-b71e-1ae5589e5f7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b8200ae-6f05-4176-863f-093b07746572> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b8200ae-6f05-4176-863f-093b07746572";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/ea15e8b8-79a2-4cde-91f7-d9f798990777/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b8200ae-6f05-4176-863f-093b07746572>.
+    
+<http://data.lblod.info/id/remote-data-objects/f82f0dd3-18ed-463c-b2e6-c3ca80b7c6e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f82f0dd3-18ed-463c-b2e6-c3ca80b7c6e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/ea15e8b8-79a2-4cde-91f7-d9f798990777/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f82f0dd3-18ed-463c-b2e6-c3ca80b7c6e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/386b69ad-c294-4dba-8b60-7845eb594b09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "386b69ad-c294-4dba-8b60-7845eb594b09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/f22506d1-76fa-4bd4-a298-f975cdf99ba0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/386b69ad-c294-4dba-8b60-7845eb594b09>.
+    
+<http://data.lblod.info/id/remote-data-objects/05ab3d8f-8973-41cb-93c1-253bc5100cfb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05ab3d8f-8973-41cb-93c1-253bc5100cfb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/f22506d1-76fa-4bd4-a298-f975cdf99ba0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05ab3d8f-8973-41cb-93c1-253bc5100cfb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c75b0721-b812-42e7-a849-bc68231c2c45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c75b0721-b812-42e7-a849-bc68231c2c45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/f22506d1-76fa-4bd4-a298-f975cdf99ba0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c75b0721-b812-42e7-a849-bc68231c2c45>.
+    
+<http://data.lblod.info/id/remote-data-objects/97b5babd-9dd4-4f6b-81e7-b18d00d8bdfe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97b5babd-9dd4-4f6b-81e7-b18d00d8bdfe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/f34b7761-58f7-42e7-ad8f-17cdd96b76e9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97b5babd-9dd4-4f6b-81e7-b18d00d8bdfe>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2a06213-5554-4f23-81c9-1accac93416b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2a06213-5554-4f23-81c9-1accac93416b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/f34b7761-58f7-42e7-ad8f-17cdd96b76e9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2a06213-5554-4f23-81c9-1accac93416b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d5c5750-903e-4b30-bc93-1dabedf0aba1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d5c5750-903e-4b30-bc93-1dabedf0aba1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/f34b7761-58f7-42e7-ad8f-17cdd96b76e9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d5c5750-903e-4b30-bc93-1dabedf0aba1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8662412c-3d6a-427f-8a20-6a657667ad8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8662412c-3d6a-427f-8a20-6a657667ad8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/f3808480-20e5-43d8-9976-aca193086fc3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8662412c-3d6a-427f-8a20-6a657667ad8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a958851-6096-4698-88f7-acd523e23478> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a958851-6096-4698-88f7-acd523e23478";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/f3808480-20e5-43d8-9976-aca193086fc3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a958851-6096-4698-88f7-acd523e23478>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0bb3030-cf1c-4e20-be6a-8eaff13b01fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0bb3030-cf1c-4e20-be6a-8eaff13b01fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/f3808480-20e5-43d8-9976-aca193086fc3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0bb3030-cf1c-4e20-be6a-8eaff13b01fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/59b62017-8f97-489c-a54b-a469adb980f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59b62017-8f97-489c-a54b-a469adb980f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/f4460d30-6d5a-45e0-8036-53229de65e2f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59b62017-8f97-489c-a54b-a469adb980f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f1f97ca-1b53-478e-a974-b68b294d5a49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f1f97ca-1b53-478e-a974-b68b294d5a49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/f4460d30-6d5a-45e0-8036-53229de65e2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f1f97ca-1b53-478e-a974-b68b294d5a49>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bdd74e1-d1d4-48af-aa37-3f89616db61d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bdd74e1-d1d4-48af-aa37-3f89616db61d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/f4460d30-6d5a-45e0-8036-53229de65e2f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bdd74e1-d1d4-48af-aa37-3f89616db61d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dbcded6-d1f1-4d8f-91c4-28b77f562c95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dbcded6-d1f1-4d8f-91c4-28b77f562c95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/f84a212d-303f-499a-9c38-7bf27ec90344/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dbcded6-d1f1-4d8f-91c4-28b77f562c95>.
+    
+<http://data.lblod.info/id/remote-data-objects/514a5dda-e0ee-4697-b338-488c052dab07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "514a5dda-e0ee-4697-b338-488c052dab07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/f84a212d-303f-499a-9c38-7bf27ec90344/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/514a5dda-e0ee-4697-b338-488c052dab07>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d7094d3-8f1d-44d1-9846-6781b9fbf9be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d7094d3-8f1d-44d1-9846-6781b9fbf9be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/f84a212d-303f-499a-9c38-7bf27ec90344/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d7094d3-8f1d-44d1-9846-6781b9fbf9be>.
+    
+<http://data.lblod.info/id/remote-data-objects/55e1c462-6cf0-415b-862c-fcc76e2f6cf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55e1c462-6cf0-415b-862c-fcc76e2f6cf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/fba784f1-bc51-40f4-8b29-55cc712947ac/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55e1c462-6cf0-415b-862c-fcc76e2f6cf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/39203fb7-d32a-49bc-bc3e-9a36a0354b31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39203fb7-d32a-49bc-bc3e-9a36a0354b31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/fba784f1-bc51-40f4-8b29-55cc712947ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39203fb7-d32a-49bc-bc3e-9a36a0354b31>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe4d4ff3-305f-4cc3-a501-6847e8bb01f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe4d4ff3-305f-4cc3-a501-6847e8bb01f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://deerlijk.meetingburger.net/vabu/fba784f1-bc51-40f4-8b29-55cc712947ac/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe4d4ff3-305f-4cc3-a501-6847e8bb01f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ad4d868-6f6f-4662-853a-21bd16f8b705> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ad4d868-6f6f-4662-853a-21bd16f8b705";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/cbs/0467bf98-ce48-44e3-ada7-d657cc0549e8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f2b432fb-1e77-4d19-9524-77e6bb5d93c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ad4d868-6f6f-4662-853a-21bd16f8b705>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201116-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201116-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201116-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201116-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/6b6795d6-7fec-4cf2-85e6-f29dd9c878ff> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6b6795d6-7fec-4cf2-85e6-f29dd9c878ff";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "65c11eb7-b120-4cdc-a60a-764059e914df";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/12299316-578e-4e2e-918f-1d7ad3f4d695> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "12299316-578e-4e2e-918f-1d7ad3f4d695";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df>.
+
+  <http://redpencil.data.gift/id/task/bc58bdea-8c94-42bc-8947-b3280efff408> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bc58bdea-8c94-42bc-8947-b3280efff408";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/6b6795d6-7fec-4cf2-85e6-f29dd9c878ff>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/12299316-578e-4e2e-918f-1d7ad3f4d695>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/3fb9076a-7a44-419d-b533-8d21e74410ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fb9076a-7a44-419d-b533-8d21e74410ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/cbs/244d9666-a417-48fb-8d92-91b40fbd697e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fb9076a-7a44-419d-b533-8d21e74410ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d4803ca-604d-4953-b0d7-0b717f6f16cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d4803ca-604d-4953-b0d7-0b717f6f16cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/cbs/3bef4c26-e49a-483a-b692-144f53be98fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d4803ca-604d-4953-b0d7-0b717f6f16cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/96253789-83d0-40ca-b90a-b9bcbb93746a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96253789-83d0-40ca-b90a-b9bcbb93746a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/cbs/3e9595f9-2c46-4d32-938d-7b8702489979/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96253789-83d0-40ca-b90a-b9bcbb93746a>.
+    
+<http://data.lblod.info/id/remote-data-objects/545d38ba-8762-4fa1-88e7-80b07df63e1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "545d38ba-8762-4fa1-88e7-80b07df63e1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/cbs/45d70aff-56a0-4966-8823-bc7c916889df/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/545d38ba-8762-4fa1-88e7-80b07df63e1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4909b2e0-c30d-42fb-9443-944ea638653f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4909b2e0-c30d-42fb-9443-944ea638653f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/cbs/586ff3e9-b99f-47e8-929d-5b0370cd2137/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4909b2e0-c30d-42fb-9443-944ea638653f>.
+    
+<http://data.lblod.info/id/remote-data-objects/933cdfa8-d7b0-49fa-bbd2-511a07048b4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "933cdfa8-d7b0-49fa-bbd2-511a07048b4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/cbs/5c952f63-6f8d-44b8-af72-7144a654f30e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/933cdfa8-d7b0-49fa-bbd2-511a07048b4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5efa59d-c89e-43b4-90aa-6efe2e9d090e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5efa59d-c89e-43b4-90aa-6efe2e9d090e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/cbs/acde20e9-98fb-4c2f-85dd-1a96678000e8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5efa59d-c89e-43b4-90aa-6efe2e9d090e>.
+    
+<http://data.lblod.info/id/remote-data-objects/92552eaf-1960-44df-b202-09a4396af948> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92552eaf-1960-44df-b202-09a4396af948";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/cbs/b05d5826-f177-421c-86b5-d39c0a748e36/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92552eaf-1960-44df-b202-09a4396af948>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3b60767-e705-453a-84d4-8ee141d7bd63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3b60767-e705-453a-84d4-8ee141d7bd63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/cbs/b16a770f-b4dc-4c4b-a21b-c63e4df1f8ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3b60767-e705-453a-84d4-8ee141d7bd63>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0866aaa-f13f-4045-84b2-832bc9ec3a2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0866aaa-f13f-4045-84b2-832bc9ec3a2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/cbs/c8f1f47f-e87d-477a-91f4-0e54ac064dfc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0866aaa-f13f-4045-84b2-832bc9ec3a2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1627e8f2-a9b9-4d71-9c36-62617c40e6a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1627e8f2-a9b9-4d71-9c36-62617c40e6a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/cbs/e1bc6ba0-ff2d-47bf-b2ed-cb4d1e12f972/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1627e8f2-a9b9-4d71-9c36-62617c40e6a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/59d7a9cc-05a0-404e-b2d3-77a8dd6b2f9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59d7a9cc-05a0-404e-b2d3-77a8dd6b2f9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/19bb55c6-de89-4d7a-bb27-2422797a07bf/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59d7a9cc-05a0-404e-b2d3-77a8dd6b2f9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f53644b-4b2b-4539-bcf3-471bca580420> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f53644b-4b2b-4539-bcf3-471bca580420";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/19bb55c6-de89-4d7a-bb27-2422797a07bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f53644b-4b2b-4539-bcf3-471bca580420>.
+    
+<http://data.lblod.info/id/remote-data-objects/801ab79f-4739-4dc5-8cb8-833182c1ea9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "801ab79f-4739-4dc5-8cb8-833182c1ea9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/19bb55c6-de89-4d7a-bb27-2422797a07bf/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/801ab79f-4739-4dc5-8cb8-833182c1ea9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/acdec78b-0af0-45f6-960e-9acbaba93aba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acdec78b-0af0-45f6-960e-9acbaba93aba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/1c3fb116-0f2d-4857-8256-f9cd90b3b871/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acdec78b-0af0-45f6-960e-9acbaba93aba>.
+    
+<http://data.lblod.info/id/remote-data-objects/8568ad89-d625-4dca-9ce9-a0adcc3d27c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8568ad89-d625-4dca-9ce9-a0adcc3d27c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/1c3fb116-0f2d-4857-8256-f9cd90b3b871/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8568ad89-d625-4dca-9ce9-a0adcc3d27c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dd65329-4f13-49a5-8eac-395a6c0afc2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dd65329-4f13-49a5-8eac-395a6c0afc2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/588753bb-ff35-4aac-bc45-0c40b8f7dd8a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dd65329-4f13-49a5-8eac-395a6c0afc2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7ed2eec-e188-4931-a11b-7298d71b1654> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7ed2eec-e188-4931-a11b-7298d71b1654";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/588753bb-ff35-4aac-bc45-0c40b8f7dd8a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7ed2eec-e188-4931-a11b-7298d71b1654>.
+    
+<http://data.lblod.info/id/remote-data-objects/06c382c3-00d5-4266-b7f3-929721be0bc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06c382c3-00d5-4266-b7f3-929721be0bc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/78b332cc-ac4d-484b-af67-ae136a7852d0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06c382c3-00d5-4266-b7f3-929721be0bc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/68f9ab4b-8060-4cbc-bb9e-c785a25bb862> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68f9ab4b-8060-4cbc-bb9e-c785a25bb862";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/78b332cc-ac4d-484b-af67-ae136a7852d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68f9ab4b-8060-4cbc-bb9e-c785a25bb862>.
+    
+<http://data.lblod.info/id/remote-data-objects/50c5a914-1073-4112-82bf-b550b4c0f5eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50c5a914-1073-4112-82bf-b550b4c0f5eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/78b332cc-ac4d-484b-af67-ae136a7852d0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50c5a914-1073-4112-82bf-b550b4c0f5eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b272ea1-b67a-47f2-a141-d26198ca667f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b272ea1-b67a-47f2-a141-d26198ca667f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/7efef806-8cd8-49e4-91ac-dccb668f8cc1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b272ea1-b67a-47f2-a141-d26198ca667f>.
+    
+<http://data.lblod.info/id/remote-data-objects/282755d6-94fb-40e0-acb3-31b5f191ab86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "282755d6-94fb-40e0-acb3-31b5f191ab86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/7efef806-8cd8-49e4-91ac-dccb668f8cc1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/282755d6-94fb-40e0-acb3-31b5f191ab86>.
+    
+<http://data.lblod.info/id/remote-data-objects/170f0c33-779c-41c9-bcef-85257c882ba6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "170f0c33-779c-41c9-bcef-85257c882ba6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/7efef806-8cd8-49e4-91ac-dccb668f8cc1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/170f0c33-779c-41c9-bcef-85257c882ba6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba543fb2-3613-4272-a2b7-10f04aa90108> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba543fb2-3613-4272-a2b7-10f04aa90108";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/823f1ac6-b37e-4571-a87e-e35498560d3a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba543fb2-3613-4272-a2b7-10f04aa90108>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b3e0dc1-4d59-4f50-be43-16c2b8b515cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b3e0dc1-4d59-4f50-be43-16c2b8b515cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/823f1ac6-b37e-4571-a87e-e35498560d3a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b3e0dc1-4d59-4f50-be43-16c2b8b515cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ea4eb59-8c35-422f-b6a8-588c84fa80fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ea4eb59-8c35-422f-b6a8-588c84fa80fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/823f1ac6-b37e-4571-a87e-e35498560d3a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ea4eb59-8c35-422f-b6a8-588c84fa80fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf265278-47f0-40f9-b399-d40f95aada24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf265278-47f0-40f9-b399-d40f95aada24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/9e01a6fa-6bf4-4baa-956c-c3640ad744ba/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf265278-47f0-40f9-b399-d40f95aada24>.
+    
+<http://data.lblod.info/id/remote-data-objects/215019f8-7843-4d00-8dde-ebf15cc2c66c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "215019f8-7843-4d00-8dde-ebf15cc2c66c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/9e01a6fa-6bf4-4baa-956c-c3640ad744ba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/215019f8-7843-4d00-8dde-ebf15cc2c66c>.
+    
+<http://data.lblod.info/id/remote-data-objects/286aa5fd-6ef9-4cdb-b72a-621e9c003d8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "286aa5fd-6ef9-4cdb-b72a-621e9c003d8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/9e01a6fa-6bf4-4baa-956c-c3640ad744ba/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/286aa5fd-6ef9-4cdb-b72a-621e9c003d8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b1afc0f-c8b5-4934-9594-c5a3a021166c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b1afc0f-c8b5-4934-9594-c5a3a021166c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/bed48424-766f-437b-b639-d5406839d800/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b1afc0f-c8b5-4934-9594-c5a3a021166c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5be0b98-22ea-45d7-a68f-e71065d20c0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5be0b98-22ea-45d7-a68f-e71065d20c0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/bed48424-766f-437b-b639-d5406839d800/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5be0b98-22ea-45d7-a68f-e71065d20c0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3720ac8a-706c-4077-8b09-900d3afb9f94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3720ac8a-706c-4077-8b09-900d3afb9f94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/bed48424-766f-437b-b639-d5406839d800/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3720ac8a-706c-4077-8b09-900d3afb9f94>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3c28820-afe0-42fb-99fa-decd7b5ca4e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3c28820-afe0-42fb-99fa-decd7b5ca4e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/d1e2aa20-6c2b-4829-a545-e5272b7fe50e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3c28820-afe0-42fb-99fa-decd7b5ca4e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6ed961a-a445-4281-8e37-fd64bbf8e5b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6ed961a-a445-4281-8e37-fd64bbf8e5b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/d1e2aa20-6c2b-4829-a545-e5272b7fe50e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6ed961a-a445-4281-8e37-fd64bbf8e5b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/17ab5452-c72b-41a9-9c64-839c8865dc2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17ab5452-c72b-41a9-9c64-839c8865dc2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/d1e2aa20-6c2b-4829-a545-e5272b7fe50e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17ab5452-c72b-41a9-9c64-839c8865dc2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/15bf8d7a-fd94-4fbd-9813-2a22875b948f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15bf8d7a-fd94-4fbd-9813-2a22875b948f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/d31b80ba-b0e6-4da8-807e-ae6f421259e6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15bf8d7a-fd94-4fbd-9813-2a22875b948f>.
+    
+<http://data.lblod.info/id/remote-data-objects/408d63fb-3584-4b49-8375-614c4781558e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "408d63fb-3584-4b49-8375-614c4781558e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/d31b80ba-b0e6-4da8-807e-ae6f421259e6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/408d63fb-3584-4b49-8375-614c4781558e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f15856d6-4746-42aa-8776-68e6e0f785e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f15856d6-4746-42aa-8776-68e6e0f785e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/d31b80ba-b0e6-4da8-807e-ae6f421259e6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f15856d6-4746-42aa-8776-68e6e0f785e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8870f30-17e6-415b-ac8f-5fe06cc2f5bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8870f30-17e6-415b-ac8f-5fe06cc2f5bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/db4017f6-a788-4384-85fa-240443be9a5d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8870f30-17e6-415b-ac8f-5fe06cc2f5bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d7edc26-8287-4ae6-962d-8164a7ee3dee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d7edc26-8287-4ae6-962d-8164a7ee3dee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/db4017f6-a788-4384-85fa-240443be9a5d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d7edc26-8287-4ae6-962d-8164a7ee3dee>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d668b5f-b3f0-492c-a54e-d44eaec7db9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d668b5f-b3f0-492c-a54e-d44eaec7db9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/db4017f6-a788-4384-85fa-240443be9a5d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d668b5f-b3f0-492c-a54e-d44eaec7db9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f23f7823-b31b-44b6-9394-6ed4fca7ffa7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f23f7823-b31b-44b6-9394-6ed4fca7ffa7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/f03ab0cb-6ca3-4540-9d71-9b1fdd9dcfb1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f23f7823-b31b-44b6-9394-6ed4fca7ffa7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9529a83-c020-4e32-8811-7ca8303816cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9529a83-c020-4e32-8811-7ca8303816cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/f03ab0cb-6ca3-4540-9d71-9b1fdd9dcfb1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9529a83-c020-4e32-8811-7ca8303816cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad766d6d-2be3-472f-8d18-5f02c9b2ba27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad766d6d-2be3-472f-8d18-5f02c9b2ba27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/f03ab0cb-6ca3-4540-9d71-9b1fdd9dcfb1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad766d6d-2be3-472f-8d18-5f02c9b2ba27>.
+    
+<http://data.lblod.info/id/remote-data-objects/3914b798-f8c2-41f5-9af7-00f034c3d6a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3914b798-f8c2-41f5-9af7-00f034c3d6a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/fc6ca189-8683-4f8d-a10c-7415184f4b25/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3914b798-f8c2-41f5-9af7-00f034c3d6a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e56a3fb-01cc-467e-9482-35282a60aa1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e56a3fb-01cc-467e-9482-35282a60aa1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/fc6ca189-8683-4f8d-a10c-7415184f4b25/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e56a3fb-01cc-467e-9482-35282a60aa1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a827a01-4e93-4249-947d-4fd48994a07a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a827a01-4e93-4249-947d-4fd48994a07a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/gr/fc6ca189-8683-4f8d-a10c-7415184f4b25/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a827a01-4e93-4249-947d-4fd48994a07a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e4abb68-b013-4adf-a411-687fd3127727> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e4abb68-b013-4adf-a411-687fd3127727";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/1bd4bce4-2c32-413a-81c0-53924cae4f6f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e4abb68-b013-4adf-a411-687fd3127727>.
+    
+<http://data.lblod.info/id/remote-data-objects/ced65e43-c85d-478a-b4b9-c831aa6d0c6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ced65e43-c85d-478a-b4b9-c831aa6d0c6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/1bd4bce4-2c32-413a-81c0-53924cae4f6f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/65c11eb7-b120-4cdc-a60a-764059e914df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ced65e43-c85d-478a-b4b9-c831aa6d0c6d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201117-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201117-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201117-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201117-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/fc951976-d99b-4d52-9e0f-ff10c4056202> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fc951976-d99b-4d52-9e0f-ff10c4056202";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "50c79e87-d86f-416b-9eda-8ecdf9a37c71";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/3ccc24aa-c3e1-4313-9e8d-c1d430c6648f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3ccc24aa-c3e1-4313-9e8d-c1d430c6648f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71>.
+
+  <http://redpencil.data.gift/id/task/7b980024-c536-4021-a5e2-61fc213434ab> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7b980024-c536-4021-a5e2-61fc213434ab";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/fc951976-d99b-4d52-9e0f-ff10c4056202>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/3ccc24aa-c3e1-4313-9e8d-c1d430c6648f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/0406d5a9-7077-49e2-8a8c-83c464472449> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0406d5a9-7077-49e2-8a8c-83c464472449";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/1bd4bce4-2c32-413a-81c0-53924cae4f6f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0406d5a9-7077-49e2-8a8c-83c464472449>.
+    
+<http://data.lblod.info/id/remote-data-objects/59a311a1-13c4-47ff-9d26-84c5d53b3130> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59a311a1-13c4-47ff-9d26-84c5d53b3130";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/24e0b861-dfff-4947-9216-46452463d5c5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59a311a1-13c4-47ff-9d26-84c5d53b3130>.
+    
+<http://data.lblod.info/id/remote-data-objects/880418fc-444e-4dc4-9f97-38773ef52230> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "880418fc-444e-4dc4-9f97-38773ef52230";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/24e0b861-dfff-4947-9216-46452463d5c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/880418fc-444e-4dc4-9f97-38773ef52230>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff63dc84-c770-4e41-82a3-aa153279a572> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff63dc84-c770-4e41-82a3-aa153279a572";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/24e0b861-dfff-4947-9216-46452463d5c5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff63dc84-c770-4e41-82a3-aa153279a572>.
+    
+<http://data.lblod.info/id/remote-data-objects/28275c78-a3b2-48f5-9836-dd54c73b208d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28275c78-a3b2-48f5-9836-dd54c73b208d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/2fd98dce-03c2-40d6-95f6-97a39871f461/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28275c78-a3b2-48f5-9836-dd54c73b208d>.
+    
+<http://data.lblod.info/id/remote-data-objects/63842d35-0f00-4299-8bee-645463716ff2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63842d35-0f00-4299-8bee-645463716ff2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/2fd98dce-03c2-40d6-95f6-97a39871f461/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63842d35-0f00-4299-8bee-645463716ff2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6cc0e4e-0e00-4588-a7cb-8f05efbd66f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6cc0e4e-0e00-4588-a7cb-8f05efbd66f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/2fd98dce-03c2-40d6-95f6-97a39871f461/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6cc0e4e-0e00-4588-a7cb-8f05efbd66f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e546a559-a556-426f-8651-8782b5f6ae45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e546a559-a556-426f-8651-8782b5f6ae45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/42500e26-c068-43e6-ac51-58c5d7e8cf2d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e546a559-a556-426f-8651-8782b5f6ae45>.
+    
+<http://data.lblod.info/id/remote-data-objects/15750f6b-088e-4030-8c82-95448aaa2f2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15750f6b-088e-4030-8c82-95448aaa2f2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/42500e26-c068-43e6-ac51-58c5d7e8cf2d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15750f6b-088e-4030-8c82-95448aaa2f2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/289ba128-428d-49f8-9617-0279747fa471> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "289ba128-428d-49f8-9617-0279747fa471";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/42500e26-c068-43e6-ac51-58c5d7e8cf2d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/289ba128-428d-49f8-9617-0279747fa471>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bc928cd-a1e4-45e5-84d7-060811cac379> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bc928cd-a1e4-45e5-84d7-060811cac379";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/562fd0dd-746d-4883-8f61-2c087f45d841/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bc928cd-a1e4-45e5-84d7-060811cac379>.
+    
+<http://data.lblod.info/id/remote-data-objects/c93cef13-bd9f-405a-9022-ff2beefc11c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c93cef13-bd9f-405a-9022-ff2beefc11c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/562fd0dd-746d-4883-8f61-2c087f45d841/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c93cef13-bd9f-405a-9022-ff2beefc11c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/034eea64-afd4-48de-9810-b4f70412d33e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "034eea64-afd4-48de-9810-b4f70412d33e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/562fd0dd-746d-4883-8f61-2c087f45d841/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/034eea64-afd4-48de-9810-b4f70412d33e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1387ae3-ef01-470d-89c0-92ea47eb89fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1387ae3-ef01-470d-89c0-92ea47eb89fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/7e3ccf71-d28f-4d5e-81da-b28f9b6fb6d1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1387ae3-ef01-470d-89c0-92ea47eb89fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/689304cb-8642-495f-9115-722cb05da623> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "689304cb-8642-495f-9115-722cb05da623";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/7e3ccf71-d28f-4d5e-81da-b28f9b6fb6d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/689304cb-8642-495f-9115-722cb05da623>.
+    
+<http://data.lblod.info/id/remote-data-objects/25b74027-399c-4006-8892-21c203a4a60c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25b74027-399c-4006-8892-21c203a4a60c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/7e3ccf71-d28f-4d5e-81da-b28f9b6fb6d1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25b74027-399c-4006-8892-21c203a4a60c>.
+    
+<http://data.lblod.info/id/remote-data-objects/43ab7464-4d15-4582-9989-231e5d55948d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43ab7464-4d15-4582-9989-231e5d55948d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/8077e909-31fd-433c-86bc-d7d558ffee35/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43ab7464-4d15-4582-9989-231e5d55948d>.
+    
+<http://data.lblod.info/id/remote-data-objects/66fe6ca5-7454-4b2e-bc5e-0370aed823ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66fe6ca5-7454-4b2e-bc5e-0370aed823ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/8077e909-31fd-433c-86bc-d7d558ffee35/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66fe6ca5-7454-4b2e-bc5e-0370aed823ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/8687ed1b-d00e-44c7-8644-5c57d0d4c9b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8687ed1b-d00e-44c7-8644-5c57d0d4c9b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/8077e909-31fd-433c-86bc-d7d558ffee35/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8687ed1b-d00e-44c7-8644-5c57d0d4c9b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe9507e2-06cf-48fe-926e-5c7c310e8d8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe9507e2-06cf-48fe-926e-5c7c310e8d8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/a6a989a0-13f0-4882-ab19-4e47a3ce16f9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe9507e2-06cf-48fe-926e-5c7c310e8d8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bc2833e-03f7-48b1-adf6-2852845e22fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bc2833e-03f7-48b1-adf6-2852845e22fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/a6a989a0-13f0-4882-ab19-4e47a3ce16f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bc2833e-03f7-48b1-adf6-2852845e22fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0fb60f9-53e7-43f1-a6d3-b6883a85db4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0fb60f9-53e7-43f1-a6d3-b6883a85db4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/a6a989a0-13f0-4882-ab19-4e47a3ce16f9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0fb60f9-53e7-43f1-a6d3-b6883a85db4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce8b2ce4-a48a-44b9-8849-b9d7f4befeac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce8b2ce4-a48a-44b9-8849-b9d7f4befeac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/b114c0bf-85e4-40b8-aa96-788da214ce82/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce8b2ce4-a48a-44b9-8849-b9d7f4befeac>.
+    
+<http://data.lblod.info/id/remote-data-objects/5aaf7640-79a3-4fab-9b3e-4c17934d73dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5aaf7640-79a3-4fab-9b3e-4c17934d73dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/b114c0bf-85e4-40b8-aa96-788da214ce82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5aaf7640-79a3-4fab-9b3e-4c17934d73dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/efbd28a8-1265-48c7-9a31-1840676c5c8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efbd28a8-1265-48c7-9a31-1840676c5c8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/b114c0bf-85e4-40b8-aa96-788da214ce82/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efbd28a8-1265-48c7-9a31-1840676c5c8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/40f6ca1e-9567-42c9-ad40-36f4dda5143f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40f6ca1e-9567-42c9-ad40-36f4dda5143f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/b8d623cd-f14d-42d4-a0b3-8b6e4d84fb9f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40f6ca1e-9567-42c9-ad40-36f4dda5143f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e30ba58-4f86-44f7-97df-95c299d7065b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e30ba58-4f86-44f7-97df-95c299d7065b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/b8d623cd-f14d-42d4-a0b3-8b6e4d84fb9f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e30ba58-4f86-44f7-97df-95c299d7065b>.
+    
+<http://data.lblod.info/id/remote-data-objects/818bb676-ae68-4ea3-9700-1de813a7875f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "818bb676-ae68-4ea3-9700-1de813a7875f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/b8d623cd-f14d-42d4-a0b3-8b6e4d84fb9f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/818bb676-ae68-4ea3-9700-1de813a7875f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a49d3bf3-5447-4a90-836f-090f6ed454f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a49d3bf3-5447-4a90-836f-090f6ed454f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/c4089157-1ba0-4447-943b-e8398e2cab22/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a49d3bf3-5447-4a90-836f-090f6ed454f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/83db3e5b-9f1a-4c74-8542-234ddd1f72a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83db3e5b-9f1a-4c74-8542-234ddd1f72a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/c4089157-1ba0-4447-943b-e8398e2cab22/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83db3e5b-9f1a-4c74-8542-234ddd1f72a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad3bd59f-43d9-45b0-8dc2-8f852f14ba52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad3bd59f-43d9-45b0-8dc2-8f852f14ba52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/c4089157-1ba0-4447-943b-e8398e2cab22/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad3bd59f-43d9-45b0-8dc2-8f852f14ba52>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a33405b-9e6c-4512-ba87-acb875eba32c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a33405b-9e6c-4512-ba87-acb875eba32c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/d6db2e06-6a94-40ff-9927-a0009b26428e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a33405b-9e6c-4512-ba87-acb875eba32c>.
+    
+<http://data.lblod.info/id/remote-data-objects/307b1601-4a4c-4a26-bdae-17d93f0a87ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "307b1601-4a4c-4a26-bdae-17d93f0a87ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/d6db2e06-6a94-40ff-9927-a0009b26428e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/307b1601-4a4c-4a26-bdae-17d93f0a87ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/337096e6-c9eb-4394-bac0-ff99bad87aca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "337096e6-c9eb-4394-bac0-ff99bad87aca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/d6db2e06-6a94-40ff-9927-a0009b26428e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/337096e6-c9eb-4394-bac0-ff99bad87aca>.
+    
+<http://data.lblod.info/id/remote-data-objects/25f9ba71-5ded-4b5d-9dcb-e89190c1b949> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25f9ba71-5ded-4b5d-9dcb-e89190c1b949";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/f988ef7b-de00-43e3-8486-efaf553a2d3e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25f9ba71-5ded-4b5d-9dcb-e89190c1b949>.
+    
+<http://data.lblod.info/id/remote-data-objects/760122c3-0e15-473e-b03f-c5c58af41fb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "760122c3-0e15-473e-b03f-c5c58af41fb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/rmw/f988ef7b-de00-43e3-8486-efaf553a2d3e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/760122c3-0e15-473e-b03f-c5c58af41fb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/85af6e38-e557-4d7c-9a9a-6745e3fb8ca9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85af6e38-e557-4d7c-9a9a-6745e3fb8ca9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/0dd6902c-04c5-4967-91cd-a1a37e980644/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85af6e38-e557-4d7c-9a9a-6745e3fb8ca9>.
+    
+<http://data.lblod.info/id/remote-data-objects/37a89bd2-7d1e-4f95-aeaa-04f6863b7052> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37a89bd2-7d1e-4f95-aeaa-04f6863b7052";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/0f289a2a-17c7-48ea-a3a3-1655bb78e5eb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37a89bd2-7d1e-4f95-aeaa-04f6863b7052>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab16aa2e-c4d9-46ac-858c-15a8f6575a40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab16aa2e-c4d9-46ac-858c-15a8f6575a40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/13e52343-5d48-492e-b52b-6ad0fdb63bdd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab16aa2e-c4d9-46ac-858c-15a8f6575a40>.
+    
+<http://data.lblod.info/id/remote-data-objects/f43573c3-ae85-447d-9a29-5f9933ddb743> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f43573c3-ae85-447d-9a29-5f9933ddb743";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/18da5124-8f48-4070-88c5-f995c56eb868/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f43573c3-ae85-447d-9a29-5f9933ddb743>.
+    
+<http://data.lblod.info/id/remote-data-objects/e51b6bac-f75d-4840-a623-84564ad0ee76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e51b6bac-f75d-4840-a623-84564ad0ee76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/19fbd3ab-82dd-44ed-b926-8cf92ab0c8b8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e51b6bac-f75d-4840-a623-84564ad0ee76>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ffcca09-5863-4aeb-aa68-3140611d70d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ffcca09-5863-4aeb-aa68-3140611d70d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/1e667199-625d-4de5-bd9a-3c82805c6efe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ffcca09-5863-4aeb-aa68-3140611d70d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5007b88f-a24e-416e-9218-bdc1b391fc4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5007b88f-a24e-416e-9218-bdc1b391fc4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/248102db-6a3d-4d10-add9-5139b3bdf795/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5007b88f-a24e-416e-9218-bdc1b391fc4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8da63bba-1b93-4dda-8c84-9ed72dbfd127> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8da63bba-1b93-4dda-8c84-9ed72dbfd127";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/26e7a0ed-4ead-4a5c-b88e-f5d82821ba9d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8da63bba-1b93-4dda-8c84-9ed72dbfd127>.
+    
+<http://data.lblod.info/id/remote-data-objects/e834ad64-a337-40db-9c3d-e380b832c5a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e834ad64-a337-40db-9c3d-e380b832c5a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/2bb831c9-9b25-4c2a-b3ee-f21fce9ab1be/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e834ad64-a337-40db-9c3d-e380b832c5a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ac7f5c5-8357-4fbb-8ce7-8d4415f28eb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ac7f5c5-8357-4fbb-8ce7-8d4415f28eb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/4c4b39a3-6050-49b6-94df-5f96894225c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ac7f5c5-8357-4fbb-8ce7-8d4415f28eb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/89b5dffb-0b94-43cc-842d-4ef909045279> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89b5dffb-0b94-43cc-842d-4ef909045279";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/4fd6045a-8b27-476f-8218-f58680a0e911/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89b5dffb-0b94-43cc-842d-4ef909045279>.
+    
+<http://data.lblod.info/id/remote-data-objects/056f3416-a1d6-4a46-bf05-d40f44501b32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "056f3416-a1d6-4a46-bf05-d40f44501b32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/530a146b-314d-4cdd-81d7-b4b66630f702/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/056f3416-a1d6-4a46-bf05-d40f44501b32>.
+    
+<http://data.lblod.info/id/remote-data-objects/83bbf9ab-ddf1-411e-be5d-fac59dd03174> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83bbf9ab-ddf1-411e-be5d-fac59dd03174";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/6e387658-ae37-4547-bbd3-b21e4bc7177c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83bbf9ab-ddf1-411e-be5d-fac59dd03174>.
+    
+<http://data.lblod.info/id/remote-data-objects/a28d14df-6d7b-44fe-922b-3722ee66a803> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a28d14df-6d7b-44fe-922b-3722ee66a803";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/7059593e-b700-49e5-bb0a-3a3c33ee6776/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/50c79e87-d86f-416b-9eda-8ecdf9a37c71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a28d14df-6d7b-44fe-922b-3722ee66a803>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201119-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201119-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201119-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201119-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b2cc6f94-f2ea-42d3-a6bd-10c8f4a78cf1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b2cc6f94-f2ea-42d3-a6bd-10c8f4a78cf1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8fedb65c-6609-48d0-b4d5-f3f869eb9555";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/fd52317b-8d5e-4c92-9d9d-7417699c030e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fd52317b-8d5e-4c92-9d9d-7417699c030e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555>.
+
+  <http://redpencil.data.gift/id/task/62e6db77-35fe-4b3c-b19d-a79c421afc49> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "62e6db77-35fe-4b3c-b19d-a79c421afc49";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b2cc6f94-f2ea-42d3-a6bd-10c8f4a78cf1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/fd52317b-8d5e-4c92-9d9d-7417699c030e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e64b3cc1-5e99-4401-972a-9fac20909cf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e64b3cc1-5e99-4401-972a-9fac20909cf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/81c1690b-9cad-46d4-87ff-60d79bdb7f33/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e64b3cc1-5e99-4401-972a-9fac20909cf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/751c2492-7127-4085-aa78-a035e1676981> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "751c2492-7127-4085-aa78-a035e1676981";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/89be87e6-c91c-4667-a865-50ecee8efde0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/751c2492-7127-4085-aa78-a035e1676981>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e41e911-6dce-4081-a80d-7917ea1ea9c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e41e911-6dce-4081-a80d-7917ea1ea9c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/8a33ff3d-c7f3-43c0-bdef-f4afe323fa22/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e41e911-6dce-4081-a80d-7917ea1ea9c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/910ddd34-9e26-445f-b3b7-76f93c82d4dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "910ddd34-9e26-445f-b3b7-76f93c82d4dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/908a91a9-b5b6-4daf-93cc-3e645c211b17/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/910ddd34-9e26-445f-b3b7-76f93c82d4dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/1940cd5a-6c4f-45ba-be75-75a7c9b5772d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1940cd5a-6c4f-45ba-be75-75a7c9b5772d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/937b36f6-66ec-4838-a20a-6874b7833fd7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1940cd5a-6c4f-45ba-be75-75a7c9b5772d>.
+    
+<http://data.lblod.info/id/remote-data-objects/29513ce6-4b47-42e2-a47d-78ea6a903ca1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29513ce6-4b47-42e2-a47d-78ea6a903ca1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/95b82c87-62df-467f-8028-9bd30d65e2e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29513ce6-4b47-42e2-a47d-78ea6a903ca1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c1ec049-d945-40c4-9519-c3acbbb321e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c1ec049-d945-40c4-9519-c3acbbb321e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/a8d42b28-3a2c-4579-a3c6-4ea723712229/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c1ec049-d945-40c4-9519-c3acbbb321e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6e94edd-8cc5-4e8b-9e34-08a4cac3829f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6e94edd-8cc5-4e8b-9e34-08a4cac3829f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/abc8f768-5527-421c-b88e-19a7e4117a51/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6e94edd-8cc5-4e8b-9e34-08a4cac3829f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4cd020b-0066-4a7b-bc71-059c95b56efb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4cd020b-0066-4a7b-bc71-059c95b56efb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/b4a65d27-9fd5-4fd1-8248-0fcead932224/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4cd020b-0066-4a7b-bc71-059c95b56efb>.
+    
+<http://data.lblod.info/id/remote-data-objects/aed395b1-0e1a-4644-8bb9-fecfaed404bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aed395b1-0e1a-4644-8bb9-fecfaed404bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/baca4cac-4f54-4dd8-9237-7416c6eae087/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aed395b1-0e1a-4644-8bb9-fecfaed404bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/18b09e28-c08c-4411-bc11-3e6973e743cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18b09e28-c08c-4411-bc11-3e6973e743cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/c837b89d-d373-421e-9fd5-9ca08b660c79/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18b09e28-c08c-4411-bc11-3e6973e743cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/285e8d32-46ad-4cd5-bfd6-22dd948b3ae9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "285e8d32-46ad-4cd5-bfd6-22dd948b3ae9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/c97b6294-3975-4969-b9e1-a6b5199528ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/285e8d32-46ad-4cd5-bfd6-22dd948b3ae9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2d2e79e-7391-42c7-bca3-c76f2a63dd4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2d2e79e-7391-42c7-bca3-c76f2a63dd4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/d66739a2-c31f-4538-96bf-7d3d508f39e8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2d2e79e-7391-42c7-bca3-c76f2a63dd4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3632d2f-62d9-4de1-a06f-4da28de60807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3632d2f-62d9-4de1-a06f-4da28de60807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/db2c3094-92ab-40d7-b9bb-b5861dfec217/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3632d2f-62d9-4de1-a06f-4da28de60807>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec563ad8-b630-466b-ab31-cb5eedbd9c8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec563ad8-b630-466b-ab31-cb5eedbd9c8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/dde29455-c833-45f0-8e18-6414b9597ace/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec563ad8-b630-466b-ab31-cb5eedbd9c8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f04b984a-86ce-4857-a624-c3909886fd17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f04b984a-86ce-4857-a624-c3909886fd17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/e0b5d91d-1a38-46ec-a9c8-1ada3b771ce1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f04b984a-86ce-4857-a624-c3909886fd17>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef24552b-62c0-409e-ae14-ae2988d5303d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef24552b-62c0-409e-ae14-ae2988d5303d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/e3f8c86b-5007-4410-bf21-b8401d795335/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef24552b-62c0-409e-ae14-ae2988d5303d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ebd348b-56d4-4657-bc9f-d0457c016a50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ebd348b-56d4-4657-bc9f-d0457c016a50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/eeebc981-9379-4c30-89d3-bd0028676cfa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ebd348b-56d4-4657-bc9f-d0457c016a50>.
+    
+<http://data.lblod.info/id/remote-data-objects/550997ac-71c5-4aa9-8398-8fd213f60e7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "550997ac-71c5-4aa9-8398-8fd213f60e7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/f7788061-d623-4945-a3da-d3dd7f08cc78/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/550997ac-71c5-4aa9-8398-8fd213f60e7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b61d338-d7d6-4ca2-8b20-76655b26fca0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b61d338-d7d6-4ca2-8b20-76655b26fca0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/f7fb7654-0afe-45a2-a1e9-278f0eca48fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b61d338-d7d6-4ca2-8b20-76655b26fca0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffbf4794-7039-4d90-af41-065e3dc727dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffbf4794-7039-4d90-af41-065e3dc727dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/fa1da462-7819-4256-847d-45c565555368/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffbf4794-7039-4d90-af41-065e3dc727dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f78febeb-4541-4535-94a3-62315b758633> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f78febeb-4541-4535-94a3-62315b758633";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://drogenbos.meetingburger.net/vabu/fb4ed0d2-d44c-4032-b691-e72a6b9d8217/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f78febeb-4541-4535-94a3-62315b758633>.
+    
+<http://data.lblod.info/id/remote-data-objects/170d4e08-9c00-4aa8-9bc5-159c513176ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "170d4e08-9c00-4aa8-9bc5-159c513176ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/04791bd7-a153-4c04-bf65-dda3a8f59d07/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/170d4e08-9c00-4aa8-9bc5-159c513176ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/9bbe4df0-aaa5-4316-8af5-f866c1647604> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9bbe4df0-aaa5-4316-8af5-f866c1647604";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/1129de92-0b1f-46d8-82bc-fdaf186d8522/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9bbe4df0-aaa5-4316-8af5-f866c1647604>.
+    
+<http://data.lblod.info/id/remote-data-objects/4adbe84a-ad93-4b98-a2ff-dda361884c73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4adbe84a-ad93-4b98-a2ff-dda361884c73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/143b7e25-9755-4b84-bfe2-8db2742cce8b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4adbe84a-ad93-4b98-a2ff-dda361884c73>.
+    
+<http://data.lblod.info/id/remote-data-objects/78be140e-51cb-4eba-a7ee-911e130c9c14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78be140e-51cb-4eba-a7ee-911e130c9c14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/14db506c-ac47-4e89-90e7-e7f289352c17/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78be140e-51cb-4eba-a7ee-911e130c9c14>.
+    
+<http://data.lblod.info/id/remote-data-objects/cced2061-f13e-4c4f-885a-f1286d002645> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cced2061-f13e-4c4f-885a-f1286d002645";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/1b10ca87-9f97-429e-b9cc-7750d33672c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cced2061-f13e-4c4f-885a-f1286d002645>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a2c4e8e-b147-4e62-b7b7-2904580310da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a2c4e8e-b147-4e62-b7b7-2904580310da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/38ec97a4-0e76-487f-a53f-51f6fa864f1e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a2c4e8e-b147-4e62-b7b7-2904580310da>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ca73703-f604-4fcb-9d33-7fd2cc8f90a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ca73703-f604-4fcb-9d33-7fd2cc8f90a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/3bf7f230-c297-4ad6-bb47-d661e1a4cced/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ca73703-f604-4fcb-9d33-7fd2cc8f90a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/800bf43b-77ee-42c0-8831-b5b566776982> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "800bf43b-77ee-42c0-8831-b5b566776982";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/3c46c27a-f999-488d-b4d8-0cf3fffccb92/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/800bf43b-77ee-42c0-8831-b5b566776982>.
+    
+<http://data.lblod.info/id/remote-data-objects/921ab26c-22d4-41a8-bcfc-f32bdb9ae879> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "921ab26c-22d4-41a8-bcfc-f32bdb9ae879";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/5730e413-47b0-4daf-9756-ffb4e4970bef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/921ab26c-22d4-41a8-bcfc-f32bdb9ae879>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e17ddc0-2d95-4c15-a09b-565fb0810fb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e17ddc0-2d95-4c15-a09b-565fb0810fb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/5776362b-30eb-4fa8-b547-490a193e9693/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e17ddc0-2d95-4c15-a09b-565fb0810fb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cf3d395-0597-46ca-bafe-40409159853d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cf3d395-0597-46ca-bafe-40409159853d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/790dd4ad-4507-4c9e-8fef-2f88ee6da223/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cf3d395-0597-46ca-bafe-40409159853d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b93f0ace-897f-4b20-9613-bff6f32ae2f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b93f0ace-897f-4b20-9613-bff6f32ae2f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/800922d9-1465-4718-a99f-37bb1c362326/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b93f0ace-897f-4b20-9613-bff6f32ae2f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae233f80-fdfc-4bd9-907a-68ce5ecb895f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae233f80-fdfc-4bd9-907a-68ce5ecb895f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/81218014-a137-4423-8def-47f3bbbd131d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae233f80-fdfc-4bd9-907a-68ce5ecb895f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7a79ae8-edef-49b2-81d2-7ec5b46098df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7a79ae8-edef-49b2-81d2-7ec5b46098df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/a92279c8-3441-4d3e-a673-b111f00f8002/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7a79ae8-edef-49b2-81d2-7ec5b46098df>.
+    
+<http://data.lblod.info/id/remote-data-objects/468569f0-408c-4caa-a46d-d8dfd9e0c0bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "468569f0-408c-4caa-a46d-d8dfd9e0c0bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/b8fb8585-88d6-4ab7-b467-43ac914ebc5f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/468569f0-408c-4caa-a46d-d8dfd9e0c0bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ef17dcc-2745-4317-b19a-07ec5c82c53c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ef17dcc-2745-4317-b19a-07ec5c82c53c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/e727deac-e592-42c8-a9ee-9f66ab7ca602/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ef17dcc-2745-4317-b19a-07ec5c82c53c>.
+    
+<http://data.lblod.info/id/remote-data-objects/42a4e7be-4d1a-4d5a-9bda-582b1ddb4c94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42a4e7be-4d1a-4d5a-9bda-582b1ddb4c94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/bb/f343a30c-5378-49da-ae7c-a4ecf8e0356c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42a4e7be-4d1a-4d5a-9bda-582b1ddb4c94>.
+    
+<http://data.lblod.info/id/remote-data-objects/49db0c3e-cd63-472c-a3ae-4fa284909175> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49db0c3e-cd63-472c-a3ae-4fa284909175";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/03d291e4-8211-4182-9a8f-faa678379eae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49db0c3e-cd63-472c-a3ae-4fa284909175>.
+    
+<http://data.lblod.info/id/remote-data-objects/500f6f7a-ba75-4c0c-83e7-637ce90b4f20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "500f6f7a-ba75-4c0c-83e7-637ce90b4f20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/04635775-ec1d-473d-bcdc-c81142df4a10/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/500f6f7a-ba75-4c0c-83e7-637ce90b4f20>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0f46b40-b18b-4fc7-9918-84dd5f1b19e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0f46b40-b18b-4fc7-9918-84dd5f1b19e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/097e4133-a398-4696-9240-2097f6798e16/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0f46b40-b18b-4fc7-9918-84dd5f1b19e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd507ec7-7750-4941-bb39-6bd599c2f01a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd507ec7-7750-4941-bb39-6bd599c2f01a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/0e33ce31-0206-4da7-9488-d8d74b21a1ca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd507ec7-7750-4941-bb39-6bd599c2f01a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7afa3433-1232-4a82-8cc5-285ad2338671> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7afa3433-1232-4a82-8cc5-285ad2338671";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/11e34588-6f0e-472f-b36d-41c7b64a88ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7afa3433-1232-4a82-8cc5-285ad2338671>.
+    
+<http://data.lblod.info/id/remote-data-objects/985ba3e0-caa3-4ad3-9190-7d218543b428> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "985ba3e0-caa3-4ad3-9190-7d218543b428";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/135e0d4f-ee86-41f4-ad3a-ae00aea5d434/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/985ba3e0-caa3-4ad3-9190-7d218543b428>.
+    
+<http://data.lblod.info/id/remote-data-objects/840ba058-bf43-4732-848a-cccdc72545b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "840ba058-bf43-4732-848a-cccdc72545b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/14b2221a-d013-4f90-97a7-e419a11aa539/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/840ba058-bf43-4732-848a-cccdc72545b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e870984-bea9-4084-a200-8f6b1f321b69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e870984-bea9-4084-a200-8f6b1f321b69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/24142bac-3f08-47a4-a440-2398989c1d65/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e870984-bea9-4084-a200-8f6b1f321b69>.
+    
+<http://data.lblod.info/id/remote-data-objects/55abc25f-ca46-4404-843c-904721d35beb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55abc25f-ca46-4404-843c-904721d35beb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/287e9e50-089b-4a53-8f3f-8854188a03d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55abc25f-ca46-4404-843c-904721d35beb>.
+    
+<http://data.lblod.info/id/remote-data-objects/96a5125e-8a51-4048-90b0-d9a50250ad5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96a5125e-8a51-4048-90b0-d9a50250ad5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/29ee11f2-ebf1-417c-9dfa-5b2d920a81ca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96a5125e-8a51-4048-90b0-d9a50250ad5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2e8df4a-2153-410a-8d6b-4ca39fb4fe88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2e8df4a-2153-410a-8d6b-4ca39fb4fe88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/3168c959-b254-4aa6-8992-b87812859d96/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8fedb65c-6609-48d0-b4d5-f3f869eb9555> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2e8df4a-2153-410a-8d6b-4ca39fb4fe88>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201120-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201120-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201120-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201120-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b4f2ee27-c543-473f-95a4-2d34ac5ff097> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b4f2ee27-c543-473f-95a4-2d34ac5ff097";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f7df1f87-ec6a-487a-9b70-c62358da1369";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/284d8fcf-290a-4b7e-a26f-5e82abb5001d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "284d8fcf-290a-4b7e-a26f-5e82abb5001d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369>.
+
+  <http://redpencil.data.gift/id/task/1b5b3265-9739-4ac9-ac1a-74a382862edc> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1b5b3265-9739-4ac9-ac1a-74a382862edc";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b4f2ee27-c543-473f-95a4-2d34ac5ff097>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/284d8fcf-290a-4b7e-a26f-5e82abb5001d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c86b5269-4be4-40b0-b7c8-ae19ec14d49f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c86b5269-4be4-40b0-b7c8-ae19ec14d49f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/382e980a-5399-4ca4-b587-7b7691049a22/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c86b5269-4be4-40b0-b7c8-ae19ec14d49f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6aae004-a8bf-4109-a0ae-d4c1ccc27a98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6aae004-a8bf-4109-a0ae-d4c1ccc27a98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/3b4be50d-2faa-44a5-a4f9-b1e5e96063a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6aae004-a8bf-4109-a0ae-d4c1ccc27a98>.
+    
+<http://data.lblod.info/id/remote-data-objects/2be50694-271f-4a0a-8101-182f78534a55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2be50694-271f-4a0a-8101-182f78534a55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/3bf96af1-965c-4bfc-ac57-56c1517c70e4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2be50694-271f-4a0a-8101-182f78534a55>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ff775ee-cecd-4f1a-8748-b0a0d3069f90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ff775ee-cecd-4f1a-8748-b0a0d3069f90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/3e18a0ab-0371-48a6-907a-3cc7d85da9d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ff775ee-cecd-4f1a-8748-b0a0d3069f90>.
+    
+<http://data.lblod.info/id/remote-data-objects/08b1c1b6-8f31-49f8-bd7e-58967ab8b9cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08b1c1b6-8f31-49f8-bd7e-58967ab8b9cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/41360e30-2b4b-4628-a7e1-73e0cafb9096/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08b1c1b6-8f31-49f8-bd7e-58967ab8b9cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d4dbf13-4c84-4eeb-9edc-1a374b3e4ae6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d4dbf13-4c84-4eeb-9edc-1a374b3e4ae6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/4336c6a4-8f94-4056-9362-496bc5c51f8b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d4dbf13-4c84-4eeb-9edc-1a374b3e4ae6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e15c911-2d72-4af5-9eb9-db6a8340a969> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e15c911-2d72-4af5-9eb9-db6a8340a969";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/45e16e73-aa91-4ff1-a665-7fbf7a185b93/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e15c911-2d72-4af5-9eb9-db6a8340a969>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a2158d6-395f-48d4-8fc5-5b5a62895353> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a2158d6-395f-48d4-8fc5-5b5a62895353";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/475c01fa-58f5-467f-a5c8-e679dc099a89/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a2158d6-395f-48d4-8fc5-5b5a62895353>.
+    
+<http://data.lblod.info/id/remote-data-objects/144faa1e-692c-4df8-a2be-5909a80be281> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "144faa1e-692c-4df8-a2be-5909a80be281";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/4a38a30e-58cf-45d4-85d5-ef301def39c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/144faa1e-692c-4df8-a2be-5909a80be281>.
+    
+<http://data.lblod.info/id/remote-data-objects/8de22599-8422-4610-b1f3-b0ab5697592a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8de22599-8422-4610-b1f3-b0ab5697592a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/4b1c0b72-56be-47a9-8999-6f899691a08e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8de22599-8422-4610-b1f3-b0ab5697592a>.
+    
+<http://data.lblod.info/id/remote-data-objects/488c90a2-9f67-49cf-ae96-6a8fefce5bd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "488c90a2-9f67-49cf-ae96-6a8fefce5bd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/4dd9d67b-0dfc-436a-aebc-0cbe31778aff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/488c90a2-9f67-49cf-ae96-6a8fefce5bd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b7ea17d-d680-4d50-9f52-7512c7d376fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b7ea17d-d680-4d50-9f52-7512c7d376fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/4df85f5d-b2d7-43dd-a0c0-05d15b88472d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b7ea17d-d680-4d50-9f52-7512c7d376fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c6d887f-d2a8-4077-8374-2aa8954e616b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c6d887f-d2a8-4077-8374-2aa8954e616b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/4e6d54cb-a152-4e87-a2bf-723106d72474/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c6d887f-d2a8-4077-8374-2aa8954e616b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1e5975f-e107-4362-8dc4-9d8e866a07cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1e5975f-e107-4362-8dc4-9d8e866a07cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/4ffea2b8-ec3e-461f-9334-ff80ce3404bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1e5975f-e107-4362-8dc4-9d8e866a07cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9a50200-e33a-4173-8733-78a12a4ffdf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9a50200-e33a-4173-8733-78a12a4ffdf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/511dbf0a-51cc-45c5-b127-649ad973bc74/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9a50200-e33a-4173-8733-78a12a4ffdf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d4b8b98-5314-4bd6-bfa8-a318d3d8e72b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d4b8b98-5314-4bd6-bfa8-a318d3d8e72b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/5268f065-2900-4f79-be52-b1d46721de5d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d4b8b98-5314-4bd6-bfa8-a318d3d8e72b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bfd92be-3b41-46f6-adcf-05e13d69ec00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bfd92be-3b41-46f6-adcf-05e13d69ec00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/572a600f-fdca-4bec-a13a-9bbf414fd279/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bfd92be-3b41-46f6-adcf-05e13d69ec00>.
+    
+<http://data.lblod.info/id/remote-data-objects/2746d621-619f-404a-b020-48339cc9c88a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2746d621-619f-404a-b020-48339cc9c88a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/5a49252d-94d2-480b-810c-04ca197589de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2746d621-619f-404a-b020-48339cc9c88a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe9929c0-9991-4ec6-91b6-7e3d797674a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe9929c0-9991-4ec6-91b6-7e3d797674a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/6496a748-fb15-41ef-8b59-a728fd01804a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe9929c0-9991-4ec6-91b6-7e3d797674a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/92bf22f5-34b3-4037-9c8d-5d18a963e07d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92bf22f5-34b3-4037-9c8d-5d18a963e07d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/6c3c6ded-1db6-4622-bc92-24862f23b79d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92bf22f5-34b3-4037-9c8d-5d18a963e07d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fff308ee-0670-465f-b4f1-0dad848e6f58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fff308ee-0670-465f-b4f1-0dad848e6f58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/6fdb869b-93d4-413e-ab25-92ed83bb8d7a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fff308ee-0670-465f-b4f1-0dad848e6f58>.
+    
+<http://data.lblod.info/id/remote-data-objects/2db5a69f-f184-455c-a4a8-5fe608d9f476> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2db5a69f-f184-455c-a4a8-5fe608d9f476";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/767844ee-d0c5-48af-a9a6-f68c10a123aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2db5a69f-f184-455c-a4a8-5fe608d9f476>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d427488-93e2-4336-814a-7f5c0b535c62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d427488-93e2-4336-814a-7f5c0b535c62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/7bf5ab18-ed57-4343-933d-e5e84d4646f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d427488-93e2-4336-814a-7f5c0b535c62>.
+    
+<http://data.lblod.info/id/remote-data-objects/373f9e47-060c-4487-a155-bce70e7d717c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "373f9e47-060c-4487-a155-bce70e7d717c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/7cf8ac0c-c0e4-4e88-a711-e1d5d679d796/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/373f9e47-060c-4487-a155-bce70e7d717c>.
+    
+<http://data.lblod.info/id/remote-data-objects/534fbb5f-a649-4501-823c-706d051e7e34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "534fbb5f-a649-4501-823c-706d051e7e34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/80119667-c63d-4c32-93a3-c93c9db5df9b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/534fbb5f-a649-4501-823c-706d051e7e34>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a90ea73-755f-47d2-8ee9-1c3ddadf659a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a90ea73-755f-47d2-8ee9-1c3ddadf659a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/914d62f0-a9f6-40f9-af75-ba2415c747a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a90ea73-755f-47d2-8ee9-1c3ddadf659a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a15fcb3a-e2db-4305-98cf-673ab2ddd4d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a15fcb3a-e2db-4305-98cf-673ab2ddd4d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/94de5e90-9afb-4c89-b475-d3a514d136bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a15fcb3a-e2db-4305-98cf-673ab2ddd4d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fbb76d1-c3b2-459d-a9a2-7824583a4713> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fbb76d1-c3b2-459d-a9a2-7824583a4713";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/972b390b-7076-4ce5-854f-d8f994513f74/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fbb76d1-c3b2-459d-a9a2-7824583a4713>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fcc07a4-105a-4a72-9e9d-dee9f34deda6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fcc07a4-105a-4a72-9e9d-dee9f34deda6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/9761c272-da61-4c73-a5d0-28949086f56d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fcc07a4-105a-4a72-9e9d-dee9f34deda6>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe13089c-7b89-4b68-af97-44707b9305b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe13089c-7b89-4b68-af97-44707b9305b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/9c25044e-0e01-4b7b-b409-86c65be6b64b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe13089c-7b89-4b68-af97-44707b9305b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/61168321-d3a0-42be-8282-107b144adae5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61168321-d3a0-42be-8282-107b144adae5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/9c6fa2c6-d8a6-4ac3-9506-6d7d3d67a657/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61168321-d3a0-42be-8282-107b144adae5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5acf5364-537c-4f29-9772-c23ad40e9352> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5acf5364-537c-4f29-9772-c23ad40e9352";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/9e252720-f47a-4c1f-a23c-ea6c05292492/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5acf5364-537c-4f29-9772-c23ad40e9352>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dc0b0d9-cac8-447e-8872-45077ab0cea1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dc0b0d9-cac8-447e-8872-45077ab0cea1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/9e2aceea-a470-4d14-a6a1-5885db287407/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dc0b0d9-cac8-447e-8872-45077ab0cea1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0203a34-f136-42e0-8461-87a9999346a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0203a34-f136-42e0-8461-87a9999346a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/a9bdae07-a38f-432f-8e5a-fea96ac6ad46/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0203a34-f136-42e0-8461-87a9999346a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea64ee3c-1dc2-4211-bd5d-bc62270fa8ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea64ee3c-1dc2-4211-bd5d-bc62270fa8ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/b1167652-592b-4f14-93b5-754889fcc9fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea64ee3c-1dc2-4211-bd5d-bc62270fa8ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/33c1b2dd-823f-45fe-b733-63fe58a81e7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33c1b2dd-823f-45fe-b733-63fe58a81e7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/b914557d-9dab-4ade-8eb9-1139ec6e6285/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33c1b2dd-823f-45fe-b733-63fe58a81e7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6e46a9d-b4cd-4f93-8735-e00cb560021c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6e46a9d-b4cd-4f93-8735-e00cb560021c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/b95ab0db-23cf-4253-b40a-06a373916d8e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6e46a9d-b4cd-4f93-8735-e00cb560021c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2153bf50-f234-43a5-bf50-e561e32cb9fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2153bf50-f234-43a5-bf50-e561e32cb9fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/babf4c25-00de-4fc1-a5ef-aba3971635b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2153bf50-f234-43a5-bf50-e561e32cb9fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/9df2c088-5a94-486b-b19d-987f7f7f877e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9df2c088-5a94-486b-b19d-987f7f7f877e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/bdaa7cc7-e6ba-4374-8861-11c74bc676af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9df2c088-5a94-486b-b19d-987f7f7f877e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d035f538-e268-4507-9396-42c1c6f4b656> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d035f538-e268-4507-9396-42c1c6f4b656";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/c05e9630-b108-4949-8d68-f68946ecad10/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d035f538-e268-4507-9396-42c1c6f4b656>.
+    
+<http://data.lblod.info/id/remote-data-objects/591a5552-8c0a-4458-96f5-3c184e4913d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "591a5552-8c0a-4458-96f5-3c184e4913d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/c3497f80-b159-4de2-aba5-41d74ce443e9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/591a5552-8c0a-4458-96f5-3c184e4913d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f63460c0-e661-4136-9a3a-f41771ff83d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f63460c0-e661-4136-9a3a-f41771ff83d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/c60ceed2-0949-46a1-81da-421145d05f61/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f63460c0-e661-4136-9a3a-f41771ff83d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3d15718-3152-4c6b-8840-db9adddd6d22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3d15718-3152-4c6b-8840-db9adddd6d22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/c69e01ef-0ed7-4994-8d6e-fac3dc36112c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3d15718-3152-4c6b-8840-db9adddd6d22>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce033fb3-6f02-407c-933a-ad3dc78d3e05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce033fb3-6f02-407c-933a-ad3dc78d3e05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/ca5f94b4-43c4-474f-aa68-e1acd9791799/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce033fb3-6f02-407c-933a-ad3dc78d3e05>.
+    
+<http://data.lblod.info/id/remote-data-objects/67f34ac9-e5e8-459a-b7b2-eab69b7cc6ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67f34ac9-e5e8-459a-b7b2-eab69b7cc6ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/d088c986-1a5a-40ca-9371-36893ad1dcad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67f34ac9-e5e8-459a-b7b2-eab69b7cc6ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0ef9c06-4f6f-4703-9439-dccb3bb7ee35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0ef9c06-4f6f-4703-9439-dccb3bb7ee35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/e0c9bffe-7f8a-4d5f-b1db-012b90136889/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0ef9c06-4f6f-4703-9439-dccb3bb7ee35>.
+    
+<http://data.lblod.info/id/remote-data-objects/e75da5bd-9994-4b4a-a767-34c148b0d962> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e75da5bd-9994-4b4a-a767-34c148b0d962";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/e5c838ce-c772-4da1-9af5-4770eac3acdc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e75da5bd-9994-4b4a-a767-34c148b0d962>.
+    
+<http://data.lblod.info/id/remote-data-objects/bedbfb2c-7a80-433f-a174-d2000c955cb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bedbfb2c-7a80-433f-a174-d2000c955cb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/e8eaeb5e-d93d-48ec-a567-d58091714fe8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bedbfb2c-7a80-433f-a174-d2000c955cb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d2d7f0f-339a-4cab-bc30-254baab91656> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d2d7f0f-339a-4cab-bc30-254baab91656";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/eb436c0a-8d29-4e46-a690-04af56dbd1a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d2d7f0f-339a-4cab-bc30-254baab91656>.
+    
+<http://data.lblod.info/id/remote-data-objects/2af32762-28ea-4bcf-8ec5-b0bfd04863c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2af32762-28ea-4bcf-8ec5-b0bfd04863c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/f4c7abd3-a4b7-4bab-be3b-906f5ba1bcf7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7df1f87-ec6a-487a-9b70-c62358da1369> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2af32762-28ea-4bcf-8ec5-b0bfd04863c6>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201121-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201121-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201121-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201121-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/cac32b18-817e-4fbb-9588-573ebf184518> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cac32b18-817e-4fbb-9588-573ebf184518";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "00d76719-1f89-43c5-9aea-b963a2d8fb94";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/76ceca8e-3c25-4950-bee2-046558399393> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "76ceca8e-3c25-4950-bee2-046558399393";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94>.
+
+  <http://redpencil.data.gift/id/task/b863eb84-532e-4f04-b1a3-269bdea2f03b> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b863eb84-532e-4f04-b1a3-269bdea2f03b";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/cac32b18-817e-4fbb-9588-573ebf184518>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/76ceca8e-3c25-4950-bee2-046558399393>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/2d5b8884-bff0-4d4e-a4cb-ae85371a4b40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d5b8884-bff0-4d4e-a4cb-ae85371a4b40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/f6627c74-9265-45f2-9f46-9fb5daffbbc5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d5b8884-bff0-4d4e-a4cb-ae85371a4b40>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1840532-535b-464d-bb38-f8d137c80f54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1840532-535b-464d-bb38-f8d137c80f54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/f770ffd5-69fe-4e69-bb64-684db4db9a52/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1840532-535b-464d-bb38-f8d137c80f54>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fd0eb8e-1b7c-4ea3-aa42-1299b4e810fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fd0eb8e-1b7c-4ea3-aa42-1299b4e810fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/f9c6f879-8e1e-45a9-a094-3d345a80e42a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fd0eb8e-1b7c-4ea3-aa42-1299b4e810fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2629a46-5844-4747-ab68-12346d684e3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2629a46-5844-4747-ab68-12346d684e3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/cbs/ffaa83b9-1045-409e-a016-1ff21282cb97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2629a46-5844-4747-ab68-12346d684e3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f30b062-abb9-4744-8084-fe7c4de5644f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f30b062-abb9-4744-8084-fe7c4de5644f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/17b94c0f-b9f8-407d-b5b5-b94c0a38edc1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f30b062-abb9-4744-8084-fe7c4de5644f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7743dae2-0c92-4d6e-bef6-f3557dde03f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7743dae2-0c92-4d6e-bef6-f3557dde03f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/17b94c0f-b9f8-407d-b5b5-b94c0a38edc1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7743dae2-0c92-4d6e-bef6-f3557dde03f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b83c532-19d9-4d51-9421-37ceba6a90d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b83c532-19d9-4d51-9421-37ceba6a90d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/17b94c0f-b9f8-407d-b5b5-b94c0a38edc1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b83c532-19d9-4d51-9421-37ceba6a90d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e683191d-de9d-4b2a-80ef-7149e212d9bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e683191d-de9d-4b2a-80ef-7149e212d9bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/21c9aa37-e732-4dd8-910e-849e7513a994/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e683191d-de9d-4b2a-80ef-7149e212d9bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/ceb52a07-4b52-4168-a1a4-b84600e4fbee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ceb52a07-4b52-4168-a1a4-b84600e4fbee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/21c9aa37-e732-4dd8-910e-849e7513a994/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ceb52a07-4b52-4168-a1a4-b84600e4fbee>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e1ed116-5491-46f3-a44d-f1b90ca191cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e1ed116-5491-46f3-a44d-f1b90ca191cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/21c9aa37-e732-4dd8-910e-849e7513a994/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e1ed116-5491-46f3-a44d-f1b90ca191cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7cef9fb-f4bd-49a8-9822-a618c52dd401> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7cef9fb-f4bd-49a8-9822-a618c52dd401";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/3438c8ef-692b-48cb-af60-b69ef3a7575d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7cef9fb-f4bd-49a8-9822-a618c52dd401>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab2486d3-5a44-4732-bb99-dd1b2c2c4efb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab2486d3-5a44-4732-bb99-dd1b2c2c4efb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/3438c8ef-692b-48cb-af60-b69ef3a7575d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab2486d3-5a44-4732-bb99-dd1b2c2c4efb>.
+    
+<http://data.lblod.info/id/remote-data-objects/5269adeb-87d9-445a-bdab-1db52cb99c6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5269adeb-87d9-445a-bdab-1db52cb99c6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/3438c8ef-692b-48cb-af60-b69ef3a7575d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5269adeb-87d9-445a-bdab-1db52cb99c6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/af118612-1abb-48ca-95c5-d3543a5ebb24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af118612-1abb-48ca-95c5-d3543a5ebb24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/4e1b73f4-9bce-463f-b01d-8828e2d62eda/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af118612-1abb-48ca-95c5-d3543a5ebb24>.
+    
+<http://data.lblod.info/id/remote-data-objects/da49b5dd-7a20-48b4-acfb-d28e6678e2a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da49b5dd-7a20-48b4-acfb-d28e6678e2a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/4e1b73f4-9bce-463f-b01d-8828e2d62eda/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da49b5dd-7a20-48b4-acfb-d28e6678e2a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b90401f9-5cc8-4dd4-84e3-f8348ab944d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b90401f9-5cc8-4dd4-84e3-f8348ab944d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/4e1b73f4-9bce-463f-b01d-8828e2d62eda/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b90401f9-5cc8-4dd4-84e3-f8348ab944d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a86bd81-c9c4-4286-bd32-b12e2b2e1178> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a86bd81-c9c4-4286-bd32-b12e2b2e1178";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/6d75d90d-d345-4041-a77d-9521784abd37/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a86bd81-c9c4-4286-bd32-b12e2b2e1178>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1da6b70-fbb5-4958-86d5-cead11078959> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1da6b70-fbb5-4958-86d5-cead11078959";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/6d75d90d-d345-4041-a77d-9521784abd37/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1da6b70-fbb5-4958-86d5-cead11078959>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b8552e6-227d-4f9e-9e7c-8df8542212da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b8552e6-227d-4f9e-9e7c-8df8542212da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/6d75d90d-d345-4041-a77d-9521784abd37/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b8552e6-227d-4f9e-9e7c-8df8542212da>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6e01aef-b830-412c-a31e-000eb521164f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6e01aef-b830-412c-a31e-000eb521164f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/765b644d-de33-4efa-9be6-0f0969cba7a9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6e01aef-b830-412c-a31e-000eb521164f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6496e44d-5f48-471b-a2a4-5d6cc96ea8e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6496e44d-5f48-471b-a2a4-5d6cc96ea8e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/765b644d-de33-4efa-9be6-0f0969cba7a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6496e44d-5f48-471b-a2a4-5d6cc96ea8e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c5b85e1-9564-4fe6-b2e0-13b6f5ab8603> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c5b85e1-9564-4fe6-b2e0-13b6f5ab8603";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/765b644d-de33-4efa-9be6-0f0969cba7a9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c5b85e1-9564-4fe6-b2e0-13b6f5ab8603>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e9ce836-4e46-4e91-a873-ea62dd41bea3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e9ce836-4e46-4e91-a873-ea62dd41bea3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/9174c59e-7738-4bc2-9844-e6e613cdedc8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e9ce836-4e46-4e91-a873-ea62dd41bea3>.
+    
+<http://data.lblod.info/id/remote-data-objects/16c159fc-7de7-45a2-bef0-bf00e8f94d7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16c159fc-7de7-45a2-bef0-bf00e8f94d7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/9174c59e-7738-4bc2-9844-e6e613cdedc8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16c159fc-7de7-45a2-bef0-bf00e8f94d7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/281dfea0-60ee-4c38-8a82-f7d79dc1b09f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "281dfea0-60ee-4c38-8a82-f7d79dc1b09f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/9174c59e-7738-4bc2-9844-e6e613cdedc8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/281dfea0-60ee-4c38-8a82-f7d79dc1b09f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6897f14b-6ffe-44e9-abb5-4ddeabd5a70e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6897f14b-6ffe-44e9-abb5-4ddeabd5a70e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/b311cedc-38e7-47d4-9fb6-7fb45e375438/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6897f14b-6ffe-44e9-abb5-4ddeabd5a70e>.
+    
+<http://data.lblod.info/id/remote-data-objects/acd078f4-f1ae-4048-aa2e-751528f78ba9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acd078f4-f1ae-4048-aa2e-751528f78ba9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/b311cedc-38e7-47d4-9fb6-7fb45e375438/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acd078f4-f1ae-4048-aa2e-751528f78ba9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d59cfd7-7fa2-4628-8ef2-e989950d2f94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d59cfd7-7fa2-4628-8ef2-e989950d2f94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/b311cedc-38e7-47d4-9fb6-7fb45e375438/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d59cfd7-7fa2-4628-8ef2-e989950d2f94>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fe070e3-0709-419c-9393-5f1f6a355780> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fe070e3-0709-419c-9393-5f1f6a355780";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/b7935a6c-39d5-4ef2-bb6e-b2f207eaccfd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fe070e3-0709-419c-9393-5f1f6a355780>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7be2262-2b97-4996-83eb-58cfe186476b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7be2262-2b97-4996-83eb-58cfe186476b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/b7935a6c-39d5-4ef2-bb6e-b2f207eaccfd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7be2262-2b97-4996-83eb-58cfe186476b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0622c6f0-9d6a-468d-9a71-5d7b489f24a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0622c6f0-9d6a-468d-9a71-5d7b489f24a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/b7935a6c-39d5-4ef2-bb6e-b2f207eaccfd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0622c6f0-9d6a-468d-9a71-5d7b489f24a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/057f8d92-ef39-44e5-bf5e-7bff72ba82eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "057f8d92-ef39-44e5-bf5e-7bff72ba82eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/ba6b264a-6f07-4961-af02-f4e6d0b6926b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/057f8d92-ef39-44e5-bf5e-7bff72ba82eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e8eacae-a970-4bf6-a4c8-d9d319336579> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e8eacae-a970-4bf6-a4c8-d9d319336579";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/ba6b264a-6f07-4961-af02-f4e6d0b6926b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e8eacae-a970-4bf6-a4c8-d9d319336579>.
+    
+<http://data.lblod.info/id/remote-data-objects/844f4ea4-5aef-4b3f-8ee8-b11f0035fcaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "844f4ea4-5aef-4b3f-8ee8-b11f0035fcaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/ba6b264a-6f07-4961-af02-f4e6d0b6926b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/844f4ea4-5aef-4b3f-8ee8-b11f0035fcaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/02656bd0-f5a1-4f7c-bcd1-cce00afc5603> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02656bd0-f5a1-4f7c-bcd1-cce00afc5603";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/d3cd0abb-fdd2-4a00-9bf3-65f6f3c86ab5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02656bd0-f5a1-4f7c-bcd1-cce00afc5603>.
+    
+<http://data.lblod.info/id/remote-data-objects/02eb20b8-580f-479c-9888-c68f3d010e7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02eb20b8-580f-479c-9888-c68f3d010e7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/d3cd0abb-fdd2-4a00-9bf3-65f6f3c86ab5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02eb20b8-580f-479c-9888-c68f3d010e7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/52f537fb-c9b5-484b-a5c9-b8969b812903> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52f537fb-c9b5-484b-a5c9-b8969b812903";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/d3cd0abb-fdd2-4a00-9bf3-65f6f3c86ab5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52f537fb-c9b5-484b-a5c9-b8969b812903>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd074046-3a3b-4aba-8bae-8d651600efdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd074046-3a3b-4aba-8bae-8d651600efdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/ddbb27eb-502e-440c-a913-ef98d08e1a2d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd074046-3a3b-4aba-8bae-8d651600efdf>.
+    
+<http://data.lblod.info/id/remote-data-objects/a52e674d-00a2-4eaa-917b-f55632c8851e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a52e674d-00a2-4eaa-917b-f55632c8851e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/ddbb27eb-502e-440c-a913-ef98d08e1a2d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a52e674d-00a2-4eaa-917b-f55632c8851e>.
+    
+<http://data.lblod.info/id/remote-data-objects/74eee33c-d49a-4370-9e88-374758c6142f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74eee33c-d49a-4370-9e88-374758c6142f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/ddbb27eb-502e-440c-a913-ef98d08e1a2d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74eee33c-d49a-4370-9e88-374758c6142f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a76c2da-85ba-4f96-bf69-32e384a2d777> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a76c2da-85ba-4f96-bf69-32e384a2d777";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/e730c068-471c-47b2-8249-7e5bcd1a134c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a76c2da-85ba-4f96-bf69-32e384a2d777>.
+    
+<http://data.lblod.info/id/remote-data-objects/977ad117-249d-4f3e-9e05-e7127fc409c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "977ad117-249d-4f3e-9e05-e7127fc409c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/e730c068-471c-47b2-8249-7e5bcd1a134c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/977ad117-249d-4f3e-9e05-e7127fc409c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/eea6e9a7-2bc4-4049-9083-ae0aeb5ceeb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eea6e9a7-2bc4-4049-9083-ae0aeb5ceeb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/e730c068-471c-47b2-8249-7e5bcd1a134c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eea6e9a7-2bc4-4049-9083-ae0aeb5ceeb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/752ee530-2dda-44b3-8066-094bacafc322> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "752ee530-2dda-44b3-8066-094bacafc322";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/f63b596d-0cea-42da-862b-a56f11633d1a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/752ee530-2dda-44b3-8066-094bacafc322>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3bb8d45-7ef8-4a76-9a86-6eb0d4615e84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3bb8d45-7ef8-4a76-9a86-6eb0d4615e84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/f63b596d-0cea-42da-862b-a56f11633d1a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3bb8d45-7ef8-4a76-9a86-6eb0d4615e84>.
+    
+<http://data.lblod.info/id/remote-data-objects/c405d1b3-1783-4815-860a-99bba6452576> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c405d1b3-1783-4815-860a-99bba6452576";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/f63b596d-0cea-42da-862b-a56f11633d1a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c405d1b3-1783-4815-860a-99bba6452576>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf84c2f5-1e93-4bd3-b871-cd07ee723f37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf84c2f5-1e93-4bd3-b871-cd07ee723f37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/fbd06153-1e90-4ae3-bf52-f37bbcb0ab0a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf84c2f5-1e93-4bd3-b871-cd07ee723f37>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd39e961-b7f3-49d4-a26e-69046c85d300> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd39e961-b7f3-49d4-a26e-69046c85d300";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/fbd06153-1e90-4ae3-bf52-f37bbcb0ab0a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd39e961-b7f3-49d4-a26e-69046c85d300>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc55a679-e6d2-4b9e-97c2-9272efb6ddd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc55a679-e6d2-4b9e-97c2-9272efb6ddd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/gr/fbd06153-1e90-4ae3-bf52-f37bbcb0ab0a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc55a679-e6d2-4b9e-97c2-9272efb6ddd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e2c64a2-4331-4e56-bf44-69e26b49f1c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e2c64a2-4331-4e56-bf44-69e26b49f1c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/0a9bb979-5507-457a-aa19-504c8e389ecc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/00d76719-1f89-43c5-9aea-b963a2d8fb94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e2c64a2-4331-4e56-bf44-69e26b49f1c4>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201122-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201122-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201122-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201122-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/93228eeb-f56b-4ba5-a8ce-5d184053efa8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "93228eeb-f56b-4ba5-a8ce-5d184053efa8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b2ada649-1e3e-41c0-a6ac-272b1771adbf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/06dc2238-47d2-464f-9cab-6497af7de7f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "06dc2238-47d2-464f-9cab-6497af7de7f4";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf>.
+
+  <http://redpencil.data.gift/id/task/327c1d44-4406-483c-a601-ffc2675bd52e> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "327c1d44-4406-483c-a601-ffc2675bd52e";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/93228eeb-f56b-4ba5-a8ce-5d184053efa8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/06dc2238-47d2-464f-9cab-6497af7de7f4>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/89982d29-e4ef-42d6-ad42-73d89bcca8b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89982d29-e4ef-42d6-ad42-73d89bcca8b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/0a9bb979-5507-457a-aa19-504c8e389ecc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89982d29-e4ef-42d6-ad42-73d89bcca8b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/71d3933a-599d-4da1-8f25-e5ca7df6b100> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71d3933a-599d-4da1-8f25-e5ca7df6b100";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/0a9bb979-5507-457a-aa19-504c8e389ecc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71d3933a-599d-4da1-8f25-e5ca7df6b100>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8fc0d00-613c-4c30-82c1-f64ea40bce09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8fc0d00-613c-4c30-82c1-f64ea40bce09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/23ac1a66-105a-417b-97ff-acae97689165/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8fc0d00-613c-4c30-82c1-f64ea40bce09>.
+    
+<http://data.lblod.info/id/remote-data-objects/82c921f3-9046-4f14-876d-eb13fbb91bbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82c921f3-9046-4f14-876d-eb13fbb91bbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/23ac1a66-105a-417b-97ff-acae97689165/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82c921f3-9046-4f14-876d-eb13fbb91bbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/907aa14d-33c4-4b61-9fb7-c835ce18ed54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "907aa14d-33c4-4b61-9fb7-c835ce18ed54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/23ac1a66-105a-417b-97ff-acae97689165/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/907aa14d-33c4-4b61-9fb7-c835ce18ed54>.
+    
+<http://data.lblod.info/id/remote-data-objects/f453f7f1-0cba-4e8a-8ee1-d1018714d080> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f453f7f1-0cba-4e8a-8ee1-d1018714d080";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/6d3f4ca5-19a2-4d86-8a18-e2d608cbeda2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f453f7f1-0cba-4e8a-8ee1-d1018714d080>.
+    
+<http://data.lblod.info/id/remote-data-objects/046a446c-9a21-4ee9-a3d6-eb4d6bf6d91a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "046a446c-9a21-4ee9-a3d6-eb4d6bf6d91a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/6d3f4ca5-19a2-4d86-8a18-e2d608cbeda2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/046a446c-9a21-4ee9-a3d6-eb4d6bf6d91a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc2fbf47-832e-4b3f-a858-900e5e96a6ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc2fbf47-832e-4b3f-a858-900e5e96a6ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/6d3f4ca5-19a2-4d86-8a18-e2d608cbeda2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc2fbf47-832e-4b3f-a858-900e5e96a6ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ad54f90-4681-49f8-afa3-fbef9d332794> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ad54f90-4681-49f8-afa3-fbef9d332794";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/7d0001b3-510c-49b2-ba45-e116d7b16f73/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ad54f90-4681-49f8-afa3-fbef9d332794>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcb0b269-82e3-4a4f-a2f3-013e9cab0de6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcb0b269-82e3-4a4f-a2f3-013e9cab0de6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/7d0001b3-510c-49b2-ba45-e116d7b16f73/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcb0b269-82e3-4a4f-a2f3-013e9cab0de6>.
+    
+<http://data.lblod.info/id/remote-data-objects/09f1dc45-01f7-4a1b-81ab-077b10c8114a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09f1dc45-01f7-4a1b-81ab-077b10c8114a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/7d0001b3-510c-49b2-ba45-e116d7b16f73/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09f1dc45-01f7-4a1b-81ab-077b10c8114a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4795f4fe-9f84-4ac8-90da-5685aa16dd45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4795f4fe-9f84-4ac8-90da-5685aa16dd45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/93664a13-2adc-47e6-b53c-911b571cfa40/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4795f4fe-9f84-4ac8-90da-5685aa16dd45>.
+    
+<http://data.lblod.info/id/remote-data-objects/acfd4f10-ccd7-4544-b8a4-5f71a6b5ef32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acfd4f10-ccd7-4544-b8a4-5f71a6b5ef32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/93664a13-2adc-47e6-b53c-911b571cfa40/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acfd4f10-ccd7-4544-b8a4-5f71a6b5ef32>.
+    
+<http://data.lblod.info/id/remote-data-objects/23a3f513-7ff9-4092-b2de-56a795c8d13a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23a3f513-7ff9-4092-b2de-56a795c8d13a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/93664a13-2adc-47e6-b53c-911b571cfa40/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23a3f513-7ff9-4092-b2de-56a795c8d13a>.
+    
+<http://data.lblod.info/id/remote-data-objects/be931d66-0bfc-4ffd-8532-1b83502f90dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be931d66-0bfc-4ffd-8532-1b83502f90dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/9a0a9135-9fea-4a47-98ac-be6dc687d8b3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be931d66-0bfc-4ffd-8532-1b83502f90dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebef7182-8b20-44e1-a1b6-daa7e5bdf885> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebef7182-8b20-44e1-a1b6-daa7e5bdf885";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/9a0a9135-9fea-4a47-98ac-be6dc687d8b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebef7182-8b20-44e1-a1b6-daa7e5bdf885>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d72ff0b-2347-4fe5-8544-ee485d244585> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d72ff0b-2347-4fe5-8544-ee485d244585";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/9a0a9135-9fea-4a47-98ac-be6dc687d8b3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d72ff0b-2347-4fe5-8544-ee485d244585>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3b52141-e76a-40cf-8142-a738c997637f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3b52141-e76a-40cf-8142-a738c997637f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/bb0c0fc4-0581-4f52-ba0a-8083c2453f65/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3b52141-e76a-40cf-8142-a738c997637f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b8ac5f9-fa05-4ba0-955f-d9349fce8442> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b8ac5f9-fa05-4ba0-955f-d9349fce8442";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/bb0c0fc4-0581-4f52-ba0a-8083c2453f65/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b8ac5f9-fa05-4ba0-955f-d9349fce8442>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ef21def-854d-49c5-a9d0-e2c215172e9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ef21def-854d-49c5-a9d0-e2c215172e9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/bb0c0fc4-0581-4f52-ba0a-8083c2453f65/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ef21def-854d-49c5-a9d0-e2c215172e9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/951ca686-51aa-46c9-88a5-c4905951eebe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "951ca686-51aa-46c9-88a5-c4905951eebe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/d31d9f11-8c28-4042-a481-10d703f8dafc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/951ca686-51aa-46c9-88a5-c4905951eebe>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5fcb68d-60cd-478a-99b0-58e736792914> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5fcb68d-60cd-478a-99b0-58e736792914";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/d31d9f11-8c28-4042-a481-10d703f8dafc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5fcb68d-60cd-478a-99b0-58e736792914>.
+    
+<http://data.lblod.info/id/remote-data-objects/76c91090-5bc6-4b0b-96d8-85141df3654b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76c91090-5bc6-4b0b-96d8-85141df3654b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/d31d9f11-8c28-4042-a481-10d703f8dafc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76c91090-5bc6-4b0b-96d8-85141df3654b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7122b109-9c5f-4f3a-a7a2-132381f5d89a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7122b109-9c5f-4f3a-a7a2-132381f5d89a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/dad5b50f-23d1-4e4e-b9d5-cde1e4eb7abc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7122b109-9c5f-4f3a-a7a2-132381f5d89a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b5afcc3-dc59-40fa-8bd5-43ae4061f56e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b5afcc3-dc59-40fa-8bd5-43ae4061f56e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/dad5b50f-23d1-4e4e-b9d5-cde1e4eb7abc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b5afcc3-dc59-40fa-8bd5-43ae4061f56e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7538e63e-acbc-417a-8434-ec0b28c72870> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7538e63e-acbc-417a-8434-ec0b28c72870";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/dad5b50f-23d1-4e4e-b9d5-cde1e4eb7abc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7538e63e-acbc-417a-8434-ec0b28c72870>.
+    
+<http://data.lblod.info/id/remote-data-objects/57292711-3094-466c-a2ec-bdcfcef1960e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57292711-3094-466c-a2ec-bdcfcef1960e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/e771338e-59f2-4bd2-a7c3-a53bb53a21ac/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57292711-3094-466c-a2ec-bdcfcef1960e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0241a731-cd74-414b-b228-76000eb27000> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0241a731-cd74-414b-b228-76000eb27000";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/e771338e-59f2-4bd2-a7c3-a53bb53a21ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0241a731-cd74-414b-b228-76000eb27000>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f0b80c9-d6bf-4752-9cd8-a4dca72a2585> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f0b80c9-d6bf-4752-9cd8-a4dca72a2585";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/e771338e-59f2-4bd2-a7c3-a53bb53a21ac/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f0b80c9-d6bf-4752-9cd8-a4dca72a2585>.
+    
+<http://data.lblod.info/id/remote-data-objects/6074ad80-54ce-4148-8171-8213d7780567> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6074ad80-54ce-4148-8171-8213d7780567";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/fb42d57c-0ff5-4df0-9f66-d4acb05bd027/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6074ad80-54ce-4148-8171-8213d7780567>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e78f6b5-6b71-4dc8-9372-5dc6a5cbddc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e78f6b5-6b71-4dc8-9372-5dc6a5cbddc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/fb42d57c-0ff5-4df0-9f66-d4acb05bd027/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e78f6b5-6b71-4dc8-9372-5dc6a5cbddc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac528840-6890-4d41-b7cb-7a396dd1e6d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac528840-6890-4d41-b7cb-7a396dd1e6d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/rmw/fb42d57c-0ff5-4df0-9f66-d4acb05bd027/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac528840-6890-4d41-b7cb-7a396dd1e6d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e131c052-127e-462e-8670-6727330745f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e131c052-127e-462e-8670-6727330745f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/1706f9f6-fc63-4328-a93b-dcbf70931ac8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e131c052-127e-462e-8670-6727330745f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/82b4c9e2-ab60-4f27-972d-f5e683748f72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82b4c9e2-ab60-4f27-972d-f5e683748f72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/18394da7-c609-4e45-89fc-addda7ccbdfd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82b4c9e2-ab60-4f27-972d-f5e683748f72>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fb8c0ff-ed96-43be-92d2-1e532dc775b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fb8c0ff-ed96-43be-92d2-1e532dc775b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/243aeba3-b431-4a6f-bd4b-2863127a5b13/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fb8c0ff-ed96-43be-92d2-1e532dc775b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c8a73a7-e30c-4445-9bcf-e38afcb95a78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c8a73a7-e30c-4445-9bcf-e38afcb95a78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/2e05b474-f1c2-4303-890f-257577343df1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c8a73a7-e30c-4445-9bcf-e38afcb95a78>.
+    
+<http://data.lblod.info/id/remote-data-objects/47f01bc3-4ba6-4840-9e14-2dea083686e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47f01bc3-4ba6-4840-9e14-2dea083686e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/3a630ea9-4c4a-4705-86fc-5209e2e4067a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47f01bc3-4ba6-4840-9e14-2dea083686e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed9a1a7a-61e9-4270-a915-8b81ab00356c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed9a1a7a-61e9-4270-a915-8b81ab00356c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/491d863e-82bb-41b0-92aa-2e5498072787/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed9a1a7a-61e9-4270-a915-8b81ab00356c>.
+    
+<http://data.lblod.info/id/remote-data-objects/99d34f41-72fa-407c-9e01-d2f27f247058> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99d34f41-72fa-407c-9e01-d2f27f247058";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/4ea5d74b-057c-4ece-a006-8ab4797d889c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99d34f41-72fa-407c-9e01-d2f27f247058>.
+    
+<http://data.lblod.info/id/remote-data-objects/44adf738-6915-42d2-bda2-06826739e6b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44adf738-6915-42d2-bda2-06826739e6b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/62e4f3ce-2eec-4b47-9974-4b02ce0b410f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44adf738-6915-42d2-bda2-06826739e6b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2556ce93-d045-4dc8-9b3e-986543a627cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2556ce93-d045-4dc8-9b3e-986543a627cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/7bdf6c7e-8522-4e34-acf9-13e3527df871/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2556ce93-d045-4dc8-9b3e-986543a627cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/50e660d2-2f6d-4d78-9b0f-779651984a77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50e660d2-2f6d-4d78-9b0f-779651984a77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/83067d84-976b-4ab2-a72f-c57ce5142210/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50e660d2-2f6d-4d78-9b0f-779651984a77>.
+    
+<http://data.lblod.info/id/remote-data-objects/a43acd0a-faa6-47cb-94e1-24da956800d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a43acd0a-faa6-47cb-94e1-24da956800d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/844f3228-1309-416c-9726-ca54b73f9808/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a43acd0a-faa6-47cb-94e1-24da956800d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc37fea6-b184-427c-969a-27de4765ea2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc37fea6-b184-427c-969a-27de4765ea2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/ad99073a-e5e6-40fe-9956-a415a057b5ca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc37fea6-b184-427c-969a-27de4765ea2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8eabe9ef-2c88-4007-9d56-9b733aa6b730> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8eabe9ef-2c88-4007-9d56-9b733aa6b730";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/ae6f1e5a-5342-4914-8d16-d6125576d737/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8eabe9ef-2c88-4007-9d56-9b733aa6b730>.
+    
+<http://data.lblod.info/id/remote-data-objects/a739a4de-2e20-4168-aa8c-344d4c866fc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a739a4de-2e20-4168-aa8c-344d4c866fc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/b1ea7a17-5d22-40e8-8409-15faf75dedbc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a739a4de-2e20-4168-aa8c-344d4c866fc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbd80748-32af-425a-b3e4-39c5b64c0b45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbd80748-32af-425a-b3e4-39c5b64c0b45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/b3dc8d7c-93e4-4ffc-a505-93efdff6093e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbd80748-32af-425a-b3e4-39c5b64c0b45>.
+    
+<http://data.lblod.info/id/remote-data-objects/a34b1e23-d9f3-49dc-af18-ede5195aa2b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a34b1e23-d9f3-49dc-af18-ede5195aa2b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/b6630ba1-643d-4522-b2e2-5bbcea1350f8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a34b1e23-d9f3-49dc-af18-ede5195aa2b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9eeb06c4-ade2-4ad4-80f7-fa3f50bc6ece> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9eeb06c4-ade2-4ad4-80f7-fa3f50bc6ece";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hemiksem.meetingburger.net/vabu/dc679e08-74a7-480e-9025-84032e18d21f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9eeb06c4-ade2-4ad4-80f7-fa3f50bc6ece>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddd208ad-476a-412e-84f2-cbe68714d873> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddd208ad-476a-412e-84f2-cbe68714d873";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/05225290-5db3-454c-b44b-63f0441bd4ba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2ada649-1e3e-41c0-a6ac-272b1771adbf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddd208ad-476a-412e-84f2-cbe68714d873>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201124-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201124-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201124-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201124-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/fec90737-f0b1-4329-9f56-84b84de796ff> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fec90737-f0b1-4329-9f56-84b84de796ff";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "db473ebd-798d-413f-8810-87926d134f9e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/313abccb-7d6c-4e3d-8222-231a68114f16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "313abccb-7d6c-4e3d-8222-231a68114f16";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e>.
+
+  <http://redpencil.data.gift/id/task/eb3a2d0d-e43e-4fa1-aae5-bc46616f0f12> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "eb3a2d0d-e43e-4fa1-aae5-bc46616f0f12";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/fec90737-f0b1-4329-9f56-84b84de796ff>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/313abccb-7d6c-4e3d-8222-231a68114f16>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c958039f-6876-4757-8f20-0589c812b03f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c958039f-6876-4757-8f20-0589c812b03f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/0afdac87-b531-4c1c-8a4d-cc84c1667a3b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c958039f-6876-4757-8f20-0589c812b03f>.
+    
+<http://data.lblod.info/id/remote-data-objects/cafc1516-e28e-4a2c-97fa-7ec77b9c993c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cafc1516-e28e-4a2c-97fa-7ec77b9c993c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/0bc9fd3e-79eb-4f3f-aa85-af871484134a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cafc1516-e28e-4a2c-97fa-7ec77b9c993c>.
+    
+<http://data.lblod.info/id/remote-data-objects/83218d75-dcd7-4a57-8d7a-f7fbf2c6ede5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83218d75-dcd7-4a57-8d7a-f7fbf2c6ede5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/0f12cca7-dee3-4dbe-8e87-9b0a01522cd3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83218d75-dcd7-4a57-8d7a-f7fbf2c6ede5>.
+    
+<http://data.lblod.info/id/remote-data-objects/062ab1ca-f201-423b-831a-9bec16d8c69e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "062ab1ca-f201-423b-831a-9bec16d8c69e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/1011221e-d8ae-4764-8b7c-88374b77eabc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/062ab1ca-f201-423b-831a-9bec16d8c69e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fef35d71-295e-4452-aa55-4fc74e54ec28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fef35d71-295e-4452-aa55-4fc74e54ec28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/15b7ae93-eb3f-4e80-b46a-21f02fa8923b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fef35d71-295e-4452-aa55-4fc74e54ec28>.
+    
+<http://data.lblod.info/id/remote-data-objects/5aaf1295-aa8d-4c99-bf91-f3a346abc45f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5aaf1295-aa8d-4c99-bf91-f3a346abc45f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/24f4818a-150b-4e5c-8fc3-9a1aad426e15/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5aaf1295-aa8d-4c99-bf91-f3a346abc45f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8211beaa-8fdb-458b-afa7-a421faf41e3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8211beaa-8fdb-458b-afa7-a421faf41e3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/279e6721-c9e4-4e54-a1cb-88602804f345/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8211beaa-8fdb-458b-afa7-a421faf41e3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7abbe79-f11c-4024-b81e-f0e4f7c162e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7abbe79-f11c-4024-b81e-f0e4f7c162e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/286d153e-bc98-45d9-b47a-2fdb51381498/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7abbe79-f11c-4024-b81e-f0e4f7c162e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9e64c3a-8828-42de-8bed-008e474fa807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9e64c3a-8828-42de-8bed-008e474fa807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/298bd564-c219-45ee-9b38-9caebc1d80f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9e64c3a-8828-42de-8bed-008e474fa807>.
+    
+<http://data.lblod.info/id/remote-data-objects/74930400-ad9e-4b62-b74a-524da55b3e8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74930400-ad9e-4b62-b74a-524da55b3e8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/3001b8d1-37e8-4c80-8a98-40745df2a8ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74930400-ad9e-4b62-b74a-524da55b3e8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/78cfc9c5-fbca-4a1c-b5fc-922ed2e0ae8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78cfc9c5-fbca-4a1c-b5fc-922ed2e0ae8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/36e59c8f-920d-4c22-a2c0-f3335043ad6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78cfc9c5-fbca-4a1c-b5fc-922ed2e0ae8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/47a88ca0-4ce0-407f-bd86-28b99f4a0da6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47a88ca0-4ce0-407f-bd86-28b99f4a0da6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/37d0f90f-db7b-4c2f-bc2b-96c02a033bba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47a88ca0-4ce0-407f-bd86-28b99f4a0da6>.
+    
+<http://data.lblod.info/id/remote-data-objects/63a87b87-a263-4bda-8e05-b6a4234f5331> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63a87b87-a263-4bda-8e05-b6a4234f5331";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/3a02d6e8-f474-4c4e-815d-7df5aa2c2f78/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63a87b87-a263-4bda-8e05-b6a4234f5331>.
+    
+<http://data.lblod.info/id/remote-data-objects/3605e9cd-636e-41c9-8287-de145ad3f8a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3605e9cd-636e-41c9-8287-de145ad3f8a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/3ffcb880-d960-4bc9-ba86-1c064040737a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3605e9cd-636e-41c9-8287-de145ad3f8a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1657f9f-f4f2-4d0d-9223-5b2bbec6e1c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1657f9f-f4f2-4d0d-9223-5b2bbec6e1c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/44d17f81-cd83-4677-89ca-1da0448ae1a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1657f9f-f4f2-4d0d-9223-5b2bbec6e1c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/033bccb6-3875-41e3-bbaf-f9d927f7c9e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "033bccb6-3875-41e3-bbaf-f9d927f7c9e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/51d129ff-aaad-47fb-ac8d-25311da50f59/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/033bccb6-3875-41e3-bbaf-f9d927f7c9e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/288158c5-b616-4736-b8fb-48df9a1a75ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "288158c5-b616-4736-b8fb-48df9a1a75ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/534db948-2516-4295-9538-dea87bb75949/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/288158c5-b616-4736-b8fb-48df9a1a75ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/793c67f2-e9e3-461e-b6bb-fce311a04b40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "793c67f2-e9e3-461e-b6bb-fce311a04b40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/5471fff3-f86b-495b-b6ab-baf1a6ddb264/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/793c67f2-e9e3-461e-b6bb-fce311a04b40>.
+    
+<http://data.lblod.info/id/remote-data-objects/02287663-aeef-4412-bae2-994f09acf234> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02287663-aeef-4412-bae2-994f09acf234";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/55357da1-7b4d-4d39-a763-7fe7c74bee8c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02287663-aeef-4412-bae2-994f09acf234>.
+    
+<http://data.lblod.info/id/remote-data-objects/b134d56b-8d27-4399-9911-cd2f12029a06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b134d56b-8d27-4399-9911-cd2f12029a06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/592b8109-68fa-4476-ac6e-455007d99619/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b134d56b-8d27-4399-9911-cd2f12029a06>.
+    
+<http://data.lblod.info/id/remote-data-objects/79fade65-0c50-4e5b-bb04-f4cc9ec6385d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79fade65-0c50-4e5b-bb04-f4cc9ec6385d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/5b3ad21f-e857-41e9-aacb-8bfe02fc245f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79fade65-0c50-4e5b-bb04-f4cc9ec6385d>.
+    
+<http://data.lblod.info/id/remote-data-objects/11b49d80-31d3-40c5-b980-769dac25266b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11b49d80-31d3-40c5-b980-769dac25266b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/5ef03098-3684-4840-a1a6-9bed068ca5fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11b49d80-31d3-40c5-b980-769dac25266b>.
+    
+<http://data.lblod.info/id/remote-data-objects/569479b5-faf4-4435-8e14-5a9b37b8e3cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "569479b5-faf4-4435-8e14-5a9b37b8e3cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/60e1a423-72b2-466b-b28b-8b5731916c82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/569479b5-faf4-4435-8e14-5a9b37b8e3cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ffee0e3-bdd4-4a53-ad62-623a4b53625b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ffee0e3-bdd4-4a53-ad62-623a4b53625b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/6484d39a-cd9f-4567-874d-83e3acb02e7d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ffee0e3-bdd4-4a53-ad62-623a4b53625b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b480a9f8-b42f-4a61-b58a-41cebb0a157c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b480a9f8-b42f-4a61-b58a-41cebb0a157c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/69074830-6295-4078-823d-bd8f701c0839/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b480a9f8-b42f-4a61-b58a-41cebb0a157c>.
+    
+<http://data.lblod.info/id/remote-data-objects/399ce661-3e5c-42b6-a289-ca8d45b14f72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "399ce661-3e5c-42b6-a289-ca8d45b14f72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/7290185d-a6b8-4a00-a22a-6b427162feef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/399ce661-3e5c-42b6-a289-ca8d45b14f72>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cab932d-0ec6-486a-8c65-56f588ff7f98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cab932d-0ec6-486a-8c65-56f588ff7f98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/7291c406-9a18-4541-8741-5338ea024b8e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cab932d-0ec6-486a-8c65-56f588ff7f98>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef70cd5f-8609-414a-bcdb-ff9973418fb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef70cd5f-8609-414a-bcdb-ff9973418fb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/79064fff-943a-41de-b63a-da915cc2ff2a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef70cd5f-8609-414a-bcdb-ff9973418fb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/575d517b-b937-4a38-affe-48f03a419877> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "575d517b-b937-4a38-affe-48f03a419877";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/7977fd07-d283-44b4-8934-29d82b82e537/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/575d517b-b937-4a38-affe-48f03a419877>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5bd33a2-a208-4d1e-b941-530ce05bd3b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5bd33a2-a208-4d1e-b941-530ce05bd3b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/7cc810ed-80ff-422a-8443-1b861120b2b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5bd33a2-a208-4d1e-b941-530ce05bd3b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/20b9a7e1-b89f-4e3c-85c3-b655e65ce210> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20b9a7e1-b89f-4e3c-85c3-b655e65ce210";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/8812f650-b889-428e-9fb9-c78dadc637fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20b9a7e1-b89f-4e3c-85c3-b655e65ce210>.
+    
+<http://data.lblod.info/id/remote-data-objects/f080b3d0-7fd8-42a9-ad91-078b35bd865d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f080b3d0-7fd8-42a9-ad91-078b35bd865d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/8cd1d1af-1128-46c4-8f49-693ccb595d48/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f080b3d0-7fd8-42a9-ad91-078b35bd865d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0766e6fb-9723-400a-92c0-df359a1b3a93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0766e6fb-9723-400a-92c0-df359a1b3a93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/94076a17-2171-4dd3-92be-38a330012b14/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0766e6fb-9723-400a-92c0-df359a1b3a93>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3881c52-ea98-4e13-9256-371f0668a7be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3881c52-ea98-4e13-9256-371f0668a7be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/956de2ea-a8fd-42f3-9772-08390dd90fc2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3881c52-ea98-4e13-9256-371f0668a7be>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d21a079-86f7-42f8-8571-ab2344bcdfbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d21a079-86f7-42f8-8571-ab2344bcdfbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/97269113-1097-424c-a06e-dd8f947fc56e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d21a079-86f7-42f8-8571-ab2344bcdfbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/551b6bec-31a4-4d5a-883f-096f342bbb45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "551b6bec-31a4-4d5a-883f-096f342bbb45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/97449a65-1274-4f42-b971-974920729a1f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/551b6bec-31a4-4d5a-883f-096f342bbb45>.
+    
+<http://data.lblod.info/id/remote-data-objects/80ca2fc2-b1eb-49a6-8794-282826468e53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80ca2fc2-b1eb-49a6-8794-282826468e53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/9a10e6c2-0a04-4dba-be0c-0f0a72658f10/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80ca2fc2-b1eb-49a6-8794-282826468e53>.
+    
+<http://data.lblod.info/id/remote-data-objects/26b10029-abd9-4cfb-af13-1e7ae1efeb12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26b10029-abd9-4cfb-af13-1e7ae1efeb12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/9bc50787-c1f3-4eef-82a4-19c4564832bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26b10029-abd9-4cfb-af13-1e7ae1efeb12>.
+    
+<http://data.lblod.info/id/remote-data-objects/b84c3a7a-aa3a-4dfb-9a85-f20d0f541a8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b84c3a7a-aa3a-4dfb-9a85-f20d0f541a8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/9c98f5c3-62ad-4dab-82f5-24bc88e8f685/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b84c3a7a-aa3a-4dfb-9a85-f20d0f541a8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/816f13e9-48b4-4369-8ffc-83fa1d25b3df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "816f13e9-48b4-4369-8ffc-83fa1d25b3df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/a088d480-f2f7-4d2f-aea8-11ee3a759d8d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/816f13e9-48b4-4369-8ffc-83fa1d25b3df>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b952e56-9942-469c-9caf-938a866abd29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b952e56-9942-469c-9caf-938a866abd29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/a0e5bce8-68c3-4380-926d-869af4de5845/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b952e56-9942-469c-9caf-938a866abd29>.
+    
+<http://data.lblod.info/id/remote-data-objects/02bbcc7f-7f20-49dc-bcc0-a40195df3cc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02bbcc7f-7f20-49dc-bcc0-a40195df3cc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/a54d7802-3f48-4e46-a735-a007f8fd879d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02bbcc7f-7f20-49dc-bcc0-a40195df3cc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/87b91da6-9ff2-4b62-8cb4-03b625e50514> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87b91da6-9ff2-4b62-8cb4-03b625e50514";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/a6989a35-5b94-494e-bcdb-3ebb4c681035/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87b91da6-9ff2-4b62-8cb4-03b625e50514>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2c866c2-740e-4344-8d4e-904eb9d8781c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2c866c2-740e-4344-8d4e-904eb9d8781c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/aa842e95-a760-4e35-bdc8-33ad9dcfeecc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2c866c2-740e-4344-8d4e-904eb9d8781c>.
+    
+<http://data.lblod.info/id/remote-data-objects/16ec07dd-f6da-47f9-89c6-20af9a02f436> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16ec07dd-f6da-47f9-89c6-20af9a02f436";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/aabb9b5a-4300-4791-b3c2-753d1cf4b38c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16ec07dd-f6da-47f9-89c6-20af9a02f436>.
+    
+<http://data.lblod.info/id/remote-data-objects/77f0e3a0-1034-4100-8600-5c980936dd9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77f0e3a0-1034-4100-8600-5c980936dd9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/ae160734-16c9-4ee8-badc-7395d4d5d494/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77f0e3a0-1034-4100-8600-5c980936dd9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/617ad94f-105f-4977-9ae4-412fd61a67cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "617ad94f-105f-4977-9ae4-412fd61a67cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/ae528625-0e4e-40d9-8e62-1c09d2bd2c4a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/617ad94f-105f-4977-9ae4-412fd61a67cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/838f21c0-51b4-4807-bb89-7ceb418bc3f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "838f21c0-51b4-4807-bb89-7ceb418bc3f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/af87391f-d7df-42a3-9e63-1c9dfb2b5fa9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/838f21c0-51b4-4807-bb89-7ceb418bc3f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1273cbc7-6e3c-40b3-924d-3dee4428e7b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1273cbc7-6e3c-40b3-924d-3dee4428e7b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/b175ba1a-6b15-4296-be99-f267f17ea25d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1273cbc7-6e3c-40b3-924d-3dee4428e7b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ed23635-33e4-4e31-a978-dc49fbcce607> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ed23635-33e4-4e31-a978-dc49fbcce607";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/b338ff03-2b31-4ef7-b868-9407d34ceeaa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/db473ebd-798d-413f-8810-87926d134f9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ed23635-33e4-4e31-a978-dc49fbcce607>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201125-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201125-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201125-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201125-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/02b36417-187f-4c15-8909-190ebc40556a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "02b36417-187f-4c15-8909-190ebc40556a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c7f0ca40-fbb7-4d6f-b45a-48ab5b201438";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ffa45849-73c1-435f-95b5-a34da96f807c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ffa45849-73c1-435f-95b5-a34da96f807c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438>.
+
+  <http://redpencil.data.gift/id/task/1431b575-e84d-46ca-9415-f417507fe420> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1431b575-e84d-46ca-9415-f417507fe420";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/02b36417-187f-4c15-8909-190ebc40556a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ffa45849-73c1-435f-95b5-a34da96f807c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c5e56989-6b84-49f5-9e3f-a55234b2d415> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5e56989-6b84-49f5-9e3f-a55234b2d415";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/b9560d3c-dc17-494b-a017-6ca4101f4462/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5e56989-6b84-49f5-9e3f-a55234b2d415>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf008f8a-61e1-431e-9034-7ea668ab163b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf008f8a-61e1-431e-9034-7ea668ab163b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/ba374289-3b6c-4f3f-81b3-e91f11d584ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf008f8a-61e1-431e-9034-7ea668ab163b>.
+    
+<http://data.lblod.info/id/remote-data-objects/68604590-64d6-493e-a3d1-a9bce5c44198> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68604590-64d6-493e-a3d1-a9bce5c44198";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/bb753ee4-2bb6-47d9-b795-4baa278f2c16/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68604590-64d6-493e-a3d1-a9bce5c44198>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4c9cc37-ce2a-46c9-a785-979c505bcaad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4c9cc37-ce2a-46c9-a785-979c505bcaad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/bf8bb111-5ba7-42b8-81d4-2b2528679887/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4c9cc37-ce2a-46c9-a785-979c505bcaad>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3bbcbfc-d552-411d-a03c-cffac25fb219> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3bbcbfc-d552-411d-a03c-cffac25fb219";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/d3b5acfe-b40a-493a-aeb2-1301434701d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3bbcbfc-d552-411d-a03c-cffac25fb219>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcb89883-9534-4803-b1f3-48af9ae13403> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcb89883-9534-4803-b1f3-48af9ae13403";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/e0fd0be0-3f94-48d4-8f69-a47232763396/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcb89883-9534-4803-b1f3-48af9ae13403>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9c959e6-1dd4-45a5-b7d8-dfa914fdfca5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9c959e6-1dd4-45a5-b7d8-dfa914fdfca5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/eb6d8763-16df-4f8e-be46-659b89651364/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9c959e6-1dd4-45a5-b7d8-dfa914fdfca5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e7ae641-09d8-4511-bf5b-fce5cb376aaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e7ae641-09d8-4511-bf5b-fce5cb376aaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/efd3220e-e798-40ec-9d55-8ba034600c2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e7ae641-09d8-4511-bf5b-fce5cb376aaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/370cc7d3-1a5a-4c62-8402-fe42b93077a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "370cc7d3-1a5a-4c62-8402-fe42b93077a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/bb/f66d80c7-ca98-4bca-ad68-1db85e82eb8f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/370cc7d3-1a5a-4c62-8402-fe42b93077a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/81186b34-ce86-4c71-a5ff-88ef4df10104> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81186b34-ce86-4c71-a5ff-88ef4df10104";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/0b79408a-71f2-4ea9-888c-07a3ac1db9a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81186b34-ce86-4c71-a5ff-88ef4df10104>.
+    
+<http://data.lblod.info/id/remote-data-objects/68d88e9b-11df-42b0-b28c-1326d863427f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68d88e9b-11df-42b0-b28c-1326d863427f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/0dd88386-34f0-4e84-8cd2-8cac5fe86674/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68d88e9b-11df-42b0-b28c-1326d863427f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c76cb0f6-ab71-4199-9971-48f46c83d047> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c76cb0f6-ab71-4199-9971-48f46c83d047";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/0de3dbec-ec66-4968-aa99-dbce34b2934b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c76cb0f6-ab71-4199-9971-48f46c83d047>.
+    
+<http://data.lblod.info/id/remote-data-objects/661dfd77-cb0a-496f-9a3c-1fd82d8f3b38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "661dfd77-cb0a-496f-9a3c-1fd82d8f3b38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/104961c5-097a-4515-a695-e713beaf1b3c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/661dfd77-cb0a-496f-9a3c-1fd82d8f3b38>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e90cc97-1086-4559-b18c-ce3ad9b1a4ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e90cc97-1086-4559-b18c-ce3ad9b1a4ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/14b9db22-a07d-46b6-ac58-73e93077b060/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e90cc97-1086-4559-b18c-ce3ad9b1a4ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7e8ac6f-d5de-45b5-848e-108cf248c0d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7e8ac6f-d5de-45b5-848e-108cf248c0d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/17fbb09a-7f6f-43dc-b98c-2d8f814efe30/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7e8ac6f-d5de-45b5-848e-108cf248c0d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c9d3937-a62b-414a-b8a8-f8485ccccc54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c9d3937-a62b-414a-b8a8-f8485ccccc54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/19d2f317-f616-4dd1-aac0-6792650faf63/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c9d3937-a62b-414a-b8a8-f8485ccccc54>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f5f3696-2ea4-4659-8a6d-e178a1a08796> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f5f3696-2ea4-4659-8a6d-e178a1a08796";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/274f48c9-5ba4-4ea9-8c4b-427b0cdcc87d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f5f3696-2ea4-4659-8a6d-e178a1a08796>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a383d34-3d4f-449c-bc93-e3bc52416b35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a383d34-3d4f-449c-bc93-e3bc52416b35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/29b35101-f789-4b8b-b959-a6274f530a1c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a383d34-3d4f-449c-bc93-e3bc52416b35>.
+    
+<http://data.lblod.info/id/remote-data-objects/895db05e-a573-4573-9768-20c426d44aea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "895db05e-a573-4573-9768-20c426d44aea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/2c397783-9ad6-4f05-9c3e-30d69e820236/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/895db05e-a573-4573-9768-20c426d44aea>.
+    
+<http://data.lblod.info/id/remote-data-objects/48b4adcc-cb80-4f01-a3c2-fc80a9b167f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48b4adcc-cb80-4f01-a3c2-fc80a9b167f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/3e6302f4-8274-46ce-9fb9-b9596a646b5e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48b4adcc-cb80-4f01-a3c2-fc80a9b167f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/58c5b7ce-6f8e-4b60-9285-45a6d32d3969> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58c5b7ce-6f8e-4b60-9285-45a6d32d3969";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/4346c86e-da93-418f-be27-34f93a7f88f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58c5b7ce-6f8e-4b60-9285-45a6d32d3969>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dd5c916-4913-4aca-ab0b-41137eef3bb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dd5c916-4913-4aca-ab0b-41137eef3bb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/43592bc4-a4af-4249-b9dd-5c7eab50f6cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dd5c916-4913-4aca-ab0b-41137eef3bb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/6be714c8-7f54-43f8-ab42-61c33a4daf11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6be714c8-7f54-43f8-ab42-61c33a4daf11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/44e89340-efb6-4218-b50c-939754fcab64/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6be714c8-7f54-43f8-ab42-61c33a4daf11>.
+    
+<http://data.lblod.info/id/remote-data-objects/10f5e1cf-8b84-4585-b2b5-537215690443> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10f5e1cf-8b84-4585-b2b5-537215690443";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/4a5d6b82-ab20-41ef-8541-f5c627f7574b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10f5e1cf-8b84-4585-b2b5-537215690443>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dcdc1bb-515b-4bf9-9ea9-731afe52d538> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dcdc1bb-515b-4bf9-9ea9-731afe52d538";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/4b4d1f7b-2086-4254-8ec7-d4de520ecb76/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dcdc1bb-515b-4bf9-9ea9-731afe52d538>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bd7dd44-a1f1-49c2-bc68-f910cd6fcf80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bd7dd44-a1f1-49c2-bc68-f910cd6fcf80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/4b804dff-6d7f-4add-8aff-5c4aba753531/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bd7dd44-a1f1-49c2-bc68-f910cd6fcf80>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d79f54c-ef04-45cd-9ff3-cb0cd68f7952> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d79f54c-ef04-45cd-9ff3-cb0cd68f7952";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/4e548ee8-0259-4c18-a2c8-7f50cccc65bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d79f54c-ef04-45cd-9ff3-cb0cd68f7952>.
+    
+<http://data.lblod.info/id/remote-data-objects/a804f41e-1047-4335-8975-aee0ffbed2dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a804f41e-1047-4335-8975-aee0ffbed2dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/4f87511b-16cb-4d19-8017-c37f441b45e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a804f41e-1047-4335-8975-aee0ffbed2dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec7b41c3-a5c4-418a-81f5-69d8c271aae7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec7b41c3-a5c4-418a-81f5-69d8c271aae7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/52829768-a5e7-4122-b8f5-0d4527c02e86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec7b41c3-a5c4-418a-81f5-69d8c271aae7>.
+    
+<http://data.lblod.info/id/remote-data-objects/787a6ddc-85c4-469a-9cb3-f79d51defc1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "787a6ddc-85c4-469a-9cb3-f79d51defc1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/5bf15a23-1ad9-459c-8489-7b6ba868bb93/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/787a6ddc-85c4-469a-9cb3-f79d51defc1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbb703c8-8c24-45c8-aac8-cc2cd7012336> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbb703c8-8c24-45c8-aac8-cc2cd7012336";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/5bfa1287-b21c-4f9c-8b5d-e134eb7ccf27/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbb703c8-8c24-45c8-aac8-cc2cd7012336>.
+    
+<http://data.lblod.info/id/remote-data-objects/e95d2322-aee4-4bf1-a4c6-f294487a08f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e95d2322-aee4-4bf1-a4c6-f294487a08f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/5ee060d2-9202-46cd-b18c-7de774a9ff42/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e95d2322-aee4-4bf1-a4c6-f294487a08f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f05babb-ed9b-4e7f-a004-3b88bcae7049> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f05babb-ed9b-4e7f-a004-3b88bcae7049";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/65aa5092-9d47-489b-ab93-6dd3848f9c6d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f05babb-ed9b-4e7f-a004-3b88bcae7049>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb1c2722-917f-4091-b471-5c14a371f2f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb1c2722-917f-4091-b471-5c14a371f2f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/66f979e6-2b7f-434d-8698-d1144ed18de3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb1c2722-917f-4091-b471-5c14a371f2f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e94ddee8-cb1a-4865-a26e-bf0b3671dd7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e94ddee8-cb1a-4865-a26e-bf0b3671dd7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/6e9b3315-447d-4d92-a437-d6fdda554bee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e94ddee8-cb1a-4865-a26e-bf0b3671dd7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/21a1ca35-cede-446b-bbe9-707ea463f4a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21a1ca35-cede-446b-bbe9-707ea463f4a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/6ffdefd5-eae5-40ec-a354-aac1386e3b45/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21a1ca35-cede-446b-bbe9-707ea463f4a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a22e7df-9ab8-4255-9e38-35031f3336ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a22e7df-9ab8-4255-9e38-35031f3336ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/7368a2d9-f9db-4410-a7d2-3ed1e563fa4b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a22e7df-9ab8-4255-9e38-35031f3336ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f9e59e5-2cb3-4c42-a95e-e6b2a071de3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f9e59e5-2cb3-4c42-a95e-e6b2a071de3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/73b7ef9c-e927-4263-b293-d8ef751d5c97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f9e59e5-2cb3-4c42-a95e-e6b2a071de3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4df8d8c-e6cb-4465-9ee5-fc2a01722a72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4df8d8c-e6cb-4465-9ee5-fc2a01722a72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/74c2d373-44d1-443e-b841-5e8e992f3129/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4df8d8c-e6cb-4465-9ee5-fc2a01722a72>.
+    
+<http://data.lblod.info/id/remote-data-objects/fabb5857-a2c3-43b0-8127-ff0ae9f14533> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fabb5857-a2c3-43b0-8127-ff0ae9f14533";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/8476b3d2-d7d1-4ff8-864c-f711537fd95f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fabb5857-a2c3-43b0-8127-ff0ae9f14533>.
+    
+<http://data.lblod.info/id/remote-data-objects/76ee11cc-f0e6-4bbf-81e7-06a10d75a21a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76ee11cc-f0e6-4bbf-81e7-06a10d75a21a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/87b95505-6265-43f0-95dd-478a92a30ef3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76ee11cc-f0e6-4bbf-81e7-06a10d75a21a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d03a228-c12f-47d4-b2bc-d95d53dd9d99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d03a228-c12f-47d4-b2bc-d95d53dd9d99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/88460d2d-eb01-4b16-a405-2748ed6f36dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d03a228-c12f-47d4-b2bc-d95d53dd9d99>.
+    
+<http://data.lblod.info/id/remote-data-objects/59db3fae-d3df-4815-bb9e-0268ef66bb48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59db3fae-d3df-4815-bb9e-0268ef66bb48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/8d59db9f-ac00-4981-924e-acd0181f59d9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59db3fae-d3df-4815-bb9e-0268ef66bb48>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad09fc63-7119-47c2-a47a-19ce29fae31b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad09fc63-7119-47c2-a47a-19ce29fae31b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/9476efa7-d9e1-4397-9977-4207c885de23/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad09fc63-7119-47c2-a47a-19ce29fae31b>.
+    
+<http://data.lblod.info/id/remote-data-objects/42a99ee0-2100-460b-8070-37ff92550c92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42a99ee0-2100-460b-8070-37ff92550c92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/96380757-edd7-4f23-820e-ad8cf0243cb6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42a99ee0-2100-460b-8070-37ff92550c92>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe43e5d8-09a2-4594-a8b4-6a0b95c61372> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe43e5d8-09a2-4594-a8b4-6a0b95c61372";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/96ef815d-56f7-494f-ba57-8bf93d8c5b6b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe43e5d8-09a2-4594-a8b4-6a0b95c61372>.
+    
+<http://data.lblod.info/id/remote-data-objects/e94a2919-efe8-4970-93e8-490adea5ee7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e94a2919-efe8-4970-93e8-490adea5ee7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/9a9b5003-29b9-46f6-84ac-897ba4cfbb97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e94a2919-efe8-4970-93e8-490adea5ee7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/605e1148-7761-41eb-b14d-6679037b31ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "605e1148-7761-41eb-b14d-6679037b31ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/9c19c55e-41d8-4bfe-b8d3-a11ba975710f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/605e1148-7761-41eb-b14d-6679037b31ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd14dbc7-ec98-43d7-abe0-f8a10578ec61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd14dbc7-ec98-43d7-abe0-f8a10578ec61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/a415c44b-85b9-45ac-9808-fcf5385f1659/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd14dbc7-ec98-43d7-abe0-f8a10578ec61>.
+    
+<http://data.lblod.info/id/remote-data-objects/db8124c9-4980-4484-9545-b9f0d24c7b5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db8124c9-4980-4484-9545-b9f0d24c7b5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/a8355c4f-46d5-4107-9e69-3aa4669486dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7f0ca40-fbb7-4d6f-b45a-48ab5b201438> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db8124c9-4980-4484-9545-b9f0d24c7b5d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201126-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201126-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201126-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201126-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/57e870b0-3b77-48ab-9630-671725d3db86> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "57e870b0-3b77-48ab-9630-671725d3db86";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "95b910a5-1bdf-4bcd-b044-ed6b289e51a6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e213c75d-cc38-4a3b-9f8e-45eff4307b09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e213c75d-cc38-4a3b-9f8e-45eff4307b09";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6>.
+
+  <http://redpencil.data.gift/id/task/6394dd23-f63c-4faf-8af0-dea134f55a7b> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6394dd23-f63c-4faf-8af0-dea134f55a7b";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/57e870b0-3b77-48ab-9630-671725d3db86>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e213c75d-cc38-4a3b-9f8e-45eff4307b09>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d468c915-0d2e-4258-8ee7-587c5f4dfbc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d468c915-0d2e-4258-8ee7-587c5f4dfbc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/ada3085b-6739-41ae-b5e7-558185666700/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d468c915-0d2e-4258-8ee7-587c5f4dfbc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ced87b30-16bd-40db-a57f-359b1b911dbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ced87b30-16bd-40db-a57f-359b1b911dbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/ae50240a-5764-4a15-8163-237710e1ce46/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ced87b30-16bd-40db-a57f-359b1b911dbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/78c5bf13-854b-4321-999a-ee40dc85cbf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78c5bf13-854b-4321-999a-ee40dc85cbf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/b34dd5dc-1a23-41b8-ac97-958a4f6b285f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78c5bf13-854b-4321-999a-ee40dc85cbf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d04ac4a-9b85-4d27-8df1-129d828a4ab7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d04ac4a-9b85-4d27-8df1-129d828a4ab7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/b5b5c8c4-22ae-49aa-a0b7-b34ab1a19f45/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d04ac4a-9b85-4d27-8df1-129d828a4ab7>.
+    
+<http://data.lblod.info/id/remote-data-objects/5373b38f-cd6f-40da-8626-2f9f07898121> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5373b38f-cd6f-40da-8626-2f9f07898121";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/b67095ab-154b-44f5-88f3-03875be403b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5373b38f-cd6f-40da-8626-2f9f07898121>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd3989ad-bee7-480f-969d-7deab3a46607> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd3989ad-bee7-480f-969d-7deab3a46607";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/b7ae9b02-9580-40be-8268-7419755449c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd3989ad-bee7-480f-969d-7deab3a46607>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e7af895-ae7f-4957-936e-46ef75b76dad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e7af895-ae7f-4957-936e-46ef75b76dad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/bb04ea41-f846-4e15-a890-76f255371589/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e7af895-ae7f-4957-936e-46ef75b76dad>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7c6fb22-aede-4679-bbac-092235827e35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7c6fb22-aede-4679-bbac-092235827e35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/bb902271-d31e-4e66-991e-86f63036625e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7c6fb22-aede-4679-bbac-092235827e35>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d1a6531-b0fa-4fa1-b532-31667c590969> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d1a6531-b0fa-4fa1-b532-31667c590969";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/bcdbebb7-16eb-404e-afb4-191954950529/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d1a6531-b0fa-4fa1-b532-31667c590969>.
+    
+<http://data.lblod.info/id/remote-data-objects/13b840a6-85da-47fe-b054-83de70bee0cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13b840a6-85da-47fe-b054-83de70bee0cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/c0e730e4-4b09-46a6-9a1b-1f5696b2e941/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13b840a6-85da-47fe-b054-83de70bee0cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/a10177b8-f225-4382-b441-a5d47de62045> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a10177b8-f225-4382-b441-a5d47de62045";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/c1409c1a-d77d-432a-940a-3319c6de3db6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a10177b8-f225-4382-b441-a5d47de62045>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef2840c6-3b66-43b9-a338-643fd322c461> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef2840c6-3b66-43b9-a338-643fd322c461";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/c27b6f1a-def8-4043-804e-9028b6258c19/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef2840c6-3b66-43b9-a338-643fd322c461>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2bd5258-5942-47af-af95-158e629b5774> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2bd5258-5942-47af-af95-158e629b5774";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/c47ecf06-635a-4a0d-bb3a-acf1adaa860b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2bd5258-5942-47af-af95-158e629b5774>.
+    
+<http://data.lblod.info/id/remote-data-objects/e275679d-a050-4965-8b8a-c8851ae3c9bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e275679d-a050-4965-8b8a-c8851ae3c9bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/c7228b63-37a9-423f-81df-51be9d3d6537/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e275679d-a050-4965-8b8a-c8851ae3c9bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa7016d6-cf76-4bc4-8b3d-d8e90e2a665a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa7016d6-cf76-4bc4-8b3d-d8e90e2a665a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/c9d2cbd0-4915-4871-9675-fb59627c34b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa7016d6-cf76-4bc4-8b3d-d8e90e2a665a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e53b65cd-2571-4025-9631-65a1818f3e93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e53b65cd-2571-4025-9631-65a1818f3e93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/cded617b-6f95-47c0-9db4-10d5f75b2f40/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e53b65cd-2571-4025-9631-65a1818f3e93>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa21d8bc-6d32-4d30-bc0b-78bf12a98007> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa21d8bc-6d32-4d30-bc0b-78bf12a98007";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/cefe243d-1416-4be7-9bc1-b1da04cd6b3e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa21d8bc-6d32-4d30-bc0b-78bf12a98007>.
+    
+<http://data.lblod.info/id/remote-data-objects/d474e1ab-04ca-474e-a27d-22d1eab0cfc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d474e1ab-04ca-474e-a27d-22d1eab0cfc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/cf2994d8-4910-4348-ada0-cae5e801e11f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d474e1ab-04ca-474e-a27d-22d1eab0cfc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/57348e18-c1a8-4cb9-b2bc-43611d45ac4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57348e18-c1a8-4cb9-b2bc-43611d45ac4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/d0829251-a928-4177-8810-9f206ceb580d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57348e18-c1a8-4cb9-b2bc-43611d45ac4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c9364b5-5ad6-4a72-b1b0-ec5610b970a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c9364b5-5ad6-4a72-b1b0-ec5610b970a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/d2e5808a-a9fd-4658-bb24-e659e9419151/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c9364b5-5ad6-4a72-b1b0-ec5610b970a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd44d2c9-a58b-49f5-b44a-ada3390218e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd44d2c9-a58b-49f5-b44a-ada3390218e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/d4562ddd-31b1-43ad-a8ef-b71325e37dd8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd44d2c9-a58b-49f5-b44a-ada3390218e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bbecfb6-2523-4358-baac-f4bc64ec94da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bbecfb6-2523-4358-baac-f4bc64ec94da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/d6791ae5-5b93-4bdd-845b-a3c12d57481e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bbecfb6-2523-4358-baac-f4bc64ec94da>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d46cc78-e402-4b3b-9f06-5365d9ab822d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d46cc78-e402-4b3b-9f06-5365d9ab822d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/dcc12bee-0f02-4af0-a909-2f7c9a7ebdcc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d46cc78-e402-4b3b-9f06-5365d9ab822d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3df6d499-a329-48ba-b290-bd06cf656e48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3df6d499-a329-48ba-b290-bd06cf656e48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/dce1fcc5-8fd3-4cd2-98cf-2a6804c565d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3df6d499-a329-48ba-b290-bd06cf656e48>.
+    
+<http://data.lblod.info/id/remote-data-objects/cefed081-b4e1-41d1-9283-24da93ce3f7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cefed081-b4e1-41d1-9283-24da93ce3f7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/dd68e06a-7c1f-4934-9e1f-c1f72b8292fb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cefed081-b4e1-41d1-9283-24da93ce3f7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e5a9a18-a948-46f6-a07d-f103ef8a1f67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e5a9a18-a948-46f6-a07d-f103ef8a1f67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/e16e6e39-9ea3-4633-98e4-f8c6ca834618/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e5a9a18-a948-46f6-a07d-f103ef8a1f67>.
+    
+<http://data.lblod.info/id/remote-data-objects/835b5462-3eb5-4894-b239-016246468491> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "835b5462-3eb5-4894-b239-016246468491";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/e3265485-1601-4a5d-92d4-fea7324ccf57/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/835b5462-3eb5-4894-b239-016246468491>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8a0f567-864d-40af-b625-03d887897ea9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8a0f567-864d-40af-b625-03d887897ea9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/e5c89516-b316-43fe-bb3c-a1be53353745/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8a0f567-864d-40af-b625-03d887897ea9>.
+    
+<http://data.lblod.info/id/remote-data-objects/530e3d2c-060f-40e2-bccb-2c1aef05ca92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "530e3d2c-060f-40e2-bccb-2c1aef05ca92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/e8c3931e-76c7-422a-98c0-4487b6c46062/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/530e3d2c-060f-40e2-bccb-2c1aef05ca92>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3a2371d-be3f-4b6f-b3a2-a0130d71c062> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3a2371d-be3f-4b6f-b3a2-a0130d71c062";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/e9eb8837-131a-41ec-a8a9-4c55f928644b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3a2371d-be3f-4b6f-b3a2-a0130d71c062>.
+    
+<http://data.lblod.info/id/remote-data-objects/67fd72bc-010e-4735-afef-972f4b14acb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67fd72bc-010e-4735-afef-972f4b14acb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/ea640eb3-b913-4e93-ab1f-777e1bab16f5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67fd72bc-010e-4735-afef-972f4b14acb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2713815-5773-47d5-8058-109daaed35fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2713815-5773-47d5-8058-109daaed35fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/ec587132-a11d-453d-b47a-68c73c0bb870/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2713815-5773-47d5-8058-109daaed35fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff5412bb-9695-43aa-92c2-39c0b2fabbb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff5412bb-9695-43aa-92c2-39c0b2fabbb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/ec7efaef-ba16-4d23-8f70-2918d76f0bae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff5412bb-9695-43aa-92c2-39c0b2fabbb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/03a336bc-fe58-4ac3-b0ca-38dee8dd4931> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03a336bc-fe58-4ac3-b0ca-38dee8dd4931";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/f07261b4-504a-4385-b4c5-341599dec8dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03a336bc-fe58-4ac3-b0ca-38dee8dd4931>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a4df1e0-f85b-4a75-85cb-fcfbba6b8856> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a4df1e0-f85b-4a75-85cb-fcfbba6b8856";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/f34a2d96-af26-4cd1-8d33-84a9b16fe5c2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a4df1e0-f85b-4a75-85cb-fcfbba6b8856>.
+    
+<http://data.lblod.info/id/remote-data-objects/c99b9a4e-acea-4965-a198-62406c922d82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c99b9a4e-acea-4965-a198-62406c922d82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/f8dc4e67-5137-4d65-ad52-656ba5fba2c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c99b9a4e-acea-4965-a198-62406c922d82>.
+    
+<http://data.lblod.info/id/remote-data-objects/41dac781-b67e-40af-b0d7-31e23d10d6c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41dac781-b67e-40af-b0d7-31e23d10d6c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/fa60c8cd-240a-4d27-b402-9c5ee0f2da52/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41dac781-b67e-40af-b0d7-31e23d10d6c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef4efd41-11f7-4c0d-9d5f-b69eff0a2e3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef4efd41-11f7-4c0d-9d5f-b69eff0a2e3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/faddec19-3a2b-4bce-b56b-2b990eca1273/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef4efd41-11f7-4c0d-9d5f-b69eff0a2e3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8364e61c-3d83-4e90-a7b0-481712a680c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8364e61c-3d83-4e90-a7b0-481712a680c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/cbs/fbabb3b2-e0af-48fd-ab08-9e1973de578f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8364e61c-3d83-4e90-a7b0-481712a680c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2ccaa31-6e33-46c8-bd55-04ab53ac2a8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2ccaa31-6e33-46c8-bd55-04ab53ac2a8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/15217b44-60ab-4e0d-8859-703a6a9065ef/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2ccaa31-6e33-46c8-bd55-04ab53ac2a8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e58805c-358a-412b-965b-459215110137> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e58805c-358a-412b-965b-459215110137";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/15217b44-60ab-4e0d-8859-703a6a9065ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e58805c-358a-412b-965b-459215110137>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb558dc6-416b-4186-9501-ec3ddc467b0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb558dc6-416b-4186-9501-ec3ddc467b0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/15217b44-60ab-4e0d-8859-703a6a9065ef/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb558dc6-416b-4186-9501-ec3ddc467b0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d6ca35c-de13-409a-8e00-0cebd1833377> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d6ca35c-de13-409a-8e00-0cebd1833377";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/19a0ba71-bbed-4a28-8fa3-72a32359b858/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d6ca35c-de13-409a-8e00-0cebd1833377>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa14c0d9-a83f-4e5b-9e58-3db95b4067eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa14c0d9-a83f-4e5b-9e58-3db95b4067eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/19a0ba71-bbed-4a28-8fa3-72a32359b858/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa14c0d9-a83f-4e5b-9e58-3db95b4067eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cd1cb40-c78a-4c09-83f1-ecd12ebf2db0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cd1cb40-c78a-4c09-83f1-ecd12ebf2db0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/19a0ba71-bbed-4a28-8fa3-72a32359b858/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cd1cb40-c78a-4c09-83f1-ecd12ebf2db0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d3fcec4-c045-4510-9145-20e9d04b20ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d3fcec4-c045-4510-9145-20e9d04b20ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/2c135835-8c08-4bea-848a-fc893d4553ed/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d3fcec4-c045-4510-9145-20e9d04b20ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/04c6030d-ffee-4a27-93f6-e32ad5c68f44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04c6030d-ffee-4a27-93f6-e32ad5c68f44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/2c135835-8c08-4bea-848a-fc893d4553ed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04c6030d-ffee-4a27-93f6-e32ad5c68f44>.
+    
+<http://data.lblod.info/id/remote-data-objects/5599285f-32c5-47fa-8904-05a8df00416c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5599285f-32c5-47fa-8904-05a8df00416c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/2c135835-8c08-4bea-848a-fc893d4553ed/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5599285f-32c5-47fa-8904-05a8df00416c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2447efb1-3836-4215-86b6-be50df93e9ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2447efb1-3836-4215-86b6-be50df93e9ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/388e78c9-e70c-413e-881f-2c7bf44a77d3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2447efb1-3836-4215-86b6-be50df93e9ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/71a3dce1-c8ad-460d-b9dd-a22ba17567b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71a3dce1-c8ad-460d-b9dd-a22ba17567b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/388e78c9-e70c-413e-881f-2c7bf44a77d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95b910a5-1bdf-4bcd-b044-ed6b289e51a6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71a3dce1-c8ad-460d-b9dd-a22ba17567b7>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201127-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201127-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201127-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201127-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3c058d00-405b-4d17-ae6e-9db8b39fb66e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3c058d00-405b-4d17-ae6e-9db8b39fb66e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "afc40261-ecc2-4567-80e7-16b1339d2f91";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c24680dc-3a25-4a44-bafc-39796c18c4f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c24680dc-3a25-4a44-bafc-39796c18c4f6";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91>.
+
+  <http://redpencil.data.gift/id/task/614e6ef3-9d29-4622-8b4e-a05fd56598e0> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "614e6ef3-9d29-4622-8b4e-a05fd56598e0";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3c058d00-405b-4d17-ae6e-9db8b39fb66e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c24680dc-3a25-4a44-bafc-39796c18c4f6>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/bdcbe06f-f246-4b89-aa96-915ae1272308> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdcbe06f-f246-4b89-aa96-915ae1272308";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/388e78c9-e70c-413e-881f-2c7bf44a77d3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdcbe06f-f246-4b89-aa96-915ae1272308>.
+    
+<http://data.lblod.info/id/remote-data-objects/b30bfc0e-7e9a-459d-a655-ab1860bc7410> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b30bfc0e-7e9a-459d-a655-ab1860bc7410";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/5e9f9b2f-69aa-409c-aec5-860110446e5d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b30bfc0e-7e9a-459d-a655-ab1860bc7410>.
+    
+<http://data.lblod.info/id/remote-data-objects/f844390f-2b8c-4c77-8245-c982c2aa43a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f844390f-2b8c-4c77-8245-c982c2aa43a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/5e9f9b2f-69aa-409c-aec5-860110446e5d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f844390f-2b8c-4c77-8245-c982c2aa43a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ea3c726-26c6-4192-ba42-a72b5cdfffd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ea3c726-26c6-4192-ba42-a72b5cdfffd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/5e9f9b2f-69aa-409c-aec5-860110446e5d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ea3c726-26c6-4192-ba42-a72b5cdfffd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b9d58c9-57d5-4425-8c2f-a650af8fa773> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b9d58c9-57d5-4425-8c2f-a650af8fa773";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/6ba4e7fc-5298-4641-a9c7-4f396dbf42ad/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b9d58c9-57d5-4425-8c2f-a650af8fa773>.
+    
+<http://data.lblod.info/id/remote-data-objects/d15d2b24-f1f9-445d-bb2a-df7c44d4317a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d15d2b24-f1f9-445d-bb2a-df7c44d4317a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/6ba4e7fc-5298-4641-a9c7-4f396dbf42ad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d15d2b24-f1f9-445d-bb2a-df7c44d4317a>.
+    
+<http://data.lblod.info/id/remote-data-objects/960e08f1-345c-4451-a696-39d579210f6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "960e08f1-345c-4451-a696-39d579210f6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/6ba4e7fc-5298-4641-a9c7-4f396dbf42ad/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/960e08f1-345c-4451-a696-39d579210f6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1ffdc33-b301-4d0c-8277-dcae275c55c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1ffdc33-b301-4d0c-8277-dcae275c55c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/7706ad06-80ca-41e6-961d-30fd1a1b149a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1ffdc33-b301-4d0c-8277-dcae275c55c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/5be1ee59-7241-4d9e-9ec6-5063d18517f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5be1ee59-7241-4d9e-9ec6-5063d18517f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/7706ad06-80ca-41e6-961d-30fd1a1b149a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5be1ee59-7241-4d9e-9ec6-5063d18517f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3d5638d-a646-434e-a1dc-a9ebba106e15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3d5638d-a646-434e-a1dc-a9ebba106e15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/7b0d8e39-f983-4b4a-aab1-a56755a0d58e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3d5638d-a646-434e-a1dc-a9ebba106e15>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c2c626e-3236-4cda-bf01-8652f8222352> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c2c626e-3236-4cda-bf01-8652f8222352";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/7b0d8e39-f983-4b4a-aab1-a56755a0d58e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c2c626e-3236-4cda-bf01-8652f8222352>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9d01e9c-9274-4ebc-b739-be9a8899e60f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9d01e9c-9274-4ebc-b739-be9a8899e60f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/7b0d8e39-f983-4b4a-aab1-a56755a0d58e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9d01e9c-9274-4ebc-b739-be9a8899e60f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fedc009-e92b-471c-a003-21dd1d5812b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fedc009-e92b-471c-a003-21dd1d5812b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/7dc50546-29ac-4b2b-b65d-cb7e26210132/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fedc009-e92b-471c-a003-21dd1d5812b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/83e7492b-adb4-41be-a70b-39de17a9ae13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83e7492b-adb4-41be-a70b-39de17a9ae13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/7dc50546-29ac-4b2b-b65d-cb7e26210132/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83e7492b-adb4-41be-a70b-39de17a9ae13>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbf203a4-bc25-458e-a940-ef67079326df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbf203a4-bc25-458e-a940-ef67079326df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/7dc50546-29ac-4b2b-b65d-cb7e26210132/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbf203a4-bc25-458e-a940-ef67079326df>.
+    
+<http://data.lblod.info/id/remote-data-objects/13e85a4d-b9f3-4f7c-b293-942950b25335> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13e85a4d-b9f3-4f7c-b293-942950b25335";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/8024cdd0-befe-4023-b131-7627a1ab91c4/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13e85a4d-b9f3-4f7c-b293-942950b25335>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b100ab2-dfd1-4e9f-8bdc-14d89b39dc20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b100ab2-dfd1-4e9f-8bdc-14d89b39dc20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/8024cdd0-befe-4023-b131-7627a1ab91c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b100ab2-dfd1-4e9f-8bdc-14d89b39dc20>.
+    
+<http://data.lblod.info/id/remote-data-objects/0896f5aa-3734-4ee1-a2dc-5b778c62773f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0896f5aa-3734-4ee1-a2dc-5b778c62773f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/8024cdd0-befe-4023-b131-7627a1ab91c4/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0896f5aa-3734-4ee1-a2dc-5b778c62773f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fe514cc-6e9f-4907-bb37-48449811b466> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fe514cc-6e9f-4907-bb37-48449811b466";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/aaca37ab-060e-45ad-8565-8a0d2e97b9d9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fe514cc-6e9f-4907-bb37-48449811b466>.
+    
+<http://data.lblod.info/id/remote-data-objects/330849e8-1aed-4034-b1d9-eba510f87029> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "330849e8-1aed-4034-b1d9-eba510f87029";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/aaca37ab-060e-45ad-8565-8a0d2e97b9d9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/330849e8-1aed-4034-b1d9-eba510f87029>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b382be8-bfb0-4a7b-8714-9122e12f67b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b382be8-bfb0-4a7b-8714-9122e12f67b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/aaca37ab-060e-45ad-8565-8a0d2e97b9d9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b382be8-bfb0-4a7b-8714-9122e12f67b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/8882bf83-f79f-4b79-acbb-419b48ac25cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8882bf83-f79f-4b79-acbb-419b48ac25cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/b5732f10-90b4-4734-950d-f5637e6d5881/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8882bf83-f79f-4b79-acbb-419b48ac25cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/6661f32e-7485-4c21-acd5-bb8e2f0907db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6661f32e-7485-4c21-acd5-bb8e2f0907db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/b5732f10-90b4-4734-950d-f5637e6d5881/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6661f32e-7485-4c21-acd5-bb8e2f0907db>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4318ff3-855b-4b5b-bab7-dd272d7f77aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4318ff3-855b-4b5b-bab7-dd272d7f77aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/b7ca6c79-3356-42db-9185-6a488d3ac956/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4318ff3-855b-4b5b-bab7-dd272d7f77aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff7c408b-7c80-4a8a-b37a-ec70848c5e65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff7c408b-7c80-4a8a-b37a-ec70848c5e65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/b7ca6c79-3356-42db-9185-6a488d3ac956/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff7c408b-7c80-4a8a-b37a-ec70848c5e65>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bcc86b4-e5c4-402a-bdaa-a69784bc7704> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bcc86b4-e5c4-402a-bdaa-a69784bc7704";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/b7ca6c79-3356-42db-9185-6a488d3ac956/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bcc86b4-e5c4-402a-bdaa-a69784bc7704>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c8969db-c03e-43f1-87b7-31feeb2e0ccf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c8969db-c03e-43f1-87b7-31feeb2e0ccf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/b91ad21f-6664-427b-8996-b0134bf3bb69/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c8969db-c03e-43f1-87b7-31feeb2e0ccf>.
+    
+<http://data.lblod.info/id/remote-data-objects/97d7ae2d-a775-442e-b128-fbaea52552bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97d7ae2d-a775-442e-b128-fbaea52552bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/b91ad21f-6664-427b-8996-b0134bf3bb69/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97d7ae2d-a775-442e-b128-fbaea52552bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d131a1de-55ca-42f9-9cfb-e601a4d3064b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d131a1de-55ca-42f9-9cfb-e601a4d3064b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/b91ad21f-6664-427b-8996-b0134bf3bb69/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d131a1de-55ca-42f9-9cfb-e601a4d3064b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c596e9ea-96b3-4510-8f0e-62bb2c9e46c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c596e9ea-96b3-4510-8f0e-62bb2c9e46c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/be6b10e9-a3ea-40d1-94a7-387c11ce8c06/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c596e9ea-96b3-4510-8f0e-62bb2c9e46c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a737d72-95a7-4315-9a9e-0da7e518a735> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a737d72-95a7-4315-9a9e-0da7e518a735";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/be6b10e9-a3ea-40d1-94a7-387c11ce8c06/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a737d72-95a7-4315-9a9e-0da7e518a735>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fff94b9-52a8-4435-b35c-20f99e1cd3d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fff94b9-52a8-4435-b35c-20f99e1cd3d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/gr/be6b10e9-a3ea-40d1-94a7-387c11ce8c06/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fff94b9-52a8-4435-b35c-20f99e1cd3d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bec727c-da9f-4f27-8287-e3d3969e1207> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bec727c-da9f-4f27-8287-e3d3969e1207";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/0e761b60-8e0f-4ccb-9876-7d6a9daac672/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bec727c-da9f-4f27-8287-e3d3969e1207>.
+    
+<http://data.lblod.info/id/remote-data-objects/b368086b-031d-4ac3-beb1-9f566538119e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b368086b-031d-4ac3-beb1-9f566538119e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/0e761b60-8e0f-4ccb-9876-7d6a9daac672/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b368086b-031d-4ac3-beb1-9f566538119e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5476481a-d98c-4827-9474-4a62c408eb9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5476481a-d98c-4827-9474-4a62c408eb9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/0e761b60-8e0f-4ccb-9876-7d6a9daac672/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5476481a-d98c-4827-9474-4a62c408eb9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf1f1963-6f57-4d14-9ba6-9da5387d5f7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf1f1963-6f57-4d14-9ba6-9da5387d5f7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/2735c73a-5f8e-496a-a4d4-f1faab0a6734/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf1f1963-6f57-4d14-9ba6-9da5387d5f7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/57e45ba2-938d-4641-85ea-8bc1925fcc87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57e45ba2-938d-4641-85ea-8bc1925fcc87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/2735c73a-5f8e-496a-a4d4-f1faab0a6734/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57e45ba2-938d-4641-85ea-8bc1925fcc87>.
+    
+<http://data.lblod.info/id/remote-data-objects/778c68bb-0422-437a-a505-d1aaa4e2b46e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "778c68bb-0422-437a-a505-d1aaa4e2b46e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/2735c73a-5f8e-496a-a4d4-f1faab0a6734/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/778c68bb-0422-437a-a505-d1aaa4e2b46e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5af4f6a0-8b60-4af6-bfec-a185d1c0d9fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5af4f6a0-8b60-4af6-bfec-a185d1c0d9fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/2aa4f16c-2ce3-49cf-8263-9c441136a779/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5af4f6a0-8b60-4af6-bfec-a185d1c0d9fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a8aa5bc-0bf5-4a10-8f0e-97132f0f9744> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a8aa5bc-0bf5-4a10-8f0e-97132f0f9744";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/2aa4f16c-2ce3-49cf-8263-9c441136a779/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a8aa5bc-0bf5-4a10-8f0e-97132f0f9744>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2edb327-9ccb-478e-9a81-fdcd813ab368> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2edb327-9ccb-478e-9a81-fdcd813ab368";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/2aa4f16c-2ce3-49cf-8263-9c441136a779/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2edb327-9ccb-478e-9a81-fdcd813ab368>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9da4f44-73c8-4299-8e67-bd8ad324a9cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9da4f44-73c8-4299-8e67-bd8ad324a9cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/39b1f385-5c0d-4fa3-a542-65282b7cb71e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9da4f44-73c8-4299-8e67-bd8ad324a9cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/f73eca77-2d9f-40da-bd23-19ad5796cc0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f73eca77-2d9f-40da-bd23-19ad5796cc0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/39b1f385-5c0d-4fa3-a542-65282b7cb71e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f73eca77-2d9f-40da-bd23-19ad5796cc0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/001d1a5c-1c7a-4fa9-b2c4-fd27d2fda858> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "001d1a5c-1c7a-4fa9-b2c4-fd27d2fda858";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/39b1f385-5c0d-4fa3-a542-65282b7cb71e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/001d1a5c-1c7a-4fa9-b2c4-fd27d2fda858>.
+    
+<http://data.lblod.info/id/remote-data-objects/5500513a-03ea-47ed-98d6-1485cf79e67b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5500513a-03ea-47ed-98d6-1485cf79e67b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/4a95c67e-5142-4e5b-ad54-12d00a9f2c8c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5500513a-03ea-47ed-98d6-1485cf79e67b>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf3f52e1-39cb-4875-b062-7beefc5c44ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf3f52e1-39cb-4875-b062-7beefc5c44ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/4a95c67e-5142-4e5b-ad54-12d00a9f2c8c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf3f52e1-39cb-4875-b062-7beefc5c44ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bf9b2ee-fc0e-4fb6-a58c-edab3afbe005> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bf9b2ee-fc0e-4fb6-a58c-edab3afbe005";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/4a95c67e-5142-4e5b-ad54-12d00a9f2c8c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bf9b2ee-fc0e-4fb6-a58c-edab3afbe005>.
+    
+<http://data.lblod.info/id/remote-data-objects/2854a03e-fa0c-4109-bee7-a48047c3f07b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2854a03e-fa0c-4109-bee7-a48047c3f07b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/5b5a7964-8f75-4710-9fa9-22f2784b0fd9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2854a03e-fa0c-4109-bee7-a48047c3f07b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d41eba54-fe5a-4315-9380-95f8162b5b1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d41eba54-fe5a-4315-9380-95f8162b5b1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/5b5a7964-8f75-4710-9fa9-22f2784b0fd9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d41eba54-fe5a-4315-9380-95f8162b5b1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe4872da-c7d8-4afe-99ee-fc363b54392c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe4872da-c7d8-4afe-99ee-fc363b54392c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/5b5a7964-8f75-4710-9fa9-22f2784b0fd9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/afc40261-ecc2-4567-80e7-16b1339d2f91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe4872da-c7d8-4afe-99ee-fc363b54392c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201129-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201129-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201129-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201129-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2fce7dfa-2dbd-453b-93f2-a6bfa8dfff5d> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2fce7dfa-2dbd-453b-93f2-a6bfa8dfff5d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "04fc603d-159a-4c2e-b0ae-b61dc1a10dae";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/40c79372-98df-44dd-8435-3c393fd921b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "40c79372-98df-44dd-8435-3c393fd921b4";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae>.
+
+  <http://redpencil.data.gift/id/task/706f9f41-c98b-4da0-8636-2199eba3245c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "706f9f41-c98b-4da0-8636-2199eba3245c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2fce7dfa-2dbd-453b-93f2-a6bfa8dfff5d>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/40c79372-98df-44dd-8435-3c393fd921b4>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/05a1fb43-531b-451c-aa2f-7137a5619de6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05a1fb43-531b-451c-aa2f-7137a5619de6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/82039065-a613-475f-8d07-3f3c8622682d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05a1fb43-531b-451c-aa2f-7137a5619de6>.
+    
+<http://data.lblod.info/id/remote-data-objects/afcaa206-c0fd-4769-ab62-6f249fac55a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afcaa206-c0fd-4769-ab62-6f249fac55a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/82039065-a613-475f-8d07-3f3c8622682d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afcaa206-c0fd-4769-ab62-6f249fac55a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f482ae4-9e68-4789-9630-0f8e7235d498> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f482ae4-9e68-4789-9630-0f8e7235d498";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/9534ddfe-c2ea-45f7-b332-eb6f846d8880/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f482ae4-9e68-4789-9630-0f8e7235d498>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce618e37-212a-498c-8d7a-678991aff726> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce618e37-212a-498c-8d7a-678991aff726";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/9534ddfe-c2ea-45f7-b332-eb6f846d8880/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce618e37-212a-498c-8d7a-678991aff726>.
+    
+<http://data.lblod.info/id/remote-data-objects/de8db960-8e3d-427e-b18c-f6537a33dcb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de8db960-8e3d-427e-b18c-f6537a33dcb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/9534ddfe-c2ea-45f7-b332-eb6f846d8880/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de8db960-8e3d-427e-b18c-f6537a33dcb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c7502ed-e892-4b02-8029-2a1bd6fc1d5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c7502ed-e892-4b02-8029-2a1bd6fc1d5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/9f67f0b9-3ab3-49c4-ba53-e62ffb2244c1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c7502ed-e892-4b02-8029-2a1bd6fc1d5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e16a24d-926d-4532-bcb6-24bdedca040f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e16a24d-926d-4532-bcb6-24bdedca040f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/9f67f0b9-3ab3-49c4-ba53-e62ffb2244c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e16a24d-926d-4532-bcb6-24bdedca040f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e475efb-1a7b-4797-b813-00daa2b8f0ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e475efb-1a7b-4797-b813-00daa2b8f0ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/9f67f0b9-3ab3-49c4-ba53-e62ffb2244c1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e475efb-1a7b-4797-b813-00daa2b8f0ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/47b20a17-46df-4ceb-a0b4-80411dbbdbaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47b20a17-46df-4ceb-a0b4-80411dbbdbaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/a383562e-06e5-4d6f-9f03-e018f890fd27/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47b20a17-46df-4ceb-a0b4-80411dbbdbaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e005b5c-a8b6-4dc3-a208-7cbcc1000d0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e005b5c-a8b6-4dc3-a208-7cbcc1000d0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/a383562e-06e5-4d6f-9f03-e018f890fd27/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e005b5c-a8b6-4dc3-a208-7cbcc1000d0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/964e14ab-4bca-4dd0-885e-b84b3fde7e69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "964e14ab-4bca-4dd0-885e-b84b3fde7e69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/a383562e-06e5-4d6f-9f03-e018f890fd27/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/964e14ab-4bca-4dd0-885e-b84b3fde7e69>.
+    
+<http://data.lblod.info/id/remote-data-objects/abba5aa4-0463-4c3f-a75f-1bf438e8adf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abba5aa4-0463-4c3f-a75f-1bf438e8adf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/a47d5a8e-66ba-43d6-9335-4d28fa143e38/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abba5aa4-0463-4c3f-a75f-1bf438e8adf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/aff9d07f-0728-47d3-9ac2-ab1600afed15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aff9d07f-0728-47d3-9ac2-ab1600afed15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/a47d5a8e-66ba-43d6-9335-4d28fa143e38/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aff9d07f-0728-47d3-9ac2-ab1600afed15>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a230068-d4d6-4ee8-85b3-02e4156f883d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a230068-d4d6-4ee8-85b3-02e4156f883d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/a47d5a8e-66ba-43d6-9335-4d28fa143e38/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a230068-d4d6-4ee8-85b3-02e4156f883d>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b72b808-dfa7-4eb3-8be8-5899707e138a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b72b808-dfa7-4eb3-8be8-5899707e138a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/c2f4f624-4844-426c-9ffc-739e7fbaf222/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b72b808-dfa7-4eb3-8be8-5899707e138a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f578453-7192-4153-b784-ba8713ee8ba4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f578453-7192-4153-b784-ba8713ee8ba4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/c2f4f624-4844-426c-9ffc-739e7fbaf222/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f578453-7192-4153-b784-ba8713ee8ba4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c047771b-35b2-40e7-b8e8-24fe5a486da2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c047771b-35b2-40e7-b8e8-24fe5a486da2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/c2f4f624-4844-426c-9ffc-739e7fbaf222/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c047771b-35b2-40e7-b8e8-24fe5a486da2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f89b500-aee4-4aa0-bf25-9af1d6a3bba7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f89b500-aee4-4aa0-bf25-9af1d6a3bba7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/d3d952c8-691a-4306-ba26-ff4793e75232/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f89b500-aee4-4aa0-bf25-9af1d6a3bba7>.
+    
+<http://data.lblod.info/id/remote-data-objects/3544bdeb-2903-4655-8c69-969654b2d06b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3544bdeb-2903-4655-8c69-969654b2d06b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/d3d952c8-691a-4306-ba26-ff4793e75232/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3544bdeb-2903-4655-8c69-969654b2d06b>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd75a14b-815c-43bc-837c-aadf9de59989> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd75a14b-815c-43bc-837c-aadf9de59989";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/d3d952c8-691a-4306-ba26-ff4793e75232/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd75a14b-815c-43bc-837c-aadf9de59989>.
+    
+<http://data.lblod.info/id/remote-data-objects/855a85b4-5f59-42eb-9367-967fa5b98015> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "855a85b4-5f59-42eb-9367-967fa5b98015";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/e480d075-263b-4d31-a4f8-78f6d50130b7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/855a85b4-5f59-42eb-9367-967fa5b98015>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1b6912d-c7a8-4acd-a666-b88b003200d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1b6912d-c7a8-4acd-a666-b88b003200d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/e480d075-263b-4d31-a4f8-78f6d50130b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1b6912d-c7a8-4acd-a666-b88b003200d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/72e4a8f9-c169-4f8f-b8ee-6186bf6d814c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72e4a8f9-c169-4f8f-b8ee-6186bf6d814c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/e480d075-263b-4d31-a4f8-78f6d50130b7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72e4a8f9-c169-4f8f-b8ee-6186bf6d814c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cb298d2-cdfc-4d50-9e7e-1c8b69445f36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cb298d2-cdfc-4d50-9e7e-1c8b69445f36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/e9c913cd-44ab-4bb3-b2e4-93fae8687dac/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cb298d2-cdfc-4d50-9e7e-1c8b69445f36>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b52e7af-180f-42fe-bab7-13fee3bc909d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b52e7af-180f-42fe-bab7-13fee3bc909d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/e9c913cd-44ab-4bb3-b2e4-93fae8687dac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b52e7af-180f-42fe-bab7-13fee3bc909d>.
+    
+<http://data.lblod.info/id/remote-data-objects/01c7ac57-d0e9-4c5e-a5bc-6740c1491614> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01c7ac57-d0e9-4c5e-a5bc-6740c1491614";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/rmw/e9c913cd-44ab-4bb3-b2e4-93fae8687dac/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01c7ac57-d0e9-4c5e-a5bc-6740c1491614>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3367b0d-2f1e-4e51-8680-14e3ecb77353> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3367b0d-2f1e-4e51-8680-14e3ecb77353";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/02d9b6fb-fb5b-40ca-abe3-82f025406f97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3367b0d-2f1e-4e51-8680-14e3ecb77353>.
+    
+<http://data.lblod.info/id/remote-data-objects/2825412e-5920-4f67-b96f-47c22a483d93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2825412e-5920-4f67-b96f-47c22a483d93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/0480a0dd-0e70-4c7e-8a20-5023957002df/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2825412e-5920-4f67-b96f-47c22a483d93>.
+    
+<http://data.lblod.info/id/remote-data-objects/a57dc8f5-ed18-4d71-ada5-aa43ad0dfd85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a57dc8f5-ed18-4d71-ada5-aa43ad0dfd85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/09529935-3909-40cc-872c-c6a3c68dc5e4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a57dc8f5-ed18-4d71-ada5-aa43ad0dfd85>.
+    
+<http://data.lblod.info/id/remote-data-objects/065c795f-4de1-4c65-b9cc-377843fdbeb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "065c795f-4de1-4c65-b9cc-377843fdbeb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/09a9fa13-6627-4eac-81c0-b1b9eadebefb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/065c795f-4de1-4c65-b9cc-377843fdbeb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/46295925-1cd8-4b9b-8086-714d707fdc9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46295925-1cd8-4b9b-8086-714d707fdc9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/0ae852e2-f8cc-438f-9ff2-491955737cfa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46295925-1cd8-4b9b-8086-714d707fdc9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf7c44b0-7fdc-4461-acfc-0146e209b22a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf7c44b0-7fdc-4461-acfc-0146e209b22a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/11c822b3-8c40-48e2-a19a-86ff13df1eb7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf7c44b0-7fdc-4461-acfc-0146e209b22a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b22cb51-bb17-4682-a9c8-08e4c14f6709> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b22cb51-bb17-4682-a9c8-08e4c14f6709";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/1214a8a7-645c-4946-9c5f-591afccdcb32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b22cb51-bb17-4682-a9c8-08e4c14f6709>.
+    
+<http://data.lblod.info/id/remote-data-objects/abc30830-0052-4f2e-92bb-d12a2feb16dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abc30830-0052-4f2e-92bb-d12a2feb16dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/16a575a9-4f64-4833-b709-63f33397d929/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abc30830-0052-4f2e-92bb-d12a2feb16dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/981ee70b-e6c2-44b5-872c-56b6d164f77d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "981ee70b-e6c2-44b5-872c-56b6d164f77d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/2966bb8a-03e6-47e8-8cfe-79f19e7793f0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/981ee70b-e6c2-44b5-872c-56b6d164f77d>.
+    
+<http://data.lblod.info/id/remote-data-objects/36cb1b51-5e86-4b24-ab73-3df1682a529b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36cb1b51-5e86-4b24-ab73-3df1682a529b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/30642497-4b97-4d60-a818-86ba47f186e4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36cb1b51-5e86-4b24-ab73-3df1682a529b>.
+    
+<http://data.lblod.info/id/remote-data-objects/49259934-b34c-42ea-b882-f696503b124b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49259934-b34c-42ea-b882-f696503b124b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/37ac552d-a00d-4662-99b4-c3ab85a0e266/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49259934-b34c-42ea-b882-f696503b124b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d898f14e-46e7-4ce4-a63e-d27eb52a6a46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d898f14e-46e7-4ce4-a63e-d27eb52a6a46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/3d28d736-d4f8-4ca0-89a9-2896e8e8cc3a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d898f14e-46e7-4ce4-a63e-d27eb52a6a46>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1c49f01-9e8f-426e-8b3a-1dc064e30d19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1c49f01-9e8f-426e-8b3a-1dc064e30d19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/449fd03a-d1bb-42b4-8882-9261dd5ded2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1c49f01-9e8f-426e-8b3a-1dc064e30d19>.
+    
+<http://data.lblod.info/id/remote-data-objects/78294281-52e0-4791-a00f-ea2d31995f9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78294281-52e0-4791-a00f-ea2d31995f9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/462521dd-384a-4977-a8d0-cf8e07d0d624/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78294281-52e0-4791-a00f-ea2d31995f9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/726ad014-4b04-486b-a67d-453815783dd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "726ad014-4b04-486b-a67d-453815783dd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/483f9c3b-2897-48ef-92a6-2f8a0fb3aaa3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/726ad014-4b04-486b-a67d-453815783dd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbae972a-3082-42f8-ae0e-d1c113dfec40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbae972a-3082-42f8-ae0e-d1c113dfec40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/4abfcad6-a7be-4d08-b94c-0797aca18bce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbae972a-3082-42f8-ae0e-d1c113dfec40>.
+    
+<http://data.lblod.info/id/remote-data-objects/7616dc0c-ef19-4bbd-820f-e758c042030e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7616dc0c-ef19-4bbd-820f-e758c042030e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/4b283878-971d-450b-a7ab-2253c204fe34/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7616dc0c-ef19-4bbd-820f-e758c042030e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3430ae41-8898-4a31-8d39-6d6d092e904c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3430ae41-8898-4a31-8d39-6d6d092e904c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/4c043f12-3d67-4b45-b6f7-fec2919d3e5c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3430ae41-8898-4a31-8d39-6d6d092e904c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4558f7dd-79b7-4a54-ba06-c12ededbe523> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4558f7dd-79b7-4a54-ba06-c12ededbe523";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/4e446bd6-7335-4f36-9dcd-408cca9d82ba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4558f7dd-79b7-4a54-ba06-c12ededbe523>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f229b3c-1e42-4701-bb0f-4bc733242fea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f229b3c-1e42-4701-bb0f-4bc733242fea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/57986d08-ac19-4493-8628-dcee81f601cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f229b3c-1e42-4701-bb0f-4bc733242fea>.
+    
+<http://data.lblod.info/id/remote-data-objects/66952996-c92e-47ce-90e1-c2abde2312cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66952996-c92e-47ce-90e1-c2abde2312cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/5ee6808f-d14b-48db-b298-5e4dec6ba040/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66952996-c92e-47ce-90e1-c2abde2312cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/f763fcc6-57a3-4f41-b434-eafc2bc64bbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f763fcc6-57a3-4f41-b434-eafc2bc64bbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/64d299a1-e840-41f2-bb5a-08fe842ee4f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f763fcc6-57a3-4f41-b434-eafc2bc64bbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/db86c25c-834c-4b62-bc27-f69fd980650f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db86c25c-834c-4b62-bc27-f69fd980650f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/6ac631f6-7e7b-4923-9f76-0ab96f3f6081/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db86c25c-834c-4b62-bc27-f69fd980650f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5126a06-fd0a-4758-80b5-8a96f00c9d21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5126a06-fd0a-4758-80b5-8a96f00c9d21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/746fd867-ba8d-4f8a-8f2b-053d41bd7e1e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04fc603d-159a-4c2e-b0ae-b61dc1a10dae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5126a06-fd0a-4758-80b5-8a96f00c9d21>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201130-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201130-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201130-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201130-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/0ca17b5a-2b4e-470f-a213-55b3951be8e1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0ca17b5a-2b4e-470f-a213-55b3951be8e1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1c77c6ea-61f5-4750-8735-3ff6ded5ddd5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f72fdcc5-035b-43a9-9395-b930e0078a5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f72fdcc5-035b-43a9-9395-b930e0078a5a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5>.
+
+  <http://redpencil.data.gift/id/task/ecbe2e55-ee08-4327-b7f1-1fcacf0efb3e> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ecbe2e55-ee08-4327-b7f1-1fcacf0efb3e";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/0ca17b5a-2b4e-470f-a213-55b3951be8e1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f72fdcc5-035b-43a9-9395-b930e0078a5a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d9b13768-2b24-430b-8e21-deb1d08de420> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9b13768-2b24-430b-8e21-deb1d08de420";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/771f205d-9c4e-42f0-acb0-966f302cd2d8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9b13768-2b24-430b-8e21-deb1d08de420>.
+    
+<http://data.lblod.info/id/remote-data-objects/1976d964-c293-49f8-83cc-88d6d9578ead> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1976d964-c293-49f8-83cc-88d6d9578ead";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/77416586-651b-45d0-8b85-9bc978b49928/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1976d964-c293-49f8-83cc-88d6d9578ead>.
+    
+<http://data.lblod.info/id/remote-data-objects/6193a7d0-5042-4a8f-9b26-fc904cfbe651> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6193a7d0-5042-4a8f-9b26-fc904cfbe651";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/7d8baf55-719e-4ae3-8eef-664f0835428f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6193a7d0-5042-4a8f-9b26-fc904cfbe651>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea0bd84c-9c91-42ef-bd50-9ea2cb0a5e2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea0bd84c-9c91-42ef-bd50-9ea2cb0a5e2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/7f692014-3683-49ae-8666-4f9a0289bd0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea0bd84c-9c91-42ef-bd50-9ea2cb0a5e2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f79a0296-3178-4326-970f-c5ecd0027a9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f79a0296-3178-4326-970f-c5ecd0027a9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/80407cda-75cb-46bd-b83c-ebce481640e4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f79a0296-3178-4326-970f-c5ecd0027a9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/07a7b7ff-993c-415f-a7a8-53a3b604cc5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07a7b7ff-993c-415f-a7a8-53a3b604cc5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/8171468b-09f9-4786-942f-7992855c8c32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07a7b7ff-993c-415f-a7a8-53a3b604cc5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5455433a-c9e2-438c-8daf-3e93c9220758> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5455433a-c9e2-438c-8daf-3e93c9220758";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/8a4fbdf5-7532-4915-ab07-78369f8db704/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5455433a-c9e2-438c-8daf-3e93c9220758>.
+    
+<http://data.lblod.info/id/remote-data-objects/509fd438-d499-437d-98bb-479a83677b7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "509fd438-d499-437d-98bb-479a83677b7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/8c161c09-152f-4e1a-b72e-668c0db24d9d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/509fd438-d499-437d-98bb-479a83677b7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddadd4e0-4ed1-4c8b-ab57-c2381d9620f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddadd4e0-4ed1-4c8b-ab57-c2381d9620f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/8cbda118-3622-4c84-93ac-3debc8efd70d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddadd4e0-4ed1-4c8b-ab57-c2381d9620f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/543351b4-4643-4ed4-9e9f-ef3735590bb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "543351b4-4643-4ed4-9e9f-ef3735590bb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/8f9c273a-a1dd-4e85-8be8-b74b56a553c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/543351b4-4643-4ed4-9e9f-ef3735590bb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/876866dd-df9b-4f83-a477-d4fcadfcdc96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "876866dd-df9b-4f83-a477-d4fcadfcdc96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/94efade8-54f3-4b7e-b47a-ec4088bd3a11/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/876866dd-df9b-4f83-a477-d4fcadfcdc96>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dda674f-9f4e-4067-9f09-5761d30923df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dda674f-9f4e-4067-9f09-5761d30923df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/9b8c50d7-bc1a-4ee9-8d29-6dcde2d9e38b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dda674f-9f4e-4067-9f09-5761d30923df>.
+    
+<http://data.lblod.info/id/remote-data-objects/61d58721-c344-4897-b230-d9da93aac34b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61d58721-c344-4897-b230-d9da93aac34b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/9fc25a9f-c2a7-42f6-b842-1d58c807c25f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61d58721-c344-4897-b230-d9da93aac34b>.
+    
+<http://data.lblod.info/id/remote-data-objects/25a7c3ae-05d2-4d98-a209-43f234c3cfba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25a7c3ae-05d2-4d98-a209-43f234c3cfba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/a399c03d-dbc6-4f1c-8e3c-1fc1ddcdb1b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25a7c3ae-05d2-4d98-a209-43f234c3cfba>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce9bd67d-edb4-40ed-8e97-b5701ca4a731> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce9bd67d-edb4-40ed-8e97-b5701ca4a731";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/a8adfa73-430f-44ad-8ba6-e9dc6a79e38a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce9bd67d-edb4-40ed-8e97-b5701ca4a731>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc7d8754-400d-4008-a30f-b17022e96abe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc7d8754-400d-4008-a30f-b17022e96abe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/a9d81f91-d14e-4fae-8219-c2a49fe0af56/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc7d8754-400d-4008-a30f-b17022e96abe>.
+    
+<http://data.lblod.info/id/remote-data-objects/3496c20d-d2d8-4703-9661-9ab9d1383507> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3496c20d-d2d8-4703-9661-9ab9d1383507";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/ac63a666-7d8c-4b5e-86ec-0f15aeeac74e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3496c20d-d2d8-4703-9661-9ab9d1383507>.
+    
+<http://data.lblod.info/id/remote-data-objects/4685fd58-3bc6-46c8-8207-4a1230b19f7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4685fd58-3bc6-46c8-8207-4a1230b19f7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/b0166a44-b134-494d-b4d7-40219f76f775/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4685fd58-3bc6-46c8-8207-4a1230b19f7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c89098b9-9c34-43a9-8b0f-f3bf50e9e9e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c89098b9-9c34-43a9-8b0f-f3bf50e9e9e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/b60a191c-a9e9-4fdf-97e4-d51467da114d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c89098b9-9c34-43a9-8b0f-f3bf50e9e9e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f0802a7-f0db-443f-b687-a40611ec87ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f0802a7-f0db-443f-b687-a40611ec87ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/b6478ad5-dba2-4d67-b5e2-46155508efd1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f0802a7-f0db-443f-b687-a40611ec87ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/93cecac3-bf4c-4267-b0ad-ad41861d5a4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93cecac3-bf4c-4267-b0ad-ad41861d5a4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/b7088068-457e-4e98-8002-5da500c72d12/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93cecac3-bf4c-4267-b0ad-ad41861d5a4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/40dcafec-5892-49ed-9ba5-6c0283cfea53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40dcafec-5892-49ed-9ba5-6c0283cfea53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/c0310b4e-5261-43e5-b639-ff99f1afa326/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40dcafec-5892-49ed-9ba5-6c0283cfea53>.
+    
+<http://data.lblod.info/id/remote-data-objects/7488fcde-1f78-487f-8eb9-462de49ba336> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7488fcde-1f78-487f-8eb9-462de49ba336";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/c2112727-6a64-41ba-91ee-ea7e283ab3fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7488fcde-1f78-487f-8eb9-462de49ba336>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b2b7364-9fce-422f-9cdf-eb687a4e1aa6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b2b7364-9fce-422f-9cdf-eb687a4e1aa6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/c45c0ec5-c1b4-4e2a-9081-59dcca564aca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b2b7364-9fce-422f-9cdf-eb687a4e1aa6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ee17415-9dcc-42c0-aeaf-babafd040ed9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ee17415-9dcc-42c0-aeaf-babafd040ed9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/c66727e7-c0df-4d3c-8a80-673cd8fbfaf3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ee17415-9dcc-42c0-aeaf-babafd040ed9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b410304e-c4cf-4b31-bd01-204080392b96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b410304e-c4cf-4b31-bd01-204080392b96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/c669da2a-6141-437c-9c9f-64a7d635f0d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b410304e-c4cf-4b31-bd01-204080392b96>.
+    
+<http://data.lblod.info/id/remote-data-objects/0583a48c-fe1a-4945-a888-09234d13faaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0583a48c-fe1a-4945-a888-09234d13faaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/c6a428a6-f555-447b-9f0d-0d3a0ac23bdf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0583a48c-fe1a-4945-a888-09234d13faaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/13fe16b7-dd08-418d-a190-ea98626862f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13fe16b7-dd08-418d-a190-ea98626862f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/cb800609-35cc-4a6d-b237-421f419f7d25/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13fe16b7-dd08-418d-a190-ea98626862f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/8417023f-0967-41b2-b202-25deeca41f10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8417023f-0967-41b2-b202-25deeca41f10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/cbb3dc4b-a313-4373-9fe7-b5fcdd02b3f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8417023f-0967-41b2-b202-25deeca41f10>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b066b87-1a50-49c0-8bd4-02c94d97b09f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b066b87-1a50-49c0-8bd4-02c94d97b09f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/cd3e230b-3206-420a-8f1b-043ca613537a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b066b87-1a50-49c0-8bd4-02c94d97b09f>.
+    
+<http://data.lblod.info/id/remote-data-objects/78e4e4dd-c5c7-4b73-85f0-9a94d025497c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78e4e4dd-c5c7-4b73-85f0-9a94d025497c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/cd5610c2-9149-42f9-bd73-e7f864a9fb8e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78e4e4dd-c5c7-4b73-85f0-9a94d025497c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7ad4b59-1962-4cbf-ab2f-0d24342319eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7ad4b59-1962-4cbf-ab2f-0d24342319eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/d8cc5336-6784-468d-bc71-55ebd13a4cd1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7ad4b59-1962-4cbf-ab2f-0d24342319eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/730975b5-db0e-4847-a5fb-2c58f5c1493b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "730975b5-db0e-4847-a5fb-2c58f5c1493b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/db0a8607-2f1f-4805-a780-e4ddb1935af7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/730975b5-db0e-4847-a5fb-2c58f5c1493b>.
+    
+<http://data.lblod.info/id/remote-data-objects/32e51076-0913-4c13-813a-c10886926617> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32e51076-0913-4c13-813a-c10886926617";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/dda90fd8-53b2-4265-a86a-704bdb609a2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32e51076-0913-4c13-813a-c10886926617>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3da5c86-69c3-474e-88d1-18fee7008c44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3da5c86-69c3-474e-88d1-18fee7008c44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/de5b92d3-0e53-44cf-a0cc-a17d25767033/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3da5c86-69c3-474e-88d1-18fee7008c44>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca8bfc4b-d7f5-43de-ac79-798931b56a5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca8bfc4b-d7f5-43de-ac79-798931b56a5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/deb6b6d4-4e1b-46d4-b1e7-5cda7be91807/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca8bfc4b-d7f5-43de-ac79-798931b56a5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5f45797-a839-46bd-bd17-f5da9c3aee8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5f45797-a839-46bd-bd17-f5da9c3aee8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/e604f4c1-92d6-43c8-9b03-365c3f17684c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5f45797-a839-46bd-bd17-f5da9c3aee8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1713432a-0dfc-4d1e-b1fd-a5a703d4f10f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1713432a-0dfc-4d1e-b1fd-a5a703d4f10f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/eb8fc81c-9cfb-4efe-8346-aac990f5aff7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1713432a-0dfc-4d1e-b1fd-a5a703d4f10f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef50e5f8-7806-4323-a19a-74fd72a0715c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef50e5f8-7806-4323-a19a-74fd72a0715c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/edbe31e5-74a3-464b-b5ef-103b949bd660/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef50e5f8-7806-4323-a19a-74fd72a0715c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c49a0ab-c771-4e2f-9d46-e83defa3aed8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c49a0ab-c771-4e2f-9d46-e83defa3aed8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/ee6c3830-1060-43a5-b922-a7ef8b4bb19c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c49a0ab-c771-4e2f-9d46-e83defa3aed8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f250ff4a-8bbf-4fe7-9bde-b5d3c08c6681> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f250ff4a-8bbf-4fe7-9bde-b5d3c08c6681";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/f04e2385-e791-412f-80b3-fdf3d55090e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f250ff4a-8bbf-4fe7-9bde-b5d3c08c6681>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8d625ea-12d3-4eaf-935a-5cb5c3022b8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8d625ea-12d3-4eaf-935a-5cb5c3022b8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/f2016ff3-1cb4-4bad-8857-75b74242beef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8d625ea-12d3-4eaf-935a-5cb5c3022b8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5517004f-8721-41e2-8e14-d92e166ff301> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5517004f-8721-41e2-8e14-d92e166ff301";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/f52fa3e0-ebb2-472b-a9dd-2e9b6ed40cd8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5517004f-8721-41e2-8e14-d92e166ff301>.
+    
+<http://data.lblod.info/id/remote-data-objects/565abaa3-e902-40cd-b8ee-f343339003f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "565abaa3-e902-40cd-b8ee-f343339003f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/f57568e6-f956-4fd0-9b37-236ad1e0223f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/565abaa3-e902-40cd-b8ee-f343339003f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e6637f2-690a-4e24-96f5-4b143a406b44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e6637f2-690a-4e24-96f5-4b143a406b44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://herselt.meetingburger.net/vabu/fb2d9005-7cdf-43a7-902d-560a185bfbc5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e6637f2-690a-4e24-96f5-4b143a406b44>.
+    
+<http://data.lblod.info/id/remote-data-objects/7855a563-f008-4464-9162-d4df61bdf057> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7855a563-f008-4464-9162-d4df61bdf057";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/018e71af-f9aa-4b84-8178-45ac0994397e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7855a563-f008-4464-9162-d4df61bdf057>.
+    
+<http://data.lblod.info/id/remote-data-objects/42b3f8e5-6fea-4073-a158-5c47b8a76831> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42b3f8e5-6fea-4073-a158-5c47b8a76831";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/035f27db-3301-4441-b047-c26e59f5f7f0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42b3f8e5-6fea-4073-a158-5c47b8a76831>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc1f9f4a-2729-4050-8dee-055958bde154> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc1f9f4a-2729-4050-8dee-055958bde154";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/08051d5f-180a-40ee-9bf6-1c1540867583/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc1f9f4a-2729-4050-8dee-055958bde154>.
+    
+<http://data.lblod.info/id/remote-data-objects/6074bc52-f9b3-476a-b221-efe9dc4955fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6074bc52-f9b3-476a-b221-efe9dc4955fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/0b396f59-81e1-4758-8913-00b3faeeafb2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6074bc52-f9b3-476a-b221-efe9dc4955fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/e94189a9-0426-46ca-bbee-fffe12c3da57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e94189a9-0426-46ca-bbee-fffe12c3da57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/0b5bda8e-6c06-4181-a256-256b7c1ef4dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c77c6ea-61f5-4750-8735-3ff6ded5ddd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e94189a9-0426-46ca-bbee-fffe12c3da57>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201131-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201131-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201131-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201131-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/65e4fa1d-2bff-4763-80b7-0309e99e3283> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "65e4fa1d-2bff-4763-80b7-0309e99e3283";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2d090cc3-c541-41db-99ff-7eb0891f04dd";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f07a09cc-6cea-455a-9a85-cccce0d218f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f07a09cc-6cea-455a-9a85-cccce0d218f1";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd>.
+
+  <http://redpencil.data.gift/id/task/6f09c27c-fd02-4ad8-be74-fe2967672bec> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6f09c27c-fd02-4ad8-be74-fe2967672bec";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/65e4fa1d-2bff-4763-80b7-0309e99e3283>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f07a09cc-6cea-455a-9a85-cccce0d218f1>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b96954a9-bb8b-4aa2-ab97-5e1861614880> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b96954a9-bb8b-4aa2-ab97-5e1861614880";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/0c734d56-07dd-4c7f-ae59-2cba10e601a0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b96954a9-bb8b-4aa2-ab97-5e1861614880>.
+    
+<http://data.lblod.info/id/remote-data-objects/4221460d-fcf2-498c-8361-fa786d46bb49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4221460d-fcf2-498c-8361-fa786d46bb49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/13701e1b-a767-4474-8638-6c2cc4054299/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4221460d-fcf2-498c-8361-fa786d46bb49>.
+    
+<http://data.lblod.info/id/remote-data-objects/703f3f7a-1eb0-4aa3-9dc2-4d670a58e504> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "703f3f7a-1eb0-4aa3-9dc2-4d670a58e504";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/13ba108f-409a-4432-ac9b-b67ff4c2730e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/703f3f7a-1eb0-4aa3-9dc2-4d670a58e504>.
+    
+<http://data.lblod.info/id/remote-data-objects/02bb0d01-ee10-4ae1-9998-61f97a73f962> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02bb0d01-ee10-4ae1-9998-61f97a73f962";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/15cb9a6d-3c10-46a8-908c-1948a9d96a03/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02bb0d01-ee10-4ae1-9998-61f97a73f962>.
+    
+<http://data.lblod.info/id/remote-data-objects/097616cc-2638-4da7-b364-94aa2a194158> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "097616cc-2638-4da7-b364-94aa2a194158";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/1e9520b0-0d32-4ed9-807c-360ff54da3b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/097616cc-2638-4da7-b364-94aa2a194158>.
+    
+<http://data.lblod.info/id/remote-data-objects/abae8d98-d183-4736-994e-3f6c3d66016d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abae8d98-d183-4736-994e-3f6c3d66016d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/20671f2b-3f4b-4e68-a231-783a79a6ed22/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abae8d98-d183-4736-994e-3f6c3d66016d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e20befa-f4d4-4b2b-8543-bc33a3ae2315> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e20befa-f4d4-4b2b-8543-bc33a3ae2315";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/208bfb11-1769-4c8f-94dc-796542a718fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e20befa-f4d4-4b2b-8543-bc33a3ae2315>.
+    
+<http://data.lblod.info/id/remote-data-objects/1afae96c-5686-4006-a0d1-8591e8406fcb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1afae96c-5686-4006-a0d1-8591e8406fcb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/20b03236-d95f-4dc0-9569-685a268c6c23/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1afae96c-5686-4006-a0d1-8591e8406fcb>.
+    
+<http://data.lblod.info/id/remote-data-objects/a23984dd-fd29-499b-8c15-13505e48661d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a23984dd-fd29-499b-8c15-13505e48661d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/23cc9457-ecd3-4612-bbec-a34690cdb2a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a23984dd-fd29-499b-8c15-13505e48661d>.
+    
+<http://data.lblod.info/id/remote-data-objects/cafc4506-d284-4e11-abf9-344ee161871d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cafc4506-d284-4e11-abf9-344ee161871d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/2a5329d7-ce48-4e49-a36d-c7e205e93b7d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cafc4506-d284-4e11-abf9-344ee161871d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8dd1f3e3-ddfd-4016-9bb5-e6b4ff3c18de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8dd1f3e3-ddfd-4016-9bb5-e6b4ff3c18de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/31fb8e0f-185e-4245-b532-bec8be11e14d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8dd1f3e3-ddfd-4016-9bb5-e6b4ff3c18de>.
+    
+<http://data.lblod.info/id/remote-data-objects/200ee49a-5cc0-4ee5-af39-9b0cdb867ecb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "200ee49a-5cc0-4ee5-af39-9b0cdb867ecb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/328deeb1-738a-4c65-a8ba-56d8e2a355db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/200ee49a-5cc0-4ee5-af39-9b0cdb867ecb>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c4a2042-1887-4c6c-a36a-3523bf2020ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c4a2042-1887-4c6c-a36a-3523bf2020ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/339c12e2-8e69-4abe-b7ad-d35215832cda/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c4a2042-1887-4c6c-a36a-3523bf2020ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/023aeab1-ea3c-4676-be7b-7cca62a57206> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "023aeab1-ea3c-4676-be7b-7cca62a57206";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/38384ad6-dd8e-4747-a01e-42fb15c63629/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/023aeab1-ea3c-4676-be7b-7cca62a57206>.
+    
+<http://data.lblod.info/id/remote-data-objects/ceb9e800-eaea-4c48-9627-f6dbcbf3b5ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ceb9e800-eaea-4c48-9627-f6dbcbf3b5ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/3ad47dab-ee63-41a3-bbbd-42e11e4a9626/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ceb9e800-eaea-4c48-9627-f6dbcbf3b5ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7d211e2-1933-4b68-85b4-30d2d2452b63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7d211e2-1933-4b68-85b4-30d2d2452b63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/3c7d4868-6ec6-449b-982b-6a232c15cc9c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7d211e2-1933-4b68-85b4-30d2d2452b63>.
+    
+<http://data.lblod.info/id/remote-data-objects/421aeaef-99a7-4491-82ad-c5f55607fa18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "421aeaef-99a7-4491-82ad-c5f55607fa18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/3d93e1f4-c95e-4bf1-bfb0-7062eeb5c0e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/421aeaef-99a7-4491-82ad-c5f55607fa18>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1e67717-ecf9-4909-ad82-58e8825279ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1e67717-ecf9-4909-ad82-58e8825279ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/3eba060f-4af5-42a8-9af0-0c5f551ed3b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1e67717-ecf9-4909-ad82-58e8825279ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/986a5fc9-cf30-477d-b1cf-950d3935155c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "986a5fc9-cf30-477d-b1cf-950d3935155c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/422748f9-eec6-4f74-9d5a-5bccce0f1c36/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/986a5fc9-cf30-477d-b1cf-950d3935155c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c2cb3ed-26f5-4236-8e67-2a146224287a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c2cb3ed-26f5-4236-8e67-2a146224287a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/49b594f2-d63d-455e-a0f7-73500c9da889/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c2cb3ed-26f5-4236-8e67-2a146224287a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a0e960f-a3e1-418e-a918-fc896ebf5322> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a0e960f-a3e1-418e-a918-fc896ebf5322";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/4a7fdae4-e354-42f1-a7b1-87742f709a77/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a0e960f-a3e1-418e-a918-fc896ebf5322>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebbc24e9-b9d0-458a-bd5c-e0772cde5a6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebbc24e9-b9d0-458a-bd5c-e0772cde5a6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/4e99b2f4-a648-4bc5-b16e-0381e93e75ed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebbc24e9-b9d0-458a-bd5c-e0772cde5a6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/31244727-747f-4a2a-a728-444c9efbd4f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31244727-747f-4a2a-a728-444c9efbd4f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/4fd13b36-7f41-4587-a551-e8fac7f04538/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31244727-747f-4a2a-a728-444c9efbd4f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff404c18-64b2-4ceb-97b7-bb3d4724ea1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff404c18-64b2-4ceb-97b7-bb3d4724ea1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/59450e64-48c7-4d0a-b69b-93e3fc2e885b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff404c18-64b2-4ceb-97b7-bb3d4724ea1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5563fada-98e8-45e7-a2ca-258069f68de8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5563fada-98e8-45e7-a2ca-258069f68de8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/59f3aab7-85ab-48e7-854c-cd81141ad76b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5563fada-98e8-45e7-a2ca-258069f68de8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f0f6b8f-658f-4732-bb92-40b026a54802> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f0f6b8f-658f-4732-bb92-40b026a54802";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/5a076c75-6029-4d76-a320-91a6001010b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f0f6b8f-658f-4732-bb92-40b026a54802>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fe3067f-f4bd-497f-8211-99c2d11dde34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fe3067f-f4bd-497f-8211-99c2d11dde34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/5ea60d15-392d-4175-bfbd-1e3c27458a68/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fe3067f-f4bd-497f-8211-99c2d11dde34>.
+    
+<http://data.lblod.info/id/remote-data-objects/831cabf5-71f1-43e0-8d68-c0a035b67384> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "831cabf5-71f1-43e0-8d68-c0a035b67384";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/66666786-e24c-47cb-9a0c-2d27463b0d4a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/831cabf5-71f1-43e0-8d68-c0a035b67384>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e0d9350-bf28-474e-8abb-cf1e242921ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e0d9350-bf28-474e-8abb-cf1e242921ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/697df0bc-0857-4b56-a043-f9d445d4bd24/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e0d9350-bf28-474e-8abb-cf1e242921ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fbd119e-52eb-4577-a535-f7e7849def97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fbd119e-52eb-4577-a535-f7e7849def97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/6a3ac34f-a515-4966-b0c1-2cb82e8347e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fbd119e-52eb-4577-a535-f7e7849def97>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cf63b55-a2e9-43e9-978b-f1edeb79fbba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cf63b55-a2e9-43e9-978b-f1edeb79fbba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/6a9ac973-59ae-4997-80a4-ffae278b7d77/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cf63b55-a2e9-43e9-978b-f1edeb79fbba>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a410882-c366-4ecb-b985-e51ef72fdfa7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a410882-c366-4ecb-b985-e51ef72fdfa7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/6b38e2b1-dcb4-46f9-97b2-c3bf8b15222a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a410882-c366-4ecb-b985-e51ef72fdfa7>.
+    
+<http://data.lblod.info/id/remote-data-objects/13c1a413-31b1-4f72-9f7a-3a97cc6c1e15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13c1a413-31b1-4f72-9f7a-3a97cc6c1e15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/6cbeccd1-06a4-43a0-af35-82992f89c0f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13c1a413-31b1-4f72-9f7a-3a97cc6c1e15>.
+    
+<http://data.lblod.info/id/remote-data-objects/a16426c5-55ec-449a-83ee-7cd378278a91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a16426c5-55ec-449a-83ee-7cd378278a91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/6d9c978c-7cb6-444d-b26e-dd3fadd95acd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a16426c5-55ec-449a-83ee-7cd378278a91>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4ac1d21-0d2e-43f2-921d-5a21067df80d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4ac1d21-0d2e-43f2-921d-5a21067df80d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/6f667deb-306b-45ed-93b3-c4b398815581/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4ac1d21-0d2e-43f2-921d-5a21067df80d>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa3bd654-7a2d-468d-9555-55464d4f13c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa3bd654-7a2d-468d-9555-55464d4f13c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/72fef2ef-9e4c-4c68-9027-33dd6c587581/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa3bd654-7a2d-468d-9555-55464d4f13c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/353d8e93-7349-4807-b0bf-16f32f32e626> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "353d8e93-7349-4807-b0bf-16f32f32e626";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/756a8c20-5c09-4340-b730-16105a6a1f43/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/353d8e93-7349-4807-b0bf-16f32f32e626>.
+    
+<http://data.lblod.info/id/remote-data-objects/b788cd08-35bd-4f4a-b97e-e728b5273e91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b788cd08-35bd-4f4a-b97e-e728b5273e91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/76a2d18a-e77d-4d15-9c6f-474dfb06c16c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b788cd08-35bd-4f4a-b97e-e728b5273e91>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c3804ff-726e-4511-a515-f24525ab509c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c3804ff-726e-4511-a515-f24525ab509c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/78ec83b2-2b38-4f22-870f-07bc0db20ebd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c3804ff-726e-4511-a515-f24525ab509c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7332b3c5-e2bb-42f3-abee-23e803aa7323> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7332b3c5-e2bb-42f3-abee-23e803aa7323";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/7d1f5a51-6850-44bc-96e5-45b1f7fdbb5e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7332b3c5-e2bb-42f3-abee-23e803aa7323>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e47e34c-4fa9-4a43-80f6-676e55125963> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e47e34c-4fa9-4a43-80f6-676e55125963";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/83fbd960-5631-4ee5-9eae-dd0b17e801ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e47e34c-4fa9-4a43-80f6-676e55125963>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7dc3eb0-14db-4076-9552-e977e30bb328> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7dc3eb0-14db-4076-9552-e977e30bb328";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/87787c7a-e258-4af0-872d-bf967d9fd617/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7dc3eb0-14db-4076-9552-e977e30bb328>.
+    
+<http://data.lblod.info/id/remote-data-objects/413d54d1-ab2b-4a92-8aa8-be8cebf59663> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "413d54d1-ab2b-4a92-8aa8-be8cebf59663";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/892823f8-bdf4-4fbb-a593-134b823a2c1b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/413d54d1-ab2b-4a92-8aa8-be8cebf59663>.
+    
+<http://data.lblod.info/id/remote-data-objects/4466015a-65f9-4e00-9ce6-39124d895c6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4466015a-65f9-4e00-9ce6-39124d895c6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/8c46bf74-a56c-4997-8495-f104e8289cda/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4466015a-65f9-4e00-9ce6-39124d895c6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/894ef489-9eb2-42b6-a5d8-15fac503ec86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "894ef489-9eb2-42b6-a5d8-15fac503ec86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/90ec5ab7-7fec-428a-afd5-a6ee033858e8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/894ef489-9eb2-42b6-a5d8-15fac503ec86>.
+    
+<http://data.lblod.info/id/remote-data-objects/821ce88f-e0d8-4ff7-8075-a5bf13b1c5b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "821ce88f-e0d8-4ff7-8075-a5bf13b1c5b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/95696504-3027-41c7-92d3-334d9eb4e227/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/821ce88f-e0d8-4ff7-8075-a5bf13b1c5b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6ffbd3e-3136-4f5c-a76b-9d0414048259> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6ffbd3e-3136-4f5c-a76b-9d0414048259";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/9db561b7-1e84-4a61-a84d-65a6f7260846/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6ffbd3e-3136-4f5c-a76b-9d0414048259>.
+    
+<http://data.lblod.info/id/remote-data-objects/9477b522-6367-4545-b346-b6c2a31447b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9477b522-6367-4545-b346-b6c2a31447b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/a0019ba3-4c2e-40a9-abf2-6457aadcdf67/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9477b522-6367-4545-b346-b6c2a31447b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/451cd6cf-f035-430d-8943-2203a114cfe4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "451cd6cf-f035-430d-8943-2203a114cfe4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/a1528783-b383-441a-8b65-6ddf93fb2f77/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/451cd6cf-f035-430d-8943-2203a114cfe4>.
+    
+<http://data.lblod.info/id/remote-data-objects/55936f17-5f10-4e15-b2a9-dfdaabd64912> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55936f17-5f10-4e15-b2a9-dfdaabd64912";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/a5915476-26d3-4aef-98d5-f14f78aa6d52/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d090cc3-c541-41db-99ff-7eb0891f04dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55936f17-5f10-4e15-b2a9-dfdaabd64912>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201132-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201132-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201132-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201132-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/ffe5c34e-e798-46cc-9f89-dfcb1efbd6e3> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ffe5c34e-e798-46cc-9f89-dfcb1efbd6e3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2f920f55-2f6e-4222-bb75-b835354a6e03";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f5bdd659-a5c0-4b3f-b94c-f597971a481e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f5bdd659-a5c0-4b3f-b94c-f597971a481e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03>.
+
+  <http://redpencil.data.gift/id/task/b31635f8-b32a-4806-877d-37436442011f> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b31635f8-b32a-4806-877d-37436442011f";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/ffe5c34e-e798-46cc-9f89-dfcb1efbd6e3>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f5bdd659-a5c0-4b3f-b94c-f597971a481e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/1e279b40-1ecf-4fed-ba39-10a595e1a1b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e279b40-1ecf-4fed-ba39-10a595e1a1b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/a8e96188-27e5-473b-a395-e9b730b3d506/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e279b40-1ecf-4fed-ba39-10a595e1a1b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/0314cd38-4013-428f-9288-4fe0c0e7ca6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0314cd38-4013-428f-9288-4fe0c0e7ca6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/a9145256-81c3-4f8a-b43b-c14fe2f83826/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0314cd38-4013-428f-9288-4fe0c0e7ca6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/023e921b-ce76-4438-9818-46b80e4eee16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "023e921b-ce76-4438-9818-46b80e4eee16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/a965b3aa-b741-4aee-9d31-6a4ea85ce010/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/023e921b-ce76-4438-9818-46b80e4eee16>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dafd85b-7c74-4f54-be19-29b8248d1d46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dafd85b-7c74-4f54-be19-29b8248d1d46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/aa2a57c7-e8ba-4919-8ae9-e922e08d2c41/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dafd85b-7c74-4f54-be19-29b8248d1d46>.
+    
+<http://data.lblod.info/id/remote-data-objects/a81da170-0b2e-44b2-bcab-bb446ae07b8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a81da170-0b2e-44b2-bcab-bb446ae07b8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/ab0cf6a6-4820-4221-99b2-b8e6aad89a1f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a81da170-0b2e-44b2-bcab-bb446ae07b8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e907b090-05c9-4045-8c84-e6807f174b11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e907b090-05c9-4045-8c84-e6807f174b11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/b22461fc-d5a5-4a8c-ae99-53d04c10ec09/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e907b090-05c9-4045-8c84-e6807f174b11>.
+    
+<http://data.lblod.info/id/remote-data-objects/da2e1c1c-beb5-4bdc-b76e-156f546d736c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da2e1c1c-beb5-4bdc-b76e-156f546d736c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/b23d3128-ed49-4f86-b713-89caf7f51c72/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da2e1c1c-beb5-4bdc-b76e-156f546d736c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcf4120e-a7b7-4bb5-902b-4483a7ec1c14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcf4120e-a7b7-4bb5-902b-4483a7ec1c14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/b887ea10-63b6-443e-94ce-48c0242b5163/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcf4120e-a7b7-4bb5-902b-4483a7ec1c14>.
+    
+<http://data.lblod.info/id/remote-data-objects/9467f872-00ac-4656-9e95-16dd0abda38e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9467f872-00ac-4656-9e95-16dd0abda38e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/ba3d8b13-8b1d-440d-bc37-cf8fa1acd9af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9467f872-00ac-4656-9e95-16dd0abda38e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a0bb004-ca58-44ee-82de-18486bcd928f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a0bb004-ca58-44ee-82de-18486bcd928f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/beb957b4-a0f8-44b0-bf8a-5f2dda785055/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a0bb004-ca58-44ee-82de-18486bcd928f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d8182dc-e83f-4ad7-97f7-8b44348c4a77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d8182dc-e83f-4ad7-97f7-8b44348c4a77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/bf16b23e-9fb0-4376-bcf9-f62ded4b2e49/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d8182dc-e83f-4ad7-97f7-8b44348c4a77>.
+    
+<http://data.lblod.info/id/remote-data-objects/3afa9c34-4778-4a81-a557-324b4eea3f01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3afa9c34-4778-4a81-a557-324b4eea3f01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/c15b0d80-ecb3-4c99-a611-b444c0f078cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3afa9c34-4778-4a81-a557-324b4eea3f01>.
+    
+<http://data.lblod.info/id/remote-data-objects/65752916-8416-437d-babd-e4382460efde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65752916-8416-437d-babd-e4382460efde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/c7ac3557-5712-4416-8f37-a0376f5fea21/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65752916-8416-437d-babd-e4382460efde>.
+    
+<http://data.lblod.info/id/remote-data-objects/aeb50ced-285e-4756-bbd4-d6f3948bc84b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aeb50ced-285e-4756-bbd4-d6f3948bc84b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/c989125f-d1a0-4fd3-b805-8ad9a90475ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aeb50ced-285e-4756-bbd4-d6f3948bc84b>.
+    
+<http://data.lblod.info/id/remote-data-objects/80bd1656-6818-49ad-8088-d78f2686676e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80bd1656-6818-49ad-8088-d78f2686676e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/ca8e1c66-3fb1-4718-9695-8f2fcaa0309a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80bd1656-6818-49ad-8088-d78f2686676e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4743b9ae-c62a-4e55-98d1-4c9f7ea8538c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4743b9ae-c62a-4e55-98d1-4c9f7ea8538c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/d6260820-bada-4772-ad79-9dcab924613f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4743b9ae-c62a-4e55-98d1-4c9f7ea8538c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d60af70b-cf9a-467e-b757-0e1b4c449697> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d60af70b-cf9a-467e-b757-0e1b4c449697";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/d67daa5c-3e74-4169-bb84-b6c332775dee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d60af70b-cf9a-467e-b757-0e1b4c449697>.
+    
+<http://data.lblod.info/id/remote-data-objects/61996a6f-ac7d-46ae-96fc-a4e97a06e29c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61996a6f-ac7d-46ae-96fc-a4e97a06e29c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/d7a74e8e-98ae-433d-8465-42a203339533/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61996a6f-ac7d-46ae-96fc-a4e97a06e29c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6c516e7-d8d3-4c2f-8ffb-56f3438c5310> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6c516e7-d8d3-4c2f-8ffb-56f3438c5310";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/e067bef2-37e0-48fb-9ce8-75902dcf77ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6c516e7-d8d3-4c2f-8ffb-56f3438c5310>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c1258c3-e8bf-495e-aa44-0f8023bb4309> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c1258c3-e8bf-495e-aa44-0f8023bb4309";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/e0de5534-19af-4205-a550-9a8efa519424/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c1258c3-e8bf-495e-aa44-0f8023bb4309>.
+    
+<http://data.lblod.info/id/remote-data-objects/e643d3be-d4ae-4295-8360-0c14654623c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e643d3be-d4ae-4295-8360-0c14654623c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/e1c7b0b0-f1dd-404b-b88c-cda83940ff65/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e643d3be-d4ae-4295-8360-0c14654623c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d57b1a7c-5361-4fa1-8b62-8894f45fc52a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d57b1a7c-5361-4fa1-8b62-8894f45fc52a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/e3b620a0-973a-46a0-8ffd-cd8ce9db5f1a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d57b1a7c-5361-4fa1-8b62-8894f45fc52a>.
+    
+<http://data.lblod.info/id/remote-data-objects/841c96dc-206b-4244-9f78-86aa6be21547> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "841c96dc-206b-4244-9f78-86aa6be21547";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/eb0f4e12-f681-4746-a4cc-b711b36a9bde/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/841c96dc-206b-4244-9f78-86aa6be21547>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca14e662-4277-43be-8a2f-be7f97f6d4bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca14e662-4277-43be-8a2f-be7f97f6d4bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/f147c51c-a9b2-4816-8dfe-c494c27b18b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca14e662-4277-43be-8a2f-be7f97f6d4bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c94f7a9-5290-404e-8b46-8c17531c47ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c94f7a9-5290-404e-8b46-8c17531c47ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/f2221029-95e7-48f5-a340-0e45f8a3afdc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c94f7a9-5290-404e-8b46-8c17531c47ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/7567a176-2b4c-42fc-aebd-a1995d0f1b84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7567a176-2b4c-42fc-aebd-a1995d0f1b84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/f37b8d70-5af5-4ab8-b355-a88af4cf9e2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7567a176-2b4c-42fc-aebd-a1995d0f1b84>.
+    
+<http://data.lblod.info/id/remote-data-objects/1eeb5c42-d687-40a6-aaf1-8e676447cc6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1eeb5c42-d687-40a6-aaf1-8e676447cc6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/fbfec339-21bf-4b97-a2ed-856db6273ae3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1eeb5c42-d687-40a6-aaf1-8e676447cc6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd74dfb5-1d9b-482f-b513-1cd90305330f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd74dfb5-1d9b-482f-b513-1cd90305330f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/fc34475c-92d2-46db-9717-e126482048c0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd74dfb5-1d9b-482f-b513-1cd90305330f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f688203d-de79-4dd9-8d1a-cccdb0a36dec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f688203d-de79-4dd9-8d1a-cccdb0a36dec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/bb/fdf60b06-3302-442a-a563-ac44a2d17cc5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f688203d-de79-4dd9-8d1a-cccdb0a36dec>.
+    
+<http://data.lblod.info/id/remote-data-objects/074ae7a8-986e-40eb-a5d6-d409483f37d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "074ae7a8-986e-40eb-a5d6-d409483f37d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/03072662-e207-47d6-9bb5-e0a4272023dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/074ae7a8-986e-40eb-a5d6-d409483f37d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/219ac5c4-33df-4cdf-9c25-12b2cfcfe8c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "219ac5c4-33df-4cdf-9c25-12b2cfcfe8c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/03e4f1e3-38fb-4cba-869d-d207ea8777fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/219ac5c4-33df-4cdf-9c25-12b2cfcfe8c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b06f4adf-98bd-49d6-8919-fa2eac83f4f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b06f4adf-98bd-49d6-8919-fa2eac83f4f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/0b928c80-d14c-4f25-b11a-ec070e8688ad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b06f4adf-98bd-49d6-8919-fa2eac83f4f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f478bf4c-a6cb-4776-a622-6b170a19ff11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f478bf4c-a6cb-4776-a622-6b170a19ff11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/0e9673b8-6431-4b36-9dc7-f73fef031261/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f478bf4c-a6cb-4776-a622-6b170a19ff11>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cc954c7-1de4-40c7-82de-5662506f963e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cc954c7-1de4-40c7-82de-5662506f963e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/11fc5e16-0020-42c8-b7b3-ac0c318199e6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cc954c7-1de4-40c7-82de-5662506f963e>.
+    
+<http://data.lblod.info/id/remote-data-objects/35c80b98-6efb-483c-abd8-63ad63c8c681> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35c80b98-6efb-483c-abd8-63ad63c8c681";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/1e892b42-cef5-4ee1-8b7c-17863e406707/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35c80b98-6efb-483c-abd8-63ad63c8c681>.
+    
+<http://data.lblod.info/id/remote-data-objects/671bbfe2-0be6-4e7a-8ed3-d86f1cdd2382> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "671bbfe2-0be6-4e7a-8ed3-d86f1cdd2382";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/2583e269-0807-4564-8776-49d63be9b34a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/671bbfe2-0be6-4e7a-8ed3-d86f1cdd2382>.
+    
+<http://data.lblod.info/id/remote-data-objects/7899e8d8-ebde-4d35-bd4d-1eec3ae76413> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7899e8d8-ebde-4d35-bd4d-1eec3ae76413";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/265face7-04b9-4ad9-a523-ffb5c63165d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7899e8d8-ebde-4d35-bd4d-1eec3ae76413>.
+    
+<http://data.lblod.info/id/remote-data-objects/830b8085-3553-4d8f-b070-9090c94c7dca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "830b8085-3553-4d8f-b070-9090c94c7dca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/26e4dfe7-9aa1-4307-a432-88a32304a3b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/830b8085-3553-4d8f-b070-9090c94c7dca>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4a53604-7c10-4f38-9cde-737051bfea25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4a53604-7c10-4f38-9cde-737051bfea25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/27abaa36-49a6-435e-bf78-c5e65d10594e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4a53604-7c10-4f38-9cde-737051bfea25>.
+    
+<http://data.lblod.info/id/remote-data-objects/df46a631-1324-43cf-95f0-57295e99f8c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df46a631-1324-43cf-95f0-57295e99f8c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/2f007ec3-99ef-416a-b24a-783da9b475d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df46a631-1324-43cf-95f0-57295e99f8c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/427866cc-97ff-4e15-9acd-4639704775ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "427866cc-97ff-4e15-9acd-4639704775ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/3129cd66-5e93-4c37-96cc-9145637e3d82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/427866cc-97ff-4e15-9acd-4639704775ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebaee488-d5bd-489e-b8ea-8eb3c63c2666> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebaee488-d5bd-489e-b8ea-8eb3c63c2666";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/36dcd6c6-71a9-4a4b-9bd2-e55e45cdd5f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebaee488-d5bd-489e-b8ea-8eb3c63c2666>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a863d5e-daa2-4ec5-adfe-f0af7a58ed95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a863d5e-daa2-4ec5-adfe-f0af7a58ed95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/39ddf8af-1998-4ce8-9501-a45d0ffbc954/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a863d5e-daa2-4ec5-adfe-f0af7a58ed95>.
+    
+<http://data.lblod.info/id/remote-data-objects/95425695-6b44-4302-a829-5323baf496bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95425695-6b44-4302-a829-5323baf496bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/40507b1f-7689-4ce0-a510-324536ba259f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95425695-6b44-4302-a829-5323baf496bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/11fe16c9-ad2a-4f8b-9e4f-4893ac3adcb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11fe16c9-ad2a-4f8b-9e4f-4893ac3adcb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/4390d3fb-b460-40ce-ab90-e64d3ccb37fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11fe16c9-ad2a-4f8b-9e4f-4893ac3adcb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/de3672ea-4604-4259-b26c-6ce136845fb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de3672ea-4604-4259-b26c-6ce136845fb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/43f5dd42-877b-4ce9-ba4b-24affec08ece/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de3672ea-4604-4259-b26c-6ce136845fb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/35ade031-4628-4c2a-b24f-efab37b6581e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35ade031-4628-4c2a-b24f-efab37b6581e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/44f40f6d-0cbc-4ae4-8b93-e715ce35969d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35ade031-4628-4c2a-b24f-efab37b6581e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d5b422b-2456-4fb0-aaaf-3166731692be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d5b422b-2456-4fb0-aaaf-3166731692be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/457a48ad-0620-4e05-bc2d-2f1319ba0cd2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d5b422b-2456-4fb0-aaaf-3166731692be>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2832d88-0240-4471-a5c4-a84a8d3b95ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2832d88-0240-4471-a5c4-a84a8d3b95ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/4b440f6d-6af8-414e-b381-b04853265364/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2832d88-0240-4471-a5c4-a84a8d3b95ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bf8a247-62fa-43cf-b461-877f04af6412> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bf8a247-62fa-43cf-b461-877f04af6412";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/4e2252d3-8882-44d0-a68c-bc3d9365fa53/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f920f55-2f6e-4222-bb75-b835354a6e03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bf8a247-62fa-43cf-b461-877f04af6412>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201133-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201133-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201133-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201133-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/db8cde3f-9dcb-4675-bd60-54a7f971058f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "db8cde3f-9dcb-4675-bd60-54a7f971058f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dd94b20e-03f9-444b-88d2-be1cb5d867c2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/60cd0716-b177-4890-bbad-2d1767d5af18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "60cd0716-b177-4890-bbad-2d1767d5af18";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2>.
+
+  <http://redpencil.data.gift/id/task/5727f8d4-0cfd-4529-acc2-3b8fb0f3eb5f> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5727f8d4-0cfd-4529-acc2-3b8fb0f3eb5f";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/db8cde3f-9dcb-4675-bd60-54a7f971058f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/60cd0716-b177-4890-bbad-2d1767d5af18>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/93b30cd8-2a43-4084-a3de-3df93fbb5907> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93b30cd8-2a43-4084-a3de-3df93fbb5907";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/51dfaf7b-a635-46e4-802a-c3241054d000/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93b30cd8-2a43-4084-a3de-3df93fbb5907>.
+    
+<http://data.lblod.info/id/remote-data-objects/43b7b20b-3664-4644-86d1-9699452e8ce9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43b7b20b-3664-4644-86d1-9699452e8ce9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/538e21c8-4ead-4ee5-933b-279e4eb14fdf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43b7b20b-3664-4644-86d1-9699452e8ce9>.
+    
+<http://data.lblod.info/id/remote-data-objects/6364816c-bbe4-460a-8bff-3d36cb97fbbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6364816c-bbe4-460a-8bff-3d36cb97fbbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/54a3d808-acd3-42a2-a505-8380d2f3af24/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6364816c-bbe4-460a-8bff-3d36cb97fbbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/892b54b9-b95d-489e-a3cf-383817368ef6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "892b54b9-b95d-489e-a3cf-383817368ef6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/5552d5b7-391d-48ed-9dff-5030c49db01e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/892b54b9-b95d-489e-a3cf-383817368ef6>.
+    
+<http://data.lblod.info/id/remote-data-objects/06cf65a2-9e15-4e9b-b43f-20aec4307db1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06cf65a2-9e15-4e9b-b43f-20aec4307db1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/57246275-43db-4d8c-b3c9-378ab69d6659/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06cf65a2-9e15-4e9b-b43f-20aec4307db1>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0c92fd3-87dc-49ba-b774-a9d9e28098b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0c92fd3-87dc-49ba-b774-a9d9e28098b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/5928c75f-de7c-4bf0-be3b-bc677f3e15dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0c92fd3-87dc-49ba-b774-a9d9e28098b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/5169938e-6a70-483d-bf72-bbba274db4a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5169938e-6a70-483d-bf72-bbba274db4a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/5d781efd-aef6-4fbf-9dd4-08f1e1324b33/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5169938e-6a70-483d-bf72-bbba274db4a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/378daa0c-97bd-48e2-95ab-3543ebc86607> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "378daa0c-97bd-48e2-95ab-3543ebc86607";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/612a9be4-3d40-4eae-b25a-802fca3c426f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/378daa0c-97bd-48e2-95ab-3543ebc86607>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f48e981-8ac0-4b05-a363-765cba3d8d41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f48e981-8ac0-4b05-a363-765cba3d8d41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/65325a6d-1888-4ec6-a3ae-cffa056e74db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f48e981-8ac0-4b05-a363-765cba3d8d41>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa8115bc-bcd7-4013-aa33-c74c6d2d4716> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa8115bc-bcd7-4013-aa33-c74c6d2d4716";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/6880b31d-f757-43a0-8e80-fa99181dfaa6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa8115bc-bcd7-4013-aa33-c74c6d2d4716>.
+    
+<http://data.lblod.info/id/remote-data-objects/3507f56a-0c4c-4b7d-a22f-f77519b21090> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3507f56a-0c4c-4b7d-a22f-f77519b21090";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/689483d3-b8f3-43d5-ab11-f15a42e242de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3507f56a-0c4c-4b7d-a22f-f77519b21090>.
+    
+<http://data.lblod.info/id/remote-data-objects/6648913a-cb0c-4ea7-8fed-f0ceb328f5da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6648913a-cb0c-4ea7-8fed-f0ceb328f5da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/7ac9921e-2cc6-40d0-9006-67dde1e28284/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6648913a-cb0c-4ea7-8fed-f0ceb328f5da>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4bb9ab0-03d2-40ca-b356-bda53dc0ca59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4bb9ab0-03d2-40ca-b356-bda53dc0ca59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/7fe31cb8-63a5-4699-b56b-dcf374325b56/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4bb9ab0-03d2-40ca-b356-bda53dc0ca59>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcf5864c-3e2e-4ece-a8fe-4cae44c98b07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcf5864c-3e2e-4ece-a8fe-4cae44c98b07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/8066379f-c6c4-4925-bb86-5247c8ca4508/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcf5864c-3e2e-4ece-a8fe-4cae44c98b07>.
+    
+<http://data.lblod.info/id/remote-data-objects/6eae96d2-c3c2-4d3c-a3ea-63b7b4a6c7ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6eae96d2-c3c2-4d3c-a3ea-63b7b4a6c7ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/8273416c-7539-4b3c-965e-7eef8f5ab089/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6eae96d2-c3c2-4d3c-a3ea-63b7b4a6c7ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/17a933b1-e4b5-49a6-996d-b7f9b0d52bc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17a933b1-e4b5-49a6-996d-b7f9b0d52bc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/8355784c-b356-436f-af85-0c13af8da758/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17a933b1-e4b5-49a6-996d-b7f9b0d52bc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/155ddef6-3acf-45d4-b974-50eeaad1b6ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "155ddef6-3acf-45d4-b974-50eeaad1b6ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/845e09dc-8bf0-4e48-8681-72e8708b5f45/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/155ddef6-3acf-45d4-b974-50eeaad1b6ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d113868-23da-4bc6-8f16-fde3a9ae0365> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d113868-23da-4bc6-8f16-fde3a9ae0365";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/8e38520d-a045-47a8-ba48-14211bd22642/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d113868-23da-4bc6-8f16-fde3a9ae0365>.
+    
+<http://data.lblod.info/id/remote-data-objects/da88ec30-b6c6-48ff-96b5-f9a790d9b995> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da88ec30-b6c6-48ff-96b5-f9a790d9b995";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/8f01b93f-ebbf-463b-8601-015dcd57fbc0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da88ec30-b6c6-48ff-96b5-f9a790d9b995>.
+    
+<http://data.lblod.info/id/remote-data-objects/a46736b1-f4b1-4284-b734-ef5b6c8fc464> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a46736b1-f4b1-4284-b734-ef5b6c8fc464";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/900bf95a-ab4f-4fba-b26f-0dba03fec868/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a46736b1-f4b1-4284-b734-ef5b6c8fc464>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4d0a29e-b3df-48fb-b051-d8ad86ed9e1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4d0a29e-b3df-48fb-b051-d8ad86ed9e1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/91198e43-39de-4ff0-9854-7584f9c83098/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4d0a29e-b3df-48fb-b051-d8ad86ed9e1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e36c9cb-cf6b-4117-8741-dc4c738dfc0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e36c9cb-cf6b-4117-8741-dc4c738dfc0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/a31fbc94-6970-44d3-ae1e-43ce9161865f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e36c9cb-cf6b-4117-8741-dc4c738dfc0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e566f50a-4d55-4800-ac42-c224aeccc089> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e566f50a-4d55-4800-ac42-c224aeccc089";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/a320f5e6-4273-443f-aaf1-676afd17f351/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e566f50a-4d55-4800-ac42-c224aeccc089>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff47be34-899c-4e0e-ab12-1a7fa69f4961> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff47be34-899c-4e0e-ab12-1a7fa69f4961";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/a5e83b76-ab77-4607-8115-64783a2d2d13/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff47be34-899c-4e0e-ab12-1a7fa69f4961>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4e786c5-334a-43be-8ec0-306cb2d76dc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4e786c5-334a-43be-8ec0-306cb2d76dc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/b2bb9b94-18ca-4c68-ac1e-1c6289f8dfdd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4e786c5-334a-43be-8ec0-306cb2d76dc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/515f8e66-52e7-49ca-b77b-a98c7f06b4c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "515f8e66-52e7-49ca-b77b-a98c7f06b4c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/b592ae35-35c7-4e35-924e-3c49fcfef4b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/515f8e66-52e7-49ca-b77b-a98c7f06b4c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf82d24d-5710-43c6-a182-a1322b759036> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf82d24d-5710-43c6-a182-a1322b759036";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/b970690c-949b-4305-9f65-4a1d227a35a0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf82d24d-5710-43c6-a182-a1322b759036>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b2c32fe-c140-4a92-b446-194a1aa3db78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b2c32fe-c140-4a92-b446-194a1aa3db78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/ba4997d1-88b1-465d-9429-c755236cc28f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b2c32fe-c140-4a92-b446-194a1aa3db78>.
+    
+<http://data.lblod.info/id/remote-data-objects/458f4056-e1cc-4705-a317-9b5acc808dbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "458f4056-e1cc-4705-a317-9b5acc808dbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/bc412046-dcbe-4082-a395-e4be0dac1753/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/458f4056-e1cc-4705-a317-9b5acc808dbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/53e1351e-abad-44cf-89d8-2b3f0f68464d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53e1351e-abad-44cf-89d8-2b3f0f68464d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/c1481e04-6ae7-4fa6-ac5c-66673ce760d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53e1351e-abad-44cf-89d8-2b3f0f68464d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d0a631c-58f6-4414-8619-fe5fd3337866> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d0a631c-58f6-4414-8619-fe5fd3337866";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/c95afb7e-f582-4ad9-862a-8339f0398ffa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d0a631c-58f6-4414-8619-fe5fd3337866>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ce120e6-0107-4e48-a794-fa9b9d7a952e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ce120e6-0107-4e48-a794-fa9b9d7a952e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/cca05467-24d4-40c8-9896-66ac0f6c02fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ce120e6-0107-4e48-a794-fa9b9d7a952e>.
+    
+<http://data.lblod.info/id/remote-data-objects/54141e9c-e49f-4741-a760-a2d9384bd6d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54141e9c-e49f-4741-a760-a2d9384bd6d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/cced4e9f-12c3-4145-96ea-50477ad70ad1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54141e9c-e49f-4741-a760-a2d9384bd6d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cde675d-e75e-4a28-b99e-18c0cecaad57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cde675d-e75e-4a28-b99e-18c0cecaad57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/d1e0ed50-b3ad-409d-b438-2882950f9e4c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cde675d-e75e-4a28-b99e-18c0cecaad57>.
+    
+<http://data.lblod.info/id/remote-data-objects/51f898e9-2fab-4f8a-9537-bbda291ee26b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51f898e9-2fab-4f8a-9537-bbda291ee26b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/d2b3d4df-cbd1-4cf8-a007-51ca23e9f50d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51f898e9-2fab-4f8a-9537-bbda291ee26b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2ac59f5-898e-47dd-bb21-3dfc6add281e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2ac59f5-898e-47dd-bb21-3dfc6add281e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/d395eab6-63c6-478d-b48a-cb29651191c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2ac59f5-898e-47dd-bb21-3dfc6add281e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3393db84-b817-4c4f-bc51-aec4329abbeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3393db84-b817-4c4f-bc51-aec4329abbeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/d4ecc6d6-4036-4565-b039-f5084fe5a0bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3393db84-b817-4c4f-bc51-aec4329abbeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/54061588-76e9-4f30-890c-a1defd8de44e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54061588-76e9-4f30-890c-a1defd8de44e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/d7fbb380-68e2-455b-9e90-2a9ea71783c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54061588-76e9-4f30-890c-a1defd8de44e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7843c053-67c2-4c11-a095-8630179b85ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7843c053-67c2-4c11-a095-8630179b85ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/dc7958e9-5668-4fad-aae3-079cef311ce3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7843c053-67c2-4c11-a095-8630179b85ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c10f153-5424-41d1-8aa8-3d5619ed5ab0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c10f153-5424-41d1-8aa8-3d5619ed5ab0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/e8c0d507-e17b-4f61-ab1d-17e132d69b22/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c10f153-5424-41d1-8aa8-3d5619ed5ab0>.
+    
+<http://data.lblod.info/id/remote-data-objects/af66be71-4909-4cb5-b218-31e74f7bed2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af66be71-4909-4cb5-b218-31e74f7bed2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/eb0706c8-82d1-4e53-885c-37b1fdcfcd2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af66be71-4909-4cb5-b218-31e74f7bed2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/90918f6d-8b86-43f9-a58f-3a670e7a29c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90918f6d-8b86-43f9-a58f-3a670e7a29c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/eda503c6-3826-45e7-9a29-c4925acb1bbc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90918f6d-8b86-43f9-a58f-3a670e7a29c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1060a5e-902a-420d-8db9-2d84093f592f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1060a5e-902a-420d-8db9-2d84093f592f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/ee401a60-046b-4e65-9f11-ce71c862aea7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1060a5e-902a-420d-8db9-2d84093f592f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6884cda1-7040-4675-a05f-85736c1fca09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6884cda1-7040-4675-a05f-85736c1fca09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/f4d422f4-1e6e-4fda-90ae-7381e7d96762/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6884cda1-7040-4675-a05f-85736c1fca09>.
+    
+<http://data.lblod.info/id/remote-data-objects/8897e58e-7377-4664-83aa-04e9d0c43e1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8897e58e-7377-4664-83aa-04e9d0c43e1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/f5b42ea6-fc38-4c47-a46b-d761d9e098d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8897e58e-7377-4664-83aa-04e9d0c43e1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a689d4ad-4bed-42f1-837a-7e9e9adb08a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a689d4ad-4bed-42f1-837a-7e9e9adb08a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/f721f52f-edc4-477f-a5df-c68721cc4158/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a689d4ad-4bed-42f1-837a-7e9e9adb08a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a447e38-ab75-44e6-b0ef-a60ff4a502c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a447e38-ab75-44e6-b0ef-a60ff4a502c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/f743e426-b841-48f0-8f1a-d5048a73f816/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a447e38-ab75-44e6-b0ef-a60ff4a502c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/463dbc31-e288-40a6-955c-add9958e185e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "463dbc31-e288-40a6-955c-add9958e185e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/fb2b631e-4ea8-4310-851e-5632cd34e82e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/463dbc31-e288-40a6-955c-add9958e185e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6df03164-fe9b-48c4-a405-8de85d3b70b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6df03164-fe9b-48c4-a405-8de85d3b70b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/cbs/fd7535a9-8aa9-452d-a348-3173eeda18a2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6df03164-fe9b-48c4-a405-8de85d3b70b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8976629a-4e90-466b-b85f-fb0585905f43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8976629a-4e90-466b-b85f-fb0585905f43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/038ce550-06eb-41af-b37d-bfe1ea3ab8ec/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dd94b20e-03f9-444b-88d2-be1cb5d867c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8976629a-4e90-466b-b85f-fb0585905f43>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201135-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201135-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201135-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201135-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/aabe968f-9f09-4a53-886c-ee0296a29fe1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "aabe968f-9f09-4a53-886c-ee0296a29fe1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9c2cca44-c550-424a-9f9a-c8f3af3556db";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/172c3619-b2e8-4130-90ee-3892b8c19bb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "172c3619-b2e8-4130-90ee-3892b8c19bb4";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db>.
+
+  <http://redpencil.data.gift/id/task/fff9585a-ab47-4080-afe5-4763f8c71b60> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fff9585a-ab47-4080-afe5-4763f8c71b60";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/aabe968f-9f09-4a53-886c-ee0296a29fe1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/172c3619-b2e8-4130-90ee-3892b8c19bb4>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/9e38c163-4aaa-4072-b1e1-e013f7250817> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e38c163-4aaa-4072-b1e1-e013f7250817";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/038ce550-06eb-41af-b37d-bfe1ea3ab8ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e38c163-4aaa-4072-b1e1-e013f7250817>.
+    
+<http://data.lblod.info/id/remote-data-objects/2222e859-15b9-41e2-bab0-9145c0031a97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2222e859-15b9-41e2-bab0-9145c0031a97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/04afd3d1-d4e7-43ff-b358-9e2517d9b818/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2222e859-15b9-41e2-bab0-9145c0031a97>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4cefc72-2c54-4623-bc97-8b67926fdf2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4cefc72-2c54-4623-bc97-8b67926fdf2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/04afd3d1-d4e7-43ff-b358-9e2517d9b818/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4cefc72-2c54-4623-bc97-8b67926fdf2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3878889-1994-448e-ab43-18deeed95361> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3878889-1994-448e-ab43-18deeed95361";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/04afd3d1-d4e7-43ff-b358-9e2517d9b818/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3878889-1994-448e-ab43-18deeed95361>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef10ecd1-e906-4131-a585-73b41f137f40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef10ecd1-e906-4131-a585-73b41f137f40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/0b028be1-4383-4c97-945a-fcda3baaa611/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef10ecd1-e906-4131-a585-73b41f137f40>.
+    
+<http://data.lblod.info/id/remote-data-objects/21f61365-6a78-4be1-8d00-338f84c9bcbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21f61365-6a78-4be1-8d00-338f84c9bcbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/0b028be1-4383-4c97-945a-fcda3baaa611/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21f61365-6a78-4be1-8d00-338f84c9bcbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/42fdb9cd-3b06-450a-96a3-3e2b70fd0d79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42fdb9cd-3b06-450a-96a3-3e2b70fd0d79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/0b028be1-4383-4c97-945a-fcda3baaa611/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42fdb9cd-3b06-450a-96a3-3e2b70fd0d79>.
+    
+<http://data.lblod.info/id/remote-data-objects/e58291cb-a145-424b-8964-f74978b0a8bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e58291cb-a145-424b-8964-f74978b0a8bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/2539e88a-ac66-44ce-adb1-e3683447cc97/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e58291cb-a145-424b-8964-f74978b0a8bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c322428a-960d-423f-8564-0792a970f8ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c322428a-960d-423f-8564-0792a970f8ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/2539e88a-ac66-44ce-adb1-e3683447cc97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c322428a-960d-423f-8564-0792a970f8ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/83179504-eeef-4ae5-a84e-e281b015cb71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83179504-eeef-4ae5-a84e-e281b015cb71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/2539e88a-ac66-44ce-adb1-e3683447cc97/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83179504-eeef-4ae5-a84e-e281b015cb71>.
+    
+<http://data.lblod.info/id/remote-data-objects/a02b1f9a-9dce-41aa-b7ef-736eba9058ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a02b1f9a-9dce-41aa-b7ef-736eba9058ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/297428b3-a5ae-406b-a3dd-5e5f4d1bf36c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a02b1f9a-9dce-41aa-b7ef-736eba9058ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/530490af-eb46-47e0-9512-72db8a2827bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "530490af-eb46-47e0-9512-72db8a2827bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/297428b3-a5ae-406b-a3dd-5e5f4d1bf36c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/530490af-eb46-47e0-9512-72db8a2827bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/60c25cf6-6fb5-4f45-b74c-2be8af48cc0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60c25cf6-6fb5-4f45-b74c-2be8af48cc0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/297428b3-a5ae-406b-a3dd-5e5f4d1bf36c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60c25cf6-6fb5-4f45-b74c-2be8af48cc0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/81040bb6-f311-4c08-93e2-31a5325a7534> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81040bb6-f311-4c08-93e2-31a5325a7534";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/3444be0d-9b68-477a-8f4c-f2f2f1a923cc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81040bb6-f311-4c08-93e2-31a5325a7534>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fa4e537-b8e5-44e1-b45b-aaad27b0cd16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fa4e537-b8e5-44e1-b45b-aaad27b0cd16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/3444be0d-9b68-477a-8f4c-f2f2f1a923cc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fa4e537-b8e5-44e1-b45b-aaad27b0cd16>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9cc24e4-9cd3-429a-a966-0ee41ed17a18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9cc24e4-9cd3-429a-a966-0ee41ed17a18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/3444be0d-9b68-477a-8f4c-f2f2f1a923cc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9cc24e4-9cd3-429a-a966-0ee41ed17a18>.
+    
+<http://data.lblod.info/id/remote-data-objects/9326b8d9-282a-4e5d-bd2b-17dad68e7aba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9326b8d9-282a-4e5d-bd2b-17dad68e7aba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/3eb3cfda-4eb5-4c71-987d-0e4560215173/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9326b8d9-282a-4e5d-bd2b-17dad68e7aba>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0be67b4-35ed-42eb-974c-eee31d21d40a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0be67b4-35ed-42eb-974c-eee31d21d40a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/3eb3cfda-4eb5-4c71-987d-0e4560215173/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0be67b4-35ed-42eb-974c-eee31d21d40a>.
+    
+<http://data.lblod.info/id/remote-data-objects/24f75fff-f38e-40c0-aad8-f54069c67335> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24f75fff-f38e-40c0-aad8-f54069c67335";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/3eb3cfda-4eb5-4c71-987d-0e4560215173/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24f75fff-f38e-40c0-aad8-f54069c67335>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9d89165-0ad5-4377-8837-91fe81d93c7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9d89165-0ad5-4377-8837-91fe81d93c7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/51a4c0f0-ef61-4240-a05d-3853fc1810ea/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9d89165-0ad5-4377-8837-91fe81d93c7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b28d48a2-b022-4a9a-b205-d4f0a5d91872> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b28d48a2-b022-4a9a-b205-d4f0a5d91872";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/51a4c0f0-ef61-4240-a05d-3853fc1810ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b28d48a2-b022-4a9a-b205-d4f0a5d91872>.
+    
+<http://data.lblod.info/id/remote-data-objects/62d7cbd2-53f9-4fb3-84d6-6d1d6674c6c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62d7cbd2-53f9-4fb3-84d6-6d1d6674c6c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/51a4c0f0-ef61-4240-a05d-3853fc1810ea/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62d7cbd2-53f9-4fb3-84d6-6d1d6674c6c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/1adcdf87-1f80-4733-be60-79ad013a0672> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1adcdf87-1f80-4733-be60-79ad013a0672";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/66460ce5-a7b8-4611-9ce7-6a121e548136/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1adcdf87-1f80-4733-be60-79ad013a0672>.
+    
+<http://data.lblod.info/id/remote-data-objects/9274db6d-3d54-4f73-a53f-bb61ea7d6860> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9274db6d-3d54-4f73-a53f-bb61ea7d6860";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/66460ce5-a7b8-4611-9ce7-6a121e548136/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9274db6d-3d54-4f73-a53f-bb61ea7d6860>.
+    
+<http://data.lblod.info/id/remote-data-objects/58da04ce-423e-4a28-9bc1-8815718419b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58da04ce-423e-4a28-9bc1-8815718419b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/66460ce5-a7b8-4611-9ce7-6a121e548136/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58da04ce-423e-4a28-9bc1-8815718419b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c17820c-e8a5-4e57-90d0-925047bd0ff6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c17820c-e8a5-4e57-90d0-925047bd0ff6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/7f4d645a-7728-411c-a6f9-f14c761841fc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c17820c-e8a5-4e57-90d0-925047bd0ff6>.
+    
+<http://data.lblod.info/id/remote-data-objects/5984d206-80fd-4f8b-810d-4556224fb1f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5984d206-80fd-4f8b-810d-4556224fb1f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/7f4d645a-7728-411c-a6f9-f14c761841fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5984d206-80fd-4f8b-810d-4556224fb1f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d94644fa-a7f3-4763-b8ea-229b729d5b41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d94644fa-a7f3-4763-b8ea-229b729d5b41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/7f4d645a-7728-411c-a6f9-f14c761841fc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d94644fa-a7f3-4763-b8ea-229b729d5b41>.
+    
+<http://data.lblod.info/id/remote-data-objects/35f9c2fa-75c0-4695-a437-01314d17f0dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35f9c2fa-75c0-4695-a437-01314d17f0dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/b04aee5b-a5fb-43ac-ba24-2ab95b4c230d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35f9c2fa-75c0-4695-a437-01314d17f0dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/be230d09-cbb1-4601-bc2a-464fa53c505e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be230d09-cbb1-4601-bc2a-464fa53c505e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/b04aee5b-a5fb-43ac-ba24-2ab95b4c230d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be230d09-cbb1-4601-bc2a-464fa53c505e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0189b08-febd-469f-9490-89b40edcfd19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0189b08-febd-469f-9490-89b40edcfd19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/b04aee5b-a5fb-43ac-ba24-2ab95b4c230d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0189b08-febd-469f-9490-89b40edcfd19>.
+    
+<http://data.lblod.info/id/remote-data-objects/e05e92ab-840c-4347-bb7f-635b5cde6759> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e05e92ab-840c-4347-bb7f-635b5cde6759";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/bfe6b3f1-7bfb-4e50-a847-abda9a778c70/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e05e92ab-840c-4347-bb7f-635b5cde6759>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bbafd13-04de-40d6-abf4-d991cdf3f78e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bbafd13-04de-40d6-abf4-d991cdf3f78e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/bfe6b3f1-7bfb-4e50-a847-abda9a778c70/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bbafd13-04de-40d6-abf4-d991cdf3f78e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8c25bb3-fbac-48bb-999b-7e1c4a5473ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8c25bb3-fbac-48bb-999b-7e1c4a5473ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/bfe6b3f1-7bfb-4e50-a847-abda9a778c70/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8c25bb3-fbac-48bb-999b-7e1c4a5473ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/94625f52-49a7-44f3-908e-499ab109540a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94625f52-49a7-44f3-908e-499ab109540a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/c2309fb3-2847-4a48-9779-80a5c1b98fee/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94625f52-49a7-44f3-908e-499ab109540a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c19756e-2954-4512-809a-ac96f01e6d1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c19756e-2954-4512-809a-ac96f01e6d1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/c2309fb3-2847-4a48-9779-80a5c1b98fee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c19756e-2954-4512-809a-ac96f01e6d1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bd567f1-2ec1-472f-9b7f-62480abea29b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bd567f1-2ec1-472f-9b7f-62480abea29b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/c2309fb3-2847-4a48-9779-80a5c1b98fee/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bd567f1-2ec1-472f-9b7f-62480abea29b>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb6425e8-7d5c-4bfb-b737-6d4890bb54ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb6425e8-7d5c-4bfb-b737-6d4890bb54ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/d7a7232b-e724-4cf7-b63f-ac05c1a3302e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb6425e8-7d5c-4bfb-b737-6d4890bb54ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/3eafc73c-b43b-4b06-b431-92acd2532d0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3eafc73c-b43b-4b06-b431-92acd2532d0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/d7a7232b-e724-4cf7-b63f-ac05c1a3302e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3eafc73c-b43b-4b06-b431-92acd2532d0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/70f18ec7-25a3-4699-947b-dace2f0144f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70f18ec7-25a3-4699-947b-dace2f0144f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/d7a7232b-e724-4cf7-b63f-ac05c1a3302e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70f18ec7-25a3-4699-947b-dace2f0144f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/137d1dcc-f91c-4969-8f2e-ed2d7421e3fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "137d1dcc-f91c-4969-8f2e-ed2d7421e3fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/daa44861-0997-4279-b88f-395d75432978/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/137d1dcc-f91c-4969-8f2e-ed2d7421e3fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3684a7f-bdc9-45b9-af30-e3a21c82b1ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3684a7f-bdc9-45b9-af30-e3a21c82b1ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/daa44861-0997-4279-b88f-395d75432978/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3684a7f-bdc9-45b9-af30-e3a21c82b1ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/245411af-ffc4-4ac7-b15b-612b32caf65c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "245411af-ffc4-4ac7-b15b-612b32caf65c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/gr/daa44861-0997-4279-b88f-395d75432978/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/245411af-ffc4-4ac7-b15b-612b32caf65c>.
+    
+<http://data.lblod.info/id/remote-data-objects/428f1a2a-f3e1-4c52-b0e0-900e396241cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "428f1a2a-f3e1-4c52-b0e0-900e396241cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/073ff14f-0b89-4109-b769-233dc3c5805f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/428f1a2a-f3e1-4c52-b0e0-900e396241cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/69538bd2-18d0-414a-bfec-7a93b5133c1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69538bd2-18d0-414a-bfec-7a93b5133c1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/073ff14f-0b89-4109-b769-233dc3c5805f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69538bd2-18d0-414a-bfec-7a93b5133c1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0937187d-59d8-44c3-9d7a-d77c18631e21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0937187d-59d8-44c3-9d7a-d77c18631e21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/073ff14f-0b89-4109-b769-233dc3c5805f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0937187d-59d8-44c3-9d7a-d77c18631e21>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bb157eb-3d6a-403b-a5a4-d484db4542a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bb157eb-3d6a-403b-a5a4-d484db4542a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/190630ff-3a59-4c14-b99b-0189050c0312/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bb157eb-3d6a-403b-a5a4-d484db4542a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a7b01c4-0dcf-4d9f-b8fd-c768b9c02da8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a7b01c4-0dcf-4d9f-b8fd-c768b9c02da8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/190630ff-3a59-4c14-b99b-0189050c0312/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a7b01c4-0dcf-4d9f-b8fd-c768b9c02da8>.
+    
+<http://data.lblod.info/id/remote-data-objects/da7bdfff-59b1-4a16-95c7-b1030fec9ae3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da7bdfff-59b1-4a16-95c7-b1030fec9ae3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/190630ff-3a59-4c14-b99b-0189050c0312/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da7bdfff-59b1-4a16-95c7-b1030fec9ae3>.
+    
+<http://data.lblod.info/id/remote-data-objects/137f5998-1053-4cab-9174-41a35fe93922> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "137f5998-1053-4cab-9174-41a35fe93922";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/1d58aae0-0d7b-4c5d-9972-34313f060524/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9c2cca44-c550-424a-9f9a-c8f3af3556db> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/137f5998-1053-4cab-9174-41a35fe93922>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201136-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201136-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201136-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201136-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/239c1818-6aa7-44ae-8860-5ab738f87061> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "239c1818-6aa7-44ae-8860-5ab738f87061";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4666893d-1497-4295-bdf6-fbaa7b302e3a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/09b16765-a8cd-4daa-9ba1-1f98b37d1d3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "09b16765-a8cd-4daa-9ba1-1f98b37d1d3b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a>.
+
+  <http://redpencil.data.gift/id/task/c9587e66-f119-413d-b27f-4bb977987881> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c9587e66-f119-413d-b27f-4bb977987881";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/239c1818-6aa7-44ae-8860-5ab738f87061>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/09b16765-a8cd-4daa-9ba1-1f98b37d1d3b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/46148c89-de2e-4164-940a-b7c44df36893> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46148c89-de2e-4164-940a-b7c44df36893";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/1d58aae0-0d7b-4c5d-9972-34313f060524/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46148c89-de2e-4164-940a-b7c44df36893>.
+    
+<http://data.lblod.info/id/remote-data-objects/daea9329-12ee-4e3a-b790-67c48efee4b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "daea9329-12ee-4e3a-b790-67c48efee4b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/1d58aae0-0d7b-4c5d-9972-34313f060524/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/daea9329-12ee-4e3a-b790-67c48efee4b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9f1fe5e-17dd-4e33-b42b-ef5f3e3a5f22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9f1fe5e-17dd-4e33-b42b-ef5f3e3a5f22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/2402a4fb-7eac-40f0-946a-017856417e48/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9f1fe5e-17dd-4e33-b42b-ef5f3e3a5f22>.
+    
+<http://data.lblod.info/id/remote-data-objects/151f6573-f690-4057-bcbd-6c32f004e7e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "151f6573-f690-4057-bcbd-6c32f004e7e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/2402a4fb-7eac-40f0-946a-017856417e48/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/151f6573-f690-4057-bcbd-6c32f004e7e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/10c7d475-93b5-4d40-8c5b-3edc6574b5ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10c7d475-93b5-4d40-8c5b-3edc6574b5ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/2402a4fb-7eac-40f0-946a-017856417e48/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10c7d475-93b5-4d40-8c5b-3edc6574b5ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/368bb1f7-fd40-4d87-adf7-eae5bd98c71e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "368bb1f7-fd40-4d87-adf7-eae5bd98c71e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/265757dc-8ddf-4f8e-bfb3-6d1baaf22e48/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/368bb1f7-fd40-4d87-adf7-eae5bd98c71e>.
+    
+<http://data.lblod.info/id/remote-data-objects/db2aded2-d853-4cbf-9375-9c50d746ce69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db2aded2-d853-4cbf-9375-9c50d746ce69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/265757dc-8ddf-4f8e-bfb3-6d1baaf22e48/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db2aded2-d853-4cbf-9375-9c50d746ce69>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b68423c-f6b1-447c-ad7e-915432da2906> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b68423c-f6b1-447c-ad7e-915432da2906";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/265757dc-8ddf-4f8e-bfb3-6d1baaf22e48/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b68423c-f6b1-447c-ad7e-915432da2906>.
+    
+<http://data.lblod.info/id/remote-data-objects/82a33f7e-2237-4849-92e6-ef3b9a9222a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82a33f7e-2237-4849-92e6-ef3b9a9222a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/3b780b1f-3893-48e8-9d97-e1699f379060/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82a33f7e-2237-4849-92e6-ef3b9a9222a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e935f5d-4168-4f8f-b752-b941dd46c557> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e935f5d-4168-4f8f-b752-b941dd46c557";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/3b780b1f-3893-48e8-9d97-e1699f379060/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e935f5d-4168-4f8f-b752-b941dd46c557>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6ef27b5-b9ab-4d0f-b336-1d96d8805d1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6ef27b5-b9ab-4d0f-b336-1d96d8805d1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/3b780b1f-3893-48e8-9d97-e1699f379060/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6ef27b5-b9ab-4d0f-b336-1d96d8805d1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed5e4851-f16d-45c9-b4db-4e10cb297646> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed5e4851-f16d-45c9-b4db-4e10cb297646";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/507f030e-e616-4bea-b0d7-a2d54d88707d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed5e4851-f16d-45c9-b4db-4e10cb297646>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e8d54be-4a3d-4473-a5f7-9734f57c89c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e8d54be-4a3d-4473-a5f7-9734f57c89c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/507f030e-e616-4bea-b0d7-a2d54d88707d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e8d54be-4a3d-4473-a5f7-9734f57c89c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4165e8a-5a5f-49f3-8c99-87c382468bc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4165e8a-5a5f-49f3-8c99-87c382468bc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/507f030e-e616-4bea-b0d7-a2d54d88707d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4165e8a-5a5f-49f3-8c99-87c382468bc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f062ee66-8ec3-44ec-926a-3405473ab43b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f062ee66-8ec3-44ec-926a-3405473ab43b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/6b498c45-7d2e-40cf-8843-67763be64cbf/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f062ee66-8ec3-44ec-926a-3405473ab43b>.
+    
+<http://data.lblod.info/id/remote-data-objects/08d7fdae-f41f-4151-a440-3e5a784aacd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08d7fdae-f41f-4151-a440-3e5a784aacd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/6b498c45-7d2e-40cf-8843-67763be64cbf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08d7fdae-f41f-4151-a440-3e5a784aacd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a82ce078-093f-4df9-8d90-16abc4523d08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a82ce078-093f-4df9-8d90-16abc4523d08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/85e4e3b9-de61-4cfb-b880-5dc6567991a7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a82ce078-093f-4df9-8d90-16abc4523d08>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c3757cb-49ee-41b7-9393-ea4d5981f66a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c3757cb-49ee-41b7-9393-ea4d5981f66a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/85e4e3b9-de61-4cfb-b880-5dc6567991a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c3757cb-49ee-41b7-9393-ea4d5981f66a>.
+    
+<http://data.lblod.info/id/remote-data-objects/54069938-4af7-4e7d-a986-7c627dcc4645> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54069938-4af7-4e7d-a986-7c627dcc4645";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/85e4e3b9-de61-4cfb-b880-5dc6567991a7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54069938-4af7-4e7d-a986-7c627dcc4645>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d80c28a-17f0-408c-a42e-8a7e800f7db6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d80c28a-17f0-408c-a42e-8a7e800f7db6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/9789a2e2-eb78-4c0e-95e8-2848fab7b5cd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d80c28a-17f0-408c-a42e-8a7e800f7db6>.
+    
+<http://data.lblod.info/id/remote-data-objects/17029313-f20a-4fa3-9f99-4d3887298fd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17029313-f20a-4fa3-9f99-4d3887298fd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/9789a2e2-eb78-4c0e-95e8-2848fab7b5cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17029313-f20a-4fa3-9f99-4d3887298fd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/24547b66-41ce-4e57-9484-980be0fd50b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24547b66-41ce-4e57-9484-980be0fd50b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/9789a2e2-eb78-4c0e-95e8-2848fab7b5cd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24547b66-41ce-4e57-9484-980be0fd50b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c80da514-8189-4502-a631-d4f1c5dccf3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c80da514-8189-4502-a631-d4f1c5dccf3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/97a94480-407e-45d1-9a0f-ccf6ef5a4c16/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c80da514-8189-4502-a631-d4f1c5dccf3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/936c351a-5e43-4d5a-8873-71d84984c42e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "936c351a-5e43-4d5a-8873-71d84984c42e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/97a94480-407e-45d1-9a0f-ccf6ef5a4c16/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/936c351a-5e43-4d5a-8873-71d84984c42e>.
+    
+<http://data.lblod.info/id/remote-data-objects/af207d14-f820-4ecf-967a-e1578ae32fca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af207d14-f820-4ecf-967a-e1578ae32fca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/97a94480-407e-45d1-9a0f-ccf6ef5a4c16/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af207d14-f820-4ecf-967a-e1578ae32fca>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cc5518c-5703-4fcf-bde4-a8f8ed59307a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cc5518c-5703-4fcf-bde4-a8f8ed59307a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/c87f93f0-6d58-4fb4-89f5-b7b04e26e824/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cc5518c-5703-4fcf-bde4-a8f8ed59307a>.
+    
+<http://data.lblod.info/id/remote-data-objects/055b1d88-df33-41f9-b747-b9e343f15dc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "055b1d88-df33-41f9-b747-b9e343f15dc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/c87f93f0-6d58-4fb4-89f5-b7b04e26e824/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/055b1d88-df33-41f9-b747-b9e343f15dc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/92703650-a76e-4da7-ba71-f9d2622c4cb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92703650-a76e-4da7-ba71-f9d2622c4cb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/c87f93f0-6d58-4fb4-89f5-b7b04e26e824/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92703650-a76e-4da7-ba71-f9d2622c4cb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/efb7cd8b-2b5c-43f1-90b6-3ed68a9e95c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efb7cd8b-2b5c-43f1-90b6-3ed68a9e95c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/d32ae09e-ccd4-42a4-a3aa-95b6eabd3f29/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efb7cd8b-2b5c-43f1-90b6-3ed68a9e95c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b2c33dc-4bc7-4cb1-9475-ffe20e5f5b1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b2c33dc-4bc7-4cb1-9475-ffe20e5f5b1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/d32ae09e-ccd4-42a4-a3aa-95b6eabd3f29/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b2c33dc-4bc7-4cb1-9475-ffe20e5f5b1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1b94808-bd56-48fc-a5c8-9e843d54896a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1b94808-bd56-48fc-a5c8-9e843d54896a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/d32ae09e-ccd4-42a4-a3aa-95b6eabd3f29/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1b94808-bd56-48fc-a5c8-9e843d54896a>.
+    
+<http://data.lblod.info/id/remote-data-objects/16bdfc62-5102-4c22-91c1-9bb03b2c148f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16bdfc62-5102-4c22-91c1-9bb03b2c148f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/dd9a8132-04da-4096-90ec-f8428bf04ced/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16bdfc62-5102-4c22-91c1-9bb03b2c148f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bcd3ec0-5d43-4cea-973e-ae4a36a5b017> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bcd3ec0-5d43-4cea-973e-ae4a36a5b017";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/dd9a8132-04da-4096-90ec-f8428bf04ced/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bcd3ec0-5d43-4cea-973e-ae4a36a5b017>.
+    
+<http://data.lblod.info/id/remote-data-objects/e20ec7d6-b33c-4033-85f1-413c66dd6e96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e20ec7d6-b33c-4033-85f1-413c66dd6e96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/dd9a8132-04da-4096-90ec-f8428bf04ced/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e20ec7d6-b33c-4033-85f1-413c66dd6e96>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff0581c8-50bb-4ace-99f9-535d9ed50d2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff0581c8-50bb-4ace-99f9-535d9ed50d2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/ffd0093d-8746-446d-9ed0-f99f90456444/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff0581c8-50bb-4ace-99f9-535d9ed50d2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/71a58b31-8d55-4e21-9e24-ba6e4f2a7188> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71a58b31-8d55-4e21-9e24-ba6e4f2a7188";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/ffd0093d-8746-446d-9ed0-f99f90456444/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71a58b31-8d55-4e21-9e24-ba6e4f2a7188>.
+    
+<http://data.lblod.info/id/remote-data-objects/e894e97e-69f8-40c5-a052-69b0274d852d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e894e97e-69f8-40c5-a052-69b0274d852d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/rmw/ffd0093d-8746-446d-9ed0-f99f90456444/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e894e97e-69f8-40c5-a052-69b0274d852d>.
+    
+<http://data.lblod.info/id/remote-data-objects/05b7f430-fcdf-4fd1-9fdb-78c7b7d8d33b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05b7f430-fcdf-4fd1-9fdb-78c7b7d8d33b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/00abb06f-b913-4990-977e-f4d91794e7c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05b7f430-fcdf-4fd1-9fdb-78c7b7d8d33b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f811231-efe5-41f4-b3f3-86ea182e8043> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f811231-efe5-41f4-b3f3-86ea182e8043";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/0a813e8b-c973-4378-9235-ca1fe30cab18/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f811231-efe5-41f4-b3f3-86ea182e8043>.
+    
+<http://data.lblod.info/id/remote-data-objects/029febf6-f063-4716-959e-27426d0ac8e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "029febf6-f063-4716-959e-27426d0ac8e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/10438966-d294-4002-bb92-bf3d24e3cec1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/029febf6-f063-4716-959e-27426d0ac8e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c99687e-cbbb-44cc-902f-1a93a7d59dd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c99687e-cbbb-44cc-902f-1a93a7d59dd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/16ed77c8-1e16-4dc2-95f0-8e9287ae68d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c99687e-cbbb-44cc-902f-1a93a7d59dd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/63ff113b-6765-4f19-bd84-7ac2d2335fe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63ff113b-6765-4f19-bd84-7ac2d2335fe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/1e487e3b-a004-44fa-9a4e-cae1271f9a1b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63ff113b-6765-4f19-bd84-7ac2d2335fe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/dedc6204-5b6e-4914-b4df-41d5a21077d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dedc6204-5b6e-4914-b4df-41d5a21077d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/1ebfa2e6-4a1d-474e-9a63-c4b7e9693d4f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dedc6204-5b6e-4914-b4df-41d5a21077d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/06aff4cf-0e1c-4b39-b8d0-ee49f1f485cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06aff4cf-0e1c-4b39-b8d0-ee49f1f485cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/2a955b6c-863d-4e57-abe9-1bbae2ca0e4d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06aff4cf-0e1c-4b39-b8d0-ee49f1f485cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/026629b3-1e66-4c0c-a1b1-119172b37820> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "026629b3-1e66-4c0c-a1b1-119172b37820";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/2ce486a8-29d3-4ee8-849d-868a598282d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/026629b3-1e66-4c0c-a1b1-119172b37820>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b37e91c-5755-41b7-95b2-207e4199aca3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b37e91c-5755-41b7-95b2-207e4199aca3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/32034387-ac9b-4c80-b8b5-6d499b682478/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b37e91c-5755-41b7-95b2-207e4199aca3>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb4908fb-73d0-47c7-a0bf-a2486a691288> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb4908fb-73d0-47c7-a0bf-a2486a691288";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/3505cba6-02fc-4c04-a235-955d44ad9689/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb4908fb-73d0-47c7-a0bf-a2486a691288>.
+    
+<http://data.lblod.info/id/remote-data-objects/48043eb5-372c-4673-a6a0-058fbeb709b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48043eb5-372c-4673-a6a0-058fbeb709b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/37cf8a5f-81a5-4e59-982c-d07cda46374e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48043eb5-372c-4673-a6a0-058fbeb709b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/90897872-2f63-4596-aa96-816e1467f852> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90897872-2f63-4596-aa96-816e1467f852";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/39100600-354f-46f1-a870-1d8e3d871a30/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90897872-2f63-4596-aa96-816e1467f852>.
+    
+<http://data.lblod.info/id/remote-data-objects/a38bf838-a13d-4235-9a15-a58b9761b43b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a38bf838-a13d-4235-9a15-a58b9761b43b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/3a1983e8-becf-476f-82f2-e1eafb852928/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4666893d-1497-4295-bdf6-fbaa7b302e3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a38bf838-a13d-4235-9a15-a58b9761b43b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201137-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201137-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201137-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201137-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/bc5c7721-3784-46eb-a24c-522d1992a9c9> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bc5c7721-3784-46eb-a24c-522d1992a9c9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dbc55802-3dfb-4adb-a021-772c0b89cc7c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/bb61d2c9-e3fe-4b83-bf15-b2bf374207e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bb61d2c9-e3fe-4b83-bf15-b2bf374207e5";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c>.
+
+  <http://redpencil.data.gift/id/task/154bb416-862b-4e9b-9ad0-20df6b92b948> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "154bb416-862b-4e9b-9ad0-20df6b92b948";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/bc5c7721-3784-46eb-a24c-522d1992a9c9>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/bb61d2c9-e3fe-4b83-bf15-b2bf374207e5>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/bd61af61-11b8-49b0-86af-7b6c9fb57748> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd61af61-11b8-49b0-86af-7b6c9fb57748";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/3d11e01c-1ce6-4f1e-928d-b8de30e15a3c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd61af61-11b8-49b0-86af-7b6c9fb57748>.
+    
+<http://data.lblod.info/id/remote-data-objects/81b11e72-7330-4669-8835-47aa2ada9451> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81b11e72-7330-4669-8835-47aa2ada9451";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/4010f2d8-220b-4c45-a763-ad3aae3c4b25/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81b11e72-7330-4669-8835-47aa2ada9451>.
+    
+<http://data.lblod.info/id/remote-data-objects/eefd668a-6487-44ae-8313-1993f1325c5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eefd668a-6487-44ae-8313-1993f1325c5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/4172d954-742b-4758-a6a5-5289f1cd7b8d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eefd668a-6487-44ae-8313-1993f1325c5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8666c701-fd5a-4804-b52b-69c6f3bf8564> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8666c701-fd5a-4804-b52b-69c6f3bf8564";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/4284b05f-e119-459b-862c-004236857fff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8666c701-fd5a-4804-b52b-69c6f3bf8564>.
+    
+<http://data.lblod.info/id/remote-data-objects/0169a69f-b297-4a1b-8fa9-d3a2593a901b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0169a69f-b297-4a1b-8fa9-d3a2593a901b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/48d39113-e958-40d0-afdd-64fa85d8dec2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0169a69f-b297-4a1b-8fa9-d3a2593a901b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9c7040c-d9b5-40b0-88e1-866d04793e4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9c7040c-d9b5-40b0-88e1-866d04793e4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/4975a7ca-4c6c-443a-be73-0ce517c239ad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9c7040c-d9b5-40b0-88e1-866d04793e4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/229e7d4e-0011-41b7-8e97-4ba3d8d00aa2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "229e7d4e-0011-41b7-8e97-4ba3d8d00aa2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/49812e54-ec13-4e54-912c-4c285947d4db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/229e7d4e-0011-41b7-8e97-4ba3d8d00aa2>.
+    
+<http://data.lblod.info/id/remote-data-objects/06021eed-60ac-469c-b6f4-c56bbaa6d53c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06021eed-60ac-469c-b6f4-c56bbaa6d53c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/5270749c-fee1-4672-940c-581c1a84f053/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06021eed-60ac-469c-b6f4-c56bbaa6d53c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e55ab0cb-b6f2-4566-94ea-5059b2b110fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e55ab0cb-b6f2-4566-94ea-5059b2b110fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/57a9400b-e7c4-4087-8dcb-04be4d69717a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e55ab0cb-b6f2-4566-94ea-5059b2b110fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/f802ad3f-bd93-48f7-af30-ca42dd9c7cb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f802ad3f-bd93-48f7-af30-ca42dd9c7cb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/5acae7c1-7051-4df6-8757-904cca8abc42/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f802ad3f-bd93-48f7-af30-ca42dd9c7cb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d83bbf6e-570a-4fd5-b26c-7d75f7e31711> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d83bbf6e-570a-4fd5-b26c-7d75f7e31711";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/5e05c10f-15e6-41dc-bb46-06ee85b79962/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d83bbf6e-570a-4fd5-b26c-7d75f7e31711>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8bb10ba-9960-4ac6-9716-d1899de8bf44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8bb10ba-9960-4ac6-9716-d1899de8bf44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/6047118c-d101-4f69-9f8b-a9b017b800f0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8bb10ba-9960-4ac6-9716-d1899de8bf44>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c65adae-3d04-4cb7-b46a-8898e3fa1a3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c65adae-3d04-4cb7-b46a-8898e3fa1a3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/6ad4bc57-f4fe-4963-a8d7-68896dc8dcd0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c65adae-3d04-4cb7-b46a-8898e3fa1a3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b298985-32ab-4dce-ab4b-10a0b237b62f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b298985-32ab-4dce-ab4b-10a0b237b62f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/6c1c4fcc-9ae6-4269-ba83-74517b41f957/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b298985-32ab-4dce-ab4b-10a0b237b62f>.
+    
+<http://data.lblod.info/id/remote-data-objects/867fdcff-1fd4-4fdf-9e60-9341495a17d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "867fdcff-1fd4-4fdf-9e60-9341495a17d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/6fe9523d-224a-4d56-a79d-e7918f4c41dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/867fdcff-1fd4-4fdf-9e60-9341495a17d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd1fea61-cc64-4738-9ce4-b2487cddbb03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd1fea61-cc64-4738-9ce4-b2487cddbb03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/7044aa06-bc07-4078-94c8-c2d6cd6b2bfa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd1fea61-cc64-4738-9ce4-b2487cddbb03>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab2518c4-9b81-4019-80f1-65e552b149a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab2518c4-9b81-4019-80f1-65e552b149a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/70f996d0-0e5d-4c53-916e-dee566450383/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab2518c4-9b81-4019-80f1-65e552b149a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/050b08ab-bc67-47cb-9a2c-aa4fb0de2d32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "050b08ab-bc67-47cb-9a2c-aa4fb0de2d32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/79273432-c2c2-4f56-ae14-a84eb054b292/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/050b08ab-bc67-47cb-9a2c-aa4fb0de2d32>.
+    
+<http://data.lblod.info/id/remote-data-objects/69c8d9ee-15d8-4f55-887b-7c5b3864c96d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69c8d9ee-15d8-4f55-887b-7c5b3864c96d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/79da4aa2-7dd3-4a43-9d8a-9d39a4cd52e9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69c8d9ee-15d8-4f55-887b-7c5b3864c96d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c17a410-c43d-4043-863e-78b1740a1866> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c17a410-c43d-4043-863e-78b1740a1866";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/85c11a97-37d0-4963-853f-4190dec58167/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c17a410-c43d-4043-863e-78b1740a1866>.
+    
+<http://data.lblod.info/id/remote-data-objects/06677c09-8fcf-4a1b-93d7-eb06cd2b1528> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06677c09-8fcf-4a1b-93d7-eb06cd2b1528";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/873a16d1-c21e-452d-9330-fb40ca64c115/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06677c09-8fcf-4a1b-93d7-eb06cd2b1528>.
+    
+<http://data.lblod.info/id/remote-data-objects/73b3fc4f-1622-45be-ab64-cbca61e94ea9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73b3fc4f-1622-45be-ab64-cbca61e94ea9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/8a5bb0c7-3dba-4a42-b058-7d6ccb88df5c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73b3fc4f-1622-45be-ab64-cbca61e94ea9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff86a416-69e0-4c64-91bf-d9770dcedce9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff86a416-69e0-4c64-91bf-d9770dcedce9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/8e629921-734e-4115-ab3c-be9bd565f032/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff86a416-69e0-4c64-91bf-d9770dcedce9>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ad789e0-8e8c-4f7b-ba09-2e2c13d2eaad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ad789e0-8e8c-4f7b-ba09-2e2c13d2eaad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/8f988558-2538-4097-8e27-26d6b9e2345a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ad789e0-8e8c-4f7b-ba09-2e2c13d2eaad>.
+    
+<http://data.lblod.info/id/remote-data-objects/717f9e9b-9aa8-4c10-b5f2-72a545b0629c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "717f9e9b-9aa8-4c10-b5f2-72a545b0629c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/90250c0d-7911-4cef-9c24-b98a24d621f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/717f9e9b-9aa8-4c10-b5f2-72a545b0629c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1608fd6e-9144-44a9-a447-f0aa3c85cd93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1608fd6e-9144-44a9-a447-f0aa3c85cd93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/91feb0d2-7e9e-4ad4-861c-d1736f92f874/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1608fd6e-9144-44a9-a447-f0aa3c85cd93>.
+    
+<http://data.lblod.info/id/remote-data-objects/88b23578-0e6e-4b25-9dd3-52d479f2ecce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88b23578-0e6e-4b25-9dd3-52d479f2ecce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/921f2e59-16a1-43a9-a1c9-42871ed149aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88b23578-0e6e-4b25-9dd3-52d479f2ecce>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1a12adb-335e-46df-960f-fcd9c2fb405e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1a12adb-335e-46df-960f-fcd9c2fb405e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/9dbe5596-613d-4713-bc0e-37ee42daf17d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1a12adb-335e-46df-960f-fcd9c2fb405e>.
+    
+<http://data.lblod.info/id/remote-data-objects/937c68e4-11e5-44ce-b65d-6f3d13863a8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "937c68e4-11e5-44ce-b65d-6f3d13863a8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/a4a9d47c-e4f4-462e-8e07-b5167724d43a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/937c68e4-11e5-44ce-b65d-6f3d13863a8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e3d249f-0f30-461a-a197-2b20b9106855> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e3d249f-0f30-461a-a197-2b20b9106855";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/a67cee1b-5469-4357-a053-a04b404974dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e3d249f-0f30-461a-a197-2b20b9106855>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9b3fa7b-50de-4d0c-9b8d-05cedc27fa02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9b3fa7b-50de-4d0c-9b8d-05cedc27fa02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/a83f40ac-c0f4-4934-a57c-b617c2120b7d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9b3fa7b-50de-4d0c-9b8d-05cedc27fa02>.
+    
+<http://data.lblod.info/id/remote-data-objects/13c3bc11-7c1f-4402-810c-bef2373ab4f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13c3bc11-7c1f-4402-810c-bef2373ab4f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/a84d4ccd-7c0b-4afb-b24e-0f0886d3f4e9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13c3bc11-7c1f-4402-810c-bef2373ab4f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa90445f-5842-40d3-9a2a-5989da920d17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa90445f-5842-40d3-9a2a-5989da920d17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/ade49a36-e4b8-424d-b919-d018721874a2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa90445f-5842-40d3-9a2a-5989da920d17>.
+    
+<http://data.lblod.info/id/remote-data-objects/a22ff555-65be-40df-bdc2-c2fb6f7d47f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a22ff555-65be-40df-bdc2-c2fb6f7d47f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/b32be9e2-4ef6-4df9-b214-33f018d23001/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a22ff555-65be-40df-bdc2-c2fb6f7d47f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f75c0524-a273-468c-9364-9f63e0fc3b0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f75c0524-a273-468c-9364-9f63e0fc3b0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/bed45c57-071a-467b-8b2c-765d59bb66f8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f75c0524-a273-468c-9364-9f63e0fc3b0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/62128b8a-f91c-43e7-89b4-86fe82043c01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62128b8a-f91c-43e7-89b4-86fe82043c01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/c29aef0e-236d-4c70-9ff9-95d9587638af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62128b8a-f91c-43e7-89b4-86fe82043c01>.
+    
+<http://data.lblod.info/id/remote-data-objects/a31d918c-a890-4d88-a2b2-be8d060359b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a31d918c-a890-4d88-a2b2-be8d060359b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/c5f8d540-a738-4d59-801e-1b42b79b12e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a31d918c-a890-4d88-a2b2-be8d060359b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/80466dcd-6486-4c9e-9dce-0947f714621a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80466dcd-6486-4c9e-9dce-0947f714621a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/cb9de66c-10f9-4fe0-afb1-3580a70cff6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80466dcd-6486-4c9e-9dce-0947f714621a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c9ea63c-fe04-48db-aa66-1c9f8cb7d6ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c9ea63c-fe04-48db-aa66-1c9f8cb7d6ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/cba81d60-30c5-4092-b5e7-d7e48362e91a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c9ea63c-fe04-48db-aa66-1c9f8cb7d6ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f44c5ed-40c1-49a9-bc17-46199d1ad02c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f44c5ed-40c1-49a9-bc17-46199d1ad02c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/cbae323c-8ce1-444e-8037-6e2d43d2cd03/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f44c5ed-40c1-49a9-bc17-46199d1ad02c>.
+    
+<http://data.lblod.info/id/remote-data-objects/955b48b7-06c3-4697-94d0-acc28bf6395d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "955b48b7-06c3-4697-94d0-acc28bf6395d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/ce106fce-293e-4e09-ab88-e328f685b210/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/955b48b7-06c3-4697-94d0-acc28bf6395d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecc5aedb-12af-462c-97e8-b76c03ead758> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecc5aedb-12af-462c-97e8-b76c03ead758";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/d3592874-46a2-4e97-9654-7c2f7047fca4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecc5aedb-12af-462c-97e8-b76c03ead758>.
+    
+<http://data.lblod.info/id/remote-data-objects/b28712e0-dcee-4fb0-849b-1b07b6731a1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b28712e0-dcee-4fb0-849b-1b07b6731a1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/d38c725b-dd9b-41ca-9999-42cb1e2bbed8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b28712e0-dcee-4fb0-849b-1b07b6731a1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/125ed869-7efc-43f6-8404-09094fce1791> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "125ed869-7efc-43f6-8404-09094fce1791";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/d581d1a0-d253-4386-9749-cf180249422f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/125ed869-7efc-43f6-8404-09094fce1791>.
+    
+<http://data.lblod.info/id/remote-data-objects/38393c1c-5adf-41a2-9db0-2ccbaada8f44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38393c1c-5adf-41a2-9db0-2ccbaada8f44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/d6c997e5-f0fa-4970-bb71-a241b12fc4e8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38393c1c-5adf-41a2-9db0-2ccbaada8f44>.
+    
+<http://data.lblod.info/id/remote-data-objects/53a76773-c9f8-4348-bf3c-2692a921020a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53a76773-c9f8-4348-bf3c-2692a921020a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/d80c71c8-09ed-49de-9d97-736cbf347444/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53a76773-c9f8-4348-bf3c-2692a921020a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc9aed2e-e675-4245-894e-c66d5e625094> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc9aed2e-e675-4245-894e-c66d5e625094";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/db89af21-57bb-4a75-bd10-f2d373592054/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc9aed2e-e675-4245-894e-c66d5e625094>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b4ab168-6bb2-4471-8cea-7dcfdc911338> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b4ab168-6bb2-4471-8cea-7dcfdc911338";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/dd7a6551-786e-4fcf-a45f-743d30c0cec5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b4ab168-6bb2-4471-8cea-7dcfdc911338>.
+    
+<http://data.lblod.info/id/remote-data-objects/0db3c084-7bb0-4d7e-a92c-bf201e84e333> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0db3c084-7bb0-4d7e-a92c-bf201e84e333";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/e61ffb1b-0257-414d-84a5-73d4ea899f4a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0db3c084-7bb0-4d7e-a92c-bf201e84e333>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c1e59d2-f38d-4624-9ded-c115a62d7dcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c1e59d2-f38d-4624-9ded-c115a62d7dcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/e7d889e5-478d-496f-a07a-7262674ce3e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbc55802-3dfb-4adb-a021-772c0b89cc7c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c1e59d2-f38d-4624-9ded-c115a62d7dcc>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201138-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201138-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201138-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201138-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2d2a8110-37fc-4827-8c5b-0f3a87b2971c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2d2a8110-37fc-4827-8c5b-0f3a87b2971c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a3d7e037-dcce-4851-93b3-ed092d8d8e89";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/045cbeca-30b5-4f82-841f-dfaea9755db9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "045cbeca-30b5-4f82-841f-dfaea9755db9";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89>.
+
+  <http://redpencil.data.gift/id/task/e7adebda-40d1-44c9-8777-3bc38ce9ba2a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e7adebda-40d1-44c9-8777-3bc38ce9ba2a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2d2a8110-37fc-4827-8c5b-0f3a87b2971c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/045cbeca-30b5-4f82-841f-dfaea9755db9>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d067f116-1bf9-4f84-96db-4dd04eb5261c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d067f116-1bf9-4f84-96db-4dd04eb5261c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/e9edaadd-0336-4f20-afb2-0452fa3998e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d067f116-1bf9-4f84-96db-4dd04eb5261c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f88d9fae-792b-49e0-90d2-fa4fed07c742> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f88d9fae-792b-49e0-90d2-fa4fed07c742";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/eb6f0745-356a-4a3a-98d2-83deb2dace46/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f88d9fae-792b-49e0-90d2-fa4fed07c742>.
+    
+<http://data.lblod.info/id/remote-data-objects/faab90f4-dffa-4b5e-972c-21a276c0b9ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "faab90f4-dffa-4b5e-972c-21a276c0b9ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/f1346c62-2b99-44f5-b667-890ad4639b53/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/faab90f4-dffa-4b5e-972c-21a276c0b9ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e47455c-1294-4063-ae57-8b9c4dfb6af8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e47455c-1294-4063-ae57-8b9c4dfb6af8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/f22a05eb-55d2-4bee-ad5a-38b711e2d929/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e47455c-1294-4063-ae57-8b9c4dfb6af8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e87a8073-20bb-4bb4-af79-6de8a7118cef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e87a8073-20bb-4bb4-af79-6de8a7118cef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://heusden-zolder.meetingburger.net/vb/f6ce97c2-704f-46a7-a669-535682183f82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e87a8073-20bb-4bb4-af79-6de8a7118cef>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff7d4ff6-1cbd-4d81-86ef-bd5f7c53cf0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff7d4ff6-1cbd-4d81-86ef-bd5f7c53cf0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/00844e87-90bd-488d-80ca-a5a4b6f16009/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff7d4ff6-1cbd-4d81-86ef-bd5f7c53cf0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e42bfd4-f1d8-4a38-8bac-a238138ca213> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e42bfd4-f1d8-4a38-8bac-a238138ca213";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/0acfbda7-05fa-4e13-85d7-70c426cff9a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e42bfd4-f1d8-4a38-8bac-a238138ca213>.
+    
+<http://data.lblod.info/id/remote-data-objects/10a717b1-5dae-4d64-8a29-f8f1b9e28cec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10a717b1-5dae-4d64-8a29-f8f1b9e28cec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/0b32f45a-4aac-4e91-a2ff-7e6b72d66f6e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10a717b1-5dae-4d64-8a29-f8f1b9e28cec>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0887e8b-cb4d-4d5c-9f4d-dfe1f565883d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0887e8b-cb4d-4d5c-9f4d-dfe1f565883d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/0f666d1d-3e4e-43b0-bd3a-a1c9a3991bcc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0887e8b-cb4d-4d5c-9f4d-dfe1f565883d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f66eea2a-bd18-47ed-9cae-b0178ae2a54d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f66eea2a-bd18-47ed-9cae-b0178ae2a54d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/14391601-0066-4d09-86bd-bcd8ec2e848f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f66eea2a-bd18-47ed-9cae-b0178ae2a54d>.
+    
+<http://data.lblod.info/id/remote-data-objects/50951f5f-6213-41bd-be9b-696eadba755b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50951f5f-6213-41bd-be9b-696eadba755b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/162a2985-ecdd-4319-9df0-34e00be7bf86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50951f5f-6213-41bd-be9b-696eadba755b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8cb0426-5d81-4c75-91ba-2020b1a3aa10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8cb0426-5d81-4c75-91ba-2020b1a3aa10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/1bb8b734-0106-4cd0-aa85-10226e9e137a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8cb0426-5d81-4c75-91ba-2020b1a3aa10>.
+    
+<http://data.lblod.info/id/remote-data-objects/00afb8d3-d403-4464-8a05-b25ae93f6186> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00afb8d3-d403-4464-8a05-b25ae93f6186";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/21c0b44d-19db-46e8-a05b-8b14aa8012b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00afb8d3-d403-4464-8a05-b25ae93f6186>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d070142-4cdb-4326-9ba2-1e440169d106> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d070142-4cdb-4326-9ba2-1e440169d106";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/222490c0-056f-4a40-a085-33f5e65f47ed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d070142-4cdb-4326-9ba2-1e440169d106>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bcf531c-0139-4108-b311-39db7913b617> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bcf531c-0139-4108-b311-39db7913b617";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/26fbf444-2213-42aa-9c75-753049c440db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bcf531c-0139-4108-b311-39db7913b617>.
+    
+<http://data.lblod.info/id/remote-data-objects/648457ec-1d17-40c6-8b10-af090186505d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "648457ec-1d17-40c6-8b10-af090186505d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/27111072-a531-4b36-8a29-95f9895e13c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/648457ec-1d17-40c6-8b10-af090186505d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c159cd72-5443-41db-b5b5-b359b715c93b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c159cd72-5443-41db-b5b5-b359b715c93b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/2e5fea7f-596b-4ad9-8925-67fea14efcea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c159cd72-5443-41db-b5b5-b359b715c93b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0138fc93-14c5-4152-97e4-4d21f780fd08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0138fc93-14c5-4152-97e4-4d21f780fd08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/2f1e6f25-bfa3-4775-9e17-5887b3b83cec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0138fc93-14c5-4152-97e4-4d21f780fd08>.
+    
+<http://data.lblod.info/id/remote-data-objects/9624094f-3c96-4f65-950b-0be39d4f5a94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9624094f-3c96-4f65-950b-0be39d4f5a94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/30d96b8b-eb5d-43ca-8206-055a7b5c6cb1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9624094f-3c96-4f65-950b-0be39d4f5a94>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1aba5db-9d50-448b-9ea6-c5682b58497f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1aba5db-9d50-448b-9ea6-c5682b58497f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/3297ca60-e5fb-4d73-bd6e-a3404ef5c907/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1aba5db-9d50-448b-9ea6-c5682b58497f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c57a88fc-bf6b-4374-8977-d5bc8a613a0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c57a88fc-bf6b-4374-8977-d5bc8a613a0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/496611a8-1f59-4274-96af-a245342b5630/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c57a88fc-bf6b-4374-8977-d5bc8a613a0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/14532f1e-5415-4664-a876-1b4f315664b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14532f1e-5415-4664-a876-1b4f315664b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/49cc1000-b644-4555-917d-703a1580eb86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14532f1e-5415-4664-a876-1b4f315664b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/30a7931d-4ab0-4ea5-9644-c51c5205db42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30a7931d-4ab0-4ea5-9644-c51c5205db42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/49cf6f81-1602-472a-a1d4-7a9d7aab18fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30a7931d-4ab0-4ea5-9644-c51c5205db42>.
+    
+<http://data.lblod.info/id/remote-data-objects/76ec86d4-dc19-47bd-8ab4-9e7eab5b54c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76ec86d4-dc19-47bd-8ab4-9e7eab5b54c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/4aa8381a-f079-44df-a424-e1d55cb9f43b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76ec86d4-dc19-47bd-8ab4-9e7eab5b54c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f12eee8-26e3-4bcb-8a71-e31d77e76971> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f12eee8-26e3-4bcb-8a71-e31d77e76971";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/6062ac8a-5422-4300-af7f-482894f9eb58/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f12eee8-26e3-4bcb-8a71-e31d77e76971>.
+    
+<http://data.lblod.info/id/remote-data-objects/3240e10b-58db-4f5d-aa2f-eddbc1093036> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3240e10b-58db-4f5d-aa2f-eddbc1093036";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/608a2d78-d894-4d50-92a6-fe1d1df8bea1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3240e10b-58db-4f5d-aa2f-eddbc1093036>.
+    
+<http://data.lblod.info/id/remote-data-objects/a69a7b69-775e-4b7c-a687-d845945342c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a69a7b69-775e-4b7c-a687-d845945342c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/63825d09-052a-4f81-8e87-25878eef8de9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a69a7b69-775e-4b7c-a687-d845945342c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/2246ed06-6264-44b2-9f08-700868ad29e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2246ed06-6264-44b2-9f08-700868ad29e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/64ccf197-e3f4-417d-a124-5c46929b9750/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2246ed06-6264-44b2-9f08-700868ad29e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/226bea8f-48b1-4dcd-b0e3-0f86a56cb030> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "226bea8f-48b1-4dcd-b0e3-0f86a56cb030";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/6bb0b2b9-b3f2-42ab-a6ad-527edfc8203b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/226bea8f-48b1-4dcd-b0e3-0f86a56cb030>.
+    
+<http://data.lblod.info/id/remote-data-objects/7078768f-76c7-4b16-9d0b-57d88e12bbc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7078768f-76c7-4b16-9d0b-57d88e12bbc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/6d86091b-aedb-403d-90a4-3b9603f115b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7078768f-76c7-4b16-9d0b-57d88e12bbc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/80e76ca3-abc5-44e4-8c46-818ef51dbd6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80e76ca3-abc5-44e4-8c46-818ef51dbd6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/6e8823f5-4375-4b1e-bc27-b45b8ec70c9f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80e76ca3-abc5-44e4-8c46-818ef51dbd6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c69a9c2f-8f61-46cb-a77d-e3af158aaca8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c69a9c2f-8f61-46cb-a77d-e3af158aaca8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/70d2ada6-9d97-4a7b-b16a-b7423324f4d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c69a9c2f-8f61-46cb-a77d-e3af158aaca8>.
+    
+<http://data.lblod.info/id/remote-data-objects/943aaf81-e3cd-4d35-a0c1-63c0f515f5c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "943aaf81-e3cd-4d35-a0c1-63c0f515f5c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/74c64647-3860-4b30-8de3-5b9d266bd02f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/943aaf81-e3cd-4d35-a0c1-63c0f515f5c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/523bd3ea-b8e3-4fdd-a92f-d96788a240e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "523bd3ea-b8e3-4fdd-a92f-d96788a240e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/7d18ef60-9393-40ea-8423-342f1c59df11/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/523bd3ea-b8e3-4fdd-a92f-d96788a240e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/562ca549-3fd9-4859-a700-8ffd4bb6ebc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "562ca549-3fd9-4859-a700-8ffd4bb6ebc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/7d899d52-6a0d-4dfd-86ba-1d7b5574b2bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/562ca549-3fd9-4859-a700-8ffd4bb6ebc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/25e74061-1259-4fe5-b0aa-cb82a18884c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25e74061-1259-4fe5-b0aa-cb82a18884c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/7f55833f-18ba-48d9-81e9-4fe070510296/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25e74061-1259-4fe5-b0aa-cb82a18884c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f37d25eb-fd33-484b-aa60-97f32c7007d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f37d25eb-fd33-484b-aa60-97f32c7007d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/82312bf5-1a0e-4c20-8d78-c98f587bcfbc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f37d25eb-fd33-484b-aa60-97f32c7007d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/754acb0b-0fc9-48da-847c-43d0a4a086fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "754acb0b-0fc9-48da-847c-43d0a4a086fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/8415607d-729d-4a4a-833e-901fa38090c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/754acb0b-0fc9-48da-847c-43d0a4a086fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bd3d48c-f915-46f8-ad7b-7d31915f1b7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bd3d48c-f915-46f8-ad7b-7d31915f1b7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/8fa18dcc-837e-401f-baee-5cbc78ee10c0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bd3d48c-f915-46f8-ad7b-7d31915f1b7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcfabf23-40f9-460b-bc62-db8de533865e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcfabf23-40f9-460b-bc62-db8de533865e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/91bd39df-b7c5-4e03-b71c-29bda1f35678/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcfabf23-40f9-460b-bc62-db8de533865e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7e3aa85-9ca5-4884-a6d2-fe8d5ffbdb1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7e3aa85-9ca5-4884-a6d2-fe8d5ffbdb1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/93641101-1be2-42b3-a336-7f5d4c0fe350/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7e3aa85-9ca5-4884-a6d2-fe8d5ffbdb1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8744afd-4798-4c23-983d-459f201202a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8744afd-4798-4c23-983d-459f201202a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/95b07fd9-9ba5-4f6f-80cf-61772687e80d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8744afd-4798-4c23-983d-459f201202a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f41d884-5642-43d2-8ad2-a2a11b2f00e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f41d884-5642-43d2-8ad2-a2a11b2f00e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/9ab4bd67-76f8-4f5a-a64a-e74aaa45b516/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f41d884-5642-43d2-8ad2-a2a11b2f00e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/17a16853-8c92-43a2-82aa-a71b8cb1a5d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17a16853-8c92-43a2-82aa-a71b8cb1a5d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/9af0c0ce-8224-47b8-a51f-9d0abc9878c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17a16853-8c92-43a2-82aa-a71b8cb1a5d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b7aa821-1d7d-490d-9f15-c841c7a50e30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b7aa821-1d7d-490d-9f15-c841c7a50e30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/9b75bf3e-246d-4beb-9700-59c0762958e8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b7aa821-1d7d-490d-9f15-c841c7a50e30>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b3281cf-c578-42e6-862f-e0477c3fecad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b3281cf-c578-42e6-862f-e0477c3fecad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/9b75f2f3-d938-4bb1-b658-428a92237afc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b3281cf-c578-42e6-862f-e0477c3fecad>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5c05e10-68d6-459e-b487-47a3f2e7f06e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5c05e10-68d6-459e-b487-47a3f2e7f06e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/9efc4a8e-1d71-4ebd-bf99-f9a20908592c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5c05e10-68d6-459e-b487-47a3f2e7f06e>.
+    
+<http://data.lblod.info/id/remote-data-objects/230c0f1c-2774-4c1d-8e4c-4626302e0fc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "230c0f1c-2774-4c1d-8e4c-4626302e0fc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/a6a093b6-66a7-4a48-a38d-d7fdfb5239ee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/230c0f1c-2774-4c1d-8e4c-4626302e0fc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c623b711-b9e3-4203-b83a-d849135ac52a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c623b711-b9e3-4203-b83a-d849135ac52a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/a76cce40-a3a7-4b1b-b22c-551dd6a15a02/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c623b711-b9e3-4203-b83a-d849135ac52a>.
+    
+<http://data.lblod.info/id/remote-data-objects/921e3eb0-0c81-4120-a71a-fd861af3ce51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "921e3eb0-0c81-4120-a71a-fd861af3ce51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/aa43eae6-1b57-45ac-98a6-0b376bc3beeb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a3d7e037-dcce-4851-93b3-ed092d8d8e89> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/921e3eb0-0c81-4120-a71a-fd861af3ce51>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201140-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201140-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201140-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201140-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/1ede6c5e-b10f-4706-9fc2-188992ee87e8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1ede6c5e-b10f-4706-9fc2-188992ee87e8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "43e5f26a-2640-4a35-a6c5-3ab8f87f3424";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/12c3a3a3-1d2a-48cf-83c1-181ddf9c2f06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "12c3a3a3-1d2a-48cf-83c1-181ddf9c2f06";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424>.
+
+  <http://redpencil.data.gift/id/task/46ddfa97-c9db-4960-8b23-23663b35a42f> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "46ddfa97-c9db-4960-8b23-23663b35a42f";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/1ede6c5e-b10f-4706-9fc2-188992ee87e8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/12c3a3a3-1d2a-48cf-83c1-181ddf9c2f06>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/58bd49e5-e824-4f80-aedf-592345616792> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58bd49e5-e824-4f80-aedf-592345616792";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/adc58af2-9860-40fd-8cd9-2fa583421752/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58bd49e5-e824-4f80-aedf-592345616792>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d6a3e92-057a-41e9-8e21-fc9e810c2fb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d6a3e92-057a-41e9-8e21-fc9e810c2fb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/b11b3908-704d-4e17-89ec-d1b6b9aecf84/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d6a3e92-057a-41e9-8e21-fc9e810c2fb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/191bbff2-691b-4993-ae53-5288dd675b79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "191bbff2-691b-4993-ae53-5288dd675b79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/bc289316-a193-4a38-8e94-9400fda1daf4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/191bbff2-691b-4993-ae53-5288dd675b79>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf3505f0-c80c-4848-a793-54cf8e42b93b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf3505f0-c80c-4848-a793-54cf8e42b93b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/bc56a00a-0b84-4c04-830e-a6e8126f88d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf3505f0-c80c-4848-a793-54cf8e42b93b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddca2f3b-e8a5-4dd4-8318-6c59c9ac3b09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddca2f3b-e8a5-4dd4-8318-6c59c9ac3b09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/bee73626-bf02-4dfa-ad3b-dcaa184a87d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddca2f3b-e8a5-4dd4-8318-6c59c9ac3b09>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2ba9519-6324-4af6-af5c-9fabbfefa249> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2ba9519-6324-4af6-af5c-9fabbfefa249";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/bf2aa0db-01b7-4378-a2ed-c72a4a832d30/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2ba9519-6324-4af6-af5c-9fabbfefa249>.
+    
+<http://data.lblod.info/id/remote-data-objects/70de30bf-2097-4060-8400-5d362e0a2926> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70de30bf-2097-4060-8400-5d362e0a2926";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/c2aee538-ee46-4f1b-9d4d-d2bfb1023564/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70de30bf-2097-4060-8400-5d362e0a2926>.
+    
+<http://data.lblod.info/id/remote-data-objects/51ecafee-073d-4637-9e8a-f91e0fcf9002> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51ecafee-073d-4637-9e8a-f91e0fcf9002";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/ca95e266-f081-44af-be4e-ba2392e614ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51ecafee-073d-4637-9e8a-f91e0fcf9002>.
+    
+<http://data.lblod.info/id/remote-data-objects/92167dbe-44a4-46f5-a6f0-79725d433a01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92167dbe-44a4-46f5-a6f0-79725d433a01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/cb3cd87d-21a5-4aa3-92b1-2dbb0b698bfd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92167dbe-44a4-46f5-a6f0-79725d433a01>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfa60dc4-e33d-4c97-8161-7566f559a195> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfa60dc4-e33d-4c97-8161-7566f559a195";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/ce5e8d0a-30db-4e92-bca2-a701a53d8141/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfa60dc4-e33d-4c97-8161-7566f559a195>.
+    
+<http://data.lblod.info/id/remote-data-objects/788d01fc-5695-41b9-8a5b-ac7bb4092639> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "788d01fc-5695-41b9-8a5b-ac7bb4092639";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/d5a6cf66-f269-4c09-9472-0736e454cd80/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/788d01fc-5695-41b9-8a5b-ac7bb4092639>.
+    
+<http://data.lblod.info/id/remote-data-objects/a173ac54-02b1-4483-932f-d237589d5499> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a173ac54-02b1-4483-932f-d237589d5499";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/d672c554-9bad-43bc-a4c3-9a49ed1b4a1f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a173ac54-02b1-4483-932f-d237589d5499>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad97d95c-06e9-475e-99d5-e0c7285e5a9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad97d95c-06e9-475e-99d5-e0c7285e5a9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/e5bc3ae2-4c26-4302-9f3f-07b81642c16c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad97d95c-06e9-475e-99d5-e0c7285e5a9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0bdbdd1-14ae-4d62-becd-0665ba2384ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0bdbdd1-14ae-4d62-becd-0665ba2384ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/e8789007-27d2-4808-9ef7-ff9a2ede6103/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0bdbdd1-14ae-4d62-becd-0665ba2384ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0921843-833a-4d7b-807b-be64edc1d40c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0921843-833a-4d7b-807b-be64edc1d40c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/f0f640c9-4ddd-48e3-b030-55e3ee015e3c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0921843-833a-4d7b-807b-be64edc1d40c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9768658-0e35-4195-96d7-7300c4f328b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9768658-0e35-4195-96d7-7300c4f328b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/f146a6dc-6d65-436c-9102-e52f1d6bf655/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9768658-0e35-4195-96d7-7300c4f328b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/274a576c-0593-4fa2-a1f4-1ed09a66539e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "274a576c-0593-4fa2-a1f4-1ed09a66539e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/f14d8fd5-ddac-4e6d-9a28-ecaa0eb2b9c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/274a576c-0593-4fa2-a1f4-1ed09a66539e>.
+    
+<http://data.lblod.info/id/remote-data-objects/817695fd-77f7-4cf2-8ccf-7729f97b98ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "817695fd-77f7-4cf2-8ccf-7729f97b98ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/f652669b-73fe-4e1c-a018-44eb03d293e5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/817695fd-77f7-4cf2-8ccf-7729f97b98ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/f31ceaa4-5531-4169-8b0e-936522373483> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f31ceaa4-5531-4169-8b0e-936522373483";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/f8739eac-c2ef-4475-abcb-c01b1c9ad261/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f31ceaa4-5531-4169-8b0e-936522373483>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2e0dbea-9f11-4ee0-b2f4-cc88b947b66e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2e0dbea-9f11-4ee0-b2f4-cc88b947b66e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/f8b543a9-2098-40e0-a9a1-e148845c1a07/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2e0dbea-9f11-4ee0-b2f4-cc88b947b66e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d23437d-a6ac-4deb-a53b-a59203dc591c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d23437d-a6ac-4deb-a53b-a59203dc591c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/fc834893-11a1-4f57-8192-6868ab8247fb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d23437d-a6ac-4deb-a53b-a59203dc591c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f45ca9a6-5491-48be-bc46-96c1653c02eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f45ca9a6-5491-48be-bc46-96c1653c02eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/fe2fe931-2c89-4467-85c2-5f3bf12d8b5e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f45ca9a6-5491-48be-bc46-96c1653c02eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/daad5af9-48e2-4b9d-baef-a146f6afe432> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "daad5af9-48e2-4b9d-baef-a146f6afe432";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/cbs/ff12750d-8691-4d28-a0d8-53f4c7383326/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/daad5af9-48e2-4b9d-baef-a146f6afe432>.
+    
+<http://data.lblod.info/id/remote-data-objects/891318b9-0647-4a65-85b0-856636c1aca7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "891318b9-0647-4a65-85b0-856636c1aca7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/gr/3086c581-b3b1-43dc-9728-4a75e3942c41/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/891318b9-0647-4a65-85b0-856636c1aca7>.
+    
+<http://data.lblod.info/id/remote-data-objects/3443d17e-d710-44cb-9680-eb6295ec8f3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3443d17e-d710-44cb-9680-eb6295ec8f3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/gr/6a801df4-ef97-4ecd-8921-cbe49f6d7392/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3443d17e-d710-44cb-9680-eb6295ec8f3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d56f0872-cbb7-4e39-9901-ac9cdb498e4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d56f0872-cbb7-4e39-9901-ac9cdb498e4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/gr/7e7d94fe-c210-4e9d-99d0-644106374784/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d56f0872-cbb7-4e39-9901-ac9cdb498e4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e8d8c60-88f4-466d-af8b-f8b3f4135da7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e8d8c60-88f4-466d-af8b-f8b3f4135da7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/gr/ae4342e1-2fd0-4e86-80b9-d0653e5b2313/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e8d8c60-88f4-466d-af8b-f8b3f4135da7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2806c9b9-c7bf-494f-904d-4b1dc4a1d898> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2806c9b9-c7bf-494f-904d-4b1dc4a1d898";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/gr/ba63849d-a575-4498-8075-aa44fa8d35e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2806c9b9-c7bf-494f-904d-4b1dc4a1d898>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2bd57d6-d403-41e6-a2de-07d2beabff5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2bd57d6-d403-41e6-a2de-07d2beabff5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/gr/bb3a1d11-342f-402d-9754-12cb039fb5d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2bd57d6-d403-41e6-a2de-07d2beabff5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/58d25298-6891-45ca-b96c-efadb3b70bfd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58d25298-6891-45ca-b96c-efadb3b70bfd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/rmw/13a0b812-d4b7-4ef4-a57d-f27764dd94cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58d25298-6891-45ca-b96c-efadb3b70bfd>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa9ffd70-8372-4290-a833-e21df84dcda7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa9ffd70-8372-4290-a833-e21df84dcda7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/rmw/3525c1b5-0814-4301-856b-380760deed4a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa9ffd70-8372-4290-a833-e21df84dcda7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e83e9709-4809-41ad-88ea-f3ac40da9701> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e83e9709-4809-41ad-88ea-f3ac40da9701";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/rmw/6f3c8e82-eb4a-49d9-8d81-800cc2e67256/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e83e9709-4809-41ad-88ea-f3ac40da9701>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f9b641c-2bfe-4fd5-a652-ad14b710b63b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f9b641c-2bfe-4fd5-a652-ad14b710b63b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/rmw/763aa192-0c64-4d3b-a07b-a61b3c767eb3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f9b641c-2bfe-4fd5-a652-ad14b710b63b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bc18282-3527-44d0-84bb-45320450abef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bc18282-3527-44d0-84bb-45320450abef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/rmw/a0f6a91d-6f79-4cd4-b700-1650e0f88ac2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bc18282-3527-44d0-84bb-45320450abef>.
+    
+<http://data.lblod.info/id/remote-data-objects/d219ca18-f9c4-4c13-9443-4acf4ec1d8d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d219ca18-f9c4-4c13-9443-4acf4ec1d8d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/rmw/cf60e158-c74e-4067-86eb-73c10167d37e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d219ca18-f9c4-4c13-9443-4acf4ec1d8d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa107650-897c-4be3-b348-515d9d99afeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa107650-897c-4be3-b348-515d9d99afeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/rmw/d97992e0-29b0-42f6-9001-740c4bdf00d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa107650-897c-4be3-b348-515d9d99afeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e60e575-f55a-4063-8a65-e9a442d28f6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e60e575-f55a-4063-8a65-e9a442d28f6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/rmw/ee40fe3b-3821-4fe1-a7a5-bcad150acdfd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e60e575-f55a-4063-8a65-e9a442d28f6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/de874e39-e0eb-4dc1-b545-7571604e95ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de874e39-e0eb-4dc1-b545-7571604e95ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/0c6a50f3-e083-4c7a-ab47-412e449b721a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de874e39-e0eb-4dc1-b545-7571604e95ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/c47af0d1-9712-4b74-8180-28e46ac378ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c47af0d1-9712-4b74-8180-28e46ac378ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/11626f4f-717b-4b31-a55b-cf5a1bdf8291/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c47af0d1-9712-4b74-8180-28e46ac378ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dbb32e1-f5b1-4cfc-899a-a788603236b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dbb32e1-f5b1-4cfc-899a-a788603236b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/11fbbbf0-b919-4a69-a64b-80db84fec4cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dbb32e1-f5b1-4cfc-899a-a788603236b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d062c39-c8c2-4ce0-b062-004c9e2a2b9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d062c39-c8c2-4ce0-b062-004c9e2a2b9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/15ccfece-a92d-4286-9965-92d2913779dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d062c39-c8c2-4ce0-b062-004c9e2a2b9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4297c5a-557e-4ccd-af4b-4f0e4ac63f92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4297c5a-557e-4ccd-af4b-4f0e4ac63f92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/200820fc-5b94-4709-9e09-95df7ce823a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4297c5a-557e-4ccd-af4b-4f0e4ac63f92>.
+    
+<http://data.lblod.info/id/remote-data-objects/a32c5d9c-0bdb-470b-aaa5-37121f221ad2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a32c5d9c-0bdb-470b-aaa5-37121f221ad2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/2873bd43-3a60-4c8c-9594-cc459808b7f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a32c5d9c-0bdb-470b-aaa5-37121f221ad2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b676987-e83d-4378-bea0-a1a5af96763c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b676987-e83d-4378-bea0-a1a5af96763c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/2cf62238-e1a6-4a14-92cc-6ced17704791/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b676987-e83d-4378-bea0-a1a5af96763c>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdfc3fb9-88ad-4eeb-b131-8a2820f24f15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdfc3fb9-88ad-4eeb-b131-8a2820f24f15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/33a73d03-1479-4a1c-a177-294b65bd05c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdfc3fb9-88ad-4eeb-b131-8a2820f24f15>.
+    
+<http://data.lblod.info/id/remote-data-objects/89eac1cf-f719-4f28-bd6a-50a922085c7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89eac1cf-f719-4f28-bd6a-50a922085c7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/3879d3de-fe29-4db6-96c5-cda40a99333d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89eac1cf-f719-4f28-bd6a-50a922085c7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/58ed2e53-0697-46a0-87e0-9229562a585c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58ed2e53-0697-46a0-87e0-9229562a585c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/38b996d2-ed79-4dd0-b4a6-273be0de2f24/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58ed2e53-0697-46a0-87e0-9229562a585c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2bd8988-2dd5-4757-9e2f-223939cdcdd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2bd8988-2dd5-4757-9e2f-223939cdcdd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/3b4d6373-f4b9-4faf-853d-13ebfb2ee915/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2bd8988-2dd5-4757-9e2f-223939cdcdd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dc6a40e-e48f-430b-b48e-979cbee2f2e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dc6a40e-e48f-430b-b48e-979cbee2f2e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/3f72f49a-41c7-43fd-9ba4-a19f50f4183d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dc6a40e-e48f-430b-b48e-979cbee2f2e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/566579f6-8fd4-4611-9857-13ea4ffad992> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "566579f6-8fd4-4611-9857-13ea4ffad992";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/46ab466f-3238-43f4-9e44-cfe628b990a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43e5f26a-2640-4a35-a6c5-3ab8f87f3424> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/566579f6-8fd4-4611-9857-13ea4ffad992>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201141-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201141-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201141-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201141-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/9aaf2993-53a0-49e4-8a26-064087d04595> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9aaf2993-53a0-49e4-8a26-064087d04595";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3e82d7c3-feea-437a-8998-8956db480eba";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/be7c253d-b8af-4ab3-8e41-05007a733348> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "be7c253d-b8af-4ab3-8e41-05007a733348";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba>.
+
+  <http://redpencil.data.gift/id/task/ef94c85b-6e33-4423-9046-4385d3e4ae61> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ef94c85b-6e33-4423-9046-4385d3e4ae61";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/9aaf2993-53a0-49e4-8a26-064087d04595>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/be7c253d-b8af-4ab3-8e41-05007a733348>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d16a05df-e405-4fcb-9adb-6e55da744a1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d16a05df-e405-4fcb-9adb-6e55da744a1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/479b7c3b-bf53-4db8-bee3-e47ef3b4469b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d16a05df-e405-4fcb-9adb-6e55da744a1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1343a383-da6f-45a9-81a2-8230fbf3782d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1343a383-da6f-45a9-81a2-8230fbf3782d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/4a5b8a8c-beb0-4592-9aed-ca26fb8fe6e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1343a383-da6f-45a9-81a2-8230fbf3782d>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf3b3998-19a2-45a8-897e-8a5bb6195653> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf3b3998-19a2-45a8-897e-8a5bb6195653";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/4bf1b33d-798f-4ac5-8bf1-d73acd074230/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf3b3998-19a2-45a8-897e-8a5bb6195653>.
+    
+<http://data.lblod.info/id/remote-data-objects/89a45260-227a-4b20-a424-096cd2ad06eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89a45260-227a-4b20-a424-096cd2ad06eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/52f63c67-092b-4e71-8d85-2ffd3d6c368e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89a45260-227a-4b20-a424-096cd2ad06eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/fadd3d68-b8f9-469c-9b29-5a0a73ae3de3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fadd3d68-b8f9-469c-9b29-5a0a73ae3de3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/54cb2ae1-b42d-4749-bc5e-b632bdadff6e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fadd3d68-b8f9-469c-9b29-5a0a73ae3de3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2992f234-7660-4c68-a061-033aca22d5c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2992f234-7660-4c68-a061-033aca22d5c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/5835bcbb-116d-4856-a1d8-d0dabd2e95f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2992f234-7660-4c68-a061-033aca22d5c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b351691e-64d8-4d2d-9759-94b96052ab4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b351691e-64d8-4d2d-9759-94b96052ab4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/58b3d84b-4ddf-4e4a-8a4c-ab32f2745505/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b351691e-64d8-4d2d-9759-94b96052ab4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f62df5d9-5c25-4753-9090-fa9620818669> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f62df5d9-5c25-4753-9090-fa9620818669";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/5f31120b-cbf4-417e-be94-e023b4d9b97e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f62df5d9-5c25-4753-9090-fa9620818669>.
+    
+<http://data.lblod.info/id/remote-data-objects/b464cebb-96c7-42ab-a31d-cbd77979a744> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b464cebb-96c7-42ab-a31d-cbd77979a744";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/613808d6-c86e-42e2-995a-5b1444f2f1c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b464cebb-96c7-42ab-a31d-cbd77979a744>.
+    
+<http://data.lblod.info/id/remote-data-objects/47716f5a-0020-4c61-94cf-74ff2a5550f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47716f5a-0020-4c61-94cf-74ff2a5550f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/61411210-2080-4210-a808-d7d75e77f1e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47716f5a-0020-4c61-94cf-74ff2a5550f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/75c7fd00-009a-47a3-89d3-f6ecac4e954a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75c7fd00-009a-47a3-89d3-f6ecac4e954a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/6725dcd5-cde9-499b-bbbb-0f57a23e9f0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75c7fd00-009a-47a3-89d3-f6ecac4e954a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f47b749-bc5d-4f35-8e89-3dea186f7cda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f47b749-bc5d-4f35-8e89-3dea186f7cda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/689b8414-8897-4c31-ab45-216619a38f83/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f47b749-bc5d-4f35-8e89-3dea186f7cda>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd3fb50f-0ef2-4dda-a3cc-2a28292fa6f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd3fb50f-0ef2-4dda-a3cc-2a28292fa6f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/6a9db1d5-a0ff-40e7-a4f0-d33399c71865/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd3fb50f-0ef2-4dda-a3cc-2a28292fa6f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ae0ea73-7d5e-4154-8b53-fda3f147ab55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ae0ea73-7d5e-4154-8b53-fda3f147ab55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/6e485bc4-5288-4d6c-b0b2-d80443f34288/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ae0ea73-7d5e-4154-8b53-fda3f147ab55>.
+    
+<http://data.lblod.info/id/remote-data-objects/84246e76-1bbd-4419-b463-d8bcee7c4e6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84246e76-1bbd-4419-b463-d8bcee7c4e6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/71ac48fa-abf7-4961-b8ad-bc400ca340a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84246e76-1bbd-4419-b463-d8bcee7c4e6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/577e25ac-ba60-4505-a546-74e2554632e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "577e25ac-ba60-4505-a546-74e2554632e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/75b47e88-330f-4d25-b5bd-0411cfdcc109/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/577e25ac-ba60-4505-a546-74e2554632e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c146a72c-8eee-428b-8145-d4af3cd4e3f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c146a72c-8eee-428b-8145-d4af3cd4e3f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/76e0d752-93fb-433c-9b32-415b89c0aa3a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c146a72c-8eee-428b-8145-d4af3cd4e3f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/22a3c35f-30d8-43f1-aa8e-810cafa79865> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22a3c35f-30d8-43f1-aa8e-810cafa79865";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/7b8c0b5c-2b08-4816-b793-6f56933c42cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22a3c35f-30d8-43f1-aa8e-810cafa79865>.
+    
+<http://data.lblod.info/id/remote-data-objects/15b954fa-a5eb-44a8-97fd-f55ceec0c86c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15b954fa-a5eb-44a8-97fd-f55ceec0c86c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/8396fc61-9b6e-4ec6-8354-7b9a78068711/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15b954fa-a5eb-44a8-97fd-f55ceec0c86c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a940498-c0b7-4668-a797-7aa31b9814cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a940498-c0b7-4668-a797-7aa31b9814cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/856a0307-0978-4f1a-b0d6-6a4f8c9b5d27/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a940498-c0b7-4668-a797-7aa31b9814cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f2b53af-04f4-42fc-877d-3fb63cb9d6d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f2b53af-04f4-42fc-877d-3fb63cb9d6d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/85cbbca7-8f09-4996-b001-9f998435e6f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f2b53af-04f4-42fc-877d-3fb63cb9d6d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/656a55bf-30e4-4d7d-818f-781d601d1898> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "656a55bf-30e4-4d7d-818f-781d601d1898";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/95d98d8c-69b3-413c-b03a-b8b30d9d3d14/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/656a55bf-30e4-4d7d-818f-781d601d1898>.
+    
+<http://data.lblod.info/id/remote-data-objects/78af7eef-1d69-4275-a18f-85aec22433db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78af7eef-1d69-4275-a18f-85aec22433db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/99a4a38a-aa1a-4607-946f-7134d43d8233/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78af7eef-1d69-4275-a18f-85aec22433db>.
+    
+<http://data.lblod.info/id/remote-data-objects/50cdf1ee-6071-4c0f-9377-448ce12d852e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50cdf1ee-6071-4c0f-9377-448ce12d852e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/9a04e5a2-4b51-4e26-9bc2-4c29cd895ccb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50cdf1ee-6071-4c0f-9377-448ce12d852e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e096654e-4b04-44ad-987c-ecaed9787449> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e096654e-4b04-44ad-987c-ecaed9787449";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/a18eaa21-6330-43c2-bdc6-3c4d75398ea9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e096654e-4b04-44ad-987c-ecaed9787449>.
+    
+<http://data.lblod.info/id/remote-data-objects/be4a80a6-488d-4e33-9d99-203fd56cd387> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be4a80a6-488d-4e33-9d99-203fd56cd387";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/a6a88b64-6f6f-4dcf-97f6-afc35e734c98/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be4a80a6-488d-4e33-9d99-203fd56cd387>.
+    
+<http://data.lblod.info/id/remote-data-objects/35fc236b-18ff-4978-a325-29e148121234> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35fc236b-18ff-4978-a325-29e148121234";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/b0118f02-53f7-490b-ab3f-4237b58f8c36/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35fc236b-18ff-4978-a325-29e148121234>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb208297-d019-4ff3-90d0-b461ee7a86e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb208297-d019-4ff3-90d0-b461ee7a86e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/b64bc895-f6a4-4304-949d-ae135abd9cdf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb208297-d019-4ff3-90d0-b461ee7a86e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/0385193a-9708-4b02-8ddd-7e026801deed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0385193a-9708-4b02-8ddd-7e026801deed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/bd850d4e-07b4-402b-b678-c3ef5f91bc56/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0385193a-9708-4b02-8ddd-7e026801deed>.
+    
+<http://data.lblod.info/id/remote-data-objects/275415ee-2533-428a-944d-9e77c3a8c085> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "275415ee-2533-428a-944d-9e77c3a8c085";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/be2e349b-c690-412e-a03c-1ca065e28cc1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/275415ee-2533-428a-944d-9e77c3a8c085>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f3ae914-1738-4696-8f6e-fa41930f108c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f3ae914-1738-4696-8f6e-fa41930f108c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/c09f21a9-81d5-4012-a7c2-cf69365e4d7d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f3ae914-1738-4696-8f6e-fa41930f108c>.
+    
+<http://data.lblod.info/id/remote-data-objects/13d61fac-8df3-45de-9b5a-2919908748ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13d61fac-8df3-45de-9b5a-2919908748ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/c1ba99a2-61a0-480a-9ed7-e2597e7b952a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13d61fac-8df3-45de-9b5a-2919908748ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed7ba2fa-ded1-42c5-b6da-72b6445b5f4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed7ba2fa-ded1-42c5-b6da-72b6445b5f4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/c2d0bccd-c791-4dbf-8ddc-c233e522aba8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed7ba2fa-ded1-42c5-b6da-72b6445b5f4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e551a8b0-c9a3-43a7-a464-d92ce020a234> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e551a8b0-c9a3-43a7-a464-d92ce020a234";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/c2fd6035-0ea4-4694-b1fc-ecac889955ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e551a8b0-c9a3-43a7-a464-d92ce020a234>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f10fa2e-2c1b-4faf-a06e-ae81e84e7b80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f10fa2e-2c1b-4faf-a06e-ae81e84e7b80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/c63948eb-3334-469b-82ce-f331c1ca35f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f10fa2e-2c1b-4faf-a06e-ae81e84e7b80>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c57edba-4ffe-412b-b641-3dbfc53d02ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c57edba-4ffe-412b-b641-3dbfc53d02ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/c748f1d8-59d8-42a1-9c65-c0ed83559159/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c57edba-4ffe-412b-b641-3dbfc53d02ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/5932808a-865d-49cf-856b-c5e83662cc29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5932808a-865d-49cf-856b-c5e83662cc29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/c82f9989-3c99-42bb-bd28-ea84e8efc11a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5932808a-865d-49cf-856b-c5e83662cc29>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed7d0b8e-a815-4249-bb26-e68cd6c9b4aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed7d0b8e-a815-4249-bb26-e68cd6c9b4aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/cd26c1ed-87bf-4b78-8fe8-f730f35fad82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed7d0b8e-a815-4249-bb26-e68cd6c9b4aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/1072b65c-7e66-4d47-a830-c76609214067> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1072b65c-7e66-4d47-a830-c76609214067";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/cf00a01a-2446-48ac-aa28-fde4b860fda7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1072b65c-7e66-4d47-a830-c76609214067>.
+    
+<http://data.lblod.info/id/remote-data-objects/931f8696-03c5-40a7-bcf6-990b3cb7dfcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "931f8696-03c5-40a7-bcf6-990b3cb7dfcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/d2420c37-8796-4a7f-a0f6-4ce099ad6f6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/931f8696-03c5-40a7-bcf6-990b3cb7dfcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/e93daecb-5a48-4807-be44-33b5b9e486cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e93daecb-5a48-4807-be44-33b5b9e486cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/d480e57d-68c8-4d27-9f38-a6ec60eff71e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e93daecb-5a48-4807-be44-33b5b9e486cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4ad9a05-d95e-40ab-a894-8f6d144776db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4ad9a05-d95e-40ab-a894-8f6d144776db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/d5161410-c592-4a58-b466-f87f613d2b91/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4ad9a05-d95e-40ab-a894-8f6d144776db>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6753c7e-cea0-4231-a291-bd87595d22a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6753c7e-cea0-4231-a291-bd87595d22a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/d8492475-6982-4a69-b21c-195aa39278bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6753c7e-cea0-4231-a291-bd87595d22a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c71f481-b67d-45d4-a0b6-aa148dc21cf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c71f481-b67d-45d4-a0b6-aa148dc21cf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/dbd64fef-a870-4097-8069-2e85852cf30d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c71f481-b67d-45d4-a0b6-aa148dc21cf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/54d90b6e-392c-4958-9faf-869d09d81397> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54d90b6e-392c-4958-9faf-869d09d81397";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/e384b593-a880-439b-ad1f-77b978b5dac7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54d90b6e-392c-4958-9faf-869d09d81397>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4b6e9ad-0f29-449e-93d0-505ef6d89a9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4b6e9ad-0f29-449e-93d0-505ef6d89a9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/e3b31663-bc75-4e7c-8f9e-134ee9887cad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4b6e9ad-0f29-449e-93d0-505ef6d89a9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5277bc99-ef82-4d57-8037-3b49571d94d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5277bc99-ef82-4d57-8037-3b49571d94d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/e57e5dab-a4e4-4df4-a770-a6fea0749718/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5277bc99-ef82-4d57-8037-3b49571d94d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/76c7a520-a1dc-4f2c-84c5-3c01d85518bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76c7a520-a1dc-4f2c-84c5-3c01d85518bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/e6c05c00-9308-4f47-8580-2ade5b5ca816/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76c7a520-a1dc-4f2c-84c5-3c01d85518bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a5fcd7d-6679-4a3a-80e7-01e9b230e1e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a5fcd7d-6679-4a3a-80e7-01e9b230e1e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/eb1c582c-634f-4125-b723-d3375bede5e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a5fcd7d-6679-4a3a-80e7-01e9b230e1e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/20058e9e-a8e2-4973-852b-861231c08e0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20058e9e-a8e2-4973-852b-861231c08e0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/f1147d34-238b-4ced-b5ff-e05f3a4574aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3e82d7c3-feea-437a-8998-8956db480eba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20058e9e-a8e2-4973-852b-861231c08e0d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201142-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201142-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201142-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201142-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b3d490d2-b2f8-4220-aea2-913942f026f7> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b3d490d2-b2f8-4220-aea2-913942f026f7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "292bb656-57ca-4df8-a1e2-c8f7c5d14a72";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/22eb6766-c105-4a66-b8be-a5c99de1e5ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "22eb6766-c105-4a66-b8be-a5c99de1e5ce";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72>.
+
+  <http://redpencil.data.gift/id/task/0af9ad59-7b2e-46e1-8614-f539a5aa571c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0af9ad59-7b2e-46e1-8614-f539a5aa571c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b3d490d2-b2f8-4220-aea2-913942f026f7>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/22eb6766-c105-4a66-b8be-a5c99de1e5ce>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c9a1153d-3a57-48de-a289-47601c449ed2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9a1153d-3a57-48de-a289-47601c449ed2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/f4fa8164-5dde-49d9-a78c-ae32adc7836c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9a1153d-3a57-48de-a289-47601c449ed2>.
+    
+<http://data.lblod.info/id/remote-data-objects/70e2f7d7-86dc-4a61-a27e-72b0c7624e00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70e2f7d7-86dc-4a61-a27e-72b0c7624e00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/f7d209e8-901a-4270-b001-2da36bd4213b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70e2f7d7-86dc-4a61-a27e-72b0c7624e00>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0165795-fbc9-465d-890b-46ab845983e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0165795-fbc9-465d-890b-46ab845983e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeilaart.meetingburger.net/vabu/fa7d43a3-6e0d-45fc-ac48-92b25fb44622/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0165795-fbc9-465d-890b-46ab845983e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b22eeddb-939f-4d1e-995e-55e82de7efc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b22eeddb-939f-4d1e-995e-55e82de7efc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/0647dbc1-5a4a-4254-a2d0-154724a9f613/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b22eeddb-939f-4d1e-995e-55e82de7efc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f3ef093-6c4b-4cf4-bdf7-96cf5fe3d59b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f3ef093-6c4b-4cf4-bdf7-96cf5fe3d59b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/06980279-efc6-42d2-acd9-df597f731701/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f3ef093-6c4b-4cf4-bdf7-96cf5fe3d59b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab9cf6f1-38c2-4035-a656-ce29af0f523b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab9cf6f1-38c2-4035-a656-ce29af0f523b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/07c2b27b-70c0-4598-9053-422f25a62cbc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab9cf6f1-38c2-4035-a656-ce29af0f523b>.
+    
+<http://data.lblod.info/id/remote-data-objects/96d799ba-2c08-455a-98ff-aa0fb383481a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96d799ba-2c08-455a-98ff-aa0fb383481a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/0a35858c-afb7-44cf-97be-b9592aca6dd0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96d799ba-2c08-455a-98ff-aa0fb383481a>.
+    
+<http://data.lblod.info/id/remote-data-objects/17937004-e71d-4072-9ebd-cec3e3a9dfcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17937004-e71d-4072-9ebd-cec3e3a9dfcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/0a374801-7037-427c-8417-3627240757be/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17937004-e71d-4072-9ebd-cec3e3a9dfcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/b775e38e-9183-406f-8436-780847d9cd60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b775e38e-9183-406f-8436-780847d9cd60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/0ccfe25b-e469-417f-bc9d-94ae5cc67475/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b775e38e-9183-406f-8436-780847d9cd60>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8606368-4a06-452f-93db-ac903a00c158> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8606368-4a06-452f-93db-ac903a00c158";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/0e97faeb-4929-4967-99e6-bb8d083659dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8606368-4a06-452f-93db-ac903a00c158>.
+    
+<http://data.lblod.info/id/remote-data-objects/17654246-e2a1-4430-bc74-ca2c6591ddf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17654246-e2a1-4430-bc74-ca2c6591ddf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/0fe8d562-868c-49c7-851e-2c6c54565847/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17654246-e2a1-4430-bc74-ca2c6591ddf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec4194d6-98ee-4cdd-9255-f9fc58a00bd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec4194d6-98ee-4cdd-9255-f9fc58a00bd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/153c42e3-bda7-4d2a-a456-24154592c21d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec4194d6-98ee-4cdd-9255-f9fc58a00bd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8328707a-1608-41e9-b6d0-e3c99a12ea5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8328707a-1608-41e9-b6d0-e3c99a12ea5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/15a7fe18-00af-4154-83a3-326f7249dd31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8328707a-1608-41e9-b6d0-e3c99a12ea5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7aa7c941-d206-4fbd-8b7d-9496281314eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7aa7c941-d206-4fbd-8b7d-9496281314eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/170b4999-ffd2-4ec7-8d6d-5448b6a16a6c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7aa7c941-d206-4fbd-8b7d-9496281314eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/084024b0-b16f-41f4-b998-34e7e10569bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "084024b0-b16f-41f4-b998-34e7e10569bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/1794ddde-eed6-45df-9756-e6bb13f35fc7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/084024b0-b16f-41f4-b998-34e7e10569bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/7faaf41c-1475-4d82-84d9-d181da31e49c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7faaf41c-1475-4d82-84d9-d181da31e49c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/1e45a23f-2069-489a-ade4-5e86a86d7816/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7faaf41c-1475-4d82-84d9-d181da31e49c>.
+    
+<http://data.lblod.info/id/remote-data-objects/111e6bee-6013-464d-b7be-7ef56a33d3cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "111e6bee-6013-464d-b7be-7ef56a33d3cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/1fa2c7c0-fc6a-4190-b651-76197d471702/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/111e6bee-6013-464d-b7be-7ef56a33d3cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/b27c753e-d201-4996-bd0a-596bbc325eb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b27c753e-d201-4996-bd0a-596bbc325eb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/21fe3068-ac11-4ee5-a921-9086f252d689/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b27c753e-d201-4996-bd0a-596bbc325eb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/59bc3565-970b-4539-a825-3577738dd72d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59bc3565-970b-4539-a825-3577738dd72d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/25f82e05-6031-49c2-92a9-0050dd258e45/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59bc3565-970b-4539-a825-3577738dd72d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a5bebb8-712f-4c71-b88e-5c045e56e340> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a5bebb8-712f-4c71-b88e-5c045e56e340";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/262371d9-0442-4b48-9451-2edddb8d23cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a5bebb8-712f-4c71-b88e-5c045e56e340>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbc34c2e-9f0f-42e3-bb92-117e93883a85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbc34c2e-9f0f-42e3-bb92-117e93883a85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/28fbb08c-0953-42a7-ba76-85c147a406ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbc34c2e-9f0f-42e3-bb92-117e93883a85>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4386835-2eba-41b4-8001-6e5189160428> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4386835-2eba-41b4-8001-6e5189160428";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/2c4573e5-cc0e-4066-89d4-96fc459519be/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4386835-2eba-41b4-8001-6e5189160428>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b48d39d-ab02-4ebd-8882-f5baaa90075c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b48d39d-ab02-4ebd-8882-f5baaa90075c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/3233b523-edc8-479d-a819-d7bef2032428/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b48d39d-ab02-4ebd-8882-f5baaa90075c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8fed8ce-64e4-4db6-8608-4f13a2ec8ce8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8fed8ce-64e4-4db6-8608-4f13a2ec8ce8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/38e77ebe-ecb0-4ee2-bdd1-f0a98c619c99/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8fed8ce-64e4-4db6-8608-4f13a2ec8ce8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d363a4b-cf5c-4b83-a5b0-37369920729c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d363a4b-cf5c-4b83-a5b0-37369920729c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/3a03d567-79ff-465b-9f2c-9b392c34cc9c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d363a4b-cf5c-4b83-a5b0-37369920729c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f08c225e-9d8f-4d3b-8c3e-a5b95959a7d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f08c225e-9d8f-4d3b-8c3e-a5b95959a7d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/413cb34e-9eeb-456c-93d8-2419d62f77d9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f08c225e-9d8f-4d3b-8c3e-a5b95959a7d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ece6e3d-ab23-413f-9d5f-35c1c0b5331d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ece6e3d-ab23-413f-9d5f-35c1c0b5331d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/4682b381-56d6-42d5-aaf8-5b2201cc52af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ece6e3d-ab23-413f-9d5f-35c1c0b5331d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ad133b7-7a7d-4cd0-a426-bd664448bb6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ad133b7-7a7d-4cd0-a426-bd664448bb6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/562dcfeb-00b8-4d2e-8dcb-1e4a2dd5e241/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ad133b7-7a7d-4cd0-a426-bd664448bb6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/25ff5a11-1bfc-4032-9c0e-911047a4527b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25ff5a11-1bfc-4032-9c0e-911047a4527b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/598b6a92-1994-483b-a67f-d78cbe2d6e65/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25ff5a11-1bfc-4032-9c0e-911047a4527b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ee43f61-2a5d-43f6-8e90-ae508227fe0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ee43f61-2a5d-43f6-8e90-ae508227fe0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/5c189d8c-784b-4b48-bc9e-e7ef45286284/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ee43f61-2a5d-43f6-8e90-ae508227fe0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/33c47dd5-9376-4a1f-8576-e78dce49f118> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33c47dd5-9376-4a1f-8576-e78dce49f118";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/5cadf8be-1a23-413f-bdb6-4e8ca7abdbc6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33c47dd5-9376-4a1f-8576-e78dce49f118>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9f9d7ef-4a38-4a09-b691-a845411e515a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9f9d7ef-4a38-4a09-b691-a845411e515a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/5d500020-4e2b-40d9-a6bd-c53b37187fbb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9f9d7ef-4a38-4a09-b691-a845411e515a>.
+    
+<http://data.lblod.info/id/remote-data-objects/01e9514e-f4a8-4232-9b85-280db3bff0f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01e9514e-f4a8-4232-9b85-280db3bff0f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/5fa15300-67d9-46aa-902a-54e26617c81f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01e9514e-f4a8-4232-9b85-280db3bff0f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/318a27e0-5913-4c00-ba5d-27007a07c4a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "318a27e0-5913-4c00-ba5d-27007a07c4a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/60597abb-24fc-40f1-99a8-043c35d50acc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/318a27e0-5913-4c00-ba5d-27007a07c4a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f20efb14-da75-4d50-96d6-b90c847c8d01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f20efb14-da75-4d50-96d6-b90c847c8d01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/70701e40-2bef-4f46-8780-b2882cb0e798/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f20efb14-da75-4d50-96d6-b90c847c8d01>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfa0a16f-c342-49a1-8b29-eaf230676da8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfa0a16f-c342-49a1-8b29-eaf230676da8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/72a19dd5-c4eb-466e-9015-e61290db49bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfa0a16f-c342-49a1-8b29-eaf230676da8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4533b160-f669-4fb4-bbab-a5150369b435> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4533b160-f669-4fb4-bbab-a5150369b435";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/7ec6b08f-ecc3-4864-901b-b3b2b9aab283/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4533b160-f669-4fb4-bbab-a5150369b435>.
+    
+<http://data.lblod.info/id/remote-data-objects/76988184-bf01-4ec0-93d8-3714a9e3f5c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76988184-bf01-4ec0-93d8-3714a9e3f5c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/7f47c0cd-9df6-4dbe-b74d-ca585fe7a682/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76988184-bf01-4ec0-93d8-3714a9e3f5c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/5188630e-1b45-4cdd-8ddf-7379ae6237ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5188630e-1b45-4cdd-8ddf-7379ae6237ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/82582273-087e-478a-8f60-99c6a7212357/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5188630e-1b45-4cdd-8ddf-7379ae6237ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/b79cef15-3b30-48b7-91ad-f4f1960e1a67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b79cef15-3b30-48b7-91ad-f4f1960e1a67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/83ba560a-556e-47b1-a47b-d695e4f6c0a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b79cef15-3b30-48b7-91ad-f4f1960e1a67>.
+    
+<http://data.lblod.info/id/remote-data-objects/47a039c7-2318-4db8-8274-8a29375df6ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47a039c7-2318-4db8-8274-8a29375df6ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/8b0d449a-ec64-4964-b3a7-e6e5f352a4d8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47a039c7-2318-4db8-8274-8a29375df6ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef988ffc-c821-4829-bec9-1af7c90795cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef988ffc-c821-4829-bec9-1af7c90795cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/8d67687b-468d-4979-9406-71c4443f1f76/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef988ffc-c821-4829-bec9-1af7c90795cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/96c4aaab-5d97-4c13-a802-09d57920e9ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96c4aaab-5d97-4c13-a802-09d57920e9ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/9c1d2a27-5f48-4fe8-9991-68368bda9853/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96c4aaab-5d97-4c13-a802-09d57920e9ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/78d39098-39ac-4b68-966f-8b8cba8d2ce6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78d39098-39ac-4b68-966f-8b8cba8d2ce6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/9f893648-f1a5-4598-ae9b-649a19e33fcb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78d39098-39ac-4b68-966f-8b8cba8d2ce6>.
+    
+<http://data.lblod.info/id/remote-data-objects/56e91bb6-8a4f-4914-a718-702d78ee4e8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56e91bb6-8a4f-4914-a718-702d78ee4e8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/a1bd9410-857d-423f-966d-4444e5cb4969/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56e91bb6-8a4f-4914-a718-702d78ee4e8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/850a3e7e-5655-4eeb-abf1-f3bbe9641ed3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "850a3e7e-5655-4eeb-abf1-f3bbe9641ed3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/a405596f-2f71-486c-934e-61b9a1508691/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/850a3e7e-5655-4eeb-abf1-f3bbe9641ed3>.
+    
+<http://data.lblod.info/id/remote-data-objects/b81b53f7-987f-448b-a555-3e88ea26b659> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b81b53f7-987f-448b-a555-3e88ea26b659";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/ac6354d2-ec25-4da5-8edc-7b9f7c1c8031/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b81b53f7-987f-448b-a555-3e88ea26b659>.
+    
+<http://data.lblod.info/id/remote-data-objects/392130b8-9fd5-47d1-a7fe-9ff393e46133> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "392130b8-9fd5-47d1-a7fe-9ff393e46133";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/afa307f6-311b-4087-8388-48349d0236b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/392130b8-9fd5-47d1-a7fe-9ff393e46133>.
+    
+<http://data.lblod.info/id/remote-data-objects/4131ebad-c36c-4229-a8d9-84b98e1f81c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4131ebad-c36c-4229-a8d9-84b98e1f81c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/b2c17b12-f176-4720-ab93-3853c47c1ac3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4131ebad-c36c-4229-a8d9-84b98e1f81c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2add653-33d5-4741-9fc7-fd4ebbbc28fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2add653-33d5-4741-9fc7-fd4ebbbc28fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/b473220c-8aab-4ead-bf9a-fae0c0c3c53c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/292bb656-57ca-4df8-a1e2-c8f7c5d14a72> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2add653-33d5-4741-9fc7-fd4ebbbc28fc>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201143-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201143-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201143-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201143-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d3a16ac9-4a26-4563-943b-95712c69d5b6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d3a16ac9-4a26-4563-943b-95712c69d5b6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4881179c-a43f-48ce-a10d-f33d0c3a342a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d26086b6-06bb-42c4-9c89-5ddc65fb461c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d26086b6-06bb-42c4-9c89-5ddc65fb461c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a>.
+
+  <http://redpencil.data.gift/id/task/5cf4ebba-c4aa-476d-b113-34f23a8d0427> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5cf4ebba-c4aa-476d-b113-34f23a8d0427";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d3a16ac9-4a26-4563-943b-95712c69d5b6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d26086b6-06bb-42c4-9c89-5ddc65fb461c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/6904c491-680f-4de7-97cf-72bcd58e7eb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6904c491-680f-4de7-97cf-72bcd58e7eb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/b4a963a8-c26b-4dd9-bc2e-457d682a1e80/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6904c491-680f-4de7-97cf-72bcd58e7eb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/be8d7bff-28d4-4862-b154-1ef615293716> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be8d7bff-28d4-4862-b154-1ef615293716";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/b51e3810-3033-428e-be80-df9aca9613eb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be8d7bff-28d4-4862-b154-1ef615293716>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae31c182-aea2-441c-bf54-afbff809a22f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae31c182-aea2-441c-bf54-afbff809a22f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/b7d37104-1d63-41cd-806c-9e4006b4364c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae31c182-aea2-441c-bf54-afbff809a22f>.
+    
+<http://data.lblod.info/id/remote-data-objects/137c57ac-fee2-490b-a705-b023caaebf33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "137c57ac-fee2-490b-a705-b023caaebf33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/ba9e7e72-8c75-4667-9a30-3d0a1343df14/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/137c57ac-fee2-490b-a705-b023caaebf33>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f0307b2-a844-43cf-9075-53430b2c2fc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f0307b2-a844-43cf-9075-53430b2c2fc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/c19c43ec-2970-4960-8794-88dc40f65379/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f0307b2-a844-43cf-9075-53430b2c2fc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9be7ca4c-603a-4417-9a6b-d34b576383ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9be7ca4c-603a-4417-9a6b-d34b576383ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/c50810fe-bac2-4713-a6c7-422e46ae3ebb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9be7ca4c-603a-4417-9a6b-d34b576383ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/e44900e2-c579-44e6-9648-9e70624cdbe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e44900e2-c579-44e6-9648-9e70624cdbe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/c6810109-1208-4dcc-a6c9-a30b6c9d1bcf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e44900e2-c579-44e6-9648-9e70624cdbe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4fd63ea-e474-4877-913a-e187cb9617aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4fd63ea-e474-4877-913a-e187cb9617aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/cb01c063-f21b-49c0-aa14-c92540e43b48/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4fd63ea-e474-4877-913a-e187cb9617aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/b32ef248-89b9-4c14-8a66-2f4e51c8c0e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b32ef248-89b9-4c14-8a66-2f4e51c8c0e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/d5b8644e-a2fc-49c2-b517-82b38d89496b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b32ef248-89b9-4c14-8a66-2f4e51c8c0e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fddd0c6-e044-4e9a-9aa2-e02bcffdddd6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fddd0c6-e044-4e9a-9aa2-e02bcffdddd6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/e51990f7-01d3-4076-94a8-5ebaab70a98f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fddd0c6-e044-4e9a-9aa2-e02bcffdddd6>.
+    
+<http://data.lblod.info/id/remote-data-objects/aeb501b3-11df-40fe-aa43-2df58ab2fdd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aeb501b3-11df-40fe-aa43-2df58ab2fdd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/e94a3530-9e84-458e-be96-2c254100921f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aeb501b3-11df-40fe-aa43-2df58ab2fdd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/635eabad-5364-4579-97e8-005ccb3a3897> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "635eabad-5364-4579-97e8-005ccb3a3897";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/eb4e3714-f990-41b7-ac23-c78bb73162df/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/635eabad-5364-4579-97e8-005ccb3a3897>.
+    
+<http://data.lblod.info/id/remote-data-objects/544d53c4-5800-496e-bee5-9b9fda2cfe15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "544d53c4-5800-496e-bee5-9b9fda2cfe15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/eb516b15-b565-4847-8fa8-6ffe592d7b6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/544d53c4-5800-496e-bee5-9b9fda2cfe15>.
+    
+<http://data.lblod.info/id/remote-data-objects/d52eeebb-b7b3-4833-bf91-eca98a5060c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d52eeebb-b7b3-4833-bf91-eca98a5060c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/f020f9e1-36d9-4084-9097-824b4191ee80/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d52eeebb-b7b3-4833-bf91-eca98a5060c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb8c0cd8-5060-44af-ae5a-4d519e83062e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb8c0cd8-5060-44af-ae5a-4d519e83062e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/f051fa23-21c1-4898-98d7-7b5794de933a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb8c0cd8-5060-44af-ae5a-4d519e83062e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b149c85-d1ff-45ef-b4ef-1b6bebde36b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b149c85-d1ff-45ef-b4ef-1b6bebde36b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/f27a6ac0-f714-43f1-8eb3-0b06468ed574/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b149c85-d1ff-45ef-b4ef-1b6bebde36b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b1b5837-9657-41e2-a38c-b94bcad1f020> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b1b5837-9657-41e2-a38c-b94bcad1f020";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/f4314d3b-2251-410e-8366-18aee5cb1ecf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b1b5837-9657-41e2-a38c-b94bcad1f020>.
+    
+<http://data.lblod.info/id/remote-data-objects/00ad20f5-4224-4e29-babe-448ac7141e5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00ad20f5-4224-4e29-babe-448ac7141e5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/f5e358f0-3a71-49ec-b849-2e1397bcc738/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00ad20f5-4224-4e29-babe-448ac7141e5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b65b0eb1-0465-423d-8aeb-5de0e420dc20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b65b0eb1-0465-423d-8aeb-5de0e420dc20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/fa5c794a-4692-495b-9435-07b25079b705/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b65b0eb1-0465-423d-8aeb-5de0e420dc20>.
+    
+<http://data.lblod.info/id/remote-data-objects/75dc4f4e-cbc1-4b4c-9515-ba9706eb1978> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75dc4f4e-cbc1-4b4c-9515-ba9706eb1978";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/faa5c80d-640c-4790-99b2-c8e37f2b2db8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75dc4f4e-cbc1-4b4c-9515-ba9706eb1978>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ff8696b-28b3-402e-925d-64420b1b681f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ff8696b-28b3-402e-925d-64420b1b681f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/fb89d061-e435-44e7-9e3b-e8af711988de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ff8696b-28b3-402e-925d-64420b1b681f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d3712db-ca5d-4e82-b4e0-a6398d822c38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d3712db-ca5d-4e82-b4e0-a6398d822c38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/cbs/fbb8895a-68d8-4b84-a2a1-5b1e564dd348/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d3712db-ca5d-4e82-b4e0-a6398d822c38>.
+    
+<http://data.lblod.info/id/remote-data-objects/b277a75f-f9b3-465f-a09c-fb76669ac619> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b277a75f-f9b3-465f-a09c-fb76669ac619";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/0396838b-a268-488d-83dd-302662fdff0d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b277a75f-f9b3-465f-a09c-fb76669ac619>.
+    
+<http://data.lblod.info/id/remote-data-objects/65fec1c9-b908-4f35-b509-fcc16ea8e022> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65fec1c9-b908-4f35-b509-fcc16ea8e022";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/0396838b-a268-488d-83dd-302662fdff0d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65fec1c9-b908-4f35-b509-fcc16ea8e022>.
+    
+<http://data.lblod.info/id/remote-data-objects/96c8269e-d16b-4831-a583-2e8d9f8d01ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96c8269e-d16b-4831-a583-2e8d9f8d01ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/0396838b-a268-488d-83dd-302662fdff0d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96c8269e-d16b-4831-a583-2e8d9f8d01ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3b5795a-7f58-486c-bee3-e5550c19c705> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3b5795a-7f58-486c-bee3-e5550c19c705";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/07dcfc37-5bee-4be3-9ffd-6c5bda58c9b6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3b5795a-7f58-486c-bee3-e5550c19c705>.
+    
+<http://data.lblod.info/id/remote-data-objects/b157dfe8-98af-45d1-9531-5c21fb075274> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b157dfe8-98af-45d1-9531-5c21fb075274";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/07dcfc37-5bee-4be3-9ffd-6c5bda58c9b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b157dfe8-98af-45d1-9531-5c21fb075274>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d6c1563-8a2f-455c-b54f-bcf585394b87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d6c1563-8a2f-455c-b54f-bcf585394b87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/07dcfc37-5bee-4be3-9ffd-6c5bda58c9b6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d6c1563-8a2f-455c-b54f-bcf585394b87>.
+    
+<http://data.lblod.info/id/remote-data-objects/59c36636-0835-4159-acaa-f703d92de46e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59c36636-0835-4159-acaa-f703d92de46e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/1506cce9-1fa9-46fe-bb87-d8c2c67c73d0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59c36636-0835-4159-acaa-f703d92de46e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6f3e36e-3fd5-4497-88c4-9a23ccc421f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6f3e36e-3fd5-4497-88c4-9a23ccc421f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/1506cce9-1fa9-46fe-bb87-d8c2c67c73d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6f3e36e-3fd5-4497-88c4-9a23ccc421f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/60aa7a83-6160-4e73-850f-cd26c7b07471> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60aa7a83-6160-4e73-850f-cd26c7b07471";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/1506cce9-1fa9-46fe-bb87-d8c2c67c73d0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60aa7a83-6160-4e73-850f-cd26c7b07471>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa4cc77c-7fc5-420f-b79e-47829dc3ef35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa4cc77c-7fc5-420f-b79e-47829dc3ef35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/1ca39fc6-b01c-4398-b422-f0127cf3d2eb/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa4cc77c-7fc5-420f-b79e-47829dc3ef35>.
+    
+<http://data.lblod.info/id/remote-data-objects/b99d65ae-8530-4d55-b4bd-382042d697ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b99d65ae-8530-4d55-b4bd-382042d697ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/1ca39fc6-b01c-4398-b422-f0127cf3d2eb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b99d65ae-8530-4d55-b4bd-382042d697ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ddb0323-2e72-4a30-b675-106de2bd0e93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ddb0323-2e72-4a30-b675-106de2bd0e93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/1ca39fc6-b01c-4398-b422-f0127cf3d2eb/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ddb0323-2e72-4a30-b675-106de2bd0e93>.
+    
+<http://data.lblod.info/id/remote-data-objects/54989f61-d9d9-4ef5-aee8-2a0f7cbb94d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54989f61-d9d9-4ef5-aee8-2a0f7cbb94d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/36d62aea-c810-452b-8675-a25bbe627d26/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54989f61-d9d9-4ef5-aee8-2a0f7cbb94d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7d57f9e-0ee4-4595-a5ae-c18a9d26726b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7d57f9e-0ee4-4595-a5ae-c18a9d26726b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/36d62aea-c810-452b-8675-a25bbe627d26/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7d57f9e-0ee4-4595-a5ae-c18a9d26726b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f422106e-4d5c-479a-8486-8137342742e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f422106e-4d5c-479a-8486-8137342742e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/36d62aea-c810-452b-8675-a25bbe627d26/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f422106e-4d5c-479a-8486-8137342742e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0c99a0c-aa6d-457e-8bfd-593fdc543ae1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0c99a0c-aa6d-457e-8bfd-593fdc543ae1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/39212ac4-a3bb-4f5d-832d-57227c37ee8c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0c99a0c-aa6d-457e-8bfd-593fdc543ae1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d08afb1a-3c5b-41b6-856f-eefbcd589060> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d08afb1a-3c5b-41b6-856f-eefbcd589060";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/39212ac4-a3bb-4f5d-832d-57227c37ee8c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d08afb1a-3c5b-41b6-856f-eefbcd589060>.
+    
+<http://data.lblod.info/id/remote-data-objects/91923b8d-3a99-41e2-9fc5-3474aa582772> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91923b8d-3a99-41e2-9fc5-3474aa582772";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/39212ac4-a3bb-4f5d-832d-57227c37ee8c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91923b8d-3a99-41e2-9fc5-3474aa582772>.
+    
+<http://data.lblod.info/id/remote-data-objects/36c4f5c9-2afc-4f34-826b-34513fcd61c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36c4f5c9-2afc-4f34-826b-34513fcd61c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/3d85356e-6789-4905-aeba-a0e5287da2aa/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36c4f5c9-2afc-4f34-826b-34513fcd61c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea018667-f3d6-4e2b-a42c-035378392711> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea018667-f3d6-4e2b-a42c-035378392711";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/3d85356e-6789-4905-aeba-a0e5287da2aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea018667-f3d6-4e2b-a42c-035378392711>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f06120b-ab7c-4ed1-8e17-3184c3384c31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f06120b-ab7c-4ed1-8e17-3184c3384c31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/3d85356e-6789-4905-aeba-a0e5287da2aa/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f06120b-ab7c-4ed1-8e17-3184c3384c31>.
+    
+<http://data.lblod.info/id/remote-data-objects/273353ec-1e75-4af1-aaf1-2bf7499c6e87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "273353ec-1e75-4af1-aaf1-2bf7499c6e87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/40a8910b-137c-468a-bb84-d2025a866a2f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/273353ec-1e75-4af1-aaf1-2bf7499c6e87>.
+    
+<http://data.lblod.info/id/remote-data-objects/c184a6c2-6225-40d6-a41f-e1b672427a7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c184a6c2-6225-40d6-a41f-e1b672427a7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/40a8910b-137c-468a-bb84-d2025a866a2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c184a6c2-6225-40d6-a41f-e1b672427a7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9596f146-545f-426f-8fef-bd8c747f7493> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9596f146-545f-426f-8fef-bd8c747f7493";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/45bed3cf-5c0d-467c-af5a-58a3b82ade4a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9596f146-545f-426f-8fef-bd8c747f7493>.
+    
+<http://data.lblod.info/id/remote-data-objects/330a5224-390a-43c2-8618-1447e0a5a110> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "330a5224-390a-43c2-8618-1447e0a5a110";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/45bed3cf-5c0d-467c-af5a-58a3b82ade4a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/330a5224-390a-43c2-8618-1447e0a5a110>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3e392b3-55ae-4657-9f2d-a7db9a396c15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3e392b3-55ae-4657-9f2d-a7db9a396c15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/45bed3cf-5c0d-467c-af5a-58a3b82ade4a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3e392b3-55ae-4657-9f2d-a7db9a396c15>.
+    
+<http://data.lblod.info/id/remote-data-objects/74ad7635-eeb1-439b-9cc9-c71d923b5095> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74ad7635-eeb1-439b-9cc9-c71d923b5095";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/6392033b-62b5-47fd-9c0a-b9532fe096f6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74ad7635-eeb1-439b-9cc9-c71d923b5095>.
+    
+<http://data.lblod.info/id/remote-data-objects/63cd602a-52a9-4ab5-a245-da9b68cdf18f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63cd602a-52a9-4ab5-a245-da9b68cdf18f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/6392033b-62b5-47fd-9c0a-b9532fe096f6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4881179c-a43f-48ce-a10d-f33d0c3a342a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63cd602a-52a9-4ab5-a245-da9b68cdf18f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201145-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201145-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201145-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201145-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f25b6c9c-58bc-4497-8548-d202e5c09c69> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f25b6c9c-58bc-4497-8548-d202e5c09c69";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9d8546d1-5979-4aeb-8599-4637534dd28f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/3d7aae4e-dbbd-4c23-ae0b-89eef3060194> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3d7aae4e-dbbd-4c23-ae0b-89eef3060194";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f>.
+
+  <http://redpencil.data.gift/id/task/a4afef3b-f3e7-4c27-bb56-3118ca916a6d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a4afef3b-f3e7-4c27-bb56-3118ca916a6d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f25b6c9c-58bc-4497-8548-d202e5c09c69>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/3d7aae4e-dbbd-4c23-ae0b-89eef3060194>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/802b816c-7dec-4978-88f1-ca1cbb1aba9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "802b816c-7dec-4978-88f1-ca1cbb1aba9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/6392033b-62b5-47fd-9c0a-b9532fe096f6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/802b816c-7dec-4978-88f1-ca1cbb1aba9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/245a4b06-46d5-4c46-a4e4-25bfe8abfe7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "245a4b06-46d5-4c46-a4e4-25bfe8abfe7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/80a5c279-82a1-49b0-9593-113a67e25cea/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/245a4b06-46d5-4c46-a4e4-25bfe8abfe7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d085b9f4-4490-45ac-8618-997dabafacbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d085b9f4-4490-45ac-8618-997dabafacbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/80a5c279-82a1-49b0-9593-113a67e25cea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d085b9f4-4490-45ac-8618-997dabafacbb>.
+    
+<http://data.lblod.info/id/remote-data-objects/82aa8e7f-2b91-45fb-becb-d0f01f4b50b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82aa8e7f-2b91-45fb-becb-d0f01f4b50b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/80a5c279-82a1-49b0-9593-113a67e25cea/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82aa8e7f-2b91-45fb-becb-d0f01f4b50b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb98a85f-eef5-4911-b87d-24b8f8d25b20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb98a85f-eef5-4911-b87d-24b8f8d25b20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/b5322603-6c97-4da5-87dc-28fdb131a0f8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb98a85f-eef5-4911-b87d-24b8f8d25b20>.
+    
+<http://data.lblod.info/id/remote-data-objects/ceed7e21-0fde-4ebf-9184-7385e7bd3e62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ceed7e21-0fde-4ebf-9184-7385e7bd3e62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/b5322603-6c97-4da5-87dc-28fdb131a0f8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ceed7e21-0fde-4ebf-9184-7385e7bd3e62>.
+    
+<http://data.lblod.info/id/remote-data-objects/10fece30-e3f3-42d1-a681-75b93ab3728a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10fece30-e3f3-42d1-a681-75b93ab3728a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/b5322603-6c97-4da5-87dc-28fdb131a0f8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10fece30-e3f3-42d1-a681-75b93ab3728a>.
+    
+<http://data.lblod.info/id/remote-data-objects/23bac12f-26ee-4dcb-83f8-b77d56377721> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23bac12f-26ee-4dcb-83f8-b77d56377721";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/c3e3de72-cf14-4fc1-bad0-139f7e309bd2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23bac12f-26ee-4dcb-83f8-b77d56377721>.
+    
+<http://data.lblod.info/id/remote-data-objects/50ea6cb0-5d36-4889-aa4f-3bbcc00026a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50ea6cb0-5d36-4889-aa4f-3bbcc00026a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/c3e3de72-cf14-4fc1-bad0-139f7e309bd2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50ea6cb0-5d36-4889-aa4f-3bbcc00026a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b68024ba-6688-4663-9ac5-49992c267b01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b68024ba-6688-4663-9ac5-49992c267b01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/c3e3de72-cf14-4fc1-bad0-139f7e309bd2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b68024ba-6688-4663-9ac5-49992c267b01>.
+    
+<http://data.lblod.info/id/remote-data-objects/39b49546-e049-4f5b-89b3-e3c151946051> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39b49546-e049-4f5b-89b3-e3c151946051";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/e4724a11-9dcf-4dd2-b28a-0f8a0e4336dd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39b49546-e049-4f5b-89b3-e3c151946051>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d184d8a-089e-4538-8e91-9d927920fc95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d184d8a-089e-4538-8e91-9d927920fc95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/e4724a11-9dcf-4dd2-b28a-0f8a0e4336dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d184d8a-089e-4538-8e91-9d927920fc95>.
+    
+<http://data.lblod.info/id/remote-data-objects/0147375c-cc32-4339-b390-1816c607b695> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0147375c-cc32-4339-b390-1816c607b695";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/e4724a11-9dcf-4dd2-b28a-0f8a0e4336dd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0147375c-cc32-4339-b390-1816c607b695>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e4e3948-d27e-4b7e-8a37-ad5836482e06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e4e3948-d27e-4b7e-8a37-ad5836482e06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/e4e1de4a-86ec-42af-967f-c108ec6be50c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e4e3948-d27e-4b7e-8a37-ad5836482e06>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3be56aa-6b87-4b6d-8dc4-a85373e7f0fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3be56aa-6b87-4b6d-8dc4-a85373e7f0fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/e4e1de4a-86ec-42af-967f-c108ec6be50c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3be56aa-6b87-4b6d-8dc4-a85373e7f0fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3d63121-13cc-43b5-bad6-96717559c897> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3d63121-13cc-43b5-bad6-96717559c897";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/e4e1de4a-86ec-42af-967f-c108ec6be50c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3d63121-13cc-43b5-bad6-96717559c897>.
+    
+<http://data.lblod.info/id/remote-data-objects/a469afeb-0498-4aed-9c69-993c262c5e14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a469afeb-0498-4aed-9c69-993c262c5e14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/ed12487f-6a1b-430e-b120-44b556b94547/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a469afeb-0498-4aed-9c69-993c262c5e14>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4e97211-835f-4bbc-b76d-a69ca1128afe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4e97211-835f-4bbc-b76d-a69ca1128afe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/ed12487f-6a1b-430e-b120-44b556b94547/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4e97211-835f-4bbc-b76d-a69ca1128afe>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a69a72f-59f2-4533-b15b-786a83af456f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a69a72f-59f2-4533-b15b-786a83af456f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/gr/ed12487f-6a1b-430e-b120-44b556b94547/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a69a72f-59f2-4533-b15b-786a83af456f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d083209-7b4d-4e05-8b6d-17b5fe14f7e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d083209-7b4d-4e05-8b6d-17b5fe14f7e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/175f8d19-642c-469d-bc11-0d94842b5bbe/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d083209-7b4d-4e05-8b6d-17b5fe14f7e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0b15a20-7029-4225-a741-1ee0516bfc26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0b15a20-7029-4225-a741-1ee0516bfc26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/175f8d19-642c-469d-bc11-0d94842b5bbe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0b15a20-7029-4225-a741-1ee0516bfc26>.
+    
+<http://data.lblod.info/id/remote-data-objects/dff2f3fe-2534-439f-aba7-a1853f1f843a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dff2f3fe-2534-439f-aba7-a1853f1f843a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/175f8d19-642c-469d-bc11-0d94842b5bbe/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dff2f3fe-2534-439f-aba7-a1853f1f843a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2bb6968-4782-4c49-ac09-4cce8ba7a8a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2bb6968-4782-4c49-ac09-4cce8ba7a8a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/22768f4d-ec5d-4273-af98-4196f35f4e35/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2bb6968-4782-4c49-ac09-4cce8ba7a8a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a000aa6c-0001-444f-b459-d7abdbadd58b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a000aa6c-0001-444f-b459-d7abdbadd58b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/22768f4d-ec5d-4273-af98-4196f35f4e35/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a000aa6c-0001-444f-b459-d7abdbadd58b>.
+    
+<http://data.lblod.info/id/remote-data-objects/61fd7266-6a9f-4442-af92-80de248467f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61fd7266-6a9f-4442-af92-80de248467f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/22768f4d-ec5d-4273-af98-4196f35f4e35/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61fd7266-6a9f-4442-af92-80de248467f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/f45fe433-82dd-430c-9475-d6d4c94f242e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f45fe433-82dd-430c-9475-d6d4c94f242e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/247f332b-c122-4c4b-81f9-086f63d7e899/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f45fe433-82dd-430c-9475-d6d4c94f242e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a748fd0-db47-4d22-917a-13d2ebc20fff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a748fd0-db47-4d22-917a-13d2ebc20fff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/247f332b-c122-4c4b-81f9-086f63d7e899/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a748fd0-db47-4d22-917a-13d2ebc20fff>.
+    
+<http://data.lblod.info/id/remote-data-objects/14107a45-0f3b-4ae2-bf3f-a02bfd41a3e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14107a45-0f3b-4ae2-bf3f-a02bfd41a3e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/247f332b-c122-4c4b-81f9-086f63d7e899/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14107a45-0f3b-4ae2-bf3f-a02bfd41a3e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a1270ec-c0b8-45c8-a50e-3e818f771219> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a1270ec-c0b8-45c8-a50e-3e818f771219";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/3e58bfc8-6e7c-42d3-92d8-4c59677e31a6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a1270ec-c0b8-45c8-a50e-3e818f771219>.
+    
+<http://data.lblod.info/id/remote-data-objects/3247793d-ed9f-45b4-83f4-3ef952f99d47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3247793d-ed9f-45b4-83f4-3ef952f99d47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/3e58bfc8-6e7c-42d3-92d8-4c59677e31a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3247793d-ed9f-45b4-83f4-3ef952f99d47>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7b1065a-d33c-46c5-8ca0-e3a3cd058696> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7b1065a-d33c-46c5-8ca0-e3a3cd058696";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/3e58bfc8-6e7c-42d3-92d8-4c59677e31a6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7b1065a-d33c-46c5-8ca0-e3a3cd058696>.
+    
+<http://data.lblod.info/id/remote-data-objects/02588096-6200-4ae7-b472-75b7d33dac88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02588096-6200-4ae7-b472-75b7d33dac88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/41b010b4-f778-4842-a3b9-8cdb8912819c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02588096-6200-4ae7-b472-75b7d33dac88>.
+    
+<http://data.lblod.info/id/remote-data-objects/949df559-57b3-44af-b281-ed61352be98e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "949df559-57b3-44af-b281-ed61352be98e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/41b010b4-f778-4842-a3b9-8cdb8912819c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/949df559-57b3-44af-b281-ed61352be98e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e19dd80a-45b4-4bb1-bc05-8d4ae0183198> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e19dd80a-45b4-4bb1-bc05-8d4ae0183198";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/41b010b4-f778-4842-a3b9-8cdb8912819c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e19dd80a-45b4-4bb1-bc05-8d4ae0183198>.
+    
+<http://data.lblod.info/id/remote-data-objects/e54a011a-2086-4aa9-8d90-355568bc9359> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e54a011a-2086-4aa9-8d90-355568bc9359";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/4dc80ad9-8e0c-4526-8849-aa84e6c36a68/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e54a011a-2086-4aa9-8d90-355568bc9359>.
+    
+<http://data.lblod.info/id/remote-data-objects/93f990e3-236c-4b78-aea8-f8b18be71caf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93f990e3-236c-4b78-aea8-f8b18be71caf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/4dc80ad9-8e0c-4526-8849-aa84e6c36a68/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93f990e3-236c-4b78-aea8-f8b18be71caf>.
+    
+<http://data.lblod.info/id/remote-data-objects/9579db5a-66f1-4e0e-8cf5-a4ca982c4158> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9579db5a-66f1-4e0e-8cf5-a4ca982c4158";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/4dc80ad9-8e0c-4526-8849-aa84e6c36a68/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9579db5a-66f1-4e0e-8cf5-a4ca982c4158>.
+    
+<http://data.lblod.info/id/remote-data-objects/b320f1f5-5533-4484-b448-f36abe2e349a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b320f1f5-5533-4484-b448-f36abe2e349a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/519e93ed-cc24-464e-b108-814bc6b7365d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b320f1f5-5533-4484-b448-f36abe2e349a>.
+    
+<http://data.lblod.info/id/remote-data-objects/69b2fea1-08cb-48e9-b0ac-5be81e7b3f6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69b2fea1-08cb-48e9-b0ac-5be81e7b3f6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/519e93ed-cc24-464e-b108-814bc6b7365d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69b2fea1-08cb-48e9-b0ac-5be81e7b3f6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3169fd5-be3c-4bc6-835d-dc2ccfc5e61e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3169fd5-be3c-4bc6-835d-dc2ccfc5e61e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/519e93ed-cc24-464e-b108-814bc6b7365d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3169fd5-be3c-4bc6-835d-dc2ccfc5e61e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cb1ac78-9f25-4a8f-bdcd-b4d7e6751163> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cb1ac78-9f25-4a8f-bdcd-b4d7e6751163";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/51e50930-2796-4991-b631-a87907a9a1fe/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cb1ac78-9f25-4a8f-bdcd-b4d7e6751163>.
+    
+<http://data.lblod.info/id/remote-data-objects/4971633b-079b-47e3-ac0b-a7ed2f874f60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4971633b-079b-47e3-ac0b-a7ed2f874f60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/51e50930-2796-4991-b631-a87907a9a1fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4971633b-079b-47e3-ac0b-a7ed2f874f60>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ed860f9-882a-4af6-a1ec-c57c4310b18e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ed860f9-882a-4af6-a1ec-c57c4310b18e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/5b9c753b-c18a-4614-a3bd-c2e1c6fad77b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ed860f9-882a-4af6-a1ec-c57c4310b18e>.
+    
+<http://data.lblod.info/id/remote-data-objects/93c763df-f2d5-45d6-88df-9a097b1d56e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93c763df-f2d5-45d6-88df-9a097b1d56e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/5b9c753b-c18a-4614-a3bd-c2e1c6fad77b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93c763df-f2d5-45d6-88df-9a097b1d56e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ad079db-9c0c-41a4-9657-fd9efd11155a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ad079db-9c0c-41a4-9657-fd9efd11155a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/5b9c753b-c18a-4614-a3bd-c2e1c6fad77b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ad079db-9c0c-41a4-9657-fd9efd11155a>.
+    
+<http://data.lblod.info/id/remote-data-objects/131d0dc2-4d73-4631-b34b-b8502567ce6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "131d0dc2-4d73-4631-b34b-b8502567ce6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/6c267ebd-7454-4236-89ed-2fc564450d87/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/131d0dc2-4d73-4631-b34b-b8502567ce6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/947fa994-2b19-4e49-8cd8-97e4c1acfada> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "947fa994-2b19-4e49-8cd8-97e4c1acfada";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/6c267ebd-7454-4236-89ed-2fc564450d87/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/947fa994-2b19-4e49-8cd8-97e4c1acfada>.
+    
+<http://data.lblod.info/id/remote-data-objects/33f44f45-01b3-4944-ab04-c6c3dcde4005> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33f44f45-01b3-4944-ab04-c6c3dcde4005";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/6c267ebd-7454-4236-89ed-2fc564450d87/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33f44f45-01b3-4944-ab04-c6c3dcde4005>.
+    
+<http://data.lblod.info/id/remote-data-objects/c94193cf-b983-4afc-9d9f-1e0ffb6aca88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c94193cf-b983-4afc-9d9f-1e0ffb6aca88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/77626420-3a8f-4144-b1cf-e973852fdaab/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c94193cf-b983-4afc-9d9f-1e0ffb6aca88>.
+    
+<http://data.lblod.info/id/remote-data-objects/b820fb0e-6910-41d0-9a57-337b21cf597a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b820fb0e-6910-41d0-9a57-337b21cf597a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/77626420-3a8f-4144-b1cf-e973852fdaab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9d8546d1-5979-4aeb-8599-4637534dd28f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b820fb0e-6910-41d0-9a57-337b21cf597a>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201146-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201146-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201146-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201146-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/cf48ddac-3dbc-45e9-b599-7c852350b2c1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cf48ddac-3dbc-45e9-b599-7c852350b2c1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "143c2912-6fc5-4668-8158-a649d693fc57";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/7ca34aea-9938-4d75-baf2-87a1bcfcb48a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7ca34aea-9938-4d75-baf2-87a1bcfcb48a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57>.
+
+  <http://redpencil.data.gift/id/task/712657a5-cc60-44c7-9110-e017cd039255> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "712657a5-cc60-44c7-9110-e017cd039255";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/cf48ddac-3dbc-45e9-b599-7c852350b2c1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/7ca34aea-9938-4d75-baf2-87a1bcfcb48a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/71715a4d-c0e0-4638-a310-c1eafb8e38c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71715a4d-c0e0-4638-a310-c1eafb8e38c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/77626420-3a8f-4144-b1cf-e973852fdaab/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71715a4d-c0e0-4638-a310-c1eafb8e38c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bfd4787-6a3d-4bfd-9e7e-8dc9e8ab6364> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bfd4787-6a3d-4bfd-9e7e-8dc9e8ab6364";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/9241d663-ab4f-4ea8-9c7e-3ee2278e8e6e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bfd4787-6a3d-4bfd-9e7e-8dc9e8ab6364>.
+    
+<http://data.lblod.info/id/remote-data-objects/55371d8b-2e03-45c6-a081-6080f7e26c50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55371d8b-2e03-45c6-a081-6080f7e26c50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/9241d663-ab4f-4ea8-9c7e-3ee2278e8e6e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55371d8b-2e03-45c6-a081-6080f7e26c50>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f4ff6e0-fbaf-40fa-8a99-01bbc146b55b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f4ff6e0-fbaf-40fa-8a99-01bbc146b55b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/9241d663-ab4f-4ea8-9c7e-3ee2278e8e6e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f4ff6e0-fbaf-40fa-8a99-01bbc146b55b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b7cf4a9-2c79-4e02-a0c4-fc4fd63d2f6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b7cf4a9-2c79-4e02-a0c4-fc4fd63d2f6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/cb7d2ab9-bc6c-4fad-b559-a0bb5d92681d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b7cf4a9-2c79-4e02-a0c4-fc4fd63d2f6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb492bf5-c212-4a39-8099-56b7682103ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb492bf5-c212-4a39-8099-56b7682103ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/cb7d2ab9-bc6c-4fad-b559-a0bb5d92681d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb492bf5-c212-4a39-8099-56b7682103ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/91f70a50-b5ae-4f83-8bca-deb424f89a4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91f70a50-b5ae-4f83-8bca-deb424f89a4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/cb7d2ab9-bc6c-4fad-b559-a0bb5d92681d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91f70a50-b5ae-4f83-8bca-deb424f89a4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/83f0d5a7-a835-4ae1-ba4e-b93ac80e36a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83f0d5a7-a835-4ae1-ba4e-b93ac80e36a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/dfda28a4-cb79-47ca-b30e-da6c56845bc7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83f0d5a7-a835-4ae1-ba4e-b93ac80e36a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d2fd34a-5cc5-4c7d-ad6a-dc51f3173b82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d2fd34a-5cc5-4c7d-ad6a-dc51f3173b82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/dfda28a4-cb79-47ca-b30e-da6c56845bc7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d2fd34a-5cc5-4c7d-ad6a-dc51f3173b82>.
+    
+<http://data.lblod.info/id/remote-data-objects/76e4867d-c702-4017-8fa4-0c43d132d7ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76e4867d-c702-4017-8fa4-0c43d132d7ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/dfda28a4-cb79-47ca-b30e-da6c56845bc7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76e4867d-c702-4017-8fa4-0c43d132d7ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed995b0f-218b-4504-bf1b-f9063b6f28ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed995b0f-218b-4504-bf1b-f9063b6f28ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/f3e32535-9a7e-4a7c-8490-d24b4d6bd746/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed995b0f-218b-4504-bf1b-f9063b6f28ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/4798f23c-3847-4999-b96b-b81cf79e2f32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4798f23c-3847-4999-b96b-b81cf79e2f32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/f3e32535-9a7e-4a7c-8490-d24b4d6bd746/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4798f23c-3847-4999-b96b-b81cf79e2f32>.
+    
+<http://data.lblod.info/id/remote-data-objects/959477f9-74e3-4493-8472-57662ec83c30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "959477f9-74e3-4493-8472-57662ec83c30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/or/f3e32535-9a7e-4a7c-8490-d24b4d6bd746/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/959477f9-74e3-4493-8472-57662ec83c30>.
+    
+<http://data.lblod.info/id/remote-data-objects/b75ddb4e-731e-46b4-9a02-f13871cc5c6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b75ddb4e-731e-46b4-9a02-f13871cc5c6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/050be073-f242-45e5-8425-0cdaadfcce08/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b75ddb4e-731e-46b4-9a02-f13871cc5c6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfbb1a10-6ed5-420f-ac14-6269d79b1a2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfbb1a10-6ed5-420f-ac14-6269d79b1a2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/06f307c2-fce7-4987-a5b5-2442df4acd06/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfbb1a10-6ed5-420f-ac14-6269d79b1a2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c449ea62-376c-4f4c-b254-3658635d79f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c449ea62-376c-4f4c-b254-3658635d79f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/087093b4-32ed-4e7b-9f39-4595582419e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c449ea62-376c-4f4c-b254-3658635d79f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6b97802-3e76-43d3-add2-606df7e912d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6b97802-3e76-43d3-add2-606df7e912d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/0a921d5f-c7fa-4ecb-80e7-727dbe0e2b71/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6b97802-3e76-43d3-add2-606df7e912d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fa6fdc7-722d-4cbe-96cf-aba5eb8ecca4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fa6fdc7-722d-4cbe-96cf-aba5eb8ecca4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/14cf18c4-a01f-4898-90a2-1f2315d2c4b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fa6fdc7-722d-4cbe-96cf-aba5eb8ecca4>.
+    
+<http://data.lblod.info/id/remote-data-objects/b08e4dec-de60-46c6-bca2-8b2b4aef5f9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b08e4dec-de60-46c6-bca2-8b2b4aef5f9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/1798ef8b-77eb-4dce-a382-d9a72802ae37/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b08e4dec-de60-46c6-bca2-8b2b4aef5f9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e76bb7c5-5755-4063-be2f-89f72ca235fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e76bb7c5-5755-4063-be2f-89f72ca235fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/1a327d75-f24d-4c12-9494-79655f3a790a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e76bb7c5-5755-4063-be2f-89f72ca235fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/30614935-d7bc-4c09-aea9-527fb7266f7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30614935-d7bc-4c09-aea9-527fb7266f7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/1ed6ac43-4a3d-4031-98e7-c3e5c2789ab3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30614935-d7bc-4c09-aea9-527fb7266f7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/36b88df3-bf89-4e59-b980-d5cda55d189c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36b88df3-bf89-4e59-b980-d5cda55d189c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/1ee637b3-30b4-48f2-b38b-3aa0ac935e3a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36b88df3-bf89-4e59-b980-d5cda55d189c>.
+    
+<http://data.lblod.info/id/remote-data-objects/87d65261-f28d-4ee8-8684-a04f06463155> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87d65261-f28d-4ee8-8684-a04f06463155";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/1f266c20-444f-4109-a9e3-00eb44edee5f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87d65261-f28d-4ee8-8684-a04f06463155>.
+    
+<http://data.lblod.info/id/remote-data-objects/de2fb08d-f0c7-4fe8-bdb9-c36c52e51219> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de2fb08d-f0c7-4fe8-bdb9-c36c52e51219";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/205b0493-b5f1-40aa-b4f2-0e46ab0e4a30/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de2fb08d-f0c7-4fe8-bdb9-c36c52e51219>.
+    
+<http://data.lblod.info/id/remote-data-objects/64bcd899-48fc-4309-9373-21004cd33997> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64bcd899-48fc-4309-9373-21004cd33997";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/263d52d7-e6aa-4d5c-aeaf-c37825984e99/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64bcd899-48fc-4309-9373-21004cd33997>.
+    
+<http://data.lblod.info/id/remote-data-objects/d321cd35-f986-40e9-ae04-8167f8110c1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d321cd35-f986-40e9-ae04-8167f8110c1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/2b784ad2-f750-4500-b748-8ad61d40e6a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d321cd35-f986-40e9-ae04-8167f8110c1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/237e7fa0-dc83-4caa-a964-08a36b0a7d08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "237e7fa0-dc83-4caa-a964-08a36b0a7d08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/30a9d64d-f9c0-418d-a546-23e2f5289351/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/237e7fa0-dc83-4caa-a964-08a36b0a7d08>.
+    
+<http://data.lblod.info/id/remote-data-objects/16bdf30f-4800-41f9-a727-0ff9b117b653> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16bdf30f-4800-41f9-a727-0ff9b117b653";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/381cb3c2-9bde-4b6c-b449-176be703dac2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16bdf30f-4800-41f9-a727-0ff9b117b653>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0d1ae78-53a8-4438-93f9-a4f3d68571dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0d1ae78-53a8-4438-93f9-a4f3d68571dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/42896340-6cec-4da4-b41d-346abeaf3b5a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0d1ae78-53a8-4438-93f9-a4f3d68571dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee821dae-e837-45a7-87ee-795fc78ef361> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee821dae-e837-45a7-87ee-795fc78ef361";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/42eaf8e5-c889-49b2-9773-95df1cce1cda/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee821dae-e837-45a7-87ee-795fc78ef361>.
+    
+<http://data.lblod.info/id/remote-data-objects/669e3c78-4ee9-4348-8aa5-19e250a413aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "669e3c78-4ee9-4348-8aa5-19e250a413aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/433e2775-0034-49c1-8333-5070a2063030/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/669e3c78-4ee9-4348-8aa5-19e250a413aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c9e7b4f-f9b9-44d8-97b7-ae6aee75e87d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c9e7b4f-f9b9-44d8-97b7-ae6aee75e87d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/43e08655-e392-4af9-b46b-ad40df9aa4bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c9e7b4f-f9b9-44d8-97b7-ae6aee75e87d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c54c3073-da41-4a69-86b9-cc3679804073> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c54c3073-da41-4a69-86b9-cc3679804073";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/45fe2d14-0f9c-463d-a64f-9013052225b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c54c3073-da41-4a69-86b9-cc3679804073>.
+    
+<http://data.lblod.info/id/remote-data-objects/14a9de19-168d-4b97-a996-b74676ba8033> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14a9de19-168d-4b97-a996-b74676ba8033";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/47a48b80-d2f5-4b88-b637-391f85768f76/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14a9de19-168d-4b97-a996-b74676ba8033>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ab00b7f-37f1-490c-b3db-8961d693502a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ab00b7f-37f1-490c-b3db-8961d693502a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/4931fea6-d6db-4344-bc3a-484b61638bfa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ab00b7f-37f1-490c-b3db-8961d693502a>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfb4e53f-d4ad-486f-bb8b-fb3347f2608f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfb4e53f-d4ad-486f-bb8b-fb3347f2608f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/4b7f7f67-7d3a-4daf-80a0-d34b4a92a196/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfb4e53f-d4ad-486f-bb8b-fb3347f2608f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0caadb7-058e-467a-a375-6f474b5847a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0caadb7-058e-467a-a375-6f474b5847a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/5025d5bc-e1e4-49e9-819c-a588924f3dcb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0caadb7-058e-467a-a375-6f474b5847a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4110ea5-8f05-4d20-b305-261745c43ef7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4110ea5-8f05-4d20-b305-261745c43ef7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/596dae93-ef2f-4578-99fc-eb7e91f4135c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4110ea5-8f05-4d20-b305-261745c43ef7>.
+    
+<http://data.lblod.info/id/remote-data-objects/956cfc47-b795-46a0-8be6-2ea850f31ff1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "956cfc47-b795-46a0-8be6-2ea850f31ff1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/5c05f975-6026-46a1-a617-889ad2505fa2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/956cfc47-b795-46a0-8be6-2ea850f31ff1>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f92ba04-90f8-47e7-82c8-13a444353b72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f92ba04-90f8-47e7-82c8-13a444353b72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/60fd5cac-8407-4e7b-b04e-c7d43dc4203d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f92ba04-90f8-47e7-82c8-13a444353b72>.
+    
+<http://data.lblod.info/id/remote-data-objects/72be3e99-b6e4-418e-8e3c-a00ce2418e4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72be3e99-b6e4-418e-8e3c-a00ce2418e4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/6cc31acd-0ba2-4f48-aabc-9198115b3820/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72be3e99-b6e4-418e-8e3c-a00ce2418e4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec10df57-2454-4a4e-a143-7450bbe8b012> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec10df57-2454-4a4e-a143-7450bbe8b012";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/6e959f44-e7fc-4f22-8f3f-8be123e34ace/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec10df57-2454-4a4e-a143-7450bbe8b012>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed438e57-1392-4ade-be0d-b009bfa61165> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed438e57-1392-4ade-be0d-b009bfa61165";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/6ebbe1dd-426c-49e8-bc4c-b323d066f971/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed438e57-1392-4ade-be0d-b009bfa61165>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c7277a6-8860-4873-9848-60d7559120ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c7277a6-8860-4873-9848-60d7559120ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/74425092-eaa8-42fd-ba1c-68b880b76280/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c7277a6-8860-4873-9848-60d7559120ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/17f8b283-1c69-4f62-a21a-e99ed9ea93f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17f8b283-1c69-4f62-a21a-e99ed9ea93f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/74ed4f21-4b32-41b3-82b7-fd66739d3b2d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17f8b283-1c69-4f62-a21a-e99ed9ea93f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd81bb86-63dc-4726-b7df-9113a11249b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd81bb86-63dc-4726-b7df-9113a11249b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/774b9785-446b-46d7-bc96-06f2f536ca78/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd81bb86-63dc-4726-b7df-9113a11249b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b743328-f0b0-47f0-b94a-628cffeebf79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b743328-f0b0-47f0-b94a-628cffeebf79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/7bf36947-af61-4e93-b8cb-1986059cda44/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b743328-f0b0-47f0-b94a-628cffeebf79>.
+    
+<http://data.lblod.info/id/remote-data-objects/70006c68-2b15-4b5f-bca8-b070c47f9fca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70006c68-2b15-4b5f-bca8-b070c47f9fca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/87a940a5-6fea-4cc3-a382-4c77621ac534/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70006c68-2b15-4b5f-bca8-b070c47f9fca>.
+    
+<http://data.lblod.info/id/remote-data-objects/c98786bc-c040-4b1c-b0a1-1859d4fab619> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c98786bc-c040-4b1c-b0a1-1859d4fab619";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/87c39e9c-e9c1-4a68-ae3e-33347c330bb7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c98786bc-c040-4b1c-b0a1-1859d4fab619>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b0aa51b-bcd1-4a95-a7d4-9331ec97f23b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b0aa51b-bcd1-4a95-a7d4-9331ec97f23b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/8aa50797-81b9-48f7-a7a9-e4749c7fd9ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/143c2912-6fc5-4668-8158-a649d693fc57> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b0aa51b-bcd1-4a95-a7d4-9331ec97f23b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201147-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201147-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201147-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201147-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c6b47e9e-144f-43a4-ad71-bb9db7d9a43b> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c6b47e9e-144f-43a4-ad71-bb9db7d9a43b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e0f775e2-c7a6-4edb-952b-8dae248369e5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/0951b0f2-3c25-4da9-ba9d-b0fe09364d1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0951b0f2-3c25-4da9-ba9d-b0fe09364d1f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5>.
+
+  <http://redpencil.data.gift/id/task/714f7bfd-f34f-4c9c-8d66-928bef00a10f> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "714f7bfd-f34f-4c9c-8d66-928bef00a10f";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c6b47e9e-144f-43a4-ad71-bb9db7d9a43b>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/0951b0f2-3c25-4da9-ba9d-b0fe09364d1f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/9fc7ce57-e782-446b-882c-a8fe49fb30fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fc7ce57-e782-446b-882c-a8fe49fb30fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/8afd2b77-7b26-4d60-8d83-3c630c4cbc37/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fc7ce57-e782-446b-882c-a8fe49fb30fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cba726d-9d82-46e6-843b-5eee6d69dc60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cba726d-9d82-46e6-843b-5eee6d69dc60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/93fb51b7-aba3-4380-964c-5a8f834fefaf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cba726d-9d82-46e6-843b-5eee6d69dc60>.
+    
+<http://data.lblod.info/id/remote-data-objects/d98ef471-5159-4b9b-acef-fed569fbdef9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d98ef471-5159-4b9b-acef-fed569fbdef9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/94fc7f2e-0336-454a-9134-2b87017ee1fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d98ef471-5159-4b9b-acef-fed569fbdef9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4a2f9db-6e2b-4ab3-9537-1bd7f5044ddf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4a2f9db-6e2b-4ab3-9537-1bd7f5044ddf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/972c3ba1-e5c0-4870-b902-f0ffe9f22ff6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4a2f9db-6e2b-4ab3-9537-1bd7f5044ddf>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8507841-ca4c-4a58-80dc-02cb27486003> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8507841-ca4c-4a58-80dc-02cb27486003";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/97f3ad23-bee9-427f-9594-101532c31539/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8507841-ca4c-4a58-80dc-02cb27486003>.
+    
+<http://data.lblod.info/id/remote-data-objects/71e721c0-14e0-4970-a6cc-79d0dab18b30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71e721c0-14e0-4970-a6cc-79d0dab18b30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/9abbc7e4-c5e6-480d-92b3-7246af94f95e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71e721c0-14e0-4970-a6cc-79d0dab18b30>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0bd7a24-5c4c-4e17-a3c3-2457494b8196> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0bd7a24-5c4c-4e17-a3c3-2457494b8196";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/9ef8fea4-5b34-4270-9719-77b9baebbf79/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0bd7a24-5c4c-4e17-a3c3-2457494b8196>.
+    
+<http://data.lblod.info/id/remote-data-objects/498703d8-8c34-4407-a2d4-8d64fe05ab3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "498703d8-8c34-4407-a2d4-8d64fe05ab3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/9f73a133-0ba8-4550-9ff2-735aacec077c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/498703d8-8c34-4407-a2d4-8d64fe05ab3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/68b110d7-49fe-4568-8818-2625340586b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68b110d7-49fe-4568-8818-2625340586b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/9fa8c94b-11bc-4eb6-98df-1949dfc88788/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68b110d7-49fe-4568-8818-2625340586b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c607da5-15c5-401e-8f64-616fd33fcbee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c607da5-15c5-401e-8f64-616fd33fcbee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/a454e2d4-db8a-4373-9fd2-1506197a901d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c607da5-15c5-401e-8f64-616fd33fcbee>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b743d02-3651-4147-b245-4a9cb3eaf3f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b743d02-3651-4147-b245-4a9cb3eaf3f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/a98d54c8-7806-4544-b1a7-c7bf4b04c659/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b743d02-3651-4147-b245-4a9cb3eaf3f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc86cbbf-9323-4f4c-a38f-d63822fd8b10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc86cbbf-9323-4f4c-a38f-d63822fd8b10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/aa5d70ad-3660-4365-ada0-e4ce54aafd39/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc86cbbf-9323-4f4c-a38f-d63822fd8b10>.
+    
+<http://data.lblod.info/id/remote-data-objects/374c3cc6-f709-43eb-a13b-e92ccc9637ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "374c3cc6-f709-43eb-a13b-e92ccc9637ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/ae8d43c0-1cfa-47fd-88f3-380b962380fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/374c3cc6-f709-43eb-a13b-e92ccc9637ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/a84386b0-edb6-4929-bd87-17dd8e662b8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a84386b0-edb6-4929-bd87-17dd8e662b8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/afdbf48e-3009-46f1-9f02-165b1f52ab62/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a84386b0-edb6-4929-bd87-17dd8e662b8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cfccc3b-e1ca-450f-9686-57491f098cc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cfccc3b-e1ca-450f-9686-57491f098cc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/b05133fa-0a26-4b38-9064-1cc5ab43fb75/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cfccc3b-e1ca-450f-9686-57491f098cc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a51a957-bb71-4e44-b335-c2377627ede7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a51a957-bb71-4e44-b335-c2377627ede7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/b1d6ea20-6976-46a3-9610-5bec0130dedb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a51a957-bb71-4e44-b335-c2377627ede7>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d9930d1-43ed-445a-a42f-de5e0e0e96a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d9930d1-43ed-445a-a42f-de5e0e0e96a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/b9e6acc7-f516-421b-8f48-66422d5ca543/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d9930d1-43ed-445a-a42f-de5e0e0e96a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3f34ee5-69ee-4d0d-9828-c5003d798920> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3f34ee5-69ee-4d0d-9828-c5003d798920";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/c5c0c289-77b9-471c-b876-7b075187b800/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3f34ee5-69ee-4d0d-9828-c5003d798920>.
+    
+<http://data.lblod.info/id/remote-data-objects/720db9e7-55f3-4816-8ee7-c1cbcf4c2663> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "720db9e7-55f3-4816-8ee7-c1cbcf4c2663";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/c731adec-6069-4a17-a3fc-f7cf9799d09e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/720db9e7-55f3-4816-8ee7-c1cbcf4c2663>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb2ea95e-d441-4ce6-9ab4-8b2e4233f950> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb2ea95e-d441-4ce6-9ab4-8b2e4233f950";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/c8c7a5f1-7815-4e86-bdd8-4d0021bea8fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb2ea95e-d441-4ce6-9ab4-8b2e4233f950>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d9fd3da-1f36-42a2-8c61-6c2e010f3b93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d9fd3da-1f36-42a2-8c61-6c2e010f3b93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/ce17d8fe-facd-4862-83b8-115ed607a3ce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d9fd3da-1f36-42a2-8c61-6c2e010f3b93>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b925deb-1445-410d-b8af-a4c3933668fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b925deb-1445-410d-b8af-a4c3933668fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/d871dd4b-ff78-443d-80a0-9519e194bfff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b925deb-1445-410d-b8af-a4c3933668fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c239fbba-cd9f-4175-b94a-e4b252af863b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c239fbba-cd9f-4175-b94a-e4b252af863b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/d986ee50-53d6-4789-b399-310e8358f887/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c239fbba-cd9f-4175-b94a-e4b252af863b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcbc1d7d-220c-4f39-b3ca-ed8086d14323> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcbc1d7d-220c-4f39-b3ca-ed8086d14323";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/dd233a49-d331-4af8-843f-ff20acd2efb7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcbc1d7d-220c-4f39-b3ca-ed8086d14323>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c4ced0c-b56c-4ceb-83c6-f435ee42fc5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c4ced0c-b56c-4ceb-83c6-f435ee42fc5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/e1d39b3f-ff4b-407b-886a-b31e364d21aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c4ced0c-b56c-4ceb-83c6-f435ee42fc5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/db781770-04cd-4969-b196-3f36b85706bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db781770-04cd-4969-b196-3f36b85706bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/e24f5fc9-2013-42d3-89c2-62a253026439/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db781770-04cd-4969-b196-3f36b85706bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/35e0e032-bea2-4f4f-94ec-57f37fc51d06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35e0e032-bea2-4f4f-94ec-57f37fc51d06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/e2b8c696-3a5e-4595-91cf-70123b01f9da/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35e0e032-bea2-4f4f-94ec-57f37fc51d06>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b5efd7a-ed3c-4c8c-ac1c-4b50634bd74c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b5efd7a-ed3c-4c8c-ac1c-4b50634bd74c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/e836a442-72da-4abb-99fd-7795fc5e270e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b5efd7a-ed3c-4c8c-ac1c-4b50634bd74c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebd4f3b1-bc82-44ed-9a0f-6c9efc1af64b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebd4f3b1-bc82-44ed-9a0f-6c9efc1af64b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/ebc8a9e0-1ef9-4df5-930c-673a3b88a00b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebd4f3b1-bc82-44ed-9a0f-6c9efc1af64b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea2e5e42-4d01-4e2d-a7e9-68d1191719d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea2e5e42-4d01-4e2d-a7e9-68d1191719d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/f6225246-ada7-4646-ac40-ca2a2c21280b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea2e5e42-4d01-4e2d-a7e9-68d1191719d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3be20fe-c969-4907-9c8c-ce21b6d90e6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3be20fe-c969-4907-9c8c-ce21b6d90e6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/f8a5fe39-5e38-4ada-b7ed-89d4c8b1cb8a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3be20fe-c969-4907-9c8c-ce21b6d90e6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/35882ff9-71c3-47f7-93d2-b0734283a604> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35882ff9-71c3-47f7-93d2-b0734283a604";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoeselt.meetingburger.net/vb/fec67199-4f15-4531-917c-37e900c94a96/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35882ff9-71c3-47f7-93d2-b0734283a604>.
+    
+<http://data.lblod.info/id/remote-data-objects/b30bdc02-5822-442e-a49e-baaafdc73624> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b30bdc02-5822-442e-a49e-baaafdc73624";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/037dbd98-c070-4445-ad9e-662f13beab32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b30bdc02-5822-442e-a49e-baaafdc73624>.
+    
+<http://data.lblod.info/id/remote-data-objects/275eb985-4a4e-43b5-972b-18c4739be1ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "275eb985-4a4e-43b5-972b-18c4739be1ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/038164ed-a24d-4c09-9ec3-e37148f70c2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/275eb985-4a4e-43b5-972b-18c4739be1ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/e08e978a-e84e-466f-bbd3-4dd2fde07fa2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e08e978a-e84e-466f-bbd3-4dd2fde07fa2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/07605411-5a88-4afe-98ad-5c41154b7007/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e08e978a-e84e-466f-bbd3-4dd2fde07fa2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f339a05-b669-44e8-9f29-aeb6a5987360> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f339a05-b669-44e8-9f29-aeb6a5987360";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/12583120-9ec9-4dd7-97ec-08d97bd89639/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f339a05-b669-44e8-9f29-aeb6a5987360>.
+    
+<http://data.lblod.info/id/remote-data-objects/eab3fbc2-efb0-4ec9-b280-90fc8823ed8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eab3fbc2-efb0-4ec9-b280-90fc8823ed8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/12d56173-23ca-4de5-b967-26ff2a55c4d8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eab3fbc2-efb0-4ec9-b280-90fc8823ed8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/91211a85-117a-41d5-81f7-144559ec66a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91211a85-117a-41d5-81f7-144559ec66a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/1649175c-5f95-488a-aa5e-b6612448d91e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91211a85-117a-41d5-81f7-144559ec66a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/35c4e18d-6827-4f2f-a159-7afe175820cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35c4e18d-6827-4f2f-a159-7afe175820cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/22c7d5e0-1bc9-47d9-ba80-66b5244c0052/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35c4e18d-6827-4f2f-a159-7afe175820cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/53a10b20-5df8-41c5-a24a-29829f219ecf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53a10b20-5df8-41c5-a24a-29829f219ecf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/2336c036-c222-4c80-b139-0915f01ec074/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53a10b20-5df8-41c5-a24a-29829f219ecf>.
+    
+<http://data.lblod.info/id/remote-data-objects/16d6d6c6-6799-43cd-9455-3dcc3a28f9e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16d6d6c6-6799-43cd-9455-3dcc3a28f9e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/2b532a2f-c928-446c-b80f-52c0ad01f787/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16d6d6c6-6799-43cd-9455-3dcc3a28f9e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/af50a2bb-5151-4a57-a430-f8ee94918cb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af50a2bb-5151-4a57-a430-f8ee94918cb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/2d5f60dc-f8ae-4f53-a1b0-1499d5628927/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af50a2bb-5151-4a57-a430-f8ee94918cb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/818b3d52-d5d0-4160-a060-871f99949727> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "818b3d52-d5d0-4160-a060-871f99949727";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/349486f3-f6a1-4ff9-a498-dee52bbb6236/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/818b3d52-d5d0-4160-a060-871f99949727>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1fd5abe-8feb-4ee6-b370-44c22cc34615> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1fd5abe-8feb-4ee6-b370-44c22cc34615";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/3576ce4a-d6d6-4b00-a14b-4d793b90a52d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1fd5abe-8feb-4ee6-b370-44c22cc34615>.
+    
+<http://data.lblod.info/id/remote-data-objects/909ca914-25a7-4cae-bfd2-60edb620eac9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "909ca914-25a7-4cae-bfd2-60edb620eac9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/3a336006-d71c-4ac5-a1d4-6fcf976a3b43/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/909ca914-25a7-4cae-bfd2-60edb620eac9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c43a5917-f4fc-46df-8b7f-6030b96628cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c43a5917-f4fc-46df-8b7f-6030b96628cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/3a86b25b-db79-409b-9c00-e1878e4b2536/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c43a5917-f4fc-46df-8b7f-6030b96628cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/7af4f26f-bbf5-47e6-919d-014c912597c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7af4f26f-bbf5-47e6-919d-014c912597c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/3a9b0357-f931-4728-925c-57f59d636673/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7af4f26f-bbf5-47e6-919d-014c912597c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5176512-6b20-4e1f-adfb-7ba591530082> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5176512-6b20-4e1f-adfb-7ba591530082";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/42d03c74-f453-4c61-b0f3-4ae9c8d01c39/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5176512-6b20-4e1f-adfb-7ba591530082>.
+    
+<http://data.lblod.info/id/remote-data-objects/08894d27-ade2-4f35-870d-57f875369d74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08894d27-ade2-4f35-870d-57f875369d74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/4bb07d0a-0a7a-4d5c-9b8c-6b631c4bdb94/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08894d27-ade2-4f35-870d-57f875369d74>.
+    
+<http://data.lblod.info/id/remote-data-objects/79de7d78-ff46-4e88-9466-71695267b743> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79de7d78-ff46-4e88-9466-71695267b743";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/4c4202d3-2947-4fc8-b70b-fae3e726dcd3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0f775e2-c7a6-4edb-952b-8dae248369e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79de7d78-ff46-4e88-9466-71695267b743>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201148-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201148-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201148-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201148-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/47ff6304-319e-499b-871a-0624aa29f6d8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "47ff6304-319e-499b-871a-0624aa29f6d8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b9dd5c61-fb50-45cc-995d-0035004f8a26";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/797a7362-a915-43e0-bcf4-87e90e3c6b77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "797a7362-a915-43e0-bcf4-87e90e3c6b77";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26>.
+
+  <http://redpencil.data.gift/id/task/948897db-3f7c-4636-a550-e66dac25fa61> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "948897db-3f7c-4636-a550-e66dac25fa61";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/47ff6304-319e-499b-871a-0624aa29f6d8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/797a7362-a915-43e0-bcf4-87e90e3c6b77>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/30c0e3df-2671-4853-82d8-30ca2569d8df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30c0e3df-2671-4853-82d8-30ca2569d8df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/51da766a-7800-40c2-a537-8a3cab92794f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30c0e3df-2671-4853-82d8-30ca2569d8df>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce3c07c4-cc36-4e5c-b138-14a5cbbecac0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce3c07c4-cc36-4e5c-b138-14a5cbbecac0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/53c5a552-9869-4922-95b7-526ff1074e26/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce3c07c4-cc36-4e5c-b138-14a5cbbecac0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2010c06a-f258-4b78-94d8-f05afcab6fde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2010c06a-f258-4b78-94d8-f05afcab6fde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/57d09634-b9b0-4c0b-a018-3bb78565a48f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2010c06a-f258-4b78-94d8-f05afcab6fde>.
+    
+<http://data.lblod.info/id/remote-data-objects/faae5aa2-da32-4567-becd-5c20b6169ed6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "faae5aa2-da32-4567-becd-5c20b6169ed6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/58b5ac01-0fc0-4620-9057-eee1e90c30bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/faae5aa2-da32-4567-becd-5c20b6169ed6>.
+    
+<http://data.lblod.info/id/remote-data-objects/338209ab-e99d-45ef-9f33-a224c7e04f69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "338209ab-e99d-45ef-9f33-a224c7e04f69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/5d1f3443-3bda-4abd-a463-c33e2356b628/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/338209ab-e99d-45ef-9f33-a224c7e04f69>.
+    
+<http://data.lblod.info/id/remote-data-objects/350f87fa-8265-47ef-bcd1-6423a8226405> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "350f87fa-8265-47ef-bcd1-6423a8226405";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/5e84c30b-cd75-4c58-a151-20a6149b7192/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/350f87fa-8265-47ef-bcd1-6423a8226405>.
+    
+<http://data.lblod.info/id/remote-data-objects/f51f7c5d-b54d-49cd-9f7a-993b94c03d67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f51f7c5d-b54d-49cd-9f7a-993b94c03d67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/600fa622-eea4-4a9e-a836-46079d1b6c8f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f51f7c5d-b54d-49cd-9f7a-993b94c03d67>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bfb33a5-638c-4893-ad48-312afd652e4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bfb33a5-638c-4893-ad48-312afd652e4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/61e63b6f-81d5-456a-92b5-00491284590c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bfb33a5-638c-4893-ad48-312afd652e4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c850fe04-90ce-4cc3-b3c1-5522801d0f57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c850fe04-90ce-4cc3-b3c1-5522801d0f57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/68defc7e-8860-468a-af47-22be05dbb6f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c850fe04-90ce-4cc3-b3c1-5522801d0f57>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1ffbba3-3d7a-4a7c-984b-b30721bd539e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1ffbba3-3d7a-4a7c-984b-b30721bd539e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/6cfd5ac9-981c-4136-8245-2ab2747674f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1ffbba3-3d7a-4a7c-984b-b30721bd539e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4cf0198-7dc9-4352-99fa-ddf7fc7615dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4cf0198-7dc9-4352-99fa-ddf7fc7615dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/71fb0fdb-d6c5-4ad9-94f3-65cbac9654f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4cf0198-7dc9-4352-99fa-ddf7fc7615dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1a14ae4-d5f8-4336-8dac-0062b2fc3703> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1a14ae4-d5f8-4336-8dac-0062b2fc3703";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/7dca757d-7fd0-4309-86ac-190e5e8d51ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1a14ae4-d5f8-4336-8dac-0062b2fc3703>.
+    
+<http://data.lblod.info/id/remote-data-objects/81266276-8feb-47ac-bb04-7bb5155b5003> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81266276-8feb-47ac-bb04-7bb5155b5003";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/84a2a31d-d308-44ff-b45f-6c987d2f4a6e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81266276-8feb-47ac-bb04-7bb5155b5003>.
+    
+<http://data.lblod.info/id/remote-data-objects/55c951ab-4f02-4445-a4c2-1412378ae7eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55c951ab-4f02-4445-a4c2-1412378ae7eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/8c39be1e-8866-48e1-81f2-c0f83dd5fe0d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55c951ab-4f02-4445-a4c2-1412378ae7eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf49f805-9cf4-4e4b-826a-723290dda273> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf49f805-9cf4-4e4b-826a-723290dda273";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/8cf5c36e-230c-43a6-9d26-789b0a3a7c02/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf49f805-9cf4-4e4b-826a-723290dda273>.
+    
+<http://data.lblod.info/id/remote-data-objects/d22d33fa-c289-4a31-9d2d-d4f2d0a72dd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d22d33fa-c289-4a31-9d2d-d4f2d0a72dd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/8d777fae-2180-40ae-9f6b-e580e3e0e70d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d22d33fa-c289-4a31-9d2d-d4f2d0a72dd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3e1dd2a-14ed-48e3-a4c7-f561a9f5aa0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3e1dd2a-14ed-48e3-a4c7-f561a9f5aa0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/8de0ff3e-507f-40af-85eb-3f7c4ae9200d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3e1dd2a-14ed-48e3-a4c7-f561a9f5aa0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5e3e6f3-53d1-4cec-81bd-0584c18250d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5e3e6f3-53d1-4cec-81bd-0584c18250d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/8f38ba23-986c-443f-adf7-51880e152207/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5e3e6f3-53d1-4cec-81bd-0584c18250d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/710ce041-91c9-497a-9250-f47288c19add> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "710ce041-91c9-497a-9250-f47288c19add";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/927e320a-8772-430b-b927-49a270606a82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/710ce041-91c9-497a-9250-f47288c19add>.
+    
+<http://data.lblod.info/id/remote-data-objects/25cc8519-1c9a-4cfa-9890-78d4a3b52d0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25cc8519-1c9a-4cfa-9890-78d4a3b52d0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/94f39d0e-d91b-47ae-ac3f-55ae4904d74a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25cc8519-1c9a-4cfa-9890-78d4a3b52d0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9846feb-c1cd-438b-a4ba-be62e70909d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9846feb-c1cd-438b-a4ba-be62e70909d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/95960bb1-c9cc-45d5-a55d-4f54d7f417e5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9846feb-c1cd-438b-a4ba-be62e70909d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/59bb4b36-e5c1-4202-9ec8-f21a860527f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59bb4b36-e5c1-4202-9ec8-f21a860527f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/96a8c6e5-36f7-45fb-99ac-253815afa046/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59bb4b36-e5c1-4202-9ec8-f21a860527f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7e269e5-6dbd-4d01-8020-4df9b574f334> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7e269e5-6dbd-4d01-8020-4df9b574f334";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/96ef8b1e-bc06-4ace-8e01-13d54caaadb7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7e269e5-6dbd-4d01-8020-4df9b574f334>.
+    
+<http://data.lblod.info/id/remote-data-objects/93ee8ddd-8669-4b49-8a05-4740e906fd17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93ee8ddd-8669-4b49-8a05-4740e906fd17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/9e95358d-290a-4a89-a805-2f7fdc7cb27e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93ee8ddd-8669-4b49-8a05-4740e906fd17>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdbe5fe4-b549-4f0e-979d-bc826a10e023> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdbe5fe4-b549-4f0e-979d-bc826a10e023";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/9ef11f73-196a-4eeb-9969-3d6c84f79a3a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdbe5fe4-b549-4f0e-979d-bc826a10e023>.
+    
+<http://data.lblod.info/id/remote-data-objects/a25a1b89-d059-44e4-9c31-6a23d1d7369e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a25a1b89-d059-44e4-9c31-6a23d1d7369e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/a04f1284-7967-45c2-aa66-f040d98a2b06/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a25a1b89-d059-44e4-9c31-6a23d1d7369e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f63432cf-fe90-4770-9850-bc2e61595cf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f63432cf-fe90-4770-9850-bc2e61595cf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/a0bcc968-f491-43d5-aaaf-f9027a8cf495/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f63432cf-fe90-4770-9850-bc2e61595cf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/30fc98ca-ceec-48fe-939e-ba6a20cd2afa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30fc98ca-ceec-48fe-939e-ba6a20cd2afa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/a2a9dc7e-5d83-4295-8f99-749bec568818/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30fc98ca-ceec-48fe-939e-ba6a20cd2afa>.
+    
+<http://data.lblod.info/id/remote-data-objects/424dfde5-faeb-4574-8080-0eb460274734> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "424dfde5-faeb-4574-8080-0eb460274734";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/a5762dbd-e134-4b64-a247-61579a905565/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/424dfde5-faeb-4574-8080-0eb460274734>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c04cb8c-4675-49fe-8005-2504c6eecc20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c04cb8c-4675-49fe-8005-2504c6eecc20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/a804aeb1-2e99-4941-9dce-7ffd009047eb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c04cb8c-4675-49fe-8005-2504c6eecc20>.
+    
+<http://data.lblod.info/id/remote-data-objects/c629af41-adb7-46be-b2b4-a2ecb688e97b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c629af41-adb7-46be-b2b4-a2ecb688e97b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/a88fb955-1c85-4295-ad8f-3f5f3b127ad0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c629af41-adb7-46be-b2b4-a2ecb688e97b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d83cac4a-6b9d-492b-9696-8044f439b17b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d83cac4a-6b9d-492b-9696-8044f439b17b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/aede81da-cf8c-46e4-bec7-636ebf6a60fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d83cac4a-6b9d-492b-9696-8044f439b17b>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd9ab0cc-c62f-480f-b941-03c82fd6be3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd9ab0cc-c62f-480f-b941-03c82fd6be3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/b08d12ec-2f8c-4657-8e7c-c2728ed4d079/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd9ab0cc-c62f-480f-b941-03c82fd6be3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0de6655-7e8c-4553-a035-286a763adba3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0de6655-7e8c-4553-a035-286a763adba3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/b2ff77d2-ca6d-43ac-a758-5deb37739b63/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0de6655-7e8c-4553-a035-286a763adba3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d492a500-35a7-4fe1-97b9-244f8c24213d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d492a500-35a7-4fe1-97b9-244f8c24213d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/bcfb8865-6d8f-4da2-90b8-db0f992b1110/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d492a500-35a7-4fe1-97b9-244f8c24213d>.
+    
+<http://data.lblod.info/id/remote-data-objects/84ca1136-30ce-46d3-9011-ed58b6b119fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84ca1136-30ce-46d3-9011-ed58b6b119fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/bd2468b4-bc3e-4a1d-a180-96cfd437f712/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84ca1136-30ce-46d3-9011-ed58b6b119fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/50057150-7ca8-448f-86ac-fa505fdd7468> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50057150-7ca8-448f-86ac-fa505fdd7468";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/ca60ee42-0d43-47b1-852e-71beeef315b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50057150-7ca8-448f-86ac-fa505fdd7468>.
+    
+<http://data.lblod.info/id/remote-data-objects/03557655-ce73-475f-9fde-af74a040b85d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03557655-ce73-475f-9fde-af74a040b85d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/d2e4aff4-97c3-4700-9238-bff2085c1a36/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03557655-ce73-475f-9fde-af74a040b85d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d05b10d-fdd9-44bf-8a5c-b8eeb86981e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d05b10d-fdd9-44bf-8a5c-b8eeb86981e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/d3ce904d-0f18-41cf-8633-9a5f7cbd3368/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d05b10d-fdd9-44bf-8a5c-b8eeb86981e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/4806fd46-5d31-4254-9a24-4ca77c409720> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4806fd46-5d31-4254-9a24-4ca77c409720";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/d7ee1c11-b007-4d1f-b314-ba90518942db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4806fd46-5d31-4254-9a24-4ca77c409720>.
+    
+<http://data.lblod.info/id/remote-data-objects/be63a34e-e4c5-4ad0-a7d3-e5de7db2a009> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be63a34e-e4c5-4ad0-a7d3-e5de7db2a009";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/db304146-e3c7-42c6-b170-015d162eb6b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be63a34e-e4c5-4ad0-a7d3-e5de7db2a009>.
+    
+<http://data.lblod.info/id/remote-data-objects/e81a6c6f-21a1-4776-a8dc-d5732781a7d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e81a6c6f-21a1-4776-a8dc-d5732781a7d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/e59eb8fb-0d3f-4cb1-b045-9c106c13f1c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e81a6c6f-21a1-4776-a8dc-d5732781a7d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/324eaa4c-f489-4b32-9a2c-fe3f146352df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "324eaa4c-f489-4b32-9a2c-fe3f146352df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/e93ac3ae-d54e-4103-8606-aa2e64778a92/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/324eaa4c-f489-4b32-9a2c-fe3f146352df>.
+    
+<http://data.lblod.info/id/remote-data-objects/67b7122e-7369-4c3e-ab4d-15e616036d96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67b7122e-7369-4c3e-ab4d-15e616036d96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/e9dbacab-a22b-412e-84c4-8143456e4e64/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67b7122e-7369-4c3e-ab4d-15e616036d96>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6b22758-9a47-4e66-b553-ca7c765c6e7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6b22758-9a47-4e66-b553-ca7c765c6e7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/eaa3cfa1-9bde-47e8-a987-66c3bdda5517/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6b22758-9a47-4e66-b553-ca7c765c6e7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c96c2004-a3f4-4e18-a370-06f7e2925a75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c96c2004-a3f4-4e18-a370-06f7e2925a75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/ec03785c-0400-4edc-895c-8f5fca33f2fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c96c2004-a3f4-4e18-a370-06f7e2925a75>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b4ab1bd-8dd1-4250-8f75-e9eba7bafa98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b4ab1bd-8dd1-4250-8f75-e9eba7bafa98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/f7e56951-0c0b-4981-92b3-de6cdcb424f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b4ab1bd-8dd1-4250-8f75-e9eba7bafa98>.
+    
+<http://data.lblod.info/id/remote-data-objects/19cd0e36-c871-4169-b721-718b4d7ba452> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19cd0e36-c871-4169-b721-718b4d7ba452";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/bb/f8807144-3f98-4b8b-88db-d82ad0e153b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19cd0e36-c871-4169-b721-718b4d7ba452>.
+    
+<http://data.lblod.info/id/remote-data-objects/88e4068d-268b-4ba0-8d0b-b8ef19d3785b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88e4068d-268b-4ba0-8d0b-b8ef19d3785b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/00773fca-86bf-4952-835e-1d437eceefca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88e4068d-268b-4ba0-8d0b-b8ef19d3785b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7f6a56e-7fde-4527-b607-059d1de5e86c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7f6a56e-7fde-4527-b607-059d1de5e86c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/023603b9-16c3-4332-beaa-ede77f42ced9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b9dd5c61-fb50-45cc-995d-0035004f8a26> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7f6a56e-7fde-4527-b607-059d1de5e86c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201149-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201149-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201149-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201149-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7d44e49c-5401-4098-b2f3-cfd0b13b678f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7d44e49c-5401-4098-b2f3-cfd0b13b678f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "291e2d4f-7ca9-4df1-9d45-1b6019d2aadf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ec2fde58-87a4-4451-a3f9-567f0181dc55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ec2fde58-87a4-4451-a3f9-567f0181dc55";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf>.
+
+  <http://redpencil.data.gift/id/task/851620e8-dc20-4f74-a247-b3d8b87209a3> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "851620e8-dc20-4f74-a247-b3d8b87209a3";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7d44e49c-5401-4098-b2f3-cfd0b13b678f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ec2fde58-87a4-4451-a3f9-567f0181dc55>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a34e2476-cb43-4e07-9f54-bef4687e649b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a34e2476-cb43-4e07-9f54-bef4687e649b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/0a745caf-58c1-454c-8cbf-63f8d1c9ea32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a34e2476-cb43-4e07-9f54-bef4687e649b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c9603d8-7351-4269-abd2-c41f6ed92b79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c9603d8-7351-4269-abd2-c41f6ed92b79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/0c2f0556-4216-4beb-8f92-9a0bc355d5be/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c9603d8-7351-4269-abd2-c41f6ed92b79>.
+    
+<http://data.lblod.info/id/remote-data-objects/707888fa-7651-4eb1-adc3-67f46b7ab8e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "707888fa-7651-4eb1-adc3-67f46b7ab8e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/137bf8e9-89e2-4179-becb-7832c5dfdfc7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/707888fa-7651-4eb1-adc3-67f46b7ab8e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/f45c3d11-99d9-4188-9cf1-4ced82433fec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f45c3d11-99d9-4188-9cf1-4ced82433fec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/1ed6fe4f-2a3a-472b-b691-6f9d82e1fcf9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f45c3d11-99d9-4188-9cf1-4ced82433fec>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5a4941b-7a40-4ccf-b4ca-a85fdc2d2d94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5a4941b-7a40-4ccf-b4ca-a85fdc2d2d94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/29e8e711-6589-44e3-b278-f733967b1dfe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5a4941b-7a40-4ccf-b4ca-a85fdc2d2d94>.
+    
+<http://data.lblod.info/id/remote-data-objects/a285645a-7969-4443-b476-8f67262aa8de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a285645a-7969-4443-b476-8f67262aa8de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/2d7a0b08-a784-4d78-9c36-09d22f703f8b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a285645a-7969-4443-b476-8f67262aa8de>.
+    
+<http://data.lblod.info/id/remote-data-objects/27114c2e-9875-444c-b302-518f3a060c37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27114c2e-9875-444c-b302-518f3a060c37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/2d91b955-5914-457c-9666-760c1f94efc3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27114c2e-9875-444c-b302-518f3a060c37>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7fe4b3b-2452-4da3-abc7-9ae1872576af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7fe4b3b-2452-4da3-abc7-9ae1872576af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/314bf408-f58a-4423-b147-56afb66c0786/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7fe4b3b-2452-4da3-abc7-9ae1872576af>.
+    
+<http://data.lblod.info/id/remote-data-objects/58b99347-4289-4695-a444-8df417100846> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58b99347-4289-4695-a444-8df417100846";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/32bc8d36-9ca4-4051-b851-33af25521a47/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58b99347-4289-4695-a444-8df417100846>.
+    
+<http://data.lblod.info/id/remote-data-objects/71ca8808-5f5f-44ff-9a42-34b067be09a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71ca8808-5f5f-44ff-9a42-34b067be09a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/3915b38b-a34d-4de0-bc84-d19a067b1dbb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71ca8808-5f5f-44ff-9a42-34b067be09a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/46f6cdef-97aa-4ee9-92d2-7b3c448335ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46f6cdef-97aa-4ee9-92d2-7b3c448335ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/3954b413-7f83-46a3-afa1-7b6c835d9a03/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46f6cdef-97aa-4ee9-92d2-7b3c448335ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/e60f92e5-2468-4b7a-b7b4-87bbdb7c97c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e60f92e5-2468-4b7a-b7b4-87bbdb7c97c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/397eaf7a-eb23-4f84-a0a4-bdf59235f4a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e60f92e5-2468-4b7a-b7b4-87bbdb7c97c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/75f9cee8-14de-4fa4-9e6c-8b5bc14d9eb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75f9cee8-14de-4fa4-9e6c-8b5bc14d9eb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/3a076679-a2e3-4594-b8a5-7cc458b40aa7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75f9cee8-14de-4fa4-9e6c-8b5bc14d9eb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea6391f9-50f7-402f-866e-0aafbc56c38b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea6391f9-50f7-402f-866e-0aafbc56c38b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/3bcf3ee8-778a-436a-b9aa-d94f12dd4635/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea6391f9-50f7-402f-866e-0aafbc56c38b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ced1efb-0d6f-48b3-92e3-5ac37d8f9a1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ced1efb-0d6f-48b3-92e3-5ac37d8f9a1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/3d0b5dec-5935-46cc-9477-95e82524ebac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ced1efb-0d6f-48b3-92e3-5ac37d8f9a1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cce3f8c-0f49-45c8-8fde-343f1c049c4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cce3f8c-0f49-45c8-8fde-343f1c049c4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/4091c234-d48e-4806-be82-3f87610141d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cce3f8c-0f49-45c8-8fde-343f1c049c4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/da0a79ed-70da-4b79-b1fd-071ae980d056> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da0a79ed-70da-4b79-b1fd-071ae980d056";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/45173372-22e8-4a5a-b3e9-ba9f0d0c906e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da0a79ed-70da-4b79-b1fd-071ae980d056>.
+    
+<http://data.lblod.info/id/remote-data-objects/63b444a9-8dd2-4cf0-94c5-9e63a5577f78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63b444a9-8dd2-4cf0-94c5-9e63a5577f78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/4697a9e9-a1fb-4103-b345-b83bf33bd62c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63b444a9-8dd2-4cf0-94c5-9e63a5577f78>.
+    
+<http://data.lblod.info/id/remote-data-objects/289f0050-d079-4510-ae9c-0d2e95984491> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "289f0050-d079-4510-ae9c-0d2e95984491";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/4aed05aa-e261-4068-b7dc-ad2945684698/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/289f0050-d079-4510-ae9c-0d2e95984491>.
+    
+<http://data.lblod.info/id/remote-data-objects/316d0919-e000-462b-88e5-b22d46409766> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "316d0919-e000-462b-88e5-b22d46409766";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/4d3e8cf5-985b-42e6-84b9-9d5a773978a2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/316d0919-e000-462b-88e5-b22d46409766>.
+    
+<http://data.lblod.info/id/remote-data-objects/1db5be10-efe7-48f7-b20b-36f7d7500c18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1db5be10-efe7-48f7-b20b-36f7d7500c18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/4e21084a-81ee-4da3-b6da-4c92a3c7c831/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1db5be10-efe7-48f7-b20b-36f7d7500c18>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbf94823-dff3-411f-96b8-26b7028df76d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbf94823-dff3-411f-96b8-26b7028df76d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/59d2c362-55e8-4c58-afa7-ef3032dfb64c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbf94823-dff3-411f-96b8-26b7028df76d>.
+    
+<http://data.lblod.info/id/remote-data-objects/62b7a4ac-0312-4033-99e6-bf7d528c2310> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62b7a4ac-0312-4033-99e6-bf7d528c2310";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/5a7ee35c-32dd-40b3-a6e9-2cec52c70a4d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62b7a4ac-0312-4033-99e6-bf7d528c2310>.
+    
+<http://data.lblod.info/id/remote-data-objects/76289225-fe51-45a5-9f3e-2227cffcf552> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76289225-fe51-45a5-9f3e-2227cffcf552";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/5d83a171-8b0e-4820-9af0-7c6c6da6683f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76289225-fe51-45a5-9f3e-2227cffcf552>.
+    
+<http://data.lblod.info/id/remote-data-objects/66c510d8-574d-4fa3-a125-95cd40acdbe6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66c510d8-574d-4fa3-a125-95cd40acdbe6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/63d51e76-7ac8-4d1b-9c9c-26b856b48e4d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66c510d8-574d-4fa3-a125-95cd40acdbe6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f05acf90-5f98-4abb-a9d9-7b43b95ba79e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f05acf90-5f98-4abb-a9d9-7b43b95ba79e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/6784985b-db48-4667-b853-60f4e5cb31d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f05acf90-5f98-4abb-a9d9-7b43b95ba79e>.
+    
+<http://data.lblod.info/id/remote-data-objects/728f301a-23a3-40f9-b370-714ab174af5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "728f301a-23a3-40f9-b370-714ab174af5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/68b3bb3a-47a0-4264-a091-76a64bde6cdb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/728f301a-23a3-40f9-b370-714ab174af5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b1ec7af-130b-45a2-8b05-dfae784bdc58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b1ec7af-130b-45a2-8b05-dfae784bdc58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/6a6bc251-6d94-4e80-a9d4-d672948971e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b1ec7af-130b-45a2-8b05-dfae784bdc58>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed6a55c4-bda1-4b62-8909-03efe6c4ecfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed6a55c4-bda1-4b62-8909-03efe6c4ecfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/75c99476-f4ae-4d72-befe-f0248a08cbe9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed6a55c4-bda1-4b62-8909-03efe6c4ecfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/39ca9c0a-5a47-4b82-b325-5f643b6c9563> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39ca9c0a-5a47-4b82-b325-5f643b6c9563";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/767ce333-4674-4f99-bf02-5712a5ffa1c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39ca9c0a-5a47-4b82-b325-5f643b6c9563>.
+    
+<http://data.lblod.info/id/remote-data-objects/03345ee8-6037-4718-9b8c-f81b339a5322> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03345ee8-6037-4718-9b8c-f81b339a5322";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/7cffb8f2-431a-4eeb-82b6-c865374ff9c0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03345ee8-6037-4718-9b8c-f81b339a5322>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4cbfd7f-936d-4f92-a501-77cae959978d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4cbfd7f-936d-4f92-a501-77cae959978d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/7e0eb3e4-b68a-43f4-9af3-fc25c89f0f34/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4cbfd7f-936d-4f92-a501-77cae959978d>.
+    
+<http://data.lblod.info/id/remote-data-objects/93b853fe-9df7-4ed1-bdb6-3891044e43f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93b853fe-9df7-4ed1-bdb6-3891044e43f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/7f2d4e09-dad6-4374-833b-dc5c32a77cbc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93b853fe-9df7-4ed1-bdb6-3891044e43f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e92e240-8032-4519-861b-541f235bb734> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e92e240-8032-4519-861b-541f235bb734";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/848ea2fe-a3eb-4684-9062-a60eb25ad207/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e92e240-8032-4519-861b-541f235bb734>.
+    
+<http://data.lblod.info/id/remote-data-objects/b01adeb5-6cb1-420b-ba9b-546891d26e12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b01adeb5-6cb1-420b-ba9b-546891d26e12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/856b3340-f567-4de6-a7de-c151ff97f4e6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b01adeb5-6cb1-420b-ba9b-546891d26e12>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a68bdf6-7c6a-4137-b28a-c3ce4d77a000> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a68bdf6-7c6a-4137-b28a-c3ce4d77a000";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/873f7c3c-5932-46e6-ab04-5d4e55b4048a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a68bdf6-7c6a-4137-b28a-c3ce4d77a000>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a1fca12-47fb-489d-b973-ff9725957ffb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a1fca12-47fb-489d-b973-ff9725957ffb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/874f0365-304b-4289-a613-1a26ef2b3759/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a1fca12-47fb-489d-b973-ff9725957ffb>.
+    
+<http://data.lblod.info/id/remote-data-objects/0582bed8-d428-414c-8d91-8e87ecfbf634> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0582bed8-d428-414c-8d91-8e87ecfbf634";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/8819ee8a-b0d1-491d-b185-0925ff0016af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0582bed8-d428-414c-8d91-8e87ecfbf634>.
+    
+<http://data.lblod.info/id/remote-data-objects/564f0775-22e6-46a8-bab1-41b1c0b1cf1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "564f0775-22e6-46a8-bab1-41b1c0b1cf1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/8c94dde8-989e-4c27-be96-1eb23a275be5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/564f0775-22e6-46a8-bab1-41b1c0b1cf1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/20f4c006-f546-4a95-87e8-7408c77cce19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20f4c006-f546-4a95-87e8-7408c77cce19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/8ebb9095-945e-4577-8f32-0ed842716ace/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20f4c006-f546-4a95-87e8-7408c77cce19>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bd3e5ba-26df-4ea2-902c-2146031f7ae0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bd3e5ba-26df-4ea2-902c-2146031f7ae0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/9122ef79-638f-4c8e-80fa-976c39c80498/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bd3e5ba-26df-4ea2-902c-2146031f7ae0>.
+    
+<http://data.lblod.info/id/remote-data-objects/91f05fa5-b62f-48a9-b41d-90fc1ee740c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91f05fa5-b62f-48a9-b41d-90fc1ee740c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/929c1662-018f-4190-98d9-8d659e02236c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91f05fa5-b62f-48a9-b41d-90fc1ee740c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d16b3b77-83fa-48df-86e9-a48ace9cf3ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d16b3b77-83fa-48df-86e9-a48ace9cf3ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/94a46dec-b6b3-4eb3-a0c7-a1ab4ea062bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d16b3b77-83fa-48df-86e9-a48ace9cf3ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/acf70d90-eeb7-4c2e-bd9a-0b220d351fce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acf70d90-eeb7-4c2e-bd9a-0b220d351fce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/9df8a794-a788-4619-8afe-2d25b6c6ea3e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acf70d90-eeb7-4c2e-bd9a-0b220d351fce>.
+    
+<http://data.lblod.info/id/remote-data-objects/df33cfd5-577f-4b5d-8f5a-a3bca12aa815> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df33cfd5-577f-4b5d-8f5a-a3bca12aa815";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/9eb0ba11-5c66-4521-9dd5-03b64fbfead8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df33cfd5-577f-4b5d-8f5a-a3bca12aa815>.
+    
+<http://data.lblod.info/id/remote-data-objects/be60915d-e1fb-4c0b-b6e6-b464bd7bb67e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be60915d-e1fb-4c0b-b6e6-b464bd7bb67e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/a1498e9c-b7b1-4014-9ff0-11c2deaebba9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be60915d-e1fb-4c0b-b6e6-b464bd7bb67e>.
+    
+<http://data.lblod.info/id/remote-data-objects/73eae5a1-64bb-42c1-b623-5caadd1e1d59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73eae5a1-64bb-42c1-b623-5caadd1e1d59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/a1cb7129-ea93-43dc-a6f3-930f0f98fdb3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73eae5a1-64bb-42c1-b623-5caadd1e1d59>.
+    
+<http://data.lblod.info/id/remote-data-objects/8da9487d-3bc6-4588-a548-9b1aa22d5454> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8da9487d-3bc6-4588-a548-9b1aa22d5454";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/a21381db-72bb-4574-a482-de6eb1ada5aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8da9487d-3bc6-4588-a548-9b1aa22d5454>.
+    
+<http://data.lblod.info/id/remote-data-objects/15bd6c7b-0f78-4e36-af96-9d942537b6af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15bd6c7b-0f78-4e36-af96-9d942537b6af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/a288def7-9d5b-4e47-b0aa-17f71fe784e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15bd6c7b-0f78-4e36-af96-9d942537b6af>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2af3ad5-4935-4407-8497-76c41f63857a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2af3ad5-4935-4407-8497-76c41f63857a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/a29a3328-3899-4618-917f-2db87aded069/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/291e2d4f-7ca9-4df1-9d45-1b6019d2aadf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2af3ad5-4935-4407-8497-76c41f63857a>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201151-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201151-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201151-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201151-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b01b3611-86b3-45d4-8ee7-5f274054a5be> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b01b3611-86b3-45d4-8ee7-5f274054a5be";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cd47aed6-012d-463e-9f55-601fa4474b3d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/39f38134-e2d9-480c-a469-120e6500b4b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "39f38134-e2d9-480c-a469-120e6500b4b1";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d>.
+
+  <http://redpencil.data.gift/id/task/c7f59e1c-ffb9-4be5-83aa-f2ff3947ce7f> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c7f59e1c-ffb9-4be5-83aa-f2ff3947ce7f";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b01b3611-86b3-45d4-8ee7-5f274054a5be>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/39f38134-e2d9-480c-a469-120e6500b4b1>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/38c6e4e0-ae2d-40c1-afff-50ca8e583e9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38c6e4e0-ae2d-40c1-afff-50ca8e583e9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/b054b4fa-7979-49ac-b7f9-49c2480ed269/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38c6e4e0-ae2d-40c1-afff-50ca8e583e9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/22de283c-8c6e-4f50-85be-21cc0b95e19f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22de283c-8c6e-4f50-85be-21cc0b95e19f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/b19b1053-3031-4fc7-a07f-69a2d30cf9a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22de283c-8c6e-4f50-85be-21cc0b95e19f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d510d251-7ce8-4a14-a9dd-6a34bcb5f37a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d510d251-7ce8-4a14-a9dd-6a34bcb5f37a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/b3b4f738-de94-41cf-a70f-6d31023bc450/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d510d251-7ce8-4a14-a9dd-6a34bcb5f37a>.
+    
+<http://data.lblod.info/id/remote-data-objects/df4adb5e-238f-4b22-9cb3-45fb8e28ab79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df4adb5e-238f-4b22-9cb3-45fb8e28ab79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/b4912841-0a40-457f-b932-dbae21b00be7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df4adb5e-238f-4b22-9cb3-45fb8e28ab79>.
+    
+<http://data.lblod.info/id/remote-data-objects/c08f4cdb-0f8a-4cc4-9562-bb82e7e3da7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c08f4cdb-0f8a-4cc4-9562-bb82e7e3da7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/b9178854-3826-4ae1-b6f5-8026b0e2c773/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c08f4cdb-0f8a-4cc4-9562-bb82e7e3da7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bec4403-ad18-4c5b-8590-8f28e10c9d61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bec4403-ad18-4c5b-8590-8f28e10c9d61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/bc693191-be78-46b5-82e6-a93a1daa6f31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bec4403-ad18-4c5b-8590-8f28e10c9d61>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9fed11d-6793-4943-aac8-044ce3d85584> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9fed11d-6793-4943-aac8-044ce3d85584";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/be444aba-7ec4-4e84-a22e-4eb060640636/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9fed11d-6793-4943-aac8-044ce3d85584>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8279b17-c379-4ca9-8bd2-a8fbc4b70595> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8279b17-c379-4ca9-8bd2-a8fbc4b70595";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/c050f4e3-c50e-4292-b81c-e39cdfd2baed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8279b17-c379-4ca9-8bd2-a8fbc4b70595>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c5393d3-ce76-498c-a012-0f2e35a79898> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c5393d3-ce76-498c-a012-0f2e35a79898";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/c23fb651-61e6-4c5c-a699-e91f8f689473/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c5393d3-ce76-498c-a012-0f2e35a79898>.
+    
+<http://data.lblod.info/id/remote-data-objects/c33a3cfd-b5fc-48d6-80ab-ad8a123444d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c33a3cfd-b5fc-48d6-80ab-ad8a123444d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/c8f776ed-0e1c-49e6-8b06-a701f839346c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c33a3cfd-b5fc-48d6-80ab-ad8a123444d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd60dd30-443e-407a-9c94-efd8ab4df05d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd60dd30-443e-407a-9c94-efd8ab4df05d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/ca4ab716-ecd4-40ea-9598-20ec907e5ce4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd60dd30-443e-407a-9c94-efd8ab4df05d>.
+    
+<http://data.lblod.info/id/remote-data-objects/661c4ba0-32e6-4e16-98e5-320aed6810e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "661c4ba0-32e6-4e16-98e5-320aed6810e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/d8522360-2a65-4423-ac54-b521b593ecc7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/661c4ba0-32e6-4e16-98e5-320aed6810e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/af491146-b53b-40e9-b18c-d448de570669> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af491146-b53b-40e9-b18c-d448de570669";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/d938214b-2d80-49c5-a767-5938490d28d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af491146-b53b-40e9-b18c-d448de570669>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f4cb471-11a5-449c-aef0-34129b92a632> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f4cb471-11a5-449c-aef0-34129b92a632";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/e5e72d78-0fee-44ef-864e-343ecb450317/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f4cb471-11a5-449c-aef0-34129b92a632>.
+    
+<http://data.lblod.info/id/remote-data-objects/5790ffa0-a5fd-4df5-8937-eb245c5d0bb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5790ffa0-a5fd-4df5-8937-eb245c5d0bb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/e93abd9d-7a15-49f2-9a21-df2957a36994/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5790ffa0-a5fd-4df5-8937-eb245c5d0bb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/24f28588-a9bb-4985-a3e3-a1de4a9ae510> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24f28588-a9bb-4985-a3e3-a1de4a9ae510";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/ea6973dd-c11e-433f-9cab-298f293ad9f8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24f28588-a9bb-4985-a3e3-a1de4a9ae510>.
+    
+<http://data.lblod.info/id/remote-data-objects/cac2b3d5-5822-4e10-912e-907d100c748b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cac2b3d5-5822-4e10-912e-907d100c748b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/f561b743-7ed4-4bed-b5ae-47f211475ac3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cac2b3d5-5822-4e10-912e-907d100c748b>.
+    
+<http://data.lblod.info/id/remote-data-objects/afc7a0ed-6f08-486a-81b9-b50269eef7af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afc7a0ed-6f08-486a-81b9-b50269eef7af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/f636fdff-e2e2-4294-94c8-7cdd1ee45154/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afc7a0ed-6f08-486a-81b9-b50269eef7af>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4046742-4aa0-4732-bf58-ed74666ba866> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4046742-4aa0-4732-bf58-ed74666ba866";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/f7f934f3-a753-4933-a1a9-fc2d39d37f79/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4046742-4aa0-4732-bf58-ed74666ba866>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1700229-2f84-4729-b382-2c2efe40e11e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1700229-2f84-4729-b382-2c2efe40e11e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/f810f2b5-22a0-45eb-a345-cff786df36cc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1700229-2f84-4729-b382-2c2efe40e11e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccd93398-287e-4329-9976-98dac34acf00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccd93398-287e-4329-9976-98dac34acf00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/cbs/fa9efb70-7b0c-45a2-8456-c49198e0a89a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccd93398-287e-4329-9976-98dac34acf00>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7705e8b-8fbc-4657-ad12-52cf29a44142> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7705e8b-8fbc-4657-ad12-52cf29a44142";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/3693bb6e-5290-4a31-ac20-488fb456cc06/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7705e8b-8fbc-4657-ad12-52cf29a44142>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a569cc2-7899-4b3b-b26e-cf9e37940ded> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a569cc2-7899-4b3b-b26e-cf9e37940ded";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/3693bb6e-5290-4a31-ac20-488fb456cc06/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a569cc2-7899-4b3b-b26e-cf9e37940ded>.
+    
+<http://data.lblod.info/id/remote-data-objects/220ca5a1-7c3a-4cc1-a9e9-847ae5aeb2ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "220ca5a1-7c3a-4cc1-a9e9-847ae5aeb2ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/3693bb6e-5290-4a31-ac20-488fb456cc06/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/220ca5a1-7c3a-4cc1-a9e9-847ae5aeb2ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/03b00baf-c778-4fac-b1fd-e9161a129638> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03b00baf-c778-4fac-b1fd-e9161a129638";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/45c8e37f-0a9b-424a-bb25-98e873149073/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03b00baf-c778-4fac-b1fd-e9161a129638>.
+    
+<http://data.lblod.info/id/remote-data-objects/198d710d-74e4-4a69-8871-db42faa3f51c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "198d710d-74e4-4a69-8871-db42faa3f51c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/45c8e37f-0a9b-424a-bb25-98e873149073/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/198d710d-74e4-4a69-8871-db42faa3f51c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f131a98-c242-4ecc-81ce-b3221bc77925> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f131a98-c242-4ecc-81ce-b3221bc77925";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/45c8e37f-0a9b-424a-bb25-98e873149073/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f131a98-c242-4ecc-81ce-b3221bc77925>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ce2251a-201f-4225-8b12-9b2c9ea28c8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ce2251a-201f-4225-8b12-9b2c9ea28c8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/625b5542-194c-4154-b188-2731465e8591/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ce2251a-201f-4225-8b12-9b2c9ea28c8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9153d19-1560-41f6-8916-4e1466d5bb54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9153d19-1560-41f6-8916-4e1466d5bb54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/625b5542-194c-4154-b188-2731465e8591/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9153d19-1560-41f6-8916-4e1466d5bb54>.
+    
+<http://data.lblod.info/id/remote-data-objects/0acbb5a4-f035-4bdb-b713-4870636e5187> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0acbb5a4-f035-4bdb-b713-4870636e5187";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/625b5542-194c-4154-b188-2731465e8591/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0acbb5a4-f035-4bdb-b713-4870636e5187>.
+    
+<http://data.lblod.info/id/remote-data-objects/754fd0e6-e8ea-4096-aae7-7200d90567e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "754fd0e6-e8ea-4096-aae7-7200d90567e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/6e660410-7228-4b2a-a721-9427d0290f94/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/754fd0e6-e8ea-4096-aae7-7200d90567e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/94086f53-f81c-4555-813a-704b7691633b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94086f53-f81c-4555-813a-704b7691633b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/6e660410-7228-4b2a-a721-9427d0290f94/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94086f53-f81c-4555-813a-704b7691633b>.
+    
+<http://data.lblod.info/id/remote-data-objects/858459a6-61b1-4b48-9f69-e415617ca94e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "858459a6-61b1-4b48-9f69-e415617ca94e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/6e660410-7228-4b2a-a721-9427d0290f94/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/858459a6-61b1-4b48-9f69-e415617ca94e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dd04b7b-fff2-4e83-954e-be8d9fa1f535> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dd04b7b-fff2-4e83-954e-be8d9fa1f535";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/7d54b566-db34-4630-973a-c355f0e84c43/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dd04b7b-fff2-4e83-954e-be8d9fa1f535>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fdf4560-7959-4c5b-bfa8-900d95cd20ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fdf4560-7959-4c5b-bfa8-900d95cd20ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/7d54b566-db34-4630-973a-c355f0e84c43/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fdf4560-7959-4c5b-bfa8-900d95cd20ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6352691-f6a3-4b71-a888-eb7dc8ec4e57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6352691-f6a3-4b71-a888-eb7dc8ec4e57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/7d54b566-db34-4630-973a-c355f0e84c43/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6352691-f6a3-4b71-a888-eb7dc8ec4e57>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9a52221-fbc9-46a0-bab2-dcf180de192e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9a52221-fbc9-46a0-bab2-dcf180de192e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/846b95b7-6e58-485e-aaab-a16864a85882/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9a52221-fbc9-46a0-bab2-dcf180de192e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b59d6dca-0648-4825-b73b-16bfe8651c87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b59d6dca-0648-4825-b73b-16bfe8651c87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/846b95b7-6e58-485e-aaab-a16864a85882/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b59d6dca-0648-4825-b73b-16bfe8651c87>.
+    
+<http://data.lblod.info/id/remote-data-objects/21382138-5f7c-4361-84dc-1f1e70a363e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21382138-5f7c-4361-84dc-1f1e70a363e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/846b95b7-6e58-485e-aaab-a16864a85882/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21382138-5f7c-4361-84dc-1f1e70a363e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7f10de9-ef84-4617-bf15-59d524129d07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7f10de9-ef84-4617-bf15-59d524129d07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/9bc76147-408f-4b74-9f8d-72089ae06a44/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7f10de9-ef84-4617-bf15-59d524129d07>.
+    
+<http://data.lblod.info/id/remote-data-objects/22e0aedd-a8fd-4848-8f43-f3b92ccbb549> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22e0aedd-a8fd-4848-8f43-f3b92ccbb549";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/9bc76147-408f-4b74-9f8d-72089ae06a44/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22e0aedd-a8fd-4848-8f43-f3b92ccbb549>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1ba4c1c-555a-4034-9680-5ac56d5de6eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1ba4c1c-555a-4034-9680-5ac56d5de6eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/9bc76147-408f-4b74-9f8d-72089ae06a44/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1ba4c1c-555a-4034-9680-5ac56d5de6eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/40e1321d-fc54-4891-9367-252e62f24813> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40e1321d-fc54-4891-9367-252e62f24813";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/a59fd158-91e3-45c0-a11c-819cd00d4fa6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40e1321d-fc54-4891-9367-252e62f24813>.
+    
+<http://data.lblod.info/id/remote-data-objects/485f89fd-5d53-4822-a1f2-a3956c466b7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "485f89fd-5d53-4822-a1f2-a3956c466b7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/a59fd158-91e3-45c0-a11c-819cd00d4fa6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/485f89fd-5d53-4822-a1f2-a3956c466b7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9052e885-406c-4ae8-9c41-380a701fb6ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9052e885-406c-4ae8-9c41-380a701fb6ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/a59fd158-91e3-45c0-a11c-819cd00d4fa6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9052e885-406c-4ae8-9c41-380a701fb6ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6bac4d6-ec0f-45c0-86b6-36b3d1be5634> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6bac4d6-ec0f-45c0-86b6-36b3d1be5634";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/b2e8449f-1281-4741-b5f0-389c11d7ed09/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6bac4d6-ec0f-45c0-86b6-36b3d1be5634>.
+    
+<http://data.lblod.info/id/remote-data-objects/055f03aa-3abd-4934-b6b3-41bd7d3a1d63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "055f03aa-3abd-4934-b6b3-41bd7d3a1d63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/b2e8449f-1281-4741-b5f0-389c11d7ed09/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/055f03aa-3abd-4934-b6b3-41bd7d3a1d63>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7856a3b-c4b8-4335-8b93-8ed11fcd33cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7856a3b-c4b8-4335-8b93-8ed11fcd33cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/b2e8449f-1281-4741-b5f0-389c11d7ed09/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7856a3b-c4b8-4335-8b93-8ed11fcd33cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/932fa439-ecaf-4b4c-84e4-4d50206f909c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "932fa439-ecaf-4b4c-84e4-4d50206f909c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/b43c65b4-3c01-4df6-85eb-f757ab61155d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/932fa439-ecaf-4b4c-84e4-4d50206f909c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fa4e918-bc8a-4e6d-a600-85e17b921c4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fa4e918-bc8a-4e6d-a600-85e17b921c4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/b43c65b4-3c01-4df6-85eb-f757ab61155d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd47aed6-012d-463e-9f55-601fa4474b3d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fa4e918-bc8a-4e6d-a600-85e17b921c4b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201152-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201152-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201152-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201152-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/0c59be02-0609-4fc5-a882-f7e6eb47e272> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0c59be02-0609-4fc5-a882-f7e6eb47e272";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f3e8dbe8-e243-4c33-a63c-27fba02b00af";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/829a8d65-363f-415a-88df-b0b64c76e696> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "829a8d65-363f-415a-88df-b0b64c76e696";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af>.
+
+  <http://redpencil.data.gift/id/task/81d053b6-47cb-4601-9a40-936ac2c4ced4> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "81d053b6-47cb-4601-9a40-936ac2c4ced4";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/0c59be02-0609-4fc5-a882-f7e6eb47e272>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/829a8d65-363f-415a-88df-b0b64c76e696>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/f1339e9e-118e-4582-bfa8-9bb6d8a11f9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1339e9e-118e-4582-bfa8-9bb6d8a11f9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/b43c65b4-3c01-4df6-85eb-f757ab61155d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1339e9e-118e-4582-bfa8-9bb6d8a11f9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9c91987-f9f0-43d2-8dc6-abf1c2342810> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9c91987-f9f0-43d2-8dc6-abf1c2342810";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/b5bd6614-a31d-4d23-80b2-f1b52dd8b4b7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9c91987-f9f0-43d2-8dc6-abf1c2342810>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b61d28b-3e23-4957-96ee-3bcd454cc466> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b61d28b-3e23-4957-96ee-3bcd454cc466";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/b5bd6614-a31d-4d23-80b2-f1b52dd8b4b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b61d28b-3e23-4957-96ee-3bcd454cc466>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb0aea26-bc06-44c8-8214-457a1c2742d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb0aea26-bc06-44c8-8214-457a1c2742d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/b5bd6614-a31d-4d23-80b2-f1b52dd8b4b7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb0aea26-bc06-44c8-8214-457a1c2742d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/65866e87-68f0-4d26-bf5f-52e95cea9a36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65866e87-68f0-4d26-bf5f-52e95cea9a36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/bceeb53b-581b-4507-8254-62bf234b070e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65866e87-68f0-4d26-bf5f-52e95cea9a36>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd5aa979-0097-4e09-8382-7212befb1269> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd5aa979-0097-4e09-8382-7212befb1269";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/bceeb53b-581b-4507-8254-62bf234b070e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd5aa979-0097-4e09-8382-7212befb1269>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3aaed85-3c3c-4117-9adf-ba4116544153> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3aaed85-3c3c-4117-9adf-ba4116544153";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/e9b3bd26-15ba-487c-9338-9dd4bc30e557/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3aaed85-3c3c-4117-9adf-ba4116544153>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a3d52e1-f95c-4a0f-b591-be2bb697a39a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a3d52e1-f95c-4a0f-b591-be2bb697a39a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/e9b3bd26-15ba-487c-9338-9dd4bc30e557/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a3d52e1-f95c-4a0f-b591-be2bb697a39a>.
+    
+<http://data.lblod.info/id/remote-data-objects/276cc061-ee31-4773-9eef-875d43ec9195> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "276cc061-ee31-4773-9eef-875d43ec9195";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/e9b3bd26-15ba-487c-9338-9dd4bc30e557/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/276cc061-ee31-4773-9eef-875d43ec9195>.
+    
+<http://data.lblod.info/id/remote-data-objects/a23fbad9-c95b-4b7f-baaf-8a390b330ac4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a23fbad9-c95b-4b7f-baaf-8a390b330ac4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/ee535294-6d6b-4982-8e7b-08daf21b984d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a23fbad9-c95b-4b7f-baaf-8a390b330ac4>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bc03e57-c94d-47f7-8d57-22b0853d65ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bc03e57-c94d-47f7-8d57-22b0853d65ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/ee535294-6d6b-4982-8e7b-08daf21b984d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bc03e57-c94d-47f7-8d57-22b0853d65ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9831608-eaa1-4512-938c-03029c742b1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9831608-eaa1-4512-938c-03029c742b1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/ee535294-6d6b-4982-8e7b-08daf21b984d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9831608-eaa1-4512-938c-03029c742b1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/27d55eb0-df03-438a-a155-8884c38eacdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27d55eb0-df03-438a-a155-8884c38eacdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/f90b06da-a599-4661-9eb2-b8d0b2feb8fb/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27d55eb0-df03-438a-a155-8884c38eacdf>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f658894-3797-4d2a-b77a-65cc7f237926> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f658894-3797-4d2a-b77a-65cc7f237926";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/f90b06da-a599-4661-9eb2-b8d0b2feb8fb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f658894-3797-4d2a-b77a-65cc7f237926>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d5bced2-e9ae-430c-afd8-9ebf811f0f17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d5bced2-e9ae-430c-afd8-9ebf811f0f17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/gr/f90b06da-a599-4661-9eb2-b8d0b2feb8fb/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d5bced2-e9ae-430c-afd8-9ebf811f0f17>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8060581-819f-441a-9607-b0aaf40e638c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8060581-819f-441a-9607-b0aaf40e638c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/04d6a58a-435a-4df2-9e25-c0ca79145cd1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8060581-819f-441a-9607-b0aaf40e638c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea1cd528-a467-4cd3-8d16-cf27883dd87b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea1cd528-a467-4cd3-8d16-cf27883dd87b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/04d6a58a-435a-4df2-9e25-c0ca79145cd1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea1cd528-a467-4cd3-8d16-cf27883dd87b>.
+    
+<http://data.lblod.info/id/remote-data-objects/31b82bda-776a-43b1-b26a-41211350ae33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31b82bda-776a-43b1-b26a-41211350ae33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/04d6a58a-435a-4df2-9e25-c0ca79145cd1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31b82bda-776a-43b1-b26a-41211350ae33>.
+    
+<http://data.lblod.info/id/remote-data-objects/70d38804-7ff8-4252-b315-6aabb28872e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70d38804-7ff8-4252-b315-6aabb28872e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/1b833a87-d2c6-4c0a-85df-fed5154e0104/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70d38804-7ff8-4252-b315-6aabb28872e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/797f08b4-a16f-43a3-b719-2e6cbc48e6e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "797f08b4-a16f-43a3-b719-2e6cbc48e6e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/1b833a87-d2c6-4c0a-85df-fed5154e0104/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/797f08b4-a16f-43a3-b719-2e6cbc48e6e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/21051608-9e9b-4751-be2e-b06cd1cdcd0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21051608-9e9b-4751-be2e-b06cd1cdcd0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/1b833a87-d2c6-4c0a-85df-fed5154e0104/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21051608-9e9b-4751-be2e-b06cd1cdcd0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/468640d4-7ad6-486a-ace9-107c9cc451fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "468640d4-7ad6-486a-ace9-107c9cc451fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/34fea615-108f-41a8-a858-52f8b0b66b66/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/468640d4-7ad6-486a-ace9-107c9cc451fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e19a087-f539-4c4e-a5d2-73bd761cba4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e19a087-f539-4c4e-a5d2-73bd761cba4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/34fea615-108f-41a8-a858-52f8b0b66b66/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e19a087-f539-4c4e-a5d2-73bd761cba4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a36a25c-50ce-4ce2-ab90-6a46143092c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a36a25c-50ce-4ce2-ab90-6a46143092c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/34fea615-108f-41a8-a858-52f8b0b66b66/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a36a25c-50ce-4ce2-ab90-6a46143092c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a842c2a-bae8-4a77-aae5-88b4fef9e586> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a842c2a-bae8-4a77-aae5-88b4fef9e586";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/3c9836ef-9bda-40aa-8bcf-2ac7366cd425/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a842c2a-bae8-4a77-aae5-88b4fef9e586>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc4c0d71-ef5e-4c27-a543-feb902d5913f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc4c0d71-ef5e-4c27-a543-feb902d5913f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/3c9836ef-9bda-40aa-8bcf-2ac7366cd425/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc4c0d71-ef5e-4c27-a543-feb902d5913f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c07499d-ea11-4932-b968-51d4273ac8f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c07499d-ea11-4932-b968-51d4273ac8f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/3c9836ef-9bda-40aa-8bcf-2ac7366cd425/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c07499d-ea11-4932-b968-51d4273ac8f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0979296-b2eb-4fdd-8b3d-ec0b37b26f8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0979296-b2eb-4fdd-8b3d-ec0b37b26f8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/539b4d9c-3ae2-4115-86e4-fa828f7b2ac2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0979296-b2eb-4fdd-8b3d-ec0b37b26f8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0e6c3a8-8fc5-4cf3-b4f2-d09198fd2c70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0e6c3a8-8fc5-4cf3-b4f2-d09198fd2c70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/539b4d9c-3ae2-4115-86e4-fa828f7b2ac2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0e6c3a8-8fc5-4cf3-b4f2-d09198fd2c70>.
+    
+<http://data.lblod.info/id/remote-data-objects/8aa78f83-a462-4e84-bea4-1c3cde21d3d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8aa78f83-a462-4e84-bea4-1c3cde21d3d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/539b4d9c-3ae2-4115-86e4-fa828f7b2ac2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8aa78f83-a462-4e84-bea4-1c3cde21d3d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/26d65ac2-bf7a-4138-a6da-184066df7a79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26d65ac2-bf7a-4138-a6da-184066df7a79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/6fb79fac-6104-433d-9e45-464c5ca6c964/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26d65ac2-bf7a-4138-a6da-184066df7a79>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd6c5a64-1879-45bf-9150-12196be7b61d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd6c5a64-1879-45bf-9150-12196be7b61d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/6fb79fac-6104-433d-9e45-464c5ca6c964/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd6c5a64-1879-45bf-9150-12196be7b61d>.
+    
+<http://data.lblod.info/id/remote-data-objects/41d5583b-93c2-4968-9e22-9c9390bd7f85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41d5583b-93c2-4968-9e22-9c9390bd7f85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/6fb79fac-6104-433d-9e45-464c5ca6c964/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41d5583b-93c2-4968-9e22-9c9390bd7f85>.
+    
+<http://data.lblod.info/id/remote-data-objects/e761ce5c-8e5e-4b8e-b788-5c77e13f5933> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e761ce5c-8e5e-4b8e-b788-5c77e13f5933";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/74ddb8fc-07a2-4c83-9174-620dc05e4b82/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e761ce5c-8e5e-4b8e-b788-5c77e13f5933>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed2b88b9-5794-4668-a94b-fbede30e5fab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed2b88b9-5794-4668-a94b-fbede30e5fab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/74ddb8fc-07a2-4c83-9174-620dc05e4b82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed2b88b9-5794-4668-a94b-fbede30e5fab>.
+    
+<http://data.lblod.info/id/remote-data-objects/67e93706-d678-4f92-add8-0d5c33a379c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67e93706-d678-4f92-add8-0d5c33a379c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/74ddb8fc-07a2-4c83-9174-620dc05e4b82/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67e93706-d678-4f92-add8-0d5c33a379c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/70b07258-d38b-43dc-8d11-b6c25362685a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70b07258-d38b-43dc-8d11-b6c25362685a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/ad422872-04c9-4569-afd0-0fd80f55370c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70b07258-d38b-43dc-8d11-b6c25362685a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b481206-ae51-4d67-9ee6-c708280f4282> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b481206-ae51-4d67-9ee6-c708280f4282";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/ad422872-04c9-4569-afd0-0fd80f55370c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b481206-ae51-4d67-9ee6-c708280f4282>.
+    
+<http://data.lblod.info/id/remote-data-objects/4535ef53-86cd-4113-aeac-d10d65885194> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4535ef53-86cd-4113-aeac-d10d65885194";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/ad422872-04c9-4569-afd0-0fd80f55370c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4535ef53-86cd-4113-aeac-d10d65885194>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3e52c50-44e1-4e1c-bd17-b27edd8d05e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3e52c50-44e1-4e1c-bd17-b27edd8d05e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/c4956e4c-27f8-4578-86dd-9698a64feb56/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3e52c50-44e1-4e1c-bd17-b27edd8d05e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ebe2549-8fb8-49e4-af0c-1dfba2ccdf17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ebe2549-8fb8-49e4-af0c-1dfba2ccdf17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/c4956e4c-27f8-4578-86dd-9698a64feb56/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ebe2549-8fb8-49e4-af0c-1dfba2ccdf17>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bb4effa-7ed2-4a8e-a7ff-f8e3aefb7df0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bb4effa-7ed2-4a8e-a7ff-f8e3aefb7df0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/c64ed679-7208-482a-a068-7c5c7b00a372/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bb4effa-7ed2-4a8e-a7ff-f8e3aefb7df0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f280d8d0-acc3-47c0-a791-8986b26ce804> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f280d8d0-acc3-47c0-a791-8986b26ce804";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/c64ed679-7208-482a-a068-7c5c7b00a372/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f280d8d0-acc3-47c0-a791-8986b26ce804>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e18919b-7bce-4ab9-b602-4e7c5f24ca2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e18919b-7bce-4ab9-b602-4e7c5f24ca2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/c64ed679-7208-482a-a068-7c5c7b00a372/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e18919b-7bce-4ab9-b602-4e7c5f24ca2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/cde00678-1a05-49f0-994a-f3c231cd4cb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cde00678-1a05-49f0-994a-f3c231cd4cb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/da0ac5ee-63ff-405c-ad74-4932bad26aff/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cde00678-1a05-49f0-994a-f3c231cd4cb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c54a60f9-44f2-44c1-9e0e-c389204dab23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c54a60f9-44f2-44c1-9e0e-c389204dab23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/da0ac5ee-63ff-405c-ad74-4932bad26aff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c54a60f9-44f2-44c1-9e0e-c389204dab23>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a02ef03-5b8d-45a8-8e64-067a60705877> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a02ef03-5b8d-45a8-8e64-067a60705877";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/da0ac5ee-63ff-405c-ad74-4932bad26aff/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a02ef03-5b8d-45a8-8e64-067a60705877>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a8209e3-ae4f-4054-a625-126e4b9bf862> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a8209e3-ae4f-4054-a625-126e4b9bf862";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/e3ac2a49-7248-4306-9170-4de70c3a166a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a8209e3-ae4f-4054-a625-126e4b9bf862>.
+    
+<http://data.lblod.info/id/remote-data-objects/69828fb3-7786-4113-ac12-36f3b0e90cde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69828fb3-7786-4113-ac12-36f3b0e90cde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/e3ac2a49-7248-4306-9170-4de70c3a166a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69828fb3-7786-4113-ac12-36f3b0e90cde>.
+    
+<http://data.lblod.info/id/remote-data-objects/895a5fba-bbda-4da7-810d-76735b59dccf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "895a5fba-bbda-4da7-810d-76735b59dccf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/e3ac2a49-7248-4306-9170-4de70c3a166a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f3e8dbe8-e243-4c33-a63c-27fba02b00af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/895a5fba-bbda-4da7-810d-76735b59dccf>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201153-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201153-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201153-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201153-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e70712e7-e25f-4759-a518-31077f16f111> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e70712e7-e25f-4759-a518-31077f16f111";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "127300c5-0843-482b-b3b7-105c16377f25";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/762b47bd-fdb3-4970-8fb2-6023e520d388> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "762b47bd-fdb3-4970-8fb2-6023e520d388";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25>.
+
+  <http://redpencil.data.gift/id/task/43882043-7320-4980-8a67-1cb0787b4e28> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "43882043-7320-4980-8a67-1cb0787b4e28";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e70712e7-e25f-4759-a518-31077f16f111>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/762b47bd-fdb3-4970-8fb2-6023e520d388>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/8e741b27-e7c5-42a1-af34-dcfb7eddec98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e741b27-e7c5-42a1-af34-dcfb7eddec98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/ee6c362c-1b27-49c2-a1e3-b26ee8dd33f9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e741b27-e7c5-42a1-af34-dcfb7eddec98>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb6aa5ab-6468-4854-9a8d-cd21f15f8e02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb6aa5ab-6468-4854-9a8d-cd21f15f8e02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/ee6c362c-1b27-49c2-a1e3-b26ee8dd33f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb6aa5ab-6468-4854-9a8d-cd21f15f8e02>.
+    
+<http://data.lblod.info/id/remote-data-objects/63b27704-9bfb-4606-8c3a-4bbbaff21b00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63b27704-9bfb-4606-8c3a-4bbbaff21b00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/ee6c362c-1b27-49c2-a1e3-b26ee8dd33f9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63b27704-9bfb-4606-8c3a-4bbbaff21b00>.
+    
+<http://data.lblod.info/id/remote-data-objects/19d09858-a8a8-4ac5-86f2-0e8dc4e46693> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19d09858-a8a8-4ac5-86f2-0e8dc4e46693";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/efe8906f-8b6b-40c3-90de-b3aa22a47d6e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19d09858-a8a8-4ac5-86f2-0e8dc4e46693>.
+    
+<http://data.lblod.info/id/remote-data-objects/188ef76a-c645-4431-a6c6-9752251686e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "188ef76a-c645-4431-a6c6-9752251686e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/efe8906f-8b6b-40c3-90de-b3aa22a47d6e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/188ef76a-c645-4431-a6c6-9752251686e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/08cf118d-ad72-4b5e-8d72-0f9bc0724506> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08cf118d-ad72-4b5e-8d72-0f9bc0724506";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/or/efe8906f-8b6b-40c3-90de-b3aa22a47d6e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08cf118d-ad72-4b5e-8d72-0f9bc0724506>.
+    
+<http://data.lblod.info/id/remote-data-objects/7263b9ee-3085-4c55-bd01-f0de28400a50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7263b9ee-3085-4c55-bd01-f0de28400a50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/05970217-eda4-4db2-a8a3-75043097ac64/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7263b9ee-3085-4c55-bd01-f0de28400a50>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9b89867-e82c-486c-9b9e-e6dee4197474> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9b89867-e82c-486c-9b9e-e6dee4197474";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/076d3b3e-c7a3-45a8-95ef-6e32b2958623/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9b89867-e82c-486c-9b9e-e6dee4197474>.
+    
+<http://data.lblod.info/id/remote-data-objects/87d7bdf1-09a5-4622-9efe-bc77c334dcdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87d7bdf1-09a5-4622-9efe-bc77c334dcdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/0ad01dac-b1bc-45e6-b95c-454e405de5d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87d7bdf1-09a5-4622-9efe-bc77c334dcdf>.
+    
+<http://data.lblod.info/id/remote-data-objects/badbf23d-60ac-4a8b-afc0-03557610d9f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "badbf23d-60ac-4a8b-afc0-03557610d9f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/0cb32370-1d7b-4be0-9990-18b91a3c3b5c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/badbf23d-60ac-4a8b-afc0-03557610d9f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/867fd206-e690-4e30-93b8-846c6a37c93d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "867fd206-e690-4e30-93b8-846c6a37c93d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/0f56dd29-d6b4-449e-9a44-fd0796aafe32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/867fd206-e690-4e30-93b8-846c6a37c93d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea1f38e4-a2cd-44e8-b99c-70586d812655> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea1f38e4-a2cd-44e8-b99c-70586d812655";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/104c2c56-c64e-4cdf-9f56-6e3951eda913/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea1f38e4-a2cd-44e8-b99c-70586d812655>.
+    
+<http://data.lblod.info/id/remote-data-objects/778efe2d-5188-40f7-a6ba-0018e8c4f01f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "778efe2d-5188-40f7-a6ba-0018e8c4f01f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/10579058-01d1-4f90-ab7b-38fcd83c3709/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/778efe2d-5188-40f7-a6ba-0018e8c4f01f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0afbc756-b44e-4b6b-9994-4b1d0cfc0af0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0afbc756-b44e-4b6b-9994-4b1d0cfc0af0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/12d271fd-38bd-4611-85f7-ed6f4edca600/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0afbc756-b44e-4b6b-9994-4b1d0cfc0af0>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5799fd5-4e68-4bfa-8a16-c45ab1b863ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5799fd5-4e68-4bfa-8a16-c45ab1b863ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/1424007c-8f54-482a-8dcd-c4a18c5a379e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5799fd5-4e68-4bfa-8a16-c45ab1b863ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1058078-c72f-4911-8e21-6b0e73e9161f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1058078-c72f-4911-8e21-6b0e73e9161f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/1aa667db-7769-49ab-9d0c-02c9df13f759/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1058078-c72f-4911-8e21-6b0e73e9161f>.
+    
+<http://data.lblod.info/id/remote-data-objects/694d21c8-82c2-411c-96ea-1627494e3023> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "694d21c8-82c2-411c-96ea-1627494e3023";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/1c4fe657-def2-4999-beee-010469a22e41/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/694d21c8-82c2-411c-96ea-1627494e3023>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dc982ba-806f-42bc-ada2-f8c408a11e1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dc982ba-806f-42bc-ada2-f8c408a11e1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/2c772ac0-bd4c-4c02-b7c3-3e0972749c71/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dc982ba-806f-42bc-ada2-f8c408a11e1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d26ad443-c783-4e08-95bd-8cf6b8d32ed9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d26ad443-c783-4e08-95bd-8cf6b8d32ed9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/38016203-86ff-4335-a191-7c5ce0f5990e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d26ad443-c783-4e08-95bd-8cf6b8d32ed9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5747bf3b-f9be-46e5-a0ce-0db2b6b62f97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5747bf3b-f9be-46e5-a0ce-0db2b6b62f97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/3a7bf6bc-8c3f-4c47-9282-8598874ad730/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5747bf3b-f9be-46e5-a0ce-0db2b6b62f97>.
+    
+<http://data.lblod.info/id/remote-data-objects/1af484d2-1055-41d6-bf0d-8703e5d9738f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1af484d2-1055-41d6-bf0d-8703e5d9738f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/3b8272c4-61f9-4d62-9f20-7a3ef3bce5fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1af484d2-1055-41d6-bf0d-8703e5d9738f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a887aeef-f9bc-445c-a055-a442a434b9cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a887aeef-f9bc-445c-a055-a442a434b9cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/3ee64dbd-172d-48b8-8e7c-8432ec373ad3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a887aeef-f9bc-445c-a055-a442a434b9cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8def409-78af-4107-96ba-45a775497e92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8def409-78af-4107-96ba-45a775497e92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/438b4d16-9daf-4b48-98d8-ed3cc0e7d4f0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8def409-78af-4107-96ba-45a775497e92>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a4b2851-6323-445e-b7f8-de1ccf53d7bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a4b2851-6323-445e-b7f8-de1ccf53d7bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/456d344d-b2df-472b-9a2d-bec0b43f8e3b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a4b2851-6323-445e-b7f8-de1ccf53d7bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/86c03c90-1640-42b0-ba55-cb7485a0cd50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86c03c90-1640-42b0-ba55-cb7485a0cd50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/47b0ef80-ed7d-4905-bca8-0e2cce22c341/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86c03c90-1640-42b0-ba55-cb7485a0cd50>.
+    
+<http://data.lblod.info/id/remote-data-objects/678be3e7-3063-418e-983f-03d009303582> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "678be3e7-3063-418e-983f-03d009303582";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/48fc3a13-b2d7-49c3-90db-84857961a80e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/678be3e7-3063-418e-983f-03d009303582>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac71bacf-211f-45d9-ba59-c4a4caf9d155> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac71bacf-211f-45d9-ba59-c4a4caf9d155";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/4907c9f6-ad49-4552-8b2e-c4069473da5f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac71bacf-211f-45d9-ba59-c4a4caf9d155>.
+    
+<http://data.lblod.info/id/remote-data-objects/45f85719-efd7-42d9-b928-0a64b563fbaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45f85719-efd7-42d9-b928-0a64b563fbaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/4b831006-e670-4f94-a698-edc505953b97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45f85719-efd7-42d9-b928-0a64b563fbaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ba884b2-1a46-43e8-8d91-f9d7bb036424> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ba884b2-1a46-43e8-8d91-f9d7bb036424";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/532c9450-e8d6-42ff-9540-96e9b2bc5b2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ba884b2-1a46-43e8-8d91-f9d7bb036424>.
+    
+<http://data.lblod.info/id/remote-data-objects/846aa549-9589-4b22-9011-be13a33a7e18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "846aa549-9589-4b22-9011-be13a33a7e18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/5a41bbd8-b40f-4352-8f4f-96317d9fc606/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/846aa549-9589-4b22-9011-be13a33a7e18>.
+    
+<http://data.lblod.info/id/remote-data-objects/1db0c1e8-c786-44d2-9dc6-2512777a0296> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1db0c1e8-c786-44d2-9dc6-2512777a0296";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/5beda5f7-5527-48e3-8d3e-c8d482ad7795/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1db0c1e8-c786-44d2-9dc6-2512777a0296>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5bca603-b7df-4aee-98e3-9b66de629397> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5bca603-b7df-4aee-98e3-9b66de629397";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/5f3333e3-c328-49b7-8a4e-2a31f7ac5f9b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5bca603-b7df-4aee-98e3-9b66de629397>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b7ea87f-5ff4-4e14-b2a9-8ac6bde8fcf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b7ea87f-5ff4-4e14-b2a9-8ac6bde8fcf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/65d1f3db-52d4-41c1-b1a3-54aa0720d740/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b7ea87f-5ff4-4e14-b2a9-8ac6bde8fcf9>.
+    
+<http://data.lblod.info/id/remote-data-objects/495ab93b-7380-4dad-9d27-f35d8f71fcea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "495ab93b-7380-4dad-9d27-f35d8f71fcea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/65dad8e9-0af8-47cb-8ac8-7c2139b2acb9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/495ab93b-7380-4dad-9d27-f35d8f71fcea>.
+    
+<http://data.lblod.info/id/remote-data-objects/45f6382e-6615-4b75-9543-6b79b623282d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45f6382e-6615-4b75-9543-6b79b623282d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/690ffd36-03ae-43e9-88cd-e4b098e7add6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45f6382e-6615-4b75-9543-6b79b623282d>.
+    
+<http://data.lblod.info/id/remote-data-objects/55246f65-8ceb-469f-818e-a54b8af8781f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55246f65-8ceb-469f-818e-a54b8af8781f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/6e0a8e7d-89b5-4515-8eed-511ad546beac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55246f65-8ceb-469f-818e-a54b8af8781f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c4fa75c-44d3-4091-93c4-77539aa6c45c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c4fa75c-44d3-4091-93c4-77539aa6c45c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/6e9449c5-dd72-4ab2-8974-35c6fd9feca4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c4fa75c-44d3-4091-93c4-77539aa6c45c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6c62678-0b43-4430-bd67-5494cee0eaa7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6c62678-0b43-4430-bd67-5494cee0eaa7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/6efc2f5e-d0ef-4738-a682-085348cf85c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6c62678-0b43-4430-bd67-5494cee0eaa7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9edd09f-07c3-40a0-9fc2-d378d94405a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9edd09f-07c3-40a0-9fc2-d378d94405a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/76ba25d8-b246-48c4-81c5-328a290aeba2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9edd09f-07c3-40a0-9fc2-d378d94405a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/603528c9-2a02-4b09-a2a7-47c37acb4aa8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "603528c9-2a02-4b09-a2a7-47c37acb4aa8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/789b9db9-1726-44a1-9bcd-63836f4d62ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/603528c9-2a02-4b09-a2a7-47c37acb4aa8>.
+    
+<http://data.lblod.info/id/remote-data-objects/2807bf15-0f7d-4507-849f-66a91ad36d74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2807bf15-0f7d-4507-849f-66a91ad36d74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/8001f1ac-4509-4c1d-8169-9289a874237c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2807bf15-0f7d-4507-849f-66a91ad36d74>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1347a8f-587a-4fae-9161-e476b647a407> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1347a8f-587a-4fae-9161-e476b647a407";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/8121b1c0-cbca-4a7e-b3cb-1e717b56182c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1347a8f-587a-4fae-9161-e476b647a407>.
+    
+<http://data.lblod.info/id/remote-data-objects/49f7378b-49f0-4e0f-980b-11a931cba114> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49f7378b-49f0-4e0f-980b-11a931cba114";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/84674ec4-5112-40cd-9fb9-e05d1b4c38a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49f7378b-49f0-4e0f-980b-11a931cba114>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e21b6dd-147f-493f-b598-e96096392b57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e21b6dd-147f-493f-b598-e96096392b57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/8778cf2d-c578-4dfc-921e-91aea00d2334/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e21b6dd-147f-493f-b598-e96096392b57>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a753128-bb21-49d9-97d6-f2f8659df1b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a753128-bb21-49d9-97d6-f2f8659df1b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/88580bc4-8ce0-453a-bee4-7a2bc77d55a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a753128-bb21-49d9-97d6-f2f8659df1b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee72ef6c-8d02-4511-bc55-0c6b0f23657e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee72ef6c-8d02-4511-bc55-0c6b0f23657e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/895ce8a8-7c65-498c-9f6f-2a082320eb7b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee72ef6c-8d02-4511-bc55-0c6b0f23657e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7afefebb-7272-4cf9-8d21-01c886ad3fc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7afefebb-7272-4cf9-8d21-01c886ad3fc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/8b5c8cc1-e81e-45ec-89e1-be02cb34a17f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7afefebb-7272-4cf9-8d21-01c886ad3fc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ece26ba-006c-4846-9159-e04e218644df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ece26ba-006c-4846-9159-e04e218644df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/8c450934-e099-496d-a604-58aed8721f35/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ece26ba-006c-4846-9159-e04e218644df>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cf7e8b3-144c-4c14-83f6-08d7b28bb988> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cf7e8b3-144c-4c14-83f6-08d7b28bb988";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/8ee918b7-90c0-44c8-b321-b6f03c230b29/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cf7e8b3-144c-4c14-83f6-08d7b28bb988>.
+    
+<http://data.lblod.info/id/remote-data-objects/916d877c-a83b-41c3-b6ff-64afb9a61768> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "916d877c-a83b-41c3-b6ff-64afb9a61768";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/944a52b7-851a-4bf7-8482-70b3cc875ec1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/127300c5-0843-482b-b3b7-105c16377f25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/916d877c-a83b-41c3-b6ff-64afb9a61768>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201154-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201154-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201154-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201154-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/90a1032e-742d-44b2-919b-27d702f60801> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "90a1032e-742d-44b2-919b-27d702f60801";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6fd49f44-8014-49ff-bf01-10fa1ffafce8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/006121ca-0f64-4826-b204-9e09f9d509ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "006121ca-0f64-4826-b204-9e09f9d509ea";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8>.
+
+  <http://redpencil.data.gift/id/task/441cf12b-2458-463a-880c-3d537f54c9e0> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "441cf12b-2458-463a-880c-3d537f54c9e0";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/90a1032e-742d-44b2-919b-27d702f60801>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/006121ca-0f64-4826-b204-9e09f9d509ea>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7050d051-62a1-46d2-934c-ef95e0ccf661> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7050d051-62a1-46d2-934c-ef95e0ccf661";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/961d6a09-976a-4494-ab33-b6047ea51210/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7050d051-62a1-46d2-934c-ef95e0ccf661>.
+    
+<http://data.lblod.info/id/remote-data-objects/727623b0-7991-42f6-b447-b8a13c5635cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "727623b0-7991-42f6-b447-b8a13c5635cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/96873b6f-61f9-4386-8c04-b87349d22021/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/727623b0-7991-42f6-b447-b8a13c5635cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7f245aa-f939-44e8-b633-9f0b1d12f86d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7f245aa-f939-44e8-b633-9f0b1d12f86d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/9ac4d19b-bba3-4cdd-b223-530187d1f3fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7f245aa-f939-44e8-b633-9f0b1d12f86d>.
+    
+<http://data.lblod.info/id/remote-data-objects/91dc71d7-a140-4925-bfff-d5fcba8165bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91dc71d7-a140-4925-bfff-d5fcba8165bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/a06b47df-8bb4-4d63-81fe-f36c533f7d18/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91dc71d7-a140-4925-bfff-d5fcba8165bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e1ea95f-1c49-4ab0-8778-d3fcb80a605e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e1ea95f-1c49-4ab0-8778-d3fcb80a605e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/a10faee8-762f-43ea-9fce-a1659f49009e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e1ea95f-1c49-4ab0-8778-d3fcb80a605e>.
+    
+<http://data.lblod.info/id/remote-data-objects/eadcd258-0163-43b3-a6f4-7f88d1d796ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eadcd258-0163-43b3-a6f4-7f88d1d796ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/a539a468-de29-4563-a06b-30fd91e04a0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eadcd258-0163-43b3-a6f4-7f88d1d796ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe081b8c-3f20-4364-ab02-599c855b42f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe081b8c-3f20-4364-ab02-599c855b42f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/aa2a23f2-0339-4061-ab1d-95b6507d323d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe081b8c-3f20-4364-ab02-599c855b42f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/3250568b-d388-4633-b226-4246c3874840> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3250568b-d388-4633-b226-4246c3874840";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/ab02f8e7-d693-4f37-8a1d-d097b53ef003/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3250568b-d388-4633-b226-4246c3874840>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9510035-5b2e-4c92-9ce1-abe161585523> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9510035-5b2e-4c92-9ce1-abe161585523";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/ad25cf9c-b2c1-491f-ba3c-89bdb4a1acb6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9510035-5b2e-4c92-9ce1-abe161585523>.
+    
+<http://data.lblod.info/id/remote-data-objects/e27f7607-2f3b-4490-9636-7e629c91583e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e27f7607-2f3b-4490-9636-7e629c91583e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/b3f1f7ce-f058-4379-964e-af6c05e9c242/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e27f7607-2f3b-4490-9636-7e629c91583e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7822d4c5-8189-4181-bde3-0190a76e491b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7822d4c5-8189-4181-bde3-0190a76e491b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/b818f557-e89f-4509-90a8-708bfe4a983f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7822d4c5-8189-4181-bde3-0190a76e491b>.
+    
+<http://data.lblod.info/id/remote-data-objects/59b769cb-876b-4785-b74c-de564add6303> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59b769cb-876b-4785-b74c-de564add6303";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/ba60dadf-c6fb-4327-9d99-e01bac498847/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59b769cb-876b-4785-b74c-de564add6303>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4afb11a-0665-42c3-9ec8-fb3e2fa761ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4afb11a-0665-42c3-9ec8-fb3e2fa761ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/bc62c5e3-6842-4a72-93c6-07fbc87b8647/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4afb11a-0665-42c3-9ec8-fb3e2fa761ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf12c763-6f90-4a9f-8a14-124a2c9cb59a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf12c763-6f90-4a9f-8a14-124a2c9cb59a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/c038ccb6-b929-463c-86e0-8d71d3e2625c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf12c763-6f90-4a9f-8a14-124a2c9cb59a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f20fc96-2142-4c35-aa67-d9dae7a9b075> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f20fc96-2142-4c35-aa67-d9dae7a9b075";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/c060cbee-f333-41a2-ae08-0993edd8afb3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f20fc96-2142-4c35-aa67-d9dae7a9b075>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a70150c-bce4-4e62-bb1a-5020486a88ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a70150c-bce4-4e62-bb1a-5020486a88ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/c26d3a76-2fed-4e9b-935f-f17045e2cf5b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a70150c-bce4-4e62-bb1a-5020486a88ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/309f9307-921d-4167-9b6f-346b8699f552> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "309f9307-921d-4167-9b6f-346b8699f552";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/c30faa52-909b-4ea2-b745-e90bc2ccac8f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/309f9307-921d-4167-9b6f-346b8699f552>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dac0007-d65f-43f5-a4f3-5a348f163df0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dac0007-d65f-43f5-a4f3-5a348f163df0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/c4083da5-a184-42ee-9c72-7211cd9fe026/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dac0007-d65f-43f5-a4f3-5a348f163df0>.
+    
+<http://data.lblod.info/id/remote-data-objects/175c83d7-c57b-4edd-a437-6a809271f245> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "175c83d7-c57b-4edd-a437-6a809271f245";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/c96e7fbe-e979-411f-bdcf-8e3530693697/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/175c83d7-c57b-4edd-a437-6a809271f245>.
+    
+<http://data.lblod.info/id/remote-data-objects/3efb5e6a-97d3-40fc-a625-0e256ebb48b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3efb5e6a-97d3-40fc-a625-0e256ebb48b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/d2cb9f7d-d8e7-434e-bfa9-d8616f7408d9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3efb5e6a-97d3-40fc-a625-0e256ebb48b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce7c3383-3e35-4316-a806-b53517a10bbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce7c3383-3e35-4316-a806-b53517a10bbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/d8baabdd-facc-4758-87ea-9004afb962c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce7c3383-3e35-4316-a806-b53517a10bbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a10bf94-b28a-4f91-822d-4bb5b0a9d2f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a10bf94-b28a-4f91-822d-4bb5b0a9d2f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/db1dc7d1-7d02-4bf1-9b0b-0c3bb8760ca0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a10bf94-b28a-4f91-822d-4bb5b0a9d2f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf8af5ff-75bd-457a-826f-3d2a9cc7f293> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf8af5ff-75bd-457a-826f-3d2a9cc7f293";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/e17aa4d3-9ef8-4b7a-b0a8-2b7bc63cfef1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf8af5ff-75bd-457a-826f-3d2a9cc7f293>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb684a72-900c-46e1-b825-7ec96c975dd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb684a72-900c-46e1-b825-7ec96c975dd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/e3f0638c-dada-4979-9396-192098155657/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb684a72-900c-46e1-b825-7ec96c975dd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7519848a-0333-45b2-bd46-d7304cc0e7ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7519848a-0333-45b2-bd46-d7304cc0e7ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/f38c8406-185f-4295-aa6c-c6f7c50bb28c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7519848a-0333-45b2-bd46-d7304cc0e7ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed6fd1fb-442d-4115-832a-809772d528e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed6fd1fb-442d-4115-832a-809772d528e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/f39bd41d-5a55-4201-be8d-ab026cc63ab6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed6fd1fb-442d-4115-832a-809772d528e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/67fc26e3-6f9b-4928-b845-5533ad5524f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67fc26e3-6f9b-4928-b845-5533ad5524f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/f4c7d1bd-5be7-48d8-b381-136a1d6453d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67fc26e3-6f9b-4928-b845-5533ad5524f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1211e03c-05a6-4761-87ab-5184907102b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1211e03c-05a6-4761-87ab-5184907102b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/fb6f51f6-9da7-4c73-b691-1eea83826150/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1211e03c-05a6-4761-87ab-5184907102b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/52008354-2df7-4c74-9a85-fd4a427a481c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52008354-2df7-4c74-9a85-fd4a427a481c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://holsbeek.meetingburger.net/vabu/fbbbe541-e6dc-49b8-bfa2-cf0fbdf51d74/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52008354-2df7-4c74-9a85-fd4a427a481c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d0bfe9f-2ec1-4d64-a087-251ff41b7aef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d0bfe9f-2ec1-4d64-a087-251ff41b7aef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/1b50bb97-4161-45bf-bd50-2232a5c7e1c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d0bfe9f-2ec1-4d64-a087-251ff41b7aef>.
+    
+<http://data.lblod.info/id/remote-data-objects/86b24d56-d98d-4eab-9c2e-09af17c5854d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86b24d56-d98d-4eab-9c2e-09af17c5854d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/1c8e8c81-47ee-4f2f-b8d1-5b2a314ba393/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86b24d56-d98d-4eab-9c2e-09af17c5854d>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfbd6c57-fdb3-4661-a6c6-b8500cbc41c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfbd6c57-fdb3-4661-a6c6-b8500cbc41c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/33c8939c-1edc-41e2-b44f-4d83f7da7367/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfbd6c57-fdb3-4661-a6c6-b8500cbc41c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea00392d-7cce-41ef-bb0c-8d5c5af26804> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea00392d-7cce-41ef-bb0c-8d5c5af26804";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/64fd6b0f-e4d5-4fe3-a582-ea1b51be8eb1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea00392d-7cce-41ef-bb0c-8d5c5af26804>.
+    
+<http://data.lblod.info/id/remote-data-objects/511e9dd9-efb9-4e4e-a8d7-70230e2cf4e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "511e9dd9-efb9-4e4e-a8d7-70230e2cf4e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/673d303f-8a13-4703-ac1f-96deae6ab2c2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/511e9dd9-efb9-4e4e-a8d7-70230e2cf4e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c35e73d3-6a3e-4555-a405-611f96eba592> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c35e73d3-6a3e-4555-a405-611f96eba592";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/74cd6a83-71d0-4a69-a080-d8de45b3db56/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c35e73d3-6a3e-4555-a405-611f96eba592>.
+    
+<http://data.lblod.info/id/remote-data-objects/6324ba45-3a94-4b6c-876f-4ffca633ccb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6324ba45-3a94-4b6c-876f-4ffca633ccb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/762e7d93-9bd1-4a5b-a252-f3092d2e0cd5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6324ba45-3a94-4b6c-876f-4ffca633ccb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c62b46e-4106-44f1-a7a5-f973bbb1d363> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c62b46e-4106-44f1-a7a5-f973bbb1d363";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/80f41a27-2b32-400d-bbd3-896da850b48d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c62b46e-4106-44f1-a7a5-f973bbb1d363>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1bab3a9-0245-41d1-9981-482cd6c85b34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1bab3a9-0245-41d1-9981-482cd6c85b34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/88c4a6e4-b0c2-476b-81c2-ea03a2b69cab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1bab3a9-0245-41d1-9981-482cd6c85b34>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f584173-290a-4391-8999-de5253d50701> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f584173-290a-4391-8999-de5253d50701";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/9c733372-4bb1-4a88-b6bc-73ad4e458570/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f584173-290a-4391-8999-de5253d50701>.
+    
+<http://data.lblod.info/id/remote-data-objects/33934ae2-588c-4243-bda0-7925943c17c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33934ae2-588c-4243-bda0-7925943c17c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/baef2c2f-aa85-404c-a14f-dea81ff4fea0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33934ae2-588c-4243-bda0-7925943c17c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7a97bfb-9efd-4738-a9f5-e11c9992b382> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7a97bfb-9efd-4738-a9f5-e11c9992b382";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/d61fd471-e0d6-438e-bcac-7bae2ec309b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7a97bfb-9efd-4738-a9f5-e11c9992b382>.
+    
+<http://data.lblod.info/id/remote-data-objects/aaff8693-8f4c-4b5a-8ee9-c41680de60d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aaff8693-8f4c-4b5a-8ee9-c41680de60d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/d7ff2eed-059f-4550-a285-2e9c8014bddd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aaff8693-8f4c-4b5a-8ee9-c41680de60d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd4d80f4-6977-463f-965f-b288925a98c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd4d80f4-6977-463f-965f-b288925a98c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/de98b360-6535-40a6-ae97-fa3d1ac9bdec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd4d80f4-6977-463f-965f-b288925a98c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bf3caec-0f14-44ec-9ac0-f2efdfe3be9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bf3caec-0f14-44ec-9ac0-f2efdfe3be9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/ec2d8462-b057-4fc3-925e-679347672d5c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bf3caec-0f14-44ec-9ac0-f2efdfe3be9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb2e59fa-6eaa-45bf-97fd-705eaf04807a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb2e59fa-6eaa-45bf-97fd-705eaf04807a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/eee769bc-465c-43b3-a3f1-c77a345f3099/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb2e59fa-6eaa-45bf-97fd-705eaf04807a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c350f30-05a5-4c9b-944a-3de2bad33bc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c350f30-05a5-4c9b-944a-3de2bad33bc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/f4a47c38-30ca-442c-8c26-8e183b2b6c2d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c350f30-05a5-4c9b-944a-3de2bad33bc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/58de2842-3d75-422b-8cf1-cfb0140ff3c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58de2842-3d75-422b-8cf1-cfb0140ff3c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/bb/ff1ff512-1fad-4dff-bf62-46ab094a0e2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58de2842-3d75-422b-8cf1-cfb0140ff3c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a44d09b4-1e86-4885-9f05-c436b631f0f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a44d09b4-1e86-4885-9f05-c436b631f0f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/23ccb7c3-1008-4bd0-835b-0ebddbf1f629/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a44d09b4-1e86-4885-9f05-c436b631f0f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/69e87976-20bf-40f3-8910-0add6574c9bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69e87976-20bf-40f3-8910-0add6574c9bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/33e881d5-b60e-4151-a675-7f04c38829ce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69e87976-20bf-40f3-8910-0add6574c9bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/a308fd6d-6480-4b17-b115-0cdcf7005527> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a308fd6d-6480-4b17-b115-0cdcf7005527";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/37785ef2-d2d9-43bf-a377-36c121a8ad56/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6fd49f44-8014-49ff-bf01-10fa1ffafce8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a308fd6d-6480-4b17-b115-0cdcf7005527>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201156-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201156-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201156-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201156-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3db8a333-0334-4c56-8156-0fecfb21d0fe> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3db8a333-0334-4c56-8156-0fecfb21d0fe";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ffb839f1-8745-47e3-ba44-a12b84e273c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ffb839f1-8745-47e3-ba44-a12b84e273c2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c>.
+
+  <http://redpencil.data.gift/id/task/8e4890d1-f49f-484f-90bb-2792e7151d58> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8e4890d1-f49f-484f-90bb-2792e7151d58";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3db8a333-0334-4c56-8156-0fecfb21d0fe>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ffb839f1-8745-47e3-ba44-a12b84e273c2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5362aa78-97ad-4e5b-bca7-65d6fec8ab47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5362aa78-97ad-4e5b-bca7-65d6fec8ab47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/4809f9ba-6ab4-44b1-961d-f68a51c6f5fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5362aa78-97ad-4e5b-bca7-65d6fec8ab47>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d62c119-c2f2-4b6e-9231-d276d0899a26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d62c119-c2f2-4b6e-9231-d276d0899a26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/4f833d5b-9ebf-4f4e-ad0b-9e96ba8c3d6c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d62c119-c2f2-4b6e-9231-d276d0899a26>.
+    
+<http://data.lblod.info/id/remote-data-objects/89c9b009-ee2f-4602-ba07-2c101f563b02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89c9b009-ee2f-4602-ba07-2c101f563b02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/774744a3-3c5e-4bbc-b4ae-e8f8399bd65c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89c9b009-ee2f-4602-ba07-2c101f563b02>.
+    
+<http://data.lblod.info/id/remote-data-objects/77d7027b-9c55-4730-ae98-af6860f9444f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77d7027b-9c55-4730-ae98-af6860f9444f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/80ca6217-339a-411f-b64d-a79edd315fe9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77d7027b-9c55-4730-ae98-af6860f9444f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ceb99a79-0435-48b7-a032-793edf536997> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ceb99a79-0435-48b7-a032-793edf536997";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/81463215-57a2-4bd3-8241-6b1323a08ebe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ceb99a79-0435-48b7-a032-793edf536997>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfe2bb5c-ff95-4b13-9af9-eea26313b06a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfe2bb5c-ff95-4b13-9af9-eea26313b06a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/8ad8e3af-4041-43f8-937d-219d10c0fea6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfe2bb5c-ff95-4b13-9af9-eea26313b06a>.
+    
+<http://data.lblod.info/id/remote-data-objects/355cb723-eafa-4863-b4ec-869efb820bad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "355cb723-eafa-4863-b4ec-869efb820bad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/9788c788-bb45-4334-9bd6-7792c12b4fb0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/355cb723-eafa-4863-b4ec-869efb820bad>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c8c2f1c-c341-41ec-98ef-af97dd61346a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c8c2f1c-c341-41ec-98ef-af97dd61346a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/ab8f22c8-f10e-494d-91e4-6b851d3df4cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c8c2f1c-c341-41ec-98ef-af97dd61346a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce7375fc-b77a-4183-b3e9-5ecb1f8b9af3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce7375fc-b77a-4183-b3e9-5ecb1f8b9af3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/b38cba6e-1df9-4eb0-9d8b-f86f8fb88802/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce7375fc-b77a-4183-b3e9-5ecb1f8b9af3>.
+    
+<http://data.lblod.info/id/remote-data-objects/0495dc44-6aca-4fec-9a9b-4231ffa5b319> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0495dc44-6aca-4fec-9a9b-4231ffa5b319";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/bae19890-ab74-4a5c-8824-6dd70bbb03c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0495dc44-6aca-4fec-9a9b-4231ffa5b319>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed58dfa9-5019-4747-961f-47ef4270a8fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed58dfa9-5019-4747-961f-47ef4270a8fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/bdb3ddff-427a-479e-a91f-79fedbbf2151/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed58dfa9-5019-4747-961f-47ef4270a8fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/402ca38b-9f10-42cf-924a-28c7110270cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "402ca38b-9f10-42cf-924a-28c7110270cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/d82fdb88-9c5f-4892-85dc-772dccf8d480/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/402ca38b-9f10-42cf-924a-28c7110270cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/829e3f44-3141-4e28-afb2-8b04b3b53253> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "829e3f44-3141-4e28-afb2-8b04b3b53253";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/dedb13fb-0273-4e90-8b7f-33bc99a9e50d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/829e3f44-3141-4e28-afb2-8b04b3b53253>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fb6783b-5643-4e26-9f67-899f506afa5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fb6783b-5643-4e26-9f67-899f506afa5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/e5a3bd39-b822-48af-8e98-14ce1f73d3fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fb6783b-5643-4e26-9f67-899f506afa5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9aa56c90-5ec6-4e00-b090-ee4762fb58b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9aa56c90-5ec6-4e00-b090-ee4762fb58b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/ebb3c00f-e7d5-4b2a-ace5-e4fcdb375567/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9aa56c90-5ec6-4e00-b090-ee4762fb58b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7842d72-67e9-4c00-aa83-dade12aa0cd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7842d72-67e9-4c00-aa83-dade12aa0cd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/f0010a07-2de8-484e-8101-63c0d20046d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7842d72-67e9-4c00-aa83-dade12aa0cd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbf5a75c-2964-42ff-9424-f5a4f1df8d41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbf5a75c-2964-42ff-9424-f5a4f1df8d41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/cbs/f554f8de-7459-4303-9f1c-e89dae41ebf6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbf5a75c-2964-42ff-9424-f5a4f1df8d41>.
+    
+<http://data.lblod.info/id/remote-data-objects/618568f4-45c9-4a19-bf14-f120b382cb05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "618568f4-45c9-4a19-bf14-f120b382cb05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/02d25035-5155-448d-953f-73760a57175f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/618568f4-45c9-4a19-bf14-f120b382cb05>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdb5cc89-d078-4739-aa5a-ada4567add0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdb5cc89-d078-4739-aa5a-ada4567add0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/02d25035-5155-448d-953f-73760a57175f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdb5cc89-d078-4739-aa5a-ada4567add0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/68252ac2-324a-4ba7-aba1-66450181a3ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68252ac2-324a-4ba7-aba1-66450181a3ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/02d25035-5155-448d-953f-73760a57175f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68252ac2-324a-4ba7-aba1-66450181a3ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/596a4293-b85a-4d8a-9e4c-edd8800611fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "596a4293-b85a-4d8a-9e4c-edd8800611fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/12cd89b8-a8fb-4002-a89e-8ac11aec6493/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/596a4293-b85a-4d8a-9e4c-edd8800611fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2663619-a52b-4832-a058-f83972177239> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2663619-a52b-4832-a058-f83972177239";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/12cd89b8-a8fb-4002-a89e-8ac11aec6493/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2663619-a52b-4832-a058-f83972177239>.
+    
+<http://data.lblod.info/id/remote-data-objects/db975399-691e-4cad-8490-4665ec857822> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db975399-691e-4cad-8490-4665ec857822";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/12cd89b8-a8fb-4002-a89e-8ac11aec6493/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db975399-691e-4cad-8490-4665ec857822>.
+    
+<http://data.lblod.info/id/remote-data-objects/d81153fd-a277-477f-8e4c-e427ac477b06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d81153fd-a277-477f-8e4c-e427ac477b06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/14757804-48b3-468d-a577-c8bedff99c89/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d81153fd-a277-477f-8e4c-e427ac477b06>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f3f1e68-20ce-4f0d-9584-6b0966b09eeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f3f1e68-20ce-4f0d-9584-6b0966b09eeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/14757804-48b3-468d-a577-c8bedff99c89/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f3f1e68-20ce-4f0d-9584-6b0966b09eeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7a96ea1-728c-4256-8a1d-d90d97d86a20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7a96ea1-728c-4256-8a1d-d90d97d86a20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/14757804-48b3-468d-a577-c8bedff99c89/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7a96ea1-728c-4256-8a1d-d90d97d86a20>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a31e53f-85f7-43d7-ad70-98d76e65df83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a31e53f-85f7-43d7-ad70-98d76e65df83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/33d5968a-a656-4ba4-8aca-54716b585ad8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a31e53f-85f7-43d7-ad70-98d76e65df83>.
+    
+<http://data.lblod.info/id/remote-data-objects/528ec2a7-9e5d-4dac-9097-d9f56ba2b523> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "528ec2a7-9e5d-4dac-9097-d9f56ba2b523";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/33d5968a-a656-4ba4-8aca-54716b585ad8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/528ec2a7-9e5d-4dac-9097-d9f56ba2b523>.
+    
+<http://data.lblod.info/id/remote-data-objects/622960c5-9910-410e-8276-24d965580280> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "622960c5-9910-410e-8276-24d965580280";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/33d5968a-a656-4ba4-8aca-54716b585ad8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/622960c5-9910-410e-8276-24d965580280>.
+    
+<http://data.lblod.info/id/remote-data-objects/5be2f01f-ecda-4a7d-beab-1e8526e45558> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5be2f01f-ecda-4a7d-beab-1e8526e45558";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/3e4142d3-12d6-43de-9f08-4aeb8c04d3d2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5be2f01f-ecda-4a7d-beab-1e8526e45558>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f3e7305-4610-4779-bf7a-5a6949c96e08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f3e7305-4610-4779-bf7a-5a6949c96e08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/3e4142d3-12d6-43de-9f08-4aeb8c04d3d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f3e7305-4610-4779-bf7a-5a6949c96e08>.
+    
+<http://data.lblod.info/id/remote-data-objects/65612445-a23c-4f4a-b254-2407a9465aac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65612445-a23c-4f4a-b254-2407a9465aac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/3e4142d3-12d6-43de-9f08-4aeb8c04d3d2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65612445-a23c-4f4a-b254-2407a9465aac>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff7d70a0-dd15-4483-a4b9-ada3c0f13c46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff7d70a0-dd15-4483-a4b9-ada3c0f13c46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/47ac4f2f-780f-43f6-adb7-16733491dc81/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff7d70a0-dd15-4483-a4b9-ada3c0f13c46>.
+    
+<http://data.lblod.info/id/remote-data-objects/35134476-3621-4e67-8876-a3a24dfe4eeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35134476-3621-4e67-8876-a3a24dfe4eeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/47ac4f2f-780f-43f6-adb7-16733491dc81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35134476-3621-4e67-8876-a3a24dfe4eeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9686f00-d5f2-4eac-a18a-69436449b344> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9686f00-d5f2-4eac-a18a-69436449b344";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/47ac4f2f-780f-43f6-adb7-16733491dc81/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9686f00-d5f2-4eac-a18a-69436449b344>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab912aee-8771-43f6-b9f6-e827db554201> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab912aee-8771-43f6-b9f6-e827db554201";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/4b42214b-163c-4061-bd74-d3f8f110da05/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab912aee-8771-43f6-b9f6-e827db554201>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1a66a2b-1c4a-41f9-9a91-72dd430c922d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1a66a2b-1c4a-41f9-9a91-72dd430c922d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/4b42214b-163c-4061-bd74-d3f8f110da05/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1a66a2b-1c4a-41f9-9a91-72dd430c922d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7868060f-7c3d-4f75-86b4-e215e4d6f842> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7868060f-7c3d-4f75-86b4-e215e4d6f842";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/64c76d21-6c3b-49c6-be94-87060fdecfcc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7868060f-7c3d-4f75-86b4-e215e4d6f842>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e0c5277-f45a-4744-b635-9fca702f9a06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e0c5277-f45a-4744-b635-9fca702f9a06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/64c76d21-6c3b-49c6-be94-87060fdecfcc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e0c5277-f45a-4744-b635-9fca702f9a06>.
+    
+<http://data.lblod.info/id/remote-data-objects/56e1828e-d013-4fb5-aed5-458194913e3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56e1828e-d013-4fb5-aed5-458194913e3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/64c76d21-6c3b-49c6-be94-87060fdecfcc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56e1828e-d013-4fb5-aed5-458194913e3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fa1e08c-4ee8-4cf1-8849-053903c86d30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fa1e08c-4ee8-4cf1-8849-053903c86d30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/7ad29595-2f31-430e-b239-3f66fc6840ae/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fa1e08c-4ee8-4cf1-8849-053903c86d30>.
+    
+<http://data.lblod.info/id/remote-data-objects/d17a524f-0c3d-4a8f-aeb7-1bcbb84074f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d17a524f-0c3d-4a8f-aeb7-1bcbb84074f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/7ad29595-2f31-430e-b239-3f66fc6840ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d17a524f-0c3d-4a8f-aeb7-1bcbb84074f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7684cbcd-c931-4aeb-b3db-e72eb6c82370> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7684cbcd-c931-4aeb-b3db-e72eb6c82370";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/7ad29595-2f31-430e-b239-3f66fc6840ae/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7684cbcd-c931-4aeb-b3db-e72eb6c82370>.
+    
+<http://data.lblod.info/id/remote-data-objects/3691a0ee-16b4-4080-9ade-8c96ab3e08d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3691a0ee-16b4-4080-9ade-8c96ab3e08d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/b8badd36-0890-44c5-be14-9c72082390f5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3691a0ee-16b4-4080-9ade-8c96ab3e08d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfa7afd8-4a4b-4436-a2e6-4fac93452c77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfa7afd8-4a4b-4436-a2e6-4fac93452c77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/b8badd36-0890-44c5-be14-9c72082390f5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfa7afd8-4a4b-4436-a2e6-4fac93452c77>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c915c88-8809-44de-8668-087b168a14d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c915c88-8809-44de-8668-087b168a14d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/b8badd36-0890-44c5-be14-9c72082390f5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c915c88-8809-44de-8668-087b168a14d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8031836f-73e4-4e69-8543-87b73603d47e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8031836f-73e4-4e69-8543-87b73603d47e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/da716f5a-4009-4748-a535-39f2a69719d8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8031836f-73e4-4e69-8543-87b73603d47e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac9a0237-6570-487e-aab0-f3937d7cd839> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac9a0237-6570-487e-aab0-f3937d7cd839";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/da716f5a-4009-4748-a535-39f2a69719d8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac9a0237-6570-487e-aab0-f3937d7cd839>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcfccc56-73fe-4199-8e1f-d7abb9595345> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcfccc56-73fe-4199-8e1f-d7abb9595345";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/da716f5a-4009-4748-a535-39f2a69719d8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcfccc56-73fe-4199-8e1f-d7abb9595345>.
+    
+<http://data.lblod.info/id/remote-data-objects/417df3a9-cbdd-43c1-9c29-3291e5e353b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "417df3a9-cbdd-43c1-9c29-3291e5e353b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/e3b91899-80ff-4fbf-8f97-6b687d4c8299/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0edb09aa-6e3f-4e7a-8207-3f493dbc5d0c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/417df3a9-cbdd-43c1-9c29-3291e5e353b1>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201157-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201157-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201157-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201157-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7af1f1c9-8065-40db-bb0a-b5c08bb8d7a5> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7af1f1c9-8065-40db-bb0a-b5c08bb8d7a5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f6951046-cea1-42d9-a0c1-c0298a6f4d57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f6951046-cea1-42d9-a0c1-c0298a6f4d57";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf>.
+
+  <http://redpencil.data.gift/id/task/bffe4ea0-8a75-43c4-acc6-025c17d48c65> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bffe4ea0-8a75-43c4-acc6-025c17d48c65";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7af1f1c9-8065-40db-bb0a-b5c08bb8d7a5>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f6951046-cea1-42d9-a0c1-c0298a6f4d57>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5a2f1fbf-6637-4922-b6dd-fc09e40605d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a2f1fbf-6637-4922-b6dd-fc09e40605d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/e3b91899-80ff-4fbf-8f97-6b687d4c8299/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a2f1fbf-6637-4922-b6dd-fc09e40605d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6064da44-e0ca-4c66-aed2-408099e32533> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6064da44-e0ca-4c66-aed2-408099e32533";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/e3b91899-80ff-4fbf-8f97-6b687d4c8299/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6064da44-e0ca-4c66-aed2-408099e32533>.
+    
+<http://data.lblod.info/id/remote-data-objects/62e756dc-6ee2-48a0-b03e-77923455fe28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62e756dc-6ee2-48a0-b03e-77923455fe28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/e4b8ff73-c36c-4954-96b8-acdcbc968b20/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62e756dc-6ee2-48a0-b03e-77923455fe28>.
+    
+<http://data.lblod.info/id/remote-data-objects/997919f7-8471-44d9-8588-d8f9ded632ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "997919f7-8471-44d9-8588-d8f9ded632ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/e4b8ff73-c36c-4954-96b8-acdcbc968b20/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/997919f7-8471-44d9-8588-d8f9ded632ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5577197-82fa-4608-8ca3-45f8b88852fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5577197-82fa-4608-8ca3-45f8b88852fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/e4b8ff73-c36c-4954-96b8-acdcbc968b20/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5577197-82fa-4608-8ca3-45f8b88852fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/93d49af0-2b49-4136-8f9c-76bc83893c8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93d49af0-2b49-4136-8f9c-76bc83893c8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/f39429fe-cc14-40f0-b4b7-79efb3f1a95e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93d49af0-2b49-4136-8f9c-76bc83893c8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/2419370d-2f1d-4fe9-9788-ef75b035ee46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2419370d-2f1d-4fe9-9788-ef75b035ee46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/f39429fe-cc14-40f0-b4b7-79efb3f1a95e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2419370d-2f1d-4fe9-9788-ef75b035ee46>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3ce9437-e861-4da9-80db-f5b3183f6052> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3ce9437-e861-4da9-80db-f5b3183f6052";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/f39429fe-cc14-40f0-b4b7-79efb3f1a95e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3ce9437-e861-4da9-80db-f5b3183f6052>.
+    
+<http://data.lblod.info/id/remote-data-objects/3813c35a-7090-42bc-b6da-1833c0201065> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3813c35a-7090-42bc-b6da-1833c0201065";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/fe346735-8c3f-4ae8-aba2-1465d5ba5f7f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3813c35a-7090-42bc-b6da-1833c0201065>.
+    
+<http://data.lblod.info/id/remote-data-objects/83281491-777b-4dc4-8840-35b736bdc0ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83281491-777b-4dc4-8840-35b736bdc0ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/fe346735-8c3f-4ae8-aba2-1465d5ba5f7f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83281491-777b-4dc4-8840-35b736bdc0ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d537669-173e-4c3f-b55b-eae50c2a9f4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d537669-173e-4c3f-b55b-eae50c2a9f4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/gr/fe346735-8c3f-4ae8-aba2-1465d5ba5f7f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d537669-173e-4c3f-b55b-eae50c2a9f4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/be38b33d-7dfc-499a-8ec0-c61f0b02c017> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be38b33d-7dfc-499a-8ec0-c61f0b02c017";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/0d4cb3a7-2d52-46d5-9661-7d4c908f0feb/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be38b33d-7dfc-499a-8ec0-c61f0b02c017>.
+    
+<http://data.lblod.info/id/remote-data-objects/682f30bf-1a0b-445d-9b96-4ca9bda61c49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "682f30bf-1a0b-445d-9b96-4ca9bda61c49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/0d4cb3a7-2d52-46d5-9661-7d4c908f0feb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/682f30bf-1a0b-445d-9b96-4ca9bda61c49>.
+    
+<http://data.lblod.info/id/remote-data-objects/b57fa948-9e6c-4578-9076-2f866508478a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b57fa948-9e6c-4578-9076-2f866508478a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/0d4cb3a7-2d52-46d5-9661-7d4c908f0feb/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b57fa948-9e6c-4578-9076-2f866508478a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f06ce6ae-c1a8-4bb7-ac43-2f2c2ab6b267> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f06ce6ae-c1a8-4bb7-ac43-2f2c2ab6b267";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/0e9e140f-3e54-4cf6-973a-4b431875e9ad/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f06ce6ae-c1a8-4bb7-ac43-2f2c2ab6b267>.
+    
+<http://data.lblod.info/id/remote-data-objects/db07f191-bfc2-4260-b3ae-f32a292b35ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db07f191-bfc2-4260-b3ae-f32a292b35ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/0e9e140f-3e54-4cf6-973a-4b431875e9ad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db07f191-bfc2-4260-b3ae-f32a292b35ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/967604c8-8228-459e-9e4d-975746ec565c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "967604c8-8228-459e-9e4d-975746ec565c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/0e9e140f-3e54-4cf6-973a-4b431875e9ad/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/967604c8-8228-459e-9e4d-975746ec565c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e05054a7-8cd0-4904-92d1-324553a2944e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e05054a7-8cd0-4904-92d1-324553a2944e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/1085237b-1bee-49c4-9627-5e71fbd5055e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e05054a7-8cd0-4904-92d1-324553a2944e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ba7a96b-111f-4466-948c-fc18876c55d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ba7a96b-111f-4466-948c-fc18876c55d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/1085237b-1bee-49c4-9627-5e71fbd5055e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ba7a96b-111f-4466-948c-fc18876c55d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b19f602-433a-4db9-865f-f32136dd5bb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b19f602-433a-4db9-865f-f32136dd5bb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/1085237b-1bee-49c4-9627-5e71fbd5055e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b19f602-433a-4db9-865f-f32136dd5bb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/13ee49cd-40eb-49c5-b729-0f879f6910b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13ee49cd-40eb-49c5-b729-0f879f6910b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/1086b671-dd13-499f-805a-9e5577cd151c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13ee49cd-40eb-49c5-b729-0f879f6910b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c6d8e3e-e9e3-4fd7-b0c3-e5ed65dd3b40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c6d8e3e-e9e3-4fd7-b0c3-e5ed65dd3b40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/1086b671-dd13-499f-805a-9e5577cd151c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c6d8e3e-e9e3-4fd7-b0c3-e5ed65dd3b40>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c6a34aa-53ec-492b-bed4-f023b7fc1ca4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c6a34aa-53ec-492b-bed4-f023b7fc1ca4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/1086b671-dd13-499f-805a-9e5577cd151c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c6a34aa-53ec-492b-bed4-f023b7fc1ca4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d1bee09-b600-4136-9032-e9da3b8028e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d1bee09-b600-4136-9032-e9da3b8028e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/3d516c50-186f-4f08-817b-959e8811793e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d1bee09-b600-4136-9032-e9da3b8028e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c15efe3-06e8-43a7-aced-c5b53c6e384a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c15efe3-06e8-43a7-aced-c5b53c6e384a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/3d516c50-186f-4f08-817b-959e8811793e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c15efe3-06e8-43a7-aced-c5b53c6e384a>.
+    
+<http://data.lblod.info/id/remote-data-objects/86fe66ca-3718-4334-85ed-de3de681d20f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86fe66ca-3718-4334-85ed-de3de681d20f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/3d516c50-186f-4f08-817b-959e8811793e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86fe66ca-3718-4334-85ed-de3de681d20f>.
+    
+<http://data.lblod.info/id/remote-data-objects/87f649ab-eedc-47be-8e63-72cdfff5844b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87f649ab-eedc-47be-8e63-72cdfff5844b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/3e33dd9d-2f8c-4a29-b04e-02a718c64b74/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87f649ab-eedc-47be-8e63-72cdfff5844b>.
+    
+<http://data.lblod.info/id/remote-data-objects/00ae5866-07d6-4967-91cf-a4754657a8cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00ae5866-07d6-4967-91cf-a4754657a8cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/3e33dd9d-2f8c-4a29-b04e-02a718c64b74/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00ae5866-07d6-4967-91cf-a4754657a8cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fa44f90-4c44-46dc-9970-5b1b69fdad45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fa44f90-4c44-46dc-9970-5b1b69fdad45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/3e33dd9d-2f8c-4a29-b04e-02a718c64b74/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fa44f90-4c44-46dc-9970-5b1b69fdad45>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb4faae1-ef00-4d39-83ea-e17897693ab4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb4faae1-ef00-4d39-83ea-e17897693ab4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/4a6ff28e-8137-43e1-ba79-e2ab59936dda/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb4faae1-ef00-4d39-83ea-e17897693ab4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ec92218-c139-4b2a-b97d-4d44f09a280b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ec92218-c139-4b2a-b97d-4d44f09a280b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/4a6ff28e-8137-43e1-ba79-e2ab59936dda/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ec92218-c139-4b2a-b97d-4d44f09a280b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5190932e-3d12-43c0-a9b6-b04d81a2bd3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5190932e-3d12-43c0-a9b6-b04d81a2bd3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/4a6ff28e-8137-43e1-ba79-e2ab59936dda/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5190932e-3d12-43c0-a9b6-b04d81a2bd3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4eb379f-4c1b-4a58-8ba1-689a0d748e5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4eb379f-4c1b-4a58-8ba1-689a0d748e5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/4a9139e2-7357-41e9-b50b-114326c927e7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4eb379f-4c1b-4a58-8ba1-689a0d748e5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/439432f3-4a9f-4a83-8a28-86e42878aa4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "439432f3-4a9f-4a83-8a28-86e42878aa4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/4a9139e2-7357-41e9-b50b-114326c927e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/439432f3-4a9f-4a83-8a28-86e42878aa4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e3b6eb6-69fe-4222-85bb-1a7393ae051f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e3b6eb6-69fe-4222-85bb-1a7393ae051f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/4a9139e2-7357-41e9-b50b-114326c927e7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e3b6eb6-69fe-4222-85bb-1a7393ae051f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fec8c6f6-4e0c-4b63-9c4e-ac756357aaa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fec8c6f6-4e0c-4b63-9c4e-ac756357aaa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/4bb58a12-49f7-46b5-a81d-102d7eb0d431/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fec8c6f6-4e0c-4b63-9c4e-ac756357aaa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/16e252ea-fb8f-435e-93b1-cb8cb6ebdac4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16e252ea-fb8f-435e-93b1-cb8cb6ebdac4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/4bb58a12-49f7-46b5-a81d-102d7eb0d431/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16e252ea-fb8f-435e-93b1-cb8cb6ebdac4>.
+    
+<http://data.lblod.info/id/remote-data-objects/9569742a-6fa4-45fb-bfb0-57466f63efef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9569742a-6fa4-45fb-bfb0-57466f63efef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/4bb58a12-49f7-46b5-a81d-102d7eb0d431/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9569742a-6fa4-45fb-bfb0-57466f63efef>.
+    
+<http://data.lblod.info/id/remote-data-objects/319b55ef-7eea-4af2-8ea9-1a9b273740f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "319b55ef-7eea-4af2-8ea9-1a9b273740f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/4c619881-239a-4eb4-845c-ba51ab901e59/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/319b55ef-7eea-4af2-8ea9-1a9b273740f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d46f992c-72d1-4363-a0eb-4b109bf96554> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d46f992c-72d1-4363-a0eb-4b109bf96554";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/4c619881-239a-4eb4-845c-ba51ab901e59/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d46f992c-72d1-4363-a0eb-4b109bf96554>.
+    
+<http://data.lblod.info/id/remote-data-objects/8da76aba-832b-4970-88ab-cb9b84a9fcec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8da76aba-832b-4970-88ab-cb9b84a9fcec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/4c619881-239a-4eb4-845c-ba51ab901e59/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8da76aba-832b-4970-88ab-cb9b84a9fcec>.
+    
+<http://data.lblod.info/id/remote-data-objects/04c6c05a-e844-4917-b979-7d4591a13213> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04c6c05a-e844-4917-b979-7d4591a13213";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/8bb33a3b-80a9-4650-a992-60ba9e92c117/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04c6c05a-e844-4917-b979-7d4591a13213>.
+    
+<http://data.lblod.info/id/remote-data-objects/13ef675c-0d39-4bf7-948f-720dca5eff8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13ef675c-0d39-4bf7-948f-720dca5eff8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/8bb33a3b-80a9-4650-a992-60ba9e92c117/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13ef675c-0d39-4bf7-948f-720dca5eff8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0db18bc0-dc49-4bdf-bfca-e9d9bd02fb36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0db18bc0-dc49-4bdf-bfca-e9d9bd02fb36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/8bb33a3b-80a9-4650-a992-60ba9e92c117/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0db18bc0-dc49-4bdf-bfca-e9d9bd02fb36>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fdb6ec8-53c5-40fb-919b-2b8f54894c36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fdb6ec8-53c5-40fb-919b-2b8f54894c36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/9db040c1-5ac3-4842-9614-a4df048fa202/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fdb6ec8-53c5-40fb-919b-2b8f54894c36>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cbd8877-244c-473c-baa9-bdfe48e8e90a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cbd8877-244c-473c-baa9-bdfe48e8e90a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/9db040c1-5ac3-4842-9614-a4df048fa202/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cbd8877-244c-473c-baa9-bdfe48e8e90a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e920dedc-6bc5-42f6-a0b7-ce0f785db078> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e920dedc-6bc5-42f6-a0b7-ce0f785db078";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/9db040c1-5ac3-4842-9614-a4df048fa202/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e920dedc-6bc5-42f6-a0b7-ce0f785db078>.
+    
+<http://data.lblod.info/id/remote-data-objects/c204f2fd-bde8-4924-aec7-8ef540d0ec70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c204f2fd-bde8-4924-aec7-8ef540d0ec70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/a3c47284-4fe1-42d3-be42-ca14e35c228b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c204f2fd-bde8-4924-aec7-8ef540d0ec70>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5cf386b-f524-4357-ba6d-6d8017cb4b19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5cf386b-f524-4357-ba6d-6d8017cb4b19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/a3c47284-4fe1-42d3-be42-ca14e35c228b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5cf386b-f524-4357-ba6d-6d8017cb4b19>.
+    
+<http://data.lblod.info/id/remote-data-objects/1dfed182-ef72-4261-99a3-edbfe6a76c71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1dfed182-ef72-4261-99a3-edbfe6a76c71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/a3c47284-4fe1-42d3-be42-ca14e35c228b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bcbdadd0-62e2-4ec5-9abd-0139b8c20fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1dfed182-ef72-4261-99a3-edbfe6a76c71>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201158-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201158-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201158-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201158-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/de787b0f-cf8d-4c63-8bec-9a151be6f597> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "de787b0f-cf8d-4c63-8bec-9a151be6f597";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a2ea2c8f-3a01-4cfe-8cd8-31b872585a38";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/746ca144-1d76-4e85-b39c-29ae0d628591> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "746ca144-1d76-4e85-b39c-29ae0d628591";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38>.
+
+  <http://redpencil.data.gift/id/task/3805419d-fa77-469e-b4c7-7ffb70702640> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3805419d-fa77-469e-b4c7-7ffb70702640";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/de787b0f-cf8d-4c63-8bec-9a151be6f597>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/746ca144-1d76-4e85-b39c-29ae0d628591>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/67323ebe-eab6-4492-8b63-6a9cda6d015b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67323ebe-eab6-4492-8b63-6a9cda6d015b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/d4159d2c-5f60-4851-8f62-a508f7814edf/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67323ebe-eab6-4492-8b63-6a9cda6d015b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0236af5d-9070-42ce-8f4a-84ea225ace27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0236af5d-9070-42ce-8f4a-84ea225ace27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/d4159d2c-5f60-4851-8f62-a508f7814edf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0236af5d-9070-42ce-8f4a-84ea225ace27>.
+    
+<http://data.lblod.info/id/remote-data-objects/714f0d0b-783d-4837-be43-528f82ad9e98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "714f0d0b-783d-4837-be43-528f82ad9e98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/d4159d2c-5f60-4851-8f62-a508f7814edf/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/714f0d0b-783d-4837-be43-528f82ad9e98>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cb6b501-a1f8-45dd-a235-bab045224292> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cb6b501-a1f8-45dd-a235-bab045224292";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/d662c4c5-3f8f-47d6-9f0b-94fa220c0c7d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cb6b501-a1f8-45dd-a235-bab045224292>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b5d4a32-e3d4-4f87-98af-c9f891d9c4ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b5d4a32-e3d4-4f87-98af-c9f891d9c4ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/rmw/d662c4c5-3f8f-47d6-9f0b-94fa220c0c7d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b5d4a32-e3d4-4f87-98af-c9f891d9c4ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/1818d008-744d-4ea5-a784-b917e9d87d07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1818d008-744d-4ea5-a784-b917e9d87d07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/013389dd-204c-487e-8a01-b9531cdf8a2a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1818d008-744d-4ea5-a784-b917e9d87d07>.
+    
+<http://data.lblod.info/id/remote-data-objects/9627bff0-eac0-4be7-b4b6-1100a66bc163> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9627bff0-eac0-4be7-b4b6-1100a66bc163";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/0cbe65ea-2741-4cc5-b92f-d7565d1546d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9627bff0-eac0-4be7-b4b6-1100a66bc163>.
+    
+<http://data.lblod.info/id/remote-data-objects/d33ce380-d02e-43a5-9f1d-f083971cf46b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d33ce380-d02e-43a5-9f1d-f083971cf46b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/12123d06-a177-4da5-8eb7-d1b11f89081a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d33ce380-d02e-43a5-9f1d-f083971cf46b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f2eb090-efd1-4ba2-8f73-a4ada8294835> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f2eb090-efd1-4ba2-8f73-a4ada8294835";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/138713f9-3dd8-4b7e-a492-35447ef87aa2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f2eb090-efd1-4ba2-8f73-a4ada8294835>.
+    
+<http://data.lblod.info/id/remote-data-objects/fccbf200-4c04-4ffe-b3a5-1cd8f028414f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fccbf200-4c04-4ffe-b3a5-1cd8f028414f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/21408dc7-9977-4cd4-bde7-8fe47423c389/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fccbf200-4c04-4ffe-b3a5-1cd8f028414f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce699794-9531-47b7-a241-a2ac04b265e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce699794-9531-47b7-a241-a2ac04b265e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/25d2c63a-01c8-46b7-a128-abc333f518b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce699794-9531-47b7-a241-a2ac04b265e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/21b731ac-1da4-4f8c-81c2-0d4792102f94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21b731ac-1da4-4f8c-81c2-0d4792102f94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/28b0b7d3-0d36-4275-b163-542f8db8970e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21b731ac-1da4-4f8c-81c2-0d4792102f94>.
+    
+<http://data.lblod.info/id/remote-data-objects/8137b7bb-f2f2-4209-9285-e41177f621d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8137b7bb-f2f2-4209-9285-e41177f621d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/3470c468-cda3-49f7-b2a6-033ce0477640/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8137b7bb-f2f2-4209-9285-e41177f621d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d56ddeb-c8cb-4bc2-a89a-db1f6d4cd149> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d56ddeb-c8cb-4bc2-a89a-db1f6d4cd149";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/52bab960-0c67-42ee-8208-2ee564132f19/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d56ddeb-c8cb-4bc2-a89a-db1f6d4cd149>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d8cd88f-d5b9-4169-abe0-9f227e963a9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d8cd88f-d5b9-4169-abe0-9f227e963a9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/5b5beb15-362f-40e4-8c73-403225db05dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d8cd88f-d5b9-4169-abe0-9f227e963a9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa6103ff-4bcd-4203-900e-360d188117f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa6103ff-4bcd-4203-900e-360d188117f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/6f8b3396-d1fc-47c5-8c44-0eeb719925a2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa6103ff-4bcd-4203-900e-360d188117f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fce9933-2f85-4c1b-82b9-af1e0d4efd74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fce9933-2f85-4c1b-82b9-af1e0d4efd74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/a4c0bcaa-a051-4109-b89d-dbed40ca0e22/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fce9933-2f85-4c1b-82b9-af1e0d4efd74>.
+    
+<http://data.lblod.info/id/remote-data-objects/955107b2-6b61-4852-ac6d-ce3070fad3dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "955107b2-6b61-4852-ac6d-ce3070fad3dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/b0ff197b-9f4c-45ee-a37f-24db3141e3e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/955107b2-6b61-4852-ac6d-ce3070fad3dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/1860aea2-d3e2-4add-a6e6-9a4ca773efa1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1860aea2-d3e2-4add-a6e6-9a4ca773efa1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/b12fc8c8-9705-47db-a452-86a3a735e593/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1860aea2-d3e2-4add-a6e6-9a4ca773efa1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8136d397-9697-4352-b522-9adb9777ae1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8136d397-9697-4352-b522-9adb9777ae1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/d096f557-82e5-46ad-9638-45884dd9cf0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8136d397-9697-4352-b522-9adb9777ae1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a53ce57-3743-4210-bfd7-c81da2ee5981> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a53ce57-3743-4210-bfd7-c81da2ee5981";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/d59a131c-fde9-4388-bd0c-ec4852ef2906/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a53ce57-3743-4210-bfd7-c81da2ee5981>.
+    
+<http://data.lblod.info/id/remote-data-objects/74e17076-be00-4b3c-87bc-178bfe17659e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74e17076-be00-4b3c-87bc-178bfe17659e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/f172818a-ff75-4405-9b26-2572fc06d9cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74e17076-be00-4b3c-87bc-178bfe17659e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1223a64f-1253-4462-9211-030f790a8ac7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1223a64f-1253-4462-9211-030f790a8ac7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/f5282dbf-9174-4442-b0cc-0d6ae01278d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1223a64f-1253-4462-9211-030f790a8ac7>.
+    
+<http://data.lblod.info/id/remote-data-objects/837610e3-14d6-49a5-b8b8-dada39592807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "837610e3-14d6-49a5-b8b8-dada39592807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/f74925f2-a827-474e-9c4a-11ae563ad4e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/837610e3-14d6-49a5-b8b8-dada39592807>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3b3d8ea-6bef-4c17-8c1b-db758fe19a23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3b3d8ea-6bef-4c17-8c1b-db758fe19a23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hoogstraten.meetingburger.net/vabu/fb987e06-3b21-4e36-87a3-ff5ceb8fe460/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3b3d8ea-6bef-4c17-8c1b-db758fe19a23>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b87486a-7a24-4de8-be3f-b4b3e2944ed8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b87486a-7a24-4de8-be3f-b4b3e2944ed8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/ac/4d057f39-17a9-4129-9a0e-7650f3655609/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b87486a-7a24-4de8-be3f-b4b3e2944ed8>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e461687-625d-4279-93e7-e748e8266022> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e461687-625d-4279-93e7-e748e8266022";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/ac/e8279193-565d-4e34-9ca1-c88994589456/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e461687-625d-4279-93e7-e748e8266022>.
+    
+<http://data.lblod.info/id/remote-data-objects/9929ab04-09f5-4ed0-9336-afc5277dfd5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9929ab04-09f5-4ed0-9336-afc5277dfd5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/avz/3b9fd8e9-4f38-42be-8cbe-c5e09f7742b8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9929ab04-09f5-4ed0-9336-afc5277dfd5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f8cbd06-d9c1-4485-b888-d718f1bbc2d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f8cbd06-d9c1-4485-b888-d718f1bbc2d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/avz/bf7cd5c9-0f73-44fa-9b93-ce9abd0a1429/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f8cbd06-d9c1-4485-b888-d718f1bbc2d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/18a5c8b6-7390-4076-b40a-802eedb32264> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18a5c8b6-7390-4076-b40a-802eedb32264";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/avz/c07f1d23-ea20-412d-bf05-d16503929463/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18a5c8b6-7390-4076-b40a-802eedb32264>.
+    
+<http://data.lblod.info/id/remote-data-objects/8748237b-c0df-473f-9029-c85b7054a5df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8748237b-c0df-473f-9029-c85b7054a5df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/bb/19361d87-3169-4698-89e4-aa8b4500da55/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8748237b-c0df-473f-9029-c85b7054a5df>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d854219-fd84-41ed-8be3-31bb7244dbd6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d854219-fd84-41ed-8be3-31bb7244dbd6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/bb/8352f8e7-35a2-4ce3-bc28-8a0ebfd698b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d854219-fd84-41ed-8be3-31bb7244dbd6>.
+    
+<http://data.lblod.info/id/remote-data-objects/907e468a-180e-42ec-8076-3a904093dc14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "907e468a-180e-42ec-8076-3a904093dc14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/bb/9725f399-1ac8-428a-bf6e-f10ae406c6d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/907e468a-180e-42ec-8076-3a904093dc14>.
+    
+<http://data.lblod.info/id/remote-data-objects/06565beb-1677-46a8-b181-485d64edea2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06565beb-1677-46a8-b181-485d64edea2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/bb/afa1b837-a1ac-47c0-ad87-a7ca47e7e404/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06565beb-1677-46a8-b181-485d64edea2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/196c7af3-46b7-4e40-8674-bb9173591f4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "196c7af3-46b7-4e40-8674-bb9173591f4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/bb/c67d4510-8369-403d-9bfa-52cca203fd21/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/196c7af3-46b7-4e40-8674-bb9173591f4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ed5a771-4ac8-422f-a0a1-9acf24c1ea27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ed5a771-4ac8-422f-a0a1-9acf24c1ea27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/bb/f7f8e05f-42e8-4ee5-b672-9def7a86f815/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ed5a771-4ac8-422f-a0a1-9acf24c1ea27>.
+    
+<http://data.lblod.info/id/remote-data-objects/824d2e43-7626-4b4c-b4c1-7147f390206a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "824d2e43-7626-4b4c-b4c1-7147f390206a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/05e4d84b-e0d5-4e50-bfa3-766873691c69/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/824d2e43-7626-4b4c-b4c1-7147f390206a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b8094e8-5268-40fa-ade6-93cd1f02fb4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b8094e8-5268-40fa-ade6-93cd1f02fb4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/0827082a-2ee1-4e41-beba-c4d5f1536ed6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b8094e8-5268-40fa-ade6-93cd1f02fb4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1c348bf-768b-4b38-b393-262136b83ff5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1c348bf-768b-4b38-b393-262136b83ff5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/115a46d4-a8c4-4b7d-9aa8-93d899a65b1b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1c348bf-768b-4b38-b393-262136b83ff5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea110024-71bf-4b8b-9593-7bbeb06aff9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea110024-71bf-4b8b-9593-7bbeb06aff9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/190a2e6d-c496-44fb-9a94-d532256affad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea110024-71bf-4b8b-9593-7bbeb06aff9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf8fb138-67b7-4234-864b-457110114ae2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf8fb138-67b7-4234-864b-457110114ae2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/27b48d7d-4950-4681-93a0-09fc152b6f0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf8fb138-67b7-4234-864b-457110114ae2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3678479a-96d1-4db0-9cab-1eaf3cb5dd3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3678479a-96d1-4db0-9cab-1eaf3cb5dd3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/3699906a-5816-4c33-9a79-49d7d34be448/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3678479a-96d1-4db0-9cab-1eaf3cb5dd3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d56f8016-75ee-4d77-a079-88f71c53a8ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d56f8016-75ee-4d77-a079-88f71c53a8ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/378c1460-4b49-46b1-acb0-543654c89201/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d56f8016-75ee-4d77-a079-88f71c53a8ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/7570c3f7-7771-4358-aace-d1a2a4a83f1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7570c3f7-7771-4358-aace-d1a2a4a83f1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/3d351190-3217-47f4-8912-d5c11740238a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7570c3f7-7771-4358-aace-d1a2a4a83f1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b131977-af9e-47a8-a215-f84a17f40af3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b131977-af9e-47a8-a215-f84a17f40af3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/480ea7f1-6e38-4701-b3a1-963c303cbff5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b131977-af9e-47a8-a215-f84a17f40af3>.
+    
+<http://data.lblod.info/id/remote-data-objects/479c49a9-bbeb-4ea8-91ed-6f15245b4fa1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "479c49a9-bbeb-4ea8-91ed-6f15245b4fa1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/4cde6c85-96a7-4954-9643-07da3fa893ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/479c49a9-bbeb-4ea8-91ed-6f15245b4fa1>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a537df8-3d32-42fe-8fc0-5d63413011c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a537df8-3d32-42fe-8fc0-5d63413011c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/5be08895-a21a-4508-b8e0-e764ea24c7aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a537df8-3d32-42fe-8fc0-5d63413011c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2191bc1-5242-4fe4-a7dd-aced37d284af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2191bc1-5242-4fe4-a7dd-aced37d284af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/5cbfb9d6-b5ae-4116-85ae-7b919f7f89f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2191bc1-5242-4fe4-a7dd-aced37d284af>.
+    
+<http://data.lblod.info/id/remote-data-objects/e832492c-a2ef-4324-b05a-44258d67f331> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e832492c-a2ef-4324-b05a-44258d67f331";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/6c879f50-6ff6-4ccf-ab89-fef046ca44a2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e832492c-a2ef-4324-b05a-44258d67f331>.
+    
+<http://data.lblod.info/id/remote-data-objects/a58b23b7-8d61-4606-9f80-fed82bc69377> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a58b23b7-8d61-4606-9f80-fed82bc69377";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/6f363181-ec04-4733-a244-c54a75269b6e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a2ea2c8f-3a01-4cfe-8cd8-31b872585a38> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a58b23b7-8d61-4606-9f80-fed82bc69377>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201159-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201159-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201159-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201159-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/278e8c72-1676-4413-963d-5b92a59723e8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "278e8c72-1676-4413-963d-5b92a59723e8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5f425212-85e0-452b-bfae-7f921ea3f2ca";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e64a4140-2f0d-447d-b660-59cb1f3f984b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e64a4140-2f0d-447d-b660-59cb1f3f984b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca>.
+
+  <http://redpencil.data.gift/id/task/35ef6789-557a-4d7d-88bd-0c43c8cef275> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "35ef6789-557a-4d7d-88bd-0c43c8cef275";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/278e8c72-1676-4413-963d-5b92a59723e8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e64a4140-2f0d-447d-b660-59cb1f3f984b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/67d41143-5595-48d3-af68-5125704f8225> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67d41143-5595-48d3-af68-5125704f8225";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/7550fcac-6dcd-4f1f-aedb-627ee3641cef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67d41143-5595-48d3-af68-5125704f8225>.
+    
+<http://data.lblod.info/id/remote-data-objects/92d6c5df-1ff4-4b2d-918e-5647239e5429> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92d6c5df-1ff4-4b2d-918e-5647239e5429";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/7610235f-ee8a-4bc6-9ae8-d1e963aea3cc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92d6c5df-1ff4-4b2d-918e-5647239e5429>.
+    
+<http://data.lblod.info/id/remote-data-objects/841e49e4-1e06-46c0-ac23-5ea701b7fdac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "841e49e4-1e06-46c0-ac23-5ea701b7fdac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/77fd4a45-edae-499d-bf12-dc6a81174996/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/841e49e4-1e06-46c0-ac23-5ea701b7fdac>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e075b1f-b753-45ee-b4ce-838ba4ba0044> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e075b1f-b753-45ee-b4ce-838ba4ba0044";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/79354592-dc4c-4310-acc9-1743b23ab02a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e075b1f-b753-45ee-b4ce-838ba4ba0044>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f6d6489-89d6-4680-8d07-831bf93d567e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f6d6489-89d6-4680-8d07-831bf93d567e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/80f98780-6b90-4736-ab0a-9225c9b47df3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f6d6489-89d6-4680-8d07-831bf93d567e>.
+    
+<http://data.lblod.info/id/remote-data-objects/af9048e8-7e03-4400-b870-8b677e7b0c2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af9048e8-7e03-4400-b870-8b677e7b0c2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/81b45408-acf0-482e-8a92-bc2c1b3cce4f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af9048e8-7e03-4400-b870-8b677e7b0c2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcb18f9f-ed01-4262-8cf7-3e5ebe8f160c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcb18f9f-ed01-4262-8cf7-3e5ebe8f160c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/85a8dc9e-1037-4770-9f48-4006c04ed219/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcb18f9f-ed01-4262-8cf7-3e5ebe8f160c>.
+    
+<http://data.lblod.info/id/remote-data-objects/178ddd5a-7ad3-4323-9d6a-02132ed8de38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "178ddd5a-7ad3-4323-9d6a-02132ed8de38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/8bcae349-cb99-4b43-bd77-ce722d9c1689/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/178ddd5a-7ad3-4323-9d6a-02132ed8de38>.
+    
+<http://data.lblod.info/id/remote-data-objects/326997aa-81a5-4dd7-a342-7051039f8332> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "326997aa-81a5-4dd7-a342-7051039f8332";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/8c70fbc0-2764-416b-b456-9d4af60a0cc7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/326997aa-81a5-4dd7-a342-7051039f8332>.
+    
+<http://data.lblod.info/id/remote-data-objects/252aa1d1-8882-41db-ab30-80bcf10f277d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "252aa1d1-8882-41db-ab30-80bcf10f277d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/92da6290-dfec-48c1-8acb-da62168cb4de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/252aa1d1-8882-41db-ab30-80bcf10f277d>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd6b3e59-1fc1-42db-9556-af7cf0943c49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd6b3e59-1fc1-42db-9556-af7cf0943c49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/92db4c5c-3861-49f7-abe1-43d9c73e7861/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd6b3e59-1fc1-42db-9556-af7cf0943c49>.
+    
+<http://data.lblod.info/id/remote-data-objects/031bbadc-e8b1-4e01-901b-7b2d47714dbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "031bbadc-e8b1-4e01-901b-7b2d47714dbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/9690ab5f-f9fc-493a-a9f7-6b4e6a111311/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/031bbadc-e8b1-4e01-901b-7b2d47714dbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/6018124c-6cfd-40bd-8ad4-f658e8dfebba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6018124c-6cfd-40bd-8ad4-f658e8dfebba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/a3f5e5f4-b851-41ae-ae7e-993a11e10602/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6018124c-6cfd-40bd-8ad4-f658e8dfebba>.
+    
+<http://data.lblod.info/id/remote-data-objects/889a4d7d-ec4a-4247-a66c-f19047516573> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "889a4d7d-ec4a-4247-a66c-f19047516573";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/ba0863f2-0360-4018-8b72-6f4346c3cfae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/889a4d7d-ec4a-4247-a66c-f19047516573>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b5f2651-c34c-4d81-be44-ff127c05984f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b5f2651-c34c-4d81-be44-ff127c05984f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/ba587ef8-5028-4c3a-81b3-5c86c7104e6b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b5f2651-c34c-4d81-be44-ff127c05984f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7e8f6a0-fe61-4675-b841-4c1153b42c01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7e8f6a0-fe61-4675-b841-4c1153b42c01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/bd82ec87-0ac6-4b6e-9078-ee2d5eb793e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7e8f6a0-fe61-4675-b841-4c1153b42c01>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e62faed-4783-49b3-be9f-191c569ed22d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e62faed-4783-49b3-be9f-191c569ed22d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/c4b66264-cf04-4d49-99c6-025172fb7e25/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e62faed-4783-49b3-be9f-191c569ed22d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5b21087-b9cb-4f8f-865b-9836c1f6689f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5b21087-b9cb-4f8f-865b-9836c1f6689f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/c58776a3-38c5-4b1a-a6c2-58e59c7d6237/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5b21087-b9cb-4f8f-865b-9836c1f6689f>.
+    
+<http://data.lblod.info/id/remote-data-objects/222b976f-e8f1-4216-b495-7a035a05b404> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "222b976f-e8f1-4216-b495-7a035a05b404";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/cb0fbbf5-6fe0-40b2-b586-e80a03740e72/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/222b976f-e8f1-4216-b495-7a035a05b404>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7034b0c-dd77-49af-b720-86c1d24eb4fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7034b0c-dd77-49af-b720-86c1d24eb4fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/d2cd1a0e-8fd3-4627-9e1b-6f63cfe862c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7034b0c-dd77-49af-b720-86c1d24eb4fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ac3efca-1fed-4acb-a9c6-b07a5eec6a34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ac3efca-1fed-4acb-a9c6-b07a5eec6a34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/d60a8a12-e77d-4b9b-af57-971163e6157e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ac3efca-1fed-4acb-a9c6-b07a5eec6a34>.
+    
+<http://data.lblod.info/id/remote-data-objects/d41828bf-a4a3-4e63-9ed4-165be694f619> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d41828bf-a4a3-4e63-9ed4-165be694f619";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/e413394e-d241-4074-a055-f01640fadd2b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d41828bf-a4a3-4e63-9ed4-165be694f619>.
+    
+<http://data.lblod.info/id/remote-data-objects/6996654b-caa6-440d-be60-54621e25330b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6996654b-caa6-440d-be60-54621e25330b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/eb931cea-a8e6-45cf-adee-cbd47cbafadc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6996654b-caa6-440d-be60-54621e25330b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa9ee0e6-d820-40d8-9659-4a6cbd81aca1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa9ee0e6-d820-40d8-9659-4a6cbd81aca1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/eea5059c-2489-4fa9-bd71-bbd8a4233c41/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa9ee0e6-d820-40d8-9659-4a6cbd81aca1>.
+    
+<http://data.lblod.info/id/remote-data-objects/05e9ebb8-e313-4ce1-867d-f5b559e1e5f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05e9ebb8-e313-4ce1-867d-f5b559e1e5f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/eff9c8c2-29e6-43fb-8d3f-e370876cf942/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05e9ebb8-e313-4ce1-867d-f5b559e1e5f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/022df7ce-0576-4f92-a1b8-abdeb31b7778> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "022df7ce-0576-4f92-a1b8-abdeb31b7778";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/cbs/fd5fff2a-2af9-429c-9dea-34ad52222c57/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/022df7ce-0576-4f92-a1b8-abdeb31b7778>.
+    
+<http://data.lblod.info/id/remote-data-objects/686dd84f-3ad5-4bb1-9cb6-0c41cbf5a562> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "686dd84f-3ad5-4bb1-9cb6-0c41cbf5a562";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/0a73b359-d9dc-4aee-9686-a7df1544b74f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/686dd84f-3ad5-4bb1-9cb6-0c41cbf5a562>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7ce2723-197c-491e-9c6f-67138b2bf605> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7ce2723-197c-491e-9c6f-67138b2bf605";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/0a73b359-d9dc-4aee-9686-a7df1544b74f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7ce2723-197c-491e-9c6f-67138b2bf605>.
+    
+<http://data.lblod.info/id/remote-data-objects/128e1a77-e869-4a30-8de5-2c79c88355f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "128e1a77-e869-4a30-8de5-2c79c88355f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/1b680b7a-756a-4563-8464-e21f3996d3e2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/128e1a77-e869-4a30-8de5-2c79c88355f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/02f5de4f-0be1-42d5-b986-9fe420bf5acd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02f5de4f-0be1-42d5-b986-9fe420bf5acd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/1b680b7a-756a-4563-8464-e21f3996d3e2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02f5de4f-0be1-42d5-b986-9fe420bf5acd>.
+    
+<http://data.lblod.info/id/remote-data-objects/c970a679-c21a-4287-b6b0-d059ab12a588> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c970a679-c21a-4287-b6b0-d059ab12a588";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/3499c6cc-99f5-48e7-8112-badb741bcbdc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c970a679-c21a-4287-b6b0-d059ab12a588>.
+    
+<http://data.lblod.info/id/remote-data-objects/1acc5521-705a-433e-b74f-64e75dc9b1bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1acc5521-705a-433e-b74f-64e75dc9b1bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/3499c6cc-99f5-48e7-8112-badb741bcbdc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1acc5521-705a-433e-b74f-64e75dc9b1bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/443fa5ad-cfc9-476f-bf26-147f4c59415b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "443fa5ad-cfc9-476f-bf26-147f4c59415b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/3499c6cc-99f5-48e7-8112-badb741bcbdc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/443fa5ad-cfc9-476f-bf26-147f4c59415b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dae544c-e3fb-4f66-b60a-cf9c3ef6bdf4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dae544c-e3fb-4f66-b60a-cf9c3ef6bdf4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/40f4650a-d876-41a5-833e-ef2324e4df09/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dae544c-e3fb-4f66-b60a-cf9c3ef6bdf4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7511ac8-e798-4c27-9c7f-2de1ceea3438> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7511ac8-e798-4c27-9c7f-2de1ceea3438";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/40f4650a-d876-41a5-833e-ef2324e4df09/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7511ac8-e798-4c27-9c7f-2de1ceea3438>.
+    
+<http://data.lblod.info/id/remote-data-objects/584909e3-b2b8-47a5-ae66-d75ba27857c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "584909e3-b2b8-47a5-ae66-d75ba27857c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/40f4650a-d876-41a5-833e-ef2324e4df09/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/584909e3-b2b8-47a5-ae66-d75ba27857c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/31581b43-5477-4e8f-a72c-ebfce26308db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31581b43-5477-4e8f-a72c-ebfce26308db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/5209884b-5fa2-4041-9611-0207d357e12a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31581b43-5477-4e8f-a72c-ebfce26308db>.
+    
+<http://data.lblod.info/id/remote-data-objects/a65edd96-f6b3-4d91-9213-a0f23e22fc58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a65edd96-f6b3-4d91-9213-a0f23e22fc58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/5209884b-5fa2-4041-9611-0207d357e12a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a65edd96-f6b3-4d91-9213-a0f23e22fc58>.
+    
+<http://data.lblod.info/id/remote-data-objects/79a17dc5-8589-4fc4-9773-7d658481e4be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79a17dc5-8589-4fc4-9773-7d658481e4be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/524d12e4-2bbb-4cec-9bd6-6579722e9ffc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79a17dc5-8589-4fc4-9773-7d658481e4be>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bd44c25-d6bf-4389-a1fd-58b11d1ded97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bd44c25-d6bf-4389-a1fd-58b11d1ded97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/524d12e4-2bbb-4cec-9bd6-6579722e9ffc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bd44c25-d6bf-4389-a1fd-58b11d1ded97>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a8edffc-44be-4a22-b988-3f8f7420e78e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a8edffc-44be-4a22-b988-3f8f7420e78e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/556df6bf-5ee8-4f5a-8bfd-10d9448a4333/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a8edffc-44be-4a22-b988-3f8f7420e78e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5915e4ee-2625-4e57-afe5-36a5962e2415> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5915e4ee-2625-4e57-afe5-36a5962e2415";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/556df6bf-5ee8-4f5a-8bfd-10d9448a4333/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5915e4ee-2625-4e57-afe5-36a5962e2415>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7d939d0-002a-4139-ac2b-0a3875450e90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7d939d0-002a-4139-ac2b-0a3875450e90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/5c3288cd-9a55-476e-addb-d1a69939067b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7d939d0-002a-4139-ac2b-0a3875450e90>.
+    
+<http://data.lblod.info/id/remote-data-objects/87617af2-0124-4f3d-810d-197b582a4211> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87617af2-0124-4f3d-810d-197b582a4211";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/5c3288cd-9a55-476e-addb-d1a69939067b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87617af2-0124-4f3d-810d-197b582a4211>.
+    
+<http://data.lblod.info/id/remote-data-objects/55051362-f731-4ea8-9b7a-6ba6f8799a90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55051362-f731-4ea8-9b7a-6ba6f8799a90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/c042537a-db45-41fd-b522-7055e26a517f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55051362-f731-4ea8-9b7a-6ba6f8799a90>.
+    
+<http://data.lblod.info/id/remote-data-objects/e04a93dd-cd55-4ff1-9267-67f47cba0c3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e04a93dd-cd55-4ff1-9267-67f47cba0c3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/c042537a-db45-41fd-b522-7055e26a517f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e04a93dd-cd55-4ff1-9267-67f47cba0c3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/04a64002-0ec1-4ae6-bae0-4d3e3382a4b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04a64002-0ec1-4ae6-bae0-4d3e3382a4b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/c042537a-db45-41fd-b522-7055e26a517f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04a64002-0ec1-4ae6-bae0-4d3e3382a4b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b09ab86-4557-4f73-942b-db05bb89f043> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b09ab86-4557-4f73-942b-db05bb89f043";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/c3d1a9a3-a6d5-4f0b-9516-c098ee64e649/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b09ab86-4557-4f73-942b-db05bb89f043>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae4d07ef-1179-4798-ab1a-fb11920bcdb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae4d07ef-1179-4798-ab1a-fb11920bcdb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/c3d1a9a3-a6d5-4f0b-9516-c098ee64e649/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae4d07ef-1179-4798-ab1a-fb11920bcdb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3169ce22-1c4f-400a-871f-df62727dfc5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3169ce22-1c4f-400a-871f-df62727dfc5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/d4d66ea9-b08d-4c7b-91c5-31b2b9089b20/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:11:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f425212-85e0-452b-bfae-7f921ea3f2ca> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3169ce22-1c4f-400a-871f-df62727dfc5f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201201-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201201-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201201-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201201-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c8ea6298-b4ec-4272-a8ab-9e2fb2c9799a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c8ea6298-b4ec-4272-a8ab-9e2fb2c9799a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "97643b28-22a8-4ac8-9e42-8e9964fcf3dd";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b3a395da-a898-47fe-8a98-ebe5211649d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b3a395da-a898-47fe-8a98-ebe5211649d9";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd>.
+
+  <http://redpencil.data.gift/id/task/582c199b-e405-48b0-824d-f9236f2e302d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "582c199b-e405-48b0-824d-f9236f2e302d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c8ea6298-b4ec-4272-a8ab-9e2fb2c9799a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b3a395da-a898-47fe-8a98-ebe5211649d9>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/3d719ac5-2ebc-416d-b954-4b81d5f90096> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d719ac5-2ebc-416d-b954-4b81d5f90096";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/d4d66ea9-b08d-4c7b-91c5-31b2b9089b20/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d719ac5-2ebc-416d-b954-4b81d5f90096>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a653e02-3176-4122-8f95-54466751b815> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a653e02-3176-4122-8f95-54466751b815";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/db31c9ee-89ff-4771-8dde-dd02ad6cb23b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a653e02-3176-4122-8f95-54466751b815>.
+    
+<http://data.lblod.info/id/remote-data-objects/9bc959c2-18cd-4a5c-aa1a-7c3b6bc6f1c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9bc959c2-18cd-4a5c-aa1a-7c3b6bc6f1c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/db31c9ee-89ff-4771-8dde-dd02ad6cb23b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9bc959c2-18cd-4a5c-aa1a-7c3b6bc6f1c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/628a3954-42a4-495d-80c5-12246300164a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "628a3954-42a4-495d-80c5-12246300164a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/db31c9ee-89ff-4771-8dde-dd02ad6cb23b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/628a3954-42a4-495d-80c5-12246300164a>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd75bec9-aa71-4236-b144-e6cbd72a26bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd75bec9-aa71-4236-b144-e6cbd72a26bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/df2ed799-649e-41c4-a3a7-aca528e23494/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd75bec9-aa71-4236-b144-e6cbd72a26bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab95ed60-2f7e-408a-a2a2-b66c3410b602> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab95ed60-2f7e-408a-a2a2-b66c3410b602";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/df2ed799-649e-41c4-a3a7-aca528e23494/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab95ed60-2f7e-408a-a2a2-b66c3410b602>.
+    
+<http://data.lblod.info/id/remote-data-objects/a412fed0-0a06-40a7-ad45-15ce2796fb24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a412fed0-0a06-40a7-ad45-15ce2796fb24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/ea797a03-1f80-4c4b-b959-0a35bb721ffc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a412fed0-0a06-40a7-ad45-15ce2796fb24>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b7b43d3-c913-4261-a46d-1c484cbedcb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b7b43d3-c913-4261-a46d-1c484cbedcb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/ea797a03-1f80-4c4b-b959-0a35bb721ffc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b7b43d3-c913-4261-a46d-1c484cbedcb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b1afac0-03a4-4ece-a3d4-365a18ef0c19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b1afac0-03a4-4ece-a3d4-365a18ef0c19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/eb86ccd8-d8ee-4ebd-be07-09cdff8fbbe5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b1afac0-03a4-4ece-a3d4-365a18ef0c19>.
+    
+<http://data.lblod.info/id/remote-data-objects/82e89fe8-9f2f-4d24-bf62-824abea99c20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82e89fe8-9f2f-4d24-bf62-824abea99c20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/gr/eb86ccd8-d8ee-4ebd-be07-09cdff8fbbe5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82e89fe8-9f2f-4d24-bf62-824abea99c20>.
+    
+<http://data.lblod.info/id/remote-data-objects/271f19b8-eb0d-4659-a35f-8fd19060c3fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "271f19b8-eb0d-4659-a35f-8fd19060c3fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/4575a3b7-adc2-46e6-9474-893224c267af/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/271f19b8-eb0d-4659-a35f-8fd19060c3fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c548172-9f7d-42a3-bd46-678431a43a71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c548172-9f7d-42a3-bd46-678431a43a71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/4575a3b7-adc2-46e6-9474-893224c267af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c548172-9f7d-42a3-bd46-678431a43a71>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf885275-e9e2-4b67-b741-97268936a532> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf885275-e9e2-4b67-b741-97268936a532";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/68206a8b-f71c-41a2-bcaa-2f1955bfc368/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf885275-e9e2-4b67-b741-97268936a532>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bc75479-1e9d-49b1-bd85-933ba0cf5d51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bc75479-1e9d-49b1-bd85-933ba0cf5d51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/68206a8b-f71c-41a2-bcaa-2f1955bfc368/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bc75479-1e9d-49b1-bd85-933ba0cf5d51>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b478306-2f19-42f3-803d-22b0e6935f40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b478306-2f19-42f3-803d-22b0e6935f40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/6de93077-aade-4345-8daa-3745c3e6d57c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b478306-2f19-42f3-803d-22b0e6935f40>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c622636-5509-4710-97e8-6e88d63dfe6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c622636-5509-4710-97e8-6e88d63dfe6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/6de93077-aade-4345-8daa-3745c3e6d57c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c622636-5509-4710-97e8-6e88d63dfe6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d018acf1-dfa7-48cb-8a86-c126a5e4aafa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d018acf1-dfa7-48cb-8a86-c126a5e4aafa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/71c986bd-33d1-4f5e-8c84-b8803589e481/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d018acf1-dfa7-48cb-8a86-c126a5e4aafa>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2491a46-6d34-46c3-a183-f06009bd625e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2491a46-6d34-46c3-a183-f06009bd625e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/71c986bd-33d1-4f5e-8c84-b8803589e481/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2491a46-6d34-46c3-a183-f06009bd625e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8e3c595-02e5-42a0-ab7b-335182deee75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8e3c595-02e5-42a0-ab7b-335182deee75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/758f5212-f75c-4e4f-8c5d-c01737716921/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8e3c595-02e5-42a0-ab7b-335182deee75>.
+    
+<http://data.lblod.info/id/remote-data-objects/d245d4ca-d75a-4d0c-8402-fa8e7a7fc6bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d245d4ca-d75a-4d0c-8402-fa8e7a7fc6bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/758f5212-f75c-4e4f-8c5d-c01737716921/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d245d4ca-d75a-4d0c-8402-fa8e7a7fc6bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/f52c0453-ed3e-4120-8ed1-659ea8496854> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f52c0453-ed3e-4120-8ed1-659ea8496854";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/789dea0b-8dd0-4a7b-a533-4c92a28fb348/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f52c0453-ed3e-4120-8ed1-659ea8496854>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cfe6688-33aa-4609-bc5f-ac3f7080b13c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cfe6688-33aa-4609-bc5f-ac3f7080b13c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/789dea0b-8dd0-4a7b-a533-4c92a28fb348/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cfe6688-33aa-4609-bc5f-ac3f7080b13c>.
+    
+<http://data.lblod.info/id/remote-data-objects/acde0ef6-73f5-4301-a9cf-e1a3954311ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acde0ef6-73f5-4301-a9cf-e1a3954311ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/8187d21b-2cee-4b44-8ffc-d34ccd317aa0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acde0ef6-73f5-4301-a9cf-e1a3954311ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/84b596d9-ba9c-42b0-bd39-0518880be7a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84b596d9-ba9c-42b0-bd39-0518880be7a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/8187d21b-2cee-4b44-8ffc-d34ccd317aa0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84b596d9-ba9c-42b0-bd39-0518880be7a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/3acfe7ef-dc60-444d-bbe4-df8df2b49d0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3acfe7ef-dc60-444d-bbe4-df8df2b49d0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/827f3a4f-ae41-48a2-ae6a-3c779fd9be51/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3acfe7ef-dc60-444d-bbe4-df8df2b49d0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/75b37c60-f505-4ea1-95d5-a696e5141389> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75b37c60-f505-4ea1-95d5-a696e5141389";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/827f3a4f-ae41-48a2-ae6a-3c779fd9be51/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75b37c60-f505-4ea1-95d5-a696e5141389>.
+    
+<http://data.lblod.info/id/remote-data-objects/13a11384-701b-40ba-bab9-189975344089> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13a11384-701b-40ba-bab9-189975344089";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/90ca04ce-5ff8-45ce-9967-cd2ab20115cb/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13a11384-701b-40ba-bab9-189975344089>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea5f3081-76c1-4e00-9837-0d9a22c2860b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea5f3081-76c1-4e00-9837-0d9a22c2860b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/90ca04ce-5ff8-45ce-9967-cd2ab20115cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea5f3081-76c1-4e00-9837-0d9a22c2860b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6af6a098-b1f0-4e82-82b2-b6597ee05984> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6af6a098-b1f0-4e82-82b2-b6597ee05984";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/a561627e-a7f4-4680-b5c9-9de4839973c2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6af6a098-b1f0-4e82-82b2-b6597ee05984>.
+    
+<http://data.lblod.info/id/remote-data-objects/288bf4a6-7043-440b-abfd-bde525783009> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "288bf4a6-7043-440b-abfd-bde525783009";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/a561627e-a7f4-4680-b5c9-9de4839973c2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/288bf4a6-7043-440b-abfd-bde525783009>.
+    
+<http://data.lblod.info/id/remote-data-objects/494de219-bb23-46bc-a9cb-370c4be98728> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "494de219-bb23-46bc-a9cb-370c4be98728";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/b6e0d60e-49e6-4cc3-af1a-358d7a6a97b0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/494de219-bb23-46bc-a9cb-370c4be98728>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2157f31-5afe-482e-b9c5-ac0f90d1f2d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2157f31-5afe-482e-b9c5-ac0f90d1f2d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/b6e0d60e-49e6-4cc3-af1a-358d7a6a97b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2157f31-5afe-482e-b9c5-ac0f90d1f2d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f918161d-22a1-4878-a226-4c0860b2c675> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f918161d-22a1-4878-a226-4c0860b2c675";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/cf4d8134-376f-4966-8e62-cd8d236bdc3a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f918161d-22a1-4878-a226-4c0860b2c675>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b142170-dd07-44af-bb8b-884c157fad6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b142170-dd07-44af-bb8b-884c157fad6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/cf4d8134-376f-4966-8e62-cd8d236bdc3a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b142170-dd07-44af-bb8b-884c157fad6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/eae8b134-7da8-4027-94b3-9ce683054213> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eae8b134-7da8-4027-94b3-9ce683054213";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/f7e46577-38b5-4b96-acc1-50bb5fdcfe2c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eae8b134-7da8-4027-94b3-9ce683054213>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dc1a3e6-27bc-460c-985a-6db468643e50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dc1a3e6-27bc-460c-985a-6db468643e50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/or/f7e46577-38b5-4b96-acc1-50bb5fdcfe2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dc1a3e6-27bc-460c-985a-6db468643e50>.
+    
+<http://data.lblod.info/id/remote-data-objects/d52e7537-c251-4fa8-bf68-667b58d14664> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d52e7537-c251-4fa8-bf68-667b58d14664";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-agb-mp/6af187e5-89dd-4357-9c8a-89da03935ea1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d52e7537-c251-4fa8-bf68-667b58d14664>.
+    
+<http://data.lblod.info/id/remote-data-objects/0119cd3b-162e-428b-8d66-e2ca0083fc68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0119cd3b-162e-428b-8d66-e2ca0083fc68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-agb-mp/73bf59de-6987-4e76-903a-085fa8582897/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0119cd3b-162e-428b-8d66-e2ca0083fc68>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d2be496-02b9-4eec-afd8-f368f152b3f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d2be496-02b9-4eec-afd8-f368f152b3f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-agb-mp/83982d57-e464-4ac3-8b6e-9ed86f5f2eb0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d2be496-02b9-4eec-afd8-f368f152b3f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/686f23cd-d1b8-45d5-a685-d6a161633f27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "686f23cd-d1b8-45d5-a685-d6a161633f27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-agb-mp/aa32ce10-d696-4785-9339-075c9aa41bb5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/686f23cd-d1b8-45d5-a685-d6a161633f27>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a6cdf86-9793-423c-8ff0-057350338134> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a6cdf86-9793-423c-8ff0-057350338134";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-agb-mp/c46ec6e8-d4cc-41cf-906e-de83a9934ede/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a6cdf86-9793-423c-8ff0-057350338134>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9cfdd57-f2e8-4a61-8b21-2e7643b443cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9cfdd57-f2e8-4a61-8b21-2e7643b443cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-agb-mp/d5afc40d-3f4b-46d0-8d47-fa6e27c20785/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9cfdd57-f2e8-4a61-8b21-2e7643b443cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/f34ec0bb-2aea-4d15-b276-6595d008feda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f34ec0bb-2aea-4d15-b276-6595d008feda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-agb-mp/de76894f-4317-4458-b387-79a364d9df1b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f34ec0bb-2aea-4d15-b276-6595d008feda>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac322886-6c84-496b-8a03-a6fc4dc4eb48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac322886-6c84-496b-8a03-a6fc4dc4eb48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-agb-mp/f0991254-3b78-4a1f-8bf6-cfc85426dc02/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac322886-6c84-496b-8a03-a6fc4dc4eb48>.
+    
+<http://data.lblod.info/id/remote-data-objects/8615d11e-9d99-4a0f-8bd4-083a8a08ed80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8615d11e-9d99-4a0f-8bd4-083a8a08ed80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-agb-s/0580aab7-9cdf-4f8a-82d8-a9ef8cd22290/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8615d11e-9d99-4a0f-8bd4-083a8a08ed80>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8cc75ee-b1aa-4ed7-9b40-2be3108a65b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8cc75ee-b1aa-4ed7-9b40-2be3108a65b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-agb-s/0937eee7-d1fd-4a97-b631-85492235d9fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8cc75ee-b1aa-4ed7-9b40-2be3108a65b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4f2cf48-5295-4f8a-98d3-009605274b52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4f2cf48-5295-4f8a-98d3-009605274b52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-agb-s/5fe8a568-d21f-46a5-9cc1-49ae8e2d0e16/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4f2cf48-5295-4f8a-98d3-009605274b52>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d40f80d-cab5-4cec-acb1-b464fdb4b929> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d40f80d-cab5-4cec-acb1-b464fdb4b929";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-agb-s/6604d561-d56a-4c94-993a-64ae6af0d1f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d40f80d-cab5-4cec-acb1-b464fdb4b929>.
+    
+<http://data.lblod.info/id/remote-data-objects/c19b4218-e4bf-4d60-a454-f59bec317303> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c19b4218-e4bf-4d60-a454-f59bec317303";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-agb-s/9bd4349c-2886-4496-a810-05fd0d28211f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c19b4218-e4bf-4d60-a454-f59bec317303>.
+    
+<http://data.lblod.info/id/remote-data-objects/066b50c2-3bf7-48fc-9009-7725d79e4c52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "066b50c2-3bf7-48fc-9009-7725d79e4c52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-agb-s/c2997771-fa17-457c-9022-cf801b98e847/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/97643b28-22a8-4ac8-9e42-8e9964fcf3dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/066b50c2-3bf7-48fc-9009-7725d79e4c52>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201202-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201202-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201202-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201202-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7d86ed92-7a4c-46bf-9966-9ac508b92a15> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7d86ed92-7a4c-46bf-9966-9ac508b92a15";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5dc6de73-681e-44e5-925c-bf3e95043d64";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e5f7086a-1eed-4753-b1ea-1fa1b6597725> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e5f7086a-1eed-4753-b1ea-1fa1b6597725";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64>.
+
+  <http://redpencil.data.gift/id/task/108970dc-8022-4327-8366-668fe5b3d448> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "108970dc-8022-4327-8366-668fe5b3d448";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7d86ed92-7a4c-46bf-9966-9ac508b92a15>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e5f7086a-1eed-4753-b1ea-1fa1b6597725>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7aa0d684-10be-45aa-bd03-9c82702207b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7aa0d684-10be-45aa-bd03-9c82702207b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-z/0798f52e-ec95-4227-ade3-fd5b59f71b7e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7aa0d684-10be-45aa-bd03-9c82702207b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/39ee3614-7be2-4bd2-9737-f9400d4066bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39ee3614-7be2-4bd2-9737-f9400d4066bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-z/161e07bb-74ac-4409-8738-5c61ae87f029/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39ee3614-7be2-4bd2-9737-f9400d4066bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/74e090f1-c3a0-4071-8919-5d4898610665> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74e090f1-c3a0-4071-8919-5d4898610665";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-z/26bbde93-1a33-4047-9ee2-c778118492ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74e090f1-c3a0-4071-8919-5d4898610665>.
+    
+<http://data.lblod.info/id/remote-data-objects/362bb57f-b4ad-47f3-aa5f-3d7a04446d1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "362bb57f-b4ad-47f3-aa5f-3d7a04446d1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-z/29aa8617-f4fe-4d93-afcb-47fe16f2c706/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/362bb57f-b4ad-47f3-aa5f-3d7a04446d1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/97d2b730-2788-4496-b9b7-ea0810d2abf3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97d2b730-2788-4496-b9b7-ea0810d2abf3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-z/2d8e106a-c96c-4e52-b3c4-e91accd1b676/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97d2b730-2788-4496-b9b7-ea0810d2abf3>.
+    
+<http://data.lblod.info/id/remote-data-objects/97ade347-9a7a-4871-8608-af8c5cfc0465> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97ade347-9a7a-4871-8608-af8c5cfc0465";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-z/32659f9c-e64b-4d93-b2c0-b66bb2dca6b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97ade347-9a7a-4871-8608-af8c5cfc0465>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d79daab-a549-499a-97f7-7afaae17707e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d79daab-a549-499a-97f7-7afaae17707e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-z/3e732740-2bcc-4fdc-b636-5a04e6a0131b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d79daab-a549-499a-97f7-7afaae17707e>.
+    
+<http://data.lblod.info/id/remote-data-objects/09df91a6-c471-472b-9924-c29332bd30d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09df91a6-c471-472b-9924-c29332bd30d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-z/48eba020-1d3c-4ee7-80b2-4a8c53af9338/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09df91a6-c471-472b-9924-c29332bd30d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e6262d0-a9a9-41d7-97ca-c7d1eced21f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e6262d0-a9a9-41d7-97ca-c7d1eced21f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-z/7e8bb5b9-98e0-4434-b2f8-28a768e30fb5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e6262d0-a9a9-41d7-97ca-c7d1eced21f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d09f6ae6-c12a-410c-afba-19433fbcae0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d09f6ae6-c12a-410c-afba-19433fbcae0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-z/8f066fe4-d303-4b8e-a86a-c732354e5e36/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d09f6ae6-c12a-410c-afba-19433fbcae0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3be954a-f250-4fcb-8003-b983dc84a224> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3be954a-f250-4fcb-8003-b983dc84a224";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-z/99155965-c60b-419f-8567-ce0711d284cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3be954a-f250-4fcb-8003-b983dc84a224>.
+    
+<http://data.lblod.info/id/remote-data-objects/916676c7-6113-4f52-bcf3-473d75374087> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "916676c7-6113-4f52-bcf3-473d75374087";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-z/99833b5d-bd42-450f-bb40-72e540251280/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/916676c7-6113-4f52-bcf3-473d75374087>.
+    
+<http://data.lblod.info/id/remote-data-objects/31bf68b5-357e-403a-9b4d-0fbc53ac4681> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31bf68b5-357e-403a-9b4d-0fbc53ac4681";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-z/ab3bcd53-9f89-4713-bfe7-ff530f82bdcd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31bf68b5-357e-403a-9b4d-0fbc53ac4681>.
+    
+<http://data.lblod.info/id/remote-data-objects/95312bb9-f10a-4498-ac14-cd170f15a219> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95312bb9-f10a-4498-ac14-cd170f15a219";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-z/d55c612b-7aaa-4eba-9541-23e5ccf7af44/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95312bb9-f10a-4498-ac14-cd170f15a219>.
+    
+<http://data.lblod.info/id/remote-data-objects/76c84340-f2cd-4d64-9c91-fed6e1b501b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76c84340-f2cd-4d64-9c91-fed6e1b501b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/rvb-z/e0e9f7cb-62e7-47e0-ab63-a3570e0509c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76c84340-f2cd-4d64-9c91-fed6e1b501b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/64fce573-532b-4da3-b520-5d3432ed7a58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64fce573-532b-4da3-b520-5d3432ed7a58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/0035b23c-b6af-4f22-b68d-2f035cd05ffa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64fce573-532b-4da3-b520-5d3432ed7a58>.
+    
+<http://data.lblod.info/id/remote-data-objects/0db65603-c1bd-4592-9180-4ed2a1f36b81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0db65603-c1bd-4592-9180-4ed2a1f36b81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/075b8f4e-8e04-4021-b4fb-5d2338ad2575/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0db65603-c1bd-4592-9180-4ed2a1f36b81>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d0da72c-03b3-48a4-9a9d-79ef2876590d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d0da72c-03b3-48a4-9a9d-79ef2876590d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/21b03143-9aa8-4bfe-be8b-b855a4496ddf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d0da72c-03b3-48a4-9a9d-79ef2876590d>.
+    
+<http://data.lblod.info/id/remote-data-objects/016a223f-a918-4ca9-911e-d27093f89224> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "016a223f-a918-4ca9-911e-d27093f89224";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/2dc99d6a-face-4a4c-b408-6f25f9a3d0d8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/016a223f-a918-4ca9-911e-d27093f89224>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcb2a552-4a2f-4476-840d-a40b29cf9cb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcb2a552-4a2f-4476-840d-a40b29cf9cb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/30310c24-42f2-469e-b636-470ed929c815/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcb2a552-4a2f-4476-840d-a40b29cf9cb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ec7434f-cdd5-4112-923b-f5d56ca7ab6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ec7434f-cdd5-4112-923b-f5d56ca7ab6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/3951579d-e1de-4037-9444-c32ebf371cbd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ec7434f-cdd5-4112-923b-f5d56ca7ab6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5105d97e-0b28-4d88-95d0-a58ccc768626> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5105d97e-0b28-4d88-95d0-a58ccc768626";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/458e2702-5654-40bd-b8bc-88c306d436dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5105d97e-0b28-4d88-95d0-a58ccc768626>.
+    
+<http://data.lblod.info/id/remote-data-objects/67ac91c8-bacd-4fa4-820e-dc97c7bde450> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67ac91c8-bacd-4fa4-820e-dc97c7bde450";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/46ff0789-d547-49ba-bd04-6ff50c5bd62b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67ac91c8-bacd-4fa4-820e-dc97c7bde450>.
+    
+<http://data.lblod.info/id/remote-data-objects/855df847-7c0d-4f92-bf4a-5032feb45a78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "855df847-7c0d-4f92-bf4a-5032feb45a78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/4b8b995a-b63f-44db-bb54-bb2c27266d92/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/855df847-7c0d-4f92-bf4a-5032feb45a78>.
+    
+<http://data.lblod.info/id/remote-data-objects/09f81083-0454-4fe4-99d0-b7ba9c5438ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09f81083-0454-4fe4-99d0-b7ba9c5438ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/5a740ec0-9889-43dc-a9b0-2be037ce91ad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09f81083-0454-4fe4-99d0-b7ba9c5438ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/60d199bb-23a5-4f62-a397-2a509da74dc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60d199bb-23a5-4f62-a397-2a509da74dc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/5d536410-849a-46ef-b502-6b10074ffc00/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60d199bb-23a5-4f62-a397-2a509da74dc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3875c87d-dd84-457e-9482-2429aa770eb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3875c87d-dd84-457e-9482-2429aa770eb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/5dc6b339-de7b-4996-8d9d-281f4d4d386d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3875c87d-dd84-457e-9482-2429aa770eb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d338c1d-e678-46ce-97b4-dde1dfe6ed16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d338c1d-e678-46ce-97b4-dde1dfe6ed16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/695f598f-4f07-422e-8685-f660a200c410/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d338c1d-e678-46ce-97b4-dde1dfe6ed16>.
+    
+<http://data.lblod.info/id/remote-data-objects/705b95ad-822f-43da-a541-bde827ac4c3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "705b95ad-822f-43da-a541-bde827ac4c3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/6c8a724e-4ceb-40a0-890c-c248f60f69a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/705b95ad-822f-43da-a541-bde827ac4c3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b36ae510-fc35-41a1-8334-527646c006fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b36ae510-fc35-41a1-8334-527646c006fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/70ff3521-8fc5-4f17-8958-29ed79468ccb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b36ae510-fc35-41a1-8334-527646c006fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/491bab5c-0192-4202-aa48-f01538dab439> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "491bab5c-0192-4202-aa48-f01538dab439";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/7363db50-2437-40d5-8237-f57de6588ef3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/491bab5c-0192-4202-aa48-f01538dab439>.
+    
+<http://data.lblod.info/id/remote-data-objects/17c8101a-4d48-4b46-b667-5f40380d2f28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17c8101a-4d48-4b46-b667-5f40380d2f28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/75c09072-88b4-4869-9c77-3799713cad6d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17c8101a-4d48-4b46-b667-5f40380d2f28>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b02ea82-df9c-4141-8312-1d910caaf26d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b02ea82-df9c-4141-8312-1d910caaf26d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/7727a68c-3880-4d2d-826b-24e8d3e5840f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b02ea82-df9c-4141-8312-1d910caaf26d>.
+    
+<http://data.lblod.info/id/remote-data-objects/20c0db24-1321-4705-8c99-b883d121b6c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20c0db24-1321-4705-8c99-b883d121b6c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/796e533b-7678-4a89-9319-3082e952d2f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20c0db24-1321-4705-8c99-b883d121b6c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e479d19d-798b-4822-a8ff-5078e4cf8d80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e479d19d-798b-4822-a8ff-5078e4cf8d80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/8a0ea777-4383-43f0-a585-24c42e74ca24/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e479d19d-798b-4822-a8ff-5078e4cf8d80>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2da78d9-2a5e-4311-8820-452919416b07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2da78d9-2a5e-4311-8820-452919416b07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/90ef65b2-f118-4fa8-adb0-dccb91112c1b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2da78d9-2a5e-4311-8820-452919416b07>.
+    
+<http://data.lblod.info/id/remote-data-objects/f730edb0-fb83-404f-97f3-1c1e03853c62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f730edb0-fb83-404f-97f3-1c1e03853c62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/9bed72ad-0171-40cc-83e8-b8d948e7db3f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f730edb0-fb83-404f-97f3-1c1e03853c62>.
+    
+<http://data.lblod.info/id/remote-data-objects/c09ab2f0-9ef3-4949-8807-04f7c30c038f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c09ab2f0-9ef3-4949-8807-04f7c30c038f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/9dcd5bfb-a469-4ff6-8203-c13ebc3eb639/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c09ab2f0-9ef3-4949-8807-04f7c30c038f>.
+    
+<http://data.lblod.info/id/remote-data-objects/63b5e4cf-536d-4b24-934c-30bf1c8edae6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63b5e4cf-536d-4b24-934c-30bf1c8edae6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/b41277a2-1f2e-41c4-8acf-193b2717309f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63b5e4cf-536d-4b24-934c-30bf1c8edae6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2c32374-23bc-4c09-915d-9a053304d536> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2c32374-23bc-4c09-915d-9a053304d536";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/cad21306-5508-420f-96eb-60da77b1ace3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2c32374-23bc-4c09-915d-9a053304d536>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f216d9f-7524-4a39-a37b-e82ec99ab72e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f216d9f-7524-4a39-a37b-e82ec99ab72e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/d275caaa-581f-4cdf-a9ac-6f68ee6880db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f216d9f-7524-4a39-a37b-e82ec99ab72e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0874cb8-4366-47d0-8f1b-83fe64b00dab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0874cb8-4366-47d0-8f1b-83fe64b00dab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/df9c2f20-5da5-4338-98e4-a328973c2f81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0874cb8-4366-47d0-8f1b-83fe64b00dab>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c0768e6-8238-472a-9ede-16db73633a20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c0768e6-8238-472a-9ede-16db73633a20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/e0c481f6-17d0-4c0c-943f-6f8003a66bf7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c0768e6-8238-472a-9ede-16db73633a20>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7d50c3a-d367-4b63-b6ff-18b2c3214cad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7d50c3a-d367-4b63-b6ff-18b2c3214cad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://houthalen-helchteren.meetingburger.net/vabu/f6e55551-a329-4c2f-b198-3aaae84b33cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7d50c3a-d367-4b63-b6ff-18b2c3214cad>.
+    
+<http://data.lblod.info/id/remote-data-objects/34490a27-d925-4bb5-b849-8c707a65e67b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34490a27-d925-4bb5-b849-8c707a65e67b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/03b0bb6d-33e6-410b-b74d-8dd1005763d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34490a27-d925-4bb5-b849-8c707a65e67b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e051c6a7-3276-4c3b-a996-6127cd980392> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e051c6a7-3276-4c3b-a996-6127cd980392";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/07be8c2c-5614-4664-9523-e3f8ddeb44f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e051c6a7-3276-4c3b-a996-6127cd980392>.
+    
+<http://data.lblod.info/id/remote-data-objects/37c2b104-a557-461f-a7b3-85384a696ddb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37c2b104-a557-461f-a7b3-85384a696ddb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/13526944-5f99-4599-8fd2-15e3bb138ce6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37c2b104-a557-461f-a7b3-85384a696ddb>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5c1d63a-c32b-41e5-95d4-dfca08870d6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5c1d63a-c32b-41e5-95d4-dfca08870d6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/14db3c57-674e-459e-b744-3be6a5dfac4f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5c1d63a-c32b-41e5-95d4-dfca08870d6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bbeb542-cabb-40d2-ae1f-44c36cdcc1ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bbeb542-cabb-40d2-ae1f-44c36cdcc1ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/27e09581-130f-42ce-a5c9-0dae7a08d316/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bbeb542-cabb-40d2-ae1f-44c36cdcc1ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/091a0b4d-b298-4bc9-a17a-381b3481a454> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "091a0b4d-b298-4bc9-a17a-381b3481a454";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/298d930a-7ad7-4563-a305-6a0f9c92b6ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5dc6de73-681e-44e5-925c-bf3e95043d64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/091a0b4d-b298-4bc9-a17a-381b3481a454>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201203-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201203-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201203-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201203-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/6f034a09-5df9-440b-8925-7c5f098eee3b> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6f034a09-5df9-440b-8925-7c5f098eee3b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a62ab20b-5a31-4a19-97ba-699550c29cd9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/530159a0-4183-4702-bab4-85016ecc27e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "530159a0-4183-4702-bab4-85016ecc27e1";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9>.
+
+  <http://redpencil.data.gift/id/task/e4b43eb1-5f23-430f-ab6a-8c01ce2bd4b5> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e4b43eb1-5f23-430f-ab6a-8c01ce2bd4b5";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/6f034a09-5df9-440b-8925-7c5f098eee3b>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/530159a0-4183-4702-bab4-85016ecc27e1>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/950f3569-a6a5-4fd4-9421-04cc14a15084> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "950f3569-a6a5-4fd4-9421-04cc14a15084";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/2bed4bbf-607e-4b9e-b6d3-8787b0267e36/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/950f3569-a6a5-4fd4-9421-04cc14a15084>.
+    
+<http://data.lblod.info/id/remote-data-objects/18de7969-0ae0-487d-9185-e1df3834c148> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18de7969-0ae0-487d-9185-e1df3834c148";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/2d9c5dd4-1678-4a62-b46f-b84ed1e88f41/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18de7969-0ae0-487d-9185-e1df3834c148>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bc6b93d-7cd1-418b-8f6f-ef8dcb7a8307> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bc6b93d-7cd1-418b-8f6f-ef8dcb7a8307";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/3239b872-204c-41ac-bde8-0775043bcf08/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bc6b93d-7cd1-418b-8f6f-ef8dcb7a8307>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ba5cd49-25db-436f-9aa6-ec7ce3e31487> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ba5cd49-25db-436f-9aa6-ec7ce3e31487";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/39e4fbb5-78bd-4794-9b10-92793e6be11e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ba5cd49-25db-436f-9aa6-ec7ce3e31487>.
+    
+<http://data.lblod.info/id/remote-data-objects/036cb894-f5aa-4479-8cec-cdf68a0e2e81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "036cb894-f5aa-4479-8cec-cdf68a0e2e81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/44c1d7c2-fb17-44ae-9e31-ab53431a14a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/036cb894-f5aa-4479-8cec-cdf68a0e2e81>.
+    
+<http://data.lblod.info/id/remote-data-objects/a536baf2-4851-4b98-81c4-712d6bc61577> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a536baf2-4851-4b98-81c4-712d6bc61577";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/4852d7fb-e4a4-4754-94f2-ec0c49279dda/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a536baf2-4851-4b98-81c4-712d6bc61577>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cad8a23-8477-49b6-97d0-11b6c70d49bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cad8a23-8477-49b6-97d0-11b6c70d49bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/4ab9e2ef-0513-4f5a-a3a7-ccfdc71f404d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cad8a23-8477-49b6-97d0-11b6c70d49bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac6ea389-98d1-4001-8855-fce6d203951f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac6ea389-98d1-4001-8855-fce6d203951f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/4bc3856b-65ab-4fda-9212-e98cde3de7a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac6ea389-98d1-4001-8855-fce6d203951f>.
+    
+<http://data.lblod.info/id/remote-data-objects/34b5128a-685e-4a07-a36a-eeef84c362fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34b5128a-685e-4a07-a36a-eeef84c362fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/4e6e7c21-9560-44eb-a3e2-f2e755f5cb06/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34b5128a-685e-4a07-a36a-eeef84c362fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/81c21b56-d482-4bdf-96a1-dda8062974b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81c21b56-d482-4bdf-96a1-dda8062974b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/54f4e542-665b-4e3c-aee6-d4386e8330bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81c21b56-d482-4bdf-96a1-dda8062974b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4f00407-ac1a-4866-a74f-f1218f5d1297> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4f00407-ac1a-4866-a74f-f1218f5d1297";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/560fa877-d81a-4967-88e3-e974b72fce12/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4f00407-ac1a-4866-a74f-f1218f5d1297>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ae855dd-9349-4f17-b2c6-f10412ce7e70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ae855dd-9349-4f17-b2c6-f10412ce7e70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/5c2d8553-611e-4d41-b20f-dad6ffc13618/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ae855dd-9349-4f17-b2c6-f10412ce7e70>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6a3058c-8cbe-4c48-aabb-cb12b1263adf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6a3058c-8cbe-4c48-aabb-cb12b1263adf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/5e16cf9e-3480-4cd7-8b04-d79cd070fbf3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6a3058c-8cbe-4c48-aabb-cb12b1263adf>.
+    
+<http://data.lblod.info/id/remote-data-objects/90c742af-13f1-4bc0-95a2-170dd0b37ec6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90c742af-13f1-4bc0-95a2-170dd0b37ec6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/5fd6354b-4d4c-4b05-91fc-769257b5a0f6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90c742af-13f1-4bc0-95a2-170dd0b37ec6>.
+    
+<http://data.lblod.info/id/remote-data-objects/02299115-e8b1-4e14-801d-d238843d5b08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02299115-e8b1-4e14-801d-d238843d5b08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/61a52ca4-e5a1-4ec8-87d5-c8eb1ff37dff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02299115-e8b1-4e14-801d-d238843d5b08>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c4ac757-72c4-4ac5-a918-c989ea0d842f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c4ac757-72c4-4ac5-a918-c989ea0d842f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/63414fe2-8ad8-42e7-b06f-ab4c76d64391/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c4ac757-72c4-4ac5-a918-c989ea0d842f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5293b30c-c6d7-48eb-bf84-de021f514ad0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5293b30c-c6d7-48eb-bf84-de021f514ad0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/644f6426-3993-4d3f-8429-97d6a5a2d976/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5293b30c-c6d7-48eb-bf84-de021f514ad0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ce2e0f1-ffa6-464b-bfd7-7a99a88bb02b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ce2e0f1-ffa6-464b-bfd7-7a99a88bb02b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/6b38378c-28cb-49f9-9b71-06977e9f5751/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ce2e0f1-ffa6-464b-bfd7-7a99a88bb02b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c0fe85a-4a78-49ec-a0f1-b67665ff763d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c0fe85a-4a78-49ec-a0f1-b67665ff763d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/74ee3d8b-f2cb-4545-a1c6-9ab12769aca4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c0fe85a-4a78-49ec-a0f1-b67665ff763d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e0d5ea9-8cb4-4c27-8696-1cb6a8d3d749> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e0d5ea9-8cb4-4c27-8696-1cb6a8d3d749";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/78ec8040-e253-42b0-8197-5ce72269c6e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e0d5ea9-8cb4-4c27-8696-1cb6a8d3d749>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c14908e-af78-4d6e-a2c0-ebe4416677d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c14908e-af78-4d6e-a2c0-ebe4416677d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/7a94ff57-8017-41d9-8caf-6d24d4a3cb9a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c14908e-af78-4d6e-a2c0-ebe4416677d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/484c051f-9d82-4493-bdb4-4c0fc7d58867> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "484c051f-9d82-4493-bdb4-4c0fc7d58867";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/7e158b1d-c2fe-421e-9674-c7a754918204/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/484c051f-9d82-4493-bdb4-4c0fc7d58867>.
+    
+<http://data.lblod.info/id/remote-data-objects/329af51a-9030-49b1-a750-c64874407b30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "329af51a-9030-49b1-a750-c64874407b30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/7ef5bf44-d7c3-4f04-a8f3-38974d400422/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/329af51a-9030-49b1-a750-c64874407b30>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e55a908-12ac-4713-acb6-67438d3a2e02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e55a908-12ac-4713-acb6-67438d3a2e02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/80d1a49f-1cb0-4469-8128-ff73aabe9fd9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e55a908-12ac-4713-acb6-67438d3a2e02>.
+    
+<http://data.lblod.info/id/remote-data-objects/2486a92f-4255-4c68-9f49-c967aec214fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2486a92f-4255-4c68-9f49-c967aec214fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/875bcb4c-c956-432a-9d4a-210a6e23b63a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2486a92f-4255-4c68-9f49-c967aec214fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d89f1f6-36a7-4fab-bdf5-2f9ebd4a5a8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d89f1f6-36a7-4fab-bdf5-2f9ebd4a5a8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/95fe6ec9-17c1-4ca9-b70d-fac35c91a8d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d89f1f6-36a7-4fab-bdf5-2f9ebd4a5a8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/29036b60-875c-40e9-8191-3a604080fa2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29036b60-875c-40e9-8191-3a604080fa2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/9983deab-2725-4a7a-87d0-65de9413335b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29036b60-875c-40e9-8191-3a604080fa2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/243d2225-5cbd-49b7-95dc-8ed2a39b17fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "243d2225-5cbd-49b7-95dc-8ed2a39b17fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/9e888da5-6f7c-4a5c-a542-2d1ccd9b97b8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/243d2225-5cbd-49b7-95dc-8ed2a39b17fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/2582b16c-330c-4830-b9c1-9482ac13ddec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2582b16c-330c-4830-b9c1-9482ac13ddec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/a8bcafa8-a2bf-459f-be1d-b29ac7e9cb58/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2582b16c-330c-4830-b9c1-9482ac13ddec>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1c77d25-4f6f-4008-8566-332ea80218d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1c77d25-4f6f-4008-8566-332ea80218d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/ae36468f-e1ed-43ea-82af-940b40a125ba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1c77d25-4f6f-4008-8566-332ea80218d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2dd166a2-ff45-46d6-a24a-4484afa3bdf4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2dd166a2-ff45-46d6-a24a-4484afa3bdf4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/af5b7381-49ed-4f2f-9df9-4ad740b5731a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2dd166a2-ff45-46d6-a24a-4484afa3bdf4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1dca0a7-2a16-489f-a892-b446ebba65a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1dca0a7-2a16-489f-a892-b446ebba65a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/b05c24ce-990d-49c8-ae49-e353cda94005/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1dca0a7-2a16-489f-a892-b446ebba65a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3d25027-292e-4075-9cff-a4a5bfd346c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3d25027-292e-4075-9cff-a4a5bfd346c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/b064ac38-f935-4f77-8ee1-37256c495f81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3d25027-292e-4075-9cff-a4a5bfd346c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/24d29e30-6342-4134-98ad-5e96d1be0226> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24d29e30-6342-4134-98ad-5e96d1be0226";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/b2a3c56a-572d-490c-8ce7-9ce3c5509c39/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24d29e30-6342-4134-98ad-5e96d1be0226>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b47288b-1678-4122-abe7-15a7201f4605> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b47288b-1678-4122-abe7-15a7201f4605";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/b51a9f8f-94b1-4be1-8583-8896e8a53fbe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b47288b-1678-4122-abe7-15a7201f4605>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9e52572-3ec0-4927-8e5e-e96e061ac054> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9e52572-3ec0-4927-8e5e-e96e061ac054";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/c099b402-11db-4332-9a42-b1c5c7fe6f90/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9e52572-3ec0-4927-8e5e-e96e061ac054>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4daf97a-f71b-41d2-9b7b-acc8ae541638> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4daf97a-f71b-41d2-9b7b-acc8ae541638";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/c3abd012-90b8-4401-bce5-e0ca1249e1ce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4daf97a-f71b-41d2-9b7b-acc8ae541638>.
+    
+<http://data.lblod.info/id/remote-data-objects/668140be-7ef3-4baf-a69e-afeb733fe6c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "668140be-7ef3-4baf-a69e-afeb733fe6c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/c89f5bb3-b5c7-44a3-87ca-6bee54ba56b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/668140be-7ef3-4baf-a69e-afeb733fe6c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d861fef-de2b-44a6-97d8-c1f1e2bcfda6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d861fef-de2b-44a6-97d8-c1f1e2bcfda6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/c92db0e2-f9ed-4a80-9726-b72df653809c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d861fef-de2b-44a6-97d8-c1f1e2bcfda6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f77b42a-deac-4c65-b1ed-401c9f1e2443> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f77b42a-deac-4c65-b1ed-401c9f1e2443";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/caf489ea-2eb1-4ff0-ba0e-25accab6621d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f77b42a-deac-4c65-b1ed-401c9f1e2443>.
+    
+<http://data.lblod.info/id/remote-data-objects/1445a5e1-f4e6-4a16-a50f-8f14d145dfeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1445a5e1-f4e6-4a16-a50f-8f14d145dfeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/da16749c-69e2-4fbc-966a-c9a0ee9df3ad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1445a5e1-f4e6-4a16-a50f-8f14d145dfeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a9d6d62-7c99-4ed4-a7a5-60ebfcb40c1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a9d6d62-7c99-4ed4-a7a5-60ebfcb40c1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/de1b2360-9873-4ee1-9a4b-3e42ebcc7593/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a9d6d62-7c99-4ed4-a7a5-60ebfcb40c1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/53c2d580-2c0d-4133-bc7f-685d700c2ac9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53c2d580-2c0d-4133-bc7f-685d700c2ac9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/dee47691-22ff-4219-a1fc-5c7246fb5b26/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53c2d580-2c0d-4133-bc7f-685d700c2ac9>.
+    
+<http://data.lblod.info/id/remote-data-objects/eeabce51-12cd-43eb-b532-1b9f5e4e3994> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eeabce51-12cd-43eb-b532-1b9f5e4e3994";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/df5b0e74-aee6-4bf7-905d-eca4469e0779/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eeabce51-12cd-43eb-b532-1b9f5e4e3994>.
+    
+<http://data.lblod.info/id/remote-data-objects/f88e5a81-87a8-48f8-a4a1-0aee0c356d9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f88e5a81-87a8-48f8-a4a1-0aee0c356d9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/df5f78ca-1b9d-4ee0-93cd-f5418d8ec510/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f88e5a81-87a8-48f8-a4a1-0aee0c356d9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5316618-40f7-456b-abc6-83f877474f9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5316618-40f7-456b-abc6-83f877474f9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/e2c87130-7ecc-433b-8a04-4affbd1f629c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5316618-40f7-456b-abc6-83f877474f9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/14a5e60c-74b1-460a-a2d4-c8a941d894a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14a5e60c-74b1-460a-a2d4-c8a941d894a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/e3582cae-e3e0-41fb-abfe-901274f0d9fb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14a5e60c-74b1-460a-a2d4-c8a941d894a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d8b1e0b-5469-4996-a004-49854c46a96a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d8b1e0b-5469-4996-a004-49854c46a96a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/e4dfce9e-03d3-4762-9759-637bbf8f9d2b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d8b1e0b-5469-4996-a004-49854c46a96a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1364c6c-7d90-4f63-84d4-b03ea4ce0917> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1364c6c-7d90-4f63-84d4-b03ea4ce0917";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/eb576efb-66f9-4e8f-9a06-f9d5fcadced3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1364c6c-7d90-4f63-84d4-b03ea4ce0917>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f7723d3-4f55-45cc-b7aa-787fe498c429> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f7723d3-4f55-45cc-b7aa-787fe498c429";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/ebee046c-ac88-4684-b97c-48db741f7925/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a62ab20b-5a31-4a19-97ba-699550c29cd9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f7723d3-4f55-45cc-b7aa-787fe498c429>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201204-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201204-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201204-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201204-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/8dd1c7f1-ff19-45e7-87bd-eab0bb07edcf> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8dd1c7f1-ff19-45e7-87bd-eab0bb07edcf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c8e93c41-1a8f-4353-b9bc-ef24d01649a4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/3e00790b-3909-4d50-8e2d-5163585c66f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3e00790b-3909-4d50-8e2d-5163585c66f4";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4>.
+
+  <http://redpencil.data.gift/id/task/e6cb4422-49a2-4f0c-a56d-6b0db0cc3c37> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e6cb4422-49a2-4f0c-a56d-6b0db0cc3c37";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/8dd1c7f1-ff19-45e7-87bd-eab0bb07edcf>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/3e00790b-3909-4d50-8e2d-5163585c66f4>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e71cef2a-cc8c-444c-b265-7f0f6f1ecabe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e71cef2a-cc8c-444c-b265-7f0f6f1ecabe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/ed97f4d4-1e7d-427f-b495-791e2e73272a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e71cef2a-cc8c-444c-b265-7f0f6f1ecabe>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd3ada17-abed-4ba1-b1e8-781d00893ccd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd3ada17-abed-4ba1-b1e8-781d00893ccd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/f5c35eb4-de2d-4152-be5a-41f989edf604/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd3ada17-abed-4ba1-b1e8-781d00893ccd>.
+    
+<http://data.lblod.info/id/remote-data-objects/1550484e-0ca8-457b-b64d-87b2be404381> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1550484e-0ca8-457b-b64d-87b2be404381";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/f5fae7a2-a577-4541-b8cf-a392ca0c381a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1550484e-0ca8-457b-b64d-87b2be404381>.
+    
+<http://data.lblod.info/id/remote-data-objects/67246bc6-7ed1-42d0-9c23-32f3368ec775> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67246bc6-7ed1-42d0-9c23-32f3368ec775";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/f9fec8d0-9c2b-4ec4-874c-bc8b86c9da37/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67246bc6-7ed1-42d0-9c23-32f3368ec775>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f57e091-befc-4620-ae0c-a1e3703134a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f57e091-befc-4620-ae0c-a1e3703134a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/fbc116a9-cc78-4c81-b1b6-2c3f8303bf79/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f57e091-befc-4620-ae0c-a1e3703134a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff9096a0-051b-4518-bf1e-cf9a2c1205e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff9096a0-051b-4518-bf1e-cf9a2c1205e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/bb/fd139143-2f0d-4372-a2a4-58586481e07a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff9096a0-051b-4518-bf1e-cf9a2c1205e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a9f39dc-4a83-4c82-809f-ebb6251b4533> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a9f39dc-4a83-4c82-809f-ebb6251b4533";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/033a466a-a6db-45b4-a7be-85ec8e90f3e8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a9f39dc-4a83-4c82-809f-ebb6251b4533>.
+    
+<http://data.lblod.info/id/remote-data-objects/3317f18a-1554-4f7d-a11e-7383098861f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3317f18a-1554-4f7d-a11e-7383098861f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/152baecc-1dab-4c70-a236-045c6cff7e3b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3317f18a-1554-4f7d-a11e-7383098861f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/080d49cc-cc56-4c5d-8f56-f34043d73f96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "080d49cc-cc56-4c5d-8f56-f34043d73f96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/182d2636-cb19-45c8-937d-62cdc3edd2a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/080d49cc-cc56-4c5d-8f56-f34043d73f96>.
+    
+<http://data.lblod.info/id/remote-data-objects/aad109ca-e721-409a-a7a0-d33275afb1c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aad109ca-e721-409a-a7a0-d33275afb1c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/19a9910f-2f51-43d4-9c38-fcbcdf65eb6c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aad109ca-e721-409a-a7a0-d33275afb1c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd3adc70-bb56-4724-b46b-ab2b36363829> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd3adc70-bb56-4724-b46b-ab2b36363829";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/19fdaf49-0e58-4f5d-adf7-c725e95050a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd3adc70-bb56-4724-b46b-ab2b36363829>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0e0b7dc-2745-49de-a92c-2d1baac02c6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0e0b7dc-2745-49de-a92c-2d1baac02c6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/1b8de2a1-ed85-4c77-932f-be8b191b4654/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0e0b7dc-2745-49de-a92c-2d1baac02c6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7298718-c56e-4e79-9f41-c94dfcbd2849> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7298718-c56e-4e79-9f41-c94dfcbd2849";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/1c66115d-bfc5-4780-8278-82123d2d33df/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7298718-c56e-4e79-9f41-c94dfcbd2849>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c9185d9-09ef-40b8-912e-7bceb179cd5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c9185d9-09ef-40b8-912e-7bceb179cd5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/1d3b572d-b49b-445e-9d4a-7207ed228f95/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c9185d9-09ef-40b8-912e-7bceb179cd5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e914d17-4d27-48e6-8f94-63083010cad4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e914d17-4d27-48e6-8f94-63083010cad4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/2040f5d2-0ee0-4813-9ae0-e6b2597e94ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e914d17-4d27-48e6-8f94-63083010cad4>.
+    
+<http://data.lblod.info/id/remote-data-objects/03dcf77e-a0a1-412a-9207-6811faccec9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03dcf77e-a0a1-412a-9207-6811faccec9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/22e0d093-9b3c-4b51-85ae-9397df298b29/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03dcf77e-a0a1-412a-9207-6811faccec9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ccf0977-d44a-4759-9046-08fc7389434f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ccf0977-d44a-4759-9046-08fc7389434f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/245ca7a8-1522-4367-9fe8-8dd769bb168c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ccf0977-d44a-4759-9046-08fc7389434f>.
+    
+<http://data.lblod.info/id/remote-data-objects/14d7f601-47b3-4389-9db9-550416752e54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14d7f601-47b3-4389-9db9-550416752e54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/2cd03ce9-b86d-4044-96ed-0c8531ec02d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14d7f601-47b3-4389-9db9-550416752e54>.
+    
+<http://data.lblod.info/id/remote-data-objects/15d8c014-6b5d-4bd1-89f0-69e9f9052d35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15d8c014-6b5d-4bd1-89f0-69e9f9052d35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/2ffead4f-7569-4a40-b19a-eed791eadef0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15d8c014-6b5d-4bd1-89f0-69e9f9052d35>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b57d4b5-0f56-494c-b9e0-b9ab9280d95d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b57d4b5-0f56-494c-b9e0-b9ab9280d95d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/32d9c9d7-e265-48b5-943c-8a0117cc70b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b57d4b5-0f56-494c-b9e0-b9ab9280d95d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8231e2b5-dcf5-486b-9d0d-d1e9d214b8e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8231e2b5-dcf5-486b-9d0d-d1e9d214b8e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/3475876e-b691-4501-ae07-44a3e7543bbb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8231e2b5-dcf5-486b-9d0d-d1e9d214b8e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7266b4e9-0533-4706-97f0-26ebfd066016> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7266b4e9-0533-4706-97f0-26ebfd066016";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/34a88e9d-15d1-4aa3-a3f2-b7ce0f25a8e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7266b4e9-0533-4706-97f0-26ebfd066016>.
+    
+<http://data.lblod.info/id/remote-data-objects/10b41829-7b8e-4423-8b57-9061a4771344> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10b41829-7b8e-4423-8b57-9061a4771344";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/3573494d-dfc2-4281-b6b9-9c0669636a48/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10b41829-7b8e-4423-8b57-9061a4771344>.
+    
+<http://data.lblod.info/id/remote-data-objects/80da01e1-3ba3-4b3b-9b9e-5cd68f926a9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80da01e1-3ba3-4b3b-9b9e-5cd68f926a9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/3a31ba5c-e1ff-4729-87f8-5ed0c3fa42bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80da01e1-3ba3-4b3b-9b9e-5cd68f926a9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/19a84da0-0974-4a81-b19b-abe1cad262e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19a84da0-0974-4a81-b19b-abe1cad262e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/40e014c9-fb5f-495e-a434-2d636c6a996c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19a84da0-0974-4a81-b19b-abe1cad262e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c97aebb-3869-48ae-8a45-5c8642dd90ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c97aebb-3869-48ae-8a45-5c8642dd90ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/43761984-3fad-4a9b-b50f-819e1d8c466e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c97aebb-3869-48ae-8a45-5c8642dd90ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/d57b1404-a60c-4955-bf2f-3d1ebcd2a261> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d57b1404-a60c-4955-bf2f-3d1ebcd2a261";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/47b19e2f-27cf-454f-9292-cb54c0a77597/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d57b1404-a60c-4955-bf2f-3d1ebcd2a261>.
+    
+<http://data.lblod.info/id/remote-data-objects/74bb8d2d-6bc5-47dd-b1be-fb1e8e5867ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74bb8d2d-6bc5-47dd-b1be-fb1e8e5867ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/47d1c0e2-872f-40a2-99b2-e7de13e48df1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74bb8d2d-6bc5-47dd-b1be-fb1e8e5867ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6c9d0c5-ca56-4478-8a67-0182502e858f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6c9d0c5-ca56-4478-8a67-0182502e858f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/4e8c03e5-ee78-4884-89e1-682c62d75a70/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6c9d0c5-ca56-4478-8a67-0182502e858f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3c62f7f-86c5-45b4-a373-59c565916345> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3c62f7f-86c5-45b4-a373-59c565916345";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/5215df27-4006-482b-a90a-a8e8b50ab95d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3c62f7f-86c5-45b4-a373-59c565916345>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe566d93-2735-42d4-a514-b924f4b8dbd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe566d93-2735-42d4-a514-b924f4b8dbd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/55f067f4-f4db-4d42-862a-5f7c565be3d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe566d93-2735-42d4-a514-b924f4b8dbd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea102e11-3170-409e-89a6-85884548cb8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea102e11-3170-409e-89a6-85884548cb8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/580e267d-56b5-4b0e-9d0a-7f38f0350584/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea102e11-3170-409e-89a6-85884548cb8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6d37533-7288-4d79-ba32-5f315da38787> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6d37533-7288-4d79-ba32-5f315da38787";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/59a5de4e-8d93-4b37-860d-820116fe04b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6d37533-7288-4d79-ba32-5f315da38787>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4b2af0f-6286-43bd-865d-80f355a80779> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4b2af0f-6286-43bd-865d-80f355a80779";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/5ad0a571-6709-41de-9169-c579dd077b6c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4b2af0f-6286-43bd-865d-80f355a80779>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd04d671-d0aa-47ee-82d0-faca89a7fda4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd04d671-d0aa-47ee-82d0-faca89a7fda4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/5f6c8e86-3355-4908-8c9d-ab1a1c792c68/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd04d671-d0aa-47ee-82d0-faca89a7fda4>.
+    
+<http://data.lblod.info/id/remote-data-objects/91a5573a-067a-4cfb-ac26-0bcbd34e18fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91a5573a-067a-4cfb-ac26-0bcbd34e18fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/614a6c6b-45e2-45e2-8d02-87cd00edd6de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91a5573a-067a-4cfb-ac26-0bcbd34e18fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/f866e4a7-2230-49e2-ac8f-3cc54f8a0292> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f866e4a7-2230-49e2-ac8f-3cc54f8a0292";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/63c255e8-dd76-45aa-8f6e-31651a2ef114/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f866e4a7-2230-49e2-ac8f-3cc54f8a0292>.
+    
+<http://data.lblod.info/id/remote-data-objects/03fedab4-02c2-4d34-97f4-ac0342831721> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03fedab4-02c2-4d34-97f4-ac0342831721";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/6adeed14-78c9-44ad-93bf-1b13e2ef0994/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03fedab4-02c2-4d34-97f4-ac0342831721>.
+    
+<http://data.lblod.info/id/remote-data-objects/093d6bf9-6270-4764-9e20-1e8cb1946e26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "093d6bf9-6270-4764-9e20-1e8cb1946e26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/6e224cb3-101e-470d-bdfb-ac701ee7f96e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/093d6bf9-6270-4764-9e20-1e8cb1946e26>.
+    
+<http://data.lblod.info/id/remote-data-objects/67310701-d450-4015-8335-08171734038d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67310701-d450-4015-8335-08171734038d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/79aefc3d-6ea8-410b-b763-344d4bd03242/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67310701-d450-4015-8335-08171734038d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6364d4ec-434d-4857-9c73-7f92b92e78eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6364d4ec-434d-4857-9c73-7f92b92e78eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/80bca9ed-e25a-4778-94b4-bf697d5583ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6364d4ec-434d-4857-9c73-7f92b92e78eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/482e65e9-07c9-4ea4-83f1-b79be1abb09b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "482e65e9-07c9-4ea4-83f1-b79be1abb09b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/814a6205-5480-461c-a653-9114570cc992/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/482e65e9-07c9-4ea4-83f1-b79be1abb09b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d86ec22-643f-4c0e-9d2c-15053fc3a7d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d86ec22-643f-4c0e-9d2c-15053fc3a7d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/838167ca-c432-4d58-a06e-56ba39de5bf7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d86ec22-643f-4c0e-9d2c-15053fc3a7d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/65d11e24-93f9-465f-9195-dce1ea28d394> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65d11e24-93f9-465f-9195-dce1ea28d394";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/85186ad2-dd78-463b-bf68-f30a926a3ec5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65d11e24-93f9-465f-9195-dce1ea28d394>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0b04194-fdb6-4253-a974-d2580c0a4a0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0b04194-fdb6-4253-a974-d2580c0a4a0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/85bc5f94-2d03-4c20-95f4-34dbeea1c563/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0b04194-fdb6-4253-a974-d2580c0a4a0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/52a0fba3-572b-42ea-be04-5cf919db76cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52a0fba3-572b-42ea-be04-5cf919db76cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/8a341ddc-1ff8-4e56-98bd-93fdc55a32af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52a0fba3-572b-42ea-be04-5cf919db76cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/62a8025a-db32-4f8d-b919-3c7b78f6109b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62a8025a-db32-4f8d-b919-3c7b78f6109b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/92a21b6e-aa2f-48ac-8a3c-8b79c47668e8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62a8025a-db32-4f8d-b919-3c7b78f6109b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6cc06b4-1b33-4aa7-b35a-d87cb0ddfdb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6cc06b4-1b33-4aa7-b35a-d87cb0ddfdb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/9b170b1a-29b4-4dfa-847a-ac061f1abf2a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6cc06b4-1b33-4aa7-b35a-d87cb0ddfdb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b2311eb-c0e4-412a-8c6d-2c7e58d0dc55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b2311eb-c0e4-412a-8c6d-2c7e58d0dc55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/9fdac04e-f301-4636-bc84-0e92ab8ba768/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b2311eb-c0e4-412a-8c6d-2c7e58d0dc55>.
+    
+<http://data.lblod.info/id/remote-data-objects/feae4577-7a14-4d8c-bd2f-cc27e9a3c297> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "feae4577-7a14-4d8c-bd2f-cc27e9a3c297";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/a4bcc176-261c-4381-a1b1-9da94ce7d8ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8e93c41-1a8f-4353-b9bc-ef24d01649a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/feae4577-7a14-4d8c-bd2f-cc27e9a3c297>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201205-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201205-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201205-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201205-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/41ba31b7-d1f8-49de-b0ee-53b184412590> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "41ba31b7-d1f8-49de-b0ee-53b184412590";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7a84a2eb-cb69-4994-8e94-2ec65ffc08f6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a2bb6524-c713-4c05-9c37-8e380eab10cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a2bb6524-c713-4c05-9c37-8e380eab10cd";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6>.
+
+  <http://redpencil.data.gift/id/task/a41c1339-a793-4753-89e3-9f489f1a3d38> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a41c1339-a793-4753-89e3-9f489f1a3d38";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/41ba31b7-d1f8-49de-b0ee-53b184412590>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a2bb6524-c713-4c05-9c37-8e380eab10cd>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d626db42-2457-4025-b481-850074d9ba71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d626db42-2457-4025-b481-850074d9ba71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/a5196f87-0886-4ef9-980c-794cf62214cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d626db42-2457-4025-b481-850074d9ba71>.
+    
+<http://data.lblod.info/id/remote-data-objects/248d8614-6339-4e53-9927-564ce4ceda87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "248d8614-6339-4e53-9927-564ce4ceda87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/a8492ef7-ff7c-4d39-8720-0d61fb523247/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/248d8614-6339-4e53-9927-564ce4ceda87>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1b76cf5-53ef-48ff-94e1-453aa0a73a95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1b76cf5-53ef-48ff-94e1-453aa0a73a95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/a85f8779-ad4a-4e17-a555-94e6958689e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1b76cf5-53ef-48ff-94e1-453aa0a73a95>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fda832f-2171-4d51-939f-28cc00cb1836> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fda832f-2171-4d51-939f-28cc00cb1836";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/ada483e2-abc0-4a01-8b3e-e75a09954ec4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fda832f-2171-4d51-939f-28cc00cb1836>.
+    
+<http://data.lblod.info/id/remote-data-objects/0566f1d4-8a17-409a-8614-6e2c8359ebc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0566f1d4-8a17-409a-8614-6e2c8359ebc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/ae5fda63-4b29-41c6-a4ed-700c2221abf4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0566f1d4-8a17-409a-8614-6e2c8359ebc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac994a4a-34a0-4903-8e23-309827dd6c26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac994a4a-34a0-4903-8e23-309827dd6c26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/b070a96e-439b-4183-8638-763d18115392/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac994a4a-34a0-4903-8e23-309827dd6c26>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e4a2f80-bcb8-4408-a7b3-ec7084de1fb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e4a2f80-bcb8-4408-a7b3-ec7084de1fb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/b361c121-1d06-43c4-a70d-64ad01c3113a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e4a2f80-bcb8-4408-a7b3-ec7084de1fb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/65e3a668-522f-455a-b572-46b7159cbfaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65e3a668-522f-455a-b572-46b7159cbfaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/b51e8d62-7482-4925-87cb-a91693ada680/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65e3a668-522f-455a-b572-46b7159cbfaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea6354cc-a252-4bf7-bf2c-7204647d8ea7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea6354cc-a252-4bf7-bf2c-7204647d8ea7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/b5967e5d-0413-4b40-8507-215f06717ce0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea6354cc-a252-4bf7-bf2c-7204647d8ea7>.
+    
+<http://data.lblod.info/id/remote-data-objects/609bcc65-ff51-4929-9bd2-b1f8aace9cf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "609bcc65-ff51-4929-9bd2-b1f8aace9cf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/ba835717-743f-4258-8004-22724f8326d9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/609bcc65-ff51-4929-9bd2-b1f8aace9cf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d15ccf7-0813-4ce7-9307-747f3397b992> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d15ccf7-0813-4ce7-9307-747f3397b992";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/bdd2c826-de14-4b67-978a-3a9d621f4889/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d15ccf7-0813-4ce7-9307-747f3397b992>.
+    
+<http://data.lblod.info/id/remote-data-objects/c988e8d9-4b0a-421f-85f1-86bcebca7a57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c988e8d9-4b0a-421f-85f1-86bcebca7a57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/bded450f-df42-443a-be67-6437b67ac827/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c988e8d9-4b0a-421f-85f1-86bcebca7a57>.
+    
+<http://data.lblod.info/id/remote-data-objects/06d3186a-bf49-4ee3-94e9-21953ac2b712> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06d3186a-bf49-4ee3-94e9-21953ac2b712";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/c0bd6b17-05a4-4ebf-8ca9-4e5dc9e6345b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06d3186a-bf49-4ee3-94e9-21953ac2b712>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd5448f0-2fb7-4d1e-9793-be7a9720a976> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd5448f0-2fb7-4d1e-9793-be7a9720a976";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/c54ae0c1-4fea-42fe-addd-e15afd97db0e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd5448f0-2fb7-4d1e-9793-be7a9720a976>.
+    
+<http://data.lblod.info/id/remote-data-objects/49afadf5-ddf5-4c05-b545-559f63210f02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49afadf5-ddf5-4c05-b545-559f63210f02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/c60a2246-7354-43dd-8cd7-c6c3f0967792/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49afadf5-ddf5-4c05-b545-559f63210f02>.
+    
+<http://data.lblod.info/id/remote-data-objects/743210a9-33d3-4d14-88c0-f6d4a842154c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "743210a9-33d3-4d14-88c0-f6d4a842154c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/cd6b57e7-d25e-4226-af86-0dd92870692b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/743210a9-33d3-4d14-88c0-f6d4a842154c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1182aa27-e4f9-4d54-8061-dcb81ff8eba6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1182aa27-e4f9-4d54-8061-dcb81ff8eba6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/cf1c2312-2ec7-4b7c-a232-6878cf9daeaf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1182aa27-e4f9-4d54-8061-dcb81ff8eba6>.
+    
+<http://data.lblod.info/id/remote-data-objects/24317df4-ca74-4a22-be85-078ff4c798fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24317df4-ca74-4a22-be85-078ff4c798fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/d43f7c93-392f-4816-8064-040e96791791/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24317df4-ca74-4a22-be85-078ff4c798fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/758b1bc8-caeb-4597-a0ac-d9c0f09a21eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "758b1bc8-caeb-4597-a0ac-d9c0f09a21eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/e71f623e-4380-4c23-9346-2882cb006f59/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/758b1bc8-caeb-4597-a0ac-d9c0f09a21eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ba4b471-0322-488b-a3cd-01c35c0f0c13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ba4b471-0322-488b-a3cd-01c35c0f0c13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/e729638f-5333-401e-8ce1-1ef33cb7a137/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ba4b471-0322-488b-a3cd-01c35c0f0c13>.
+    
+<http://data.lblod.info/id/remote-data-objects/c23da5ad-7a8a-42c3-ba8b-299eb0ac4cdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c23da5ad-7a8a-42c3-ba8b-299eb0ac4cdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/ea6cef6c-3cc1-418f-91b9-d9bbedbbd988/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c23da5ad-7a8a-42c3-ba8b-299eb0ac4cdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/b347b97a-1875-4134-b20c-a60e09b7f429> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b347b97a-1875-4134-b20c-a60e09b7f429";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/ed89e5ce-c643-4311-b289-83e473968987/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b347b97a-1875-4134-b20c-a60e09b7f429>.
+    
+<http://data.lblod.info/id/remote-data-objects/45d4327b-2709-48fd-abbf-dc772141e01f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45d4327b-2709-48fd-abbf-dc772141e01f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/edbb2c4c-32e7-4b61-be76-ac29c368e4b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45d4327b-2709-48fd-abbf-dc772141e01f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ef5f23b-99a1-4a6d-9b44-7ed3a837b985> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ef5f23b-99a1-4a6d-9b44-7ed3a837b985";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/f39e600f-2de7-4014-bf36-6626cc898a13/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ef5f23b-99a1-4a6d-9b44-7ed3a837b985>.
+    
+<http://data.lblod.info/id/remote-data-objects/84bfdb9d-b868-4691-9f1a-c96491daaebf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84bfdb9d-b868-4691-9f1a-c96491daaebf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/fb953513-1568-4669-bb1e-58ea0e48e794/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84bfdb9d-b868-4691-9f1a-c96491daaebf>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d0a400b-309b-4592-a6fe-68a1670cf261> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d0a400b-309b-4592-a6fe-68a1670cf261";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/cbs/fe5b6bfc-3fbc-4f20-9e21-0cc2c0d59bfb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d0a400b-309b-4592-a6fe-68a1670cf261>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b89d134-107a-445e-bfe6-c5cfede0654a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b89d134-107a-445e-bfe6-c5cfede0654a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/1a8af175-1b40-4647-a996-a3cee72b6d53/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b89d134-107a-445e-bfe6-c5cfede0654a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bac5699a-b160-413a-a7f0-f08e9cb753a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bac5699a-b160-413a-a7f0-f08e9cb753a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/1a8af175-1b40-4647-a996-a3cee72b6d53/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bac5699a-b160-413a-a7f0-f08e9cb753a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e31f32b-abc9-45dc-a743-b0d7a0faae12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e31f32b-abc9-45dc-a743-b0d7a0faae12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/1a8af175-1b40-4647-a996-a3cee72b6d53/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e31f32b-abc9-45dc-a743-b0d7a0faae12>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e91423a-b5a1-44e0-8406-a8338175569c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e91423a-b5a1-44e0-8406-a8338175569c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/2d531a0d-1649-4ec3-854b-81c83d178252/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e91423a-b5a1-44e0-8406-a8338175569c>.
+    
+<http://data.lblod.info/id/remote-data-objects/257d3c48-3876-40cd-9241-4a10e6089ca5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "257d3c48-3876-40cd-9241-4a10e6089ca5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/2d531a0d-1649-4ec3-854b-81c83d178252/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/257d3c48-3876-40cd-9241-4a10e6089ca5>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ab23d17-08cc-45c9-930a-315b4dfe093c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ab23d17-08cc-45c9-930a-315b4dfe093c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/2d531a0d-1649-4ec3-854b-81c83d178252/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ab23d17-08cc-45c9-930a-315b4dfe093c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e346edeb-05e9-4d00-b89a-4cbb4a811a4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e346edeb-05e9-4d00-b89a-4cbb4a811a4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/3025688a-fe46-4649-b6a8-dc2893c74e8f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e346edeb-05e9-4d00-b89a-4cbb4a811a4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e6a9462-b752-4d36-b58e-61825096f6ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e6a9462-b752-4d36-b58e-61825096f6ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/3025688a-fe46-4649-b6a8-dc2893c74e8f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e6a9462-b752-4d36-b58e-61825096f6ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/45686d70-fd24-47aa-a73b-29c5af82e012> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45686d70-fd24-47aa-a73b-29c5af82e012";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/3025688a-fe46-4649-b6a8-dc2893c74e8f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45686d70-fd24-47aa-a73b-29c5af82e012>.
+    
+<http://data.lblod.info/id/remote-data-objects/788cdf86-6129-4952-87ee-49d9efff59a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "788cdf86-6129-4952-87ee-49d9efff59a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/4a2d3c42-7e2c-44fa-810b-9bf0523dbd45/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/788cdf86-6129-4952-87ee-49d9efff59a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e293ebe-1d8b-4f25-858d-aaf88874d5a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e293ebe-1d8b-4f25-858d-aaf88874d5a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/4a2d3c42-7e2c-44fa-810b-9bf0523dbd45/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e293ebe-1d8b-4f25-858d-aaf88874d5a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4949a5cf-01cb-476b-a6a3-d8edfa7b5148> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4949a5cf-01cb-476b-a6a3-d8edfa7b5148";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/4a2d3c42-7e2c-44fa-810b-9bf0523dbd45/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4949a5cf-01cb-476b-a6a3-d8edfa7b5148>.
+    
+<http://data.lblod.info/id/remote-data-objects/24e994b8-aec7-47ca-b751-bb51724b6fac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24e994b8-aec7-47ca-b751-bb51724b6fac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/4e9e8966-5ae3-4355-982c-d0981f88dbe3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24e994b8-aec7-47ca-b751-bb51724b6fac>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3c52379-fd90-4029-8d0a-5ca193249a9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3c52379-fd90-4029-8d0a-5ca193249a9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/4e9e8966-5ae3-4355-982c-d0981f88dbe3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3c52379-fd90-4029-8d0a-5ca193249a9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/09f0c63a-8b5f-46e4-8192-2b8108548bb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09f0c63a-8b5f-46e4-8192-2b8108548bb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/4e9e8966-5ae3-4355-982c-d0981f88dbe3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09f0c63a-8b5f-46e4-8192-2b8108548bb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/16cca051-0847-412b-836e-81c76e5f8207> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16cca051-0847-412b-836e-81c76e5f8207";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/4f3a7d6d-46ae-4326-9a90-381c34a56ec0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16cca051-0847-412b-836e-81c76e5f8207>.
+    
+<http://data.lblod.info/id/remote-data-objects/096d17d0-4f03-4d5e-bcf9-7a01f339804e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "096d17d0-4f03-4d5e-bcf9-7a01f339804e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/4f3a7d6d-46ae-4326-9a90-381c34a56ec0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/096d17d0-4f03-4d5e-bcf9-7a01f339804e>.
+    
+<http://data.lblod.info/id/remote-data-objects/14af39cd-3dc6-4ae3-8be4-3538663e4d12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14af39cd-3dc6-4ae3-8be4-3538663e4d12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/4f3a7d6d-46ae-4326-9a90-381c34a56ec0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14af39cd-3dc6-4ae3-8be4-3538663e4d12>.
+    
+<http://data.lblod.info/id/remote-data-objects/08d8a886-8bcb-46ca-bf6b-c2a13a209af2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08d8a886-8bcb-46ca-bf6b-c2a13a209af2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/503a8d24-763e-4ec3-a42b-caac69acd60b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08d8a886-8bcb-46ca-bf6b-c2a13a209af2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f99ff5f5-2fe0-4511-8c10-8950eaf181a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f99ff5f5-2fe0-4511-8c10-8950eaf181a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/503a8d24-763e-4ec3-a42b-caac69acd60b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f99ff5f5-2fe0-4511-8c10-8950eaf181a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/4db32399-5f55-4805-96ad-4ae9c4afab0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4db32399-5f55-4805-96ad-4ae9c4afab0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/503a8d24-763e-4ec3-a42b-caac69acd60b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4db32399-5f55-4805-96ad-4ae9c4afab0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f90ee4f-d3c3-4be9-a4ad-6cea1c11aa8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f90ee4f-d3c3-4be9-a4ad-6cea1c11aa8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/85cf4a8c-e131-4be7-b654-591819fe9943/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f90ee4f-d3c3-4be9-a4ad-6cea1c11aa8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7431406-f526-4a83-b2b3-794330f9ed93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7431406-f526-4a83-b2b3-794330f9ed93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/85cf4a8c-e131-4be7-b654-591819fe9943/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7431406-f526-4a83-b2b3-794330f9ed93>.
+    
+<http://data.lblod.info/id/remote-data-objects/64c1c826-6886-4ad0-ad4e-37d904158377> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64c1c826-6886-4ad0-ad4e-37d904158377";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/85cf4a8c-e131-4be7-b654-591819fe9943/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a84a2eb-cb69-4994-8e94-2ec65ffc08f6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64c1c826-6886-4ad0-ad4e-37d904158377>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201207-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201207-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201207-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201207-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/8d20b6ca-c515-4588-bf00-62c3109242db> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8d20b6ca-c515-4588-bf00-62c3109242db";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0708ce20-0f4a-4f90-92c4-52b64b1db071";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/839e2607-08ee-4ed4-b87c-096e570cacc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "839e2607-08ee-4ed4-b87c-096e570cacc4";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071>.
+
+  <http://redpencil.data.gift/id/task/db38c17e-9899-4f3f-b548-7d8cff0e2423> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "db38c17e-9899-4f3f-b548-7d8cff0e2423";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/8d20b6ca-c515-4588-bf00-62c3109242db>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/839e2607-08ee-4ed4-b87c-096e570cacc4>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/867953af-c051-43da-b436-b3a2e71ed90d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "867953af-c051-43da-b436-b3a2e71ed90d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/8f1724b5-bafd-4fa2-b8f5-c6fcb438e257/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/867953af-c051-43da-b436-b3a2e71ed90d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f4321a7-f301-4226-937a-8661becc2a8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f4321a7-f301-4226-937a-8661becc2a8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/8f1724b5-bafd-4fa2-b8f5-c6fcb438e257/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f4321a7-f301-4226-937a-8661becc2a8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7f75990-4395-4acb-8638-54cad6ce52b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7f75990-4395-4acb-8638-54cad6ce52b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/8f1724b5-bafd-4fa2-b8f5-c6fcb438e257/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7f75990-4395-4acb-8638-54cad6ce52b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/34149144-5b96-4c94-95f4-0cb47783d379> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34149144-5b96-4c94-95f4-0cb47783d379";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/914b5a16-938c-4d0e-9dc0-43788e2a11ed/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34149144-5b96-4c94-95f4-0cb47783d379>.
+    
+<http://data.lblod.info/id/remote-data-objects/3886d8d1-f68a-4a48-8854-d89d78fef5bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3886d8d1-f68a-4a48-8854-d89d78fef5bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/914b5a16-938c-4d0e-9dc0-43788e2a11ed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3886d8d1-f68a-4a48-8854-d89d78fef5bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/91f7bc0b-9ac2-4933-988a-93c215dfc949> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91f7bc0b-9ac2-4933-988a-93c215dfc949";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/914b5a16-938c-4d0e-9dc0-43788e2a11ed/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91f7bc0b-9ac2-4933-988a-93c215dfc949>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ab43883-b48b-45c0-95e1-cdf8897c5308> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ab43883-b48b-45c0-95e1-cdf8897c5308";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/9fbf0adb-4599-4723-aa89-697915eada62/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ab43883-b48b-45c0-95e1-cdf8897c5308>.
+    
+<http://data.lblod.info/id/remote-data-objects/38aca889-0bec-4bb8-9f0e-f9c80430d89a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38aca889-0bec-4bb8-9f0e-f9c80430d89a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/9fbf0adb-4599-4723-aa89-697915eada62/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38aca889-0bec-4bb8-9f0e-f9c80430d89a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bed1b36f-7601-4891-9ac7-6ee1dc5554ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bed1b36f-7601-4891-9ac7-6ee1dc5554ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/a19da35d-aa61-4e2e-a547-81fd96da876c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bed1b36f-7601-4891-9ac7-6ee1dc5554ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0943824-05c0-4201-8416-76cda4de2127> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0943824-05c0-4201-8416-76cda4de2127";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/a19da35d-aa61-4e2e-a547-81fd96da876c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0943824-05c0-4201-8416-76cda4de2127>.
+    
+<http://data.lblod.info/id/remote-data-objects/06d3ac57-1332-4d21-9b93-87a26f7d2794> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06d3ac57-1332-4d21-9b93-87a26f7d2794";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/a19da35d-aa61-4e2e-a547-81fd96da876c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06d3ac57-1332-4d21-9b93-87a26f7d2794>.
+    
+<http://data.lblod.info/id/remote-data-objects/e652a03f-a9d6-483f-bc4b-2ca1a873ca49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e652a03f-a9d6-483f-bc4b-2ca1a873ca49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/a953cebd-b2d7-44a6-81d5-2b54fa3cf5a3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e652a03f-a9d6-483f-bc4b-2ca1a873ca49>.
+    
+<http://data.lblod.info/id/remote-data-objects/c560cb5d-72d4-4fc6-90d1-a7275131a2df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c560cb5d-72d4-4fc6-90d1-a7275131a2df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/a953cebd-b2d7-44a6-81d5-2b54fa3cf5a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c560cb5d-72d4-4fc6-90d1-a7275131a2df>.
+    
+<http://data.lblod.info/id/remote-data-objects/b90c6421-c2f0-4289-a90f-ec8c7aee75a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b90c6421-c2f0-4289-a90f-ec8c7aee75a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/a953cebd-b2d7-44a6-81d5-2b54fa3cf5a3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b90c6421-c2f0-4289-a90f-ec8c7aee75a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae6a4052-3c01-4bda-bab1-abaeb2419932> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae6a4052-3c01-4bda-bab1-abaeb2419932";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/cfacfff9-8c0f-42c5-b5da-2accd2aeb7a8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae6a4052-3c01-4bda-bab1-abaeb2419932>.
+    
+<http://data.lblod.info/id/remote-data-objects/91138ac5-8dad-4ad1-93c0-d1bf436def1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91138ac5-8dad-4ad1-93c0-d1bf436def1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/cfacfff9-8c0f-42c5-b5da-2accd2aeb7a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91138ac5-8dad-4ad1-93c0-d1bf436def1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9468230-cd0f-468c-a0e7-fd0c0fad58b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9468230-cd0f-468c-a0e7-fd0c0fad58b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/cfacfff9-8c0f-42c5-b5da-2accd2aeb7a8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9468230-cd0f-468c-a0e7-fd0c0fad58b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c28512e6-0dd5-4062-b958-c357127f609d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c28512e6-0dd5-4062-b958-c357127f609d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/d8d4ef63-aaa2-4a95-a920-996531a39cb1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c28512e6-0dd5-4062-b958-c357127f609d>.
+    
+<http://data.lblod.info/id/remote-data-objects/15579ba9-1fe3-456e-b59f-5c29d75b8b61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15579ba9-1fe3-456e-b59f-5c29d75b8b61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/gr/d8d4ef63-aaa2-4a95-a920-996531a39cb1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15579ba9-1fe3-456e-b59f-5c29d75b8b61>.
+    
+<http://data.lblod.info/id/remote-data-objects/12ce557a-33cb-4781-ab06-d3f8dd3837a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12ce557a-33cb-4781-ab06-d3f8dd3837a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/06cc0d36-b62a-47b6-8843-9ecf5cc80609/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12ce557a-33cb-4781-ab06-d3f8dd3837a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6af84b2a-da1c-430a-a8b8-3489baceb0cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6af84b2a-da1c-430a-a8b8-3489baceb0cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/06cc0d36-b62a-47b6-8843-9ecf5cc80609/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6af84b2a-da1c-430a-a8b8-3489baceb0cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ff5be06-437f-4cc7-9ad9-2239d84530ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ff5be06-437f-4cc7-9ad9-2239d84530ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/06cc0d36-b62a-47b6-8843-9ecf5cc80609/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ff5be06-437f-4cc7-9ad9-2239d84530ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/7edb7b65-0c8f-471b-8c56-550a69020d3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7edb7b65-0c8f-471b-8c56-550a69020d3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/0d567853-5dbc-4980-920c-bac159056011/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7edb7b65-0c8f-471b-8c56-550a69020d3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccf49078-5d5d-4f0c-8ed1-edccdbe80807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccf49078-5d5d-4f0c-8ed1-edccdbe80807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/0d567853-5dbc-4980-920c-bac159056011/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccf49078-5d5d-4f0c-8ed1-edccdbe80807>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e9bc465-a93c-439a-a5bc-a3681ac21f49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e9bc465-a93c-439a-a5bc-a3681ac21f49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/0d567853-5dbc-4980-920c-bac159056011/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e9bc465-a93c-439a-a5bc-a3681ac21f49>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0ab0db9-458f-4850-8408-272fbea08939> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0ab0db9-458f-4850-8408-272fbea08939";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/399f3bcf-793d-4a78-b294-30df80d1f0b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0ab0db9-458f-4850-8408-272fbea08939>.
+    
+<http://data.lblod.info/id/remote-data-objects/27e72e45-94e5-4064-9fbe-339aefada662> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27e72e45-94e5-4064-9fbe-339aefada662";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/399f3bcf-793d-4a78-b294-30df80d1f0b9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27e72e45-94e5-4064-9fbe-339aefada662>.
+    
+<http://data.lblod.info/id/remote-data-objects/17992e6a-61ff-4804-8bd9-03f638033905> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17992e6a-61ff-4804-8bd9-03f638033905";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/4a8ff089-6ee4-4aa1-a6fc-309dddc68dfd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17992e6a-61ff-4804-8bd9-03f638033905>.
+    
+<http://data.lblod.info/id/remote-data-objects/b649c816-43ac-42e7-814d-e676c3944afe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b649c816-43ac-42e7-814d-e676c3944afe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/4a8ff089-6ee4-4aa1-a6fc-309dddc68dfd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b649c816-43ac-42e7-814d-e676c3944afe>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a05f2f1-31f2-4d54-a77d-e42dbbf241e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a05f2f1-31f2-4d54-a77d-e42dbbf241e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/4a8ff089-6ee4-4aa1-a6fc-309dddc68dfd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a05f2f1-31f2-4d54-a77d-e42dbbf241e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/cad6d6b0-fa09-44de-b8fa-63eded71b2fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cad6d6b0-fa09-44de-b8fa-63eded71b2fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/65d5d075-0827-4273-be68-e068213ef5de/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cad6d6b0-fa09-44de-b8fa-63eded71b2fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5ea56ca-1dce-4b52-a688-bd2406a1a2b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5ea56ca-1dce-4b52-a688-bd2406a1a2b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/65d5d075-0827-4273-be68-e068213ef5de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5ea56ca-1dce-4b52-a688-bd2406a1a2b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/68582cad-b605-4a79-a0d7-a5f873eba3d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68582cad-b605-4a79-a0d7-a5f873eba3d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/6c32bee2-83c8-4cc8-ac09-852c112c8152/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68582cad-b605-4a79-a0d7-a5f873eba3d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b1d1b46-a1c6-4c9d-809f-98eb974641e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b1d1b46-a1c6-4c9d-809f-98eb974641e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/6c32bee2-83c8-4cc8-ac09-852c112c8152/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b1d1b46-a1c6-4c9d-809f-98eb974641e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ea00efb-eb13-427c-b166-b0a9d47e9c12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ea00efb-eb13-427c-b166-b0a9d47e9c12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/6c32bee2-83c8-4cc8-ac09-852c112c8152/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ea00efb-eb13-427c-b166-b0a9d47e9c12>.
+    
+<http://data.lblod.info/id/remote-data-objects/00ec5c24-41ca-496c-9193-07d54eec4466> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00ec5c24-41ca-496c-9193-07d54eec4466";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/8a1a7062-89a0-4f9c-908d-4d0c831ff4fa/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00ec5c24-41ca-496c-9193-07d54eec4466>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8153b7e-da99-4f13-83da-fb98872acb52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8153b7e-da99-4f13-83da-fb98872acb52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/8a1a7062-89a0-4f9c-908d-4d0c831ff4fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8153b7e-da99-4f13-83da-fb98872acb52>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6ff2b99-0a3a-453e-a259-7b53ee648067> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6ff2b99-0a3a-453e-a259-7b53ee648067";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/8a1a7062-89a0-4f9c-908d-4d0c831ff4fa/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6ff2b99-0a3a-453e-a259-7b53ee648067>.
+    
+<http://data.lblod.info/id/remote-data-objects/bba7879a-8779-49a3-b1ca-bcdf26b334b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bba7879a-8779-49a3-b1ca-bcdf26b334b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/9617b2d2-ee21-4c10-9a1a-1585c1653800/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bba7879a-8779-49a3-b1ca-bcdf26b334b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa5cc8e8-c4a3-4914-933e-9bf2a434eb3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa5cc8e8-c4a3-4914-933e-9bf2a434eb3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/9617b2d2-ee21-4c10-9a1a-1585c1653800/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa5cc8e8-c4a3-4914-933e-9bf2a434eb3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a53e7c94-4093-4cff-bbcc-404b8f5ba310> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a53e7c94-4093-4cff-bbcc-404b8f5ba310";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/9617b2d2-ee21-4c10-9a1a-1585c1653800/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a53e7c94-4093-4cff-bbcc-404b8f5ba310>.
+    
+<http://data.lblod.info/id/remote-data-objects/68f4299e-36b6-44c5-bbe8-beacfa2fd60b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68f4299e-36b6-44c5-bbe8-beacfa2fd60b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/961a3807-9c1d-4ec9-bf6c-989839059f8e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68f4299e-36b6-44c5-bbe8-beacfa2fd60b>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa66d858-1b72-4d1d-a13f-3939e6ad83a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa66d858-1b72-4d1d-a13f-3939e6ad83a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/961a3807-9c1d-4ec9-bf6c-989839059f8e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa66d858-1b72-4d1d-a13f-3939e6ad83a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/87313867-3a06-4038-a62f-2f09a27f6c25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87313867-3a06-4038-a62f-2f09a27f6c25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/961a3807-9c1d-4ec9-bf6c-989839059f8e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87313867-3a06-4038-a62f-2f09a27f6c25>.
+    
+<http://data.lblod.info/id/remote-data-objects/c966fffa-3422-4122-8141-f09e47a36f7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c966fffa-3422-4122-8141-f09e47a36f7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/97503ca3-057c-4bbe-b8fb-c17532f297bb/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c966fffa-3422-4122-8141-f09e47a36f7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/754eac74-3607-4e88-9c56-9ab51b728a13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "754eac74-3607-4e88-9c56-9ab51b728a13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/97503ca3-057c-4bbe-b8fb-c17532f297bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/754eac74-3607-4e88-9c56-9ab51b728a13>.
+    
+<http://data.lblod.info/id/remote-data-objects/cecca700-9ecb-44d1-98e1-5c8ac4f50bae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cecca700-9ecb-44d1-98e1-5c8ac4f50bae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/97503ca3-057c-4bbe-b8fb-c17532f297bb/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cecca700-9ecb-44d1-98e1-5c8ac4f50bae>.
+    
+<http://data.lblod.info/id/remote-data-objects/d64a6f88-ead4-4202-8a84-d5e10dfb2986> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d64a6f88-ead4-4202-8a84-d5e10dfb2986";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/9c47ec08-2b6a-41b8-9c27-3dcd071c452a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d64a6f88-ead4-4202-8a84-d5e10dfb2986>.
+    
+<http://data.lblod.info/id/remote-data-objects/01f4d176-cab0-4a89-afd4-e864c47027ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01f4d176-cab0-4a89-afd4-e864c47027ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/9c47ec08-2b6a-41b8-9c27-3dcd071c452a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01f4d176-cab0-4a89-afd4-e864c47027ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9aa8546-9714-4172-a840-ae5e11923655> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9aa8546-9714-4172-a840-ae5e11923655";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/9c47ec08-2b6a-41b8-9c27-3dcd071c452a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0708ce20-0f4a-4f90-92c4-52b64b1db071> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9aa8546-9714-4172-a840-ae5e11923655>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201208-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201208-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201208-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201208-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/8cce3a3d-9c87-4613-a66d-273ea02116cf> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8cce3a3d-9c87-4613-a66d-273ea02116cf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3989c1a3-e28c-413c-9bab-394865f6bd91";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/da7498db-2128-4176-874f-d0acbfd9f582> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "da7498db-2128-4176-874f-d0acbfd9f582";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91>.
+
+  <http://redpencil.data.gift/id/task/b024bf55-bb3e-4565-a544-c7f25be38089> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b024bf55-bb3e-4565-a544-c7f25be38089";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/8cce3a3d-9c87-4613-a66d-273ea02116cf>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/da7498db-2128-4176-874f-d0acbfd9f582>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/231d9b56-265f-4fd3-8261-08d86b3050e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "231d9b56-265f-4fd3-8261-08d86b3050e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/ab7fd7f9-e0b8-47a8-a8be-8806f81dc8e0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/231d9b56-265f-4fd3-8261-08d86b3050e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fe05602-e325-4274-aa1d-a15e43f2044c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fe05602-e325-4274-aa1d-a15e43f2044c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/ab7fd7f9-e0b8-47a8-a8be-8806f81dc8e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fe05602-e325-4274-aa1d-a15e43f2044c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c166c8ae-1e4a-4827-ac43-4ce9ad8098c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c166c8ae-1e4a-4827-ac43-4ce9ad8098c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/ab7fd7f9-e0b8-47a8-a8be-8806f81dc8e0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c166c8ae-1e4a-4827-ac43-4ce9ad8098c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c79ddb0-5ce3-4413-b431-f47084e2cfca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c79ddb0-5ce3-4413-b431-f47084e2cfca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/f19fd45a-2532-470f-b1db-f6ccd9fab84d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c79ddb0-5ce3-4413-b431-f47084e2cfca>.
+    
+<http://data.lblod.info/id/remote-data-objects/abda8a6a-804b-4d6d-a925-c08f7c101a29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abda8a6a-804b-4d6d-a925-c08f7c101a29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/f19fd45a-2532-470f-b1db-f6ccd9fab84d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abda8a6a-804b-4d6d-a925-c08f7c101a29>.
+    
+<http://data.lblod.info/id/remote-data-objects/36e7aafc-66db-4449-bdb1-3799c7321d2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36e7aafc-66db-4449-bdb1-3799c7321d2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/f19fd45a-2532-470f-b1db-f6ccd9fab84d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36e7aafc-66db-4449-bdb1-3799c7321d2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b017fcbd-4d28-457e-ba14-b820ad60275c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b017fcbd-4d28-457e-ba14-b820ad60275c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/f3dd1db8-604e-48d7-b958-1676daf6b987/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b017fcbd-4d28-457e-ba14-b820ad60275c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e21319fc-55c2-4f54-bb4b-691bea779e7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e21319fc-55c2-4f54-bb4b-691bea779e7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/f3dd1db8-604e-48d7-b958-1676daf6b987/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e21319fc-55c2-4f54-bb4b-691bea779e7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/20d6e5c6-5b4b-4a5a-801e-23ee0cc8f250> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20d6e5c6-5b4b-4a5a-801e-23ee0cc8f250";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/f3dd1db8-604e-48d7-b958-1676daf6b987/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20d6e5c6-5b4b-4a5a-801e-23ee0cc8f250>.
+    
+<http://data.lblod.info/id/remote-data-objects/5218ea59-7b66-4a40-a012-612905b6d183> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5218ea59-7b66-4a40-a012-612905b6d183";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/f9a1c79c-5fd2-4c85-b37d-c432248ed0d7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5218ea59-7b66-4a40-a012-612905b6d183>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd6b9ff3-47fb-4913-941c-31c92a258db6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd6b9ff3-47fb-4913-941c-31c92a258db6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/f9a1c79c-5fd2-4c85-b37d-c432248ed0d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd6b9ff3-47fb-4913-941c-31c92a258db6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cac76ef-55b7-4470-827c-7ec6843c8066> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cac76ef-55b7-4470-827c-7ec6843c8066";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/or/f9a1c79c-5fd2-4c85-b37d-c432248ed0d7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cac76ef-55b7-4470-827c-7ec6843c8066>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1e0faa1-e9ce-455a-9b5e-ccc86cce276a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1e0faa1-e9ce-455a-9b5e-ccc86cce276a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/rvb/03568784-9156-449f-8bb3-431ef2173447/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1e0faa1-e9ce-455a-9b5e-ccc86cce276a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3db4153e-e934-454c-9e8d-5dcdf96ddbf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3db4153e-e934-454c-9e8d-5dcdf96ddbf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/rvb/03f43b83-a479-4980-8068-093ada763033/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3db4153e-e934-454c-9e8d-5dcdf96ddbf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0acc0744-c1f5-41bf-82fc-679836ee1d04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0acc0744-c1f5-41bf-82fc-679836ee1d04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/rvb/0ff8b841-1000-4a9f-8a74-92cc5dd8d075/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0acc0744-c1f5-41bf-82fc-679836ee1d04>.
+    
+<http://data.lblod.info/id/remote-data-objects/b93e1c6d-0b12-4000-bbb5-9cf9c8fe9d51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b93e1c6d-0b12-4000-bbb5-9cf9c8fe9d51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/rvb/724d722b-922d-4c93-aff1-5ac861614124/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b93e1c6d-0b12-4000-bbb5-9cf9c8fe9d51>.
+    
+<http://data.lblod.info/id/remote-data-objects/6100d1bd-8724-458e-9f9a-02f019b7b651> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6100d1bd-8724-458e-9f9a-02f019b7b651";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/rvb/76513cfc-6f60-43a7-9408-fb3828042ce1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6100d1bd-8724-458e-9f9a-02f019b7b651>.
+    
+<http://data.lblod.info/id/remote-data-objects/d90dc42b-8384-49a7-8e03-39c5685f5119> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d90dc42b-8384-49a7-8e03-39c5685f5119";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/rvb/9375816c-30ad-4a79-ba69-e42fe4bd2f4f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d90dc42b-8384-49a7-8e03-39c5685f5119>.
+    
+<http://data.lblod.info/id/remote-data-objects/492bc0f2-5089-48c0-91c2-5e15040d99c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "492bc0f2-5089-48c0-91c2-5e15040d99c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/rvb/b084a18e-9176-4349-8536-26c345031872/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/492bc0f2-5089-48c0-91c2-5e15040d99c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/471394f0-1951-44a7-89fe-8a38d461303a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "471394f0-1951-44a7-89fe-8a38d461303a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/rvb/b570235f-6217-4760-97d1-0dcc2f6ba51c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/471394f0-1951-44a7-89fe-8a38d461303a>.
+    
+<http://data.lblod.info/id/remote-data-objects/251902ee-613d-4a23-bced-61d19659ab7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "251902ee-613d-4a23-bced-61d19659ab7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/rvb/c89539c2-d2fa-428c-ab34-2d81c830745c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/251902ee-613d-4a23-bced-61d19659ab7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3b6d52c-7468-41a4-84eb-95b927b72584> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3b6d52c-7468-41a4-84eb-95b927b72584";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/01ea1d77-facb-425c-aa5a-d861eefaac62/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3b6d52c-7468-41a4-84eb-95b927b72584>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a2a4a2f-0933-4ff8-abcd-aaad0f293d80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a2a4a2f-0933-4ff8-abcd-aaad0f293d80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/077b4030-381f-42be-812e-6f2a4216acf4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a2a4a2f-0933-4ff8-abcd-aaad0f293d80>.
+    
+<http://data.lblod.info/id/remote-data-objects/6feb2594-4576-4602-a0ad-85ae9876c00f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6feb2594-4576-4602-a0ad-85ae9876c00f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/0b18e3ac-6a2a-4c22-b5b4-a7102078fec7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6feb2594-4576-4602-a0ad-85ae9876c00f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f5b24af-8a21-4416-9ce0-6280bf91df6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f5b24af-8a21-4416-9ce0-6280bf91df6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/14efa9e7-df0b-4df9-9f62-19d88e097f17/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f5b24af-8a21-4416-9ce0-6280bf91df6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/46508b4a-a75a-46b2-a14c-b7287c8d1db3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46508b4a-a75a-46b2-a14c-b7287c8d1db3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/18bf352e-00d3-4f37-a337-203507d9caf9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46508b4a-a75a-46b2-a14c-b7287c8d1db3>.
+    
+<http://data.lblod.info/id/remote-data-objects/0075c992-75e5-417c-9a54-9c77e5de2ba8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0075c992-75e5-417c-9a54-9c77e5de2ba8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/2295daf5-272f-4f74-aaf4-852e67b16a16/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0075c992-75e5-417c-9a54-9c77e5de2ba8>.
+    
+<http://data.lblod.info/id/remote-data-objects/128a2d2c-b854-4694-baf4-438d1d7df53a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "128a2d2c-b854-4694-baf4-438d1d7df53a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/23690111-b9c9-4757-8c16-495680b45220/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/128a2d2c-b854-4694-baf4-438d1d7df53a>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb4c27c0-e868-42d5-a71f-d32851df00ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb4c27c0-e868-42d5-a71f-d32851df00ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/271fe5ba-391a-4776-977b-ac4e413a1c62/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb4c27c0-e868-42d5-a71f-d32851df00ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e9c64f6-9775-499c-bac3-67ffabb24fc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e9c64f6-9775-499c-bac3-67ffabb24fc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/27afc2ac-f0ec-4277-9c1d-d1e207f34a0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e9c64f6-9775-499c-bac3-67ffabb24fc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/14189a6a-890e-4730-bfd7-ed9083c5dd87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14189a6a-890e-4730-bfd7-ed9083c5dd87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/2b0cbb77-47fc-4686-a04c-97e76e177b89/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14189a6a-890e-4730-bfd7-ed9083c5dd87>.
+    
+<http://data.lblod.info/id/remote-data-objects/d23bdaa5-d792-49c1-887f-6b8585549992> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d23bdaa5-d792-49c1-887f-6b8585549992";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/2e7aaddf-dd7d-4955-a238-095bb7617f02/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d23bdaa5-d792-49c1-887f-6b8585549992>.
+    
+<http://data.lblod.info/id/remote-data-objects/f842aba6-eecf-4b00-97b4-42b58c9d91b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f842aba6-eecf-4b00-97b4-42b58c9d91b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/310e440f-558f-4cca-8a3d-ff0cfa824a73/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f842aba6-eecf-4b00-97b4-42b58c9d91b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/4632f3c1-2eef-4c05-bc50-aaee2eae82eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4632f3c1-2eef-4c05-bc50-aaee2eae82eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/34efc493-9168-4c6e-a459-69b94c12b980/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4632f3c1-2eef-4c05-bc50-aaee2eae82eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a6f46c5-2794-484a-b196-883fef2389c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a6f46c5-2794-484a-b196-883fef2389c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/38f6af40-6aab-435b-9010-c640203e961a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a6f46c5-2794-484a-b196-883fef2389c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed856e8a-b699-4d4c-b420-82440719d2e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed856e8a-b699-4d4c-b420-82440719d2e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/3ce8734d-d640-48b3-a2fe-700664af2977/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed856e8a-b699-4d4c-b420-82440719d2e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c7b3fc4-59e0-406d-b751-7456bc065328> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c7b3fc4-59e0-406d-b751-7456bc065328";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/40ca2601-21a5-420c-a716-2a8a2c733732/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c7b3fc4-59e0-406d-b751-7456bc065328>.
+    
+<http://data.lblod.info/id/remote-data-objects/71eda942-41e4-4b08-8e5a-95238e943448> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71eda942-41e4-4b08-8e5a-95238e943448";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/42452663-83d0-4504-be29-263e90696c7c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71eda942-41e4-4b08-8e5a-95238e943448>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc6ba484-9d28-45ed-a7ff-1af33b4c2b99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc6ba484-9d28-45ed-a7ff-1af33b4c2b99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/47966956-53a3-45ff-86e6-e0f9112ef749/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc6ba484-9d28-45ed-a7ff-1af33b4c2b99>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b9b3604-32d1-4c4a-be09-f7e387c83872> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b9b3604-32d1-4c4a-be09-f7e387c83872";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/4db62674-24c5-4c77-b045-82a465b5bdbc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b9b3604-32d1-4c4a-be09-f7e387c83872>.
+    
+<http://data.lblod.info/id/remote-data-objects/4204b7d8-95e0-41d8-8600-0fd32429bf9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4204b7d8-95e0-41d8-8600-0fd32429bf9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/51ef9b14-0f81-45cc-93fd-0c9c0e3ec369/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4204b7d8-95e0-41d8-8600-0fd32429bf9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ebe8dd0-d704-43ba-b757-44a26ef7822d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ebe8dd0-d704-43ba-b757-44a26ef7822d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/52b8ae21-b477-4307-bc79-2f08d74a7ebc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ebe8dd0-d704-43ba-b757-44a26ef7822d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f33663a1-2826-4824-947a-e1d5012baa9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f33663a1-2826-4824-947a-e1d5012baa9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/53f9b002-ad06-4f33-bb32-9862e8c336d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f33663a1-2826-4824-947a-e1d5012baa9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe47a7b7-e8c1-4cc8-b0d2-b4e1de4af987> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe47a7b7-e8c1-4cc8-b0d2-b4e1de4af987";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/56cebb1b-8eb2-47ae-b3fe-e6bd36ae08b8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe47a7b7-e8c1-4cc8-b0d2-b4e1de4af987>.
+    
+<http://data.lblod.info/id/remote-data-objects/a23c5d09-6f08-4ccb-afc0-4feb39924e43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a23c5d09-6f08-4ccb-afc0-4feb39924e43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/5f40f766-e54e-4f79-a1ff-eaca6aa001dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a23c5d09-6f08-4ccb-afc0-4feb39924e43>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e846895-962f-42ea-9890-06f7461a4262> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e846895-962f-42ea-9890-06f7461a4262";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/6719e514-d369-4ad6-b48a-252cfd0ffc04/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e846895-962f-42ea-9890-06f7461a4262>.
+    
+<http://data.lblod.info/id/remote-data-objects/00f989df-7b44-43d7-b0e0-cc29dd734e3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00f989df-7b44-43d7-b0e0-cc29dd734e3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/68549b45-8c78-495b-83f5-6881fa375cf3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00f989df-7b44-43d7-b0e0-cc29dd734e3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a725507-f214-415f-8afb-35549dc019ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a725507-f214-415f-8afb-35549dc019ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/69020def-7930-4f46-92f0-bcea5a4dbc9b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a725507-f214-415f-8afb-35549dc019ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8fe88ef-efa3-4cb1-a99e-80293bc679e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8fe88ef-efa3-4cb1-a99e-80293bc679e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/6c97fbdf-8d3d-40a4-91aa-624894877736/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8fe88ef-efa3-4cb1-a99e-80293bc679e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/43f77e76-7727-4315-9797-eb8d18339671> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43f77e76-7727-4315-9797-eb8d18339671";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/7739fd35-c792-4001-8150-f9e9a8f8678e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3989c1a3-e28c-413c-9bab-394865f6bd91> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43f77e76-7727-4315-9797-eb8d18339671>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201209-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201209-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201209-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201209-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/4e44ae18-f37f-43e8-9789-f71718befaa0> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4e44ae18-f37f-43e8-9789-f71718befaa0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9171b37f-1acb-4e9e-96ae-3b9c7c60aad9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/868a245e-1a12-4eed-803b-c815d3390241> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "868a245e-1a12-4eed-803b-c815d3390241";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9>.
+
+  <http://redpencil.data.gift/id/task/d361d4fb-f0ea-488d-ab76-bb2cfbf2108d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d361d4fb-f0ea-488d-ab76-bb2cfbf2108d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/4e44ae18-f37f-43e8-9789-f71718befaa0>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/868a245e-1a12-4eed-803b-c815d3390241>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/9e9106d9-3d7a-47e8-8905-88933e202b97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e9106d9-3d7a-47e8-8905-88933e202b97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/7a0e0019-c4c8-4220-8b30-3caf335bfa06/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e9106d9-3d7a-47e8-8905-88933e202b97>.
+    
+<http://data.lblod.info/id/remote-data-objects/d41fa42e-f696-451d-9e3f-0d6c0751ac58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d41fa42e-f696-451d-9e3f-0d6c0751ac58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/7c5a67dd-25c2-4b7e-98b9-e8b75426c4ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d41fa42e-f696-451d-9e3f-0d6c0751ac58>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7f5dc27-8200-4ce2-95db-42d3b42c110a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7f5dc27-8200-4ce2-95db-42d3b42c110a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/7f6f4949-8cff-49a6-9388-9761ec07955d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7f5dc27-8200-4ce2-95db-42d3b42c110a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a24d9a89-a807-42aa-8800-eedb04380275> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a24d9a89-a807-42aa-8800-eedb04380275";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/83d48dec-78fe-4c73-acb6-d345534154b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a24d9a89-a807-42aa-8800-eedb04380275>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f81b5a4-ad71-4c42-99c3-303968eab001> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f81b5a4-ad71-4c42-99c3-303968eab001";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/898e43e7-279c-4a28-9061-34287dc49348/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f81b5a4-ad71-4c42-99c3-303968eab001>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5a21dac-74b5-4ab7-aee3-91b2ee04aa16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5a21dac-74b5-4ab7-aee3-91b2ee04aa16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/98a9e96a-0b7b-4065-90f2-b935f4b7cc5c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5a21dac-74b5-4ab7-aee3-91b2ee04aa16>.
+    
+<http://data.lblod.info/id/remote-data-objects/c521fc30-323b-4d23-8a32-26685e80267f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c521fc30-323b-4d23-8a32-26685e80267f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/9975558b-cedc-4850-bb52-9489f630070d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c521fc30-323b-4d23-8a32-26685e80267f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d32044fa-8b7b-4682-8c8b-44155d93eed0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d32044fa-8b7b-4682-8c8b-44155d93eed0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/9b3defc8-cd2e-4e5b-91cd-b1bb8c6b99e4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d32044fa-8b7b-4682-8c8b-44155d93eed0>.
+    
+<http://data.lblod.info/id/remote-data-objects/45b529cd-c528-4238-887c-f99297025f7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45b529cd-c528-4238-887c-f99297025f7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/a712cc22-953b-43ca-8f2e-3c6bd2796737/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45b529cd-c528-4238-887c-f99297025f7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbed979b-860b-4765-b90b-53fc5f34c7b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbed979b-860b-4765-b90b-53fc5f34c7b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/adcafa76-cb8f-4b79-98a4-0b2609050483/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbed979b-860b-4765-b90b-53fc5f34c7b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/acaf399c-7be8-4b08-b446-2a7047d3b314> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acaf399c-7be8-4b08-b446-2a7047d3b314";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/b230f0be-b7e6-4689-8718-50fa9d097162/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acaf399c-7be8-4b08-b446-2a7047d3b314>.
+    
+<http://data.lblod.info/id/remote-data-objects/adc20e7b-980d-4069-bd45-5f1e3aeab566> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "adc20e7b-980d-4069-bd45-5f1e3aeab566";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/b6faf4c0-79ab-402a-80da-712e76a7fd9c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/adc20e7b-980d-4069-bd45-5f1e3aeab566>.
+    
+<http://data.lblod.info/id/remote-data-objects/91218f9c-11df-4a4d-bd56-5c66b8ea17b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91218f9c-11df-4a4d-bd56-5c66b8ea17b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/c1023c38-c02b-461a-bc85-a1d1c0c863b8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91218f9c-11df-4a4d-bd56-5c66b8ea17b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/d901fe92-0844-4232-b0aa-bad8cd59645a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d901fe92-0844-4232-b0aa-bad8cd59645a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/c45a3e43-3afb-4bc1-b651-75e163217ae1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d901fe92-0844-4232-b0aa-bad8cd59645a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6005196e-3046-426e-a1fc-ef0529796b71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6005196e-3046-426e-a1fc-ef0529796b71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/c85c702f-e269-4cc2-aad5-d2126d6cc024/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6005196e-3046-426e-a1fc-ef0529796b71>.
+    
+<http://data.lblod.info/id/remote-data-objects/9858faea-41ce-4833-998f-1fec2356664f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9858faea-41ce-4833-998f-1fec2356664f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/cbb063e7-629b-4616-a587-db62a91c348d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9858faea-41ce-4833-998f-1fec2356664f>.
+    
+<http://data.lblod.info/id/remote-data-objects/28276acc-934e-4e19-8787-9a4ff9e53a88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28276acc-934e-4e19-8787-9a4ff9e53a88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/d09404d8-2b01-4789-aee8-6ae88f767681/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28276acc-934e-4e19-8787-9a4ff9e53a88>.
+    
+<http://data.lblod.info/id/remote-data-objects/6944ad97-a800-4cc0-af37-18fba1770369> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6944ad97-a800-4cc0-af37-18fba1770369";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/d38044b6-83c1-4ab4-b06e-4c059f789853/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6944ad97-a800-4cc0-af37-18fba1770369>.
+    
+<http://data.lblod.info/id/remote-data-objects/30e35e23-11a6-405e-85a1-3b525b1bc819> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30e35e23-11a6-405e-85a1-3b525b1bc819";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/d3c4571f-c089-4207-b000-be93a0ea390b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30e35e23-11a6-405e-85a1-3b525b1bc819>.
+    
+<http://data.lblod.info/id/remote-data-objects/72e84efc-059b-4165-b5e6-4f2ca70f080f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72e84efc-059b-4165-b5e6-4f2ca70f080f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/d4113996-e0b9-40b4-b3b7-02ec5f1b3133/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72e84efc-059b-4165-b5e6-4f2ca70f080f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9b1179b-ef48-4c2f-a8b3-5ff3f3ddb7fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9b1179b-ef48-4c2f-a8b3-5ff3f3ddb7fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/d42fa3fc-c4c7-49e5-aa99-b31eca69acca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9b1179b-ef48-4c2f-a8b3-5ff3f3ddb7fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/648b758a-dade-41f4-a1e9-e698b462fe20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "648b758a-dade-41f4-a1e9-e698b462fe20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/d4a89684-2505-4609-9631-8705422be63d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/648b758a-dade-41f4-a1e9-e698b462fe20>.
+    
+<http://data.lblod.info/id/remote-data-objects/8dfdf4a1-4424-4c82-be25-26a988a49312> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8dfdf4a1-4424-4c82-be25-26a988a49312";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/d845d42d-3d71-46e0-bc64-65b44493f49d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8dfdf4a1-4424-4c82-be25-26a988a49312>.
+    
+<http://data.lblod.info/id/remote-data-objects/361710a7-d3f5-4281-a9fb-a593500b3784> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "361710a7-d3f5-4281-a9fb-a593500b3784";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/db27ef07-8bc6-4c8e-a46e-a438476b6fe8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/361710a7-d3f5-4281-a9fb-a593500b3784>.
+    
+<http://data.lblod.info/id/remote-data-objects/a42e62ae-85b6-4caa-b0f4-5397dbd9d706> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a42e62ae-85b6-4caa-b0f4-5397dbd9d706";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/dc624b06-3fe6-4445-801d-51322ef1aa25/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a42e62ae-85b6-4caa-b0f4-5397dbd9d706>.
+    
+<http://data.lblod.info/id/remote-data-objects/35b9bfad-1811-4079-ac72-6e8a08ac872c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35b9bfad-1811-4079-ac72-6e8a08ac872c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/df87fb94-355a-4070-ab5e-c397defd5f47/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35b9bfad-1811-4079-ac72-6e8a08ac872c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3fdfce6-e1f4-49ba-86a7-c5e14fac0c25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3fdfce6-e1f4-49ba-86a7-c5e14fac0c25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/e01ec0b6-c935-45be-a17a-db34dfaa2dca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3fdfce6-e1f4-49ba-86a7-c5e14fac0c25>.
+    
+<http://data.lblod.info/id/remote-data-objects/00ee381b-b3fc-458b-be32-17b75520ce9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00ee381b-b3fc-458b-be32-17b75520ce9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/ea7e9f55-13e9-4cc2-bb6f-a3dd23917baa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00ee381b-b3fc-458b-be32-17b75520ce9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4e30140-2dce-4779-87f7-d3e5c5a7fcb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4e30140-2dce-4779-87f7-d3e5c5a7fcb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/f91309e4-2f13-41ad-b7ad-5848178b97e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4e30140-2dce-4779-87f7-d3e5c5a7fcb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9bdc304-d3fb-40f2-874b-61acc07e47ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9bdc304-d3fb-40f2-874b-61acc07e47ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/fcbb7e33-e9a4-449c-91d3-9f915187b39a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9bdc304-d3fb-40f2-874b-61acc07e47ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a9cdfca-a170-4545-b2f5-58275c955e80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a9cdfca-a170-4545-b2f5-58275c955e80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hove.meetingburger.net/vabu/ff2f236a-2ab1-4fe8-9200-1ed22bca2fd3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a9cdfca-a170-4545-b2f5-58275c955e80>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f71b228-1127-4a6f-8eaf-07bb4b9a8ce3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f71b228-1127-4a6f-8eaf-07bb4b9a8ce3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/agb-sport-rvb/1998914a-6fd1-4ee7-b42b-fd9a702a2ceb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f71b228-1127-4a6f-8eaf-07bb4b9a8ce3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d62f8a6f-2a76-4ce4-b692-dd2e3302dbe4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d62f8a6f-2a76-4ce4-b692-dd2e3302dbe4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/agb-sport-rvb/32d2ab7c-3e9d-4e3a-ad17-b52c1350d318/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d62f8a6f-2a76-4ce4-b692-dd2e3302dbe4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a0a029f-00fa-409a-9817-5ff8d2288d3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a0a029f-00fa-409a-9817-5ff8d2288d3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/agb-sport-rvb/3775f0ff-b966-4aea-bf00-52733e8d1601/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a0a029f-00fa-409a-9817-5ff8d2288d3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/068416a2-0326-4fda-bd2d-b49ae0ced935> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "068416a2-0326-4fda-bd2d-b49ae0ced935";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/agb-sport-rvb/39b905d5-34fc-4685-86f0-1ef322a88b00/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/068416a2-0326-4fda-bd2d-b49ae0ced935>.
+    
+<http://data.lblod.info/id/remote-data-objects/a85a92cb-de53-41fa-be2e-d9da646501ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a85a92cb-de53-41fa-be2e-d9da646501ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/agb-sport-rvb/67f21e4c-b394-4084-92fd-49c448a57ed5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a85a92cb-de53-41fa-be2e-d9da646501ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d20a1fd-5376-4ca2-a1c4-5078c5837917> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d20a1fd-5376-4ca2-a1c4-5078c5837917";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/agb-sport-rvb/6d799a2a-ac29-478d-92f6-b07e91083acb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d20a1fd-5376-4ca2-a1c4-5078c5837917>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab72094e-15f3-4aec-9f9a-029b53b2c454> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab72094e-15f3-4aec-9f9a-029b53b2c454";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/agb-sport-rvb/6e7edad0-3126-4b29-b160-755fafea0f99/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab72094e-15f3-4aec-9f9a-029b53b2c454>.
+    
+<http://data.lblod.info/id/remote-data-objects/40825db2-480a-4885-b428-b85323020fe1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40825db2-480a-4885-b428-b85323020fe1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/agb-sport-rvb/94ca4aeb-533c-4476-9761-7b8d04cd6cb7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40825db2-480a-4885-b428-b85323020fe1>.
+    
+<http://data.lblod.info/id/remote-data-objects/15f96e62-21b7-4049-995e-ebc0665d13a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15f96e62-21b7-4049-995e-ebc0665d13a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/agb-sport-rvb/ab4eaec9-8336-4943-958f-986f413311b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15f96e62-21b7-4049-995e-ebc0665d13a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/10e48503-227d-4e4d-aafc-d66b2fd93261> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10e48503-227d-4e4d-aafc-d66b2fd93261";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/agb-sport-rvb/c71bd782-c24f-4caf-a0e5-3fd7aa2e4835/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10e48503-227d-4e4d-aafc-d66b2fd93261>.
+    
+<http://data.lblod.info/id/remote-data-objects/3637172b-67d4-46cd-aac7-05d8b29a105c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3637172b-67d4-46cd-aac7-05d8b29a105c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/agb-sport-rvb/cb39ce43-52c0-455d-a357-7f84e9c7e7ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3637172b-67d4-46cd-aac7-05d8b29a105c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8d8acb9-638b-496e-a2a3-556ba02cb42e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8d8acb9-638b-496e-a2a3-556ba02cb42e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/agb-sport-rvb/d6bfbc54-f793-4368-8192-9ac7629ab893/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8d8acb9-638b-496e-a2a3-556ba02cb42e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8707211-d930-49a5-a9e2-f2d984c6bd2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8707211-d930-49a5-a9e2-f2d984c6bd2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/agb-sport-rvb/eb0f52a5-5487-488a-883a-3e42c30d255e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8707211-d930-49a5-a9e2-f2d984c6bd2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/782c86ff-609c-4e89-a4ee-eba94d9225a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "782c86ff-609c-4e89-a4ee-eba94d9225a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/AVW/85fea504-0b2d-427e-9f41-ac130ddfd4dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/782c86ff-609c-4e89-a4ee-eba94d9225a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/69e95860-5598-4604-b13b-322a45a35f24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69e95860-5598-4604-b13b-322a45a35f24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/06752179-5f36-4f67-89c6-c3d0e63318cc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69e95860-5598-4604-b13b-322a45a35f24>.
+    
+<http://data.lblod.info/id/remote-data-objects/11dde385-659b-4b3c-af6e-04961207cdf0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11dde385-659b-4b3c-af6e-04961207cdf0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/099a2fb8-24d5-4ed6-85fc-41105febd456/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11dde385-659b-4b3c-af6e-04961207cdf0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bfc9062-dd3d-44a1-9dc1-2a10f726b02a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bfc9062-dd3d-44a1-9dc1-2a10f726b02a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/0eadc075-15e5-4545-8d97-805ea09c8f94/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bfc9062-dd3d-44a1-9dc1-2a10f726b02a>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdd94b50-f4d2-4108-b124-439f8af68913> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdd94b50-f4d2-4108-b124-439f8af68913";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/3798a147-f994-4a80-8d1e-5b3285f64ca4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdd94b50-f4d2-4108-b124-439f8af68913>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee688c73-4581-4539-9949-e49451a74ff7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee688c73-4581-4539-9949-e49451a74ff7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/4513a344-4585-456e-93a7-d0556fb187e8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9171b37f-1acb-4e9e-96ae-3b9c7c60aad9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee688c73-4581-4539-9949-e49451a74ff7>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201210-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201210-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201210-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201210-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/93eda224-3e03-4934-adea-4b289cd1206d> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "93eda224-3e03-4934-adea-4b289cd1206d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0aa5a59a-9f7e-4208-9282-d4fa1bb49945";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9724cfe7-1bd0-40d9-a092-c588ffdca4a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9724cfe7-1bd0-40d9-a092-c588ffdca4a8";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945>.
+
+  <http://redpencil.data.gift/id/task/7c9228e8-feac-4074-8616-a264d602a5d0> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7c9228e8-feac-4074-8616-a264d602a5d0";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/93eda224-3e03-4934-adea-4b289cd1206d>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9724cfe7-1bd0-40d9-a092-c588ffdca4a8>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c89c0da1-0d57-40d0-b339-961523925fbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c89c0da1-0d57-40d0-b339-961523925fbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/4daf7246-7a30-4178-a7fb-f36bc06369e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c89c0da1-0d57-40d0-b339-961523925fbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e7d8f2a-6303-4e98-b88d-a6995cfa9a0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e7d8f2a-6303-4e98-b88d-a6995cfa9a0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/4f3ee664-504e-467a-9414-dfb6615ccb06/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e7d8f2a-6303-4e98-b88d-a6995cfa9a0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/37dcc8e3-0c95-4364-adb0-e507956968b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37dcc8e3-0c95-4364-adb0-e507956968b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/62b69e02-c2cb-4d6a-8d50-5ea782833c02/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37dcc8e3-0c95-4364-adb0-e507956968b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/17e57b71-78b7-40f4-a309-f866004d423a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17e57b71-78b7-40f4-a309-f866004d423a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/66eed267-6a48-482d-9523-5558c0f0c071/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17e57b71-78b7-40f4-a309-f866004d423a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2877a2f0-4413-4adf-a247-e4cfa197d446> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2877a2f0-4413-4adf-a247-e4cfa197d446";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/689eb0b7-e489-4499-9a94-bdc82ce8cd2d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2877a2f0-4413-4adf-a247-e4cfa197d446>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce2ae69b-eaeb-414f-91e9-a8d8d537e804> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce2ae69b-eaeb-414f-91e9-a8d8d537e804";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/6c371248-df48-447f-a558-e28845baac27/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce2ae69b-eaeb-414f-91e9-a8d8d537e804>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b14fd54-33e9-44a2-bb72-020973adf48f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b14fd54-33e9-44a2-bb72-020973adf48f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/7047f58e-b564-4122-9fc8-7ddcb275018e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b14fd54-33e9-44a2-bb72-020973adf48f>.
+    
+<http://data.lblod.info/id/remote-data-objects/26e93168-bdfc-4b9c-a4c9-eb7bf3eaff3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26e93168-bdfc-4b9c-a4c9-eb7bf3eaff3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/721453f8-0a13-4b41-a047-224d37ae0b0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26e93168-bdfc-4b9c-a4c9-eb7bf3eaff3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd74fdcf-7138-47a6-b18a-fee56a150e8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd74fdcf-7138-47a6-b18a-fee56a150e8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/7fc315ba-b71f-44d7-94fb-0a470d701dc3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd74fdcf-7138-47a6-b18a-fee56a150e8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/dafdfdd5-dc20-4ca9-bbe0-f7578a293dd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dafdfdd5-dc20-4ca9-bbe0-f7578a293dd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/857be964-6e95-4df5-839a-c0af2e7237c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dafdfdd5-dc20-4ca9-bbe0-f7578a293dd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b26f751-6026-4d6a-b12c-047f2f71aa3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b26f751-6026-4d6a-b12c-047f2f71aa3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/8a612197-f27a-4557-9d5f-8fa4130eec7e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b26f751-6026-4d6a-b12c-047f2f71aa3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/aed238db-d39e-4a8e-938e-52fa33c46255> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aed238db-d39e-4a8e-938e-52fa33c46255";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/97f54c58-8e46-41ee-8f65-7e40835e83a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aed238db-d39e-4a8e-938e-52fa33c46255>.
+    
+<http://data.lblod.info/id/remote-data-objects/40a52311-a371-4e44-b09e-ead84d79ba24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40a52311-a371-4e44-b09e-ead84d79ba24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/9966199a-dc5b-4364-b2df-75327c810fcf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40a52311-a371-4e44-b09e-ead84d79ba24>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8e24a34-5bfd-4905-919b-0c8e3c2c4d2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8e24a34-5bfd-4905-919b-0c8e3c2c4d2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/9b7fd145-4148-4647-924b-e043878bbca2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8e24a34-5bfd-4905-919b-0c8e3c2c4d2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3afadfae-bbfb-4996-8bd0-cc658b6331b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3afadfae-bbfb-4996-8bd0-cc658b6331b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/9cecb329-9fc5-4b82-b524-957f79a4f830/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3afadfae-bbfb-4996-8bd0-cc658b6331b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/631f9ba9-2477-4ef5-b946-f7229768a530> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "631f9ba9-2477-4ef5-b946-f7229768a530";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/9d78a9cb-7710-44a9-af5b-5dd92aceddaa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/631f9ba9-2477-4ef5-b946-f7229768a530>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0a4aaba-c519-403d-a467-b8c15b7178d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0a4aaba-c519-403d-a467-b8c15b7178d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/a020299b-21b3-4431-bf8f-88dd2965af05/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0a4aaba-c519-403d-a467-b8c15b7178d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e85d769b-d79e-4fe0-a058-dff7f8974b81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e85d769b-d79e-4fe0-a058-dff7f8974b81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/aa04dfad-ce58-4ffa-962e-bacbd37ce473/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e85d769b-d79e-4fe0-a058-dff7f8974b81>.
+    
+<http://data.lblod.info/id/remote-data-objects/a026526b-b44a-4c80-a5a7-57634520627d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a026526b-b44a-4c80-a5a7-57634520627d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/b0f8f540-28ce-4c3c-acd8-34c3f690a496/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a026526b-b44a-4c80-a5a7-57634520627d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc6cd484-6387-4cbb-b7ff-4974ddee1305> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc6cd484-6387-4cbb-b7ff-4974ddee1305";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/b237a22e-ae5e-4166-a280-2f6091589da0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc6cd484-6387-4cbb-b7ff-4974ddee1305>.
+    
+<http://data.lblod.info/id/remote-data-objects/deeed19e-b8aa-431b-b727-0e7afc805f22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "deeed19e-b8aa-431b-b727-0e7afc805f22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/ba3a63ad-56fd-4146-86b1-b8eda7dfe664/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/deeed19e-b8aa-431b-b727-0e7afc805f22>.
+    
+<http://data.lblod.info/id/remote-data-objects/b15bd776-ed97-4b4b-aeca-55e496e6cbca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b15bd776-ed97-4b4b-aeca-55e496e6cbca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/c5c05cc5-5a86-450e-a733-b0f89d84c0b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b15bd776-ed97-4b4b-aeca-55e496e6cbca>.
+    
+<http://data.lblod.info/id/remote-data-objects/413bc2eb-9870-479a-8edf-382ed92e8910> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "413bc2eb-9870-479a-8edf-382ed92e8910";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/c5da3143-5353-4f30-bfd2-0e546c08bcdb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/413bc2eb-9870-479a-8edf-382ed92e8910>.
+    
+<http://data.lblod.info/id/remote-data-objects/390209e9-084d-47da-9f47-6145ba30b9af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "390209e9-084d-47da-9f47-6145ba30b9af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/c78b4a36-1782-45ba-95a6-03060c0532ee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/390209e9-084d-47da-9f47-6145ba30b9af>.
+    
+<http://data.lblod.info/id/remote-data-objects/a354494d-0ab1-4393-aea6-13f46936ff8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a354494d-0ab1-4393-aea6-13f46936ff8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/c828ae30-d60f-4a5e-be25-386b1b108753/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a354494d-0ab1-4393-aea6-13f46936ff8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea544317-6b5c-4478-b3fe-7c795a811deb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea544317-6b5c-4478-b3fe-7c795a811deb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/cb83f281-f67d-4207-97c5-af66e456228b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea544317-6b5c-4478-b3fe-7c795a811deb>.
+    
+<http://data.lblod.info/id/remote-data-objects/71f70d0a-aaef-4d10-b870-16747a139c84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71f70d0a-aaef-4d10-b870-16747a139c84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/cec0ec9c-51f4-4c6d-802d-d5239473defb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71f70d0a-aaef-4d10-b870-16747a139c84>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bffc9fb-a8c5-4b39-8a56-b0b48c8682fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bffc9fb-a8c5-4b39-8a56-b0b48c8682fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/d75ceeaf-030d-4685-91ed-283cf218f858/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bffc9fb-a8c5-4b39-8a56-b0b48c8682fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d2e8796-606a-43d1-a30e-afd52b3d17e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d2e8796-606a-43d1-a30e-afd52b3d17e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/dfcf2019-a944-497b-affb-bf6dde27808b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d2e8796-606a-43d1-a30e-afd52b3d17e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d785e04f-fbc5-4bdf-86e2-35be7b05bf62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d785e04f-fbc5-4bdf-86e2-35be7b05bf62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/ec92785c-228a-4484-8167-edd6610eceb9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d785e04f-fbc5-4bdf-86e2-35be7b05bf62>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d115c3b-6b94-4dd6-b7ff-d13c88b8eeea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d115c3b-6b94-4dd6-b7ff-d13c88b8eeea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/f38dfb28-ca3a-4441-97f7-dfd6ac7f6d27/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d115c3b-6b94-4dd6-b7ff-d13c88b8eeea>.
+    
+<http://data.lblod.info/id/remote-data-objects/d731a409-7236-4cdf-a26c-d8fdfa524e39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d731a409-7236-4cdf-a26c-d8fdfa524e39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/f870e617-46a6-471c-b29f-cfc47b58f0d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d731a409-7236-4cdf-a26c-d8fdfa524e39>.
+    
+<http://data.lblod.info/id/remote-data-objects/88bf50f2-9a5c-48af-aacc-1336a813b728> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88bf50f2-9a5c-48af-aacc-1336a813b728";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/f9c6b2a3-0428-4ddb-b529-c3b91a714eba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88bf50f2-9a5c-48af-aacc-1336a813b728>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbda0add-cdf9-4a77-9804-550e190064d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbda0add-cdf9-4a77-9804-550e190064d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/fab9e0d4-9913-445f-ac2e-cfba8ebb02bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbda0add-cdf9-4a77-9804-550e190064d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3763ff11-bf25-4bba-b5ec-56088933a255> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3763ff11-bf25-4bba-b5ec-56088933a255";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/bb/ffead687-43db-41c3-8280-04cabba8b461/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3763ff11-bf25-4bba-b5ec-56088933a255>.
+    
+<http://data.lblod.info/id/remote-data-objects/50a20500-5fe2-415d-9589-12d0eb0d818c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50a20500-5fe2-415d-9589-12d0eb0d818c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/0586b45c-f9a9-4ee7-8669-1754fc1dc9b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50a20500-5fe2-415d-9589-12d0eb0d818c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d41c8d3f-403e-4d34-ba48-57ecebe6df1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d41c8d3f-403e-4d34-ba48-57ecebe6df1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/07165fad-c689-40dc-817d-fb68fa959a30/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d41c8d3f-403e-4d34-ba48-57ecebe6df1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/39a8aea1-cfd8-4c26-a436-965e57e414f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39a8aea1-cfd8-4c26-a436-965e57e414f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/0f87610a-f11b-43ea-81fb-c80a1bafbc71/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39a8aea1-cfd8-4c26-a436-965e57e414f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/df68b3f7-7e0e-4bd3-ba55-36ac75e13474> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df68b3f7-7e0e-4bd3-ba55-36ac75e13474";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/15be3ca5-4bde-4506-9d67-71a18dcb244a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df68b3f7-7e0e-4bd3-ba55-36ac75e13474>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5764e11-f408-40bc-8536-23cbdeaef66f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5764e11-f408-40bc-8536-23cbdeaef66f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/1b87602d-d5a7-4154-8322-15189ca18262/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5764e11-f408-40bc-8536-23cbdeaef66f>.
+    
+<http://data.lblod.info/id/remote-data-objects/86bb8f02-e65d-4659-982c-65bdbc228904> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86bb8f02-e65d-4659-982c-65bdbc228904";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/2863392f-e582-4a2d-8db2-de48e3580e19/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86bb8f02-e65d-4659-982c-65bdbc228904>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f577897-b930-468f-a889-e1238381114d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f577897-b930-468f-a889-e1238381114d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/2aa2cae4-b1f5-4f14-96d8-3cf9b250fb62/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f577897-b930-468f-a889-e1238381114d>.
+    
+<http://data.lblod.info/id/remote-data-objects/13896701-0ea4-407b-ae12-883326dd1b74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13896701-0ea4-407b-ae12-883326dd1b74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/2bcb4935-85c6-4cee-9f90-ce9b200d9e43/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13896701-0ea4-407b-ae12-883326dd1b74>.
+    
+<http://data.lblod.info/id/remote-data-objects/2189306f-a6a7-4049-b425-383fc13789e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2189306f-a6a7-4049-b425-383fc13789e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/2be676cf-361f-4475-a3c5-09700579cc4c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2189306f-a6a7-4049-b425-383fc13789e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/aeb75acb-471d-4d0c-8675-bb45b6b421dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aeb75acb-471d-4d0c-8675-bb45b6b421dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/2eefc83e-3d78-4db2-8efc-77f11eeb192a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aeb75acb-471d-4d0c-8675-bb45b6b421dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7e13d07-ee5e-4901-acab-12b7ddde964a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7e13d07-ee5e-4901-acab-12b7ddde964a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/2f50d6c1-c516-45e4-9740-9bb916ae6cc4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7e13d07-ee5e-4901-acab-12b7ddde964a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cbe5651-d6d1-4ac7-9a04-9974753c0bd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cbe5651-d6d1-4ac7-9a04-9974753c0bd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/31b65e7a-2f18-4988-848f-fec4b10bdc91/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cbe5651-d6d1-4ac7-9a04-9974753c0bd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2f4b10e-47b3-49ad-b806-3bd1e85c2217> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2f4b10e-47b3-49ad-b806-3bd1e85c2217";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/3243b589-b532-4cd7-811a-d96c4e735da6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2f4b10e-47b3-49ad-b806-3bd1e85c2217>.
+    
+<http://data.lblod.info/id/remote-data-objects/feb577b2-3edd-442c-9626-7618ed1b1499> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "feb577b2-3edd-442c-9626-7618ed1b1499";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/3629a3d5-7e58-4231-b573-6d673ce8309c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/feb577b2-3edd-442c-9626-7618ed1b1499>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ffb4028-6720-4b13-a83f-80ab4581ac27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ffb4028-6720-4b13-a83f-80ab4581ac27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/3f817a5e-d967-47ba-b996-d1879ca3d51b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aa5a59a-9f7e-4208-9282-d4fa1bb49945> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ffb4028-6720-4b13-a83f-80ab4581ac27>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201212-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201212-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201212-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201212-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/1e4524a1-b2d0-47d8-894f-4576125dd4e9> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1e4524a1-b2d0-47d8-894f-4576125dd4e9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b7ff7135-0a16-40f7-9ec3-f165db964a9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b7ff7135-0a16-40f7-9ec3-f165db964a9a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3>.
+
+  <http://redpencil.data.gift/id/task/ff85aa42-dd54-42c0-bfc6-1ab479913347> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ff85aa42-dd54-42c0-bfc6-1ab479913347";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/1e4524a1-b2d0-47d8-894f-4576125dd4e9>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b7ff7135-0a16-40f7-9ec3-f165db964a9a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/129b7140-fe79-4a88-ace9-890c43a6ad8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "129b7140-fe79-4a88-ace9-890c43a6ad8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/4107f031-9d9f-4c30-a33d-a2ea15b9c782/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/129b7140-fe79-4a88-ace9-890c43a6ad8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1de8f703-cc7c-4d3a-a3d1-b40fdf3eb315> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1de8f703-cc7c-4d3a-a3d1-b40fdf3eb315";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/5189d1e0-c74c-4abb-9f4b-b2b4cd143c64/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1de8f703-cc7c-4d3a-a3d1-b40fdf3eb315>.
+    
+<http://data.lblod.info/id/remote-data-objects/eeca42f3-f0fa-4e91-8a45-faba398ad202> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eeca42f3-f0fa-4e91-8a45-faba398ad202";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/5e76deca-c83d-40f3-bb20-2733d4c767fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eeca42f3-f0fa-4e91-8a45-faba398ad202>.
+    
+<http://data.lblod.info/id/remote-data-objects/71480c55-69ff-4ba5-846d-bd905597ec64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71480c55-69ff-4ba5-846d-bd905597ec64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/656f5a68-fb90-4765-86f8-19532123a5a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71480c55-69ff-4ba5-846d-bd905597ec64>.
+    
+<http://data.lblod.info/id/remote-data-objects/e22cf1c9-1af8-4337-aa33-061e9a1a6b6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e22cf1c9-1af8-4337-aa33-061e9a1a6b6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/6864688f-0df1-4714-aa57-e703b6259ce8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e22cf1c9-1af8-4337-aa33-061e9a1a6b6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac3b83e8-2881-4850-a73b-2ec4a702d896> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac3b83e8-2881-4850-a73b-2ec4a702d896";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/6c69e4ae-e0ea-4a6d-bdf8-9684669325bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac3b83e8-2881-4850-a73b-2ec4a702d896>.
+    
+<http://data.lblod.info/id/remote-data-objects/81f1072f-f82d-464e-b2f3-c6d3ef8af004> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81f1072f-f82d-464e-b2f3-c6d3ef8af004";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/72458655-3db0-4a2f-b6b0-d4d2e2aaebb6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81f1072f-f82d-464e-b2f3-c6d3ef8af004>.
+    
+<http://data.lblod.info/id/remote-data-objects/676dc88a-8e24-43ff-add6-a47e9cf0b272> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "676dc88a-8e24-43ff-add6-a47e9cf0b272";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/768b9d5f-3364-4db8-94f5-5ba8e80346ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/676dc88a-8e24-43ff-add6-a47e9cf0b272>.
+    
+<http://data.lblod.info/id/remote-data-objects/acc372c3-03f4-4907-83bb-0179611f894a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acc372c3-03f4-4907-83bb-0179611f894a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/769e4695-8a2e-48fd-bbcf-2fe9b4ab52cc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acc372c3-03f4-4907-83bb-0179611f894a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c402b3ea-8c9c-4591-a2c0-a25edcc8ec04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c402b3ea-8c9c-4591-a2c0-a25edcc8ec04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/7987acff-d8ab-43cd-b6b2-1f25995ea334/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c402b3ea-8c9c-4591-a2c0-a25edcc8ec04>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b101ed8-2e1d-40c1-b7c6-137124a2714c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b101ed8-2e1d-40c1-b7c6-137124a2714c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/7ab35dc8-64d3-4e9b-a033-05949c984502/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b101ed8-2e1d-40c1-b7c6-137124a2714c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e6858b6-4f5e-4b9c-91c3-23d772b9b263> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e6858b6-4f5e-4b9c-91c3-23d772b9b263";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/7c2942a5-3e7a-4bc7-a842-d8cdfe0d4c94/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e6858b6-4f5e-4b9c-91c3-23d772b9b263>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a95d06e-d28b-438b-ae52-b1a213c47fcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a95d06e-d28b-438b-ae52-b1a213c47fcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/83d8aa8a-4265-4d8b-96ac-111b03970baa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a95d06e-d28b-438b-ae52-b1a213c47fcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/55b9fe64-abbf-49de-872f-eb5a8f7df5d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55b9fe64-abbf-49de-872f-eb5a8f7df5d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/84eebc62-abdc-4158-94c2-a59484a8015f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55b9fe64-abbf-49de-872f-eb5a8f7df5d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac071a3e-279f-42bb-aa23-dd066b61f0bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac071a3e-279f-42bb-aa23-dd066b61f0bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/89c5a2a0-7197-4195-88a3-8e7f5e8c055e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac071a3e-279f-42bb-aa23-dd066b61f0bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4fc9bef-2d0b-43ff-a340-796c14de9c15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4fc9bef-2d0b-43ff-a340-796c14de9c15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/8cdbe8e8-a86a-4ce1-876a-e3782c419cd4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4fc9bef-2d0b-43ff-a340-796c14de9c15>.
+    
+<http://data.lblod.info/id/remote-data-objects/c88a6164-89af-4b8a-86ca-caaadc944fc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c88a6164-89af-4b8a-86ca-caaadc944fc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/8db58bda-23db-4f61-b2f5-e8f96904f372/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c88a6164-89af-4b8a-86ca-caaadc944fc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/73f36e31-71bf-473a-bbbd-8b65498cdf2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73f36e31-71bf-473a-bbbd-8b65498cdf2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/94525867-5e5b-4ce5-8406-d745374d20b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73f36e31-71bf-473a-bbbd-8b65498cdf2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0684666b-d17a-47da-bf7a-86d090f22792> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0684666b-d17a-47da-bf7a-86d090f22792";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/ad3e742f-4566-41bd-9b7e-c76b3100911d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0684666b-d17a-47da-bf7a-86d090f22792>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8a4d59f-29e0-4805-ac2b-f00f74531b6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8a4d59f-29e0-4805-ac2b-f00f74531b6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/b087f458-c1ae-4601-93a3-e795a28f5f97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8a4d59f-29e0-4805-ac2b-f00f74531b6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/20de0cc8-a24f-4d32-9f01-0c2ecaef0239> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20de0cc8-a24f-4d32-9f01-0c2ecaef0239";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/b0f6cf0f-03db-4992-a237-3ecae4a3a16c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20de0cc8-a24f-4d32-9f01-0c2ecaef0239>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b67e161-6737-4191-af03-555b328c139a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b67e161-6737-4191-af03-555b328c139a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/b1572852-8fc1-4b7c-a65b-d2a8afb6dbae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b67e161-6737-4191-af03-555b328c139a>.
+    
+<http://data.lblod.info/id/remote-data-objects/05cce928-d7b6-4a5e-8612-2cf30d80a984> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05cce928-d7b6-4a5e-8612-2cf30d80a984";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/b3a666cd-6110-4096-a777-cf0267c5210a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05cce928-d7b6-4a5e-8612-2cf30d80a984>.
+    
+<http://data.lblod.info/id/remote-data-objects/d570a71e-3e7e-4c89-9d55-18d91f0a5e6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d570a71e-3e7e-4c89-9d55-18d91f0a5e6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/b3a6faf5-96e5-4d05-a3ab-1c0ba5e7506a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d570a71e-3e7e-4c89-9d55-18d91f0a5e6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8525c48d-fb2a-43e0-8d4d-0b6506ceed95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8525c48d-fb2a-43e0-8d4d-0b6506ceed95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/b852bd21-748a-4f78-a5c9-d05a25587578/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8525c48d-fb2a-43e0-8d4d-0b6506ceed95>.
+    
+<http://data.lblod.info/id/remote-data-objects/24f6d5d4-7583-4c8d-a96a-5e297dba1f2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24f6d5d4-7583-4c8d-a96a-5e297dba1f2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/b931cc1d-7151-4847-8f05-af44d59492f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24f6d5d4-7583-4c8d-a96a-5e297dba1f2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f131aa41-8d3e-4db8-bcfd-87fd67d0f16c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f131aa41-8d3e-4db8-bcfd-87fd67d0f16c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/b9a77735-4f5f-4646-9318-2ab6cdb2c868/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f131aa41-8d3e-4db8-bcfd-87fd67d0f16c>.
+    
+<http://data.lblod.info/id/remote-data-objects/192d9642-7436-4048-b35d-dfa46d25691c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "192d9642-7436-4048-b35d-dfa46d25691c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/b9e53185-3f10-4cb5-b024-b0a5d39595f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/192d9642-7436-4048-b35d-dfa46d25691c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2bfd4ce-7c52-43c5-b6d9-2f956bd3acb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2bfd4ce-7c52-43c5-b6d9-2f956bd3acb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/bd6bac64-ee55-443a-8db1-8b80e8eefd9c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2bfd4ce-7c52-43c5-b6d9-2f956bd3acb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ab0254b-5a9f-44ff-ba1b-79fac3a1c22d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ab0254b-5a9f-44ff-ba1b-79fac3a1c22d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/bd8c006a-4863-426d-9d08-7a1a55aa3a16/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ab0254b-5a9f-44ff-ba1b-79fac3a1c22d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2393406-f575-4745-bd7e-ceda9dd35523> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2393406-f575-4745-bd7e-ceda9dd35523";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/be1443b2-531f-44dc-82c3-b8bbeb72c80b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2393406-f575-4745-bd7e-ceda9dd35523>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe578f0b-bef7-4a65-8813-a7a42457ad2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe578f0b-bef7-4a65-8813-a7a42457ad2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/be45305a-ba19-41ae-b14f-3b782a7a4e5c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe578f0b-bef7-4a65-8813-a7a42457ad2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dceae2a-65dc-4b70-bc02-fd1978f4ffd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dceae2a-65dc-4b70-bc02-fd1978f4ffd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/c4641b0a-2940-4b30-b8dd-fe84d205b730/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dceae2a-65dc-4b70-bc02-fd1978f4ffd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/221814cf-9704-41a0-a3b0-1169d92bd232> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "221814cf-9704-41a0-a3b0-1169d92bd232";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/c50f9c23-ec6e-4bd3-95bd-ba97a8bc5251/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/221814cf-9704-41a0-a3b0-1169d92bd232>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c677b15-e53d-40f7-a5ba-e5cef0851a6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c677b15-e53d-40f7-a5ba-e5cef0851a6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/c797503d-e5c3-421d-bd11-beddf4080ab5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c677b15-e53d-40f7-a5ba-e5cef0851a6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c6b4e6d-81b6-488a-bbd2-84291e9ce094> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c6b4e6d-81b6-488a-bbd2-84291e9ce094";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/cd36debb-bb83-4402-adab-3663ab7f69c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c6b4e6d-81b6-488a-bbd2-84291e9ce094>.
+    
+<http://data.lblod.info/id/remote-data-objects/dad6487e-98ec-4acb-9c1a-9608cb7ecf67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dad6487e-98ec-4acb-9c1a-9608cb7ecf67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/ce32fa3e-d283-479b-9743-4f1f7bec8467/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dad6487e-98ec-4acb-9c1a-9608cb7ecf67>.
+    
+<http://data.lblod.info/id/remote-data-objects/298bc227-63bd-4e2b-a491-d7fa3388d10f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "298bc227-63bd-4e2b-a491-d7fa3388d10f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/ce556066-376a-4ce9-a91c-c9c77eacf0be/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/298bc227-63bd-4e2b-a491-d7fa3388d10f>.
+    
+<http://data.lblod.info/id/remote-data-objects/62c9a967-4bdb-4a39-9099-b2d2c9f023f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62c9a967-4bdb-4a39-9099-b2d2c9f023f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/d1dc7d58-7d1d-4051-bbf3-1e2b04bc3ac8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62c9a967-4bdb-4a39-9099-b2d2c9f023f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/675dd2f7-9d96-42bb-9105-9b716e150233> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "675dd2f7-9d96-42bb-9105-9b716e150233";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/da57d18e-d7be-466a-a4e8-3ff9b499c767/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/675dd2f7-9d96-42bb-9105-9b716e150233>.
+    
+<http://data.lblod.info/id/remote-data-objects/dda442e1-915f-4210-937f-99d91ca63cf7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dda442e1-915f-4210-937f-99d91ca63cf7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/dacd7629-c7de-4c91-b5b5-ece56e84bcd9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dda442e1-915f-4210-937f-99d91ca63cf7>.
+    
+<http://data.lblod.info/id/remote-data-objects/cac6602f-bd6b-4237-8eb7-0f5a5ec89f6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cac6602f-bd6b-4237-8eb7-0f5a5ec89f6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/def82e80-00d1-4bd2-8c75-7daba32cd479/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cac6602f-bd6b-4237-8eb7-0f5a5ec89f6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e83658ce-6b21-44d9-b6af-bb50c8b8b64b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e83658ce-6b21-44d9-b6af-bb50c8b8b64b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/e6b7c73d-12c8-4042-9173-540ce003f627/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e83658ce-6b21-44d9-b6af-bb50c8b8b64b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e4bfa51-373f-4e8d-8582-63f299d80b46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e4bfa51-373f-4e8d-8582-63f299d80b46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/e9a0df08-6501-4944-bbb0-be795d5c3eff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e4bfa51-373f-4e8d-8582-63f299d80b46>.
+    
+<http://data.lblod.info/id/remote-data-objects/7762d814-6d36-4044-8dbb-cfbdaeec916e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7762d814-6d36-4044-8dbb-cfbdaeec916e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/eb912653-d62c-4401-af9c-9777d01615c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7762d814-6d36-4044-8dbb-cfbdaeec916e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbac1ddd-8f0e-4b6d-861a-27cd05ca42b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbac1ddd-8f0e-4b6d-861a-27cd05ca42b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/ec99b4a9-1853-4fc6-9346-fce9b98496b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbac1ddd-8f0e-4b6d-861a-27cd05ca42b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f40e6a14-6f81-4640-adf6-2f3473927f62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f40e6a14-6f81-4640-adf6-2f3473927f62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/f1b572db-8786-403b-8d41-45fa13366a07/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f40e6a14-6f81-4640-adf6-2f3473927f62>.
+    
+<http://data.lblod.info/id/remote-data-objects/d71beb34-2aad-4023-add9-f0878834913a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d71beb34-2aad-4023-add9-f0878834913a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/f31520dc-9e66-43b2-a68d-340ff18c784f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d71beb34-2aad-4023-add9-f0878834913a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e50f0d77-f18f-413a-9308-a5f6a78a4402> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e50f0d77-f18f-413a-9308-a5f6a78a4402";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/f53d65ea-992e-47b3-8136-7b9a93ca0d5e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e50f0d77-f18f-413a-9308-a5f6a78a4402>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe7bc1b1-3833-46a8-9041-79ded2c257f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe7bc1b1-3833-46a8-9041-79ded2c257f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/cbs/f5432575-419f-4bd5-a206-de4fa6fd12e4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f6dd8edd-09d4-4bff-8eb4-61ac7e31e2f3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe7bc1b1-3833-46a8-9041-79ded2c257f3>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201213-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201213-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201213-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201213-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/86560dd0-559a-4fea-a163-fc8ac89a6b60> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "86560dd0-559a-4fea-a163-fc8ac89a6b60";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "05ede135-15ca-44e1-b8c1-f47f7efb3de2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d38135bd-431c-4ff2-961a-424d60bf9e6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d38135bd-431c-4ff2-961a-424d60bf9e6b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2>.
+
+  <http://redpencil.data.gift/id/task/a767e3db-042a-4cba-acbc-7216bad4fbc9> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a767e3db-042a-4cba-acbc-7216bad4fbc9";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/86560dd0-559a-4fea-a163-fc8ac89a6b60>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d38135bd-431c-4ff2-961a-424d60bf9e6b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/f15440a5-00b0-46aa-be37-bec177a45da2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f15440a5-00b0-46aa-be37-bec177a45da2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/00f287da-2b86-457f-91af-2cbefcb75ea3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f15440a5-00b0-46aa-be37-bec177a45da2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ac516db-73e8-41e5-af94-483ad209c0ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ac516db-73e8-41e5-af94-483ad209c0ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/00f287da-2b86-457f-91af-2cbefcb75ea3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ac516db-73e8-41e5-af94-483ad209c0ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c8bb9e5-4985-404b-a038-cc0d14e20d89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c8bb9e5-4985-404b-a038-cc0d14e20d89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/00f287da-2b86-457f-91af-2cbefcb75ea3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c8bb9e5-4985-404b-a038-cc0d14e20d89>.
+    
+<http://data.lblod.info/id/remote-data-objects/97de2564-9ef8-44fa-98be-3c6ca468d8a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97de2564-9ef8-44fa-98be-3c6ca468d8a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/07cc2ffb-63e9-4c1b-9743-f86942efc14c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97de2564-9ef8-44fa-98be-3c6ca468d8a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e95bdb8-5e72-45c8-b593-ba83a918cec8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e95bdb8-5e72-45c8-b593-ba83a918cec8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/07cc2ffb-63e9-4c1b-9743-f86942efc14c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e95bdb8-5e72-45c8-b593-ba83a918cec8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e22ad85-2c86-4fc9-94bc-65f808c0bade> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e22ad85-2c86-4fc9-94bc-65f808c0bade";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/07cc2ffb-63e9-4c1b-9743-f86942efc14c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e22ad85-2c86-4fc9-94bc-65f808c0bade>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bd2b55d-9040-4d75-aa1a-870a7a7ede41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bd2b55d-9040-4d75-aa1a-870a7a7ede41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/2ac529bf-a3db-4adc-81b7-c994db7287b6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bd2b55d-9040-4d75-aa1a-870a7a7ede41>.
+    
+<http://data.lblod.info/id/remote-data-objects/03319001-6482-4098-bdca-b195299f21f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03319001-6482-4098-bdca-b195299f21f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/2ac529bf-a3db-4adc-81b7-c994db7287b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03319001-6482-4098-bdca-b195299f21f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e32f1e4-96b0-48fc-a853-ea0afb8a6825> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e32f1e4-96b0-48fc-a853-ea0afb8a6825";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/2ac529bf-a3db-4adc-81b7-c994db7287b6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e32f1e4-96b0-48fc-a853-ea0afb8a6825>.
+    
+<http://data.lblod.info/id/remote-data-objects/66552619-3644-4932-9b3e-36de28fb0de5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66552619-3644-4932-9b3e-36de28fb0de5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/462e4cb6-211f-4959-8c2c-a02534a85242/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66552619-3644-4932-9b3e-36de28fb0de5>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6332e4a-c2bd-46b9-bfdd-d3d799a35160> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6332e4a-c2bd-46b9-bfdd-d3d799a35160";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/462e4cb6-211f-4959-8c2c-a02534a85242/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6332e4a-c2bd-46b9-bfdd-d3d799a35160>.
+    
+<http://data.lblod.info/id/remote-data-objects/40fb5e96-cf94-41ff-b7e8-dabf85de08b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40fb5e96-cf94-41ff-b7e8-dabf85de08b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/462e4cb6-211f-4959-8c2c-a02534a85242/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40fb5e96-cf94-41ff-b7e8-dabf85de08b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cd5a49d-129c-459d-be24-b14029717d94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cd5a49d-129c-459d-be24-b14029717d94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/51dff24f-8cf7-45fb-b788-c0b7bb452091/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cd5a49d-129c-459d-be24-b14029717d94>.
+    
+<http://data.lblod.info/id/remote-data-objects/9541c211-9562-412d-b0cd-96b09e041cbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9541c211-9562-412d-b0cd-96b09e041cbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/51dff24f-8cf7-45fb-b788-c0b7bb452091/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9541c211-9562-412d-b0cd-96b09e041cbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c01ff02-45ac-45b9-ba2a-563c3f58eaf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c01ff02-45ac-45b9-ba2a-563c3f58eaf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/51dff24f-8cf7-45fb-b788-c0b7bb452091/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c01ff02-45ac-45b9-ba2a-563c3f58eaf9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f00a4fb-c38e-43ce-8d38-527d9d6e11b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f00a4fb-c38e-43ce-8d38-527d9d6e11b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/700539fc-ca73-4fd0-8024-0e8b0822326d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f00a4fb-c38e-43ce-8d38-527d9d6e11b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/6138262f-1760-4bb5-90be-46b7b079e8d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6138262f-1760-4bb5-90be-46b7b079e8d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/700539fc-ca73-4fd0-8024-0e8b0822326d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6138262f-1760-4bb5-90be-46b7b079e8d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a7f4ed5-7fc3-42e9-b8b5-703f98835aaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a7f4ed5-7fc3-42e9-b8b5-703f98835aaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/700539fc-ca73-4fd0-8024-0e8b0822326d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a7f4ed5-7fc3-42e9-b8b5-703f98835aaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/325fff81-d45f-42fc-ae3c-f1b59e94a816> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "325fff81-d45f-42fc-ae3c-f1b59e94a816";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/70d018d4-2886-4b89-9b79-4995ed560d71/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/325fff81-d45f-42fc-ae3c-f1b59e94a816>.
+    
+<http://data.lblod.info/id/remote-data-objects/25454338-cfe4-487c-acf5-d5edb6099084> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25454338-cfe4-487c-acf5-d5edb6099084";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/70d018d4-2886-4b89-9b79-4995ed560d71/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25454338-cfe4-487c-acf5-d5edb6099084>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8ad38da-82d5-432a-8b28-d59195803c65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8ad38da-82d5-432a-8b28-d59195803c65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/70d018d4-2886-4b89-9b79-4995ed560d71/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8ad38da-82d5-432a-8b28-d59195803c65>.
+    
+<http://data.lblod.info/id/remote-data-objects/14b08c3c-09d0-4d3c-95d7-b1923c6e5a61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14b08c3c-09d0-4d3c-95d7-b1923c6e5a61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/777a1994-7cb0-48aa-aa8b-dfde3c98dbf7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14b08c3c-09d0-4d3c-95d7-b1923c6e5a61>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba52cfa4-5943-45f3-bf6a-0766d0f435eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba52cfa4-5943-45f3-bf6a-0766d0f435eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/777a1994-7cb0-48aa-aa8b-dfde3c98dbf7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba52cfa4-5943-45f3-bf6a-0766d0f435eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f852b78-bfa3-445d-814f-c045ac316220> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f852b78-bfa3-445d-814f-c045ac316220";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/870f0b17-c849-4c61-ab9d-f414054f0814/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f852b78-bfa3-445d-814f-c045ac316220>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c0a82c7-813a-4d1a-858a-b9266b6e2070> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c0a82c7-813a-4d1a-858a-b9266b6e2070";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/870f0b17-c849-4c61-ab9d-f414054f0814/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c0a82c7-813a-4d1a-858a-b9266b6e2070>.
+    
+<http://data.lblod.info/id/remote-data-objects/b91785d7-3a6c-4a57-bcad-4f1c425d401d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b91785d7-3a6c-4a57-bcad-4f1c425d401d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/870f0b17-c849-4c61-ab9d-f414054f0814/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b91785d7-3a6c-4a57-bcad-4f1c425d401d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c2e791d-1b88-4e43-8a9a-f145937c831e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c2e791d-1b88-4e43-8a9a-f145937c831e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/976d9f49-a25e-442c-b77e-1e6250c58ec7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c2e791d-1b88-4e43-8a9a-f145937c831e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c7ea3f7-bfee-4aba-91d5-2c22bff207d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c7ea3f7-bfee-4aba-91d5-2c22bff207d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/976d9f49-a25e-442c-b77e-1e6250c58ec7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c7ea3f7-bfee-4aba-91d5-2c22bff207d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6189900-8d8f-42f1-b41f-1edf65bed4de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6189900-8d8f-42f1-b41f-1edf65bed4de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/976d9f49-a25e-442c-b77e-1e6250c58ec7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6189900-8d8f-42f1-b41f-1edf65bed4de>.
+    
+<http://data.lblod.info/id/remote-data-objects/c94cd50a-1b45-4568-b470-34c551c1721b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c94cd50a-1b45-4568-b470-34c551c1721b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/a5424c5e-2d8b-4ff5-afd6-12a9ff030359/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c94cd50a-1b45-4568-b470-34c551c1721b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1afe057e-e80b-4fde-9079-393840d2c9f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1afe057e-e80b-4fde-9079-393840d2c9f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/a5424c5e-2d8b-4ff5-afd6-12a9ff030359/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1afe057e-e80b-4fde-9079-393840d2c9f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/21b499ec-edca-44f3-920b-aacf0969ed35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21b499ec-edca-44f3-920b-aacf0969ed35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/a5424c5e-2d8b-4ff5-afd6-12a9ff030359/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21b499ec-edca-44f3-920b-aacf0969ed35>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fc6328f-9532-4b8c-a032-ef5d52b20b8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fc6328f-9532-4b8c-a032-ef5d52b20b8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/e0fdaa7f-2797-4c9b-b5fc-a3fddfe07d92/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fc6328f-9532-4b8c-a032-ef5d52b20b8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/142a89d5-ace0-4e4e-8a9b-0ea15399a1cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "142a89d5-ace0-4e4e-8a9b-0ea15399a1cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/e0fdaa7f-2797-4c9b-b5fc-a3fddfe07d92/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/142a89d5-ace0-4e4e-8a9b-0ea15399a1cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/644992aa-baaa-4c5f-93d6-91594b39a170> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "644992aa-baaa-4c5f-93d6-91594b39a170";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/e0fdaa7f-2797-4c9b-b5fc-a3fddfe07d92/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/644992aa-baaa-4c5f-93d6-91594b39a170>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b7e8b10-96aa-4423-905d-1b411f59afd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b7e8b10-96aa-4423-905d-1b411f59afd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/f030d0b3-a5e8-4d6a-b706-f1aaf8c07b13/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b7e8b10-96aa-4423-905d-1b411f59afd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/994ffe06-0d4f-40e6-88f0-9b54a7588ad2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "994ffe06-0d4f-40e6-88f0-9b54a7588ad2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/f030d0b3-a5e8-4d6a-b706-f1aaf8c07b13/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/994ffe06-0d4f-40e6-88f0-9b54a7588ad2>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecbbda7b-fdad-4d2d-a65c-44d30b49c296> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecbbda7b-fdad-4d2d-a65c-44d30b49c296";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/f030d0b3-a5e8-4d6a-b706-f1aaf8c07b13/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecbbda7b-fdad-4d2d-a65c-44d30b49c296>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfcbdecb-06d4-4a8e-ab15-b19779589acb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfcbdecb-06d4-4a8e-ab15-b19779589acb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/f6673dae-1192-4e4c-897c-a4fc2537b4e3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfcbdecb-06d4-4a8e-ab15-b19779589acb>.
+    
+<http://data.lblod.info/id/remote-data-objects/f37cd087-2b28-49cb-8026-06d25a40cdf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f37cd087-2b28-49cb-8026-06d25a40cdf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/f6673dae-1192-4e4c-897c-a4fc2537b4e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f37cd087-2b28-49cb-8026-06d25a40cdf9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6dcb4e0-ec99-4cee-8e7c-12659c2be3d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6dcb4e0-ec99-4cee-8e7c-12659c2be3d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/gr/f6673dae-1192-4e4c-897c-a4fc2537b4e3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6dcb4e0-ec99-4cee-8e7c-12659c2be3d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e0fb3d8-2dc3-4b51-9895-1fa68980b649> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e0fb3d8-2dc3-4b51-9895-1fa68980b649";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/0c0cac60-ca12-4128-a234-ba73aec55cf2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e0fb3d8-2dc3-4b51-9895-1fa68980b649>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c6c5400-7742-439f-ac17-447fe3646e31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c6c5400-7742-439f-ac17-447fe3646e31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/0c0cac60-ca12-4128-a234-ba73aec55cf2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c6c5400-7742-439f-ac17-447fe3646e31>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6cb236e-3f04-4278-85a9-79a27767da17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6cb236e-3f04-4278-85a9-79a27767da17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/0c0cac60-ca12-4128-a234-ba73aec55cf2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6cb236e-3f04-4278-85a9-79a27767da17>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9207fc0-4805-4ae0-bb5d-3a12ec75a573> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9207fc0-4805-4ae0-bb5d-3a12ec75a573";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/17679aaa-2ac1-438d-ad31-e7937b379dac/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9207fc0-4805-4ae0-bb5d-3a12ec75a573>.
+    
+<http://data.lblod.info/id/remote-data-objects/2953be4f-37cb-4b70-bdab-017c0cdd03b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2953be4f-37cb-4b70-bdab-017c0cdd03b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/17679aaa-2ac1-438d-ad31-e7937b379dac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2953be4f-37cb-4b70-bdab-017c0cdd03b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a200e6e-7371-409a-9f74-7d1fb6d150a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a200e6e-7371-409a-9f74-7d1fb6d150a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/17679aaa-2ac1-438d-ad31-e7937b379dac/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a200e6e-7371-409a-9f74-7d1fb6d150a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ea8c0b5-7f5c-4e0e-88ec-6c00f8a9dbbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ea8c0b5-7f5c-4e0e-88ec-6c00f8a9dbbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/382ccbfb-8a6b-4616-8d88-b89048acfc78/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ea8c0b5-7f5c-4e0e-88ec-6c00f8a9dbbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fc03afc-c8b3-48c6-8ea0-913ee45e60af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fc03afc-c8b3-48c6-8ea0-913ee45e60af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/382ccbfb-8a6b-4616-8d88-b89048acfc78/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fc03afc-c8b3-48c6-8ea0-913ee45e60af>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a106236-b4d6-4603-9341-9cae30eb1454> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a106236-b4d6-4603-9341-9cae30eb1454";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/382ccbfb-8a6b-4616-8d88-b89048acfc78/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05ede135-15ca-44e1-b8c1-f47f7efb3de2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a106236-b4d6-4603-9341-9cae30eb1454>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201214-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201214-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201214-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201214-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a9b0d2ff-10ff-43f3-be52-4f3e0c727fd7> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a9b0d2ff-10ff-43f3-be52-4f3e0c727fd7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0aad7ca1-62dc-4112-a1e6-b1f3d15b462f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/0a94acbf-67be-4e7d-aa80-21905e04dd75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0a94acbf-67be-4e7d-aa80-21905e04dd75";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f>.
+
+  <http://redpencil.data.gift/id/task/06859901-be44-4fbf-ac7f-8f0f7dbca1ce> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "06859901-be44-4fbf-ac7f-8f0f7dbca1ce";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a9b0d2ff-10ff-43f3-be52-4f3e0c727fd7>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/0a94acbf-67be-4e7d-aa80-21905e04dd75>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e461b102-53c5-4dc0-80e1-820cae262163> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e461b102-53c5-4dc0-80e1-820cae262163";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/558e5467-d24e-4f75-bd00-a59bc09b4343/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e461b102-53c5-4dc0-80e1-820cae262163>.
+    
+<http://data.lblod.info/id/remote-data-objects/692ba8d4-cbde-4c0f-a9bf-a1be0a69e00f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "692ba8d4-cbde-4c0f-a9bf-a1be0a69e00f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/558e5467-d24e-4f75-bd00-a59bc09b4343/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/692ba8d4-cbde-4c0f-a9bf-a1be0a69e00f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7d9d95a-ca57-4f6c-9542-136cd64abe40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7d9d95a-ca57-4f6c-9542-136cd64abe40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/558e5467-d24e-4f75-bd00-a59bc09b4343/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7d9d95a-ca57-4f6c-9542-136cd64abe40>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ea6072f-95bf-43f3-84ae-1c50a6bb2da4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ea6072f-95bf-43f3-84ae-1c50a6bb2da4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/7a679ce1-970a-40e1-b23b-0510517f5b23/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ea6072f-95bf-43f3-84ae-1c50a6bb2da4>.
+    
+<http://data.lblod.info/id/remote-data-objects/154774bb-6f96-46a7-87f5-25e18777d3ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "154774bb-6f96-46a7-87f5-25e18777d3ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/7a679ce1-970a-40e1-b23b-0510517f5b23/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/154774bb-6f96-46a7-87f5-25e18777d3ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4c2e2a8-bfa9-406a-9f01-7bbaae6e8261> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4c2e2a8-bfa9-406a-9f01-7bbaae6e8261";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/7a679ce1-970a-40e1-b23b-0510517f5b23/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4c2e2a8-bfa9-406a-9f01-7bbaae6e8261>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e05c988-0ec9-4394-9368-4148bfb317ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e05c988-0ec9-4394-9368-4148bfb317ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/87f2d560-44dd-4c68-a462-93fd1f6ad4ae/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e05c988-0ec9-4394-9368-4148bfb317ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/08f83bb0-fed6-46ed-ab46-f19d34d56c5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08f83bb0-fed6-46ed-ab46-f19d34d56c5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/87f2d560-44dd-4c68-a462-93fd1f6ad4ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08f83bb0-fed6-46ed-ab46-f19d34d56c5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3ff1ce3-8b51-4cf4-bdab-76f5edde487f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3ff1ce3-8b51-4cf4-bdab-76f5edde487f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/87f2d560-44dd-4c68-a462-93fd1f6ad4ae/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3ff1ce3-8b51-4cf4-bdab-76f5edde487f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe8cfe61-e083-4cac-b43b-997d6dcc4bd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe8cfe61-e083-4cac-b43b-997d6dcc4bd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/93081c44-1567-4a03-a20a-ccf76cf7604d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe8cfe61-e083-4cac-b43b-997d6dcc4bd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5da03e2e-d316-443b-9569-bfa459c56199> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5da03e2e-d316-443b-9569-bfa459c56199";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/93081c44-1567-4a03-a20a-ccf76cf7604d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5da03e2e-d316-443b-9569-bfa459c56199>.
+    
+<http://data.lblod.info/id/remote-data-objects/86cf83ea-e7f4-4ab9-befe-a394133bc840> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86cf83ea-e7f4-4ab9-befe-a394133bc840";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/93081c44-1567-4a03-a20a-ccf76cf7604d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86cf83ea-e7f4-4ab9-befe-a394133bc840>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2dbef45-69fa-4f05-8f24-7e6a5d1d35d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2dbef45-69fa-4f05-8f24-7e6a5d1d35d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/ac3be5e3-cce7-48bf-aded-b1d700fad403/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2dbef45-69fa-4f05-8f24-7e6a5d1d35d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/787b646f-7946-49ad-b4c4-1a01fa067718> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "787b646f-7946-49ad-b4c4-1a01fa067718";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/ac3be5e3-cce7-48bf-aded-b1d700fad403/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/787b646f-7946-49ad-b4c4-1a01fa067718>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5da8456-c5da-4039-836f-1191671aa808> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5da8456-c5da-4039-836f-1191671aa808";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/ac3be5e3-cce7-48bf-aded-b1d700fad403/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5da8456-c5da-4039-836f-1191671aa808>.
+    
+<http://data.lblod.info/id/remote-data-objects/11c23a92-8801-4f3a-b45a-b6fb4a4aeed0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11c23a92-8801-4f3a-b45a-b6fb4a4aeed0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/cfda0d35-c0eb-43c7-892d-9af13791c13e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11c23a92-8801-4f3a-b45a-b6fb4a4aeed0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9e96fa8-9cbb-4603-b627-5b1ca2689b0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9e96fa8-9cbb-4603-b627-5b1ca2689b0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/cfda0d35-c0eb-43c7-892d-9af13791c13e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9e96fa8-9cbb-4603-b627-5b1ca2689b0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/71abad78-6b35-442e-a3c0-ec248b6b4a60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71abad78-6b35-442e-a3c0-ec248b6b4a60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/cfda0d35-c0eb-43c7-892d-9af13791c13e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71abad78-6b35-442e-a3c0-ec248b6b4a60>.
+    
+<http://data.lblod.info/id/remote-data-objects/8da3668a-16e7-4a75-b06f-eff1ff1b0c09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8da3668a-16e7-4a75-b06f-eff1ff1b0c09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/daabcc1c-2b1a-446e-9e62-5a65c486c4d6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8da3668a-16e7-4a75-b06f-eff1ff1b0c09>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f21edd0-65b3-4223-9a1c-1f27324d152d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f21edd0-65b3-4223-9a1c-1f27324d152d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/daabcc1c-2b1a-446e-9e62-5a65c486c4d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f21edd0-65b3-4223-9a1c-1f27324d152d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d1fc5cf-7f32-4489-8aab-0c3875ed9c0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d1fc5cf-7f32-4489-8aab-0c3875ed9c0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/daabcc1c-2b1a-446e-9e62-5a65c486c4d6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d1fc5cf-7f32-4489-8aab-0c3875ed9c0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/813119a0-3216-4c01-bf51-7018e673fbcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "813119a0-3216-4c01-bf51-7018e673fbcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/e0b5c94c-861d-4461-86aa-5bee457dbd15/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/813119a0-3216-4c01-bf51-7018e673fbcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/09221e06-e62d-4c7f-b8d6-dfb95218beba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09221e06-e62d-4c7f-b8d6-dfb95218beba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/e0b5c94c-861d-4461-86aa-5bee457dbd15/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09221e06-e62d-4c7f-b8d6-dfb95218beba>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e5669e4-a1c0-453f-8296-fc1b206adac7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e5669e4-a1c0-453f-8296-fc1b206adac7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/e0b5c94c-861d-4461-86aa-5bee457dbd15/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e5669e4-a1c0-453f-8296-fc1b206adac7>.
+    
+<http://data.lblod.info/id/remote-data-objects/3de4948a-1ce7-46c8-a76a-8625d1976d27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3de4948a-1ce7-46c8-a76a-8625d1976d27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/e84dd4a3-053b-40f1-ac5e-6c6eeb9c492f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3de4948a-1ce7-46c8-a76a-8625d1976d27>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bb46109-9711-403f-ada0-5d762a3cad68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bb46109-9711-403f-ada0-5d762a3cad68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/e84dd4a3-053b-40f1-ac5e-6c6eeb9c492f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bb46109-9711-403f-ada0-5d762a3cad68>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc8836d9-7eb9-400b-8a30-00fd9000497e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc8836d9-7eb9-400b-8a30-00fd9000497e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/efd5897f-89d9-48e1-bc1e-ea904c6bc84b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc8836d9-7eb9-400b-8a30-00fd9000497e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d1b64ce-b5bd-497d-b25b-b29b72a5307f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d1b64ce-b5bd-497d-b25b-b29b72a5307f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/efd5897f-89d9-48e1-bc1e-ea904c6bc84b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d1b64ce-b5bd-497d-b25b-b29b72a5307f>.
+    
+<http://data.lblod.info/id/remote-data-objects/004d34e5-d2df-4f6d-812b-9c05feb0aa44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "004d34e5-d2df-4f6d-812b-9c05feb0aa44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/efd5897f-89d9-48e1-bc1e-ea904c6bc84b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/004d34e5-d2df-4f6d-812b-9c05feb0aa44>.
+    
+<http://data.lblod.info/id/remote-data-objects/6eaab6d0-f89d-4f11-a378-4d0ae15c4940> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6eaab6d0-f89d-4f11-a378-4d0ae15c4940";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/f3a778ba-8d73-49da-879c-1d6066fe52b4/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6eaab6d0-f89d-4f11-a378-4d0ae15c4940>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3ab0ef1-4782-48f3-8f97-b37726d41a25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3ab0ef1-4782-48f3-8f97-b37726d41a25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/f3a778ba-8d73-49da-879c-1d6066fe52b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3ab0ef1-4782-48f3-8f97-b37726d41a25>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ea790ba-e645-489d-8e42-8d1f9f382b0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ea790ba-e645-489d-8e42-8d1f9f382b0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/or/f3a778ba-8d73-49da-879c-1d6066fe52b4/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ea790ba-e645-489d-8e42-8d1f9f382b0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bbe031d-2c58-47a4-a33e-b8aa44fbd637> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bbe031d-2c58-47a4-a33e-b8aa44fbd637";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/RVBW/595254e7-c242-4e08-a754-db1f1bdece97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bbe031d-2c58-47a4-a33e-b8aa44fbd637>.
+    
+<http://data.lblod.info/id/remote-data-objects/452a62f7-1823-404a-8968-c7a48343b43b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "452a62f7-1823-404a-8968-c7a48343b43b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/RVBW/7375bd0c-4319-482d-9a6f-83875d1cdccf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/452a62f7-1823-404a-8968-c7a48343b43b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d568e041-16e5-4a36-ac8e-b28a7c9d0009> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d568e041-16e5-4a36-ac8e-b28a7c9d0009";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/RVBW/cbefd7b2-e7d3-4cff-be42-152ab32cb1a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d568e041-16e5-4a36-ac8e-b28a7c9d0009>.
+    
+<http://data.lblod.info/id/remote-data-objects/01d97dc3-523b-48e0-891b-b71592cd01db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01d97dc3-523b-48e0-891b-b71592cd01db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/RVBW/ccf6b93e-d1db-4af8-8b0f-2d1ad8eec5bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01d97dc3-523b-48e0-891b-b71592cd01db>.
+    
+<http://data.lblod.info/id/remote-data-objects/595a72fa-861c-416a-bb1e-fb45a2428064> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "595a72fa-861c-416a-bb1e-fb45a2428064";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/RVBW/fd6de692-0479-4381-87c5-9a2931628228/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/595a72fa-861c-416a-bb1e-fb45a2428064>.
+    
+<http://data.lblod.info/id/remote-data-objects/67e298e5-2073-417c-a21a-76a8af09b5b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67e298e5-2073-417c-a21a-76a8af09b5b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/010e505c-146c-405f-abb6-f689e36c8440/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67e298e5-2073-417c-a21a-76a8af09b5b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d04c356-e4f3-4639-b4cf-875898e81667> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d04c356-e4f3-4639-b4cf-875898e81667";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/0ab483c8-9b21-495b-9a4c-1aaadb8621d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d04c356-e4f3-4639-b4cf-875898e81667>.
+    
+<http://data.lblod.info/id/remote-data-objects/492c1212-9ace-4680-ac06-e6b4ef559980> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "492c1212-9ace-4680-ac06-e6b4ef559980";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/0b0dcbfe-2077-4385-ac7d-262aae88f340/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/492c1212-9ace-4680-ac06-e6b4ef559980>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5e23845-cbc2-404d-94b5-d0902705a375> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5e23845-cbc2-404d-94b5-d0902705a375";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/13680951-6598-42b4-a35d-74088e2e2ff1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5e23845-cbc2-404d-94b5-d0902705a375>.
+    
+<http://data.lblod.info/id/remote-data-objects/8dc30bbc-b6ff-4edc-8f63-e8eb0770a9cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8dc30bbc-b6ff-4edc-8f63-e8eb0770a9cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/2008f8f8-48a3-45a1-bbd9-311781c80106/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8dc30bbc-b6ff-4edc-8f63-e8eb0770a9cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/61a13adb-d544-43e5-b481-8273e3577892> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61a13adb-d544-43e5-b481-8273e3577892";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/250d8b7f-2908-4fa0-a9fd-208b11c59284/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61a13adb-d544-43e5-b481-8273e3577892>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d34c940-156f-4455-88b9-1f565322fd8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d34c940-156f-4455-88b9-1f565322fd8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/28615980-bf2a-4a00-81e1-ffe2f651aa32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d34c940-156f-4455-88b9-1f565322fd8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/df2c2e28-befc-4010-84b8-44a7a5d74d7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df2c2e28-befc-4010-84b8-44a7a5d74d7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/286af1f1-d1ca-441f-8247-767ff7b40a0f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df2c2e28-befc-4010-84b8-44a7a5d74d7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bdaca36-69e0-4a6d-97c2-b27b906b729c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bdaca36-69e0-4a6d-97c2-b27b906b729c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/2b29a3af-c18c-46b7-9e4d-49460a8d8611/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bdaca36-69e0-4a6d-97c2-b27b906b729c>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfa4b42f-52e7-4b7c-9b35-bf7fff5eb7df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfa4b42f-52e7-4b7c-9b35-bf7fff5eb7df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/2c8d4410-7036-4e76-9a70-36b35f940b4d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfa4b42f-52e7-4b7c-9b35-bf7fff5eb7df>.
+    
+<http://data.lblod.info/id/remote-data-objects/818b1065-ebec-4d5b-9872-4e99b074e166> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "818b1065-ebec-4d5b-9872-4e99b074e166";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/2e75bdee-6a9f-4225-9286-fbe1e9b31993/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/818b1065-ebec-4d5b-9872-4e99b074e166>.
+    
+<http://data.lblod.info/id/remote-data-objects/6146cabe-6355-4788-bcd4-2921ef48d52f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6146cabe-6355-4788-bcd4-2921ef48d52f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/3770ef63-fb9c-4a1e-bafe-cfd3b856155e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6146cabe-6355-4788-bcd4-2921ef48d52f>.
+    
+<http://data.lblod.info/id/remote-data-objects/245deddd-6b0a-406f-ba85-8cabed366f67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "245deddd-6b0a-406f-ba85-8cabed366f67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/46207468-8a15-478b-b7f7-fa5a969aee0f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0aad7ca1-62dc-4112-a1e6-b1f3d15b462f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/245deddd-6b0a-406f-ba85-8cabed366f67>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201215-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201215-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201215-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201215-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f6a4e294-f115-461c-a9ed-7c3d3e0da364> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f6a4e294-f115-461c-a9ed-7c3d3e0da364";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a1f66a3e-febc-401c-a45b-63449ffaa2cd";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a19114ca-96dd-4315-99b8-837af6d91172> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a19114ca-96dd-4315-99b8-837af6d91172";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd>.
+
+  <http://redpencil.data.gift/id/task/52c58cc7-576b-4aed-9ca2-39f12a1e28f4> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "52c58cc7-576b-4aed-9ca2-39f12a1e28f4";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f6a4e294-f115-461c-a9ed-7c3d3e0da364>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a19114ca-96dd-4315-99b8-837af6d91172>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/08ffe9cc-7984-4964-bb5a-6326d0c3d834> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08ffe9cc-7984-4964-bb5a-6326d0c3d834";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/467d264e-0d89-41c4-a364-716178e6aa72/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08ffe9cc-7984-4964-bb5a-6326d0c3d834>.
+    
+<http://data.lblod.info/id/remote-data-objects/f690eb2c-d6dc-4879-b3c9-415a47f7d20a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f690eb2c-d6dc-4879-b3c9-415a47f7d20a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/4ac90aa5-bf08-4fb2-b23c-d94efbe2b3c7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f690eb2c-d6dc-4879-b3c9-415a47f7d20a>.
+    
+<http://data.lblod.info/id/remote-data-objects/61a49166-ff91-43c7-b54e-3d5c25d0823a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61a49166-ff91-43c7-b54e-3d5c25d0823a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/58dbaf83-2c42-4c70-a9d6-f53faf61d619/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61a49166-ff91-43c7-b54e-3d5c25d0823a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ad175df-fda7-454b-9d34-1a35cff1eb4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ad175df-fda7-454b-9d34-1a35cff1eb4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/5cf90be2-34bd-4d29-8039-7b3d387905d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ad175df-fda7-454b-9d34-1a35cff1eb4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ba8d385-1c30-4689-b496-498e2aa8aa16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ba8d385-1c30-4689-b496-498e2aa8aa16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/64ae0f59-3ee4-4856-9dbc-02d7b88fcb85/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ba8d385-1c30-4689-b496-498e2aa8aa16>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbcf98d5-ce58-4f23-9004-95d7e05f716b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbcf98d5-ce58-4f23-9004-95d7e05f716b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/654987f9-f624-4703-afdf-fbb258a947e5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbcf98d5-ce58-4f23-9004-95d7e05f716b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3170ad67-ab77-4c3c-aedf-d21b23bcfc15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3170ad67-ab77-4c3c-aedf-d21b23bcfc15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/68fc39a9-a565-4a92-abba-b2159ab07037/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3170ad67-ab77-4c3c-aedf-d21b23bcfc15>.
+    
+<http://data.lblod.info/id/remote-data-objects/11b94a80-e493-479f-8da3-5fdb8705ae1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11b94a80-e493-479f-8da3-5fdb8705ae1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/715fd9cb-f0f7-426e-8c79-e57dcb68ee08/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11b94a80-e493-479f-8da3-5fdb8705ae1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/78ca54b4-513c-4871-a445-8d6741fe4f2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78ca54b4-513c-4871-a445-8d6741fe4f2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/766b9f16-9051-43b9-8d2e-519d15c5f5c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78ca54b4-513c-4871-a445-8d6741fe4f2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/db5e6f38-70e6-4b71-8dc2-90b7133fc423> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db5e6f38-70e6-4b71-8dc2-90b7133fc423";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/7ec49a63-a8d3-4898-987d-d4cd920b8d76/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db5e6f38-70e6-4b71-8dc2-90b7133fc423>.
+    
+<http://data.lblod.info/id/remote-data-objects/13744910-8ab5-4b58-b535-1c95aceff20a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13744910-8ab5-4b58-b535-1c95aceff20a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/83c83f8a-41b9-43df-862a-eaba8d9775c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13744910-8ab5-4b58-b535-1c95aceff20a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d46b333-ee31-4f29-a329-8d7dc891821d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d46b333-ee31-4f29-a329-8d7dc891821d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/846f8bfa-6964-4d55-91cc-0457f30e8a90/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d46b333-ee31-4f29-a329-8d7dc891821d>.
+    
+<http://data.lblod.info/id/remote-data-objects/096f341d-2cfd-4d79-b77a-4c44973f2bdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "096f341d-2cfd-4d79-b77a-4c44973f2bdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/8805200e-ddcb-40e1-9125-44e516e2d33f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/096f341d-2cfd-4d79-b77a-4c44973f2bdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/94151b6d-90ce-4305-82a4-72e9dc5e4c94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94151b6d-90ce-4305-82a4-72e9dc5e4c94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/8c78ceab-e232-4c2f-93c9-abbdc240461f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94151b6d-90ce-4305-82a4-72e9dc5e4c94>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a291fd7-bd8f-42fe-901a-cda2760e4f33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a291fd7-bd8f-42fe-901a-cda2760e4f33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/8e6ca59d-e995-46a7-a878-da884078705f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a291fd7-bd8f-42fe-901a-cda2760e4f33>.
+    
+<http://data.lblod.info/id/remote-data-objects/820618d6-056e-4477-a48d-fd7b810e96b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "820618d6-056e-4477-a48d-fd7b810e96b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/92caed21-0f29-47d6-bc7a-e7fda6144ef8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/820618d6-056e-4477-a48d-fd7b810e96b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cca314f-a4e9-4e38-ae4f-8f6e8e0763f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cca314f-a4e9-4e38-ae4f-8f6e8e0763f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/969d7761-9bc0-4ef6-a125-a479faaa2adb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cca314f-a4e9-4e38-ae4f-8f6e8e0763f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ffec0a4-6ba6-4c1d-9a71-e2f9e7dbd2b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ffec0a4-6ba6-4c1d-9a71-e2f9e7dbd2b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/9d867a93-123a-4c4c-a8be-e15a15aa4995/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ffec0a4-6ba6-4c1d-9a71-e2f9e7dbd2b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/49306191-4a2a-4650-8f2e-64b5b7f80b23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49306191-4a2a-4650-8f2e-64b5b7f80b23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/a05183d2-f21a-41a5-b4b0-391f614e5ef8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49306191-4a2a-4650-8f2e-64b5b7f80b23>.
+    
+<http://data.lblod.info/id/remote-data-objects/6657b0a7-4cc3-4529-a886-8984c4bbfe35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6657b0a7-4cc3-4529-a886-8984c4bbfe35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/a0a81a60-adb1-48cc-9399-185084c1520a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6657b0a7-4cc3-4529-a886-8984c4bbfe35>.
+    
+<http://data.lblod.info/id/remote-data-objects/b872e889-88ea-41fb-b90b-2d33d0639c02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b872e889-88ea-41fb-b90b-2d33d0639c02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/a40efb5e-9d3d-4116-a6d3-b1c1ba5dfa67/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b872e889-88ea-41fb-b90b-2d33d0639c02>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e85ede8-aa72-4532-9fd6-92bb4da6b00d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e85ede8-aa72-4532-9fd6-92bb4da6b00d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/a753f7a7-12f5-499f-85de-05b0af260b55/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e85ede8-aa72-4532-9fd6-92bb4da6b00d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3472208d-a718-427b-9f1d-5eb38bc1b7f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3472208d-a718-427b-9f1d-5eb38bc1b7f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/ad5bb791-b0ec-4c4c-9d8a-ba5ecd4cd2eb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3472208d-a718-427b-9f1d-5eb38bc1b7f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/635313cc-6db3-4ad2-b9e3-6b269076a5cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "635313cc-6db3-4ad2-b9e3-6b269076a5cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/ae0da6bc-e6e6-4518-9403-c1d76509194a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/635313cc-6db3-4ad2-b9e3-6b269076a5cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e72cfca-bb17-4beb-84b5-4c67c8e295f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e72cfca-bb17-4beb-84b5-4c67c8e295f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/b0ce401f-8350-482d-a01c-77dc5897d80c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e72cfca-bb17-4beb-84b5-4c67c8e295f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6840e74e-c00b-4b9f-afda-15ecb976939a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6840e74e-c00b-4b9f-afda-15ecb976939a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/b29c0bc3-9b3e-456d-8205-97c00db4d5a2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6840e74e-c00b-4b9f-afda-15ecb976939a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9f0706e-d996-4464-bfea-4e65e7d9e2e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9f0706e-d996-4464-bfea-4e65e7d9e2e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/b41ca3c5-1e73-4244-90a1-6254f1272da1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9f0706e-d996-4464-bfea-4e65e7d9e2e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc1cb4c6-e847-47d2-a133-5933a19209d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc1cb4c6-e847-47d2-a133-5933a19209d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/b50bc047-00b0-4d05-b826-f0af3cf8a3f5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc1cb4c6-e847-47d2-a133-5933a19209d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/35ce0c2b-de5a-4a11-9073-0af94230847b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35ce0c2b-de5a-4a11-9073-0af94230847b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/b66d433f-94b4-42e5-bb29-341cbd44333f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35ce0c2b-de5a-4a11-9073-0af94230847b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9846674-aa03-4a47-9ec8-c0f1281a6808> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9846674-aa03-4a47-9ec8-c0f1281a6808";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/b6f448d9-7719-448e-907e-8c4d33880059/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9846674-aa03-4a47-9ec8-c0f1281a6808>.
+    
+<http://data.lblod.info/id/remote-data-objects/f576f551-4ec6-4bc3-afa3-217e88012111> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f576f551-4ec6-4bc3-afa3-217e88012111";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/bd013487-80d6-4951-b87d-f582f9747e76/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f576f551-4ec6-4bc3-afa3-217e88012111>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fe5e396-2e03-4a74-b274-5a2135b53442> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fe5e396-2e03-4a74-b274-5a2135b53442";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/bd0a7ee0-71be-4f70-b6a5-4390b746e779/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fe5e396-2e03-4a74-b274-5a2135b53442>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9cf0404-9db7-455f-9f95-7cd19ed8a198> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9cf0404-9db7-455f-9f95-7cd19ed8a198";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/c0157e8d-3799-4e68-95e5-37d5dd220e3d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9cf0404-9db7-455f-9f95-7cd19ed8a198>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cb0e95e-706f-4bad-afa4-ff4217696d54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cb0e95e-706f-4bad-afa4-ff4217696d54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/c2138c06-2bf8-4fcf-a713-1e19bce4f2cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cb0e95e-706f-4bad-afa4-ff4217696d54>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc1b3395-21f5-4f4f-9611-87aaaab49308> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc1b3395-21f5-4f4f-9611-87aaaab49308";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/c97f9a9e-f6e5-45fb-8054-157d98c6a7c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc1b3395-21f5-4f4f-9611-87aaaab49308>.
+    
+<http://data.lblod.info/id/remote-data-objects/f960260a-a50e-4ce2-8ecb-d07e45dbb9ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f960260a-a50e-4ce2-8ecb-d07e45dbb9ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/ca8c5006-384b-46d0-8015-710a8f0bfdff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f960260a-a50e-4ce2-8ecb-d07e45dbb9ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f936315-c390-4be0-b366-9c2bac9cdb52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f936315-c390-4be0-b366-9c2bac9cdb52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/cb85d18d-ff77-4660-9f49-ee7e5916dc4b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f936315-c390-4be0-b366-9c2bac9cdb52>.
+    
+<http://data.lblod.info/id/remote-data-objects/279c6263-434d-4cf4-b999-9fb63f968063> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "279c6263-434d-4cf4-b999-9fb63f968063";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/cbb62a1d-dd92-4e78-8008-8dd97169f327/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/279c6263-434d-4cf4-b999-9fb63f968063>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cdc8d29-7171-4db5-873d-ad32597272c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cdc8d29-7171-4db5-873d-ad32597272c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/d052a7df-9b72-4974-92c6-36612d46c0f8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cdc8d29-7171-4db5-873d-ad32597272c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/03261f43-4d40-46f4-bc0f-4b146206b002> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03261f43-4d40-46f4-bc0f-4b146206b002";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/d0f03871-42ea-4e1f-9c45-5c323cc7232a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03261f43-4d40-46f4-bc0f-4b146206b002>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbf4f13f-d2d2-483f-86ef-02a51405f6f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbf4f13f-d2d2-483f-86ef-02a51405f6f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/db2ad2a1-6a4f-475a-a04e-ae87133f0bd0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbf4f13f-d2d2-483f-86ef-02a51405f6f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bfb8042-f00b-4aaa-b3cd-b00914a3497f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bfb8042-f00b-4aaa-b3cd-b00914a3497f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/dbce406f-348b-48ce-8a92-c317c6f00199/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bfb8042-f00b-4aaa-b3cd-b00914a3497f>.
+    
+<http://data.lblod.info/id/remote-data-objects/db83631c-b6d4-4e9c-a6b4-baccc9f4c881> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db83631c-b6d4-4e9c-a6b4-baccc9f4c881";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/e12ec29a-4383-4039-ac38-5c8bfde246d8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db83631c-b6d4-4e9c-a6b4-baccc9f4c881>.
+    
+<http://data.lblod.info/id/remote-data-objects/804f9c05-a620-4ee1-808f-edbb7a227af1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "804f9c05-a620-4ee1-808f-edbb7a227af1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/e68890c0-f058-4193-85a1-1c3ecf470c36/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/804f9c05-a620-4ee1-808f-edbb7a227af1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a700f4d1-500c-46d3-8ccc-8866d3fe67a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a700f4d1-500c-46d3-8ccc-8866d3fe67a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/e71ac992-6ad9-4d3a-b90d-7702b4615314/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a700f4d1-500c-46d3-8ccc-8866d3fe67a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f13dfd32-f4a7-490a-843b-e63da6d5f79e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f13dfd32-f4a7-490a-843b-e63da6d5f79e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/f8a347c6-4f94-440a-8a27-4c5c176064ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f13dfd32-f4a7-490a-843b-e63da6d5f79e>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa86a0ca-7c6b-480d-b689-f97845f50798> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa86a0ca-7c6b-480d-b689-f97845f50798";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://hulshout.meetingburger.net/vabu/ff8f11d4-ace6-48e0-b640-fb95aaa00ee7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa86a0ca-7c6b-480d-b689-f97845f50798>.
+    
+<http://data.lblod.info/id/remote-data-objects/f299d45d-909b-42b8-a134-0d9700854980> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f299d45d-909b-42b8-a134-0d9700854980";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/0046bff2-ef11-4222-bc80-162dd49d7baa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f299d45d-909b-42b8-a134-0d9700854980>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ab2000d-f04c-418b-9683-7f3e6cb60e27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ab2000d-f04c-418b-9683-7f3e6cb60e27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/0132ef24-84b3-4cee-90cc-f85077969876/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ab2000d-f04c-418b-9683-7f3e6cb60e27>.
+    
+<http://data.lblod.info/id/remote-data-objects/da4b7608-07a3-4e74-ac6c-ac009a915b53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da4b7608-07a3-4e74-ac6c-ac009a915b53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/018cc6b6-5ba4-47d3-aaf1-a12c33ecdcc6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1f66a3e-febc-401c-a45b-63449ffaa2cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da4b7608-07a3-4e74-ac6c-ac009a915b53>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201217-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201217-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201217-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201217-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/32862b27-3c92-4125-baf3-557354577713> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "32862b27-3c92-4125-baf3-557354577713";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c263d945-6675-4c8a-a4a6-1fa1522b85a2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b45dc2d6-89ca-4a53-9d7f-817687e61e32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b45dc2d6-89ca-4a53-9d7f-817687e61e32";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2>.
+
+  <http://redpencil.data.gift/id/task/e86ead2d-a4a5-42ae-aad1-b1fba6a72d1e> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e86ead2d-a4a5-42ae-aad1-b1fba6a72d1e";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/32862b27-3c92-4125-baf3-557354577713>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b45dc2d6-89ca-4a53-9d7f-817687e61e32>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/555ceaa7-e09f-44f9-a1ec-73a635bbc4ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "555ceaa7-e09f-44f9-a1ec-73a635bbc4ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/06ab1a42-286b-43a6-aa1f-71c78b55e7d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/555ceaa7-e09f-44f9-a1ec-73a635bbc4ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/63c86d72-ae84-48fb-80a5-85fce005eed5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63c86d72-ae84-48fb-80a5-85fce005eed5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/07ad0cfa-3f36-4960-a6b3-bebe15e06d2e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63c86d72-ae84-48fb-80a5-85fce005eed5>.
+    
+<http://data.lblod.info/id/remote-data-objects/31ea3a10-2218-4231-82a8-4034997e692e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31ea3a10-2218-4231-82a8-4034997e692e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/14061f9e-bfeb-48e2-bbf3-76a3296126e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31ea3a10-2218-4231-82a8-4034997e692e>.
+    
+<http://data.lblod.info/id/remote-data-objects/693b143f-5bc1-40e9-a787-929e4bea874b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "693b143f-5bc1-40e9-a787-929e4bea874b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/25cde56e-c6cb-43c4-b481-d01862f8c24b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/693b143f-5bc1-40e9-a787-929e4bea874b>.
+    
+<http://data.lblod.info/id/remote-data-objects/724b995a-3bf9-4a8f-8d93-eb2af2e0015a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "724b995a-3bf9-4a8f-8d93-eb2af2e0015a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/29950e4f-6d40-43fb-be9f-2ebaaff2412f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/724b995a-3bf9-4a8f-8d93-eb2af2e0015a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a73b73b0-5bba-47ca-a426-2e1878066157> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a73b73b0-5bba-47ca-a426-2e1878066157";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/2bc848d7-b25b-4d28-899e-f7204c348810/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a73b73b0-5bba-47ca-a426-2e1878066157>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac69ee81-786a-4f35-9039-0ddbac556ba2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac69ee81-786a-4f35-9039-0ddbac556ba2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/34fe024c-5e75-4106-91c4-139063f01c18/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac69ee81-786a-4f35-9039-0ddbac556ba2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0188cb66-0890-4e9b-9d9b-3edec74c9db1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0188cb66-0890-4e9b-9d9b-3edec74c9db1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/4196ee22-536f-41ae-b40b-e6b78a21dc85/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0188cb66-0890-4e9b-9d9b-3edec74c9db1>.
+    
+<http://data.lblod.info/id/remote-data-objects/74ea4952-6190-49be-9d68-89d2daf07e8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74ea4952-6190-49be-9d68-89d2daf07e8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/42b14c8f-addb-4d8f-9007-cb5cd55519e9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74ea4952-6190-49be-9d68-89d2daf07e8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f56a40c5-aabd-4634-94fc-52c21176d372> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f56a40c5-aabd-4634-94fc-52c21176d372";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/4661702b-717d-48b4-ada6-6fea2dc9e780/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f56a40c5-aabd-4634-94fc-52c21176d372>.
+    
+<http://data.lblod.info/id/remote-data-objects/d57d0884-1c1d-4aef-8d54-25286ed5fdb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d57d0884-1c1d-4aef-8d54-25286ed5fdb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/4732bfb7-3a18-45c5-b5b9-924957ca8c70/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d57d0884-1c1d-4aef-8d54-25286ed5fdb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5917ff0d-7179-40e9-ba8a-d8055dbf24b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5917ff0d-7179-40e9-ba8a-d8055dbf24b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/4959f697-89fb-4381-9892-4b916c6cdbcb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5917ff0d-7179-40e9-ba8a-d8055dbf24b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/27dc35ff-fab6-4621-87d2-9abc550aa644> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27dc35ff-fab6-4621-87d2-9abc550aa644";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/4a3a378a-8055-4ee8-b603-d50072781865/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27dc35ff-fab6-4621-87d2-9abc550aa644>.
+    
+<http://data.lblod.info/id/remote-data-objects/058dabea-af9a-4a04-99ec-b83222b074c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "058dabea-af9a-4a04-99ec-b83222b074c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/513fbcdd-8edb-4ba9-8839-dacdbae26841/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/058dabea-af9a-4a04-99ec-b83222b074c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f4496da-8ead-41ad-bef4-7ed7b84721f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f4496da-8ead-41ad-bef4-7ed7b84721f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/52811b6d-78a0-4b9c-a3f8-a338739ccb2a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f4496da-8ead-41ad-bef4-7ed7b84721f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4879c9f3-ed8a-43c5-80c5-f8ef2d744969> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4879c9f3-ed8a-43c5-80c5-f8ef2d744969";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/5b381f9e-3c92-425e-bde4-003722dee965/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4879c9f3-ed8a-43c5-80c5-f8ef2d744969>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d062ac1-435a-4edf-a653-788f524b131a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d062ac1-435a-4edf-a653-788f524b131a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/5cd9359a-8141-409c-9467-63f9c80cb77c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d062ac1-435a-4edf-a653-788f524b131a>.
+    
+<http://data.lblod.info/id/remote-data-objects/86f5afe8-73cf-4acd-acbf-e674e2aa4581> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86f5afe8-73cf-4acd-acbf-e674e2aa4581";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/65fc410c-a28e-4028-b479-d243aaffa410/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86f5afe8-73cf-4acd-acbf-e674e2aa4581>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f44b474-5666-4e79-a4b6-a997c1a8ab58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f44b474-5666-4e79-a4b6-a997c1a8ab58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/6c759793-623e-404c-8c9e-cc11b7f3a0e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f44b474-5666-4e79-a4b6-a997c1a8ab58>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc0dae10-02e1-4455-9d48-23d3a47a2c7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc0dae10-02e1-4455-9d48-23d3a47a2c7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/6e250a75-6070-4efb-9326-53e995931c53/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc0dae10-02e1-4455-9d48-23d3a47a2c7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/18ccb800-5afd-4952-8cf5-ccb70c5132bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18ccb800-5afd-4952-8cf5-ccb70c5132bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/712393d5-8bfc-475e-88cb-b5cfd22002b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18ccb800-5afd-4952-8cf5-ccb70c5132bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b409a51-1607-47c8-a330-c0e475a0501f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b409a51-1607-47c8-a330-c0e475a0501f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/71dfd32d-057a-4a0c-84a0-4f742426c15c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b409a51-1607-47c8-a330-c0e475a0501f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3b9ed1c-4036-4429-b323-3246907dedf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3b9ed1c-4036-4429-b323-3246907dedf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/78b681b9-ddb2-4f0b-a9d5-0a13dac5e3ba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3b9ed1c-4036-4429-b323-3246907dedf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d1d37de-227a-45c5-ab0b-f4d943115e51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d1d37de-227a-45c5-ab0b-f4d943115e51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/7c9d013a-da81-4d9f-990b-0e48773210af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d1d37de-227a-45c5-ab0b-f4d943115e51>.
+    
+<http://data.lblod.info/id/remote-data-objects/353edc0e-7983-4b09-ba16-86bd9b3d387f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "353edc0e-7983-4b09-ba16-86bd9b3d387f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/7ddffce5-828e-4d6a-b26a-0f4de084bd9e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/353edc0e-7983-4b09-ba16-86bd9b3d387f>.
+    
+<http://data.lblod.info/id/remote-data-objects/19eefccd-b536-43bb-af88-9bf08413b4f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19eefccd-b536-43bb-af88-9bf08413b4f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/7f2e06eb-069f-421a-9497-71c32297dd27/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19eefccd-b536-43bb-af88-9bf08413b4f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/96c5aeb4-376a-4b14-9140-d6572ff38d96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96c5aeb4-376a-4b14-9140-d6572ff38d96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/8324229f-c6cc-420c-8b98-3711cca78d1d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96c5aeb4-376a-4b14-9140-d6572ff38d96>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dcca4b3-6fe5-41a0-93c7-69523b3c8cc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dcca4b3-6fe5-41a0-93c7-69523b3c8cc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/8dd4dfea-7230-4328-b788-beb819bef508/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dcca4b3-6fe5-41a0-93c7-69523b3c8cc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/867330da-9182-47a7-9cfa-855df0a84df6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "867330da-9182-47a7-9cfa-855df0a84df6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/8e534ccd-d38d-44ba-9786-5f4fe58d9aab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/867330da-9182-47a7-9cfa-855df0a84df6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad0a8f09-9b12-47e8-b626-96fea07c562a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad0a8f09-9b12-47e8-b626-96fea07c562a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/9fddfc33-d58c-4a94-9867-cbf2c84e7dfa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad0a8f09-9b12-47e8-b626-96fea07c562a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bb52c79-7c53-4bfe-b2b7-8b1ae803b4f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bb52c79-7c53-4bfe-b2b7-8b1ae803b4f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/a949d6fc-986d-45cb-91f2-9c8abb4665f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bb52c79-7c53-4bfe-b2b7-8b1ae803b4f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/699fa8d2-47d9-49a9-ba06-f72d6b07ce09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "699fa8d2-47d9-49a9-ba06-f72d6b07ce09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/abda0152-d1e4-4265-b511-412b5fadbce9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/699fa8d2-47d9-49a9-ba06-f72d6b07ce09>.
+    
+<http://data.lblod.info/id/remote-data-objects/325ce118-583b-40b2-b259-ad16579e7d6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "325ce118-583b-40b2-b259-ad16579e7d6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/adccf5a1-4827-472e-970a-5d56d6ac5f0e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/325ce118-583b-40b2-b259-ad16579e7d6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c9384da-3055-4ad4-9e4c-07441e19fde4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c9384da-3055-4ad4-9e4c-07441e19fde4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/bae7c387-e965-418e-a03f-0e5833740629/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c9384da-3055-4ad4-9e4c-07441e19fde4>.
+    
+<http://data.lblod.info/id/remote-data-objects/06d96af5-729a-48eb-bf9d-98a503a04002> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06d96af5-729a-48eb-bf9d-98a503a04002";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/dced815f-b3e1-4ae9-9edd-d0d131a01cd7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06d96af5-729a-48eb-bf9d-98a503a04002>.
+    
+<http://data.lblod.info/id/remote-data-objects/432064a8-a19b-48af-be68-c93452a5e109> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "432064a8-a19b-48af-be68-c93452a5e109";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/e5a99977-7c37-4e48-9148-189e601029ed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/432064a8-a19b-48af-be68-c93452a5e109>.
+    
+<http://data.lblod.info/id/remote-data-objects/0abd48ab-7a03-4a4a-878a-4c7f4d870dcf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0abd48ab-7a03-4a4a-878a-4c7f4d870dcf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/f7bd1fae-3b82-4c6f-8d3f-03b5d7c81870/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0abd48ab-7a03-4a4a-878a-4c7f4d870dcf>.
+    
+<http://data.lblod.info/id/remote-data-objects/466d98d3-0d4a-4dc4-a39c-867aa8d25322> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "466d98d3-0d4a-4dc4-a39c-867aa8d25322";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/f822a88e-2e71-4d68-bc1f-f0525033fd8f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/466d98d3-0d4a-4dc4-a39c-867aa8d25322>.
+    
+<http://data.lblod.info/id/remote-data-objects/3944f658-eaf4-4e12-ac06-a3ce7a73977b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3944f658-eaf4-4e12-ac06-a3ce7a73977b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/fc0abe35-20fd-4801-8a30-2dd0c631cb52/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3944f658-eaf4-4e12-ac06-a3ce7a73977b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c53a74dd-7afd-4eee-a598-19eb0c4c5f7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c53a74dd-7afd-4eee-a598-19eb0c4c5f7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/fc920499-c3c1-45fc-a4c6-3f910b828e74/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c53a74dd-7afd-4eee-a598-19eb0c4c5f7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4af01ee-98e1-4fb9-bc79-ff2b313d64c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4af01ee-98e1-4fb9-bc79-ff2b313d64c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/bb/fe3a8465-84c2-4c43-94eb-db4d139f8f4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4af01ee-98e1-4fb9-bc79-ff2b313d64c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/98d52932-af59-40d7-8ad6-e2b80584058d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98d52932-af59-40d7-8ad6-e2b80584058d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/00018a6e-79a0-4cd9-9a2f-171e51bd2fb1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98d52932-af59-40d7-8ad6-e2b80584058d>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa31f46b-fccc-409e-ba48-d55d7f084041> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa31f46b-fccc-409e-ba48-d55d7f084041";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/076a07ac-c038-4e58-8015-7d70607fcc99/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa31f46b-fccc-409e-ba48-d55d7f084041>.
+    
+<http://data.lblod.info/id/remote-data-objects/73aef7bb-8199-48a1-985a-cb6f95ec59a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73aef7bb-8199-48a1-985a-cb6f95ec59a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/07cb4db9-05e2-446b-ad6a-598d824ebd90/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73aef7bb-8199-48a1-985a-cb6f95ec59a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0a5aeee-9fec-4cf9-9361-f9c8185a7c57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0a5aeee-9fec-4cf9-9361-f9c8185a7c57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/0e0b2526-b07e-4eff-9d45-844245c2dfb1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0a5aeee-9fec-4cf9-9361-f9c8185a7c57>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d11c5a5-6fc7-4464-8b53-7ce98cd773d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d11c5a5-6fc7-4464-8b53-7ce98cd773d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/1bc93271-d938-4301-8b58-1c5d1f06a4bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d11c5a5-6fc7-4464-8b53-7ce98cd773d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b071c27-1e0d-4ba2-a52d-4a2f80789f62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b071c27-1e0d-4ba2-a52d-4a2f80789f62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/1c598a8b-33dc-4f96-9752-b2de6920a7a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b071c27-1e0d-4ba2-a52d-4a2f80789f62>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc34f200-db71-42e2-a5fc-2e02cebd8d19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc34f200-db71-42e2-a5fc-2e02cebd8d19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/230827fe-31b8-46ff-b8f9-4bfb50974026/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc34f200-db71-42e2-a5fc-2e02cebd8d19>.
+    
+<http://data.lblod.info/id/remote-data-objects/d686a4d5-1a1e-4f31-ae52-0f512e8a5507> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d686a4d5-1a1e-4f31-ae52-0f512e8a5507";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/24c90b74-c0ad-48c2-8b06-ad91415d9ba7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d686a4d5-1a1e-4f31-ae52-0f512e8a5507>.
+    
+<http://data.lblod.info/id/remote-data-objects/0306bf2a-c199-4bb1-a3a5-9f54be26b4d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0306bf2a-c199-4bb1-a3a5-9f54be26b4d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/29d3889a-3c1c-4d2b-a8b3-932424756b61/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c263d945-6675-4c8a-a4a6-1fa1522b85a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0306bf2a-c199-4bb1-a3a5-9f54be26b4d1>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201218-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201218-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201218-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201218-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3c6635a9-945f-42a5-8fec-ae7b83c7ad01> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3c6635a9-945f-42a5-8fec-ae7b83c7ad01";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c694a818-474f-4023-9618-ebfe8fa7f5ad";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/35a30af5-1a04-45c6-afe0-ce37d09c5ab5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "35a30af5-1a04-45c6-afe0-ce37d09c5ab5";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad>.
+
+  <http://redpencil.data.gift/id/task/be268b63-0cb4-43f1-a273-ed0e04aa8f93> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "be268b63-0cb4-43f1-a273-ed0e04aa8f93";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3c6635a9-945f-42a5-8fec-ae7b83c7ad01>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/35a30af5-1a04-45c6-afe0-ce37d09c5ab5>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5342f213-a970-42b5-89d8-8b59fe11e3d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5342f213-a970-42b5-89d8-8b59fe11e3d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/2e9a05e4-d302-4b4d-8b01-ec46925ac7c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5342f213-a970-42b5-89d8-8b59fe11e3d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/68bb695d-5052-4a25-856a-402c734f00b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68bb695d-5052-4a25-856a-402c734f00b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/2fdd5b09-8821-4952-999d-6d4cfe88bdde/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68bb695d-5052-4a25-856a-402c734f00b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c27ca991-1989-46c8-bcbe-095f8a7ff39d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c27ca991-1989-46c8-bcbe-095f8a7ff39d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/32902eaa-3f22-4e12-85c0-e08e31a80767/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c27ca991-1989-46c8-bcbe-095f8a7ff39d>.
+    
+<http://data.lblod.info/id/remote-data-objects/453e639f-80b7-4157-99a3-a21612257bc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "453e639f-80b7-4157-99a3-a21612257bc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/3606b8fe-7bf6-4187-ad75-c86091951d29/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/453e639f-80b7-4157-99a3-a21612257bc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ddc5944-4ece-4a77-99e5-520eb262da85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ddc5944-4ece-4a77-99e5-520eb262da85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/37384a68-6833-432a-8d45-e1baa776d80d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ddc5944-4ece-4a77-99e5-520eb262da85>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd4119f0-19d7-4902-a303-836344abc508> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd4119f0-19d7-4902-a303-836344abc508";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/3a58a82d-58a9-4a77-ba31-177c55c9d514/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd4119f0-19d7-4902-a303-836344abc508>.
+    
+<http://data.lblod.info/id/remote-data-objects/450f5e1c-e1ca-440b-97d6-512a47fd093e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "450f5e1c-e1ca-440b-97d6-512a47fd093e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/3ae2c41d-1de6-47c1-b245-09649493f96b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/450f5e1c-e1ca-440b-97d6-512a47fd093e>.
+    
+<http://data.lblod.info/id/remote-data-objects/32ce5c8b-6567-453d-877d-fee77f00195d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32ce5c8b-6567-453d-877d-fee77f00195d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/45d6f399-27e6-4940-b673-28f76726dcd3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32ce5c8b-6567-453d-877d-fee77f00195d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7808396b-2498-4fc1-94f3-3f3edec4e048> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7808396b-2498-4fc1-94f3-3f3edec4e048";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/4ad4a5cc-21c1-4354-8027-1fe8e05ec65c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7808396b-2498-4fc1-94f3-3f3edec4e048>.
+    
+<http://data.lblod.info/id/remote-data-objects/abb547ff-89d0-470d-8cd3-f77827c1789f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abb547ff-89d0-470d-8cd3-f77827c1789f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/4c49dd57-af2f-4f86-b425-71d47f1f85f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abb547ff-89d0-470d-8cd3-f77827c1789f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f639322d-43ee-4775-a4fc-ca94daa17b76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f639322d-43ee-4775-a4fc-ca94daa17b76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/4e588e15-d6eb-49ee-bb1a-ba154aaf552d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f639322d-43ee-4775-a4fc-ca94daa17b76>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0fb317f-97e1-4f3f-bca0-599be0d9ce10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0fb317f-97e1-4f3f-bca0-599be0d9ce10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/50d8f1b0-c9b8-4ff0-8a50-371e9021bd05/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0fb317f-97e1-4f3f-bca0-599be0d9ce10>.
+    
+<http://data.lblod.info/id/remote-data-objects/9122d1e8-fbd8-4e6d-869f-84797d16e2ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9122d1e8-fbd8-4e6d-869f-84797d16e2ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/51e72590-c31d-48c7-86a4-a9a0897bc101/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9122d1e8-fbd8-4e6d-869f-84797d16e2ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b48f1d8-03e8-4081-bc00-3d99ded7071f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b48f1d8-03e8-4081-bc00-3d99ded7071f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/525f6a14-2fa4-4bc6-afe0-8ffc469fd701/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b48f1d8-03e8-4081-bc00-3d99ded7071f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2873645-f9f8-4c4d-91f1-b6f50527a6c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2873645-f9f8-4c4d-91f1-b6f50527a6c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/58cdfa0d-da50-43ed-ae68-c49cd44fd5b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2873645-f9f8-4c4d-91f1-b6f50527a6c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2132078-2dcc-4143-838c-521f367f2b6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2132078-2dcc-4143-838c-521f367f2b6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/641f68a3-7511-4f43-9f2d-3c63e578b6c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2132078-2dcc-4143-838c-521f367f2b6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3be0ad0c-0ac1-406e-9e84-f34a4b84a2a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3be0ad0c-0ac1-406e-9e84-f34a4b84a2a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/7271e648-c3c7-483d-a06f-eb270a4540a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3be0ad0c-0ac1-406e-9e84-f34a4b84a2a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/97ca83f4-3c96-47cd-b83a-786e7b22f0ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97ca83f4-3c96-47cd-b83a-786e7b22f0ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/747c09b9-e1bb-4c76-92f6-40b781e7903f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97ca83f4-3c96-47cd-b83a-786e7b22f0ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/384fe12c-8e3d-4d14-b9ff-bb3cb7cf3906> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "384fe12c-8e3d-4d14-b9ff-bb3cb7cf3906";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/77086ece-4715-4838-84f4-6d1f70079544/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/384fe12c-8e3d-4d14-b9ff-bb3cb7cf3906>.
+    
+<http://data.lblod.info/id/remote-data-objects/00293e12-fa2a-48dd-b1e3-2a630edd67c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00293e12-fa2a-48dd-b1e3-2a630edd67c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/79f9f0cd-c78b-44e8-8b64-7a115371b37a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00293e12-fa2a-48dd-b1e3-2a630edd67c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8071aea5-1697-4007-a5c3-b5fe3471a604> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8071aea5-1697-4007-a5c3-b5fe3471a604";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/7f49014a-efb1-4d33-bfc7-3cf612df5b00/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8071aea5-1697-4007-a5c3-b5fe3471a604>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a4de12b-a151-4f79-9701-f7b845c8e50f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a4de12b-a151-4f79-9701-f7b845c8e50f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/7fa167c8-61d9-4f63-a36f-07047f40a32a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a4de12b-a151-4f79-9701-f7b845c8e50f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ee28d28-ea58-41f3-85f4-154dc874489c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ee28d28-ea58-41f3-85f4-154dc874489c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/82953647-3e68-4405-aa08-a375a47a8a1c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ee28d28-ea58-41f3-85f4-154dc874489c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f820bf0-aaff-4638-b806-94ac2e0a2c1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f820bf0-aaff-4638-b806-94ac2e0a2c1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/83cc5225-13e0-48e1-a78e-ca06dd8385a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f820bf0-aaff-4638-b806-94ac2e0a2c1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/41bad793-5165-4ad5-b173-fa95849dd765> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41bad793-5165-4ad5-b173-fa95849dd765";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/86275e61-3824-4e70-86ce-7c164fd53f41/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41bad793-5165-4ad5-b173-fa95849dd765>.
+    
+<http://data.lblod.info/id/remote-data-objects/74abed71-ecd7-47a2-b843-96166923bc3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74abed71-ecd7-47a2-b843-96166923bc3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/8e47a26a-2b18-430b-a136-f678eee9e95a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74abed71-ecd7-47a2-b843-96166923bc3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/83eb8207-aee5-4499-b34d-d70020b8f625> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83eb8207-aee5-4499-b34d-d70020b8f625";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/9f16b7b6-7c15-428f-9f92-3ba1fbf66b21/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83eb8207-aee5-4499-b34d-d70020b8f625>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ac03949-1144-40e7-8fcd-7caaf2b3eac6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ac03949-1144-40e7-8fcd-7caaf2b3eac6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/9f9eb3bb-61f7-4139-b073-42c591813fd4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ac03949-1144-40e7-8fcd-7caaf2b3eac6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9223aa6a-3f7a-4de1-a0f8-583b1553784c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9223aa6a-3f7a-4de1-a0f8-583b1553784c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/a39dc84c-4432-4d8f-a15d-11b832a14374/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9223aa6a-3f7a-4de1-a0f8-583b1553784c>.
+    
+<http://data.lblod.info/id/remote-data-objects/510349ef-6f5c-478c-ac61-7ca3c0fce750> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "510349ef-6f5c-478c-ac61-7ca3c0fce750";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/a4af7504-f95f-41ef-9c8d-88a4751fab2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/510349ef-6f5c-478c-ac61-7ca3c0fce750>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5b139f3-5088-4346-8a12-80f9608cf9f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5b139f3-5088-4346-8a12-80f9608cf9f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/a567ed62-6f5e-4ea5-9a64-4380a65a224a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5b139f3-5088-4346-8a12-80f9608cf9f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3488b5f-432d-44c0-b8cc-a1884e4784eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3488b5f-432d-44c0-b8cc-a1884e4784eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/b32c5dbb-3268-41df-9708-63078b0743c2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3488b5f-432d-44c0-b8cc-a1884e4784eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8a88e07-d1f6-4d8e-9c72-cb27fce054fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8a88e07-d1f6-4d8e-9c72-cb27fce054fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/b5c9f640-0a38-4c66-bfe8-dd322bb6a935/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8a88e07-d1f6-4d8e-9c72-cb27fce054fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/738abaf5-7cfb-47da-a506-edc7a4c3dd9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "738abaf5-7cfb-47da-a506-edc7a4c3dd9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/b6c3ddc1-5cee-49d0-9db8-6bcf23457718/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/738abaf5-7cfb-47da-a506-edc7a4c3dd9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ad40b9f-d11b-4430-95c4-496528f8265b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ad40b9f-d11b-4430-95c4-496528f8265b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/b92581c1-40c6-4e34-80ee-8bae7287a1a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ad40b9f-d11b-4430-95c4-496528f8265b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec476273-f40d-40e4-82a9-324ca63fb287> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec476273-f40d-40e4-82a9-324ca63fb287";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/bb3afb2c-13b8-4201-a657-6d9b527e2470/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec476273-f40d-40e4-82a9-324ca63fb287>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3fc790c-e270-4386-9d7e-53c0430898ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3fc790c-e270-4386-9d7e-53c0430898ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/bd55da42-0098-4865-a485-c26215879137/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3fc790c-e270-4386-9d7e-53c0430898ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/4db9cb6d-0485-4443-9cf8-52d00ce335a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4db9cb6d-0485-4443-9cf8-52d00ce335a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/bfa96e81-9ed5-40b7-bd40-7bb39c4a0fc6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4db9cb6d-0485-4443-9cf8-52d00ce335a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1071b5fb-f75e-4ad5-b9e5-b39508521a96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1071b5fb-f75e-4ad5-b9e5-b39508521a96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/c4b2f523-22d2-40df-8198-fd29e9a30b3f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1071b5fb-f75e-4ad5-b9e5-b39508521a96>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7e0881b-a984-4eba-8df0-0dd145656408> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7e0881b-a984-4eba-8df0-0dd145656408";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/c73a112d-df04-4faf-abe2-e8f1e240627f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7e0881b-a984-4eba-8df0-0dd145656408>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2e0ad93-b38f-4949-815f-b5018f7c1715> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2e0ad93-b38f-4949-815f-b5018f7c1715";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/cb50c821-6822-4a72-87b8-83c5fe9dc2fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2e0ad93-b38f-4949-815f-b5018f7c1715>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a8497d9-8e66-4079-9b87-e7c178bb62c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a8497d9-8e66-4079-9b87-e7c178bb62c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/d1a1be7e-7551-48bf-b248-19974de69fcb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a8497d9-8e66-4079-9b87-e7c178bb62c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/431014f2-a106-4b0a-9093-b4114dca5108> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "431014f2-a106-4b0a-9093-b4114dca5108";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/da969e9d-df38-4d60-914f-fb6696efc36d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/431014f2-a106-4b0a-9093-b4114dca5108>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb155978-f381-435a-b549-f1a8aa46941a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb155978-f381-435a-b549-f1a8aa46941a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/e1fceeaa-34d0-450c-8917-763695eac88a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb155978-f381-435a-b549-f1a8aa46941a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8557659-e220-4e75-b9b0-c83ee3ab185c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8557659-e220-4e75-b9b0-c83ee3ab185c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/e2387e33-b1cd-44c8-ae68-7ff9fdc461cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8557659-e220-4e75-b9b0-c83ee3ab185c>.
+    
+<http://data.lblod.info/id/remote-data-objects/10fde203-869f-40f3-8ca0-7b18f9ee4523> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10fde203-869f-40f3-8ca0-7b18f9ee4523";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/e3362596-d1ea-4a6b-a042-a396dd9be88d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10fde203-869f-40f3-8ca0-7b18f9ee4523>.
+    
+<http://data.lblod.info/id/remote-data-objects/e90afc22-c762-44db-bb5e-780886cdcd5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e90afc22-c762-44db-bb5e-780886cdcd5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/e4532d2b-ea3f-494b-a7e9-b78e808fa3cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e90afc22-c762-44db-bb5e-780886cdcd5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/acb443c7-f08e-4959-89a4-38c454645c4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acb443c7-f08e-4959-89a4-38c454645c4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/e4ba3ce0-8953-441e-ae17-d9ca1874fdf4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acb443c7-f08e-4959-89a4-38c454645c4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/836a4d39-69c9-4da7-bfc9-47799a093231> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "836a4d39-69c9-4da7-bfc9-47799a093231";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/e5cb5660-8fa0-4943-8944-0ee3c8d4ff28/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/836a4d39-69c9-4da7-bfc9-47799a093231>.
+    
+<http://data.lblod.info/id/remote-data-objects/69dd0961-59aa-4ef5-b5e7-91b40924e126> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69dd0961-59aa-4ef5-b5e7-91b40924e126";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/e7ad1a2c-f55e-4d18-9960-7ef9a4d2fab5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c694a818-474f-4023-9618-ebfe8fa7f5ad> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69dd0961-59aa-4ef5-b5e7-91b40924e126>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201219-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201219-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201219-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201219-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c3f40a09-3055-4901-9838-6b2cec9f990e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c3f40a09-3055-4901-9838-6b2cec9f990e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "570778c8-7ef9-4d46-9ac2-5972c3c9e0cd";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b7c74dc3-38c6-4b1b-8b39-288441a070c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b7c74dc3-38c6-4b1b-8b39-288441a070c7";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd>.
+
+  <http://redpencil.data.gift/id/task/b348f9af-639c-4c7d-9de7-6ed37af4ca32> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b348f9af-639c-4c7d-9de7-6ed37af4ca32";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c3f40a09-3055-4901-9838-6b2cec9f990e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b7c74dc3-38c6-4b1b-8b39-288441a070c7>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5f586d96-9f51-4676-adfc-ea368bbba9d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f586d96-9f51-4676-adfc-ea368bbba9d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/f042d4c2-0fad-43d8-9b6e-31c573a82b8f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f586d96-9f51-4676-adfc-ea368bbba9d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/01f09c37-f27e-4290-9924-b7a012a12baf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01f09c37-f27e-4290-9924-b7a012a12baf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/f2f8bbbc-1434-486b-909c-79e78f5f4be1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01f09c37-f27e-4290-9924-b7a012a12baf>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba55b85c-04a0-43af-9d0f-de27cc627ab7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba55b85c-04a0-43af-9d0f-de27cc627ab7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/f3e3dc0b-de32-40a2-a5ff-9336e34105b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba55b85c-04a0-43af-9d0f-de27cc627ab7>.
+    
+<http://data.lblod.info/id/remote-data-objects/46595d3f-07c3-4ec0-b1c4-4eebef1a04fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46595d3f-07c3-4ec0-b1c4-4eebef1a04fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/f62e01f4-6c3e-4614-82a9-80737709ea64/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46595d3f-07c3-4ec0-b1c4-4eebef1a04fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/53524e1a-8b38-44df-92f3-27d1a8a67378> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53524e1a-8b38-44df-92f3-27d1a8a67378";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/cbs/fd8eecf6-1984-4830-a942-af08c44ffb87/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53524e1a-8b38-44df-92f3-27d1a8a67378>.
+    
+<http://data.lblod.info/id/remote-data-objects/9faedea9-5339-439d-bf2c-d8ab3a41fa94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9faedea9-5339-439d-bf2c-d8ab3a41fa94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/00bd6d3c-5420-4ec6-8ef4-2b71d0e1188d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9faedea9-5339-439d-bf2c-d8ab3a41fa94>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf87bfa0-d564-4125-a5bd-137d11257b86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf87bfa0-d564-4125-a5bd-137d11257b86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/00bd6d3c-5420-4ec6-8ef4-2b71d0e1188d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf87bfa0-d564-4125-a5bd-137d11257b86>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a4ce5e8-9291-4f6b-8205-8737e5d94054> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a4ce5e8-9291-4f6b-8205-8737e5d94054";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/00bd6d3c-5420-4ec6-8ef4-2b71d0e1188d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a4ce5e8-9291-4f6b-8205-8737e5d94054>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dcee0eb-0bc9-4021-9eef-5d5c4f854f29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dcee0eb-0bc9-4021-9eef-5d5c4f854f29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/1841081b-7efb-4204-86be-5b0d28b87b00/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dcee0eb-0bc9-4021-9eef-5d5c4f854f29>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d94623d-5160-430c-b46b-cdc9bb6eb4a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d94623d-5160-430c-b46b-cdc9bb6eb4a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/1841081b-7efb-4204-86be-5b0d28b87b00/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d94623d-5160-430c-b46b-cdc9bb6eb4a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/27fb23b9-8e8e-4bc8-8701-afa4e8b7defe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27fb23b9-8e8e-4bc8-8701-afa4e8b7defe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/1841081b-7efb-4204-86be-5b0d28b87b00/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27fb23b9-8e8e-4bc8-8701-afa4e8b7defe>.
+    
+<http://data.lblod.info/id/remote-data-objects/99d5fdd4-6934-44a7-a207-535c62e8b4e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99d5fdd4-6934-44a7-a207-535c62e8b4e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/20530e65-4389-42e4-95e1-b68fcbee3787/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99d5fdd4-6934-44a7-a207-535c62e8b4e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b26df67-1cb2-4325-b072-aacffff7717d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b26df67-1cb2-4325-b072-aacffff7717d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/20530e65-4389-42e4-95e1-b68fcbee3787/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b26df67-1cb2-4325-b072-aacffff7717d>.
+    
+<http://data.lblod.info/id/remote-data-objects/194e208d-467c-4a81-9dfe-24a7e52126ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "194e208d-467c-4a81-9dfe-24a7e52126ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/20530e65-4389-42e4-95e1-b68fcbee3787/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/194e208d-467c-4a81-9dfe-24a7e52126ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed9b8196-c956-4b3f-a6f2-04076e17fc2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed9b8196-c956-4b3f-a6f2-04076e17fc2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/37fa0a3c-0076-4a76-8e7c-c99d6cd42d7e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed9b8196-c956-4b3f-a6f2-04076e17fc2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9056dc00-7dc1-4926-9fd3-fffb21dedfe0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9056dc00-7dc1-4926-9fd3-fffb21dedfe0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/37fa0a3c-0076-4a76-8e7c-c99d6cd42d7e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9056dc00-7dc1-4926-9fd3-fffb21dedfe0>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbddb8fd-bce4-458e-864d-102968cbef03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbddb8fd-bce4-458e-864d-102968cbef03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/37fa0a3c-0076-4a76-8e7c-c99d6cd42d7e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbddb8fd-bce4-458e-864d-102968cbef03>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc045a97-8d98-4eee-84cd-5835bc3679a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc045a97-8d98-4eee-84cd-5835bc3679a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/39d3921d-ac6c-40d9-8713-8f56f2af115b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc045a97-8d98-4eee-84cd-5835bc3679a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c3978ac-cc7c-42f4-a8a5-cefa0d1d8cb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c3978ac-cc7c-42f4-a8a5-cefa0d1d8cb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/39d3921d-ac6c-40d9-8713-8f56f2af115b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c3978ac-cc7c-42f4-a8a5-cefa0d1d8cb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0fe7387-9526-4090-a640-26224e140401> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0fe7387-9526-4090-a640-26224e140401";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/39d3921d-ac6c-40d9-8713-8f56f2af115b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0fe7387-9526-4090-a640-26224e140401>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5eddd48-1ed5-44c9-b20b-d4bcfa43f259> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5eddd48-1ed5-44c9-b20b-d4bcfa43f259";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/591f8c9f-7bb8-4c13-a645-dde6f06bee32/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5eddd48-1ed5-44c9-b20b-d4bcfa43f259>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a7d2622-5036-4153-981e-cbf70c8d24e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a7d2622-5036-4153-981e-cbf70c8d24e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/591f8c9f-7bb8-4c13-a645-dde6f06bee32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a7d2622-5036-4153-981e-cbf70c8d24e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/93b5a96d-c7eb-4792-8642-d39b9cc474b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93b5a96d-c7eb-4792-8642-d39b9cc474b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/591f8c9f-7bb8-4c13-a645-dde6f06bee32/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93b5a96d-c7eb-4792-8642-d39b9cc474b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2c536ea-1cb8-48fb-94cd-9362419a6193> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2c536ea-1cb8-48fb-94cd-9362419a6193";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/5da7c151-971a-4849-9cff-0756512ed228/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2c536ea-1cb8-48fb-94cd-9362419a6193>.
+    
+<http://data.lblod.info/id/remote-data-objects/79e214a8-b088-400c-ab89-276baf3901f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79e214a8-b088-400c-ab89-276baf3901f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/5da7c151-971a-4849-9cff-0756512ed228/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79e214a8-b088-400c-ab89-276baf3901f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fc2c569-cb94-4039-a8b0-50aa0b3901b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fc2c569-cb94-4039-a8b0-50aa0b3901b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/5da7c151-971a-4849-9cff-0756512ed228/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fc2c569-cb94-4039-a8b0-50aa0b3901b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d238ff63-69ee-48eb-b8a9-16c12a93f013> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d238ff63-69ee-48eb-b8a9-16c12a93f013";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/6075aa03-8578-49ab-b849-b87861acb962/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d238ff63-69ee-48eb-b8a9-16c12a93f013>.
+    
+<http://data.lblod.info/id/remote-data-objects/842665a8-893a-43e8-aa2c-ec36af86bf4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "842665a8-893a-43e8-aa2c-ec36af86bf4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/6075aa03-8578-49ab-b849-b87861acb962/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/842665a8-893a-43e8-aa2c-ec36af86bf4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/47c94f7a-ffff-4c09-b59e-27cc9d68d750> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47c94f7a-ffff-4c09-b59e-27cc9d68d750";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/6075aa03-8578-49ab-b849-b87861acb962/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47c94f7a-ffff-4c09-b59e-27cc9d68d750>.
+    
+<http://data.lblod.info/id/remote-data-objects/af5a1a61-d30f-4278-826d-087fb1524301> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af5a1a61-d30f-4278-826d-087fb1524301";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/68c04778-bf08-4b61-a527-24d8ea22a64f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af5a1a61-d30f-4278-826d-087fb1524301>.
+    
+<http://data.lblod.info/id/remote-data-objects/4aa55ad2-56a3-4d30-a211-c2667f255582> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4aa55ad2-56a3-4d30-a211-c2667f255582";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/68c04778-bf08-4b61-a527-24d8ea22a64f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4aa55ad2-56a3-4d30-a211-c2667f255582>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcf4fc9b-e5b4-4bde-87c1-80f3c52629ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcf4fc9b-e5b4-4bde-87c1-80f3c52629ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/68c04778-bf08-4b61-a527-24d8ea22a64f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcf4fc9b-e5b4-4bde-87c1-80f3c52629ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/43bedb50-097b-4ce4-95ea-d948216a2cf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43bedb50-097b-4ce4-95ea-d948216a2cf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/7fa4be25-a117-4b49-b7c3-3c83f8baf0c6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43bedb50-097b-4ce4-95ea-d948216a2cf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b678ccf7-b1f8-4b9c-8795-6de564e234c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b678ccf7-b1f8-4b9c-8795-6de564e234c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/7fa4be25-a117-4b49-b7c3-3c83f8baf0c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b678ccf7-b1f8-4b9c-8795-6de564e234c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ecf0e00-9c65-40a7-9cbe-728932f0c94f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ecf0e00-9c65-40a7-9cbe-728932f0c94f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/809c7d19-1ebc-4e8e-b555-a44bbe207c1c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ecf0e00-9c65-40a7-9cbe-728932f0c94f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f6a25ef-91ba-4602-ba4c-9a3c99622737> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f6a25ef-91ba-4602-ba4c-9a3c99622737";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/809c7d19-1ebc-4e8e-b555-a44bbe207c1c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f6a25ef-91ba-4602-ba4c-9a3c99622737>.
+    
+<http://data.lblod.info/id/remote-data-objects/f684f840-f8fe-4085-9feb-858feaa70e58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f684f840-f8fe-4085-9feb-858feaa70e58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/809c7d19-1ebc-4e8e-b555-a44bbe207c1c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f684f840-f8fe-4085-9feb-858feaa70e58>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1d2c1b6-3c22-4ef0-84c1-e95ddae3ebb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1d2c1b6-3c22-4ef0-84c1-e95ddae3ebb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/901f263c-fc28-4bc0-9c07-aef64f4ca340/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1d2c1b6-3c22-4ef0-84c1-e95ddae3ebb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/95a7bd4a-f200-4e10-851c-5e59ef7e312d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95a7bd4a-f200-4e10-851c-5e59ef7e312d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/901f263c-fc28-4bc0-9c07-aef64f4ca340/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95a7bd4a-f200-4e10-851c-5e59ef7e312d>.
+    
+<http://data.lblod.info/id/remote-data-objects/00cbc4cd-1c25-430a-bbf9-d3c270362723> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00cbc4cd-1c25-430a-bbf9-d3c270362723";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/901f263c-fc28-4bc0-9c07-aef64f4ca340/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00cbc4cd-1c25-430a-bbf9-d3c270362723>.
+    
+<http://data.lblod.info/id/remote-data-objects/9de6eb97-f4da-4517-a8ec-3903e12fd351> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9de6eb97-f4da-4517-a8ec-3903e12fd351";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/a17d8d15-7087-43a6-8f93-5bd15a468abb/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9de6eb97-f4da-4517-a8ec-3903e12fd351>.
+    
+<http://data.lblod.info/id/remote-data-objects/93347d39-9a4e-44cd-84c0-64f8ee0965af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93347d39-9a4e-44cd-84c0-64f8ee0965af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/a17d8d15-7087-43a6-8f93-5bd15a468abb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93347d39-9a4e-44cd-84c0-64f8ee0965af>.
+    
+<http://data.lblod.info/id/remote-data-objects/7061cca9-ac5b-490b-9af0-5a7e030c0447> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7061cca9-ac5b-490b-9af0-5a7e030c0447";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/a17d8d15-7087-43a6-8f93-5bd15a468abb/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7061cca9-ac5b-490b-9af0-5a7e030c0447>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a7111ce-64d3-4628-97f7-f7473aa32806> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a7111ce-64d3-4628-97f7-f7473aa32806";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/ba41456c-7c04-46d3-a909-5c0ac6d54cf0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a7111ce-64d3-4628-97f7-f7473aa32806>.
+    
+<http://data.lblod.info/id/remote-data-objects/97299d08-49e9-49e0-ac50-8451a738ebec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97299d08-49e9-49e0-ac50-8451a738ebec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/ba41456c-7c04-46d3-a909-5c0ac6d54cf0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97299d08-49e9-49e0-ac50-8451a738ebec>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce83cdbd-71c4-4135-aeaa-511238157c1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce83cdbd-71c4-4135-aeaa-511238157c1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/ba41456c-7c04-46d3-a909-5c0ac6d54cf0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce83cdbd-71c4-4135-aeaa-511238157c1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0379ad9-ecce-4e8b-8da8-b31c041e5e4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0379ad9-ecce-4e8b-8da8-b31c041e5e4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/d7dac6b9-bcc8-43d8-b16f-e00cdb78f090/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0379ad9-ecce-4e8b-8da8-b31c041e5e4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9eef115-2024-47b1-9fa3-55cfd7949f71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9eef115-2024-47b1-9fa3-55cfd7949f71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/d7dac6b9-bcc8-43d8-b16f-e00cdb78f090/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9eef115-2024-47b1-9fa3-55cfd7949f71>.
+    
+<http://data.lblod.info/id/remote-data-objects/1044b177-ae96-46b1-a33c-8301b807d526> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1044b177-ae96-46b1-a33c-8301b807d526";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/gr/d7dac6b9-bcc8-43d8-b16f-e00cdb78f090/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1044b177-ae96-46b1-a33c-8301b807d526>.
+    
+<http://data.lblod.info/id/remote-data-objects/051f667b-1a77-438b-87da-6fd82f49bcbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "051f667b-1a77-438b-87da-6fd82f49bcbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/1b8b6317-33a3-430c-be6a-305bd56856db/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/570778c8-7ef9-4d46-9ac2-5972c3c9e0cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/051f667b-1a77-438b-87da-6fd82f49bcbd>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201220-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201220-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201220-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201220-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a90b67ee-b418-4071-adfc-b18ffebcc9b1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a90b67ee-b418-4071-adfc-b18ffebcc9b1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "de167279-0888-4cff-ad69-2105d6924d6d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/8f2c4010-f00b-4ee4-840b-789f755a94f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8f2c4010-f00b-4ee4-840b-789f755a94f6";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d>.
+
+  <http://redpencil.data.gift/id/task/585bea49-a41c-4895-94a1-0ad1cb835df1> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "585bea49-a41c-4895-94a1-0ad1cb835df1";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a90b67ee-b418-4071-adfc-b18ffebcc9b1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/8f2c4010-f00b-4ee4-840b-789f755a94f6>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/6f1659af-7094-420a-8251-e543347ad2af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f1659af-7094-420a-8251-e543347ad2af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/1b8b6317-33a3-430c-be6a-305bd56856db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f1659af-7094-420a-8251-e543347ad2af>.
+    
+<http://data.lblod.info/id/remote-data-objects/9094a9de-676c-40da-af8f-aecf9f4eebac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9094a9de-676c-40da-af8f-aecf9f4eebac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/1b8b6317-33a3-430c-be6a-305bd56856db/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9094a9de-676c-40da-af8f-aecf9f4eebac>.
+    
+<http://data.lblod.info/id/remote-data-objects/5188083b-e036-4aab-af3a-602071922afb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5188083b-e036-4aab-af3a-602071922afb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/1c501dde-914e-4f4b-b518-308d7b86f8f5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5188083b-e036-4aab-af3a-602071922afb>.
+    
+<http://data.lblod.info/id/remote-data-objects/67b0422a-35ff-41da-9cfd-fe83f050948c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67b0422a-35ff-41da-9cfd-fe83f050948c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/1c501dde-914e-4f4b-b518-308d7b86f8f5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67b0422a-35ff-41da-9cfd-fe83f050948c>.
+    
+<http://data.lblod.info/id/remote-data-objects/115aa63d-949b-4b8a-a85c-8a5cd948009e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "115aa63d-949b-4b8a-a85c-8a5cd948009e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/1c501dde-914e-4f4b-b518-308d7b86f8f5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/115aa63d-949b-4b8a-a85c-8a5cd948009e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f24e466-0569-431b-8e14-7ab1998cd83f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f24e466-0569-431b-8e14-7ab1998cd83f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/1da4b969-dfba-403e-ba10-49e2db2f0257/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f24e466-0569-431b-8e14-7ab1998cd83f>.
+    
+<http://data.lblod.info/id/remote-data-objects/af37095a-0045-417f-b0e6-b13a181ee6c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af37095a-0045-417f-b0e6-b13a181ee6c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/1da4b969-dfba-403e-ba10-49e2db2f0257/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af37095a-0045-417f-b0e6-b13a181ee6c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ebf5f82-5276-4001-985e-103c9e2e3a8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ebf5f82-5276-4001-985e-103c9e2e3a8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/1da4b969-dfba-403e-ba10-49e2db2f0257/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ebf5f82-5276-4001-985e-103c9e2e3a8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c685487-7f1e-41a5-aa3f-f05d26f37f55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c685487-7f1e-41a5-aa3f-f05d26f37f55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/21102989-5ffd-45dd-a6f5-dd7f3a80964e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c685487-7f1e-41a5-aa3f-f05d26f37f55>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fe5fcd6-1ed4-4c83-8a29-1483eacef62e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fe5fcd6-1ed4-4c83-8a29-1483eacef62e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/21102989-5ffd-45dd-a6f5-dd7f3a80964e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fe5fcd6-1ed4-4c83-8a29-1483eacef62e>.
+    
+<http://data.lblod.info/id/remote-data-objects/052ccb4a-8ba0-4e73-89ef-d2976b8d90fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "052ccb4a-8ba0-4e73-89ef-d2976b8d90fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/21102989-5ffd-45dd-a6f5-dd7f3a80964e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/052ccb4a-8ba0-4e73-89ef-d2976b8d90fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4e16d10-54e8-4405-9828-af08216c0860> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4e16d10-54e8-4405-9828-af08216c0860";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/38cbbdce-dc2b-4854-b4a9-7db30213b2be/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4e16d10-54e8-4405-9828-af08216c0860>.
+    
+<http://data.lblod.info/id/remote-data-objects/763ced4b-bbbc-42cf-a3ad-28612daaba55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "763ced4b-bbbc-42cf-a3ad-28612daaba55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/38cbbdce-dc2b-4854-b4a9-7db30213b2be/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/763ced4b-bbbc-42cf-a3ad-28612daaba55>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d960b6d-8862-4f04-bd07-ed6b1b609356> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d960b6d-8862-4f04-bd07-ed6b1b609356";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/46248d60-8156-4faf-9876-14b2a2aa739d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d960b6d-8862-4f04-bd07-ed6b1b609356>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c892536-549e-4f56-a7d8-f5a0579bac68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c892536-549e-4f56-a7d8-f5a0579bac68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/46248d60-8156-4faf-9876-14b2a2aa739d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c892536-549e-4f56-a7d8-f5a0579bac68>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b0275b2-c1ca-416e-86ea-a42bd7745869> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b0275b2-c1ca-416e-86ea-a42bd7745869";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/46248d60-8156-4faf-9876-14b2a2aa739d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b0275b2-c1ca-416e-86ea-a42bd7745869>.
+    
+<http://data.lblod.info/id/remote-data-objects/56d6534a-786f-40ba-9085-e4ea84a6c30b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56d6534a-786f-40ba-9085-e4ea84a6c30b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/475ec95b-e228-4961-b9b9-ba0ca0426a98/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56d6534a-786f-40ba-9085-e4ea84a6c30b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e5bf6c8-ff69-4226-8d52-65fbe8d60c93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e5bf6c8-ff69-4226-8d52-65fbe8d60c93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/475ec95b-e228-4961-b9b9-ba0ca0426a98/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e5bf6c8-ff69-4226-8d52-65fbe8d60c93>.
+    
+<http://data.lblod.info/id/remote-data-objects/7906225a-ee1c-4965-9161-8282631930bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7906225a-ee1c-4965-9161-8282631930bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/475ec95b-e228-4961-b9b9-ba0ca0426a98/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7906225a-ee1c-4965-9161-8282631930bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c38df03-9ee2-44d0-bcfe-4fe23aea41ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c38df03-9ee2-44d0-bcfe-4fe23aea41ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/5c1bca65-2a7f-4d00-9c47-c25fb5d2d93e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c38df03-9ee2-44d0-bcfe-4fe23aea41ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/52a7706d-9e3d-4067-ada6-6d15eab00111> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52a7706d-9e3d-4067-ada6-6d15eab00111";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/5c1bca65-2a7f-4d00-9c47-c25fb5d2d93e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52a7706d-9e3d-4067-ada6-6d15eab00111>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed86414e-9fb9-4e22-a8a2-bbb18eb8e0f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed86414e-9fb9-4e22-a8a2-bbb18eb8e0f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/5c1bca65-2a7f-4d00-9c47-c25fb5d2d93e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed86414e-9fb9-4e22-a8a2-bbb18eb8e0f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d321fd53-824b-4232-9492-fcdc0d07ecce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d321fd53-824b-4232-9492-fcdc0d07ecce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/6d2b18e2-d3dc-44f3-a6d8-56a30ca3edc7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d321fd53-824b-4232-9492-fcdc0d07ecce>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe37f507-fdd5-4d62-aaf6-05836d505d89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe37f507-fdd5-4d62-aaf6-05836d505d89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/6d2b18e2-d3dc-44f3-a6d8-56a30ca3edc7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe37f507-fdd5-4d62-aaf6-05836d505d89>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef5c7a00-5ecb-4ad8-bc38-62571b45395d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef5c7a00-5ecb-4ad8-bc38-62571b45395d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/6d2b18e2-d3dc-44f3-a6d8-56a30ca3edc7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef5c7a00-5ecb-4ad8-bc38-62571b45395d>.
+    
+<http://data.lblod.info/id/remote-data-objects/543bdc2a-d249-4c1d-9467-0401eea45ba6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "543bdc2a-d249-4c1d-9467-0401eea45ba6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/80ecede9-2474-427f-ab8f-062f37ec8dd8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/543bdc2a-d249-4c1d-9467-0401eea45ba6>.
+    
+<http://data.lblod.info/id/remote-data-objects/96e681f0-0fb8-4b4f-8976-8eb1c0d05005> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96e681f0-0fb8-4b4f-8976-8eb1c0d05005";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/80ecede9-2474-427f-ab8f-062f37ec8dd8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96e681f0-0fb8-4b4f-8976-8eb1c0d05005>.
+    
+<http://data.lblod.info/id/remote-data-objects/61edf809-50e7-434d-bcdc-d180a9881f5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61edf809-50e7-434d-bcdc-d180a9881f5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/80ecede9-2474-427f-ab8f-062f37ec8dd8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61edf809-50e7-434d-bcdc-d180a9881f5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fddb9018-b73c-4231-a5f6-ad3c6795caba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fddb9018-b73c-4231-a5f6-ad3c6795caba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/cc48fa57-1a4f-419e-bb63-eda357a0626e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fddb9018-b73c-4231-a5f6-ad3c6795caba>.
+    
+<http://data.lblod.info/id/remote-data-objects/d11ebfd6-27fc-40db-99ec-e29d2e99ed47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d11ebfd6-27fc-40db-99ec-e29d2e99ed47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/cc48fa57-1a4f-419e-bb63-eda357a0626e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d11ebfd6-27fc-40db-99ec-e29d2e99ed47>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3b359ec-555d-4b27-a6d7-b06a3cbda31f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3b359ec-555d-4b27-a6d7-b06a3cbda31f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/cc48fa57-1a4f-419e-bb63-eda357a0626e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3b359ec-555d-4b27-a6d7-b06a3cbda31f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f4f6454-3ab4-49a6-9224-e854204fcb18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f4f6454-3ab4-49a6-9224-e854204fcb18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/ce7b4bc5-1108-42bb-ac37-58a738137b74/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f4f6454-3ab4-49a6-9224-e854204fcb18>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b7d1537-2698-4b8e-af88-6349ba01fd48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b7d1537-2698-4b8e-af88-6349ba01fd48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/ce7b4bc5-1108-42bb-ac37-58a738137b74/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b7d1537-2698-4b8e-af88-6349ba01fd48>.
+    
+<http://data.lblod.info/id/remote-data-objects/dddb1fa0-ce0a-493e-b52d-1ae5aceac26f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dddb1fa0-ce0a-493e-b52d-1ae5aceac26f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/ce7b4bc5-1108-42bb-ac37-58a738137b74/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dddb1fa0-ce0a-493e-b52d-1ae5aceac26f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1420b5e7-a835-42dd-b66c-63a025e0f8e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1420b5e7-a835-42dd-b66c-63a025e0f8e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/d13c8ce4-e3f4-4d9f-b6ae-47f4ba411573/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1420b5e7-a835-42dd-b66c-63a025e0f8e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b8660de-204f-4fe7-a26b-f9f073b4e3f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b8660de-204f-4fe7-a26b-f9f073b4e3f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/d13c8ce4-e3f4-4d9f-b6ae-47f4ba411573/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b8660de-204f-4fe7-a26b-f9f073b4e3f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/919292df-bc69-47cf-9fa1-4226a0ce684d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "919292df-bc69-47cf-9fa1-4226a0ce684d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/d13c8ce4-e3f4-4d9f-b6ae-47f4ba411573/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/919292df-bc69-47cf-9fa1-4226a0ce684d>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a538c40-91d9-48d0-ae9d-cbf753cb4e22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a538c40-91d9-48d0-ae9d-cbf753cb4e22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/d1a8e7c5-68c1-42d5-9f28-4741aba9ca1d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a538c40-91d9-48d0-ae9d-cbf753cb4e22>.
+    
+<http://data.lblod.info/id/remote-data-objects/584890ea-87fe-4466-a9d4-6fa0211da96c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "584890ea-87fe-4466-a9d4-6fa0211da96c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/d1a8e7c5-68c1-42d5-9f28-4741aba9ca1d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/584890ea-87fe-4466-a9d4-6fa0211da96c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a74f4b6-f371-4d33-a9ff-331ce65cd258> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a74f4b6-f371-4d33-a9ff-331ce65cd258";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/d1a8e7c5-68c1-42d5-9f28-4741aba9ca1d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a74f4b6-f371-4d33-a9ff-331ce65cd258>.
+    
+<http://data.lblod.info/id/remote-data-objects/32f5f9b1-2f67-4792-807f-da5eb4675ebb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32f5f9b1-2f67-4792-807f-da5eb4675ebb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/f93c6cbb-dbc3-4ac5-a1be-aa5c220203aa/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32f5f9b1-2f67-4792-807f-da5eb4675ebb>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b2654bd-f3f7-4f92-a954-91ced6cdd0ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b2654bd-f3f7-4f92-a954-91ced6cdd0ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/f93c6cbb-dbc3-4ac5-a1be-aa5c220203aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b2654bd-f3f7-4f92-a954-91ced6cdd0ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/790a7b54-e267-4456-a384-e9de0ba7b275> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "790a7b54-e267-4456-a384-e9de0ba7b275";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/rmw/f93c6cbb-dbc3-4ac5-a1be-aa5c220203aa/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/790a7b54-e267-4456-a384-e9de0ba7b275>.
+    
+<http://data.lblod.info/id/remote-data-objects/50af8791-8cf9-4017-ae6d-e644b2c958b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50af8791-8cf9-4017-ae6d-e644b2c958b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/04e9bc7a-e42c-49a8-ba9c-ce43ce038486/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50af8791-8cf9-4017-ae6d-e644b2c958b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1e6fe28-aed1-4e14-a601-4e36fe34855d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1e6fe28-aed1-4e14-a601-4e36fe34855d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/08f51c57-acbd-411c-b264-25a5c808a87c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1e6fe28-aed1-4e14-a601-4e36fe34855d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c62028fa-73df-4909-a227-bdf96ad0b0cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c62028fa-73df-4909-a227-bdf96ad0b0cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/0c15dd4b-44dd-48b8-a414-649e9bfa4e4d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c62028fa-73df-4909-a227-bdf96ad0b0cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/7edca3e2-0bf8-4494-a2ee-4d75b8a888f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7edca3e2-0bf8-4494-a2ee-4d75b8a888f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/13ed3bdb-5275-454e-97cb-f2f4be388f03/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7edca3e2-0bf8-4494-a2ee-4d75b8a888f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/182701c4-ad4d-4a4c-b4ff-bbd903b77a0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "182701c4-ad4d-4a4c-b4ff-bbd903b77a0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/1e3b4d70-1541-4648-bc81-c7abed940345/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/182701c4-ad4d-4a4c-b4ff-bbd903b77a0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/776e0a9a-2a76-47bb-aead-fc2e7a5818ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "776e0a9a-2a76-47bb-aead-fc2e7a5818ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/21e10d03-5869-441a-be04-a967dbf921ee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/776e0a9a-2a76-47bb-aead-fc2e7a5818ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5a24f77-7d32-480a-81fc-46859afe85f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5a24f77-7d32-480a-81fc-46859afe85f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/23a466a6-00c4-498b-b794-253126eb28c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de167279-0888-4cff-ad69-2105d6924d6d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5a24f77-7d32-480a-81fc-46859afe85f8>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201221-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201221-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201221-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201221-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/232b6c16-a3b7-405b-a7d1-3fce12d2503c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "232b6c16-a3b7-405b-a7d1-3fce12d2503c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "408c2f83-403c-47cb-8494-e5f7abcbec94";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9db85ef9-e85b-4184-b7f2-34b3f89428df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9db85ef9-e85b-4184-b7f2-34b3f89428df";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94>.
+
+  <http://redpencil.data.gift/id/task/b87d0beb-9389-4c3c-aa4d-48939fb45b8e> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b87d0beb-9389-4c3c-aa4d-48939fb45b8e";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/232b6c16-a3b7-405b-a7d1-3fce12d2503c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9db85ef9-e85b-4184-b7f2-34b3f89428df>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/abea9eac-a412-45bf-a16d-4567fb19158d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abea9eac-a412-45bf-a16d-4567fb19158d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/2544fbab-2f4f-4ec6-8cae-1afaad39b069/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abea9eac-a412-45bf-a16d-4567fb19158d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c618c1a-d887-43b4-a57e-998fb83ed886> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c618c1a-d887-43b4-a57e-998fb83ed886";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/3357f86b-7029-48db-9879-30096557d1c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c618c1a-d887-43b4-a57e-998fb83ed886>.
+    
+<http://data.lblod.info/id/remote-data-objects/b585d139-826d-4dda-aa6f-2c905860311f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b585d139-826d-4dda-aa6f-2c905860311f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/3a998e7a-c92c-4171-9d62-50f62bf89b23/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b585d139-826d-4dda-aa6f-2c905860311f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8db603e5-8b7c-48b4-a3ad-c8fab93e14d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8db603e5-8b7c-48b4-a3ad-c8fab93e14d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/49381362-b8c1-4825-aea7-c591843892ce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8db603e5-8b7c-48b4-a3ad-c8fab93e14d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5aeb412-c188-4d44-a6bf-f904a43cb078> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5aeb412-c188-4d44-a6bf-f904a43cb078";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/49b97701-d5ce-4ce8-acb2-9a9c1c70fbdf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5aeb412-c188-4d44-a6bf-f904a43cb078>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f1a000f-2a99-45b5-acbb-913ce30de336> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f1a000f-2a99-45b5-acbb-913ce30de336";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/4d107d13-af14-413b-82be-445694791c76/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f1a000f-2a99-45b5-acbb-913ce30de336>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e84cc83-34ea-4005-a2a1-839366d3681c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e84cc83-34ea-4005-a2a1-839366d3681c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/530c1f2b-7233-4e71-87b5-b3b86524af74/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e84cc83-34ea-4005-a2a1-839366d3681c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f45039d2-1798-4e57-a128-5269b1f84925> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f45039d2-1798-4e57-a128-5269b1f84925";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/59cf29f3-5e98-4f88-b143-e91efd9c5d45/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f45039d2-1798-4e57-a128-5269b1f84925>.
+    
+<http://data.lblod.info/id/remote-data-objects/67b51284-8383-49d5-9188-85b26f854b31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67b51284-8383-49d5-9188-85b26f854b31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/5aa4f6aa-b9ea-43d6-8d48-4f08706902a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67b51284-8383-49d5-9188-85b26f854b31>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c2c35cf-9090-4c5d-b9fc-3c13e0b4af43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c2c35cf-9090-4c5d-b9fc-3c13e0b4af43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/5c3d90c7-e748-44b1-9b61-fd3da33c7c21/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c2c35cf-9090-4c5d-b9fc-3c13e0b4af43>.
+    
+<http://data.lblod.info/id/remote-data-objects/10d8dc29-1280-4994-9fa0-b5d715489aa7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10d8dc29-1280-4994-9fa0-b5d715489aa7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/5d0b351d-bb70-4c09-bc03-e15edf0d19a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10d8dc29-1280-4994-9fa0-b5d715489aa7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a753b0f3-43c3-4489-9026-2e92e10828ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a753b0f3-43c3-4489-9026-2e92e10828ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/5e67912e-01ba-44be-b1bc-ff77a814da45/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a753b0f3-43c3-4489-9026-2e92e10828ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/667ed516-4e81-4ea8-818f-ce4631f1639c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "667ed516-4e81-4ea8-818f-ce4631f1639c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/6355a2b4-144a-40ef-a811-b9c309ed1716/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/667ed516-4e81-4ea8-818f-ce4631f1639c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4417a13-5fec-4398-970b-a5e0f42ff708> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4417a13-5fec-4398-970b-a5e0f42ff708";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/64453fbf-7a7f-4c55-85bc-25077d9a5111/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4417a13-5fec-4398-970b-a5e0f42ff708>.
+    
+<http://data.lblod.info/id/remote-data-objects/79053c7f-cfca-4668-8ab1-384dd0f362a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79053c7f-cfca-4668-8ab1-384dd0f362a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/67d31fe1-f32c-4ee1-a28f-d82c04254676/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79053c7f-cfca-4668-8ab1-384dd0f362a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/07b2f246-a1f1-49d4-ab7e-a057c21669f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07b2f246-a1f1-49d4-ab7e-a057c21669f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/6d26d67a-84a2-4b99-9c1f-caedd1e8ffae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07b2f246-a1f1-49d4-ab7e-a057c21669f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/64d08ca3-51f0-4fdb-b013-6e7ab38b982b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64d08ca3-51f0-4fdb-b013-6e7ab38b982b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/6db15470-74ed-4531-b3c7-dc1e9baca2df/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64d08ca3-51f0-4fdb-b013-6e7ab38b982b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0953d623-bde4-44f7-8b38-a9306483322c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0953d623-bde4-44f7-8b38-a9306483322c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/7023f930-b24a-4e41-a08c-1cb0fdb501d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0953d623-bde4-44f7-8b38-a9306483322c>.
+    
+<http://data.lblod.info/id/remote-data-objects/feb328ae-b04e-42c1-80f6-f82862a79a1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "feb328ae-b04e-42c1-80f6-f82862a79a1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/7c598857-73ff-4b79-8e10-93c897088e9c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/feb328ae-b04e-42c1-80f6-f82862a79a1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac8df116-31d2-4715-ab5f-088ccd01d5d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac8df116-31d2-4715-ab5f-088ccd01d5d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/7ddfb056-faf2-491d-a64e-90e4f525ca5e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac8df116-31d2-4715-ab5f-088ccd01d5d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b65ada40-1c9e-4d2e-a346-f605edd2249d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b65ada40-1c9e-4d2e-a346-f605edd2249d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/7e0eb895-07d6-4842-9901-c546e54c64e8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b65ada40-1c9e-4d2e-a346-f605edd2249d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cdb3164-e53a-40cc-91b6-d2767e5e032d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cdb3164-e53a-40cc-91b6-d2767e5e032d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/7e473ef8-0303-40c6-a1ca-03b70037da0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cdb3164-e53a-40cc-91b6-d2767e5e032d>.
+    
+<http://data.lblod.info/id/remote-data-objects/756a69f9-a65d-477a-b28a-2cdaeadf7144> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "756a69f9-a65d-477a-b28a-2cdaeadf7144";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/7ecda071-6bbf-4cc5-a57d-0cfbec1badcf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/756a69f9-a65d-477a-b28a-2cdaeadf7144>.
+    
+<http://data.lblod.info/id/remote-data-objects/125f365c-9ca3-413c-8cf8-66bc37239777> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "125f365c-9ca3-413c-8cf8-66bc37239777";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/8444dde7-7c54-4b5f-baa9-28974eeb98a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/125f365c-9ca3-413c-8cf8-66bc37239777>.
+    
+<http://data.lblod.info/id/remote-data-objects/44c1d868-0e43-43b6-9f99-eefc5e79e4d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44c1d868-0e43-43b6-9f99-eefc5e79e4d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/8c52b1bb-8539-4571-828f-facf01295bb1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44c1d868-0e43-43b6-9f99-eefc5e79e4d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b036e3a-28d9-44fd-8a80-65b35bb38cf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b036e3a-28d9-44fd-8a80-65b35bb38cf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/8c63683f-1a20-402b-ba4d-81901edd2f1e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b036e3a-28d9-44fd-8a80-65b35bb38cf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/610d3283-9989-4d67-8342-87a6fcedddba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "610d3283-9989-4d67-8342-87a6fcedddba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/9d8c3e5b-e5ed-4058-8393-fd1cbddd5246/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/610d3283-9989-4d67-8342-87a6fcedddba>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf5546e8-0932-47cc-96e1-0f8746f52bae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf5546e8-0932-47cc-96e1-0f8746f52bae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/9dd41899-6e61-4b76-9f7a-52815cfa2bc5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf5546e8-0932-47cc-96e1-0f8746f52bae>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3ef42cb-d860-407f-b040-5e733d6241ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3ef42cb-d860-407f-b040-5e733d6241ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/a091a1a8-df40-4df8-bdd4-ffcf7c9bfe3c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3ef42cb-d860-407f-b040-5e733d6241ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/737b8343-d53e-4926-b5b3-9dec823fed41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "737b8343-d53e-4926-b5b3-9dec823fed41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/a98447d8-af7c-4498-82c1-cbcb52522903/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/737b8343-d53e-4926-b5b3-9dec823fed41>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1a4ab6f-31a8-483a-9c90-629bf3d63212> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1a4ab6f-31a8-483a-9c90-629bf3d63212";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/adc776b8-0b14-4730-bde0-256a9def243d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1a4ab6f-31a8-483a-9c90-629bf3d63212>.
+    
+<http://data.lblod.info/id/remote-data-objects/90abd48b-d2e6-428b-b95b-0be745392742> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90abd48b-d2e6-428b-b95b-0be745392742";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/b337c196-cb0d-424a-843d-ee2daf0db998/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90abd48b-d2e6-428b-b95b-0be745392742>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0af39ae-ec8d-45f0-8755-fdeafcc468f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0af39ae-ec8d-45f0-8755-fdeafcc468f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/b56c28b7-e492-487c-90ec-df07a9e7c31e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0af39ae-ec8d-45f0-8755-fdeafcc468f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/9399ce2e-4b80-4251-a4e9-dc8ab0e51d4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9399ce2e-4b80-4251-a4e9-dc8ab0e51d4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/b9d225eb-5aa2-49ca-aa5d-da896ffb6d13/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9399ce2e-4b80-4251-a4e9-dc8ab0e51d4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c177589-50e6-4e3d-8be1-10ae1920effd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c177589-50e6-4e3d-8be1-10ae1920effd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/bacc120a-f576-48aa-acc3-bbbb22f943c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c177589-50e6-4e3d-8be1-10ae1920effd>.
+    
+<http://data.lblod.info/id/remote-data-objects/48a32308-900f-4f08-8a1e-6229fa681e0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48a32308-900f-4f08-8a1e-6229fa681e0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/c1be6612-6311-420d-9088-797abbf771db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48a32308-900f-4f08-8a1e-6229fa681e0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab3517fd-688f-4ef9-8372-41d5ff6c9231> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab3517fd-688f-4ef9-8372-41d5ff6c9231";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/cbe8e2bb-e2ee-45e4-95ff-e52e13065f1b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab3517fd-688f-4ef9-8372-41d5ff6c9231>.
+    
+<http://data.lblod.info/id/remote-data-objects/11aada23-b5ce-40db-ace2-0f076aa73edd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11aada23-b5ce-40db-ace2-0f076aa73edd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/cef0fde6-6e5b-4cfc-8cb8-e6c833d2fee3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11aada23-b5ce-40db-ace2-0f076aa73edd>.
+    
+<http://data.lblod.info/id/remote-data-objects/30da6a7f-04dc-4051-b546-8760cac21e61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30da6a7f-04dc-4051-b546-8760cac21e61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/cfea3613-af1c-49c0-a3d6-1a1e6fc900d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30da6a7f-04dc-4051-b546-8760cac21e61>.
+    
+<http://data.lblod.info/id/remote-data-objects/92c7a08b-65c8-464c-b373-00556adaec7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92c7a08b-65c8-464c-b373-00556adaec7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/d19c3130-a456-4f44-9317-728c2335a3cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92c7a08b-65c8-464c-b373-00556adaec7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/578db362-6619-4e1f-ac25-53dc280d6be1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "578db362-6619-4e1f-ac25-53dc280d6be1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/d58e7b6f-0dd8-49a3-b85d-6a84c8e34b2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/578db362-6619-4e1f-ac25-53dc280d6be1>.
+    
+<http://data.lblod.info/id/remote-data-objects/67ca8e9a-e468-4dab-8e5d-9854ca5ad501> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67ca8e9a-e468-4dab-8e5d-9854ca5ad501";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/d84e99cc-7067-439c-95dc-d57eea94cfc1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67ca8e9a-e468-4dab-8e5d-9854ca5ad501>.
+    
+<http://data.lblod.info/id/remote-data-objects/9517fe7e-8b50-4d94-b9df-0b964e8c3e16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9517fe7e-8b50-4d94-b9df-0b964e8c3e16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/dbe501c1-2539-42e2-b5a9-dd5b0b0a8fb4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9517fe7e-8b50-4d94-b9df-0b964e8c3e16>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ec31e0c-c218-4bd9-b0de-333aab30723f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ec31e0c-c218-4bd9-b0de-333aab30723f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/de77ef1b-e1fb-4dd4-8ed7-c86638d9fede/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ec31e0c-c218-4bd9-b0de-333aab30723f>.
+    
+<http://data.lblod.info/id/remote-data-objects/07663c85-c897-448e-bbac-6306ef53737d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07663c85-c897-448e-bbac-6306ef53737d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/e49f4320-0c4b-499c-87d0-089cb4480f33/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07663c85-c897-448e-bbac-6306ef53737d>.
+    
+<http://data.lblod.info/id/remote-data-objects/26f05b09-9ffa-495a-9002-1193abedb2bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26f05b09-9ffa-495a-9002-1193abedb2bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/e8e48aa5-5429-4f88-a472-4643f4183d40/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26f05b09-9ffa-495a-9002-1193abedb2bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc14627f-be4b-4423-ba5d-77bf2b199470> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc14627f-be4b-4423-ba5d-77bf2b199470";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/eab2e675-2735-49d3-9804-666476e38d7f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc14627f-be4b-4423-ba5d-77bf2b199470>.
+    
+<http://data.lblod.info/id/remote-data-objects/87d58a78-f4af-42e8-b504-5458d34dfca2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87d58a78-f4af-42e8-b504-5458d34dfca2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/f0bb1c8f-12d8-49b9-a441-6aa8b1acfed9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87d58a78-f4af-42e8-b504-5458d34dfca2>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc4acbb1-0fe3-456d-ae4d-3312d20e49d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc4acbb1-0fe3-456d-ae4d-3312d20e49d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/f13af942-12da-4bf6-aaac-c65e62276793/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc4acbb1-0fe3-456d-ae4d-3312d20e49d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/26691859-bd51-47d8-9e21-2e552e145943> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26691859-bd51-47d8-9e21-2e552e145943";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/f4cbeaab-f8f6-467f-abc1-6329ba1b5f23/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/408c2f83-403c-47cb-8494-e5f7abcbec94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26691859-bd51-47d8-9e21-2e552e145943>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201223-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201223-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201223-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201223-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e5f3886a-2cd5-460a-947e-f27116add954> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e5f3886a-2cd5-460a-947e-f27116add954";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d0740494-88fe-4305-85d7-ac985c479a5e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f0366bef-0971-453c-b0a1-e46406157fb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f0366bef-0971-453c-b0a1-e46406157fb4";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e>.
+
+  <http://redpencil.data.gift/id/task/b882b2ac-6b69-45fd-9ef8-1a7f6a3959d5> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b882b2ac-6b69-45fd-9ef8-1a7f6a3959d5";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e5f3886a-2cd5-460a-947e-f27116add954>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f0366bef-0971-453c-b0a1-e46406157fb4>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/938fccd8-3cb2-4d61-98c3-2d1a07f03a3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "938fccd8-3cb2-4d61-98c3-2d1a07f03a3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/f4e61c71-54ee-423c-b324-a0fab169adde/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/938fccd8-3cb2-4d61-98c3-2d1a07f03a3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b320eec-4533-4635-b994-17d5f3e25c39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b320eec-4533-4635-b994-17d5f3e25c39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/fa6ce197-ae9e-43c5-b92d-721456b4e712/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b320eec-4533-4635-b994-17d5f3e25c39>.
+    
+<http://data.lblod.info/id/remote-data-objects/d59eddd8-d37a-4f8b-8d04-781f08a5295b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d59eddd8-d37a-4f8b-8d04-781f08a5295b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kasterlee.meetingburger.net/vabu/fe183684-448f-4974-adce-1d16d6ecc567/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d59eddd8-d37a-4f8b-8d04-781f08a5295b>.
+    
+<http://data.lblod.info/id/remote-data-objects/55784d06-386c-4c4b-8261-51b3372f1dec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55784d06-386c-4c4b-8261-51b3372f1dec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/00a4cb4b-431d-4188-888e-7ced1594bf30/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55784d06-386c-4c4b-8261-51b3372f1dec>.
+    
+<http://data.lblod.info/id/remote-data-objects/365ae947-5278-4cae-b6c7-b729d97b43bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "365ae947-5278-4cae-b6c7-b729d97b43bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/06bc1000-c86c-480b-bf50-5f3f7c42ec15/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/365ae947-5278-4cae-b6c7-b729d97b43bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/fde859fe-2e77-418c-a3b4-4545a5f97619> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fde859fe-2e77-418c-a3b4-4545a5f97619";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/0796cd24-eb2c-4a58-9af4-2621c003d604/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fde859fe-2e77-418c-a3b4-4545a5f97619>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5968e13-d813-46d2-9737-d71f83c04932> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5968e13-d813-46d2-9737-d71f83c04932";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/172c10fa-a135-43a6-8e2c-c3a22039c93e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5968e13-d813-46d2-9737-d71f83c04932>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ffac311-6863-4b75-a075-f2cb6fb2a69d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ffac311-6863-4b75-a075-f2cb6fb2a69d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/18f1bd27-b6ff-47cf-a5ea-2cbccf182221/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ffac311-6863-4b75-a075-f2cb6fb2a69d>.
+    
+<http://data.lblod.info/id/remote-data-objects/356464a4-3158-4da0-a9fa-b566c76c4805> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "356464a4-3158-4da0-a9fa-b566c76c4805";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/1c249efb-39a9-4dc0-ace6-c5bbeb697dc9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/356464a4-3158-4da0-a9fa-b566c76c4805>.
+    
+<http://data.lblod.info/id/remote-data-objects/44f5d870-0bc0-4ba8-b3a5-69a674760f51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44f5d870-0bc0-4ba8-b3a5-69a674760f51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/2f20b8c5-105d-4e7d-81f4-e8665252b16c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44f5d870-0bc0-4ba8-b3a5-69a674760f51>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d56341d-7cb0-494a-868b-644d1c207d85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d56341d-7cb0-494a-868b-644d1c207d85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/39138530-05bb-422b-b8ed-7029f875d026/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d56341d-7cb0-494a-868b-644d1c207d85>.
+    
+<http://data.lblod.info/id/remote-data-objects/23ba995b-9750-40d0-bfb6-7350ecce47da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23ba995b-9750-40d0-bfb6-7350ecce47da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/6004e33b-cd20-44f6-8410-ca2bc65a6200/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23ba995b-9750-40d0-bfb6-7350ecce47da>.
+    
+<http://data.lblod.info/id/remote-data-objects/e933ff4b-c954-423b-bb51-c3dcc6dbb015> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e933ff4b-c954-423b-bb51-c3dcc6dbb015";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/60c56678-e72e-47a1-baf4-20c7e08a4fa2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e933ff4b-c954-423b-bb51-c3dcc6dbb015>.
+    
+<http://data.lblod.info/id/remote-data-objects/30920ded-119e-451b-9d9e-2cbe0dc047cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30920ded-119e-451b-9d9e-2cbe0dc047cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/6825a9d1-5fc4-4019-b57e-cb9cdc35a792/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30920ded-119e-451b-9d9e-2cbe0dc047cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce38e6eb-2d39-451a-b3e9-c6872d631979> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce38e6eb-2d39-451a-b3e9-c6872d631979";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/6e2fdd0a-499f-4a75-b864-235b31a1197b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce38e6eb-2d39-451a-b3e9-c6872d631979>.
+    
+<http://data.lblod.info/id/remote-data-objects/97ed8e1d-b750-4e09-8ff2-c084f8d7bbdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97ed8e1d-b750-4e09-8ff2-c084f8d7bbdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/6eada8e8-6fad-45ce-9f18-129e3979ddeb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97ed8e1d-b750-4e09-8ff2-c084f8d7bbdf>.
+    
+<http://data.lblod.info/id/remote-data-objects/048f2c12-64cd-4bf3-8606-e66121cdc654> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "048f2c12-64cd-4bf3-8606-e66121cdc654";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/79e67ef9-79dd-4ee6-ab9f-c79cb9a904cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/048f2c12-64cd-4bf3-8606-e66121cdc654>.
+    
+<http://data.lblod.info/id/remote-data-objects/efebecc0-f59c-4ae7-8c20-2b731caa3cac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efebecc0-f59c-4ae7-8c20-2b731caa3cac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/7c5e6e01-422d-4dcd-8f53-f3ba6c232d1c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efebecc0-f59c-4ae7-8c20-2b731caa3cac>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2e2ee48-237d-4b63-a152-5cbc3279426f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2e2ee48-237d-4b63-a152-5cbc3279426f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/7e092497-5ff5-41ed-95f9-54c6a5c512d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2e2ee48-237d-4b63-a152-5cbc3279426f>.
+    
+<http://data.lblod.info/id/remote-data-objects/25b5114b-9463-4c4d-923f-3c9469eb7154> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25b5114b-9463-4c4d-923f-3c9469eb7154";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/7e8fa716-9fc0-4a92-9850-5724f25550f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25b5114b-9463-4c4d-923f-3c9469eb7154>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a3f0ee6-b5c9-4afa-a894-d68e328dec15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a3f0ee6-b5c9-4afa-a894-d68e328dec15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/8188a6a3-addd-46f5-849d-93c323b61bff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a3f0ee6-b5c9-4afa-a894-d68e328dec15>.
+    
+<http://data.lblod.info/id/remote-data-objects/c96d3c18-4d5a-499f-90b5-71a4beb2c53b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c96d3c18-4d5a-499f-90b5-71a4beb2c53b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/a8e6164c-afe7-4ebd-9ddc-b5b18e5a815a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c96d3c18-4d5a-499f-90b5-71a4beb2c53b>.
+    
+<http://data.lblod.info/id/remote-data-objects/711b7dca-01a6-42c4-9a1f-98ac2ecbdcee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "711b7dca-01a6-42c4-9a1f-98ac2ecbdcee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/a91857fc-0c00-4d31-b2fd-900f67f0cca7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/711b7dca-01a6-42c4-9a1f-98ac2ecbdcee>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdea0433-7215-4f51-840d-39234205bf7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdea0433-7215-4f51-840d-39234205bf7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/aaf439c8-27d6-4843-a2c5-bc5b41950b16/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdea0433-7215-4f51-840d-39234205bf7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c72651a-ddab-44b1-b712-4ad6439b6752> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c72651a-ddab-44b1-b712-4ad6439b6752";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/ad74b26b-b86f-424e-b735-df3136423c31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c72651a-ddab-44b1-b712-4ad6439b6752>.
+    
+<http://data.lblod.info/id/remote-data-objects/8870cb20-ccf3-4bd7-91c5-8229232cbdf7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8870cb20-ccf3-4bd7-91c5-8229232cbdf7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/b80a0bdc-96c4-4849-b243-9aa65bbb5161/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8870cb20-ccf3-4bd7-91c5-8229232cbdf7>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbc27b00-60b4-4165-b4e0-601d16170d22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbc27b00-60b4-4165-b4e0-601d16170d22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/c0d2ecf8-1a94-4b09-9242-a5bc0a46595f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbc27b00-60b4-4165-b4e0-601d16170d22>.
+    
+<http://data.lblod.info/id/remote-data-objects/608eaa0b-49bb-4630-8101-385371759ce1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "608eaa0b-49bb-4630-8101-385371759ce1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/c14f0fd2-f8c0-45f0-aa79-0d6765027fcb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/608eaa0b-49bb-4630-8101-385371759ce1>.
+    
+<http://data.lblod.info/id/remote-data-objects/65f260ba-8b2e-405e-8ed9-c1ca0ae4c090> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65f260ba-8b2e-405e-8ed9-c1ca0ae4c090";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/c7b3f334-e33a-4b8d-8fb5-6e0ab9f4a886/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65f260ba-8b2e-405e-8ed9-c1ca0ae4c090>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ede1815-1c7b-472b-977d-488103b43b1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ede1815-1c7b-472b-977d-488103b43b1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/cb70e823-d07d-4fc0-ae1b-bf678e945cf6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ede1815-1c7b-472b-977d-488103b43b1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fce6516-9eb4-46a0-924f-245b1e50a031> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fce6516-9eb4-46a0-924f-245b1e50a031";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/cd16c65e-a70e-4ca8-bfc9-5ca599a277f8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fce6516-9eb4-46a0-924f-245b1e50a031>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8dc62d7-3ae6-414c-8fc4-b0a709df4475> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8dc62d7-3ae6-414c-8fc4-b0a709df4475";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/d0af1ae5-4226-4d10-a7f3-1ac2b44bfd45/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8dc62d7-3ae6-414c-8fc4-b0a709df4475>.
+    
+<http://data.lblod.info/id/remote-data-objects/7579201c-88bd-4d8b-ba1b-3d7a75671a4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7579201c-88bd-4d8b-ba1b-3d7a75671a4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/dd600d19-5495-4c80-855b-82430a0b04be/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7579201c-88bd-4d8b-ba1b-3d7a75671a4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7861be6b-9309-4345-8cfb-d0af174570e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7861be6b-9309-4345-8cfb-d0af174570e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/dffdcf5f-b4a6-49ae-9398-c1437bdf8a71/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7861be6b-9309-4345-8cfb-d0af174570e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ff3151d-f0e0-4260-b900-dca88c015373> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ff3151d-f0e0-4260-b900-dca88c015373";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/e8f864ba-9bbf-40b3-aa07-7562b480e5dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ff3151d-f0e0-4260-b900-dca88c015373>.
+    
+<http://data.lblod.info/id/remote-data-objects/531e06c1-7fba-4555-9d78-e73595035b68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "531e06c1-7fba-4555-9d78-e73595035b68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/e96ad4e8-42da-4f34-adcc-3c148e229f4f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/531e06c1-7fba-4555-9d78-e73595035b68>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b5f8603-950a-4588-98c0-77fe7882ac94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b5f8603-950a-4588-98c0-77fe7882ac94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/ebadbc49-5c39-4a00-81e5-06dbd39028b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b5f8603-950a-4588-98c0-77fe7882ac94>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ad896c1-10ea-4507-a163-c3e61f3b5742> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ad896c1-10ea-4507-a163-c3e61f3b5742";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/f467c881-8ffd-46b8-b10b-0d9eac6771f5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ad896c1-10ea-4507-a163-c3e61f3b5742>.
+    
+<http://data.lblod.info/id/remote-data-objects/b390d807-4493-4e57-86b5-ffe642f25258> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b390d807-4493-4e57-86b5-ffe642f25258";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/f484d16c-d041-47b3-9caf-898810eaa64a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b390d807-4493-4e57-86b5-ffe642f25258>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ac36438-49de-4950-ad90-cc50af47b849> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ac36438-49de-4950-ad90-cc50af47b849";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/f8132168-af84-4e62-9f92-3de6b526b976/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ac36438-49de-4950-ad90-cc50af47b849>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cc7185b-2307-49ec-8fb7-12f6df2dde62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cc7185b-2307-49ec-8fb7-12f6df2dde62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/cbs/fc6a2d17-e19f-41e0-8b49-97220454a51e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cc7185b-2307-49ec-8fb7-12f6df2dde62>.
+    
+<http://data.lblod.info/id/remote-data-objects/28f69690-832d-4c84-b05c-4c9eeddbabe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28f69690-832d-4c84-b05c-4c9eeddbabe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/04b601b9-fcf8-4efe-8a74-cce88628928d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28f69690-832d-4c84-b05c-4c9eeddbabe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1000a758-b301-4480-91a4-318663f83832> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1000a758-b301-4480-91a4-318663f83832";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/04b601b9-fcf8-4efe-8a74-cce88628928d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1000a758-b301-4480-91a4-318663f83832>.
+    
+<http://data.lblod.info/id/remote-data-objects/822fbd6d-ea88-4a83-ac0c-8977d2a63fff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "822fbd6d-ea88-4a83-ac0c-8977d2a63fff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/1b08f7ca-bdd5-4b9a-80fa-04527b354a2a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/822fbd6d-ea88-4a83-ac0c-8977d2a63fff>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d27c591-a418-4340-9898-5517096789ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d27c591-a418-4340-9898-5517096789ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/1b08f7ca-bdd5-4b9a-80fa-04527b354a2a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d27c591-a418-4340-9898-5517096789ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/4867672d-265a-42e0-bcf7-a51f8e49b67d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4867672d-265a-42e0-bcf7-a51f8e49b67d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/2bb0d622-cdce-4d9c-a9d1-fb70e5c408a3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4867672d-265a-42e0-bcf7-a51f8e49b67d>.
+    
+<http://data.lblod.info/id/remote-data-objects/609f4224-31a2-424c-bae2-4b76ed4af3f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "609f4224-31a2-424c-bae2-4b76ed4af3f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/2bb0d622-cdce-4d9c-a9d1-fb70e5c408a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/609f4224-31a2-424c-bae2-4b76ed4af3f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/40ad54fd-d0be-4483-bc1c-8d9f30664117> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40ad54fd-d0be-4483-bc1c-8d9f30664117";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/5a134783-638c-461d-8db1-f9e434c7842e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40ad54fd-d0be-4483-bc1c-8d9f30664117>.
+    
+<http://data.lblod.info/id/remote-data-objects/3034e49a-852c-4cfd-86e4-3aa1dda6ad81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3034e49a-852c-4cfd-86e4-3aa1dda6ad81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/5a134783-638c-461d-8db1-f9e434c7842e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3034e49a-852c-4cfd-86e4-3aa1dda6ad81>.
+    
+<http://data.lblod.info/id/remote-data-objects/c801adaa-3352-4e5d-9aa4-49ebf24c1253> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c801adaa-3352-4e5d-9aa4-49ebf24c1253";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/6db81f6f-f2a3-48e7-9246-33dce76eae7c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0740494-88fe-4305-85d7-ac985c479a5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c801adaa-3352-4e5d-9aa4-49ebf24c1253>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201224-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201224-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201224-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201224-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d4b8e84f-7e5d-4ede-95ee-20b191fc6eef> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d4b8e84f-7e5d-4ede-95ee-20b191fc6eef";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "42d32230-52b4-4f99-ae9f-a7014e7c4211";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/dbd332c1-cd1c-483f-8ed5-6b8fd2c0e2ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dbd332c1-cd1c-483f-8ed5-6b8fd2c0e2ce";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211>.
+
+  <http://redpencil.data.gift/id/task/59be41a8-42f8-425c-8ef2-126dc046e9ef> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "59be41a8-42f8-425c-8ef2-126dc046e9ef";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d4b8e84f-7e5d-4ede-95ee-20b191fc6eef>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/dbd332c1-cd1c-483f-8ed5-6b8fd2c0e2ce>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c37e1865-77e0-4443-86ec-36724668e43a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c37e1865-77e0-4443-86ec-36724668e43a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/6db81f6f-f2a3-48e7-9246-33dce76eae7c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c37e1865-77e0-4443-86ec-36724668e43a>.
+    
+<http://data.lblod.info/id/remote-data-objects/965a8189-4d97-473f-bdfe-d04b5492b0af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "965a8189-4d97-473f-bdfe-d04b5492b0af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/72cdb984-732c-4810-b106-41ba2011dfa2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/965a8189-4d97-473f-bdfe-d04b5492b0af>.
+    
+<http://data.lblod.info/id/remote-data-objects/237e27fc-dd6f-4613-8209-87a41ac545b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "237e27fc-dd6f-4613-8209-87a41ac545b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/72cdb984-732c-4810-b106-41ba2011dfa2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/237e27fc-dd6f-4613-8209-87a41ac545b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbbd7d42-fc34-4c93-beeb-3f91233870fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbbd7d42-fc34-4c93-beeb-3f91233870fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/a17b339e-f855-4f43-a5ff-eceb1fc103ee/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbbd7d42-fc34-4c93-beeb-3f91233870fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc14e3ea-8ef4-46cd-8096-6e31b5f226c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc14e3ea-8ef4-46cd-8096-6e31b5f226c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/a17b339e-f855-4f43-a5ff-eceb1fc103ee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc14e3ea-8ef4-46cd-8096-6e31b5f226c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ead3dd0-03b3-46e0-94b6-7e6bff009c95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ead3dd0-03b3-46e0-94b6-7e6bff009c95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/cb4d8c49-1f72-4250-8a75-dff498ac45e2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ead3dd0-03b3-46e0-94b6-7e6bff009c95>.
+    
+<http://data.lblod.info/id/remote-data-objects/48222988-a7a0-446f-b2f0-7a2b8904c25c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48222988-a7a0-446f-b2f0-7a2b8904c25c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/cb4d8c49-1f72-4250-8a75-dff498ac45e2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48222988-a7a0-446f-b2f0-7a2b8904c25c>.
+    
+<http://data.lblod.info/id/remote-data-objects/38a2798f-89b1-4fa7-a2e4-2d13f4d803e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38a2798f-89b1-4fa7-a2e4-2d13f4d803e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/cbf2e578-abe5-4392-8315-72fa428f4b34/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38a2798f-89b1-4fa7-a2e4-2d13f4d803e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/01d12c9d-fe1c-4318-8e3d-c9bb237ecd8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01d12c9d-fe1c-4318-8e3d-c9bb237ecd8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/gr/cbf2e578-abe5-4392-8315-72fa428f4b34/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01d12c9d-fe1c-4318-8e3d-c9bb237ecd8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0541d96d-09d4-4275-8ece-945bb7e9a80b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0541d96d-09d4-4275-8ece-945bb7e9a80b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rmw/3fa76a33-4c98-4c4a-95dd-c1cc460cfd81/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0541d96d-09d4-4275-8ece-945bb7e9a80b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1356ac6-ba4c-43f5-b39b-4f5c067588b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1356ac6-ba4c-43f5-b39b-4f5c067588b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rmw/3fa76a33-4c98-4c4a-95dd-c1cc460cfd81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1356ac6-ba4c-43f5-b39b-4f5c067588b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9656387b-6bc5-47f4-847d-de85a3d201a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9656387b-6bc5-47f4-847d-de85a3d201a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rmw/456b0edf-3d72-4236-807f-16664de42f60/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9656387b-6bc5-47f4-847d-de85a3d201a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a7eef2a-44f3-4d5e-8b61-ee53c1107a0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a7eef2a-44f3-4d5e-8b61-ee53c1107a0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rmw/456b0edf-3d72-4236-807f-16664de42f60/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a7eef2a-44f3-4d5e-8b61-ee53c1107a0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4389384c-231c-4fbc-b70a-736788d09f17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4389384c-231c-4fbc-b70a-736788d09f17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rmw/50881c95-f3e0-4ae0-bbd9-b43a840af945/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4389384c-231c-4fbc-b70a-736788d09f17>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1f8369c-f753-4f0d-9e52-4cf5c7c17c7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1f8369c-f753-4f0d-9e52-4cf5c7c17c7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rmw/50881c95-f3e0-4ae0-bbd9-b43a840af945/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1f8369c-f753-4f0d-9e52-4cf5c7c17c7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/809da352-f261-4d02-8cca-835531b3b540> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "809da352-f261-4d02-8cca-835531b3b540";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rmw/795c6d84-299c-4e47-a352-2c247c596d1b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/809da352-f261-4d02-8cca-835531b3b540>.
+    
+<http://data.lblod.info/id/remote-data-objects/c04874df-37f3-4e5e-98a6-a9368b6b5534> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c04874df-37f3-4e5e-98a6-a9368b6b5534";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rmw/795c6d84-299c-4e47-a352-2c247c596d1b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c04874df-37f3-4e5e-98a6-a9368b6b5534>.
+    
+<http://data.lblod.info/id/remote-data-objects/604b156e-8add-4297-b37a-ae4498e7a48c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "604b156e-8add-4297-b37a-ae4498e7a48c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rmw/894aff0d-9dd6-44b3-8cc7-1c0cd8a3c57e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/604b156e-8add-4297-b37a-ae4498e7a48c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a135985a-7a5b-4c33-92e9-448630df7583> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a135985a-7a5b-4c33-92e9-448630df7583";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rmw/894aff0d-9dd6-44b3-8cc7-1c0cd8a3c57e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a135985a-7a5b-4c33-92e9-448630df7583>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0f72fcd-30ed-4427-bb7f-314e6a89abc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0f72fcd-30ed-4427-bb7f-314e6a89abc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rmw/d10e88f4-2639-49e0-8621-adaf6e9d5b2e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0f72fcd-30ed-4427-bb7f-314e6a89abc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef74c45e-ace7-4b07-9333-c00ba0e09e70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef74c45e-ace7-4b07-9333-c00ba0e09e70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rmw/d10e88f4-2639-49e0-8621-adaf6e9d5b2e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef74c45e-ace7-4b07-9333-c00ba0e09e70>.
+    
+<http://data.lblod.info/id/remote-data-objects/d19b2c7a-de6c-43f5-96a3-4eb64f9062a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d19b2c7a-de6c-43f5-96a3-4eb64f9062a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rmw/e7b9183e-fa92-4eb2-8acd-33c3c32e2295/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d19b2c7a-de6c-43f5-96a3-4eb64f9062a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/628b9aab-e3a8-4492-b073-44bb47607588> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "628b9aab-e3a8-4492-b073-44bb47607588";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rmw/e7b9183e-fa92-4eb2-8acd-33c3c32e2295/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/628b9aab-e3a8-4492-b073-44bb47607588>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb4f56c5-186b-40f6-9c2d-f68860d93a8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb4f56c5-186b-40f6-9c2d-f68860d93a8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rmw/ebac3e79-138d-4a33-bb96-907640a5b91d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb4f56c5-186b-40f6-9c2d-f68860d93a8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/80bf8e9f-9773-4cd9-9419-f3c1d5bd2ef4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80bf8e9f-9773-4cd9-9419-f3c1d5bd2ef4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rmw/ebac3e79-138d-4a33-bb96-907640a5b91d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80bf8e9f-9773-4cd9-9419-f3c1d5bd2ef4>.
+    
+<http://data.lblod.info/id/remote-data-objects/46ab6505-840e-46fd-81f9-339173578835> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46ab6505-840e-46fd-81f9-339173578835";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rvb/1e8131a2-296d-4e49-a142-19f9415988fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46ab6505-840e-46fd-81f9-339173578835>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b63629d-002e-4c97-bd98-ebc899ba48f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b63629d-002e-4c97-bd98-ebc899ba48f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rvb/4bfb4aa6-e44c-4ea3-8950-1685b40e8b90/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b63629d-002e-4c97-bd98-ebc899ba48f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb261df2-e2ee-43a9-bde7-aa88fdb01690> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb261df2-e2ee-43a9-bde7-aa88fdb01690";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rvb/5ca04052-72bd-485a-934d-b83d91fe07bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb261df2-e2ee-43a9-bde7-aa88fdb01690>.
+    
+<http://data.lblod.info/id/remote-data-objects/29cdc11f-1cd4-4a3d-90ed-cd20c3d929d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29cdc11f-1cd4-4a3d-90ed-cd20c3d929d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rvb/cc29fc09-6c80-4946-842e-90897b43010c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29cdc11f-1cd4-4a3d-90ed-cd20c3d929d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9e47f04-2687-4ad6-9312-80016bab10dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9e47f04-2687-4ad6-9312-80016bab10dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/rvb/e5ac9d94-06a2-4e74-acd3-018187cf8c46/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9e47f04-2687-4ad6-9312-80016bab10dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/18acd298-d99c-4459-9f39-4c6c1900f5f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18acd298-d99c-4459-9f39-4c6c1900f5f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/27894ad5-0d5c-442b-ba9f-fc6959578ad0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18acd298-d99c-4459-9f39-4c6c1900f5f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6db925c-ff1b-4f2b-a31b-06a1d46c441e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6db925c-ff1b-4f2b-a31b-06a1d46c441e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/296d28dc-98f3-45f9-94c8-293440c3b6f0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6db925c-ff1b-4f2b-a31b-06a1d46c441e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9b55457-45cd-4035-99e0-ca169f730dc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9b55457-45cd-4035-99e0-ca169f730dc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/3283f219-0052-4ee6-b84d-0e4e640ace8f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9b55457-45cd-4035-99e0-ca169f730dc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/be7102bb-8cbf-466b-aeb8-c4a47f280c4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be7102bb-8cbf-466b-aeb8-c4a47f280c4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/34c17644-1170-45ed-9443-9dd0ab73ceaf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be7102bb-8cbf-466b-aeb8-c4a47f280c4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5eac07b4-21f3-4998-a9b6-66df3625b659> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5eac07b4-21f3-4998-a9b6-66df3625b659";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/3c00a6c2-132e-4f01-8515-af5ebca56871/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5eac07b4-21f3-4998-a9b6-66df3625b659>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa877c38-9f7a-44c4-af92-c8df78e12151> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa877c38-9f7a-44c4-af92-c8df78e12151";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/5662ed5c-c049-4897-905b-f6aac41eb1b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa877c38-9f7a-44c4-af92-c8df78e12151>.
+    
+<http://data.lblod.info/id/remote-data-objects/5047a095-c93b-4113-a8ab-8c8e65ec2af8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5047a095-c93b-4113-a8ab-8c8e65ec2af8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/56eacaa6-b614-4b27-aac8-d730ebc37c24/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5047a095-c93b-4113-a8ab-8c8e65ec2af8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b829decf-1dd3-4dda-9a4e-931378ec0f64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b829decf-1dd3-4dda-9a4e-931378ec0f64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/59d08992-953e-4a5c-ac90-40f40d00f0ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b829decf-1dd3-4dda-9a4e-931378ec0f64>.
+    
+<http://data.lblod.info/id/remote-data-objects/97b2511b-e8b8-4073-a8db-0c78b9a20035> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97b2511b-e8b8-4073-a8db-0c78b9a20035";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/69254827-3e3f-42f1-a640-e5a97c4bd795/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97b2511b-e8b8-4073-a8db-0c78b9a20035>.
+    
+<http://data.lblod.info/id/remote-data-objects/85394142-86c7-41be-830c-c0345015d9e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85394142-86c7-41be-830c-c0345015d9e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/6daf6973-3857-4e2e-8fea-3f6791c3494c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85394142-86c7-41be-830c-c0345015d9e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/37f0719d-93fa-4869-abb6-6af9a79462ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37f0719d-93fa-4869-abb6-6af9a79462ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/7125c13d-2d09-46e9-88e7-92e7bdfa5222/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37f0719d-93fa-4869-abb6-6af9a79462ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8b94436-733d-421d-a8f4-ba7125124656> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8b94436-733d-421d-a8f4-ba7125124656";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/88f5e257-d3ea-4c44-8c77-3c47972e5e2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8b94436-733d-421d-a8f4-ba7125124656>.
+    
+<http://data.lblod.info/id/remote-data-objects/cad33747-382b-413a-9bfa-c5d0b485fa3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cad33747-382b-413a-9bfa-c5d0b485fa3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/8c92039d-568b-45bc-af47-ab905440a411/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cad33747-382b-413a-9bfa-c5d0b485fa3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f18487b9-55f9-4ada-bb25-083a88d1ece8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f18487b9-55f9-4ada-bb25-083a88d1ece8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/adfac2a0-d5af-4648-9f52-eb328381ea4a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f18487b9-55f9-4ada-bb25-083a88d1ece8>.
+    
+<http://data.lblod.info/id/remote-data-objects/90114661-e018-40c7-a9f6-c1d48d5f6d72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90114661-e018-40c7-a9f6-c1d48d5f6d72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/b2e6c2b9-4e19-4fc2-957f-8c6b10f6d483/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90114661-e018-40c7-a9f6-c1d48d5f6d72>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d0b65bc-c45c-43fa-ace4-10b2c9e1abc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d0b65bc-c45c-43fa-ace4-10b2c9e1abc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/c5e60e7c-e18d-454b-92f8-6275bf75dc86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d0b65bc-c45c-43fa-ace4-10b2c9e1abc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e308e2b7-eccb-42af-983a-86f8b4fbe698> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e308e2b7-eccb-42af-983a-86f8b4fbe698";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/c6aa4135-3827-49f8-9888-ce4dc4485c0e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e308e2b7-eccb-42af-983a-86f8b4fbe698>.
+    
+<http://data.lblod.info/id/remote-data-objects/96f78c7a-2ff5-4ca8-8f14-10701cb1ffd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96f78c7a-2ff5-4ca8-8f14-10701cb1ffd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/d8a9e773-e951-460c-a8a4-fecea8ea36cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96f78c7a-2ff5-4ca8-8f14-10701cb1ffd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f199da91-8668-4cd7-af40-e9ff77c33650> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f199da91-8668-4cd7-af40-e9ff77c33650";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/e5d4d85f-3bf4-4b3f-97b9-ff7a07ca6c07/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f199da91-8668-4cd7-af40-e9ff77c33650>.
+    
+<http://data.lblod.info/id/remote-data-objects/e54b9f6b-3b77-4912-a5ce-eeadcdc2b83d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e54b9f6b-3b77-4912-a5ce-eeadcdc2b83d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://keerbergen.meetingburger.net/vabu/ffa04d27-1532-4cf1-998a-24876f657f9c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42d32230-52b4-4f99-ae9f-a7014e7c4211> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e54b9f6b-3b77-4912-a5ce-eeadcdc2b83d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201225-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201225-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201225-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201225-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/da03829b-c17f-45fb-a3d1-c88f83d7ee8f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "da03829b-c17f-45fb-a3d1-c88f83d7ee8f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4a79b16f-5602-4051-9f38-36bc6fffe269";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e0953b7b-9b19-4284-932a-f13b2ffc72dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e0953b7b-9b19-4284-932a-f13b2ffc72dd";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269>.
+
+  <http://redpencil.data.gift/id/task/01b1a348-342e-4076-ad37-9c17f3a4e1bf> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "01b1a348-342e-4076-ad37-9c17f3a4e1bf";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/da03829b-c17f-45fb-a3d1-c88f83d7ee8f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e0953b7b-9b19-4284-932a-f13b2ffc72dd>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/8c86ddb7-ea06-4390-9f66-caae81503c93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c86ddb7-ea06-4390-9f66-caae81503c93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/012f2b52-c34a-4b20-8e03-4e7fa6da1793/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c86ddb7-ea06-4390-9f66-caae81503c93>.
+    
+<http://data.lblod.info/id/remote-data-objects/40fad4d3-2ca8-4644-b0fa-5f3e464e94d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40fad4d3-2ca8-4644-b0fa-5f3e464e94d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/03a3a97d-34e5-4258-8bd5-4c112e2d27d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40fad4d3-2ca8-4644-b0fa-5f3e464e94d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/52236ad0-250f-4acb-af01-fe7fc6c44d0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52236ad0-250f-4acb-af01-fe7fc6c44d0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/0abfc1b3-778c-4d59-9949-5eae73675cf4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52236ad0-250f-4acb-af01-fe7fc6c44d0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a08c26ec-4cd0-41c7-aeed-5d564a5e423c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a08c26ec-4cd0-41c7-aeed-5d564a5e423c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/0da5f3fb-b2cf-4531-9695-9f5c86f8e5f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a08c26ec-4cd0-41c7-aeed-5d564a5e423c>.
+    
+<http://data.lblod.info/id/remote-data-objects/da616959-123b-40b3-bfa1-8f8e0f847db2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da616959-123b-40b3-bfa1-8f8e0f847db2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/115e8197-7a55-43dd-bcfd-7324e61f3bda/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da616959-123b-40b3-bfa1-8f8e0f847db2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0714d48-5ac5-4b3a-a83e-d4468e3a4f46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0714d48-5ac5-4b3a-a83e-d4468e3a4f46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/1833ec8d-53b1-4900-b112-c4122621c8ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0714d48-5ac5-4b3a-a83e-d4468e3a4f46>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ff47ae3-0477-4ebc-91d2-7e5cc9dfc5a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ff47ae3-0477-4ebc-91d2-7e5cc9dfc5a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/18a8de76-6386-46f9-987b-23d3e0501f0a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ff47ae3-0477-4ebc-91d2-7e5cc9dfc5a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b6310c7-b194-42b5-8cbe-9a23fb6b954f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b6310c7-b194-42b5-8cbe-9a23fb6b954f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/1ea93312-793d-486b-bd53-8a5752855b81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b6310c7-b194-42b5-8cbe-9a23fb6b954f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9d04e02-6564-463e-95fe-d4fd32ce1379> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9d04e02-6564-463e-95fe-d4fd32ce1379";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/2db10820-0c85-4e07-8452-0a992d577852/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9d04e02-6564-463e-95fe-d4fd32ce1379>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcbb9f96-3804-40d5-8b83-1bf08176ceef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcbb9f96-3804-40d5-8b83-1bf08176ceef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/36d63e31-ae38-4bb4-bb6b-27f77cbff1a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcbb9f96-3804-40d5-8b83-1bf08176ceef>.
+    
+<http://data.lblod.info/id/remote-data-objects/76d8bb53-cfe0-4874-bbd4-52dddbc8069b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76d8bb53-cfe0-4874-bbd4-52dddbc8069b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/38552f5a-e060-4c75-a9e9-f0be33a20544/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76d8bb53-cfe0-4874-bbd4-52dddbc8069b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e78f5ee3-cf49-4c19-a102-71c85b1ed6b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e78f5ee3-cf49-4c19-a102-71c85b1ed6b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/465a1b1c-2fe4-4002-a9d2-7d984c979e24/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e78f5ee3-cf49-4c19-a102-71c85b1ed6b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/719599e2-2680-4fc0-896d-0ee3d9576327> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "719599e2-2680-4fc0-896d-0ee3d9576327";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/4694da8b-dbf5-4a9a-97f6-24ef6182de74/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/719599e2-2680-4fc0-896d-0ee3d9576327>.
+    
+<http://data.lblod.info/id/remote-data-objects/cda3637a-bf07-4022-a308-f93e55f9d6d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cda3637a-bf07-4022-a308-f93e55f9d6d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/475b29b9-c677-46ad-93db-7e6a7d0ada69/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cda3637a-bf07-4022-a308-f93e55f9d6d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7afe6a9-c1f0-4899-801d-fa88f62d3541> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7afe6a9-c1f0-4899-801d-fa88f62d3541";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/4cf852d3-045c-417d-8599-46768b2e4dbf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7afe6a9-c1f0-4899-801d-fa88f62d3541>.
+    
+<http://data.lblod.info/id/remote-data-objects/393da5e5-b63a-44ad-aa4c-cad5cc821c1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "393da5e5-b63a-44ad-aa4c-cad5cc821c1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/54674dfe-fcac-4018-928d-29e4e5289bbb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/393da5e5-b63a-44ad-aa4c-cad5cc821c1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee1b1c08-b3f5-4175-b68e-3ae07eea0e46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee1b1c08-b3f5-4175-b68e-3ae07eea0e46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/610b526b-8db4-451f-a3ba-6397ef05aaf1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee1b1c08-b3f5-4175-b68e-3ae07eea0e46>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c6d48f7-b235-470c-9c5f-4fedd07baef8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c6d48f7-b235-470c-9c5f-4fedd07baef8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/685ef95d-e964-4406-bfa5-92f913946498/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c6d48f7-b235-470c-9c5f-4fedd07baef8>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c15f8c9-05ed-4b96-9266-81241bb786c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c15f8c9-05ed-4b96-9266-81241bb786c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/6d7506d7-d772-4b6b-8043-6c1300cecedc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c15f8c9-05ed-4b96-9266-81241bb786c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6ec079d-089f-43d4-a35c-928a94a76cd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6ec079d-089f-43d4-a35c-928a94a76cd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/75f09477-0b4b-489c-88b7-8316d4a79ba6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6ec079d-089f-43d4-a35c-928a94a76cd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/017ace0e-fab3-4e09-97cc-e03eafa8e2b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "017ace0e-fab3-4e09-97cc-e03eafa8e2b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/792841a2-07e4-4bd3-b64b-d9e6b43a54a0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/017ace0e-fab3-4e09-97cc-e03eafa8e2b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2fbd80d-7e57-41a3-8777-18ecd0bd6c52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2fbd80d-7e57-41a3-8777-18ecd0bd6c52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/7dd35a31-0de4-4cdd-92a4-5fa5a240f0af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2fbd80d-7e57-41a3-8777-18ecd0bd6c52>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4033377-4b2d-45a2-827b-720e17c0ae62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4033377-4b2d-45a2-827b-720e17c0ae62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/7f6f93d2-a882-4ec6-8db4-3524bc228aa1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4033377-4b2d-45a2-827b-720e17c0ae62>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f9a9879-fd7a-4416-92a8-4060a11e66e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f9a9879-fd7a-4416-92a8-4060a11e66e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/7fc2a100-7bf2-4261-ba15-cca1aca4bb0c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f9a9879-fd7a-4416-92a8-4060a11e66e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfa8d809-3a83-48a2-b34a-1addc05f8835> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfa8d809-3a83-48a2-b34a-1addc05f8835";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/82311b1f-40d7-4860-8c66-67fadd3dffb9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfa8d809-3a83-48a2-b34a-1addc05f8835>.
+    
+<http://data.lblod.info/id/remote-data-objects/002727d5-8db3-4b7e-9652-2e0c9b3d4aea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "002727d5-8db3-4b7e-9652-2e0c9b3d4aea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/8879aa91-d514-4a66-b895-850b11d7db03/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/002727d5-8db3-4b7e-9652-2e0c9b3d4aea>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebc1483a-9aec-425e-8f1a-4884aab3ed2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebc1483a-9aec-425e-8f1a-4884aab3ed2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/a0d2d0a7-ab65-4c09-9f74-4037025c47bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebc1483a-9aec-425e-8f1a-4884aab3ed2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/eac6ff0e-314c-4614-8100-4e577c2b224c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eac6ff0e-314c-4614-8100-4e577c2b224c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/a9c2d501-20d0-44cb-b905-f7e6e90a397f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eac6ff0e-314c-4614-8100-4e577c2b224c>.
+    
+<http://data.lblod.info/id/remote-data-objects/13913546-7608-46e3-9068-b431bd179823> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13913546-7608-46e3-9068-b431bd179823";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/ab9c6175-4e1a-4c10-969f-a006fc5e878d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13913546-7608-46e3-9068-b431bd179823>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a41e299-6ba1-44c2-a063-411fd45e6367> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a41e299-6ba1-44c2-a063-411fd45e6367";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/ac65a08c-d46d-46ea-b285-634fdddd74e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a41e299-6ba1-44c2-a063-411fd45e6367>.
+    
+<http://data.lblod.info/id/remote-data-objects/543aa318-3f2c-40cd-8679-f73d2bf9f0c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "543aa318-3f2c-40cd-8679-f73d2bf9f0c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/ae9547c7-2fa5-4823-b8ee-1245e098f906/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/543aa318-3f2c-40cd-8679-f73d2bf9f0c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee2b25b3-f2a8-4db4-9687-9883cc981155> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee2b25b3-f2a8-4db4-9687-9883cc981155";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/aeec6242-98e0-4f8a-9160-4ee3361feb58/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee2b25b3-f2a8-4db4-9687-9883cc981155>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3971370-f498-45f2-ba83-bb717ebcff98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3971370-f498-45f2-ba83-bb717ebcff98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/b1a8ba96-f70e-4845-a345-5568aaa29989/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3971370-f498-45f2-ba83-bb717ebcff98>.
+    
+<http://data.lblod.info/id/remote-data-objects/07309867-fc75-4ad4-be80-343f8c857f1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07309867-fc75-4ad4-be80-343f8c857f1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/b62b4973-63e3-4020-9d68-2c030db6aba5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07309867-fc75-4ad4-be80-343f8c857f1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7b5ee65-d6c8-44c4-9c12-3a4c88fce73f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7b5ee65-d6c8-44c4-9c12-3a4c88fce73f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/be40b6d5-a119-4feb-8b5e-082a5baa29ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7b5ee65-d6c8-44c4-9c12-3a4c88fce73f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3bd7f1e-f389-4569-87b7-f961832e3c24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3bd7f1e-f389-4569-87b7-f961832e3c24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/c55ae6ba-e7df-472f-b438-f9c48b8d4222/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3bd7f1e-f389-4569-87b7-f961832e3c24>.
+    
+<http://data.lblod.info/id/remote-data-objects/10f8e7a1-d1fb-42a8-a5fc-eb0941c8d277> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10f8e7a1-d1fb-42a8-a5fc-eb0941c8d277";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/d3f4c39a-67e9-429c-8938-e89205f99fa1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10f8e7a1-d1fb-42a8-a5fc-eb0941c8d277>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ec9c1c6-6983-4963-8379-182e8030d4e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ec9c1c6-6983-4963-8379-182e8030d4e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/dda751b6-c61b-475b-8bf7-112db9699033/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ec9c1c6-6983-4963-8379-182e8030d4e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e63b64ba-737d-40bd-a3fe-0529676963b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e63b64ba-737d-40bd-a3fe-0529676963b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/df63e65a-029b-4a18-9558-12c13ca16bd4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e63b64ba-737d-40bd-a3fe-0529676963b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d206c9ad-941a-4fca-b760-0d7fad2473c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d206c9ad-941a-4fca-b760-0d7fad2473c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/e40b8205-86ad-4f76-9b84-c9fc2f5a536d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d206c9ad-941a-4fca-b760-0d7fad2473c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/418271a2-5ff7-4a0a-adfa-18840409bae7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "418271a2-5ff7-4a0a-adfa-18840409bae7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/f44f3d1b-7f0b-433b-bb5e-d456f3137e60/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/418271a2-5ff7-4a0a-adfa-18840409bae7>.
+    
+<http://data.lblod.info/id/remote-data-objects/40a51ba5-6b30-48b8-a0fc-0563999c079e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40a51ba5-6b30-48b8-a0fc-0563999c079e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/cbs/f951fa58-1c3a-4a3f-9f61-93f17a73a377/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40a51ba5-6b30-48b8-a0fc-0563999c079e>.
+    
+<http://data.lblod.info/id/remote-data-objects/11c0baeb-5c8e-4aae-b912-ab2e39d75ef7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11c0baeb-5c8e-4aae-b912-ab2e39d75ef7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/0cc2b8f9-d20e-404f-a770-681537cde0e0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11c0baeb-5c8e-4aae-b912-ab2e39d75ef7>.
+    
+<http://data.lblod.info/id/remote-data-objects/20ffafea-4f31-4c8e-8220-c655150f96b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20ffafea-4f31-4c8e-8220-c655150f96b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/0cc2b8f9-d20e-404f-a770-681537cde0e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20ffafea-4f31-4c8e-8220-c655150f96b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4c7e3fa-0e0c-4b92-8183-ed4a770c2023> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4c7e3fa-0e0c-4b92-8183-ed4a770c2023";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/270db024-4a83-4fdc-8b4c-b04b4157c602/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4c7e3fa-0e0c-4b92-8183-ed4a770c2023>.
+    
+<http://data.lblod.info/id/remote-data-objects/24c32d45-e4e0-4920-99c2-562cca9de495> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24c32d45-e4e0-4920-99c2-562cca9de495";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/270db024-4a83-4fdc-8b4c-b04b4157c602/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24c32d45-e4e0-4920-99c2-562cca9de495>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5e73a0d-d82f-4aa0-9a2a-f591da73b9f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5e73a0d-d82f-4aa0-9a2a-f591da73b9f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/270db024-4a83-4fdc-8b4c-b04b4157c602/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5e73a0d-d82f-4aa0-9a2a-f591da73b9f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d814473b-1387-4eaa-8af5-5d06f850283d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d814473b-1387-4eaa-8af5-5d06f850283d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/29e363f0-3979-4085-b039-3552f5c3c102/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d814473b-1387-4eaa-8af5-5d06f850283d>.
+    
+<http://data.lblod.info/id/remote-data-objects/489286e9-565c-4937-9f8a-af1ebb2a4c4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "489286e9-565c-4937-9f8a-af1ebb2a4c4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/29e363f0-3979-4085-b039-3552f5c3c102/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/489286e9-565c-4937-9f8a-af1ebb2a4c4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ac988a6-9b7e-4f12-9f7e-fd642b48b7f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ac988a6-9b7e-4f12-9f7e-fd642b48b7f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/29e363f0-3979-4085-b039-3552f5c3c102/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a79b16f-5602-4051-9f38-36bc6fffe269> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ac988a6-9b7e-4f12-9f7e-fd642b48b7f1>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201226-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201226-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201226-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201226-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2189d0ca-4ae5-4b22-ba03-0393d3b100f7> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2189d0ca-4ae5-4b22-ba03-0393d3b100f7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "74184cad-348b-4823-b280-49f8595f0d34";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/164511d4-a993-40ed-890f-c24e3627e959> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "164511d4-a993-40ed-890f-c24e3627e959";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34>.
+
+  <http://redpencil.data.gift/id/task/6b4f8236-4ce5-433a-902c-a70c663e412d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6b4f8236-4ce5-433a-902c-a70c663e412d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2189d0ca-4ae5-4b22-ba03-0393d3b100f7>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/164511d4-a993-40ed-890f-c24e3627e959>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/f4556ccd-dff0-45e2-bbcc-649dd5041e8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4556ccd-dff0-45e2-bbcc-649dd5041e8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/47600934-89e7-4b31-884f-5d6451f5493d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4556ccd-dff0-45e2-bbcc-649dd5041e8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6143b59-f313-4ddd-b4ef-ae2143d57abb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6143b59-f313-4ddd-b4ef-ae2143d57abb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/47600934-89e7-4b31-884f-5d6451f5493d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6143b59-f313-4ddd-b4ef-ae2143d57abb>.
+    
+<http://data.lblod.info/id/remote-data-objects/92a396ed-7728-413a-aa39-940484607ae3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92a396ed-7728-413a-aa39-940484607ae3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/47600934-89e7-4b31-884f-5d6451f5493d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92a396ed-7728-413a-aa39-940484607ae3>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5c96394-c00b-4352-8e33-13a24fe92f9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5c96394-c00b-4352-8e33-13a24fe92f9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/49a04142-7b15-4f9a-af8d-d4e238b1a7ac/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5c96394-c00b-4352-8e33-13a24fe92f9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/01e81097-5527-45b4-8869-0b224a8a1923> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01e81097-5527-45b4-8869-0b224a8a1923";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/49a04142-7b15-4f9a-af8d-d4e238b1a7ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01e81097-5527-45b4-8869-0b224a8a1923>.
+    
+<http://data.lblod.info/id/remote-data-objects/60588319-0e65-4beb-9ae1-c2271ae9f48a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60588319-0e65-4beb-9ae1-c2271ae9f48a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/49a04142-7b15-4f9a-af8d-d4e238b1a7ac/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60588319-0e65-4beb-9ae1-c2271ae9f48a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe005e68-04b2-4f83-b3c1-7be6adb5e8a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe005e68-04b2-4f83-b3c1-7be6adb5e8a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/6e7ad7e2-8c1d-473b-8818-a84683c8fe18/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe005e68-04b2-4f83-b3c1-7be6adb5e8a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad7ee673-ffb2-4454-a44e-0f61ac28851c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad7ee673-ffb2-4454-a44e-0f61ac28851c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/6e7ad7e2-8c1d-473b-8818-a84683c8fe18/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad7ee673-ffb2-4454-a44e-0f61ac28851c>.
+    
+<http://data.lblod.info/id/remote-data-objects/49505b30-db9b-4688-b42f-b25fa1a96f0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49505b30-db9b-4688-b42f-b25fa1a96f0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/6e7ad7e2-8c1d-473b-8818-a84683c8fe18/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49505b30-db9b-4688-b42f-b25fa1a96f0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/26b4ea73-4a9b-4628-885f-6da1bd1858a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26b4ea73-4a9b-4628-885f-6da1bd1858a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/8b96c735-818d-4aff-9e3f-80e99888de19/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26b4ea73-4a9b-4628-885f-6da1bd1858a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/360de00b-d04e-4f34-9905-cb698edf6b2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "360de00b-d04e-4f34-9905-cb698edf6b2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/8b96c735-818d-4aff-9e3f-80e99888de19/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/360de00b-d04e-4f34-9905-cb698edf6b2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9cb83bd-426a-4277-b558-3f1bac8ebea7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9cb83bd-426a-4277-b558-3f1bac8ebea7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/8b96c735-818d-4aff-9e3f-80e99888de19/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9cb83bd-426a-4277-b558-3f1bac8ebea7>.
+    
+<http://data.lblod.info/id/remote-data-objects/97ade097-d8b6-42c2-9539-550984790ec0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97ade097-d8b6-42c2-9539-550984790ec0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/962ab0d2-ca54-48ab-92d7-81e9ee189f30/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97ade097-d8b6-42c2-9539-550984790ec0>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fe801a2-8520-4dff-afbb-a845088c479b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fe801a2-8520-4dff-afbb-a845088c479b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/962ab0d2-ca54-48ab-92d7-81e9ee189f30/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fe801a2-8520-4dff-afbb-a845088c479b>.
+    
+<http://data.lblod.info/id/remote-data-objects/66172a31-1c35-4033-95f2-f16d5c4dd982> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66172a31-1c35-4033-95f2-f16d5c4dd982";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/962ab0d2-ca54-48ab-92d7-81e9ee189f30/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66172a31-1c35-4033-95f2-f16d5c4dd982>.
+    
+<http://data.lblod.info/id/remote-data-objects/0565a0d6-5aa9-4963-8ffb-eef7e8560236> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0565a0d6-5aa9-4963-8ffb-eef7e8560236";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/9835d8fb-250f-4e98-8e56-3f5caea6f7bb/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0565a0d6-5aa9-4963-8ffb-eef7e8560236>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d9c4168-1eac-497f-93d8-4611cfdb61cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d9c4168-1eac-497f-93d8-4611cfdb61cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/9835d8fb-250f-4e98-8e56-3f5caea6f7bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d9c4168-1eac-497f-93d8-4611cfdb61cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd6192ff-ea07-4aa4-9f3c-bb518cdc74c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd6192ff-ea07-4aa4-9f3c-bb518cdc74c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/9835d8fb-250f-4e98-8e56-3f5caea6f7bb/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd6192ff-ea07-4aa4-9f3c-bb518cdc74c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed93f557-143b-42eb-9003-3dd8bb65aee3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed93f557-143b-42eb-9003-3dd8bb65aee3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/afc7c693-201b-4379-ab58-8ab5499b5e87/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed93f557-143b-42eb-9003-3dd8bb65aee3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7efafe8b-f5c7-44c5-b389-ad905fdd0dd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7efafe8b-f5c7-44c5-b389-ad905fdd0dd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/afc7c693-201b-4379-ab58-8ab5499b5e87/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7efafe8b-f5c7-44c5-b389-ad905fdd0dd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b615cb2-a441-453d-88e8-b23f0f9a4474> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b615cb2-a441-453d-88e8-b23f0f9a4474";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/afc7c693-201b-4379-ab58-8ab5499b5e87/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b615cb2-a441-453d-88e8-b23f0f9a4474>.
+    
+<http://data.lblod.info/id/remote-data-objects/68c1ead5-4dae-421c-9535-f3cc6f4b387a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68c1ead5-4dae-421c-9535-f3cc6f4b387a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/eebb2d45-c6cd-459c-8ddc-1a0fc9b7a816/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68c1ead5-4dae-421c-9535-f3cc6f4b387a>.
+    
+<http://data.lblod.info/id/remote-data-objects/64e5701d-3b6c-4291-9fdc-c9d97fa8b134> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64e5701d-3b6c-4291-9fdc-c9d97fa8b134";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/eebb2d45-c6cd-459c-8ddc-1a0fc9b7a816/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64e5701d-3b6c-4291-9fdc-c9d97fa8b134>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ec34ea9-f451-4a05-a2c2-ae88c768013a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ec34ea9-f451-4a05-a2c2-ae88c768013a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/gr/eebb2d45-c6cd-459c-8ddc-1a0fc9b7a816/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ec34ea9-f451-4a05-a2c2-ae88c768013a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a929a6d3-2eb7-4f0e-b49b-27978407f2cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a929a6d3-2eb7-4f0e-b49b-27978407f2cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/12c67a29-efed-459c-a311-573960878ca2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a929a6d3-2eb7-4f0e-b49b-27978407f2cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/330e39d6-d8c3-41f4-89f0-94bbe07e3bfc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "330e39d6-d8c3-41f4-89f0-94bbe07e3bfc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/12c67a29-efed-459c-a311-573960878ca2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/330e39d6-d8c3-41f4-89f0-94bbe07e3bfc>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1a59a6b-055f-4281-b522-d4f15e68fdf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1a59a6b-055f-4281-b522-d4f15e68fdf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/12c67a29-efed-459c-a311-573960878ca2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1a59a6b-055f-4281-b522-d4f15e68fdf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a571e2c0-3fa8-4373-9ec4-88d3644c9141> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a571e2c0-3fa8-4373-9ec4-88d3644c9141";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/27bff023-c129-43b8-8c8b-25d4c7255e24/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a571e2c0-3fa8-4373-9ec4-88d3644c9141>.
+    
+<http://data.lblod.info/id/remote-data-objects/30e265fb-136f-417d-bb27-cb02ed64da48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30e265fb-136f-417d-bb27-cb02ed64da48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/27bff023-c129-43b8-8c8b-25d4c7255e24/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30e265fb-136f-417d-bb27-cb02ed64da48>.
+    
+<http://data.lblod.info/id/remote-data-objects/4be0e939-c800-4a66-824d-289f1e0c3ae6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4be0e939-c800-4a66-824d-289f1e0c3ae6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/3015c944-4604-40c9-bab3-020a3b9148c5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4be0e939-c800-4a66-824d-289f1e0c3ae6>.
+    
+<http://data.lblod.info/id/remote-data-objects/15aa3f9f-498f-41a9-b196-086b414885c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15aa3f9f-498f-41a9-b196-086b414885c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/3015c944-4604-40c9-bab3-020a3b9148c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15aa3f9f-498f-41a9-b196-086b414885c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d5ec04b-6d70-4880-92b2-511d5254076b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d5ec04b-6d70-4880-92b2-511d5254076b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/3015c944-4604-40c9-bab3-020a3b9148c5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d5ec04b-6d70-4880-92b2-511d5254076b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e62f2794-4243-44df-b5ef-14976499c047> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e62f2794-4243-44df-b5ef-14976499c047";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/650c0ee5-78e2-4e58-b0fa-94b273d421ff/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e62f2794-4243-44df-b5ef-14976499c047>.
+    
+<http://data.lblod.info/id/remote-data-objects/67264447-e733-403f-a331-368e6d7cbb88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67264447-e733-403f-a331-368e6d7cbb88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/650c0ee5-78e2-4e58-b0fa-94b273d421ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67264447-e733-403f-a331-368e6d7cbb88>.
+    
+<http://data.lblod.info/id/remote-data-objects/954d5b36-0e83-4ac9-902c-e51bd1c089f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "954d5b36-0e83-4ac9-902c-e51bd1c089f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/650c0ee5-78e2-4e58-b0fa-94b273d421ff/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/954d5b36-0e83-4ac9-902c-e51bd1c089f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/58aa15f9-942f-4ecc-8083-f566845ebae9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58aa15f9-942f-4ecc-8083-f566845ebae9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/82576540-dd32-4d22-812a-8d0f8af57bc7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58aa15f9-942f-4ecc-8083-f566845ebae9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9150f668-338b-4bb8-982c-279829821ea4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9150f668-338b-4bb8-982c-279829821ea4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/82576540-dd32-4d22-812a-8d0f8af57bc7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9150f668-338b-4bb8-982c-279829821ea4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e59f9be3-c03f-405b-a212-77637cf5dd34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e59f9be3-c03f-405b-a212-77637cf5dd34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/96515ad0-a798-4d26-a503-05c5ddc8ffc7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e59f9be3-c03f-405b-a212-77637cf5dd34>.
+    
+<http://data.lblod.info/id/remote-data-objects/568f12f5-971d-42be-be7a-df27512e5cc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "568f12f5-971d-42be-be7a-df27512e5cc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/96515ad0-a798-4d26-a503-05c5ddc8ffc7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/568f12f5-971d-42be-be7a-df27512e5cc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/32129557-d647-483b-9f91-ae24e10bdfe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32129557-d647-483b-9f91-ae24e10bdfe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/96515ad0-a798-4d26-a503-05c5ddc8ffc7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32129557-d647-483b-9f91-ae24e10bdfe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f450ce3-3ee2-4494-9bf2-d438e532afab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f450ce3-3ee2-4494-9bf2-d438e532afab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/cfd3d8f4-737e-49fa-b674-cdf3770ff005/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f450ce3-3ee2-4494-9bf2-d438e532afab>.
+    
+<http://data.lblod.info/id/remote-data-objects/356b1686-f115-404e-877e-3c3e43684e4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "356b1686-f115-404e-877e-3c3e43684e4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/cfd3d8f4-737e-49fa-b674-cdf3770ff005/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/356b1686-f115-404e-877e-3c3e43684e4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2f72cd6-adf7-48d6-aacf-dd17e3349236> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2f72cd6-adf7-48d6-aacf-dd17e3349236";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/cfd3d8f4-737e-49fa-b674-cdf3770ff005/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2f72cd6-adf7-48d6-aacf-dd17e3349236>.
+    
+<http://data.lblod.info/id/remote-data-objects/e43bfe6c-9233-43e2-8974-fd0cf9915011> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e43bfe6c-9233-43e2-8974-fd0cf9915011";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/e2729276-8b1b-45a7-8d47-0b29a2e847d7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e43bfe6c-9233-43e2-8974-fd0cf9915011>.
+    
+<http://data.lblod.info/id/remote-data-objects/54c13017-4e1b-462e-bb18-89f10b8d5353> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54c13017-4e1b-462e-bb18-89f10b8d5353";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/e2729276-8b1b-45a7-8d47-0b29a2e847d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54c13017-4e1b-462e-bb18-89f10b8d5353>.
+    
+<http://data.lblod.info/id/remote-data-objects/f41a191e-0414-4b1c-821b-46c8c9ae7205> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f41a191e-0414-4b1c-821b-46c8c9ae7205";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/e2729276-8b1b-45a7-8d47-0b29a2e847d7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f41a191e-0414-4b1c-821b-46c8c9ae7205>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e638373-6fce-4656-ba71-e3b988bcce51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e638373-6fce-4656-ba71-e3b988bcce51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/f20762df-536e-4baa-86ab-8df345df4447/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e638373-6fce-4656-ba71-e3b988bcce51>.
+    
+<http://data.lblod.info/id/remote-data-objects/2af51f40-101f-482c-94df-78d1d98e9647> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2af51f40-101f-482c-94df-78d1d98e9647";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/f20762df-536e-4baa-86ab-8df345df4447/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2af51f40-101f-482c-94df-78d1d98e9647>.
+    
+<http://data.lblod.info/id/remote-data-objects/97c843ab-3587-40bf-bd36-0c257b87cedd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97c843ab-3587-40bf-bd36-0c257b87cedd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/f20762df-536e-4baa-86ab-8df345df4447/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97c843ab-3587-40bf-bd36-0c257b87cedd>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b8dbe61-3130-4b74-b913-827cd3854cef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b8dbe61-3130-4b74-b913-827cd3854cef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/fd389e61-4948-4a96-852c-4d7e1e2c210f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74184cad-348b-4823-b280-49f8595f0d34> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b8dbe61-3130-4b74-b913-827cd3854cef>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201228-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201228-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201228-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201228-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/4d23ea72-2f26-4221-9bbb-323171844045> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4d23ea72-2f26-4221-9bbb-323171844045";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2187f246-f492-4c8f-9b9d-47951862d7cb";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e9ccc38d-ac49-41e9-b1e3-b14fcb519359> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e9ccc38d-ac49-41e9-b1e3-b14fcb519359";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb>.
+
+  <http://redpencil.data.gift/id/task/447913d7-4d53-4cd0-b41c-ee9b09c8bb7e> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "447913d7-4d53-4cd0-b41c-ee9b09c8bb7e";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/4d23ea72-2f26-4221-9bbb-323171844045>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e9ccc38d-ac49-41e9-b1e3-b14fcb519359>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/235799cb-de0c-4a8e-8b74-95e30260bf1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "235799cb-de0c-4a8e-8b74-95e30260bf1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/fd389e61-4948-4a96-852c-4d7e1e2c210f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/235799cb-de0c-4a8e-8b74-95e30260bf1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbfffc23-18c1-4e01-8dee-4c8e0f17d9fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbfffc23-18c1-4e01-8dee-4c8e0f17d9fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/rmw/fd389e61-4948-4a96-852c-4d7e1e2c210f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbfffc23-18c1-4e01-8dee-4c8e0f17d9fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/38f86787-4085-425e-9603-1946f918800c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38f86787-4085-425e-9603-1946f918800c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/040cddb2-255d-47e1-ad21-2214a58a5bcb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38f86787-4085-425e-9603-1946f918800c>.
+    
+<http://data.lblod.info/id/remote-data-objects/624a18ee-1738-48fc-9044-023007d273d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "624a18ee-1738-48fc-9044-023007d273d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/06994f64-81bb-4cf0-8ffd-bfaf1244255d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/624a18ee-1738-48fc-9044-023007d273d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c01e69e-1e25-4f07-8ed1-3c6531a8dcc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c01e69e-1e25-4f07-8ed1-3c6531a8dcc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/079508e8-6af5-4944-a6d2-85f66bc2f0b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c01e69e-1e25-4f07-8ed1-3c6531a8dcc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f631f65c-c56d-43d5-8858-43d1f8c1adde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f631f65c-c56d-43d5-8858-43d1f8c1adde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/1de042d7-f2f1-493d-88fa-79a4b602ea2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f631f65c-c56d-43d5-8858-43d1f8c1adde>.
+    
+<http://data.lblod.info/id/remote-data-objects/6187bc44-9596-49f5-b208-fa7b4f79fed9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6187bc44-9596-49f5-b208-fa7b4f79fed9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/23aac256-9493-4556-a84e-7433bacc5ef1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6187bc44-9596-49f5-b208-fa7b4f79fed9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c990c8eb-9942-4ac3-99c7-4b9086813f54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c990c8eb-9942-4ac3-99c7-4b9086813f54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/2c8108bd-216d-4df8-81b1-0c6dd66acfeb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c990c8eb-9942-4ac3-99c7-4b9086813f54>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fd62adf-f41d-4dac-a95a-7d482a1656c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fd62adf-f41d-4dac-a95a-7d482a1656c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/3856fbbb-1788-451f-96b0-7702a72b5b3c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fd62adf-f41d-4dac-a95a-7d482a1656c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea982772-55b4-4263-b554-29c157f61ad3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea982772-55b4-4263-b554-29c157f61ad3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/4a73d000-e2b6-47ef-8add-edeec3430572/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea982772-55b4-4263-b554-29c157f61ad3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad95c6a4-6646-4239-8822-7d8ef413665b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad95c6a4-6646-4239-8822-7d8ef413665b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/4fe3a2a6-1478-4354-9a6a-1d19b10a4470/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad95c6a4-6646-4239-8822-7d8ef413665b>.
+    
+<http://data.lblod.info/id/remote-data-objects/320b804b-cc30-4aee-b25a-b3aa78b3aa2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "320b804b-cc30-4aee-b25a-b3aa78b3aa2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/5ae48a78-620e-4142-9ca7-72be8e9607ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/320b804b-cc30-4aee-b25a-b3aa78b3aa2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dc048aa-405a-4329-b5c1-bb14367e2c72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dc048aa-405a-4329-b5c1-bb14367e2c72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/5c60c406-7e3e-45b0-b3a7-bdf3b3f2da5d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dc048aa-405a-4329-b5c1-bb14367e2c72>.
+    
+<http://data.lblod.info/id/remote-data-objects/0532e942-228f-49a3-8188-4a56a23eb509> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0532e942-228f-49a3-8188-4a56a23eb509";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/62d1c1c7-fafa-4feb-9f60-0a6e9bc0665f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0532e942-228f-49a3-8188-4a56a23eb509>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6225e9f-92f7-4525-bc08-cd5be7c3270e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6225e9f-92f7-4525-bc08-cd5be7c3270e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/678c33aa-93ab-4a83-bc0a-2ff3772b8032/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6225e9f-92f7-4525-bc08-cd5be7c3270e>.
+    
+<http://data.lblod.info/id/remote-data-objects/01784fae-08dc-42cf-945b-a4f3679fa684> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01784fae-08dc-42cf-945b-a4f3679fa684";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/7502823e-f66d-42f5-b2e7-b6e8dbfe0d74/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01784fae-08dc-42cf-945b-a4f3679fa684>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1b4bba2-b84d-4bd0-a96a-32dd3b6afa4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1b4bba2-b84d-4bd0-a96a-32dd3b6afa4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/7ef298b5-fe1e-42a3-bc32-8e76346a4273/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1b4bba2-b84d-4bd0-a96a-32dd3b6afa4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5f971ab-fb3e-4a43-9537-52ab01d64ee0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5f971ab-fb3e-4a43-9537-52ab01d64ee0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/97a91ce9-499d-40b5-baeb-5858d32d13ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5f971ab-fb3e-4a43-9537-52ab01d64ee0>.
+    
+<http://data.lblod.info/id/remote-data-objects/522d66b3-d9d0-42c3-b0fd-bbc79ada07ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "522d66b3-d9d0-42c3-b0fd-bbc79ada07ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/9d528919-f6aa-491f-a8d4-645e2388cb41/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/522d66b3-d9d0-42c3-b0fd-bbc79ada07ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c2dacf8-e0f6-4725-aefe-578829408d75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c2dacf8-e0f6-4725-aefe-578829408d75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/a8d67567-c015-4e93-b4bf-322a9d391cb8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c2dacf8-e0f6-4725-aefe-578829408d75>.
+    
+<http://data.lblod.info/id/remote-data-objects/46022cd5-9f73-46e6-a04e-7795fb20df21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46022cd5-9f73-46e6-a04e-7795fb20df21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/a945b65f-fa65-4ea0-a053-a585b7a6d7fb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46022cd5-9f73-46e6-a04e-7795fb20df21>.
+    
+<http://data.lblod.info/id/remote-data-objects/d830bf1b-fb29-4396-96a2-590cdfa00789> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d830bf1b-fb29-4396-96a2-590cdfa00789";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/acfd6270-a8d3-4c9d-90ad-e2067912dffe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d830bf1b-fb29-4396-96a2-590cdfa00789>.
+    
+<http://data.lblod.info/id/remote-data-objects/df660979-7afa-408a-933a-2245107c2344> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df660979-7afa-408a-933a-2245107c2344";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/d16d154e-1acf-464e-8db0-7f344fb2257c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df660979-7afa-408a-933a-2245107c2344>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd84206e-091c-4e09-a09f-3735fe75a570> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd84206e-091c-4e09-a09f-3735fe75a570";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/d9e9eacc-7ce7-47f4-83db-589be21c92ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd84206e-091c-4e09-a09f-3735fe75a570>.
+    
+<http://data.lblod.info/id/remote-data-objects/558da273-5c69-4e0a-b50f-6af391527d1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "558da273-5c69-4e0a-b50f-6af391527d1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/dbde834c-399b-4705-b511-a859e7ccc048/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/558da273-5c69-4e0a-b50f-6af391527d1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c8f296c-883b-4e1b-ac12-36157bc65a03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c8f296c-883b-4e1b-ac12-36157bc65a03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/ddb974c9-4fff-4a87-9989-504d2ff47d9a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c8f296c-883b-4e1b-ac12-36157bc65a03>.
+    
+<http://data.lblod.info/id/remote-data-objects/06908bd0-abb8-4b86-b638-c95177358eba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06908bd0-abb8-4b86-b638-c95177358eba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/ef077a84-493b-441b-97fe-5756c6c57d55/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06908bd0-abb8-4b86-b638-c95177358eba>.
+    
+<http://data.lblod.info/id/remote-data-objects/e163f4a3-0be3-4d56-b55c-51b3c8a8e06d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e163f4a3-0be3-4d56-b55c-51b3c8a8e06d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://kraainem.meetingburger.net/vabu/f4bd8931-3570-4bcb-b08e-ba52bf4a2b91/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e163f4a3-0be3-4d56-b55c-51b3c8a8e06d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec9469ee-c7a9-4674-8f1a-fc94837b50d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec9469ee-c7a9-4674-8f1a-fc94837b50d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec9469ee-c7a9-4674-8f1a-fc94837b50d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e54ca6ee-35fe-48c2-abfa-b64b6c82a48c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e54ca6ee-35fe-48c2-abfa-b64b6c82a48c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e54ca6ee-35fe-48c2-abfa-b64b6c82a48c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f88a356-1824-431a-bce8-49b4eaab2531> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f88a356-1824-431a-bce8-49b4eaab2531";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f88a356-1824-431a-bce8-49b4eaab2531>.
+    
+<http://data.lblod.info/id/remote-data-objects/1031d097-e523-4a84-bede-0481b709e030> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1031d097-e523-4a84-bede-0481b709e030";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1031d097-e523-4a84-bede-0481b709e030>.
+    
+<http://data.lblod.info/id/remote-data-objects/b33ba78a-e65d-4bae-88f6-ac99e154a723> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b33ba78a-e65d-4bae-88f6-ac99e154a723";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b33ba78a-e65d-4bae-88f6-ac99e154a723>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cbf6896-9bb7-4f39-ba2a-a7420cc24750> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cbf6896-9bb7-4f39-ba2a-a7420cc24750";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cbf6896-9bb7-4f39-ba2a-a7420cc24750>.
+    
+<http://data.lblod.info/id/remote-data-objects/25565570-bb85-4c6a-99f8-397e617b568f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25565570-bb85-4c6a-99f8-397e617b568f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25565570-bb85-4c6a-99f8-397e617b568f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4efee94-b2fb-4db7-8999-bee6b90b2dc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4efee94-b2fb-4db7-8999-bee6b90b2dc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4efee94-b2fb-4db7-8999-bee6b90b2dc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a6fb94e-e55c-4c1c-a4be-121231e3097f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a6fb94e-e55c-4c1c-a4be-121231e3097f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a6fb94e-e55c-4c1c-a4be-121231e3097f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab9c048d-87bb-4921-8e92-8b6dca19a76f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab9c048d-87bb-4921-8e92-8b6dca19a76f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab9c048d-87bb-4921-8e92-8b6dca19a76f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f33e70a3-5fab-4ff5-bcfd-54dcc1f77351> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f33e70a3-5fab-4ff5-bcfd-54dcc1f77351";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f33e70a3-5fab-4ff5-bcfd-54dcc1f77351>.
+    
+<http://data.lblod.info/id/remote-data-objects/75463dd2-7dd0-455c-a101-0a373854a333> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75463dd2-7dd0-455c-a101-0a373854a333";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75463dd2-7dd0-455c-a101-0a373854a333>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fe1bd47-3373-462a-b72d-311461f029e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fe1bd47-3373-462a-b72d-311461f029e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fe1bd47-3373-462a-b72d-311461f029e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/272eaae5-0d6f-4958-a8a0-e24012264cf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "272eaae5-0d6f-4958-a8a0-e24012264cf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/272eaae5-0d6f-4958-a8a0-e24012264cf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a43a350-f8f8-418e-b206-71869164bdc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a43a350-f8f8-418e-b206-71869164bdc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a43a350-f8f8-418e-b206-71869164bdc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1fe5013-99ce-48d9-82cb-55615f27c407> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1fe5013-99ce-48d9-82cb-55615f27c407";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1fe5013-99ce-48d9-82cb-55615f27c407>.
+    
+<http://data.lblod.info/id/remote-data-objects/9760c1a4-1dd9-4fc9-9828-a2071551dc4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9760c1a4-1dd9-4fc9-9828-a2071551dc4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9760c1a4-1dd9-4fc9-9828-a2071551dc4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9928eb81-22f5-4021-9ee7-92e11fa12c5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9928eb81-22f5-4021-9ee7-92e11fa12c5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9928eb81-22f5-4021-9ee7-92e11fa12c5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cc41bf0-ed19-4b01-b491-8feacdf7f592> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cc41bf0-ed19-4b01-b491-8feacdf7f592";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cc41bf0-ed19-4b01-b491-8feacdf7f592>.
+    
+<http://data.lblod.info/id/remote-data-objects/8988a44f-d7e4-497a-960a-9a822d604c7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8988a44f-d7e4-497a-960a-9a822d604c7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8988a44f-d7e4-497a-960a-9a822d604c7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4f1704e-cf70-48bf-96b6-534887c890a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4f1704e-cf70-48bf-96b6-534887c890a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4f1704e-cf70-48bf-96b6-534887c890a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e128b06c-446c-4510-bbf1-e7a8bc3b8abd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e128b06c-446c-4510-bbf1-e7a8bc3b8abd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2187f246-f492-4c8f-9b9d-47951862d7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e128b06c-446c-4510-bbf1-e7a8bc3b8abd>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201229-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201229-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201229-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201229-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c025c2cd-3e10-4bdf-a891-b60c2041932d> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c025c2cd-3e10-4bdf-a891-b60c2041932d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "71320592-24d3-4875-8f68-0f5788c3904b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/842addda-f20f-40d7-a3df-601e5102dfd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "842addda-f20f-40d7-a3df-601e5102dfd1";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b>.
+
+  <http://redpencil.data.gift/id/task/810e08d4-ba49-4e5b-80be-7b36cb131385> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "810e08d4-ba49-4e5b-80be-7b36cb131385";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c025c2cd-3e10-4bdf-a891-b60c2041932d>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/842addda-f20f-40d7-a3df-601e5102dfd1>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b8a84b4a-a3ec-40b1-8bd7-79f27f6d8fb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8a84b4a-a3ec-40b1-8bd7-79f27f6d8fb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8a84b4a-a3ec-40b1-8bd7-79f27f6d8fb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/878c9334-3d61-42bf-9cca-76c2af9db518> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "878c9334-3d61-42bf-9cca-76c2af9db518";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/878c9334-3d61-42bf-9cca-76c2af9db518>.
+    
+<http://data.lblod.info/id/remote-data-objects/9768a298-cc35-486d-a410-acfa579a7247> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9768a298-cc35-486d-a410-acfa579a7247";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_15-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9768a298-cc35-486d-a410-acfa579a7247>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5ff1638-298d-4bf4-9e82-866a21f96a8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5ff1638-298d-4bf4-9e82-866a21f96a8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5ff1638-298d-4bf4-9e82-866a21f96a8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a77c62b-65c4-4fb5-bab3-7ea550ff88cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a77c62b-65c4-4fb5-bab3-7ea550ff88cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a77c62b-65c4-4fb5-bab3-7ea550ff88cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/056c6e2d-98a2-4697-82b7-e359d89cc4db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "056c6e2d-98a2-4697-82b7-e359d89cc4db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/056c6e2d-98a2-4697-82b7-e359d89cc4db>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4c9f6db-7cfa-4a15-9232-3308da0774dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4c9f6db-7cfa-4a15-9232-3308da0774dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4c9f6db-7cfa-4a15-9232-3308da0774dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7285d48-b243-494a-b405-a253cd031958> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7285d48-b243-494a-b405-a253cd031958";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7285d48-b243-494a-b405-a253cd031958>.
+    
+<http://data.lblod.info/id/remote-data-objects/6587c04a-05ea-4577-a46e-1deb88d3bd33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6587c04a-05ea-4577-a46e-1deb88d3bd33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6587c04a-05ea-4577-a46e-1deb88d3bd33>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a623a2c-a95b-4079-b2b1-4001aee738ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a623a2c-a95b-4079-b2b1-4001aee738ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a623a2c-a95b-4079-b2b1-4001aee738ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a279e44-da2a-4da1-a0e4-77c992e89a38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a279e44-da2a-4da1-a0e4-77c992e89a38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a279e44-da2a-4da1-a0e4-77c992e89a38>.
+    
+<http://data.lblod.info/id/remote-data-objects/36ecd35d-63b4-4f90-8f2d-9982f47bd15a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36ecd35d-63b4-4f90-8f2d-9982f47bd15a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36ecd35d-63b4-4f90-8f2d-9982f47bd15a>.
+    
+<http://data.lblod.info/id/remote-data-objects/12f94174-bce0-4c91-91fc-5071d24dd1b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12f94174-bce0-4c91-91fc-5071d24dd1b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12f94174-bce0-4c91-91fc-5071d24dd1b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d64c92f4-086b-44fe-bf20-3b59e898ab78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d64c92f4-086b-44fe-bf20-3b59e898ab78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d64c92f4-086b-44fe-bf20-3b59e898ab78>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1f6051b-92c5-478a-afa9-7e922d99d73f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1f6051b-92c5-478a-afa9-7e922d99d73f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1f6051b-92c5-478a-afa9-7e922d99d73f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0152e661-e4f5-4477-8f18-63a6b9a97fb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0152e661-e4f5-4477-8f18-63a6b9a97fb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0152e661-e4f5-4477-8f18-63a6b9a97fb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/842053a9-bcfb-46b7-8e41-65be0b63fed6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "842053a9-bcfb-46b7-8e41-65be0b63fed6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/842053a9-bcfb-46b7-8e41-65be0b63fed6>.
+    
+<http://data.lblod.info/id/remote-data-objects/3457c48b-9354-4edc-9812-209d37b90bb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3457c48b-9354-4edc-9812-209d37b90bb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3457c48b-9354-4edc-9812-209d37b90bb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f8bddfa-6a29-4848-8b30-efe02bf93559> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f8bddfa-6a29-4848-8b30-efe02bf93559";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_26-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f8bddfa-6a29-4848-8b30-efe02bf93559>.
+    
+<http://data.lblod.info/id/remote-data-objects/d42454c8-b73f-4854-8d07-0d47137c0c1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d42454c8-b73f-4854-8d07-0d47137c0c1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d42454c8-b73f-4854-8d07-0d47137c0c1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0123ffb2-612f-4abd-b476-47c68d3ce500> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0123ffb2-612f-4abd-b476-47c68d3ce500";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0123ffb2-612f-4abd-b476-47c68d3ce500>.
+    
+<http://data.lblod.info/id/remote-data-objects/3eae4144-cce5-43fe-84c8-8e3bd6b393e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3eae4144-cce5-43fe-84c8-8e3bd6b393e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3eae4144-cce5-43fe-84c8-8e3bd6b393e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/18240bdc-b1a5-4632-9e00-9db55ec9054c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18240bdc-b1a5-4632-9e00-9db55ec9054c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18240bdc-b1a5-4632-9e00-9db55ec9054c>.
+    
+<http://data.lblod.info/id/remote-data-objects/18dc4880-efb3-4b69-9228-50fbd11dfae7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18dc4880-efb3-4b69-9228-50fbd11dfae7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18dc4880-efb3-4b69-9228-50fbd11dfae7>.
+    
+<http://data.lblod.info/id/remote-data-objects/930ec6c8-056f-4024-bb72-c7acd41526cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "930ec6c8-056f-4024-bb72-c7acd41526cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/930ec6c8-056f-4024-bb72-c7acd41526cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/13457b00-84d8-4853-adc1-8e3035a71142> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13457b00-84d8-4853-adc1-8e3035a71142";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_01-02-2022_34883.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13457b00-84d8-4853-adc1-8e3035a71142>.
+    
+<http://data.lblod.info/id/remote-data-objects/5eb42761-5536-455a-829f-3e3112c2b963> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5eb42761-5536-455a-829f-3e3112c2b963";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_01-03-2022_35883.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5eb42761-5536-455a-829f-3e3112c2b963>.
+    
+<http://data.lblod.info/id/remote-data-objects/303ffc3e-09ef-4281-b84b-f6efe0d6abc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "303ffc3e-09ef-4281-b84b-f6efe0d6abc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_01-03-2022_35966.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/303ffc3e-09ef-4281-b84b-f6efe0d6abc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/497e78c8-d617-4e63-baa8-f0aa3632533c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "497e78c8-d617-4e63-baa8-f0aa3632533c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_01-03-2022_35974.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/497e78c8-d617-4e63-baa8-f0aa3632533c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2425ab0-4326-49b4-af4d-88c2ad3124c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2425ab0-4326-49b4-af4d-88c2ad3124c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_01-03-2022_35978.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2425ab0-4326-49b4-af4d-88c2ad3124c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/acbc41c1-b977-42b3-bfe5-5e21b9fb29e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acbc41c1-b977-42b3-bfe5-5e21b9fb29e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_01-03-2022_36079.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acbc41c1-b977-42b3-bfe5-5e21b9fb29e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed4477d7-49a3-4e6e-a66b-cfd0a4e56f13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed4477d7-49a3-4e6e-a66b-cfd0a4e56f13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_01-03-2022_36080.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed4477d7-49a3-4e6e-a66b-cfd0a4e56f13>.
+    
+<http://data.lblod.info/id/remote-data-objects/4273f9d5-828d-48c8-80ed-f32cbee17829> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4273f9d5-828d-48c8-80ed-f32cbee17829";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_03-05-2022_37438.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4273f9d5-828d-48c8-80ed-f32cbee17829>.
+    
+<http://data.lblod.info/id/remote-data-objects/43d117d4-bcc5-4648-a73d-b1ae4d496a58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43d117d4-bcc5-4648-a73d-b1ae4d496a58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_03-05-2022_37449.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43d117d4-bcc5-4648-a73d-b1ae4d496a58>.
+    
+<http://data.lblod.info/id/remote-data-objects/71757e9b-0091-44c2-b1f9-f1e23fc3f00f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71757e9b-0091-44c2-b1f9-f1e23fc3f00f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_03-05-2022_37453.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71757e9b-0091-44c2-b1f9-f1e23fc3f00f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2a86901-33e7-4ccf-95d3-89ace69f88e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2a86901-33e7-4ccf-95d3-89ace69f88e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_03-05-2022_37471.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2a86901-33e7-4ccf-95d3-89ace69f88e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/767cc59f-1805-400a-843a-e8dc4f2a71e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "767cc59f-1805-400a-843a-e8dc4f2a71e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_03-05-2022_37491.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/767cc59f-1805-400a-843a-e8dc4f2a71e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/018c1791-7270-49e4-9ad6-b7cf0513f378> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "018c1791-7270-49e4-9ad6-b7cf0513f378";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_03-05-2022_37554.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/018c1791-7270-49e4-9ad6-b7cf0513f378>.
+    
+<http://data.lblod.info/id/remote-data-objects/65083834-23dc-452f-9d68-cac612013758> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65083834-23dc-452f-9d68-cac612013758";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_04-01-2022_34579.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65083834-23dc-452f-9d68-cac612013758>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a20546f-7e57-4897-8e19-fbac42a2e3b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a20546f-7e57-4897-8e19-fbac42a2e3b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_04-01-2022_34618.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a20546f-7e57-4897-8e19-fbac42a2e3b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fa0d864-84c9-4ea4-883b-cc6bc785c59e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fa0d864-84c9-4ea4-883b-cc6bc785c59e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_05-04-2022_36660.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fa0d864-84c9-4ea4-883b-cc6bc785c59e>.
+    
+<http://data.lblod.info/id/remote-data-objects/514212a9-feb8-4a95-9c93-8b7ff282c960> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "514212a9-feb8-4a95-9c93-8b7ff282c960";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_05-04-2022_36834.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/514212a9-feb8-4a95-9c93-8b7ff282c960>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cea35d8-a7ca-4d15-a1bf-d25a380af239> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cea35d8-a7ca-4d15-a1bf-d25a380af239";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_05-04-2022_36841.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cea35d8-a7ca-4d15-a1bf-d25a380af239>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9e352c9-252b-4351-9fb1-7850bbfb2835> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9e352c9-252b-4351-9fb1-7850bbfb2835";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_05-04-2022_36843.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9e352c9-252b-4351-9fb1-7850bbfb2835>.
+    
+<http://data.lblod.info/id/remote-data-objects/80b36a6f-c434-46e5-95f5-a801a61b287e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80b36a6f-c434-46e5-95f5-a801a61b287e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_05-04-2022_36852.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80b36a6f-c434-46e5-95f5-a801a61b287e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c271f33-60f3-4672-8326-308bd13f0b8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c271f33-60f3-4672-8326-308bd13f0b8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_05-04-2022_36854.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c271f33-60f3-4672-8326-308bd13f0b8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/741078b4-b2d1-4a2d-9c5b-cad218aca559> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "741078b4-b2d1-4a2d-9c5b-cad218aca559";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_05-04-2022_36860.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/741078b4-b2d1-4a2d-9c5b-cad218aca559>.
+    
+<http://data.lblod.info/id/remote-data-objects/f40cae4c-b3b8-4549-acaa-971d5f73f622> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f40cae4c-b3b8-4549-acaa-971d5f73f622";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_05-04-2022_36888.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f40cae4c-b3b8-4549-acaa-971d5f73f622>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c2360cd-215f-4ada-8b81-4b6eb4d45740> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c2360cd-215f-4ada-8b81-4b6eb4d45740";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_05-04-2022_36929.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c2360cd-215f-4ada-8b81-4b6eb4d45740>.
+    
+<http://data.lblod.info/id/remote-data-objects/2509fae7-3d68-47c8-9483-4ff72a75863a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2509fae7-3d68-47c8-9483-4ff72a75863a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_05-04-2022_36975.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71320592-24d3-4875-8f68-0f5788c3904b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2509fae7-3d68-47c8-9483-4ff72a75863a>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201230-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201230-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201230-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201230-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/97702a2b-5225-4c04-9e87-45426d6acfee> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "97702a2b-5225-4c04-9e87-45426d6acfee";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "171f544e-160b-4408-ae0a-9748478fed17";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b22b9bcb-811a-4ce8-83eb-6ff2312e29e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b22b9bcb-811a-4ce8-83eb-6ff2312e29e6";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17>.
+
+  <http://redpencil.data.gift/id/task/79bfb34d-8f6d-4c5b-946e-cc9b3d1625b2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "79bfb34d-8f6d-4c5b-946e-cc9b3d1625b2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/97702a2b-5225-4c04-9e87-45426d6acfee>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b22b9bcb-811a-4ce8-83eb-6ff2312e29e6>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/ffd8cd96-db60-4b5d-97e3-cc65f084e51d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffd8cd96-db60-4b5d-97e3-cc65f084e51d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_05-10-2021_32452.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffd8cd96-db60-4b5d-97e3-cc65f084e51d>.
+    
+<http://data.lblod.info/id/remote-data-objects/37721237-e6aa-4575-aa6d-18d00a1e775e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37721237-e6aa-4575-aa6d-18d00a1e775e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_05-10-2021_32471.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37721237-e6aa-4575-aa6d-18d00a1e775e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e318c99-9a82-4890-aa8c-0bd34ffd8c75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e318c99-9a82-4890-aa8c-0bd34ffd8c75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_06-07-2022_38849.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e318c99-9a82-4890-aa8c-0bd34ffd8c75>.
+    
+<http://data.lblod.info/id/remote-data-objects/377fe6cb-4f2b-4b50-bc93-fb43d881ad5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "377fe6cb-4f2b-4b50-bc93-fb43d881ad5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_06-07-2022_38850.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/377fe6cb-4f2b-4b50-bc93-fb43d881ad5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7edc46c-ae56-4b64-a212-212e9d5b60b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7edc46c-ae56-4b64-a212-212e9d5b60b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_06-07-2022_38896.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7edc46c-ae56-4b64-a212-212e9d5b60b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/57e30b3b-6413-411f-a2d4-4e26ee3f5f16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57e30b3b-6413-411f-a2d4-4e26ee3f5f16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_06-07-2022_38897.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57e30b3b-6413-411f-a2d4-4e26ee3f5f16>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8d8cf60-3c7a-47bf-811f-e89da2df482e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8d8cf60-3c7a-47bf-811f-e89da2df482e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_06-07-2022_38912.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8d8cf60-3c7a-47bf-811f-e89da2df482e>.
+    
+<http://data.lblod.info/id/remote-data-objects/eaedd3bd-f141-4a7d-8efd-caa44a4dd9c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eaedd3bd-f141-4a7d-8efd-caa44a4dd9c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_06-07-2022_39027.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eaedd3bd-f141-4a7d-8efd-caa44a4dd9c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e17d7d0f-c562-40ea-bf46-692dec5301b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e17d7d0f-c562-40ea-bf46-692dec5301b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_07-06-2022_38299.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e17d7d0f-c562-40ea-bf46-692dec5301b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a509130f-ba3f-4db1-a628-688d0f872a52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a509130f-ba3f-4db1-a628-688d0f872a52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_07-06-2022_38307.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a509130f-ba3f-4db1-a628-688d0f872a52>.
+    
+<http://data.lblod.info/id/remote-data-objects/013841c3-8e0a-41a4-8215-d350f34615ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "013841c3-8e0a-41a4-8215-d350f34615ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_07-06-2022_38310.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/013841c3-8e0a-41a4-8215-d350f34615ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/80105f19-29f5-418d-8a1d-eb42a0398f6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80105f19-29f5-418d-8a1d-eb42a0398f6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_07-06-2022_38314.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80105f19-29f5-418d-8a1d-eb42a0398f6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d00918b-992d-4a60-b256-a83936e1a77d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d00918b-992d-4a60-b256-a83936e1a77d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_07-12-2021_33565.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d00918b-992d-4a60-b256-a83936e1a77d>.
+    
+<http://data.lblod.info/id/remote-data-objects/82d1fe84-175c-4966-8b23-a6e47b8f0560> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82d1fe84-175c-4966-8b23-a6e47b8f0560";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_07-12-2021_34100.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82d1fe84-175c-4966-8b23-a6e47b8f0560>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2516432-8984-4089-8efc-df51175ce574> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2516432-8984-4089-8efc-df51175ce574";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_08-02-2022_35285.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2516432-8984-4089-8efc-df51175ce574>.
+    
+<http://data.lblod.info/id/remote-data-objects/e69364ee-14cb-44b0-b4d7-bb786c1d39a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e69364ee-14cb-44b0-b4d7-bb786c1d39a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_08-02-2022_35338.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e69364ee-14cb-44b0-b4d7-bb786c1d39a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cc92686-2d56-43d9-a9a9-aef508bb77b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cc92686-2d56-43d9-a9a9-aef508bb77b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_08-02-2022_35342.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cc92686-2d56-43d9-a9a9-aef508bb77b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/08c552c9-54d7-4403-b3ac-ea9dafd9d9ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08c552c9-54d7-4403-b3ac-ea9dafd9d9ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_08-03-2022_36056.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08c552c9-54d7-4403-b3ac-ea9dafd9d9ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e680bc3-077d-4a4d-aedf-f7ea478e9891> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e680bc3-077d-4a4d-aedf-f7ea478e9891";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_09-11-2021_33375.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e680bc3-077d-4a4d-aedf-f7ea478e9891>.
+    
+<http://data.lblod.info/id/remote-data-objects/79dd6cea-dddf-480c-afb1-91f04eb52d1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79dd6cea-dddf-480c-afb1-91f04eb52d1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_10-05-2022_37637.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79dd6cea-dddf-480c-afb1-91f04eb52d1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1686dc12-4ece-4894-bb75-6f2a011fa797> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1686dc12-4ece-4894-bb75-6f2a011fa797";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_10-05-2022_37638.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1686dc12-4ece-4894-bb75-6f2a011fa797>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae3951e5-a3aa-4734-a1b5-cc545996d8ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae3951e5-a3aa-4734-a1b5-cc545996d8ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_10-05-2022_37654.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae3951e5-a3aa-4734-a1b5-cc545996d8ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4d74687-dc16-464f-83e3-cf25b52e085f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4d74687-dc16-464f-83e3-cf25b52e085f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_11-01-2022_34725.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4d74687-dc16-464f-83e3-cf25b52e085f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5063d3d-af5a-4d05-99c6-ffed1569b33b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5063d3d-af5a-4d05-99c6-ffed1569b33b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_12-04-2022_36949.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5063d3d-af5a-4d05-99c6-ffed1569b33b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f34b10d-9527-4a75-90ed-11bb497eafbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f34b10d-9527-4a75-90ed-11bb497eafbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_12-04-2022_36994.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f34b10d-9527-4a75-90ed-11bb497eafbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0b9a888-0fe8-4c55-8ccd-ae1b94a9b2c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0b9a888-0fe8-4c55-8ccd-ae1b94a9b2c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_12-04-2022_36995.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0b9a888-0fe8-4c55-8ccd-ae1b94a9b2c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/58aef42f-a8b3-468c-835f-05a20995674a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58aef42f-a8b3-468c-835f-05a20995674a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_12-04-2022_37000.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58aef42f-a8b3-468c-835f-05a20995674a>.
+    
+<http://data.lblod.info/id/remote-data-objects/19001c01-9193-4820-a99e-11ba9014d4a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19001c01-9193-4820-a99e-11ba9014d4a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_12-04-2022_37081.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19001c01-9193-4820-a99e-11ba9014d4a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/20da0bf8-88a7-45ea-a63c-64780e52402c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20da0bf8-88a7-45ea-a63c-64780e52402c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_12-04-2022_37091.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20da0bf8-88a7-45ea-a63c-64780e52402c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee9cc333-e3de-46a1-83bc-08b880096c22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee9cc333-e3de-46a1-83bc-08b880096c22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_12-04-2022_37095.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee9cc333-e3de-46a1-83bc-08b880096c22>.
+    
+<http://data.lblod.info/id/remote-data-objects/56b35149-d26a-4d24-acca-0c978aa6687f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56b35149-d26a-4d24-acca-0c978aa6687f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_12-04-2022_37121.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56b35149-d26a-4d24-acca-0c978aa6687f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8c6ba5a-f521-489d-a455-f2c149def23e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8c6ba5a-f521-489d-a455-f2c149def23e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_12-10-2021_32593.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8c6ba5a-f521-489d-a455-f2c149def23e>.
+    
+<http://data.lblod.info/id/remote-data-objects/99ca3791-3521-45f3-88ff-b759aed79752> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99ca3791-3521-45f3-88ff-b759aed79752";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_14-06-2022_38406.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99ca3791-3521-45f3-88ff-b759aed79752>.
+    
+<http://data.lblod.info/id/remote-data-objects/3950d6c3-0323-4b4d-b317-d37628d459b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3950d6c3-0323-4b4d-b317-d37628d459b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_14-06-2022_38409.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3950d6c3-0323-4b4d-b317-d37628d459b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e11ca284-a729-4d85-9eb0-7d9853c4b798> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e11ca284-a729-4d85-9eb0-7d9853c4b798";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_14-06-2022_38455.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e11ca284-a729-4d85-9eb0-7d9853c4b798>.
+    
+<http://data.lblod.info/id/remote-data-objects/c04f930e-4384-40fe-b5d7-bae855203429> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c04f930e-4384-40fe-b5d7-bae855203429";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_14-06-2022_38526.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c04f930e-4384-40fe-b5d7-bae855203429>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3bf8766-f4d7-4075-abdf-ef8eabaa7802> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3bf8766-f4d7-4075-abdf-ef8eabaa7802";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_15-02-2022_35689.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3bf8766-f4d7-4075-abdf-ef8eabaa7802>.
+    
+<http://data.lblod.info/id/remote-data-objects/be1c28b2-f728-4e86-a649-9ed8223170ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be1c28b2-f728-4e86-a649-9ed8223170ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_15-02-2022_35690.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be1c28b2-f728-4e86-a649-9ed8223170ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/543aeec9-4632-4832-aff7-987334159df0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "543aeec9-4632-4832-aff7-987334159df0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_15-02-2022_35691.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/543aeec9-4632-4832-aff7-987334159df0>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e36b425-2615-48cc-975a-3eb725faf034> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e36b425-2615-48cc-975a-3eb725faf034";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_15-02-2022_35694.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e36b425-2615-48cc-975a-3eb725faf034>.
+    
+<http://data.lblod.info/id/remote-data-objects/0779ce33-efa1-429b-938b-224371277db6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0779ce33-efa1-429b-938b-224371277db6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_15-02-2022_35758.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0779ce33-efa1-429b-938b-224371277db6>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b2bb6e1-1f73-4f93-b596-db2c6acddc0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b2bb6e1-1f73-4f93-b596-db2c6acddc0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_15-02-2022_35764.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b2bb6e1-1f73-4f93-b596-db2c6acddc0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec958f77-23e0-4b10-a09a-52af175aa37a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec958f77-23e0-4b10-a09a-52af175aa37a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_15-02-2022_35768.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec958f77-23e0-4b10-a09a-52af175aa37a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ca6fa3f-88f7-407f-9d80-860c719f1ee8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ca6fa3f-88f7-407f-9d80-860c719f1ee8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_15-03-2022_35984.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ca6fa3f-88f7-407f-9d80-860c719f1ee8>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c37628a-757f-4f8d-bbe8-9a4ff9c96960> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c37628a-757f-4f8d-bbe8-9a4ff9c96960";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_15-03-2022_36240.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c37628a-757f-4f8d-bbe8-9a4ff9c96960>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ac9932c-298e-42f4-ac90-a3cc2cf67473> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ac9932c-298e-42f4-ac90-a3cc2cf67473";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_15-03-2022_36266.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ac9932c-298e-42f4-ac90-a3cc2cf67473>.
+    
+<http://data.lblod.info/id/remote-data-objects/2365601a-9c62-43dd-a7bd-5fcb0aedaae2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2365601a-9c62-43dd-a7bd-5fcb0aedaae2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_15-03-2022_36269.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2365601a-9c62-43dd-a7bd-5fcb0aedaae2>.
+    
+<http://data.lblod.info/id/remote-data-objects/5115b185-0799-4ff1-a580-e7729cb9ef8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5115b185-0799-4ff1-a580-e7729cb9ef8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_15-03-2022_36379.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5115b185-0799-4ff1-a580-e7729cb9ef8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d64bb73-368e-4aec-b31c-21bf27700e3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d64bb73-368e-4aec-b31c-21bf27700e3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_16-11-2021_33491.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d64bb73-368e-4aec-b31c-21bf27700e3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/66b1d5c7-0682-45f3-b810-df10936250aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66b1d5c7-0682-45f3-b810-df10936250aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_17-05-2022_37446.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171f544e-160b-4408-ae0a-9748478fed17> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66b1d5c7-0682-45f3-b810-df10936250aa>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201231-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201231-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201231-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201231-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a6ace639-3d93-4a1d-82fc-12eef52ce906> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a6ace639-3d93-4a1d-82fc-12eef52ce906";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0488f3d4-c20e-4398-b75c-990d7cb63d90";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/494962a6-2355-4de8-823e-9fa01c0d1aab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "494962a6-2355-4de8-823e-9fa01c0d1aab";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90>.
+
+  <http://redpencil.data.gift/id/task/f958f0d8-ee46-45d0-8f1c-36877d3b048b> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f958f0d8-ee46-45d0-8f1c-36877d3b048b";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a6ace639-3d93-4a1d-82fc-12eef52ce906>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/494962a6-2355-4de8-823e-9fa01c0d1aab>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/2dfe8c40-e4c7-465b-82f9-766855f58dd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2dfe8c40-e4c7-465b-82f9-766855f58dd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_17-05-2022_37806.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2dfe8c40-e4c7-465b-82f9-766855f58dd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc371659-5ff2-4c7a-8722-76143c4fb3e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc371659-5ff2-4c7a-8722-76143c4fb3e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_17-05-2022_37820.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc371659-5ff2-4c7a-8722-76143c4fb3e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd065501-bba1-46a2-b5f4-a0d791ca5d74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd065501-bba1-46a2-b5f4-a0d791ca5d74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_17-05-2022_37845.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd065501-bba1-46a2-b5f4-a0d791ca5d74>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1c8ddff-2cf5-40f7-a2c9-76f1381c7f41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1c8ddff-2cf5-40f7-a2c9-76f1381c7f41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_17-05-2022_37861.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1c8ddff-2cf5-40f7-a2c9-76f1381c7f41>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d9f934e-1059-4a20-8b22-87d7fc99a234> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d9f934e-1059-4a20-8b22-87d7fc99a234";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_17-05-2022_37925.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d9f934e-1059-4a20-8b22-87d7fc99a234>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0113dfc-b92e-4069-8ac1-cb74c207429d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0113dfc-b92e-4069-8ac1-cb74c207429d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_17-05-2022_37965.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0113dfc-b92e-4069-8ac1-cb74c207429d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a343e663-7507-4a73-b3ed-bfc3b3ba1488> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a343e663-7507-4a73-b3ed-bfc3b3ba1488";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_18-01-2022_34743.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a343e663-7507-4a73-b3ed-bfc3b3ba1488>.
+    
+<http://data.lblod.info/id/remote-data-objects/463dbe34-b0b7-4a13-b129-be0cc8ec0d53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "463dbe34-b0b7-4a13-b129-be0cc8ec0d53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_18-01-2022_34789.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/463dbe34-b0b7-4a13-b129-be0cc8ec0d53>.
+    
+<http://data.lblod.info/id/remote-data-objects/b04fe17b-af62-4c2a-8c7b-132467e93fa2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b04fe17b-af62-4c2a-8c7b-132467e93fa2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_19-04-2022_37183.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b04fe17b-af62-4c2a-8c7b-132467e93fa2>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e4716f4-2bea-42c5-bb20-972d12f10eb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e4716f4-2bea-42c5-bb20-972d12f10eb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_19-07-2022_39045.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e4716f4-2bea-42c5-bb20-972d12f10eb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7baafa8e-5bd2-45fa-996e-f8792e07d7bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7baafa8e-5bd2-45fa-996e-f8792e07d7bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_19-07-2022_39254.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7baafa8e-5bd2-45fa-996e-f8792e07d7bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/59fec22d-677b-4ee4-b9c9-01196ec47f9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59fec22d-677b-4ee4-b9c9-01196ec47f9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_19-07-2022_39261.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59fec22d-677b-4ee4-b9c9-01196ec47f9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bb4a4e3-a4a6-40f8-9d05-66176e46ff5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bb4a4e3-a4a6-40f8-9d05-66176e46ff5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_19-07-2022_39271.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bb4a4e3-a4a6-40f8-9d05-66176e46ff5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e513ca2-377c-497d-aa1d-0bc6ac7555de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e513ca2-377c-497d-aa1d-0bc6ac7555de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_19-07-2022_39274.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e513ca2-377c-497d-aa1d-0bc6ac7555de>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fd54eec-72f8-498e-8f2c-189a4e79bee1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fd54eec-72f8-498e-8f2c-189a4e79bee1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_19-07-2022_39286.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fd54eec-72f8-498e-8f2c-189a4e79bee1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e164774b-f4c9-4293-931d-2d5a62d35598> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e164774b-f4c9-4293-931d-2d5a62d35598";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_19-07-2022_39290.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e164774b-f4c9-4293-931d-2d5a62d35598>.
+    
+<http://data.lblod.info/id/remote-data-objects/69a5e74d-d258-4430-9d36-82ad7a581165> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69a5e74d-d258-4430-9d36-82ad7a581165";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_19-10-2021_32807.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69a5e74d-d258-4430-9d36-82ad7a581165>.
+    
+<http://data.lblod.info/id/remote-data-objects/c35d6389-b1f8-4537-902a-c671c7590cd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c35d6389-b1f8-4537-902a-c671c7590cd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_19-10-2021_32831.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c35d6389-b1f8-4537-902a-c671c7590cd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e94835ea-4048-46cb-a176-41823c13452b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e94835ea-4048-46cb-a176-41823c13452b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_21-06-2022_38318.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e94835ea-4048-46cb-a176-41823c13452b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9321b39d-0431-4e89-88de-c8586d5087e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9321b39d-0431-4e89-88de-c8586d5087e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_21-06-2022_38544.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9321b39d-0431-4e89-88de-c8586d5087e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5c7ab9f-9af5-4fa7-b787-370d85193c8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5c7ab9f-9af5-4fa7-b787-370d85193c8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_21-06-2022_38557.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5c7ab9f-9af5-4fa7-b787-370d85193c8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/712033c3-df97-416c-b52e-8a6de779a493> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "712033c3-df97-416c-b52e-8a6de779a493";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_21-06-2022_38558.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/712033c3-df97-416c-b52e-8a6de779a493>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd7671f2-0679-4a9a-8543-01d1b12259b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd7671f2-0679-4a9a-8543-01d1b12259b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_21-06-2022_38618.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd7671f2-0679-4a9a-8543-01d1b12259b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/23dd5dca-6825-4087-9efb-d30a9974ab6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23dd5dca-6825-4087-9efb-d30a9974ab6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_21-12-2021_34337.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23dd5dca-6825-4087-9efb-d30a9974ab6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/46f7c4b2-94dc-477f-9d62-531fb658ded5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46f7c4b2-94dc-477f-9d62-531fb658ded5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-02-2022_35483.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46f7c4b2-94dc-477f-9d62-531fb658ded5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a78d765-e12e-4419-984a-87c47b0b7915> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a78d765-e12e-4419-984a-87c47b0b7915";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-02-2022_35511.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a78d765-e12e-4419-984a-87c47b0b7915>.
+    
+<http://data.lblod.info/id/remote-data-objects/cebee733-a170-46e6-9956-3fc59d055bef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cebee733-a170-46e6-9956-3fc59d055bef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-02-2022_35636.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cebee733-a170-46e6-9956-3fc59d055bef>.
+    
+<http://data.lblod.info/id/remote-data-objects/34ce6403-6954-4917-8b8a-715dc758a652> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34ce6403-6954-4917-8b8a-715dc758a652";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-02-2022_35659.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34ce6403-6954-4917-8b8a-715dc758a652>.
+    
+<http://data.lblod.info/id/remote-data-objects/46dd6197-8426-4ff6-b959-3ba33cb086b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46dd6197-8426-4ff6-b959-3ba33cb086b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-02-2022_35797.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46dd6197-8426-4ff6-b959-3ba33cb086b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1de7688-1dc7-488c-b5a5-e9b05513288b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1de7688-1dc7-488c-b5a5-e9b05513288b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-02-2022_35800.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1de7688-1dc7-488c-b5a5-e9b05513288b>.
+    
+<http://data.lblod.info/id/remote-data-objects/55a1ac35-fa65-46cc-943f-abc13d081c53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55a1ac35-fa65-46cc-943f-abc13d081c53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-02-2022_35914.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55a1ac35-fa65-46cc-943f-abc13d081c53>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2855042-7f95-4ca3-9002-db0dfd832049> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2855042-7f95-4ca3-9002-db0dfd832049";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-03-2022_36296.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2855042-7f95-4ca3-9002-db0dfd832049>.
+    
+<http://data.lblod.info/id/remote-data-objects/80be06ac-d77a-47c6-9ee7-74a58de03987> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80be06ac-d77a-47c6-9ee7-74a58de03987";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-03-2022_36343.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80be06ac-d77a-47c6-9ee7-74a58de03987>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb217b72-5242-42df-ad84-7595d0d8d9c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb217b72-5242-42df-ad84-7595d0d8d9c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-03-2022_36418.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb217b72-5242-42df-ad84-7595d0d8d9c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5e0fdf7-2a50-4b86-87ab-bb7aba72763b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5e0fdf7-2a50-4b86-87ab-bb7aba72763b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-03-2022_36437.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5e0fdf7-2a50-4b86-87ab-bb7aba72763b>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb027da4-f1bd-43e0-b993-ea17038a44a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb027da4-f1bd-43e0-b993-ea17038a44a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-03-2022_36440.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb027da4-f1bd-43e0-b993-ea17038a44a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/24f83099-6e8b-4e56-a5ba-4649d52d299b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24f83099-6e8b-4e56-a5ba-4649d52d299b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-03-2022_36446.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24f83099-6e8b-4e56-a5ba-4649d52d299b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d019045-f0ac-4bc3-afc2-92a1e0f9d343> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d019045-f0ac-4bc3-afc2-92a1e0f9d343";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-03-2022_36450.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d019045-f0ac-4bc3-afc2-92a1e0f9d343>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6c55fda-edc0-472b-a6b6-865c445343e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6c55fda-edc0-472b-a6b6-865c445343e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-03-2022_36453.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6c55fda-edc0-472b-a6b6-865c445343e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/82c2081f-086e-4d81-91cb-a6cde71000cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82c2081f-086e-4d81-91cb-a6cde71000cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-03-2022_36459.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82c2081f-086e-4d81-91cb-a6cde71000cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/57b7377c-814c-440c-a5cf-59584193627d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57b7377c-814c-440c-a5cf-59584193627d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_22-03-2022_36535.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57b7377c-814c-440c-a5cf-59584193627d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a9a8328-f674-41b8-98ac-28ea4cb04588> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a9a8328-f674-41b8-98ac-28ea4cb04588";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_23-11-2021_33437.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a9a8328-f674-41b8-98ac-28ea4cb04588>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f1c628d-d69c-4bfc-b78d-1ef90a320a7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f1c628d-d69c-4bfc-b78d-1ef90a320a7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_23-11-2021_33474.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f1c628d-d69c-4bfc-b78d-1ef90a320a7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d775217-e6ce-43b8-9865-31828058bdfc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d775217-e6ce-43b8-9865-31828058bdfc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_23-11-2021_33475.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d775217-e6ce-43b8-9865-31828058bdfc>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a658aa2-43a8-47b8-ae63-0c73ed6474a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a658aa2-43a8-47b8-ae63-0c73ed6474a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_23-11-2021_33508.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a658aa2-43a8-47b8-ae63-0c73ed6474a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ebdb60d-c46a-4644-94c7-d0674c75b1f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ebdb60d-c46a-4644-94c7-d0674c75b1f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_24-05-2022_37974.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ebdb60d-c46a-4644-94c7-d0674c75b1f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/51585f89-4e5d-4f90-a051-e790bcdabd10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51585f89-4e5d-4f90-a051-e790bcdabd10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_24-05-2022_38001.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51585f89-4e5d-4f90-a051-e790bcdabd10>.
+    
+<http://data.lblod.info/id/remote-data-objects/24bffcea-65c1-4a72-bdb2-b4cd556edaf4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24bffcea-65c1-4a72-bdb2-b4cd556edaf4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_24-05-2022_38113.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24bffcea-65c1-4a72-bdb2-b4cd556edaf4>.
+    
+<http://data.lblod.info/id/remote-data-objects/80daf621-3c15-47ee-a860-4068bb58e75c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80daf621-3c15-47ee-a860-4068bb58e75c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_24-05-2022_38114.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80daf621-3c15-47ee-a860-4068bb58e75c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6754e3a-ad8b-4be9-90dc-ab49c6a36429> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6754e3a-ad8b-4be9-90dc-ab49c6a36429";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_24-05-2022_38121.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0488f3d4-c20e-4398-b75c-990d7cb63d90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6754e3a-ad8b-4be9-90dc-ab49c6a36429>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201233-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201233-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201233-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201233-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/919404f0-30f9-4aaa-a89e-05215864400e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "919404f0-30f9-4aaa-a89e-05215864400e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cf13965d-569a-4152-a715-5975ca2d6cb5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/cad53d9a-fdbe-4043-b8f3-26dc8c20e5d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cad53d9a-fdbe-4043-b8f3-26dc8c20e5d3";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5>.
+
+  <http://redpencil.data.gift/id/task/f5dd3ecf-4bc5-4aab-9b82-40005bb1702a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f5dd3ecf-4bc5-4aab-9b82-40005bb1702a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/919404f0-30f9-4aaa-a89e-05215864400e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/cad53d9a-fdbe-4043-b8f3-26dc8c20e5d3>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/af30d557-1fee-4710-80b8-015fa7ebf517> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af30d557-1fee-4710-80b8-015fa7ebf517";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_24-05-2022_38150.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af30d557-1fee-4710-80b8-015fa7ebf517>.
+    
+<http://data.lblod.info/id/remote-data-objects/aeb1a2d7-b2db-4452-a306-d31b412c820e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aeb1a2d7-b2db-4452-a306-d31b412c820e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_25-01-2022_34866.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aeb1a2d7-b2db-4452-a306-d31b412c820e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ec99805-b33f-487b-9032-7d46e1bd0f42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ec99805-b33f-487b-9032-7d46e1bd0f42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_25-01-2022_34990.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ec99805-b33f-487b-9032-7d46e1bd0f42>.
+    
+<http://data.lblod.info/id/remote-data-objects/0999b70b-895f-44bb-a284-6cd31e2c90f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0999b70b-895f-44bb-a284-6cd31e2c90f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_25-01-2022_34999.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0999b70b-895f-44bb-a284-6cd31e2c90f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7a388c7-f034-4f4e-a0c4-574da370cc1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7a388c7-f034-4f4e-a0c4-574da370cc1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_26-04-2022_37259.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7a388c7-f034-4f4e-a0c4-574da370cc1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/68ad4237-28eb-46fb-a3f0-275c336d633d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68ad4237-28eb-46fb-a3f0-275c336d633d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_26-04-2022_37367.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68ad4237-28eb-46fb-a3f0-275c336d633d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c29db1c8-dc08-4568-85a3-97a1983c1a62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c29db1c8-dc08-4568-85a3-97a1983c1a62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_26-04-2022_37386.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c29db1c8-dc08-4568-85a3-97a1983c1a62>.
+    
+<http://data.lblod.info/id/remote-data-objects/7561a326-ed77-49c1-ae69-43581d60421f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7561a326-ed77-49c1-ae69-43581d60421f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_26-10-2021_32758.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7561a326-ed77-49c1-ae69-43581d60421f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d36b5b9a-8195-4f28-b604-3c855d7f32db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d36b5b9a-8195-4f28-b604-3c855d7f32db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_26-10-2021_32759.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d36b5b9a-8195-4f28-b604-3c855d7f32db>.
+    
+<http://data.lblod.info/id/remote-data-objects/947d44cf-e86c-4609-b9ae-fa3d5d0dd1c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "947d44cf-e86c-4609-b9ae-fa3d5d0dd1c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_26-10-2021_32902.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/947d44cf-e86c-4609-b9ae-fa3d5d0dd1c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/55e6140f-f55d-4eee-9e8d-fcd2e5f4256c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55e6140f-f55d-4eee-9e8d-fcd2e5f4256c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_26-10-2021_32921.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55e6140f-f55d-4eee-9e8d-fcd2e5f4256c>.
+    
+<http://data.lblod.info/id/remote-data-objects/863a30ba-c391-49e3-8b43-5d6c159b6193> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "863a30ba-c391-49e3-8b43-5d6c159b6193";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_26-10-2021_32929.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/863a30ba-c391-49e3-8b43-5d6c159b6193>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0b4af7c-9184-47ae-ad78-b175191415d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0b4af7c-9184-47ae-ad78-b175191415d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_26-10-2021_32966.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0b4af7c-9184-47ae-ad78-b175191415d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9621a403-01d6-48e6-a76c-67cd94d78673> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9621a403-01d6-48e6-a76c-67cd94d78673";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_26-10-2021_32987.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9621a403-01d6-48e6-a76c-67cd94d78673>.
+    
+<http://data.lblod.info/id/remote-data-objects/f37473d0-df82-4ce7-83f1-d51087de619b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f37473d0-df82-4ce7-83f1-d51087de619b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_26-10-2021_33034.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f37473d0-df82-4ce7-83f1-d51087de619b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ccb6ee6-ca23-4682-8fa4-500c056bc0ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ccb6ee6-ca23-4682-8fa4-500c056bc0ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_28-06-2022_38418.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ccb6ee6-ca23-4682-8fa4-500c056bc0ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bd80f1d-3151-4141-9be7-347ef56bf551> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bd80f1d-3151-4141-9be7-347ef56bf551";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_28-06-2022_38690.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bd80f1d-3151-4141-9be7-347ef56bf551>.
+    
+<http://data.lblod.info/id/remote-data-objects/310c850e-d94a-43bd-85c6-3089dd0d8f12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "310c850e-d94a-43bd-85c6-3089dd0d8f12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_28-06-2022_38694.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/310c850e-d94a-43bd-85c6-3089dd0d8f12>.
+    
+<http://data.lblod.info/id/remote-data-objects/11946302-e93a-4bf4-8b0a-dc99fa15b380> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11946302-e93a-4bf4-8b0a-dc99fa15b380";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_28-06-2022_38697.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11946302-e93a-4bf4-8b0a-dc99fa15b380>.
+    
+<http://data.lblod.info/id/remote-data-objects/04243b59-8478-4476-9f16-ed8d7dce7f7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04243b59-8478-4476-9f16-ed8d7dce7f7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_28-06-2022_38716.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04243b59-8478-4476-9f16-ed8d7dce7f7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7567cd5c-0497-4eed-b458-5f66c82ccbd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7567cd5c-0497-4eed-b458-5f66c82ccbd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_28-06-2022_38718.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7567cd5c-0497-4eed-b458-5f66c82ccbd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dcfca54-1c37-4216-98b9-09c27a05fc2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dcfca54-1c37-4216-98b9-09c27a05fc2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_28-06-2022_38729.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dcfca54-1c37-4216-98b9-09c27a05fc2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0528fa38-09b8-4b2a-84ae-8a94ca7ee2a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0528fa38-09b8-4b2a-84ae-8a94ca7ee2a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_28-06-2022_38732.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0528fa38-09b8-4b2a-84ae-8a94ca7ee2a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/086b9d83-a123-4821-a0a4-853f4f99028b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "086b9d83-a123-4821-a0a4-853f4f99028b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_28-06-2022_38737.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/086b9d83-a123-4821-a0a4-853f4f99028b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8403b15-9fc3-4a79-85f5-48c0cab6135f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8403b15-9fc3-4a79-85f5-48c0cab6135f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_28-06-2022_38741.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8403b15-9fc3-4a79-85f5-48c0cab6135f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3abc386f-51a7-4e60-8773-55a0d0c2c85a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3abc386f-51a7-4e60-8773-55a0d0c2c85a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_28-06-2022_38743.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3abc386f-51a7-4e60-8773-55a0d0c2c85a>.
+    
+<http://data.lblod.info/id/remote-data-objects/63877632-f274-4232-a7e8-8591943ae662> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63877632-f274-4232-a7e8-8591943ae662";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_28-06-2022_38818.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63877632-f274-4232-a7e8-8591943ae662>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5f88041-af62-41ad-b3ad-1155f647a774> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5f88041-af62-41ad-b3ad-1155f647a774";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_28-06-2022_38842.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5f88041-af62-41ad-b3ad-1155f647a774>.
+    
+<http://data.lblod.info/id/remote-data-objects/4185af0c-1f19-4642-af15-bc8caeb538f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4185af0c-1f19-4642-af15-bc8caeb538f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_29-03-2022_36595.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4185af0c-1f19-4642-af15-bc8caeb538f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8329ee28-7824-40cd-b32f-3a709feb016e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8329ee28-7824-40cd-b32f-3a709feb016e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_29-03-2022_36599.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8329ee28-7824-40cd-b32f-3a709feb016e>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa58cf2c-b9df-4c8e-9577-877f6adeff65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa58cf2c-b9df-4c8e-9577-877f6adeff65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_29-03-2022_36603.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa58cf2c-b9df-4c8e-9577-877f6adeff65>.
+    
+<http://data.lblod.info/id/remote-data-objects/a82775c1-d0df-428e-be7c-653eb0b23e06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a82775c1-d0df-428e-be7c-653eb0b23e06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_29-03-2022_36622.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a82775c1-d0df-428e-be7c-653eb0b23e06>.
+    
+<http://data.lblod.info/id/remote-data-objects/22e8b8e9-0e2c-4e9c-b364-627d12cb025a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22e8b8e9-0e2c-4e9c-b364-627d12cb025a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_29-03-2022_36626.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22e8b8e9-0e2c-4e9c-b364-627d12cb025a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c059e38-28a8-4031-bc21-cb5ddad7425b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c059e38-28a8-4031-bc21-cb5ddad7425b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_29-03-2022_36637.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c059e38-28a8-4031-bc21-cb5ddad7425b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f433015b-be94-4875-b6ae-d92a181dc703> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f433015b-be94-4875-b6ae-d92a181dc703";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_29-03-2022_36639.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f433015b-be94-4875-b6ae-d92a181dc703>.
+    
+<http://data.lblod.info/id/remote-data-objects/27d50dd0-f1b2-4baa-a192-27fabdab6161> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27d50dd0-f1b2-4baa-a192-27fabdab6161";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_29-03-2022_36643.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27d50dd0-f1b2-4baa-a192-27fabdab6161>.
+    
+<http://data.lblod.info/id/remote-data-objects/078f2ce6-db6d-4f01-b3d4-8fb96ded38b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "078f2ce6-db6d-4f01-b3d4-8fb96ded38b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_30-11-2021_33764.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/078f2ce6-db6d-4f01-b3d4-8fb96ded38b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/66a6e6b2-508d-4945-8c7d-2c2baee88253> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66a6e6b2-508d-4945-8c7d-2c2baee88253";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_31-05-2022_37833.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66a6e6b2-508d-4945-8c7d-2c2baee88253>.
+    
+<http://data.lblod.info/id/remote-data-objects/40100ab6-44c5-4d8e-a756-5c9f866ad871> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40100ab6-44c5-4d8e-a756-5c9f866ad871";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_31-05-2022_38043.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40100ab6-44c5-4d8e-a756-5c9f866ad871>.
+    
+<http://data.lblod.info/id/remote-data-objects/357ce8be-cd0f-4172-aa6b-be0ea93f6504> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "357ce8be-cd0f-4172-aa6b-be0ea93f6504";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_31-05-2022_38123.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/357ce8be-cd0f-4172-aa6b-be0ea93f6504>.
+    
+<http://data.lblod.info/id/remote-data-objects/8766909e-efee-4d3d-9f3e-acf4fe4642e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8766909e-efee-4d3d-9f3e-acf4fe4642e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_31-05-2022_38177.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8766909e-efee-4d3d-9f3e-acf4fe4642e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/19430e2c-7752-4300-b25d-0e9c4c24461a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19430e2c-7752-4300-b25d-0e9c4c24461a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_31-05-2022_38181.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19430e2c-7752-4300-b25d-0e9c4c24461a>.
+    
+<http://data.lblod.info/id/remote-data-objects/079f3a8b-b9b0-4e63-8e28-dfd71d6955b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "079f3a8b-b9b0-4e63-8e28-dfd71d6955b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_31-05-2022_38182.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/079f3a8b-b9b0-4e63-8e28-dfd71d6955b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bcaf7fa-57ee-4d4c-855e-d259bc969308> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bcaf7fa-57ee-4d4c-855e-d259bc969308";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_31-05-2022_38213.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bcaf7fa-57ee-4d4c-855e-d259bc969308>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c240b13-fc45-449a-af98-6782fb488059> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c240b13-fc45-449a-af98-6782fb488059";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/2a30f0e2100b381f9ea5cc4f31ec2c72e2d89947754a08d1d33e4d5f77406132/GetPublication?filename=Uittreksels_31-05-2022_38215.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c240b13-fc45-449a-af98-6782fb488059>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cc9aa78-7864-4d36-b3ff-fe4c63998a19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cc9aa78-7864-4d36-b3ff-fe4c63998a19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cc9aa78-7864-4d36-b3ff-fe4c63998a19>.
+    
+<http://data.lblod.info/id/remote-data-objects/40649be8-c751-4213-a538-7aeecb0d3010> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40649be8-c751-4213-a538-7aeecb0d3010";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40649be8-c751-4213-a538-7aeecb0d3010>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7d998cd-f413-438c-b530-1be85f5b0c3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7d998cd-f413-438c-b530-1be85f5b0c3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7d998cd-f413-438c-b530-1be85f5b0c3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e73254e-9c0a-43d2-a720-c9558c858ecc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e73254e-9c0a-43d2-a720-c9558c858ecc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e73254e-9c0a-43d2-a720-c9558c858ecc>.
+    
+<http://data.lblod.info/id/remote-data-objects/28e91bf6-8b30-4728-aed6-0768b01aea1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28e91bf6-8b30-4728-aed6-0768b01aea1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf13965d-569a-4152-a715-5975ca2d6cb5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28e91bf6-8b30-4728-aed6-0768b01aea1a>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201234-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201234-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201234-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201234-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7e181414-1d66-478e-a340-42efb2b225f1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7e181414-1d66-478e-a340-42efb2b225f1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9b5d166b-1356-41ac-b624-d2a212885c32";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4f63b5af-d81c-4a35-8052-bfc83494d35a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4f63b5af-d81c-4a35-8052-bfc83494d35a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32>.
+
+  <http://redpencil.data.gift/id/task/4cb26f3d-5cc5-4079-8575-c7ffd93e9d19> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4cb26f3d-5cc5-4079-8575-c7ffd93e9d19";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7e181414-1d66-478e-a340-42efb2b225f1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4f63b5af-d81c-4a35-8052-bfc83494d35a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4b35b71d-0956-4206-b881-8790fc3ace6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b35b71d-0956-4206-b881-8790fc3ace6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b35b71d-0956-4206-b881-8790fc3ace6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/498e5d2e-ed7b-41aa-bfc1-ed576b79996e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "498e5d2e-ed7b-41aa-bfc1-ed576b79996e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/498e5d2e-ed7b-41aa-bfc1-ed576b79996e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3955a654-5137-489a-9a16-3542978aa340> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3955a654-5137-489a-9a16-3542978aa340";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3955a654-5137-489a-9a16-3542978aa340>.
+    
+<http://data.lblod.info/id/remote-data-objects/75476579-b6c5-44d2-a170-bac957540f5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75476579-b6c5-44d2-a170-bac957540f5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75476579-b6c5-44d2-a170-bac957540f5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/16981828-84b6-4100-9cdf-706315a6ac76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16981828-84b6-4100-9cdf-706315a6ac76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16981828-84b6-4100-9cdf-706315a6ac76>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ebbaf38-ba07-45bf-a659-ffbecde3c82b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ebbaf38-ba07-45bf-a659-ffbecde3c82b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ebbaf38-ba07-45bf-a659-ffbecde3c82b>.
+    
+<http://data.lblod.info/id/remote-data-objects/40abc437-a850-40ca-9534-e139c2205bb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40abc437-a850-40ca-9534-e139c2205bb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40abc437-a850-40ca-9534-e139c2205bb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/042a1086-ed07-4db4-a61f-125bd9b950fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "042a1086-ed07-4db4-a61f-125bd9b950fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/042a1086-ed07-4db4-a61f-125bd9b950fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d7ccef1-96fd-4f7f-9223-4a9ce59c9389> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d7ccef1-96fd-4f7f-9223-4a9ce59c9389";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d7ccef1-96fd-4f7f-9223-4a9ce59c9389>.
+    
+<http://data.lblod.info/id/remote-data-objects/64e42d65-9351-4b8a-b58d-209a86414fb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64e42d65-9351-4b8a-b58d-209a86414fb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64e42d65-9351-4b8a-b58d-209a86414fb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/adcc24c4-1612-41be-96c9-fb3464eb4b14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "adcc24c4-1612-41be-96c9-fb3464eb4b14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/adcc24c4-1612-41be-96c9-fb3464eb4b14>.
+    
+<http://data.lblod.info/id/remote-data-objects/3725364d-0808-4e80-8a4a-0481f95dbbc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3725364d-0808-4e80-8a4a-0481f95dbbc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3725364d-0808-4e80-8a4a-0481f95dbbc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/eacb2bb0-ad08-48de-8c34-a2dbebb6a99b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eacb2bb0-ad08-48de-8c34-a2dbebb6a99b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eacb2bb0-ad08-48de-8c34-a2dbebb6a99b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6a77e23-45fb-4bbc-8a2c-d90f3415dd27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6a77e23-45fb-4bbc-8a2c-d90f3415dd27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6a77e23-45fb-4bbc-8a2c-d90f3415dd27>.
+    
+<http://data.lblod.info/id/remote-data-objects/56979576-55c0-4299-ba2e-b6f37bb8bbc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56979576-55c0-4299-ba2e-b6f37bb8bbc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56979576-55c0-4299-ba2e-b6f37bb8bbc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/4088767e-d58e-45ab-b297-ea36fef2aa26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4088767e-d58e-45ab-b297-ea36fef2aa26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4088767e-d58e-45ab-b297-ea36fef2aa26>.
+    
+<http://data.lblod.info/id/remote-data-objects/48b37e24-b731-47d5-af6f-00055c8cfa6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48b37e24-b731-47d5-af6f-00055c8cfa6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48b37e24-b731-47d5-af6f-00055c8cfa6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccc39263-a8b0-44bd-8940-8064bef4763b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccc39263-a8b0-44bd-8940-8064bef4763b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccc39263-a8b0-44bd-8940-8064bef4763b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6ab7eda-cff8-4f18-a475-8b26013d2c1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6ab7eda-cff8-4f18-a475-8b26013d2c1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6ab7eda-cff8-4f18-a475-8b26013d2c1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f910b53e-1fe0-4d3c-be56-76ccb19a6b45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f910b53e-1fe0-4d3c-be56-76ccb19a6b45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f910b53e-1fe0-4d3c-be56-76ccb19a6b45>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd4ba855-137c-402e-a70c-0a6f7ddfdaf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd4ba855-137c-402e-a70c-0a6f7ddfdaf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd4ba855-137c-402e-a70c-0a6f7ddfdaf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a16741b9-f523-4c2f-808d-040219ac02b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a16741b9-f523-4c2f-808d-040219ac02b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a16741b9-f523-4c2f-808d-040219ac02b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c426bea-3b38-4ef0-81e6-5f461dfbc749> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c426bea-3b38-4ef0-81e6-5f461dfbc749";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c426bea-3b38-4ef0-81e6-5f461dfbc749>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd8a9c08-b0b2-4eca-893e-c10e44aae33b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd8a9c08-b0b2-4eca-893e-c10e44aae33b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd8a9c08-b0b2-4eca-893e-c10e44aae33b>.
+    
+<http://data.lblod.info/id/remote-data-objects/08823d7a-376d-4aa0-bd63-892a13547c34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08823d7a-376d-4aa0-bd63-892a13547c34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08823d7a-376d-4aa0-bd63-892a13547c34>.
+    
+<http://data.lblod.info/id/remote-data-objects/75dab59c-cffe-4515-a297-bbcbb8052b3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75dab59c-cffe-4515-a297-bbcbb8052b3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75dab59c-cffe-4515-a297-bbcbb8052b3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fabb341-8c09-4b57-a2e7-00dd6d4cd0f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fabb341-8c09-4b57-a2e7-00dd6d4cd0f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fabb341-8c09-4b57-a2e7-00dd6d4cd0f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/11fadcdb-da3d-43e7-8c9c-5496ac1ebd8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11fadcdb-da3d-43e7-8c9c-5496ac1ebd8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11fadcdb-da3d-43e7-8c9c-5496ac1ebd8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba440fcb-4b75-4f20-a3e6-2e39ae20b253> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba440fcb-4b75-4f20-a3e6-2e39ae20b253";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba440fcb-4b75-4f20-a3e6-2e39ae20b253>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9bd26b8-cd53-4685-8258-bd62691bf46b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9bd26b8-cd53-4685-8258-bd62691bf46b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9bd26b8-cd53-4685-8258-bd62691bf46b>.
+    
+<http://data.lblod.info/id/remote-data-objects/35df6a77-6735-46b3-b74a-194315131d57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35df6a77-6735-46b3-b74a-194315131d57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35df6a77-6735-46b3-b74a-194315131d57>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdfe4a90-a761-410f-a439-9aaeb8619613> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdfe4a90-a761-410f-a439-9aaeb8619613";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdfe4a90-a761-410f-a439-9aaeb8619613>.
+    
+<http://data.lblod.info/id/remote-data-objects/b776e3b9-b13e-4922-8020-6e77789f1eeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b776e3b9-b13e-4922-8020-6e77789f1eeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b776e3b9-b13e-4922-8020-6e77789f1eeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6984fb1-9bdd-4d81-9a4b-1fcb0c2edc9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6984fb1-9bdd-4d81-9a4b-1fcb0c2edc9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=BesluitenLijst_Vast%20bureau_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6984fb1-9bdd-4d81-9a4b-1fcb0c2edc9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/afbfe1f2-6f13-4905-bd2d-604d36c797bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afbfe1f2-6f13-4905-bd2d-604d36c797bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/92d7ef6198e8985676cc16a790e430c15efd851ffd0e49434fc43f57b2301a14/GetPublication?filename=Uittreksels_23-11-2021_33534.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afbfe1f2-6f13-4905-bd2d-604d36c797bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e82ac39-7d48-4283-85fc-ccc7afcb7749> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e82ac39-7d48-4283-85fc-ccc7afcb7749";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e82ac39-7d48-4283-85fc-ccc7afcb7749>.
+    
+<http://data.lblod.info/id/remote-data-objects/06addf12-e9d4-4107-a4a9-6f73513e58ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06addf12-e9d4-4107-a4a9-6f73513e58ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06addf12-e9d4-4107-a4a9-6f73513e58ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/63090e51-33d3-43ef-bb09-c6f1ed653177> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63090e51-33d3-43ef-bb09-c6f1ed653177";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63090e51-33d3-43ef-bb09-c6f1ed653177>.
+    
+<http://data.lblod.info/id/remote-data-objects/a416d300-76ea-490f-bb7a-ce08a5170109> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a416d300-76ea-490f-bb7a-ce08a5170109";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_02-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a416d300-76ea-490f-bb7a-ce08a5170109>.
+    
+<http://data.lblod.info/id/remote-data-objects/2559dce9-3e1f-47fa-8e85-01fa646a6c3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2559dce9-3e1f-47fa-8e85-01fa646a6c3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2559dce9-3e1f-47fa-8e85-01fa646a6c3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e7f8ee7-4757-4375-977a-b8a1a7483cef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e7f8ee7-4757-4375-977a-b8a1a7483cef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e7f8ee7-4757-4375-977a-b8a1a7483cef>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c9b3dd2-df7a-4402-a3ff-970ec25312ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c9b3dd2-df7a-4402-a3ff-970ec25312ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c9b3dd2-df7a-4402-a3ff-970ec25312ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fc1a20c-9f9a-4faa-93df-1b28cc9e86ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fc1a20c-9f9a-4faa-93df-1b28cc9e86ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fc1a20c-9f9a-4faa-93df-1b28cc9e86ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca2ce7dc-fe7e-4a87-b45c-9668135e107a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca2ce7dc-fe7e-4a87-b45c-9668135e107a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca2ce7dc-fe7e-4a87-b45c-9668135e107a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f2f2b5f-9c43-44ab-af14-8ff7b9372966> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f2f2b5f-9c43-44ab-af14-8ff7b9372966";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f2f2b5f-9c43-44ab-af14-8ff7b9372966>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d26f9fe-b6ef-4b7d-b040-47c8e52ba66f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d26f9fe-b6ef-4b7d-b040-47c8e52ba66f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d26f9fe-b6ef-4b7d-b040-47c8e52ba66f>.
+    
+<http://data.lblod.info/id/remote-data-objects/89a42fee-5231-4f1e-a159-2bbe397884f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89a42fee-5231-4f1e-a159-2bbe397884f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89a42fee-5231-4f1e-a159-2bbe397884f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1353b744-beef-4366-a8df-e9e8789eecec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1353b744-beef-4366-a8df-e9e8789eecec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_04-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1353b744-beef-4366-a8df-e9e8789eecec>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4cfdc63-c61e-412f-affd-23bc11c10652> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4cfdc63-c61e-412f-affd-23bc11c10652";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4cfdc63-c61e-412f-affd-23bc11c10652>.
+    
+<http://data.lblod.info/id/remote-data-objects/01de60db-031f-4ba3-9a09-d8084d0933bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01de60db-031f-4ba3-9a09-d8084d0933bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9b5d166b-1356-41ac-b624-d2a212885c32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01de60db-031f-4ba3-9a09-d8084d0933bc>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201235-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201235-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201235-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201235-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d9e11098-2a6e-47a4-8299-82fe11abd560> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d9e11098-2a6e-47a4-8299-82fe11abd560";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f20e0c36-1716-459a-90f1-57ada8045bc2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/576ec1ee-8be0-4128-8d49-071e50dca953> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "576ec1ee-8be0-4128-8d49-071e50dca953";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2>.
+
+  <http://redpencil.data.gift/id/task/a4944fb5-3c9e-4f50-a43c-f5e087f17d58> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a4944fb5-3c9e-4f50-a43c-f5e087f17d58";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d9e11098-2a6e-47a4-8299-82fe11abd560>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/576ec1ee-8be0-4128-8d49-071e50dca953>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/1de86849-926b-4576-aa19-b0f91de70523> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1de86849-926b-4576-aa19-b0f91de70523";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1de86849-926b-4576-aa19-b0f91de70523>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b5d0da8-95b7-4ac9-bccb-b588e8f5570a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b5d0da8-95b7-4ac9-bccb-b588e8f5570a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b5d0da8-95b7-4ac9-bccb-b588e8f5570a>.
+    
+<http://data.lblod.info/id/remote-data-objects/75411598-b1d9-40ce-9553-8ed09bb9ddda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75411598-b1d9-40ce-9553-8ed09bb9ddda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_05-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75411598-b1d9-40ce-9553-8ed09bb9ddda>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4bbb7c9-73b8-47cf-8949-c8e3a5bee3fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4bbb7c9-73b8-47cf-8949-c8e3a5bee3fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4bbb7c9-73b8-47cf-8949-c8e3a5bee3fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e828140-3b9e-4c90-9a1f-249f73f13218> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e828140-3b9e-4c90-9a1f-249f73f13218";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e828140-3b9e-4c90-9a1f-249f73f13218>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2b2f691-94e2-4830-ac03-3c5e368a6d0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2b2f691-94e2-4830-ac03-3c5e368a6d0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2b2f691-94e2-4830-ac03-3c5e368a6d0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e392c54a-6440-4708-8a2e-44536090dbfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e392c54a-6440-4708-8a2e-44536090dbfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e392c54a-6440-4708-8a2e-44536090dbfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cb0ebff-d25a-4a58-9a31-2eda85942a67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cb0ebff-d25a-4a58-9a31-2eda85942a67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cb0ebff-d25a-4a58-9a31-2eda85942a67>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d564611-dd41-4a13-82bf-8eb3643c3c09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d564611-dd41-4a13-82bf-8eb3643c3c09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d564611-dd41-4a13-82bf-8eb3643c3c09>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f14ecab-8b4f-41b9-af0e-149a84a16d94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f14ecab-8b4f-41b9-af0e-149a84a16d94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f14ecab-8b4f-41b9-af0e-149a84a16d94>.
+    
+<http://data.lblod.info/id/remote-data-objects/50c47c8c-7e03-4a05-aced-4faa08f1f3a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50c47c8c-7e03-4a05-aced-4faa08f1f3a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50c47c8c-7e03-4a05-aced-4faa08f1f3a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbc7a769-d5e8-43a6-a3d6-9b8b378d7cb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbc7a769-d5e8-43a6-a3d6-9b8b378d7cb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbc7a769-d5e8-43a6-a3d6-9b8b378d7cb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/827d8cda-7448-4193-aba0-9a2d41fcd696> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "827d8cda-7448-4193-aba0-9a2d41fcd696";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/827d8cda-7448-4193-aba0-9a2d41fcd696>.
+    
+<http://data.lblod.info/id/remote-data-objects/dea593dd-ed46-4a35-8764-09565e6339c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dea593dd-ed46-4a35-8764-09565e6339c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_11-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dea593dd-ed46-4a35-8764-09565e6339c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e8ffd66-255e-4fc3-83e7-26b8627f888a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e8ffd66-255e-4fc3-83e7-26b8627f888a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e8ffd66-255e-4fc3-83e7-26b8627f888a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d28ec744-5681-4344-8edd-ffff8839f96f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d28ec744-5681-4344-8edd-ffff8839f96f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d28ec744-5681-4344-8edd-ffff8839f96f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1cfb791-3b99-4839-bb4d-0ed009c2b294> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1cfb791-3b99-4839-bb4d-0ed009c2b294";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1cfb791-3b99-4839-bb4d-0ed009c2b294>.
+    
+<http://data.lblod.info/id/remote-data-objects/cee2af77-58ee-4ed4-949a-c71c0322ae0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cee2af77-58ee-4ed4-949a-c71c0322ae0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cee2af77-58ee-4ed4-949a-c71c0322ae0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f815a11d-ef2b-4947-8b7f-cf1a4826df42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f815a11d-ef2b-4947-8b7f-cf1a4826df42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f815a11d-ef2b-4947-8b7f-cf1a4826df42>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f553ea7-6af6-492a-bd81-50f81f6755b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f553ea7-6af6-492a-bd81-50f81f6755b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f553ea7-6af6-492a-bd81-50f81f6755b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/98e40c8b-45b7-4fdb-b997-73b14c7ddc43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98e40c8b-45b7-4fdb-b997-73b14c7ddc43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98e40c8b-45b7-4fdb-b997-73b14c7ddc43>.
+    
+<http://data.lblod.info/id/remote-data-objects/42ac712d-8ce7-476d-bfe1-e37475a35b0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42ac712d-8ce7-476d-bfe1-e37475a35b0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42ac712d-8ce7-476d-bfe1-e37475a35b0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/41d39860-234e-418c-8ec8-dd3b21034860> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41d39860-234e-418c-8ec8-dd3b21034860";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41d39860-234e-418c-8ec8-dd3b21034860>.
+    
+<http://data.lblod.info/id/remote-data-objects/b61e9ea7-2988-4919-a07b-a331c6fd10c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b61e9ea7-2988-4919-a07b-a331c6fd10c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b61e9ea7-2988-4919-a07b-a331c6fd10c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a48f5597-b869-4b49-9489-9f44888a74c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a48f5597-b869-4b49-9489-9f44888a74c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_16-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a48f5597-b869-4b49-9489-9f44888a74c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1243476-c73c-4026-a4f8-093436937782> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1243476-c73c-4026-a4f8-093436937782";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1243476-c73c-4026-a4f8-093436937782>.
+    
+<http://data.lblod.info/id/remote-data-objects/69d76073-ca37-4234-99cc-c91881a14daa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69d76073-ca37-4234-99cc-c91881a14daa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69d76073-ca37-4234-99cc-c91881a14daa>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c800ed5-782c-4fed-beda-4ac9522287cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c800ed5-782c-4fed-beda-4ac9522287cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c800ed5-782c-4fed-beda-4ac9522287cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/057a6a2b-bd7e-44bd-8f36-972630f373a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "057a6a2b-bd7e-44bd-8f36-972630f373a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/057a6a2b-bd7e-44bd-8f36-972630f373a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb2507fe-cee1-4cb4-9570-d5c28c69f44d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb2507fe-cee1-4cb4-9570-d5c28c69f44d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb2507fe-cee1-4cb4-9570-d5c28c69f44d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6d8086a-358e-42d5-89a1-9b2214653c7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6d8086a-358e-42d5-89a1-9b2214653c7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_17-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6d8086a-358e-42d5-89a1-9b2214653c7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/17f0d491-ce1b-49b0-868b-4e50f3098081> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17f0d491-ce1b-49b0-868b-4e50f3098081";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17f0d491-ce1b-49b0-868b-4e50f3098081>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f3ad382-92e5-48d6-8573-2265d5af6335> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f3ad382-92e5-48d6-8573-2265d5af6335";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f3ad382-92e5-48d6-8573-2265d5af6335>.
+    
+<http://data.lblod.info/id/remote-data-objects/352f641d-eaa8-4472-9585-f24329eb8a91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "352f641d-eaa8-4472-9585-f24329eb8a91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/352f641d-eaa8-4472-9585-f24329eb8a91>.
+    
+<http://data.lblod.info/id/remote-data-objects/210ed68d-9ee4-408d-904e-f6ac6da18e50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "210ed68d-9ee4-408d-904e-f6ac6da18e50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/210ed68d-9ee4-408d-904e-f6ac6da18e50>.
+    
+<http://data.lblod.info/id/remote-data-objects/08be2b1c-e2e2-41e9-96fb-f1dcbe41b366> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08be2b1c-e2e2-41e9-96fb-f1dcbe41b366";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08be2b1c-e2e2-41e9-96fb-f1dcbe41b366>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a9efea4-fa95-4dc8-81a3-4d808f23cd82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a9efea4-fa95-4dc8-81a3-4d808f23cd82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a9efea4-fa95-4dc8-81a3-4d808f23cd82>.
+    
+<http://data.lblod.info/id/remote-data-objects/d194228e-85ab-43b5-bd6b-2a4b77e4409b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d194228e-85ab-43b5-bd6b-2a4b77e4409b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d194228e-85ab-43b5-bd6b-2a4b77e4409b>.
+    
+<http://data.lblod.info/id/remote-data-objects/bad6e681-1ac4-442d-82f3-2cbaab6991d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bad6e681-1ac4-442d-82f3-2cbaab6991d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bad6e681-1ac4-442d-82f3-2cbaab6991d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/24c3d3d7-d497-4ac6-9138-fa37e33aaf48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24c3d3d7-d497-4ac6-9138-fa37e33aaf48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24c3d3d7-d497-4ac6-9138-fa37e33aaf48>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e215e4a-19d9-4211-b089-4d53f71eee90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e215e4a-19d9-4211-b089-4d53f71eee90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e215e4a-19d9-4211-b089-4d53f71eee90>.
+    
+<http://data.lblod.info/id/remote-data-objects/cca97b59-7874-4c1a-a521-462aaf965d7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cca97b59-7874-4c1a-a521-462aaf965d7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cca97b59-7874-4c1a-a521-462aaf965d7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e5ab3e9-be17-4770-9c1d-5f1cd46d60c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e5ab3e9-be17-4770-9c1d-5f1cd46d60c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e5ab3e9-be17-4770-9c1d-5f1cd46d60c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c79070a1-61f6-4443-8397-6637a8142af3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c79070a1-61f6-4443-8397-6637a8142af3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_22-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c79070a1-61f6-4443-8397-6637a8142af3>.
+    
+<http://data.lblod.info/id/remote-data-objects/94f2b79d-a072-4435-ab5e-f4f827551395> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94f2b79d-a072-4435-ab5e-f4f827551395";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94f2b79d-a072-4435-ab5e-f4f827551395>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb80a77f-2428-47f4-996e-3d419b589166> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb80a77f-2428-47f4-996e-3d419b589166";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb80a77f-2428-47f4-996e-3d419b589166>.
+    
+<http://data.lblod.info/id/remote-data-objects/f52e1eff-a055-4fb7-b41a-5767959476b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f52e1eff-a055-4fb7-b41a-5767959476b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f52e1eff-a055-4fb7-b41a-5767959476b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4254028b-0752-47c7-8ce5-17e18b13092f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4254028b-0752-47c7-8ce5-17e18b13092f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4254028b-0752-47c7-8ce5-17e18b13092f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1363f98c-b8f6-4dee-b224-18f64a3d3ac5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1363f98c-b8f6-4dee-b224-18f64a3d3ac5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1363f98c-b8f6-4dee-b224-18f64a3d3ac5>.
+    
+<http://data.lblod.info/id/remote-data-objects/dda99514-4b34-4367-8e93-1c27f86e0528> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dda99514-4b34-4367-8e93-1c27f86e0528";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f20e0c36-1716-459a-90f1-57ada8045bc2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dda99514-4b34-4367-8e93-1c27f86e0528>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201236-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201236-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201236-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201236-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b5be8504-3c88-496f-b6c4-24bc6ab11b92> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b5be8504-3c88-496f-b6c4-24bc6ab11b92";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "62948358-5ac2-4ec3-a26e-43ca86183814";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/7e5c4142-21a6-4049-af56-18bade04f348> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7e5c4142-21a6-4049-af56-18bade04f348";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814>.
+
+  <http://redpencil.data.gift/id/task/160a33d6-51fc-4113-84f0-56e0cc884322> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "160a33d6-51fc-4113-84f0-56e0cc884322";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b5be8504-3c88-496f-b6c4-24bc6ab11b92>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/7e5c4142-21a6-4049-af56-18bade04f348>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/303d0152-9896-46e0-bdaa-def24c4b20b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "303d0152-9896-46e0-bdaa-def24c4b20b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/303d0152-9896-46e0-bdaa-def24c4b20b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e543e04a-cdaa-496f-8162-b53a7831d53f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e543e04a-cdaa-496f-8162-b53a7831d53f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e543e04a-cdaa-496f-8162-b53a7831d53f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f23ffd5-b458-44a4-9f87-26eee65290ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f23ffd5-b458-44a4-9f87-26eee65290ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f23ffd5-b458-44a4-9f87-26eee65290ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a09084f-0a0d-44b8-8006-8dda4bfea1d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a09084f-0a0d-44b8-8006-8dda4bfea1d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a09084f-0a0d-44b8-8006-8dda4bfea1d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/de106e87-248b-42f0-b45c-722f3b8c78c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de106e87-248b-42f0-b45c-722f3b8c78c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de106e87-248b-42f0-b45c-722f3b8c78c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f312e3d-763b-4108-82a9-56b2fd8271ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f312e3d-763b-4108-82a9-56b2fd8271ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f312e3d-763b-4108-82a9-56b2fd8271ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ff84af1-1833-421d-96dc-c240736402e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ff84af1-1833-421d-96dc-c240736402e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ff84af1-1833-421d-96dc-c240736402e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/afebf713-df25-4a59-81f4-5d0da0e9c6b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afebf713-df25-4a59-81f4-5d0da0e9c6b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afebf713-df25-4a59-81f4-5d0da0e9c6b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a39c1cce-2e4e-4d54-a413-711e26c7be1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a39c1cce-2e4e-4d54-a413-711e26c7be1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a39c1cce-2e4e-4d54-a413-711e26c7be1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/466f589c-04a6-48a5-888a-960d8e5b6484> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "466f589c-04a6-48a5-888a-960d8e5b6484";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/466f589c-04a6-48a5-888a-960d8e5b6484>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ce52f5d-646f-470a-9775-7a4a216a3edf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ce52f5d-646f-470a-9775-7a4a216a3edf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_29-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ce52f5d-646f-470a-9775-7a4a216a3edf>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cd6f690-4768-4d45-a20f-f3255bf86b91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cd6f690-4768-4d45-a20f-f3255bf86b91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cd6f690-4768-4d45-a20f-f3255bf86b91>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5423a1c-f8f5-4a11-9e25-64a3217b9a55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5423a1c-f8f5-4a11-9e25-64a3217b9a55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5423a1c-f8f5-4a11-9e25-64a3217b9a55>.
+    
+<http://data.lblod.info/id/remote-data-objects/b50d6ea1-a8ed-467b-895d-a9f0025ffaac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b50d6ea1-a8ed-467b-895d-a9f0025ffaac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b50d6ea1-a8ed-467b-895d-a9f0025ffaac>.
+    
+<http://data.lblod.info/id/remote-data-objects/f47324ae-c02a-4ca8-9103-41f54bac5699> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f47324ae-c02a-4ca8-9103-41f54bac5699";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f47324ae-c02a-4ca8-9103-41f54bac5699>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd5f3afd-ea47-4c34-adea-1c7889350233> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd5f3afd-ea47-4c34-adea-1c7889350233";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd5f3afd-ea47-4c34-adea-1c7889350233>.
+    
+<http://data.lblod.info/id/remote-data-objects/36a40bdd-3e58-4158-b81f-36a8aa7a230b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36a40bdd-3e58-4158-b81f-36a8aa7a230b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_01-02-2022_35078.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36a40bdd-3e58-4158-b81f-36a8aa7a230b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b188938-8f31-401b-8093-30580a40c512> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b188938-8f31-401b-8093-30580a40c512";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_01-02-2022_35080.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b188938-8f31-401b-8093-30580a40c512>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8e90035-5d62-4d03-adfa-a2e026c4ecc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8e90035-5d62-4d03-adfa-a2e026c4ecc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_01-02-2022_35088.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8e90035-5d62-4d03-adfa-a2e026c4ecc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fa3d408-1f1c-4d77-b2d9-18123d918b53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fa3d408-1f1c-4d77-b2d9-18123d918b53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_01-02-2022_35093.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fa3d408-1f1c-4d77-b2d9-18123d918b53>.
+    
+<http://data.lblod.info/id/remote-data-objects/c28c70a6-58b2-4401-8db2-6b55172b7e3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c28c70a6-58b2-4401-8db2-6b55172b7e3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_01-02-2022_35157.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c28c70a6-58b2-4401-8db2-6b55172b7e3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/99f3d939-07a3-4d67-8b2d-2818220f2780> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99f3d939-07a3-4d67-8b2d-2818220f2780";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_01-02-2022_35177.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99f3d939-07a3-4d67-8b2d-2818220f2780>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc9913ef-c314-4fc8-a90f-2c1aee2ca442> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc9913ef-c314-4fc8-a90f-2c1aee2ca442";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_01-02-2022_35185.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc9913ef-c314-4fc8-a90f-2c1aee2ca442>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0864f6d-354b-4e4d-b96b-72f9a06d85a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0864f6d-354b-4e4d-b96b-72f9a06d85a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_01-02-2022_35192.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0864f6d-354b-4e4d-b96b-72f9a06d85a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a426f32d-5f62-40d2-9f7d-cc8c333a9c08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a426f32d-5f62-40d2-9f7d-cc8c333a9c08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_01-02-2022_35196.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a426f32d-5f62-40d2-9f7d-cc8c333a9c08>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f2b7028-66ec-4dfb-8856-cb4bdccd20f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f2b7028-66ec-4dfb-8856-cb4bdccd20f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_01-02-2022_35203.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f2b7028-66ec-4dfb-8856-cb4bdccd20f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7967315-8ce7-4de7-89a2-a7ffc66146dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7967315-8ce7-4de7-89a2-a7ffc66146dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_01-02-2022_35254.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7967315-8ce7-4de7-89a2-a7ffc66146dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b4965af-8136-4688-8ba5-0ba4b69321c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b4965af-8136-4688-8ba5-0ba4b69321c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_01-02-2022_35264.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b4965af-8136-4688-8ba5-0ba4b69321c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1a39f0b-8577-4ae5-99a4-b961ee3d0d5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1a39f0b-8577-4ae5-99a4-b961ee3d0d5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_01-02-2022_35283.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1a39f0b-8577-4ae5-99a4-b961ee3d0d5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdead0a4-a772-4d71-b9bd-45a21ea6cfc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdead0a4-a772-4d71-b9bd-45a21ea6cfc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_01-04-2022_36943.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdead0a4-a772-4d71-b9bd-45a21ea6cfc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/5df7ca57-7590-4468-abb7-ff2525e1f185> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5df7ca57-7590-4468-abb7-ff2525e1f185";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_01-04-2022_36946.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5df7ca57-7590-4468-abb7-ff2525e1f185>.
+    
+<http://data.lblod.info/id/remote-data-objects/ede04359-886c-49b2-bd9f-ae995326b7f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ede04359-886c-49b2-bd9f-ae995326b7f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_02-06-2022_38341.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ede04359-886c-49b2-bd9f-ae995326b7f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c22bef8-9f0c-45b9-a5c0-91837a85b98e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c22bef8-9f0c-45b9-a5c0-91837a85b98e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_02-06-2022_38343.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c22bef8-9f0c-45b9-a5c0-91837a85b98e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7d4ee21-24ea-4d46-8102-7c60e48ec72d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7d4ee21-24ea-4d46-8102-7c60e48ec72d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_02-12-2021_34106.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7d4ee21-24ea-4d46-8102-7c60e48ec72d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d945c0fa-042f-4dcd-83b1-296a958aca97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d945c0fa-042f-4dcd-83b1-296a958aca97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_02-12-2021_34110.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d945c0fa-042f-4dcd-83b1-296a958aca97>.
+    
+<http://data.lblod.info/id/remote-data-objects/99c2a151-6567-4c88-8084-b81254ca4ae9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99c2a151-6567-4c88-8084-b81254ca4ae9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-02-2022_35355.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99c2a151-6567-4c88-8084-b81254ca4ae9>.
+    
+<http://data.lblod.info/id/remote-data-objects/58774a92-4b75-4b6c-9e11-d76297cb073d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58774a92-4b75-4b6c-9e11-d76297cb073d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37440.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58774a92-4b75-4b6c-9e11-d76297cb073d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b2ba57f-99b1-4545-9c46-edaba84f6c1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b2ba57f-99b1-4545-9c46-edaba84f6c1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37450.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b2ba57f-99b1-4545-9c46-edaba84f6c1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccf6a6e8-cfb2-4211-9581-2cf216887171> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccf6a6e8-cfb2-4211-9581-2cf216887171";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37455.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccf6a6e8-cfb2-4211-9581-2cf216887171>.
+    
+<http://data.lblod.info/id/remote-data-objects/defcf6ce-70be-4922-876e-549647d222d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "defcf6ce-70be-4922-876e-549647d222d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37462.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/defcf6ce-70be-4922-876e-549647d222d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/65acd641-2f4b-424c-9983-fcc218e2973f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65acd641-2f4b-424c-9983-fcc218e2973f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37468.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65acd641-2f4b-424c-9983-fcc218e2973f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef8620f9-f868-4e4c-b5c2-056008a080ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef8620f9-f868-4e4c-b5c2-056008a080ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37474.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef8620f9-f868-4e4c-b5c2-056008a080ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/e650fed7-8bac-4e03-addd-a27a208f79da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e650fed7-8bac-4e03-addd-a27a208f79da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37497.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e650fed7-8bac-4e03-addd-a27a208f79da>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b687268-1ea7-419c-a593-2b2aaca3abba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b687268-1ea7-419c-a593-2b2aaca3abba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37500.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b687268-1ea7-419c-a593-2b2aaca3abba>.
+    
+<http://data.lblod.info/id/remote-data-objects/fec5a555-f6b2-4d19-a0e1-7d93009712ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fec5a555-f6b2-4d19-a0e1-7d93009712ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37510.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fec5a555-f6b2-4d19-a0e1-7d93009712ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/f30e5e08-03d3-45d9-8b2b-66b3b98325bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f30e5e08-03d3-45d9-8b2b-66b3b98325bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37511.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f30e5e08-03d3-45d9-8b2b-66b3b98325bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f87e20f-7a4f-4f59-aacd-742be141ef60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f87e20f-7a4f-4f59-aacd-742be141ef60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37517.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f87e20f-7a4f-4f59-aacd-742be141ef60>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7796a72-cd95-4db2-b3c8-96a9a3815e09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7796a72-cd95-4db2-b3c8-96a9a3815e09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37527.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7796a72-cd95-4db2-b3c8-96a9a3815e09>.
+    
+<http://data.lblod.info/id/remote-data-objects/3244a7d9-f4d0-4b3c-9052-8d5d439906a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3244a7d9-f4d0-4b3c-9052-8d5d439906a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37561.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3244a7d9-f4d0-4b3c-9052-8d5d439906a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0b1ac3e-c6bf-44a7-bac7-b3ac20231aa9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0b1ac3e-c6bf-44a7-bac7-b3ac20231aa9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37565.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62948358-5ac2-4ec3-a26e-43ca86183814> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0b1ac3e-c6bf-44a7-bac7-b3ac20231aa9>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201237-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201237-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201237-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201237-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/90650ed3-932f-444c-b6df-6341e1241285> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "90650ed3-932f-444c-b6df-6341e1241285";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "85e8ba05-6baf-46b2-b62b-752266576a03";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/0b984d94-d9b5-457b-839e-ab9c65b46dcf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0b984d94-d9b5-457b-839e-ab9c65b46dcf";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03>.
+
+  <http://redpencil.data.gift/id/task/0c3f759b-4ea1-45a5-be8f-473a4421047d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0c3f759b-4ea1-45a5-be8f-473a4421047d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/90650ed3-932f-444c-b6df-6341e1241285>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/0b984d94-d9b5-457b-839e-ab9c65b46dcf>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/3d27c256-aa13-4b5b-897d-ab31890d7083> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d27c256-aa13-4b5b-897d-ab31890d7083";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37567.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d27c256-aa13-4b5b-897d-ab31890d7083>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a4d1ca9-1b26-41ca-b6b9-a1a3c740a1c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a4d1ca9-1b26-41ca-b6b9-a1a3c740a1c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37616.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a4d1ca9-1b26-41ca-b6b9-a1a3c740a1c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b1a8181-fdf3-4a37-b2f9-bb0213a1034e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b1a8181-fdf3-4a37-b2f9-bb0213a1034e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-05-2022_37773.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b1a8181-fdf3-4a37-b2f9-bb0213a1034e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d9c7bb0-20a6-4482-bb7e-8a114d1d5142> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d9c7bb0-20a6-4482-bb7e-8a114d1d5142";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-11-2021_33099.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d9c7bb0-20a6-4482-bb7e-8a114d1d5142>.
+    
+<http://data.lblod.info/id/remote-data-objects/77e0fa3a-3aec-4a89-9822-a39bf22d202f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77e0fa3a-3aec-4a89-9822-a39bf22d202f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_03-11-2021_33128.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77e0fa3a-3aec-4a89-9822-a39bf22d202f>.
+    
+<http://data.lblod.info/id/remote-data-objects/745a6d71-8bdb-411f-a257-c021fbbab805> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "745a6d71-8bdb-411f-a257-c021fbbab805";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_04-01-2022_34626.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/745a6d71-8bdb-411f-a257-c021fbbab805>.
+    
+<http://data.lblod.info/id/remote-data-objects/92e7015d-c7aa-4c98-820d-e6898e38e475> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92e7015d-c7aa-4c98-820d-e6898e38e475";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_04-01-2022_34628.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92e7015d-c7aa-4c98-820d-e6898e38e475>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b065b3a-d1dc-438b-90d7-9959418c55e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b065b3a-d1dc-438b-90d7-9959418c55e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_04-01-2022_34648.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b065b3a-d1dc-438b-90d7-9959418c55e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcdb9b97-31d4-4a11-bbf0-07c94dbb8fe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcdb9b97-31d4-4a11-bbf0-07c94dbb8fe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_04-01-2022_34660.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcdb9b97-31d4-4a11-bbf0-07c94dbb8fe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0bd6093-5124-457d-9f35-2da9fe77ed05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0bd6093-5124-457d-9f35-2da9fe77ed05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_04-01-2022_34666.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0bd6093-5124-457d-9f35-2da9fe77ed05>.
+    
+<http://data.lblod.info/id/remote-data-objects/06dbff87-ebea-4c46-aaa3-ef3db15e791b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06dbff87-ebea-4c46-aaa3-ef3db15e791b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_04-05-2022_37680.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06dbff87-ebea-4c46-aaa3-ef3db15e791b>.
+    
+<http://data.lblod.info/id/remote-data-objects/87a5f8b6-9729-4f6e-ac39-fdc43b47567e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87a5f8b6-9729-4f6e-ac39-fdc43b47567e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_04-11-2021_33234.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87a5f8b6-9729-4f6e-ac39-fdc43b47567e>.
+    
+<http://data.lblod.info/id/remote-data-objects/145cbc57-3025-45c2-9757-8783a6b49b2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "145cbc57-3025-45c2-9757-8783a6b49b2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-01-2022_34681.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/145cbc57-3025-45c2-9757-8783a6b49b2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b612b7e-c842-48fb-bfb6-400de7c8c220> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b612b7e-c842-48fb-bfb6-400de7c8c220";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-04-2022_36844.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b612b7e-c842-48fb-bfb6-400de7c8c220>.
+    
+<http://data.lblod.info/id/remote-data-objects/43420c50-4990-4eb3-9668-61ebe4bf64a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43420c50-4990-4eb3-9668-61ebe4bf64a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-04-2022_36870.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43420c50-4990-4eb3-9668-61ebe4bf64a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/77feb4d5-fd98-435e-80c8-a2a815299e10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77feb4d5-fd98-435e-80c8-a2a815299e10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-04-2022_36872.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77feb4d5-fd98-435e-80c8-a2a815299e10>.
+    
+<http://data.lblod.info/id/remote-data-objects/82fbde59-e79a-4461-a204-bba21b0051c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82fbde59-e79a-4461-a204-bba21b0051c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-04-2022_36876.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82fbde59-e79a-4461-a204-bba21b0051c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f9e2f46-c037-439a-b4e5-d0b5dc24bd40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f9e2f46-c037-439a-b4e5-d0b5dc24bd40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-04-2022_36878.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f9e2f46-c037-439a-b4e5-d0b5dc24bd40>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ffc4b83-7fb6-492f-a7ee-bcf0b3c593a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ffc4b83-7fb6-492f-a7ee-bcf0b3c593a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-04-2022_36885.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ffc4b83-7fb6-492f-a7ee-bcf0b3c593a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c83e812e-5db0-4ff8-9f1a-96337a70e25a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c83e812e-5db0-4ff8-9f1a-96337a70e25a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-04-2022_37010.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c83e812e-5db0-4ff8-9f1a-96337a70e25a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a9f7645-ff8b-40b4-9c5e-b2c8b25e7409> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a9f7645-ff8b-40b4-9c5e-b2c8b25e7409";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-05-2022_37713.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a9f7645-ff8b-40b4-9c5e-b2c8b25e7409>.
+    
+<http://data.lblod.info/id/remote-data-objects/fee6e890-b2d4-4a42-8012-e5e4c22b985c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fee6e890-b2d4-4a42-8012-e5e4c22b985c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-10-2021_32368.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fee6e890-b2d4-4a42-8012-e5e4c22b985c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d565baf8-ab52-45ad-b12b-d3681b0df5ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d565baf8-ab52-45ad-b12b-d3681b0df5ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-10-2021_32383.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d565baf8-ab52-45ad-b12b-d3681b0df5ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3b8bf37-96ad-4fff-917f-ee78f5852b6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3b8bf37-96ad-4fff-917f-ee78f5852b6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-10-2021_32388.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3b8bf37-96ad-4fff-917f-ee78f5852b6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/74329ebb-92f8-424d-ba85-32c175f1bfa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74329ebb-92f8-424d-ba85-32c175f1bfa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-10-2021_32459.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74329ebb-92f8-424d-ba85-32c175f1bfa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec5070ca-1a63-469f-81b9-847f1e958003> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec5070ca-1a63-469f-81b9-847f1e958003";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-10-2021_32468.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec5070ca-1a63-469f-81b9-847f1e958003>.
+    
+<http://data.lblod.info/id/remote-data-objects/1949f141-2aa9-41e6-9277-2b3e912fbdb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1949f141-2aa9-41e6-9277-2b3e912fbdb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-10-2021_32490.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1949f141-2aa9-41e6-9277-2b3e912fbdb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/6eb8fa94-628a-4adb-99b1-ee45e55f5997> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6eb8fa94-628a-4adb-99b1-ee45e55f5997";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-10-2021_32526.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6eb8fa94-628a-4adb-99b1-ee45e55f5997>.
+    
+<http://data.lblod.info/id/remote-data-objects/daf982b8-0e7f-4343-a3e5-a55e15537050> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "daf982b8-0e7f-4343-a3e5-a55e15537050";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_05-11-2021_33325.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/daf982b8-0e7f-4343-a3e5-a55e15537050>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2ff3547-b12f-4838-b076-a83e8a1366de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2ff3547-b12f-4838-b076-a83e8a1366de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_06-04-2022_37023.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2ff3547-b12f-4838-b076-a83e8a1366de>.
+    
+<http://data.lblod.info/id/remote-data-objects/511c3d44-87c9-4f36-b492-6a8bd80487a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "511c3d44-87c9-4f36-b492-6a8bd80487a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_06-10-2021_32556.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/511c3d44-87c9-4f36-b492-6a8bd80487a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/abbff09d-4de9-47d6-8733-7805b6799845> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abbff09d-4de9-47d6-8733-7805b6799845";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_07-06-2022_38301.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abbff09d-4de9-47d6-8733-7805b6799845>.
+    
+<http://data.lblod.info/id/remote-data-objects/e859cda6-7e6e-4893-a39b-c502cd60646d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e859cda6-7e6e-4893-a39b-c502cd60646d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_07-06-2022_38350.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e859cda6-7e6e-4893-a39b-c502cd60646d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fc5c6c4-19dd-4d73-af6b-8e52aac2b6e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fc5c6c4-19dd-4d73-af6b-8e52aac2b6e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_07-06-2022_38360.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fc5c6c4-19dd-4d73-af6b-8e52aac2b6e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/be4aacb1-5523-413a-964c-892b3db82f90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be4aacb1-5523-413a-964c-892b3db82f90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_07-06-2022_38364.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be4aacb1-5523-413a-964c-892b3db82f90>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bceea87-de11-4733-adc1-0748beec9b65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bceea87-de11-4733-adc1-0748beec9b65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_07-06-2022_38392.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bceea87-de11-4733-adc1-0748beec9b65>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ecd9305-5f15-47b6-985b-f728288c8081> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ecd9305-5f15-47b6-985b-f728288c8081";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_07-06-2022_38417.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ecd9305-5f15-47b6-985b-f728288c8081>.
+    
+<http://data.lblod.info/id/remote-data-objects/da1bb42e-38ba-470a-84df-f144f17f1f38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da1bb42e-38ba-470a-84df-f144f17f1f38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_07-10-2021_32594.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da1bb42e-38ba-470a-84df-f144f17f1f38>.
+    
+<http://data.lblod.info/id/remote-data-objects/b79d836c-6211-4c6d-9094-72fe548e2393> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b79d836c-6211-4c6d-9094-72fe548e2393";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_07-10-2021_32599.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b79d836c-6211-4c6d-9094-72fe548e2393>.
+    
+<http://data.lblod.info/id/remote-data-objects/8247ce7f-6f8f-401f-8240-706d80a886cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8247ce7f-6f8f-401f-8240-706d80a886cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_07-10-2021_32601.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8247ce7f-6f8f-401f-8240-706d80a886cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3cc73f2-48ec-4e7c-b05a-845af65cfe8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3cc73f2-48ec-4e7c-b05a-845af65cfe8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_07-10-2021_32607.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3cc73f2-48ec-4e7c-b05a-845af65cfe8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1b99fe4-feb7-4928-aede-0da0602f0567> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1b99fe4-feb7-4928-aede-0da0602f0567";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-02-2022_35305.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1b99fe4-feb7-4928-aede-0da0602f0567>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d799a0b-335e-4c61-a4af-fb5b22fb13f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d799a0b-335e-4c61-a4af-fb5b22fb13f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-02-2022_35308.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d799a0b-335e-4c61-a4af-fb5b22fb13f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/956f6bc4-bb87-44ac-8876-0adfe1a153e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "956f6bc4-bb87-44ac-8876-0adfe1a153e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-02-2022_35323.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/956f6bc4-bb87-44ac-8876-0adfe1a153e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb47455b-e77a-4033-913a-e58b633571c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb47455b-e77a-4033-913a-e58b633571c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-02-2022_35387.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb47455b-e77a-4033-913a-e58b633571c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/506035dd-5dff-40de-a1a8-3cc003714bcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "506035dd-5dff-40de-a1a8-3cc003714bcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-02-2022_35394.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/506035dd-5dff-40de-a1a8-3cc003714bcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9a64545-3832-4dbc-b8c8-6f70a64a51c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9a64545-3832-4dbc-b8c8-6f70a64a51c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-02-2022_35400.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9a64545-3832-4dbc-b8c8-6f70a64a51c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f869dada-3d85-4202-a844-dc61caceff79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f869dada-3d85-4202-a844-dc61caceff79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-02-2022_35432.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f869dada-3d85-4202-a844-dc61caceff79>.
+    
+<http://data.lblod.info/id/remote-data-objects/82d60ffb-aaed-48db-9fd9-c9d6e5a4a8ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82d60ffb-aaed-48db-9fd9-c9d6e5a4a8ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-03-2022_36141.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82d60ffb-aaed-48db-9fd9-c9d6e5a4a8ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/9629044f-52cb-4d89-8ee3-d2304791c5c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9629044f-52cb-4d89-8ee3-d2304791c5c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-03-2022_36142.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85e8ba05-6baf-46b2-b62b-752266576a03> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9629044f-52cb-4d89-8ee3-d2304791c5c9>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201239-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201239-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201239-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201239-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/1e3729ea-816f-4de2-a307-e77e66d1f712> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1e3729ea-816f-4de2-a307-e77e66d1f712";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "092b3c09-afd3-40c5-9358-6d422c40ce49";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/19655429-75e9-4c6d-a6ce-d754f85cfb3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "19655429-75e9-4c6d-a6ce-d754f85cfb3d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49>.
+
+  <http://redpencil.data.gift/id/task/8504922d-229a-4755-9e3d-cf6f6461f6e2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8504922d-229a-4755-9e3d-cf6f6461f6e2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/1e3729ea-816f-4de2-a307-e77e66d1f712>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/19655429-75e9-4c6d-a6ce-d754f85cfb3d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e753abc4-1d43-4fb7-9b2b-674b63f1df7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e753abc4-1d43-4fb7-9b2b-674b63f1df7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-03-2022_36143.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e753abc4-1d43-4fb7-9b2b-674b63f1df7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a924de6c-7bfa-4244-928e-a3890116b563> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a924de6c-7bfa-4244-928e-a3890116b563";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-03-2022_36147.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a924de6c-7bfa-4244-928e-a3890116b563>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1c2bd8c-e58e-4dfc-8070-911aa6b76add> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1c2bd8c-e58e-4dfc-8070-911aa6b76add";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-03-2022_36156.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1c2bd8c-e58e-4dfc-8070-911aa6b76add>.
+    
+<http://data.lblod.info/id/remote-data-objects/355637dd-fd8c-4ad6-a60b-c834dc7d6a1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "355637dd-fd8c-4ad6-a60b-c834dc7d6a1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-03-2022_36185.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/355637dd-fd8c-4ad6-a60b-c834dc7d6a1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3661569c-2c0b-48f5-b8b0-2283286cfa43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3661569c-2c0b-48f5-b8b0-2283286cfa43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-03-2022_36202.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3661569c-2c0b-48f5-b8b0-2283286cfa43>.
+    
+<http://data.lblod.info/id/remote-data-objects/03a48298-95db-4d98-a332-57293c36249c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03a48298-95db-4d98-a332-57293c36249c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-03-2022_36225.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03a48298-95db-4d98-a332-57293c36249c>.
+    
+<http://data.lblod.info/id/remote-data-objects/83aff1b3-79f8-4ef2-a4d6-760cbbb8caee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83aff1b3-79f8-4ef2-a4d6-760cbbb8caee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-03-2022_36228.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83aff1b3-79f8-4ef2-a4d6-760cbbb8caee>.
+    
+<http://data.lblod.info/id/remote-data-objects/fec828d6-8b7f-4665-a086-dc223a47be56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fec828d6-8b7f-4665-a086-dc223a47be56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-03-2022_36231.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fec828d6-8b7f-4665-a086-dc223a47be56>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8f961c7-0c75-48a3-8ebf-e4163dd3cd82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8f961c7-0c75-48a3-8ebf-e4163dd3cd82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-03-2022_36237.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8f961c7-0c75-48a3-8ebf-e4163dd3cd82>.
+    
+<http://data.lblod.info/id/remote-data-objects/413058b9-3c98-4260-8809-ef5f8bbd4264> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "413058b9-3c98-4260-8809-ef5f8bbd4264";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-03-2022_36272.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/413058b9-3c98-4260-8809-ef5f8bbd4264>.
+    
+<http://data.lblod.info/id/remote-data-objects/87f30f3b-5f8c-4be0-afcf-c5509818f138> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87f30f3b-5f8c-4be0-afcf-c5509818f138";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_08-03-2022_36275.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87f30f3b-5f8c-4be0-afcf-c5509818f138>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f9584f9-1cde-4c62-be68-a0a6b22b3617> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f9584f9-1cde-4c62-be68-a0a6b22b3617";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_09-02-2022_35518.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f9584f9-1cde-4c62-be68-a0a6b22b3617>.
+    
+<http://data.lblod.info/id/remote-data-objects/b442c248-0e5f-4e46-b41c-5a938fea059f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b442c248-0e5f-4e46-b41c-5a938fea059f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_09-02-2022_35532.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b442c248-0e5f-4e46-b41c-5a938fea059f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a593a5c1-157d-4a45-92bb-86fac59fd36f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a593a5c1-157d-4a45-92bb-86fac59fd36f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_09-02-2022_35535.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a593a5c1-157d-4a45-92bb-86fac59fd36f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e58bc339-87ef-4d65-a318-dde94de03e13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e58bc339-87ef-4d65-a318-dde94de03e13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_09-02-2022_35539.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e58bc339-87ef-4d65-a318-dde94de03e13>.
+    
+<http://data.lblod.info/id/remote-data-objects/130f6cb4-2231-4d31-ad74-0e7912d35f61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "130f6cb4-2231-4d31-ad74-0e7912d35f61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_09-02-2022_35577.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/130f6cb4-2231-4d31-ad74-0e7912d35f61>.
+    
+<http://data.lblod.info/id/remote-data-objects/f557e0de-5205-4df0-a8ae-5a5035f6cefe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f557e0de-5205-4df0-a8ae-5a5035f6cefe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_09-11-2021_33186.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f557e0de-5205-4df0-a8ae-5a5035f6cefe>.
+    
+<http://data.lblod.info/id/remote-data-objects/53cee037-b343-46fd-b963-62fbe1ce5149> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53cee037-b343-46fd-b963-62fbe1ce5149";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_09-11-2021_33205.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53cee037-b343-46fd-b963-62fbe1ce5149>.
+    
+<http://data.lblod.info/id/remote-data-objects/081c2383-c53b-44d0-95a6-5ad95e0a7711> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "081c2383-c53b-44d0-95a6-5ad95e0a7711";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_09-11-2021_33211.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/081c2383-c53b-44d0-95a6-5ad95e0a7711>.
+    
+<http://data.lblod.info/id/remote-data-objects/e312cd44-0e6e-48f8-9c94-f57766791427> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e312cd44-0e6e-48f8-9c94-f57766791427";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_09-11-2021_33230.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e312cd44-0e6e-48f8-9c94-f57766791427>.
+    
+<http://data.lblod.info/id/remote-data-objects/d965490e-6c91-440d-ac46-1e05b32607a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d965490e-6c91-440d-ac46-1e05b32607a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_09-11-2021_33242.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d965490e-6c91-440d-ac46-1e05b32607a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4526d849-b02c-46be-b4ee-4fa0563e3cb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4526d849-b02c-46be-b4ee-4fa0563e3cb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_09-11-2021_33263.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4526d849-b02c-46be-b4ee-4fa0563e3cb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ecc0ec4-1200-4092-8d6f-63234cba03dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ecc0ec4-1200-4092-8d6f-63234cba03dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_09-11-2021_33299.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ecc0ec4-1200-4092-8d6f-63234cba03dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/8221cb28-de64-4248-a262-37eb93d9595f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8221cb28-de64-4248-a262-37eb93d9595f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_09-11-2021_33319.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8221cb28-de64-4248-a262-37eb93d9595f>.
+    
+<http://data.lblod.info/id/remote-data-objects/22d25f00-0cc7-4a0b-9abe-bca62b95a6e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22d25f00-0cc7-4a0b-9abe-bca62b95a6e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_09-11-2021_33366.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22d25f00-0cc7-4a0b-9abe-bca62b95a6e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc477f96-33a8-4d61-9c4a-134bf8e4bace> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc477f96-33a8-4d61-9c4a-134bf8e4bace";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_10-03-2022_36348.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc477f96-33a8-4d61-9c4a-134bf8e4bace>.
+    
+<http://data.lblod.info/id/remote-data-objects/55b16078-fe07-4d45-9e15-aed70b4ee228> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55b16078-fe07-4d45-9e15-aed70b4ee228";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_10-05-2022_37695.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55b16078-fe07-4d45-9e15-aed70b4ee228>.
+    
+<http://data.lblod.info/id/remote-data-objects/147a4a02-a225-4d87-b229-0a3fca128e25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "147a4a02-a225-4d87-b229-0a3fca128e25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_10-05-2022_37710.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/147a4a02-a225-4d87-b229-0a3fca128e25>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f84867e-6812-48d0-baaf-1d0ac90fe680> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f84867e-6812-48d0-baaf-1d0ac90fe680";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_10-05-2022_37741.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f84867e-6812-48d0-baaf-1d0ac90fe680>.
+    
+<http://data.lblod.info/id/remote-data-objects/61ebb7ec-5a6f-45dd-a42a-b71a1529caeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61ebb7ec-5a6f-45dd-a42a-b71a1529caeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_10-05-2022_37760.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61ebb7ec-5a6f-45dd-a42a-b71a1529caeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e7f88bf-b820-431d-b49d-a1d7c920248b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e7f88bf-b820-431d-b49d-a1d7c920248b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_10-05-2022_37763.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e7f88bf-b820-431d-b49d-a1d7c920248b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d206439-dafc-48cc-8c63-5ed58a0b2cdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d206439-dafc-48cc-8c63-5ed58a0b2cdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_10-05-2022_37766.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d206439-dafc-48cc-8c63-5ed58a0b2cdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb959b16-b1dc-49be-b633-f88c8d86e03d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb959b16-b1dc-49be-b633-f88c8d86e03d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_10-05-2022_37803.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb959b16-b1dc-49be-b633-f88c8d86e03d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff4b2772-5220-4f95-a4cd-eebe8c22d6f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff4b2772-5220-4f95-a4cd-eebe8c22d6f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_10-05-2022_37808.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff4b2772-5220-4f95-a4cd-eebe8c22d6f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/acb34182-662e-4a9d-96db-146003d33ca2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acb34182-662e-4a9d-96db-146003d33ca2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_11-01-2022_34690.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acb34182-662e-4a9d-96db-146003d33ca2>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a1bd8a5-06b1-4aaa-9165-277e5f09374e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a1bd8a5-06b1-4aaa-9165-277e5f09374e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_11-01-2022_34696.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a1bd8a5-06b1-4aaa-9165-277e5f09374e>.
+    
+<http://data.lblod.info/id/remote-data-objects/55e70e99-d2ac-4eb7-80d4-66e7f2b1e26c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55e70e99-d2ac-4eb7-80d4-66e7f2b1e26c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_11-01-2022_34697.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55e70e99-d2ac-4eb7-80d4-66e7f2b1e26c>.
+    
+<http://data.lblod.info/id/remote-data-objects/91216b5c-cc8a-485e-baf5-c5380e7414f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91216b5c-cc8a-485e-baf5-c5380e7414f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_11-01-2022_34707.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91216b5c-cc8a-485e-baf5-c5380e7414f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f826618-72db-4297-9e8d-d467708110e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f826618-72db-4297-9e8d-d467708110e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_11-01-2022_34730.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f826618-72db-4297-9e8d-d467708110e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e134531-9f50-47ec-8c97-9ca63a75788c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e134531-9f50-47ec-8c97-9ca63a75788c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_11-01-2022_34740.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e134531-9f50-47ec-8c97-9ca63a75788c>.
+    
+<http://data.lblod.info/id/remote-data-objects/92ee6d54-833a-4e30-aecc-24d82f8c7f76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92ee6d54-833a-4e30-aecc-24d82f8c7f76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_11-01-2022_34781.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92ee6d54-833a-4e30-aecc-24d82f8c7f76>.
+    
+<http://data.lblod.info/id/remote-data-objects/01802795-beee-42f4-a766-72cbeaf69c70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01802795-beee-42f4-a766-72cbeaf69c70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_11-03-2022_36378.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01802795-beee-42f4-a766-72cbeaf69c70>.
+    
+<http://data.lblod.info/id/remote-data-objects/3eb076ad-7484-47d1-ba87-e1f31cf77be7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3eb076ad-7484-47d1-ba87-e1f31cf77be7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_11-03-2022_36400.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3eb076ad-7484-47d1-ba87-e1f31cf77be7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e4afdb9-a15c-4c84-b6c0-8ba6bbe717c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e4afdb9-a15c-4c84-b6c0-8ba6bbe717c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_11-03-2022_36408.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e4afdb9-a15c-4c84-b6c0-8ba6bbe717c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c376d47-b713-4f1c-8067-399b3d7bfb33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c376d47-b713-4f1c-8067-399b3d7bfb33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-04-2022_37003.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c376d47-b713-4f1c-8067-399b3d7bfb33>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc940933-ecce-4757-8095-efc906bb4105> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc940933-ecce-4757-8095-efc906bb4105";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-04-2022_37006.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc940933-ecce-4757-8095-efc906bb4105>.
+    
+<http://data.lblod.info/id/remote-data-objects/79bfc3fc-3780-4d4e-b3b0-37db9ca9ca07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79bfc3fc-3780-4d4e-b3b0-37db9ca9ca07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-04-2022_37049.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79bfc3fc-3780-4d4e-b3b0-37db9ca9ca07>.
+    
+<http://data.lblod.info/id/remote-data-objects/762e4390-b8ed-4cca-9e9f-bebccf8c1ef3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "762e4390-b8ed-4cca-9e9f-bebccf8c1ef3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-04-2022_37050.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/762e4390-b8ed-4cca-9e9f-bebccf8c1ef3>.
+    
+<http://data.lblod.info/id/remote-data-objects/726c14bb-2bb9-402f-b6ed-3f171b738c30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "726c14bb-2bb9-402f-b6ed-3f171b738c30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-04-2022_37054.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/726c14bb-2bb9-402f-b6ed-3f171b738c30>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed75b598-16a0-4665-862a-4efb58e9f0cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed75b598-16a0-4665-862a-4efb58e9f0cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-04-2022_37058.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092b3c09-afd3-40c5-9358-6d422c40ce49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed75b598-16a0-4665-862a-4efb58e9f0cd>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201240-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201240-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201240-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201240-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/450a1fb5-38d1-4965-8656-31eeb5a435be> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "450a1fb5-38d1-4965-8656-31eeb5a435be";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "723e49fd-bbe3-4674-a907-ecb3b5082201";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a3c9d6b1-0e1f-4ae3-b675-40d9d5caf455> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a3c9d6b1-0e1f-4ae3-b675-40d9d5caf455";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201>.
+
+  <http://redpencil.data.gift/id/task/570a352a-5b7e-4bd3-bade-c150767b51a9> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "570a352a-5b7e-4bd3-bade-c150767b51a9";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/450a1fb5-38d1-4965-8656-31eeb5a435be>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a3c9d6b1-0e1f-4ae3-b675-40d9d5caf455>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/fa41921c-c462-4e16-9d5b-902cd37304ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa41921c-c462-4e16-9d5b-902cd37304ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-04-2022_37063.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa41921c-c462-4e16-9d5b-902cd37304ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7ed49a7-7f36-4091-8a38-57f7c5a8a6f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7ed49a7-7f36-4091-8a38-57f7c5a8a6f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-04-2022_37065.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7ed49a7-7f36-4091-8a38-57f7c5a8a6f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d21c480a-0c3f-49e2-b457-195814f24292> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d21c480a-0c3f-49e2-b457-195814f24292";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-04-2022_37068.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d21c480a-0c3f-49e2-b457-195814f24292>.
+    
+<http://data.lblod.info/id/remote-data-objects/153a97b3-9313-49f1-9969-c200e95766bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "153a97b3-9313-49f1-9969-c200e95766bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-04-2022_37086.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/153a97b3-9313-49f1-9969-c200e95766bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea88b3c5-5b8e-4920-874d-e560e9335503> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea88b3c5-5b8e-4920-874d-e560e9335503";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-04-2022_37149.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea88b3c5-5b8e-4920-874d-e560e9335503>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebe8fa5b-eea2-4a24-beaa-7ccb9dc0e764> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebe8fa5b-eea2-4a24-beaa-7ccb9dc0e764";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-07-2022_39128.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebe8fa5b-eea2-4a24-beaa-7ccb9dc0e764>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffe7e517-39aa-4087-a4e2-ae9e45bdab3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffe7e517-39aa-4087-a4e2-ae9e45bdab3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-07-2022_39133.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffe7e517-39aa-4087-a4e2-ae9e45bdab3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1139a3c0-9083-49e1-80fe-74dfac51859b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1139a3c0-9083-49e1-80fe-74dfac51859b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-07-2022_39135.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1139a3c0-9083-49e1-80fe-74dfac51859b>.
+    
+<http://data.lblod.info/id/remote-data-objects/452a5d59-13bd-4b78-815f-55faafddaeaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "452a5d59-13bd-4b78-815f-55faafddaeaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-07-2022_39140.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/452a5d59-13bd-4b78-815f-55faafddaeaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ba2dd58-ba94-4187-8656-1dde519502fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ba2dd58-ba94-4187-8656-1dde519502fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-07-2022_39143.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ba2dd58-ba94-4187-8656-1dde519502fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/326d1319-01f9-4184-8c80-4df8035a17c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "326d1319-01f9-4184-8c80-4df8035a17c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-07-2022_39161.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/326d1319-01f9-4184-8c80-4df8035a17c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1aee593-dd97-4406-a0d3-03a105786866> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1aee593-dd97-4406-a0d3-03a105786866";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-07-2022_39164.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1aee593-dd97-4406-a0d3-03a105786866>.
+    
+<http://data.lblod.info/id/remote-data-objects/03fd8636-7221-4a63-8823-8be602c89cd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03fd8636-7221-4a63-8823-8be602c89cd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-07-2022_39169.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03fd8636-7221-4a63-8823-8be602c89cd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/03b93e4f-9915-4d6f-b0ee-a9578fadef64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03b93e4f-9915-4d6f-b0ee-a9578fadef64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-07-2022_39170.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03b93e4f-9915-4d6f-b0ee-a9578fadef64>.
+    
+<http://data.lblod.info/id/remote-data-objects/13ab68a3-6e2a-4c32-8ec9-9b06a4df4dbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13ab68a3-6e2a-4c32-8ec9-9b06a4df4dbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-07-2022_39172.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13ab68a3-6e2a-4c32-8ec9-9b06a4df4dbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9ac28ae-91b8-4f71-a1e0-c1872b04a299> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9ac28ae-91b8-4f71-a1e0-c1872b04a299";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-07-2022_39223.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9ac28ae-91b8-4f71-a1e0-c1872b04a299>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5266efc-90c8-4999-9190-54455c066098> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5266efc-90c8-4999-9190-54455c066098";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-10-2021_32559.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5266efc-90c8-4999-9190-54455c066098>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8499241-b1af-4a11-bd71-e059ca23bcd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8499241-b1af-4a11-bd71-e059ca23bcd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-10-2021_32587.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8499241-b1af-4a11-bd71-e059ca23bcd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef9a1fb5-bc25-4097-85db-63166556697f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef9a1fb5-bc25-4097-85db-63166556697f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-10-2021_32629.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef9a1fb5-bc25-4097-85db-63166556697f>.
+    
+<http://data.lblod.info/id/remote-data-objects/24340961-fa8b-4de2-9d68-95d00da9ca51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24340961-fa8b-4de2-9d68-95d00da9ca51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-10-2021_32632.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24340961-fa8b-4de2-9d68-95d00da9ca51>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b87abbc-e19d-4898-9bbe-14003b7223fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b87abbc-e19d-4898-9bbe-14003b7223fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-10-2021_32635.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b87abbc-e19d-4898-9bbe-14003b7223fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/89fe9ce8-667b-4264-bef1-e8f5bbdbab3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89fe9ce8-667b-4264-bef1-e8f5bbdbab3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_12-10-2021_32644.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89fe9ce8-667b-4264-bef1-e8f5bbdbab3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/964f41ea-6f3f-491a-8b4f-731948de2bb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "964f41ea-6f3f-491a-8b4f-731948de2bb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_13-05-2022_37943.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/964f41ea-6f3f-491a-8b4f-731948de2bb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc79f9b0-b940-4642-b585-aa1b0b2183e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc79f9b0-b940-4642-b585-aa1b0b2183e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_13-05-2022_37946.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc79f9b0-b940-4642-b585-aa1b0b2183e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/1680abb8-f64b-48d1-b0f6-aa44de5e5b4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1680abb8-f64b-48d1-b0f6-aa44de5e5b4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_14-04-2022_37228.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1680abb8-f64b-48d1-b0f6-aa44de5e5b4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0a73ef2-fe35-42a3-8fc3-cf957888cdee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0a73ef2-fe35-42a3-8fc3-cf957888cdee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_14-04-2022_37229.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0a73ef2-fe35-42a3-8fc3-cf957888cdee>.
+    
+<http://data.lblod.info/id/remote-data-objects/507ae777-f81d-4887-b25a-3661b17b8d02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "507ae777-f81d-4887-b25a-3661b17b8d02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_14-04-2022_37254.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/507ae777-f81d-4887-b25a-3661b17b8d02>.
+    
+<http://data.lblod.info/id/remote-data-objects/6faece06-242a-439f-a8a0-165c3aeda663> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6faece06-242a-439f-a8a0-165c3aeda663";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_14-06-2022_38453.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6faece06-242a-439f-a8a0-165c3aeda663>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ac07ea4-4592-4b6f-b6ce-993e254177d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ac07ea4-4592-4b6f-b6ce-993e254177d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_14-06-2022_38482.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ac07ea4-4592-4b6f-b6ce-993e254177d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/55a1bc1d-86f0-43b8-9a2b-12b20901243e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55a1bc1d-86f0-43b8-9a2b-12b20901243e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_14-06-2022_38485.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55a1bc1d-86f0-43b8-9a2b-12b20901243e>.
+    
+<http://data.lblod.info/id/remote-data-objects/336d40a6-f572-4a86-80d4-d3ffaabde74f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "336d40a6-f572-4a86-80d4-d3ffaabde74f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_14-06-2022_38488.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/336d40a6-f572-4a86-80d4-d3ffaabde74f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ec0bdac-61b7-4f2d-984a-4f70c8499f92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ec0bdac-61b7-4f2d-984a-4f70c8499f92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_14-06-2022_38521.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ec0bdac-61b7-4f2d-984a-4f70c8499f92>.
+    
+<http://data.lblod.info/id/remote-data-objects/18a3297c-1e71-4aec-aa75-b487c433b311> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18a3297c-1e71-4aec-aa75-b487c433b311";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_14-06-2022_38525.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18a3297c-1e71-4aec-aa75-b487c433b311>.
+    
+<http://data.lblod.info/id/remote-data-objects/0afed280-00a8-4a60-8135-a5bebd26e89a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0afed280-00a8-4a60-8135-a5bebd26e89a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_14-06-2022_38529.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0afed280-00a8-4a60-8135-a5bebd26e89a>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcea219d-b0f6-4014-9ee9-3bf0735446c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcea219d-b0f6-4014-9ee9-3bf0735446c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_14-06-2022_38533.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcea219d-b0f6-4014-9ee9-3bf0735446c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a792609e-7dcd-44d1-bc69-797859dcdc2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a792609e-7dcd-44d1-bc69-797859dcdc2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_14-06-2022_38536.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a792609e-7dcd-44d1-bc69-797859dcdc2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fc059af-0b0b-4733-a5da-487aa733e24e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fc059af-0b0b-4733-a5da-487aa733e24e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_14-07-2022_39250.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fc059af-0b0b-4733-a5da-487aa733e24e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec28497d-f613-4ab4-96e6-b6c09e08d02e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec28497d-f613-4ab4-96e6-b6c09e08d02e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_14-07-2022_39273.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec28497d-f613-4ab4-96e6-b6c09e08d02e>.
+    
+<http://data.lblod.info/id/remote-data-objects/49835b3c-1124-443d-94df-f18eb65bd63d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49835b3c-1124-443d-94df-f18eb65bd63d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_14-10-2021_32783.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49835b3c-1124-443d-94df-f18eb65bd63d>.
+    
+<http://data.lblod.info/id/remote-data-objects/992b8e87-5294-4581-9da5-4da3ef74dc69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "992b8e87-5294-4581-9da5-4da3ef74dc69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_14-10-2021_32784.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/992b8e87-5294-4581-9da5-4da3ef74dc69>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec92c92e-d234-4ed8-b516-e6362c916f69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec92c92e-d234-4ed8-b516-e6362c916f69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-02-2022_35440.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec92c92e-d234-4ed8-b516-e6362c916f69>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab0a33ff-0ebe-42cb-b869-fd1a3c1bd445> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab0a33ff-0ebe-42cb-b869-fd1a3c1bd445";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-02-2022_35451.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab0a33ff-0ebe-42cb-b869-fd1a3c1bd445>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c826827-401f-4bb9-9d3b-d0a0382fda4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c826827-401f-4bb9-9d3b-d0a0382fda4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-02-2022_35454.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c826827-401f-4bb9-9d3b-d0a0382fda4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d75b43a5-36f7-4d4f-8d56-14241d38ef06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d75b43a5-36f7-4d4f-8d56-14241d38ef06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-02-2022_35557.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d75b43a5-36f7-4d4f-8d56-14241d38ef06>.
+    
+<http://data.lblod.info/id/remote-data-objects/73b12d63-b3ea-4a37-aa13-a275668f4a36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73b12d63-b3ea-4a37-aa13-a275668f4a36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-02-2022_35560.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73b12d63-b3ea-4a37-aa13-a275668f4a36>.
+    
+<http://data.lblod.info/id/remote-data-objects/daf7380a-b2fa-4fde-8311-3c21eaf111d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "daf7380a-b2fa-4fde-8311-3c21eaf111d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-02-2022_35565.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/daf7380a-b2fa-4fde-8311-3c21eaf111d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1ef3a13-9aef-467b-b251-5c3e34dcf2e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1ef3a13-9aef-467b-b251-5c3e34dcf2e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-02-2022_35574.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1ef3a13-9aef-467b-b251-5c3e34dcf2e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dc60f6b-8577-4cf4-9393-00c12924765d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dc60f6b-8577-4cf4-9393-00c12924765d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-02-2022_35578.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dc60f6b-8577-4cf4-9393-00c12924765d>.
+    
+<http://data.lblod.info/id/remote-data-objects/72bc5447-2562-468e-a7aa-22035970f0a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72bc5447-2562-468e-a7aa-22035970f0a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-02-2022_35581.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72bc5447-2562-468e-a7aa-22035970f0a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/85c7126c-5e4c-4e50-975b-db44e0d1ee4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85c7126c-5e4c-4e50-975b-db44e0d1ee4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-02-2022_35812.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/723e49fd-bbe3-4674-a907-ecb3b5082201> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85c7126c-5e4c-4e50-975b-db44e0d1ee4a>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201241-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201241-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201241-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201241-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b8019076-b464-4932-8ec4-bb8ab1f620d4> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b8019076-b464-4932-8ec4-bb8ab1f620d4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "495fd115-64b4-4c3c-ba7d-d3464eed5dc6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/5fde315c-f60c-4752-91b9-f4eff42df926> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5fde315c-f60c-4752-91b9-f4eff42df926";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6>.
+
+  <http://redpencil.data.gift/id/task/137ff314-efbb-4525-b880-a96c096c87db> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "137ff314-efbb-4525-b880-a96c096c87db";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b8019076-b464-4932-8ec4-bb8ab1f620d4>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/5fde315c-f60c-4752-91b9-f4eff42df926>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7bd9d710-3626-452f-a37e-d9325541f7b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bd9d710-3626-452f-a37e-d9325541f7b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-03-2022_36244.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bd9d710-3626-452f-a37e-d9325541f7b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7404418-66db-4d75-8a0c-991aeb81876b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7404418-66db-4d75-8a0c-991aeb81876b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-03-2022_36249.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7404418-66db-4d75-8a0c-991aeb81876b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0565818-b52c-4988-8bd2-8b947ae5bd9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0565818-b52c-4988-8bd2-8b947ae5bd9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-03-2022_36313.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0565818-b52c-4988-8bd2-8b947ae5bd9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bf7b1c9-8d6f-4b27-8e9e-c612758ff448> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bf7b1c9-8d6f-4b27-8e9e-c612758ff448";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-03-2022_36316.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bf7b1c9-8d6f-4b27-8e9e-c612758ff448>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a10bc87-fbfe-4c6e-96dd-a08c62b4853a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a10bc87-fbfe-4c6e-96dd-a08c62b4853a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-03-2022_36320.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a10bc87-fbfe-4c6e-96dd-a08c62b4853a>.
+    
+<http://data.lblod.info/id/remote-data-objects/936aac8f-5b6f-48bf-b65c-8ed5e4d3b729> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "936aac8f-5b6f-48bf-b65c-8ed5e4d3b729";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-03-2022_36337.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/936aac8f-5b6f-48bf-b65c-8ed5e4d3b729>.
+    
+<http://data.lblod.info/id/remote-data-objects/7812a487-c00c-472e-b570-7058aca9b8a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7812a487-c00c-472e-b570-7058aca9b8a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-03-2022_36339.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7812a487-c00c-472e-b570-7058aca9b8a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cdda7bc-2c60-4f0f-a8fc-76aae006b80e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cdda7bc-2c60-4f0f-a8fc-76aae006b80e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-03-2022_36359.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cdda7bc-2c60-4f0f-a8fc-76aae006b80e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ceebd974-5d43-42c5-8a44-cd895a3b1ecb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ceebd974-5d43-42c5-8a44-cd895a3b1ecb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_15-06-2022_38574.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ceebd974-5d43-42c5-8a44-cd895a3b1ecb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c18829b3-d8be-4f23-8114-e8fc076ec46e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c18829b3-d8be-4f23-8114-e8fc076ec46e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_16-02-2022_35817.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c18829b3-d8be-4f23-8114-e8fc076ec46e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d81fd47b-ba0e-41b4-aca5-32658a9bff88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d81fd47b-ba0e-41b4-aca5-32658a9bff88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_16-02-2022_35823.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d81fd47b-ba0e-41b4-aca5-32658a9bff88>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a170e00-9e3c-400a-b0d3-a1a2f2f39ebd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a170e00-9e3c-400a-b0d3-a1a2f2f39ebd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_16-06-2022_38606.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a170e00-9e3c-400a-b0d3-a1a2f2f39ebd>.
+    
+<http://data.lblod.info/id/remote-data-objects/7808cf77-1b26-4906-837d-be2d9a2df1fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7808cf77-1b26-4906-837d-be2d9a2df1fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_16-06-2022_38612.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7808cf77-1b26-4906-837d-be2d9a2df1fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7e93c00-ca5a-43d6-a1cd-4ce6df9d054e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7e93c00-ca5a-43d6-a1cd-4ce6df9d054e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_16-06-2022_38633.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7e93c00-ca5a-43d6-a1cd-4ce6df9d054e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f69c56ad-4480-4e27-ba47-cb50c0a981ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f69c56ad-4480-4e27-ba47-cb50c0a981ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_16-11-2021_33344.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f69c56ad-4480-4e27-ba47-cb50c0a981ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbed486c-fe3c-4c82-8f18-6d0b0402710f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbed486c-fe3c-4c82-8f18-6d0b0402710f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_16-11-2021_33347.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbed486c-fe3c-4c82-8f18-6d0b0402710f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a945b373-72de-4d21-8321-b6356b7facc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a945b373-72de-4d21-8321-b6356b7facc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_16-11-2021_33352.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a945b373-72de-4d21-8321-b6356b7facc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/93d97938-5fa0-480e-a42e-09e1b6e0637f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93d97938-5fa0-480e-a42e-09e1b6e0637f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_16-11-2021_33360.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93d97938-5fa0-480e-a42e-09e1b6e0637f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1486dfbb-42a7-428e-80f5-def898f7bdad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1486dfbb-42a7-428e-80f5-def898f7bdad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_16-11-2021_33376.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1486dfbb-42a7-428e-80f5-def898f7bdad>.
+    
+<http://data.lblod.info/id/remote-data-objects/849820e3-54ee-43d5-b4ae-5f74c4a04928> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "849820e3-54ee-43d5-b4ae-5f74c4a04928";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_16-11-2021_33516.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/849820e3-54ee-43d5-b4ae-5f74c4a04928>.
+    
+<http://data.lblod.info/id/remote-data-objects/07018e42-c50e-4628-8552-5e2c558f05b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07018e42-c50e-4628-8552-5e2c558f05b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-02-2022_35844.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07018e42-c50e-4628-8552-5e2c558f05b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf1bae45-232e-4efa-948e-013b7cf67be5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf1bae45-232e-4efa-948e-013b7cf67be5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-02-2022_35877.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf1bae45-232e-4efa-948e-013b7cf67be5>.
+    
+<http://data.lblod.info/id/remote-data-objects/97a98bc7-f2d4-41db-9dc7-c0d4299c2b71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97a98bc7-f2d4-41db-9dc7-c0d4299c2b71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-03-2022_36526.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97a98bc7-f2d4-41db-9dc7-c0d4299c2b71>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b58c167-aa65-4f83-8d81-d3e9787b5678> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b58c167-aa65-4f83-8d81-d3e9787b5678";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-05-2022_37811.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b58c167-aa65-4f83-8d81-d3e9787b5678>.
+    
+<http://data.lblod.info/id/remote-data-objects/07cae99b-f17b-4aa1-bd12-357833952391> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07cae99b-f17b-4aa1-bd12-357833952391";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-05-2022_37823.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07cae99b-f17b-4aa1-bd12-357833952391>.
+    
+<http://data.lblod.info/id/remote-data-objects/68151205-b15e-43db-852b-ad693751a5b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68151205-b15e-43db-852b-ad693751a5b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-05-2022_37869.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68151205-b15e-43db-852b-ad693751a5b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a169eca-d187-480c-b65a-a386d7752eec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a169eca-d187-480c-b65a-a386d7752eec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-05-2022_37875.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a169eca-d187-480c-b65a-a386d7752eec>.
+    
+<http://data.lblod.info/id/remote-data-objects/17302f67-5e9f-4540-96cd-d76b9a0b9cf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17302f67-5e9f-4540-96cd-d76b9a0b9cf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-05-2022_37908.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17302f67-5e9f-4540-96cd-d76b9a0b9cf9>.
+    
+<http://data.lblod.info/id/remote-data-objects/13a77b6f-553c-42ec-a957-9889147e8deb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13a77b6f-553c-42ec-a957-9889147e8deb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-05-2022_37912.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13a77b6f-553c-42ec-a957-9889147e8deb>.
+    
+<http://data.lblod.info/id/remote-data-objects/54377f15-c2c7-4d37-b028-29542d8853ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54377f15-c2c7-4d37-b028-29542d8853ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-05-2022_37920.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54377f15-c2c7-4d37-b028-29542d8853ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/b28ce746-77ef-4784-8d6b-daac569e7ec5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b28ce746-77ef-4784-8d6b-daac569e7ec5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-05-2022_37924.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b28ce746-77ef-4784-8d6b-daac569e7ec5>.
+    
+<http://data.lblod.info/id/remote-data-objects/92403571-62bd-47fc-a0e6-f595884ee149> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92403571-62bd-47fc-a0e6-f595884ee149";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-05-2022_37951.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92403571-62bd-47fc-a0e6-f595884ee149>.
+    
+<http://data.lblod.info/id/remote-data-objects/39053114-ca2b-4f1d-9c75-a6df863661e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39053114-ca2b-4f1d-9c75-a6df863661e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-05-2022_37953.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39053114-ca2b-4f1d-9c75-a6df863661e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d8891ef-a322-4289-b51b-4801300fc825> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d8891ef-a322-4289-b51b-4801300fc825";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-05-2022_37973.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d8891ef-a322-4289-b51b-4801300fc825>.
+    
+<http://data.lblod.info/id/remote-data-objects/72e21ecf-05a2-4d37-a3d5-2ea92b86db06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72e21ecf-05a2-4d37-a3d5-2ea92b86db06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-05-2022_38010.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72e21ecf-05a2-4d37-a3d5-2ea92b86db06>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccbf7795-34d2-4741-91cc-b5c261b3bb12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccbf7795-34d2-4741-91cc-b5c261b3bb12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-05-2022_38012.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccbf7795-34d2-4741-91cc-b5c261b3bb12>.
+    
+<http://data.lblod.info/id/remote-data-objects/0be37b29-104d-46bd-b7fc-ad18ff80fe8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0be37b29-104d-46bd-b7fc-ad18ff80fe8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-06-2022_38648.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0be37b29-104d-46bd-b7fc-ad18ff80fe8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/836199c8-55c5-482b-a74c-cdfa8331c213> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "836199c8-55c5-482b-a74c-cdfa8331c213";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-06-2022_38658.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/836199c8-55c5-482b-a74c-cdfa8331c213>.
+    
+<http://data.lblod.info/id/remote-data-objects/3abc1734-1ec8-4abc-8680-89a8c163c286> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3abc1734-1ec8-4abc-8680-89a8c163c286";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-11-2021_33538.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3abc1734-1ec8-4abc-8680-89a8c163c286>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc56a654-33c4-4f4c-b51b-bb3101c30f1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc56a654-33c4-4f4c-b51b-bb3101c30f1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_17-11-2021_33553.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc56a654-33c4-4f4c-b51b-bb3101c30f1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b307495c-ba80-4146-8805-f83b6d32aaed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b307495c-ba80-4146-8805-f83b6d32aaed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_18-01-2022_34786.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b307495c-ba80-4146-8805-f83b6d32aaed>.
+    
+<http://data.lblod.info/id/remote-data-objects/968da44d-ba84-4fa5-8ba6-e7f141beac98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "968da44d-ba84-4fa5-8ba6-e7f141beac98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_18-01-2022_34798.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/968da44d-ba84-4fa5-8ba6-e7f141beac98>.
+    
+<http://data.lblod.info/id/remote-data-objects/da01a55b-aa89-4b11-b142-210190f6206e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da01a55b-aa89-4b11-b142-210190f6206e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_18-01-2022_34831.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da01a55b-aa89-4b11-b142-210190f6206e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bbc55c8-5200-4905-af03-9fe1811ee9ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bbc55c8-5200-4905-af03-9fe1811ee9ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_18-01-2022_34862.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bbc55c8-5200-4905-af03-9fe1811ee9ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/f94a6e2e-2673-4c8f-86e6-5c2a82a252ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f94a6e2e-2673-4c8f-86e6-5c2a82a252ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_18-01-2022_34871.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f94a6e2e-2673-4c8f-86e6-5c2a82a252ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/8be25633-b0ea-4301-b4e1-1792e883afb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8be25633-b0ea-4301-b4e1-1792e883afb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_18-01-2022_34924.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8be25633-b0ea-4301-b4e1-1792e883afb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/040837b8-9c74-4850-88d0-b30d30988452> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "040837b8-9c74-4850-88d0-b30d30988452";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_18-05-2022_38064.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/040837b8-9c74-4850-88d0-b30d30988452>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bcd091f-d033-4018-90dd-a6ca18b6052f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bcd091f-d033-4018-90dd-a6ca18b6052f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_18-05-2022_38072.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bcd091f-d033-4018-90dd-a6ca18b6052f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a252ef4-f439-44fc-adf0-70bdd72d88b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a252ef4-f439-44fc-adf0-70bdd72d88b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_18-11-2021_33642.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a252ef4-f439-44fc-adf0-70bdd72d88b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb9cd316-07c0-4148-a59c-3a014e165319> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb9cd316-07c0-4148-a59c-3a014e165319";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_19-04-2022_37126.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/495fd115-64b4-4c3c-ba7d-d3464eed5dc6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb9cd316-07c0-4148-a59c-3a014e165319>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201242-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201242-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201242-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201242-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/33150d38-3f82-4f23-9d61-25c186375937> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "33150d38-3f82-4f23-9d61-25c186375937";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "13e9a625-f4c2-4040-907f-ac1789020c27";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/0ed100a6-65c6-4246-9cec-de1480406112> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0ed100a6-65c6-4246-9cec-de1480406112";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27>.
+
+  <http://redpencil.data.gift/id/task/d75d0907-d6f8-4441-8738-ab6bc283a0ab> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d75d0907-d6f8-4441-8738-ab6bc283a0ab";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/33150d38-3f82-4f23-9d61-25c186375937>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/0ed100a6-65c6-4246-9cec-de1480406112>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b8215d8b-2f3e-44c3-b844-7a25a4d83751> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8215d8b-2f3e-44c3-b844-7a25a4d83751";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_19-04-2022_37153.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8215d8b-2f3e-44c3-b844-7a25a4d83751>.
+    
+<http://data.lblod.info/id/remote-data-objects/99d4ec43-b40c-4651-9307-b292fccb55cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99d4ec43-b40c-4651-9307-b292fccb55cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_19-04-2022_37162.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99d4ec43-b40c-4651-9307-b292fccb55cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/3399c4b6-9025-448b-9c35-742d24e594e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3399c4b6-9025-448b-9c35-742d24e594e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_19-04-2022_37195.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3399c4b6-9025-448b-9c35-742d24e594e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7b36cff-2828-4743-a996-d0e711100feb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7b36cff-2828-4743-a996-d0e711100feb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_19-04-2022_37198.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7b36cff-2828-4743-a996-d0e711100feb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4b199ce-9770-4d27-ad7c-895cb8580123> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4b199ce-9770-4d27-ad7c-895cb8580123";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_19-04-2022_37203.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4b199ce-9770-4d27-ad7c-895cb8580123>.
+    
+<http://data.lblod.info/id/remote-data-objects/821f0163-d3a5-45d3-a321-06ca6997498a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "821f0163-d3a5-45d3-a321-06ca6997498a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_19-04-2022_37205.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/821f0163-d3a5-45d3-a321-06ca6997498a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d943dc80-75eb-4289-ba14-f252ab794ace> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d943dc80-75eb-4289-ba14-f252ab794ace";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_19-04-2022_37234.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d943dc80-75eb-4289-ba14-f252ab794ace>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8878001-3b9d-4c99-90d2-1534249a0ac7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8878001-3b9d-4c99-90d2-1534249a0ac7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_19-04-2022_37271.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8878001-3b9d-4c99-90d2-1534249a0ac7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a236a32-03a5-400d-a28c-6bd256bc6e62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a236a32-03a5-400d-a28c-6bd256bc6e62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_19-07-2022_39275.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a236a32-03a5-400d-a28c-6bd256bc6e62>.
+    
+<http://data.lblod.info/id/remote-data-objects/7217205d-8872-4b6f-98c4-327d24f1b782> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7217205d-8872-4b6f-98c4-327d24f1b782";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_19-07-2022_39283.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7217205d-8872-4b6f-98c4-327d24f1b782>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c6e50f0-70f0-4e98-9c90-ac2d14c83d9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c6e50f0-70f0-4e98-9c90-ac2d14c83d9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_19-07-2022_39287.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c6e50f0-70f0-4e98-9c90-ac2d14c83d9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdac67bd-7f61-4a17-b20e-496693910289> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdac67bd-7f61-4a17-b20e-496693910289";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_19-07-2022_39301.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdac67bd-7f61-4a17-b20e-496693910289>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e9f65b6-9d11-42eb-9ff8-792c5b8ab6eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e9f65b6-9d11-42eb-9ff8-792c5b8ab6eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_19-07-2022_39317.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e9f65b6-9d11-42eb-9ff8-792c5b8ab6eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/2970117a-878f-480b-8efd-14686048985b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2970117a-878f-480b-8efd-14686048985b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_20-04-2022_37274.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2970117a-878f-480b-8efd-14686048985b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d85246ee-5118-479e-b755-c70a99ba0251> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d85246ee-5118-479e-b755-c70a99ba0251";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_21-06-2022_38578.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d85246ee-5118-479e-b755-c70a99ba0251>.
+    
+<http://data.lblod.info/id/remote-data-objects/211ee1e9-78fb-4234-a496-146c69881b83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "211ee1e9-78fb-4234-a496-146c69881b83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_21-06-2022_38581.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/211ee1e9-78fb-4234-a496-146c69881b83>.
+    
+<http://data.lblod.info/id/remote-data-objects/1036fff2-a033-455f-b6e5-52e238b5e8d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1036fff2-a033-455f-b6e5-52e238b5e8d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_21-06-2022_38653.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1036fff2-a033-455f-b6e5-52e238b5e8d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e843f210-faaf-45f3-ab57-6c4b657dd15e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e843f210-faaf-45f3-ab57-6c4b657dd15e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_21-06-2022_38668.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e843f210-faaf-45f3-ab57-6c4b657dd15e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a790296b-85e5-4aa4-bf83-aaa51248da62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a790296b-85e5-4aa4-bf83-aaa51248da62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_21-06-2022_38670.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a790296b-85e5-4aa4-bf83-aaa51248da62>.
+    
+<http://data.lblod.info/id/remote-data-objects/b84feda4-e9ad-4b2a-ba0b-48a285824544> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b84feda4-e9ad-4b2a-ba0b-48a285824544";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_21-06-2022_38673.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b84feda4-e9ad-4b2a-ba0b-48a285824544>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2c50949-cadc-4e57-8805-ae533f0c331f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2c50949-cadc-4e57-8805-ae533f0c331f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_21-06-2022_38676.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2c50949-cadc-4e57-8805-ae533f0c331f>.
+    
+<http://data.lblod.info/id/remote-data-objects/52fbc2c4-32ef-4a84-957b-f17abd51975d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52fbc2c4-32ef-4a84-957b-f17abd51975d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-02-2022_35866.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52fbc2c4-32ef-4a84-957b-f17abd51975d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f444cbc9-72cc-4cc9-96d3-9ae18717e14a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f444cbc9-72cc-4cc9-96d3-9ae18717e14a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-02-2022_35927.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f444cbc9-72cc-4cc9-96d3-9ae18717e14a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e886e6b-40af-49a9-871f-d8338e9b1c26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e886e6b-40af-49a9-871f-d8338e9b1c26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-02-2022_35972.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e886e6b-40af-49a9-871f-d8338e9b1c26>.
+    
+<http://data.lblod.info/id/remote-data-objects/669a8e6e-95b7-4fca-97be-b43b1128f5e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "669a8e6e-95b7-4fca-97be-b43b1128f5e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-02-2022_35976.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/669a8e6e-95b7-4fca-97be-b43b1128f5e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5b3c8cc-9fcf-4811-9745-f5f2167a5381> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5b3c8cc-9fcf-4811-9745-f5f2167a5381";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-02-2022_35986.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5b3c8cc-9fcf-4811-9745-f5f2167a5381>.
+    
+<http://data.lblod.info/id/remote-data-objects/340aef4e-e909-488d-ac73-ace0cf7ec568> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "340aef4e-e909-488d-ac73-ace0cf7ec568";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-03-2022_36410.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/340aef4e-e909-488d-ac73-ace0cf7ec568>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1265a61-add3-4ee4-ac83-218d54ec9d60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1265a61-add3-4ee4-ac83-218d54ec9d60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-03-2022_36422.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1265a61-add3-4ee4-ac83-218d54ec9d60>.
+    
+<http://data.lblod.info/id/remote-data-objects/40daa978-d704-48bf-a485-49d7f085042d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40daa978-d704-48bf-a485-49d7f085042d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-03-2022_36424.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40daa978-d704-48bf-a485-49d7f085042d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bc4e6f6-fee0-4d97-b4bf-4cf024629a2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bc4e6f6-fee0-4d97-b4bf-4cf024629a2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-03-2022_36479.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bc4e6f6-fee0-4d97-b4bf-4cf024629a2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac38df45-4ffa-4d86-9b33-b8cd89ce37e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac38df45-4ffa-4d86-9b33-b8cd89ce37e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-03-2022_36481.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac38df45-4ffa-4d86-9b33-b8cd89ce37e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f34ca5a1-8a8d-48ae-afbe-5f62f4515c69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f34ca5a1-8a8d-48ae-afbe-5f62f4515c69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-03-2022_36486.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f34ca5a1-8a8d-48ae-afbe-5f62f4515c69>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3755478-0d2a-411c-95f2-d6ae9fcef2fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3755478-0d2a-411c-95f2-d6ae9fcef2fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-03-2022_36502.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3755478-0d2a-411c-95f2-d6ae9fcef2fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2403f83-0585-4751-a51e-26fed2db42dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2403f83-0585-4751-a51e-26fed2db42dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-03-2022_36505.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2403f83-0585-4751-a51e-26fed2db42dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff666895-7cb1-451d-9c39-5f3c26ea4b99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff666895-7cb1-451d-9c39-5f3c26ea4b99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-03-2022_36508.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff666895-7cb1-451d-9c39-5f3c26ea4b99>.
+    
+<http://data.lblod.info/id/remote-data-objects/675ba822-9d7e-40ef-ade5-8d74a87c7159> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "675ba822-9d7e-40ef-ade5-8d74a87c7159";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-03-2022_36585.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/675ba822-9d7e-40ef-ade5-8d74a87c7159>.
+    
+<http://data.lblod.info/id/remote-data-objects/0df59887-78dc-4b2b-8907-2280bd700994> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0df59887-78dc-4b2b-8907-2280bd700994";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-03-2022_36588.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0df59887-78dc-4b2b-8907-2280bd700994>.
+    
+<http://data.lblod.info/id/remote-data-objects/53a47e80-de24-4571-992e-1a20c4ea4424> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53a47e80-de24-4571-992e-1a20c4ea4424";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-03-2022_36634.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53a47e80-de24-4571-992e-1a20c4ea4424>.
+    
+<http://data.lblod.info/id/remote-data-objects/b37bae8e-be7c-4cd2-9140-29afd2d0b81d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b37bae8e-be7c-4cd2-9140-29afd2d0b81d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-06-2022_38787.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b37bae8e-be7c-4cd2-9140-29afd2d0b81d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7f1a05b-cf5b-4d4d-9b4d-454237596534> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7f1a05b-cf5b-4d4d-9b4d-454237596534";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_22-06-2022_38789.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7f1a05b-cf5b-4d4d-9b4d-454237596534>.
+    
+<http://data.lblod.info/id/remote-data-objects/74961596-14d6-42ad-b1ba-786f028fd7dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74961596-14d6-42ad-b1ba-786f028fd7dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_23-02-2022_35996.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74961596-14d6-42ad-b1ba-786f028fd7dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6d5f559-c513-4781-b290-880393935d95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6d5f559-c513-4781-b290-880393935d95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_23-02-2022_36031.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6d5f559-c513-4781-b290-880393935d95>.
+    
+<http://data.lblod.info/id/remote-data-objects/2031dfa4-aa98-46d8-b408-4c93dd23bc0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2031dfa4-aa98-46d8-b408-4c93dd23bc0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_23-11-2021_33511.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2031dfa4-aa98-46d8-b408-4c93dd23bc0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd151ed2-a940-4065-864c-6c3d2f216f55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd151ed2-a940-4065-864c-6c3d2f216f55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_23-11-2021_33546.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd151ed2-a940-4065-864c-6c3d2f216f55>.
+    
+<http://data.lblod.info/id/remote-data-objects/615d134c-b57f-4b75-a19f-54d900846863> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "615d134c-b57f-4b75-a19f-54d900846863";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_23-11-2021_33570.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/615d134c-b57f-4b75-a19f-54d900846863>.
+    
+<http://data.lblod.info/id/remote-data-objects/47a8f096-58ef-452b-8131-6df9eec614fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47a8f096-58ef-452b-8131-6df9eec614fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_23-11-2021_33574.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47a8f096-58ef-452b-8131-6df9eec614fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/807c01e1-5ab4-4dde-9f92-fc6767ce1b61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "807c01e1-5ab4-4dde-9f92-fc6767ce1b61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_23-11-2021_33579.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/807c01e1-5ab4-4dde-9f92-fc6767ce1b61>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e461f89-967d-439f-b184-f4a0ecff1e11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e461f89-967d-439f-b184-f4a0ecff1e11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_23-11-2021_33583.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e461f89-967d-439f-b184-f4a0ecff1e11>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e166551-4824-44ca-a61d-74159bb4ba0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e166551-4824-44ca-a61d-74159bb4ba0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_23-11-2021_33596.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e166551-4824-44ca-a61d-74159bb4ba0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d8a7841-e5dc-45ac-b25e-f94e3ac08fb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d8a7841-e5dc-45ac-b25e-f94e3ac08fb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_23-11-2021_33728.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/13e9a625-f4c2-4040-907f-ac1789020c27> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d8a7841-e5dc-45ac-b25e-f94e3ac08fb1>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201244-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201244-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201244-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201244-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/928f26e0-f997-4c8a-9be6-60ce69747089> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "928f26e0-f997-4c8a-9be6-60ce69747089";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5c18b8fb-19ca-4620-9112-466300a196eb";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6ff4b0ac-6717-4eff-909b-1d28199d0bdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6ff4b0ac-6717-4eff-909b-1d28199d0bdd";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb>.
+
+  <http://redpencil.data.gift/id/task/c015654d-0f75-4917-a226-eb442fd9041e> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c015654d-0f75-4917-a226-eb442fd9041e";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/928f26e0-f997-4c8a-9be6-60ce69747089>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6ff4b0ac-6717-4eff-909b-1d28199d0bdd>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/6480a526-54ca-4f2d-881a-922b51c5befc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6480a526-54ca-4f2d-881a-922b51c5befc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_23-11-2021_33735.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6480a526-54ca-4f2d-881a-922b51c5befc>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf4c8813-e9d4-4f15-82fd-411659230291> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf4c8813-e9d4-4f15-82fd-411659230291";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_23-11-2021_33756.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf4c8813-e9d4-4f15-82fd-411659230291>.
+    
+<http://data.lblod.info/id/remote-data-objects/e74b9e4f-b090-4a8f-b38e-5eca92795d3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e74b9e4f-b090-4a8f-b38e-5eca92795d3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_23-11-2021_33757.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e74b9e4f-b090-4a8f-b38e-5eca92795d3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdfbd49a-fbe2-4b72-bfa4-d87b0ace791e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdfbd49a-fbe2-4b72-bfa4-d87b0ace791e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_23-11-2021_33784.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdfbd49a-fbe2-4b72-bfa4-d87b0ace791e>.
+    
+<http://data.lblod.info/id/remote-data-objects/dafd7bed-391c-4f8f-a73e-dd14f3849546> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dafd7bed-391c-4f8f-a73e-dd14f3849546";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_23-11-2021_33786.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dafd7bed-391c-4f8f-a73e-dd14f3849546>.
+    
+<http://data.lblod.info/id/remote-data-objects/3efc8bee-9716-4f7e-b8a3-e5ef3c746895> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3efc8bee-9716-4f7e-b8a3-e5ef3c746895";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_24-01-2022_35041.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3efc8bee-9716-4f7e-b8a3-e5ef3c746895>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b0ce5c8-ed92-49ba-8f6f-8b0a6be54df0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b0ce5c8-ed92-49ba-8f6f-8b0a6be54df0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_24-05-2022_38099.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b0ce5c8-ed92-49ba-8f6f-8b0a6be54df0>.
+    
+<http://data.lblod.info/id/remote-data-objects/28db3bce-8810-473a-96ef-fe9a17a590cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28db3bce-8810-473a-96ef-fe9a17a590cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_24-05-2022_38106.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28db3bce-8810-473a-96ef-fe9a17a590cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/8eafb395-fca0-4124-8167-08d0c4099a6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8eafb395-fca0-4124-8167-08d0c4099a6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_24-05-2022_38152.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8eafb395-fca0-4124-8167-08d0c4099a6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c96c34c0-49b8-46e4-af17-62e7cd480817> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c96c34c0-49b8-46e4-af17-62e7cd480817";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_24-05-2022_38159.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c96c34c0-49b8-46e4-af17-62e7cd480817>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dd8cef9-b8aa-4241-9d84-9553bcf77033> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dd8cef9-b8aa-4241-9d84-9553bcf77033";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_24-05-2022_38163.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dd8cef9-b8aa-4241-9d84-9553bcf77033>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddc9dda3-e92d-4c94-b97a-e74e3d242663> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddc9dda3-e92d-4c94-b97a-e74e3d242663";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_24-05-2022_38166.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddc9dda3-e92d-4c94-b97a-e74e3d242663>.
+    
+<http://data.lblod.info/id/remote-data-objects/489554f9-d8dd-49cf-a778-c481771d6a65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "489554f9-d8dd-49cf-a778-c481771d6a65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_24-05-2022_38193.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/489554f9-d8dd-49cf-a778-c481771d6a65>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc654cab-49c9-4d87-9238-36faf39390f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc654cab-49c9-4d87-9238-36faf39390f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_24-05-2022_38195.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc654cab-49c9-4d87-9238-36faf39390f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb6076bb-26f3-4f9a-a94e-cce343e1023e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb6076bb-26f3-4f9a-a94e-cce343e1023e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_24-05-2022_38198.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb6076bb-26f3-4f9a-a94e-cce343e1023e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f328922-eac2-4cb7-8aa7-685fe531959a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f328922-eac2-4cb7-8aa7-685fe531959a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_24-05-2022_38199.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f328922-eac2-4cb7-8aa7-685fe531959a>.
+    
+<http://data.lblod.info/id/remote-data-objects/734450fb-3358-4f98-a792-cc3c38195f1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "734450fb-3358-4f98-a792-cc3c38195f1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_24-05-2022_38204.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/734450fb-3358-4f98-a792-cc3c38195f1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c491ae6c-cb7c-491e-96c7-44c997dee98d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c491ae6c-cb7c-491e-96c7-44c997dee98d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_24-06-2022_38826.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c491ae6c-cb7c-491e-96c7-44c997dee98d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e65b08a-e7f0-4664-990f-a6bb85907340> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e65b08a-e7f0-4664-990f-a6bb85907340";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_24-06-2022_38830.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e65b08a-e7f0-4664-990f-a6bb85907340>.
+    
+<http://data.lblod.info/id/remote-data-objects/aafa4a5a-f35b-46d7-a143-1bd12c0f1f80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aafa4a5a-f35b-46d7-a143-1bd12c0f1f80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_24-11-2021_33806.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aafa4a5a-f35b-46d7-a143-1bd12c0f1f80>.
+    
+<http://data.lblod.info/id/remote-data-objects/347e5e33-b394-46d8-a435-651ccfa8b1ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "347e5e33-b394-46d8-a435-651ccfa8b1ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_25-01-2022_34917.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/347e5e33-b394-46d8-a435-651ccfa8b1ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4c648ce-d8b5-45d1-ae0f-af79cb61903e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4c648ce-d8b5-45d1-ae0f-af79cb61903e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_25-01-2022_34918.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4c648ce-d8b5-45d1-ae0f-af79cb61903e>.
+    
+<http://data.lblod.info/id/remote-data-objects/957a9e1f-8e92-4bda-874c-734cec763811> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "957a9e1f-8e92-4bda-874c-734cec763811";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_25-01-2022_34963.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/957a9e1f-8e92-4bda-874c-734cec763811>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e063b96-5a16-4ad5-9af5-b17d1e575334> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e063b96-5a16-4ad5-9af5-b17d1e575334";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_25-01-2022_35002.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e063b96-5a16-4ad5-9af5-b17d1e575334>.
+    
+<http://data.lblod.info/id/remote-data-objects/37155bd3-d3a9-40ab-9d48-04d3dc09cf9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37155bd3-d3a9-40ab-9d48-04d3dc09cf9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_25-01-2022_35005.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37155bd3-d3a9-40ab-9d48-04d3dc09cf9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/37c70ce7-5d68-4d55-b0aa-161fc6303eab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37c70ce7-5d68-4d55-b0aa-161fc6303eab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_25-01-2022_35010.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37c70ce7-5d68-4d55-b0aa-161fc6303eab>.
+    
+<http://data.lblod.info/id/remote-data-objects/66cd0a04-10b7-4cd5-95ce-676cdefae96a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66cd0a04-10b7-4cd5-95ce-676cdefae96a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_25-01-2022_35030.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66cd0a04-10b7-4cd5-95ce-676cdefae96a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e470edb9-356d-4126-839f-6b57cd3d806d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e470edb9-356d-4126-839f-6b57cd3d806d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_25-11-2021_33870.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e470edb9-356d-4126-839f-6b57cd3d806d>.
+    
+<http://data.lblod.info/id/remote-data-objects/422825ef-8ada-4d28-92a3-db6a0b926473> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "422825ef-8ada-4d28-92a3-db6a0b926473";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_26-01-2022_35122.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/422825ef-8ada-4d28-92a3-db6a0b926473>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1c18113-df45-4383-a43d-1517580d8f13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1c18113-df45-4383-a43d-1517580d8f13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_26-01-2022_35153.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1c18113-df45-4383-a43d-1517580d8f13>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c81ae20-5adc-4f8c-a1b8-05762ef7373e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c81ae20-5adc-4f8c-a1b8-05762ef7373e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_26-04-2022_37355.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c81ae20-5adc-4f8c-a1b8-05762ef7373e>.
+    
+<http://data.lblod.info/id/remote-data-objects/94f6fae0-c47b-41ae-bec5-3e5f078d1d0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94f6fae0-c47b-41ae-bec5-3e5f078d1d0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_26-04-2022_37364.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94f6fae0-c47b-41ae-bec5-3e5f078d1d0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9469aedf-273d-4264-88a4-c1cc77b3e88c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9469aedf-273d-4264-88a4-c1cc77b3e88c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_26-04-2022_37365.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9469aedf-273d-4264-88a4-c1cc77b3e88c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d912e854-c18e-46e9-8f5c-d1d82a398d11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d912e854-c18e-46e9-8f5c-d1d82a398d11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_26-04-2022_37371.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d912e854-c18e-46e9-8f5c-d1d82a398d11>.
+    
+<http://data.lblod.info/id/remote-data-objects/ceb14f05-8554-4592-99f6-f00eb84647c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ceb14f05-8554-4592-99f6-f00eb84647c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_26-04-2022_37382.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ceb14f05-8554-4592-99f6-f00eb84647c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/580851ac-a944-438c-9772-ddd5611268e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "580851ac-a944-438c-9772-ddd5611268e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_26-04-2022_37388.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/580851ac-a944-438c-9772-ddd5611268e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b70bb81-6e09-4f41-a009-c144bb4754f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b70bb81-6e09-4f41-a009-c144bb4754f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_26-04-2022_37409.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b70bb81-6e09-4f41-a009-c144bb4754f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6532de3-8b79-4faa-a20a-c49be6c6cac5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6532de3-8b79-4faa-a20a-c49be6c6cac5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_26-04-2022_37460.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6532de3-8b79-4faa-a20a-c49be6c6cac5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fa21377-4522-4051-8fff-b1dafa2e8b9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fa21377-4522-4051-8fff-b1dafa2e8b9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_26-04-2022_37465.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fa21377-4522-4051-8fff-b1dafa2e8b9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cdf4c99-8afa-4c82-a9e6-f3369dcbbeec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cdf4c99-8afa-4c82-a9e6-f3369dcbbeec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_26-04-2022_37466.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cdf4c99-8afa-4c82-a9e6-f3369dcbbeec>.
+    
+<http://data.lblod.info/id/remote-data-objects/29760d82-b8b6-4fd3-99a4-14261e44cf01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29760d82-b8b6-4fd3-99a4-14261e44cf01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_27-06-2022_38889.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29760d82-b8b6-4fd3-99a4-14261e44cf01>.
+    
+<http://data.lblod.info/id/remote-data-objects/819ec2b3-2ca5-4c9b-8495-2f8a6e80ab9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "819ec2b3-2ca5-4c9b-8495-2f8a6e80ab9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_27-06-2022_38891.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/819ec2b3-2ca5-4c9b-8495-2f8a6e80ab9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a579d39b-15f7-4619-8e3d-7b284db25656> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a579d39b-15f7-4619-8e3d-7b284db25656";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_27-10-2021_33095.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a579d39b-15f7-4619-8e3d-7b284db25656>.
+    
+<http://data.lblod.info/id/remote-data-objects/b35fd9b9-35b9-4051-b510-0475965d8dda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b35fd9b9-35b9-4051-b510-0475965d8dda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_28-06-2022_38681.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b35fd9b9-35b9-4051-b510-0475965d8dda>.
+    
+<http://data.lblod.info/id/remote-data-objects/1235ca11-8170-4cff-9b79-98037ab8bb70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1235ca11-8170-4cff-9b79-98037ab8bb70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_28-06-2022_38765.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1235ca11-8170-4cff-9b79-98037ab8bb70>.
+    
+<http://data.lblod.info/id/remote-data-objects/0753d02b-5360-4dc3-a641-3301cddc4220> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0753d02b-5360-4dc3-a641-3301cddc4220";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_28-06-2022_38837.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0753d02b-5360-4dc3-a641-3301cddc4220>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b8cb430-90af-442d-aa52-61afa18847b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b8cb430-90af-442d-aa52-61afa18847b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_28-06-2022_38845.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b8cb430-90af-442d-aa52-61afa18847b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/03a69637-59af-4467-a9d2-e8fa0d14c51d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03a69637-59af-4467-a9d2-e8fa0d14c51d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_28-06-2022_38852.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03a69637-59af-4467-a9d2-e8fa0d14c51d>.
+    
+<http://data.lblod.info/id/remote-data-objects/989ec7bf-d892-422f-8adc-aee9806e7899> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "989ec7bf-d892-422f-8adc-aee9806e7899";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_28-06-2022_38853.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/989ec7bf-d892-422f-8adc-aee9806e7899>.
+    
+<http://data.lblod.info/id/remote-data-objects/c786ef40-441d-425e-a891-cab9dfbebcee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c786ef40-441d-425e-a891-cab9dfbebcee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_28-06-2022_38870.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c18b8fb-19ca-4620-9112-466300a196eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c786ef40-441d-425e-a891-cab9dfbebcee>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201245-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201245-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201245-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201245-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/9f061d56-1c45-4108-8a50-757979fc4b9b> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9f061d56-1c45-4108-8a50-757979fc4b9b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "56e50562-13ef-4736-a9a5-3ad57d10d6b6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9a77dcc3-a5fa-4a2b-838a-9a9f49753d21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9a77dcc3-a5fa-4a2b-838a-9a9f49753d21";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6>.
+
+  <http://redpencil.data.gift/id/task/21460440-bdeb-4173-9558-0d702140c4fb> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "21460440-bdeb-4173-9558-0d702140c4fb";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/9f061d56-1c45-4108-8a50-757979fc4b9b>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9a77dcc3-a5fa-4a2b-838a-9a9f49753d21>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e9dbad45-aa4b-4c86-8869-b3a5915c0ac5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9dbad45-aa4b-4c86-8869-b3a5915c0ac5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_28-06-2022_38875.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9dbad45-aa4b-4c86-8869-b3a5915c0ac5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fb47c36-4b29-4b5d-84d9-328ae01bdc43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fb47c36-4b29-4b5d-84d9-328ae01bdc43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_28-06-2022_38877.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fb47c36-4b29-4b5d-84d9-328ae01bdc43>.
+    
+<http://data.lblod.info/id/remote-data-objects/04137926-6ad4-4592-b540-69fbfc40b0f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04137926-6ad4-4592-b540-69fbfc40b0f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_28-06-2022_38919.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04137926-6ad4-4592-b540-69fbfc40b0f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/1912a347-f81d-4705-a784-50f84a9b3741> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1912a347-f81d-4705-a784-50f84a9b3741";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_29-03-2022_36618.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1912a347-f81d-4705-a784-50f84a9b3741>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9736178-0a19-4b43-897c-6116a1de4ed9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9736178-0a19-4b43-897c-6116a1de4ed9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_29-03-2022_36656.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9736178-0a19-4b43-897c-6116a1de4ed9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c300c873-d79f-4fdb-bad8-e8fb975fcd4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c300c873-d79f-4fdb-bad8-e8fb975fcd4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_29-03-2022_36728.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c300c873-d79f-4fdb-bad8-e8fb975fcd4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5b29401-b861-45e9-badd-5abe8501fc36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5b29401-b861-45e9-badd-5abe8501fc36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_29-03-2022_36765.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5b29401-b861-45e9-badd-5abe8501fc36>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e9f9b8d-393f-4b3e-98ca-91a8636443fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e9f9b8d-393f-4b3e-98ca-91a8636443fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_29-03-2022_36780.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e9f9b8d-393f-4b3e-98ca-91a8636443fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c40cc21b-aeb5-4525-ac95-2d83f337941f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c40cc21b-aeb5-4525-ac95-2d83f337941f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_29-03-2022_36794.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c40cc21b-aeb5-4525-ac95-2d83f337941f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7783aa72-2fbe-4b4f-800e-d646414017f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7783aa72-2fbe-4b4f-800e-d646414017f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_29-03-2022_36797.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7783aa72-2fbe-4b4f-800e-d646414017f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d23d48fb-808c-4b8e-977b-d8a23aafc421> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d23d48fb-808c-4b8e-977b-d8a23aafc421";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_29-03-2022_36802.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d23d48fb-808c-4b8e-977b-d8a23aafc421>.
+    
+<http://data.lblod.info/id/remote-data-objects/75dcf32d-c16b-4e83-81b7-8796e55d6be8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75dcf32d-c16b-4e83-81b7-8796e55d6be8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_29-03-2022_36812.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75dcf32d-c16b-4e83-81b7-8796e55d6be8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3c9a0c6-f0b5-4ddf-89be-24966f9d9087> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3c9a0c6-f0b5-4ddf-89be-24966f9d9087";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_29-03-2022_36828.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3c9a0c6-f0b5-4ddf-89be-24966f9d9087>.
+    
+<http://data.lblod.info/id/remote-data-objects/6092dee6-49ab-4215-95c2-8656625610a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6092dee6-49ab-4215-95c2-8656625610a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_29-06-2022_38958.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6092dee6-49ab-4215-95c2-8656625610a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/2834fe69-5c73-4cf5-91de-b1190a064368> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2834fe69-5c73-4cf5-91de-b1190a064368";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_29-10-2021_33166.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2834fe69-5c73-4cf5-91de-b1190a064368>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2419007-c0c5-4c56-80f5-64e7b819bea1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2419007-c0c5-4c56-80f5-64e7b819bea1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_29-10-2021_33167.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2419007-c0c5-4c56-80f5-64e7b819bea1>.
+    
+<http://data.lblod.info/id/remote-data-objects/23e3f709-b197-4db3-8608-88ac9a650514> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23e3f709-b197-4db3-8608-88ac9a650514";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_30-05-2022_38274.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23e3f709-b197-4db3-8608-88ac9a650514>.
+    
+<http://data.lblod.info/id/remote-data-objects/98658027-597b-42f8-97e2-6de051a792ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98658027-597b-42f8-97e2-6de051a792ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_30-11-2021_33833.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98658027-597b-42f8-97e2-6de051a792ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/d46d400e-78f9-44a0-abb3-35c4e5a60abe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d46d400e-78f9-44a0-abb3-35c4e5a60abe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_30-11-2021_33850.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d46d400e-78f9-44a0-abb3-35c4e5a60abe>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2bf849f-e2ca-49e0-85b7-d5bcdc507896> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2bf849f-e2ca-49e0-85b7-d5bcdc507896";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_30-11-2021_33860.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2bf849f-e2ca-49e0-85b7-d5bcdc507896>.
+    
+<http://data.lblod.info/id/remote-data-objects/d76d37ea-3cba-4aee-84af-f21077b0345a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d76d37ea-3cba-4aee-84af-f21077b0345a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_30-11-2021_33943.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d76d37ea-3cba-4aee-84af-f21077b0345a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f9f0697-fada-411d-a4c1-67d654968cea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f9f0697-fada-411d-a4c1-67d654968cea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_30-11-2021_33947.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f9f0697-fada-411d-a4c1-67d654968cea>.
+    
+<http://data.lblod.info/id/remote-data-objects/78ac89c8-4c8c-4841-a09c-80aa5f7195ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78ac89c8-4c8c-4841-a09c-80aa5f7195ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_31-03-2022_36887.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78ac89c8-4c8c-4841-a09c-80aa5f7195ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e88ce2c-51fe-471d-96f9-3adb9ca5b0fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e88ce2c-51fe-471d-96f9-3adb9ca5b0fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_31-03-2022_36891.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e88ce2c-51fe-471d-96f9-3adb9ca5b0fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc0046de-7474-42e4-b16d-c2764702dbee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc0046de-7474-42e4-b16d-c2764702dbee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_31-03-2022_36895.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc0046de-7474-42e4-b16d-c2764702dbee>.
+    
+<http://data.lblod.info/id/remote-data-objects/d85cbd7f-491d-493c-8574-f0668da0dda9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d85cbd7f-491d-493c-8574-f0668da0dda9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_31-05-2022_38233.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d85cbd7f-491d-493c-8574-f0668da0dda9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9795b61e-ddf0-4fc4-ba0d-e95f20dd445b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9795b61e-ddf0-4fc4-ba0d-e95f20dd445b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_31-05-2022_38236.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9795b61e-ddf0-4fc4-ba0d-e95f20dd445b>.
+    
+<http://data.lblod.info/id/remote-data-objects/01c2d670-5256-43fb-82c0-6740e52e3b66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01c2d670-5256-43fb-82c0-6740e52e3b66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_31-05-2022_38238.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01c2d670-5256-43fb-82c0-6740e52e3b66>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cb20646-7fab-4467-92b9-f2ab57bbf474> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cb20646-7fab-4467-92b9-f2ab57bbf474";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_31-05-2022_38255.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cb20646-7fab-4467-92b9-f2ab57bbf474>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2b29bad-0a39-48a5-a74a-3e84d077e431> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2b29bad-0a39-48a5-a74a-3e84d077e431";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_31-05-2022_38266.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2b29bad-0a39-48a5-a74a-3e84d077e431>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf1dc0ac-0515-4c9a-b5ab-cffa2bec0db4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf1dc0ac-0515-4c9a-b5ab-cffa2bec0db4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_31-05-2022_38273.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf1dc0ac-0515-4c9a-b5ab-cffa2bec0db4>.
+    
+<http://data.lblod.info/id/remote-data-objects/167dee8c-07ee-4b02-85cb-2b106da6e654> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "167dee8c-07ee-4b02-85cb-2b106da6e654";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/cad2c7fd3e970184b5db8db1928df26624734b4576ba9e905e3aace323045b7a/GetPublication?filename=Uittreksels_31-05-2022_38313.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/167dee8c-07ee-4b02-85cb-2b106da6e654>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef9c4dc2-6ac7-4cc9-891a-479efad2c12e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef9c4dc2-6ac7-4cc9-891a-479efad2c12e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Agenda_Gemeenteraad_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef9c4dc2-6ac7-4cc9-891a-479efad2c12e>.
+    
+<http://data.lblod.info/id/remote-data-objects/497e8fee-2efe-4e4b-967c-d5d5a7efbdd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "497e8fee-2efe-4e4b-967c-d5d5a7efbdd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Agenda_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/497e8fee-2efe-4e4b-967c-d5d5a7efbdd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1de66fc-f309-4d04-a442-4380ff7d7f32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1de66fc-f309-4d04-a442-4380ff7d7f32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Agenda_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1de66fc-f309-4d04-a442-4380ff7d7f32>.
+    
+<http://data.lblod.info/id/remote-data-objects/c40f081d-f6c7-4561-b377-c115bcf07e49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c40f081d-f6c7-4561-b377-c115bcf07e49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Agenda_Gemeenteraad_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c40f081d-f6c7-4561-b377-c115bcf07e49>.
+    
+<http://data.lblod.info/id/remote-data-objects/7feaba34-282e-4e97-9f2e-c164e5aa30cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7feaba34-282e-4e97-9f2e-c164e5aa30cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Agenda_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7feaba34-282e-4e97-9f2e-c164e5aa30cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e70cbf6-06cc-48be-b7fe-59dcd119103d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e70cbf6-06cc-48be-b7fe-59dcd119103d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Agenda_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e70cbf6-06cc-48be-b7fe-59dcd119103d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e9944d3-b264-4d5e-b68f-6ae24eacdc79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e9944d3-b264-4d5e-b68f-6ae24eacdc79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Agenda_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e9944d3-b264-4d5e-b68f-6ae24eacdc79>.
+    
+<http://data.lblod.info/id/remote-data-objects/46ab5e5f-9f8e-4fe9-a899-47739bdfb557> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46ab5e5f-9f8e-4fe9-a899-47739bdfb557";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Agenda_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46ab5e5f-9f8e-4fe9-a899-47739bdfb557>.
+    
+<http://data.lblod.info/id/remote-data-objects/40d271c2-21f6-4d67-be69-ce1be00295bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40d271c2-21f6-4d67-be69-ce1be00295bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Agenda_Gemeenteraad_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40d271c2-21f6-4d67-be69-ce1be00295bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/001f4193-26f7-411d-a2d1-d36f7a7da231> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "001f4193-26f7-411d-a2d1-d36f7a7da231";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Agenda_Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/001f4193-26f7-411d-a2d1-d36f7a7da231>.
+    
+<http://data.lblod.info/id/remote-data-objects/50e7e177-fffc-46c3-b7a4-4a26599c8ae1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50e7e177-fffc-46c3-b7a4-4a26599c8ae1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=BesluitenLijst_Gemeenteraad_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50e7e177-fffc-46c3-b7a4-4a26599c8ae1>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf3ab8f1-ee0e-4b03-995b-9591a7f0a9c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf3ab8f1-ee0e-4b03-995b-9591a7f0a9c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=BesluitenLijst_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf3ab8f1-ee0e-4b03-995b-9591a7f0a9c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/47e65d1f-df3f-4ed9-9e37-548565b17245> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47e65d1f-df3f-4ed9-9e37-548565b17245";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47e65d1f-df3f-4ed9-9e37-548565b17245>.
+    
+<http://data.lblod.info/id/remote-data-objects/491a6baf-1b1d-4b72-a0bb-03e56be08990> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "491a6baf-1b1d-4b72-a0bb-03e56be08990";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/491a6baf-1b1d-4b72-a0bb-03e56be08990>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4013df7-4aea-4365-a2a2-de9494710e5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4013df7-4aea-4365-a2a2-de9494710e5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4013df7-4aea-4365-a2a2-de9494710e5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c738298-89ff-46d7-ad57-61206c395021> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c738298-89ff-46d7-ad57-61206c395021";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c738298-89ff-46d7-ad57-61206c395021>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fe9af1c-74cf-42b8-b8ba-509f9e075098> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fe9af1c-74cf-42b8-b8ba-509f9e075098";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fe9af1c-74cf-42b8-b8ba-509f9e075098>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bc4a307-d526-41bb-b1b5-2635b4bedbf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bc4a307-d526-41bb-b1b5-2635b4bedbf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/56e50562-13ef-4736-a9a5-3ad57d10d6b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bc4a307-d526-41bb-b1b5-2635b4bedbf2>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201246-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201246-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201246-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201246-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/fdd02725-5ec7-4785-9e1b-c97c4ed4f102> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fdd02725-5ec7-4785-9e1b-c97c4ed4f102";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "401acc54-5173-4151-bf1c-49e066b06fc7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b9e48a92-4bde-4c91-99e2-bfc0c9860897> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b9e48a92-4bde-4c91-99e2-bfc0c9860897";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7>.
+
+  <http://redpencil.data.gift/id/task/41afa2eb-df85-4e28-a8d5-000c2ec23986> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "41afa2eb-df85-4e28-a8d5-000c2ec23986";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/fdd02725-5ec7-4785-9e1b-c97c4ed4f102>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b9e48a92-4bde-4c91-99e2-bfc0c9860897>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5ac7631c-2d2c-4400-bbce-f2a375c1ab52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ac7631c-2d2c-4400-bbce-f2a375c1ab52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=BesluitenLijst_Gemeenteraad_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ac7631c-2d2c-4400-bbce-f2a375c1ab52>.
+    
+<http://data.lblod.info/id/remote-data-objects/cca95dbf-02fa-4e2d-9f3d-f4ae81ba84d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cca95dbf-02fa-4e2d-9f3d-f4ae81ba84d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=BesluitenLijst_Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cca95dbf-02fa-4e2d-9f3d-f4ae81ba84d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/622d662b-fd8d-4c0b-af27-d7be450970ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "622d662b-fd8d-4c0b-af27-d7be450970ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Notulen_Gemeenteraad_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/622d662b-fd8d-4c0b-af27-d7be450970ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/7024bf3a-ed47-4aae-8fa0-8bc302c5014e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7024bf3a-ed47-4aae-8fa0-8bc302c5014e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Notulen_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7024bf3a-ed47-4aae-8fa0-8bc302c5014e>.
+    
+<http://data.lblod.info/id/remote-data-objects/36ca5bff-a0c9-41e6-8ee2-f34ef04897b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36ca5bff-a0c9-41e6-8ee2-f34ef04897b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Notulen_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36ca5bff-a0c9-41e6-8ee2-f34ef04897b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b32e1eb-2665-43e1-b8c0-35fd551a5265> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b32e1eb-2665-43e1-b8c0-35fd551a5265";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Notulen_Gemeenteraad_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b32e1eb-2665-43e1-b8c0-35fd551a5265>.
+    
+<http://data.lblod.info/id/remote-data-objects/822efd69-2ae0-4863-bb0a-4da6143efaf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "822efd69-2ae0-4863-bb0a-4da6143efaf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Notulen_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/822efd69-2ae0-4863-bb0a-4da6143efaf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6184437-cbfb-4ae0-81ea-87b3b1a119fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6184437-cbfb-4ae0-81ea-87b3b1a119fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Notulen_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6184437-cbfb-4ae0-81ea-87b3b1a119fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbc47a73-fb18-4246-aa4e-c7848ffd125b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbc47a73-fb18-4246-aa4e-c7848ffd125b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Notulen_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbc47a73-fb18-4246-aa4e-c7848ffd125b>.
+    
+<http://data.lblod.info/id/remote-data-objects/74361f70-9dce-4bb6-80b0-7b500148e1a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74361f70-9dce-4bb6-80b0-7b500148e1a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Notulen_Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74361f70-9dce-4bb6-80b0-7b500148e1a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/667c55e5-ef0d-4cea-a640-886d33d4ee73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "667c55e5-ef0d-4cea-a640-886d33d4ee73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_15-12-2021_32613.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/667c55e5-ef0d-4cea-a640-886d33d4ee73>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ce2fd84-c143-4ffd-84ed-2f0a952b1852> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ce2fd84-c143-4ffd-84ed-2f0a952b1852";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_15-12-2021_33153.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ce2fd84-c143-4ffd-84ed-2f0a952b1852>.
+    
+<http://data.lblod.info/id/remote-data-objects/28b5926d-4cdb-4d6e-8f61-7cc6c7cd0777> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28b5926d-4cdb-4d6e-8f61-7cc6c7cd0777";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_15-12-2021_33533.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28b5926d-4cdb-4d6e-8f61-7cc6c7cd0777>.
+    
+<http://data.lblod.info/id/remote-data-objects/651fd045-684d-419f-8779-f9d029c95c68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "651fd045-684d-419f-8779-f9d029c95c68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_15-12-2021_33639.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/651fd045-684d-419f-8779-f9d029c95c68>.
+    
+<http://data.lblod.info/id/remote-data-objects/334539fd-501a-4846-88cb-1471c8b842c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "334539fd-501a-4846-88cb-1471c8b842c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_15-12-2021_33656.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/334539fd-501a-4846-88cb-1471c8b842c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d6e5251-6da4-4d11-9df9-05956af0fd9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d6e5251-6da4-4d11-9df9-05956af0fd9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_15-12-2021_33818.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d6e5251-6da4-4d11-9df9-05956af0fd9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/898896ad-6e59-4b2c-be42-5c06e7bc6af6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "898896ad-6e59-4b2c-be42-5c06e7bc6af6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_15-12-2021_33918.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/898896ad-6e59-4b2c-be42-5c06e7bc6af6>.
+    
+<http://data.lblod.info/id/remote-data-objects/94b66bfb-8e71-46d1-8656-878e7f147883> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94b66bfb-8e71-46d1-8656-878e7f147883";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_16-12-2021_33623.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94b66bfb-8e71-46d1-8656-878e7f147883>.
+    
+<http://data.lblod.info/id/remote-data-objects/95844952-fcda-49c3-ae5c-91f2c3ecb91d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95844952-fcda-49c3-ae5c-91f2c3ecb91d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_16-12-2021_33627.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95844952-fcda-49c3-ae5c-91f2c3ecb91d>.
+    
+<http://data.lblod.info/id/remote-data-objects/426fd387-25c0-40c4-b122-406e8f98dc4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "426fd387-25c0-40c4-b122-406e8f98dc4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_16-12-2021_33635.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/426fd387-25c0-40c4-b122-406e8f98dc4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/273caeb4-55dd-4470-b01b-dd70211c3525> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "273caeb4-55dd-4470-b01b-dd70211c3525";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_16-12-2021_33980.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/273caeb4-55dd-4470-b01b-dd70211c3525>.
+    
+<http://data.lblod.info/id/remote-data-objects/605a3df4-a501-4a4b-be5a-f69525d333d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "605a3df4-a501-4a4b-be5a-f69525d333d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_16-12-2021_34002.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/605a3df4-a501-4a4b-be5a-f69525d333d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/35aec15c-b8c4-4e3e-a13f-2a8b94deb9cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35aec15c-b8c4-4e3e-a13f-2a8b94deb9cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_16-12-2021_34003.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35aec15c-b8c4-4e3e-a13f-2a8b94deb9cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/2674a76f-aa40-4226-a1b3-a2dadaea3093> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2674a76f-aa40-4226-a1b3-a2dadaea3093";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_16-12-2021_34004.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2674a76f-aa40-4226-a1b3-a2dadaea3093>.
+    
+<http://data.lblod.info/id/remote-data-objects/e652a0d1-1a09-458d-9481-04f7de1b64ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e652a0d1-1a09-458d-9481-04f7de1b64ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_24-02-2022_35838.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e652a0d1-1a09-458d-9481-04f7de1b64ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9e6dff7-4086-46df-ad51-2cc8208dc5fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9e6dff7-4086-46df-ad51-2cc8208dc5fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_25-05-2022_37824.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9e6dff7-4086-46df-ad51-2cc8208dc5fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/e336071f-ccc6-4170-aeae-70946f0fc858> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e336071f-ccc6-4170-aeae-70946f0fc858";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_25-05-2022_37825.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e336071f-ccc6-4170-aeae-70946f0fc858>.
+    
+<http://data.lblod.info/id/remote-data-objects/340af3b7-5573-4e91-930e-a411501e60e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "340af3b7-5573-4e91-930e-a411501e60e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_25-05-2022_38019.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/340af3b7-5573-4e91-930e-a411501e60e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/31d15d60-8859-4deb-b8e3-603d67fdd82c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31d15d60-8859-4deb-b8e3-603d67fdd82c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_25-05-2022_38029.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31d15d60-8859-4deb-b8e3-603d67fdd82c>.
+    
+<http://data.lblod.info/id/remote-data-objects/049c581a-4619-48df-8066-0953264ba51a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "049c581a-4619-48df-8066-0953264ba51a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_25-05-2022_38030.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/049c581a-4619-48df-8066-0953264ba51a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d421729c-2562-40d3-a980-cc74abc5def5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d421729c-2562-40d3-a980-cc74abc5def5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_25-11-2021_32242.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d421729c-2562-40d3-a980-cc74abc5def5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b76dd4b-86cf-41c6-a414-99942621bbeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b76dd4b-86cf-41c6-a414-99942621bbeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_25-11-2021_32243.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b76dd4b-86cf-41c6-a414-99942621bbeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/62c8f689-6ae0-433a-a828-99816cf68629> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62c8f689-6ae0-433a-a828-99816cf68629";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_27-01-2022_34955.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62c8f689-6ae0-433a-a828-99816cf68629>.
+    
+<http://data.lblod.info/id/remote-data-objects/17836354-bb34-4bf3-a2fd-0df20dd157c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17836354-bb34-4bf3-a2fd-0df20dd157c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_27-01-2022_34956.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17836354-bb34-4bf3-a2fd-0df20dd157c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fcc8a4d-619a-46b9-bb83-0e021552a26d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fcc8a4d-619a-46b9-bb83-0e021552a26d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-04-2022_37284.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fcc8a4d-619a-46b9-bb83-0e021552a26d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1be56d22-6203-4445-8d61-b9b087053f7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1be56d22-6203-4445-8d61-b9b087053f7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-04-2022_37285.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1be56d22-6203-4445-8d61-b9b087053f7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/980a0c7b-feef-4228-868d-63eaa2cd85e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "980a0c7b-feef-4228-868d-63eaa2cd85e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-04-2022_37286.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/980a0c7b-feef-4228-868d-63eaa2cd85e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/fad4858f-4e7e-4961-9dc0-1da8e75ef819> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fad4858f-4e7e-4961-9dc0-1da8e75ef819";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-04-2022_37287.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fad4858f-4e7e-4961-9dc0-1da8e75ef819>.
+    
+<http://data.lblod.info/id/remote-data-objects/47037009-ce2c-4171-a636-68915ed2f101> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47037009-ce2c-4171-a636-68915ed2f101";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-04-2022_37291.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47037009-ce2c-4171-a636-68915ed2f101>.
+    
+<http://data.lblod.info/id/remote-data-objects/f919a635-11bc-4aec-9879-916c1a59c76e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f919a635-11bc-4aec-9879-916c1a59c76e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-04-2022_37295.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f919a635-11bc-4aec-9879-916c1a59c76e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fca96b30-561d-480a-a6b0-066119590c43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fca96b30-561d-480a-a6b0-066119590c43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-04-2022_37299.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fca96b30-561d-480a-a6b0-066119590c43>.
+    
+<http://data.lblod.info/id/remote-data-objects/453f526a-66d1-4ba7-9566-3f93fa884951> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "453f526a-66d1-4ba7-9566-3f93fa884951";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-10-2021_32217.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/453f526a-66d1-4ba7-9566-3f93fa884951>.
+    
+<http://data.lblod.info/id/remote-data-objects/35175c40-8eb5-44a6-8322-f609a9af6cc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35175c40-8eb5-44a6-8322-f609a9af6cc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-10-2021_32218.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35175c40-8eb5-44a6-8322-f609a9af6cc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/91139977-3785-4354-8e0e-642ab373d13e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91139977-3785-4354-8e0e-642ab373d13e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-10-2021_32219.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91139977-3785-4354-8e0e-642ab373d13e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fe8102e-833b-4a6c-9332-760992e06798> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fe8102e-833b-4a6c-9332-760992e06798";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-10-2021_32220.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fe8102e-833b-4a6c-9332-760992e06798>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6187cd3-b919-485f-a2d4-6a31b97c2f9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6187cd3-b919-485f-a2d4-6a31b97c2f9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-10-2021_32221.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6187cd3-b919-485f-a2d4-6a31b97c2f9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbcdbad0-686b-4535-b133-0bbd2214f0cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbcdbad0-686b-4535-b133-0bbd2214f0cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-10-2021_32222.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbcdbad0-686b-4535-b133-0bbd2214f0cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/112e5eba-e81e-4212-9d1f-834a1f64f5f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "112e5eba-e81e-4212-9d1f-834a1f64f5f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-10-2021_32223.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/112e5eba-e81e-4212-9d1f-834a1f64f5f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d5e680b-c789-4a66-bc0e-5647717f8188> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d5e680b-c789-4a66-bc0e-5647717f8188";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-10-2021_32224.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d5e680b-c789-4a66-bc0e-5647717f8188>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ca993bb-9501-4647-92d4-7933484ea8a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ca993bb-9501-4647-92d4-7933484ea8a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-10-2021_32225.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/401acc54-5173-4151-bf1c-49e066b06fc7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ca993bb-9501-4647-92d4-7933484ea8a1>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201247-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201247-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201247-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201247-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/9fb917a4-f603-4be9-9737-36ab01ac61bd> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9fb917a4-f603-4be9-9737-36ab01ac61bd";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "17804716-17ef-45c1-bb87-7368494040eb";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/2ce42bdc-36fa-4734-b274-332ad1649ea5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2ce42bdc-36fa-4734-b274-332ad1649ea5";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb>.
+
+  <http://redpencil.data.gift/id/task/19d2153f-9d11-419b-9552-8f964192a36e> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "19d2153f-9d11-419b-9552-8f964192a36e";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/9fb917a4-f603-4be9-9737-36ab01ac61bd>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/2ce42bdc-36fa-4734-b274-332ad1649ea5>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/2bec427c-8435-4f94-8e9d-d8dec7e166bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bec427c-8435-4f94-8e9d-d8dec7e166bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-10-2021_32493.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bec427c-8435-4f94-8e9d-d8dec7e166bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/53a8ee16-2389-4b0d-ad27-cc06bedccc24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53a8ee16-2389-4b0d-ad27-cc06bedccc24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-10-2021_32588.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53a8ee16-2389-4b0d-ad27-cc06bedccc24>.
+    
+<http://data.lblod.info/id/remote-data-objects/22e475e2-70bf-45a2-9f20-2a5c472e54ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22e475e2-70bf-45a2-9f20-2a5c472e54ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-10-2021_32603.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22e475e2-70bf-45a2-9f20-2a5c472e54ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/a62af4f1-8988-4ce8-aca0-c44ede306594> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a62af4f1-8988-4ce8-aca0-c44ede306594";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-10-2021_32611.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a62af4f1-8988-4ce8-aca0-c44ede306594>.
+    
+<http://data.lblod.info/id/remote-data-objects/3265efe3-8583-4b7b-a46c-2831209182e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3265efe3-8583-4b7b-a46c-2831209182e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_28-10-2021_32836.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3265efe3-8583-4b7b-a46c-2831209182e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b634e8c0-132b-4650-a864-0e4d4c84b92b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b634e8c0-132b-4650-a864-0e4d4c84b92b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_31-03-2022_36718.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b634e8c0-132b-4650-a864-0e4d4c84b92b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7684e921-9f8d-4415-bbbe-06f408e1fbbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7684e921-9f8d-4415-bbbe-06f408e1fbbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_31-03-2022_36720.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7684e921-9f8d-4415-bbbe-06f408e1fbbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/8227c705-e596-402f-b3bd-f5d17154e7ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8227c705-e596-402f-b3bd-f5d17154e7ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/e53b7bad2bcbeb0009bf474484ec8e66f52c14f7e769a3c5e32e98074166d7ed/GetPublication?filename=Uittreksels_31-03-2022_36725.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8227c705-e596-402f-b3bd-f5d17154e7ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b75c96a-389b-4c2e-9651-c1c1c0ed1820> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b75c96a-389b-4c2e-9651-c1c1c0ed1820";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b75c96a-389b-4c2e-9651-c1c1c0ed1820>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b539493-8eba-41be-a3fb-d812cd954b24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b539493-8eba-41be-a3fb-d812cd954b24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b539493-8eba-41be-a3fb-d812cd954b24>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d44f9c7-1d6a-4c0e-bd8a-e70e8e478b58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d44f9c7-1d6a-4c0e-bd8a-e70e8e478b58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d44f9c7-1d6a-4c0e-bd8a-e70e8e478b58>.
+    
+<http://data.lblod.info/id/remote-data-objects/2022ce36-aba9-45ee-954a-7e44402bb2e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2022ce36-aba9-45ee-954a-7e44402bb2e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2022ce36-aba9-45ee-954a-7e44402bb2e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/50eee484-77dd-4f1a-8772-bd485445dcf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50eee484-77dd-4f1a-8772-bd485445dcf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50eee484-77dd-4f1a-8772-bd485445dcf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/480fe5ca-f962-4fd6-815e-d12f004a527b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "480fe5ca-f962-4fd6-815e-d12f004a527b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/480fe5ca-f962-4fd6-815e-d12f004a527b>.
+    
+<http://data.lblod.info/id/remote-data-objects/39ac24dd-77d6-42a7-a0ce-5a739f0e300a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39ac24dd-77d6-42a7-a0ce-5a739f0e300a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39ac24dd-77d6-42a7-a0ce-5a739f0e300a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d42d22b-b28a-4efe-bc10-a305c12c8203> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d42d22b-b28a-4efe-bc10-a305c12c8203";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d42d22b-b28a-4efe-bc10-a305c12c8203>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d6b85b6-6a91-4a39-95c7-efa6fdb0abca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d6b85b6-6a91-4a39-95c7-efa6fdb0abca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d6b85b6-6a91-4a39-95c7-efa6fdb0abca>.
+    
+<http://data.lblod.info/id/remote-data-objects/53a135d2-8b7b-40f1-8302-8605118a4cb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53a135d2-8b7b-40f1-8302-8605118a4cb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53a135d2-8b7b-40f1-8302-8605118a4cb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/609fdfbb-49d1-4f0d-b035-0d358a0b163d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "609fdfbb-49d1-4f0d-b035-0d358a0b163d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/609fdfbb-49d1-4f0d-b035-0d358a0b163d>.
+    
+<http://data.lblod.info/id/remote-data-objects/528e9ea2-d8b2-43de-b4f8-a1ae30209b07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "528e9ea2-d8b2-43de-b4f8-a1ae30209b07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/528e9ea2-d8b2-43de-b4f8-a1ae30209b07>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc23d484-d543-4c70-97ec-99969ae83196> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc23d484-d543-4c70-97ec-99969ae83196";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc23d484-d543-4c70-97ec-99969ae83196>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a6b6a9e-9a39-4d5e-9158-34914b024761> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a6b6a9e-9a39-4d5e-9158-34914b024761";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a6b6a9e-9a39-4d5e-9158-34914b024761>.
+    
+<http://data.lblod.info/id/remote-data-objects/90f7f431-dfa7-4a38-99dd-c4ff814ce3e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90f7f431-dfa7-4a38-99dd-c4ff814ce3e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90f7f431-dfa7-4a38-99dd-c4ff814ce3e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/55191437-35b0-496e-a27e-d5d16703ea81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55191437-35b0-496e-a27e-d5d16703ea81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55191437-35b0-496e-a27e-d5d16703ea81>.
+    
+<http://data.lblod.info/id/remote-data-objects/9910596b-bd7d-4169-9b9a-f261c973bba0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9910596b-bd7d-4169-9b9a-f261c973bba0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9910596b-bd7d-4169-9b9a-f261c973bba0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecca4575-ef6d-4326-adb3-6e790bcf851c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecca4575-ef6d-4326-adb3-6e790bcf851c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecca4575-ef6d-4326-adb3-6e790bcf851c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ab2b0c7-dbcf-42b3-9ca8-c6e39e6d04aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ab2b0c7-dbcf-42b3-9ca8-c6e39e6d04aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ab2b0c7-dbcf-42b3-9ca8-c6e39e6d04aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2e2389e-262b-48be-9214-6d266266199a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2e2389e-262b-48be-9214-6d266266199a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2e2389e-262b-48be-9214-6d266266199a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fdb5dbb-cb3a-41eb-8dce-d045dc592d0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fdb5dbb-cb3a-41eb-8dce-d045dc592d0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fdb5dbb-cb3a-41eb-8dce-d045dc592d0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7689b188-acb5-4f9c-9ad4-dbe37d4d3aa9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7689b188-acb5-4f9c-9ad4-dbe37d4d3aa9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7689b188-acb5-4f9c-9ad4-dbe37d4d3aa9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1f84692-f205-45cd-abd0-42067edbe862> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1f84692-f205-45cd-abd0-42067edbe862";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1f84692-f205-45cd-abd0-42067edbe862>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbfd1e2a-3a00-4bc0-a50b-227007fbbc72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbfd1e2a-3a00-4bc0-a50b-227007fbbc72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbfd1e2a-3a00-4bc0-a50b-227007fbbc72>.
+    
+<http://data.lblod.info/id/remote-data-objects/a23cd349-b659-457e-9663-b656f432818b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a23cd349-b659-457e-9663-b656f432818b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a23cd349-b659-457e-9663-b656f432818b>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb6417db-a3e0-451b-bb9f-c199f6a7082e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb6417db-a3e0-451b-bb9f-c199f6a7082e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb6417db-a3e0-451b-bb9f-c199f6a7082e>.
+    
+<http://data.lblod.info/id/remote-data-objects/25bfac18-f1a3-4838-8cc3-9dc35fe79951> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25bfac18-f1a3-4838-8cc3-9dc35fe79951";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25bfac18-f1a3-4838-8cc3-9dc35fe79951>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fe6abb9-546f-411b-95ea-4804b891bb60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fe6abb9-546f-411b-95ea-4804b891bb60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fe6abb9-546f-411b-95ea-4804b891bb60>.
+    
+<http://data.lblod.info/id/remote-data-objects/b514dcd3-b615-45d8-bbb9-f15e3710baf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b514dcd3-b615-45d8-bbb9-f15e3710baf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b514dcd3-b615-45d8-bbb9-f15e3710baf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/86d7066d-7910-4118-bb01-4dc33006e35c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86d7066d-7910-4118-bb01-4dc33006e35c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Uittreksels_15-12-2021_33921.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86d7066d-7910-4118-bb01-4dc33006e35c>.
+    
+<http://data.lblod.info/id/remote-data-objects/027f4c1f-895b-4052-96a0-df6f2dcd0f07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "027f4c1f-895b-4052-96a0-df6f2dcd0f07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Uittreksels_15-12-2021_33922.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/027f4c1f-895b-4052-96a0-df6f2dcd0f07>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb7ea868-45ef-4f97-a9dc-c6fc6b0fb2bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb7ea868-45ef-4f97-a9dc-c6fc6b0fb2bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Uittreksels_15-12-2021_34108.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb7ea868-45ef-4f97-a9dc-c6fc6b0fb2bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c20404a-3fb3-4c2b-a8bc-531aa61f9700> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c20404a-3fb3-4c2b-a8bc-531aa61f9700";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Uittreksels_16-12-2021_33920.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c20404a-3fb3-4c2b-a8bc-531aa61f9700>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3f4b381-ec41-4f5b-9c17-735697cbf73a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3f4b381-ec41-4f5b-9c17-735697cbf73a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Uittreksels_25-05-2022_37826.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3f4b381-ec41-4f5b-9c17-735697cbf73a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e60334f2-e788-4e62-a7bc-7d6dcabbd2eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e60334f2-e788-4e62-a7bc-7d6dcabbd2eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Uittreksels_25-05-2022_38018.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e60334f2-e788-4e62-a7bc-7d6dcabbd2eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba312467-078d-4d5a-82c7-955c50715f52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba312467-078d-4d5a-82c7-955c50715f52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Uittreksels_25-11-2021_31243.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba312467-078d-4d5a-82c7-955c50715f52>.
+    
+<http://data.lblod.info/id/remote-data-objects/45a0c3b6-a8f9-424b-9a6c-3bef900e9ac4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45a0c3b6-a8f9-424b-9a6c-3bef900e9ac4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Uittreksels_25-11-2021_32910.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45a0c3b6-a8f9-424b-9a6c-3bef900e9ac4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a9c3d59-0757-475f-b411-8819d255720a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a9c3d59-0757-475f-b411-8819d255720a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Uittreksels_28-10-2021_32589.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a9c3d59-0757-475f-b411-8819d255720a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac6273d5-463d-4aaa-9f98-2048d09cc717> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac6273d5-463d-4aaa-9f98-2048d09cc717";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Uittreksels_28-10-2021_32590.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac6273d5-463d-4aaa-9f98-2048d09cc717>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1f86ecf-6caa-4681-b329-139f642e13b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1f86ecf-6caa-4681-b329-139f642e13b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.assenede.be/LBLODWeb/Home/Overzicht/f829015b2d27d7f7965f3cb71aa26d7f2e56226994d6a7bba292b9bd01d56669/GetPublication?filename=Uittreksels_28-10-2021_32840.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1f86ecf-6caa-4681-b329-139f642e13b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/79409c6c-9a7f-4fb8-b1e2-23f86f257251> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79409c6c-9a7f-4fb8-b1e2-23f86f257251";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79409c6c-9a7f-4fb8-b1e2-23f86f257251>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbca6e0c-155d-49ad-b47e-4a272d0dfc4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbca6e0c-155d-49ad-b47e-4a272d0dfc4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/17804716-17ef-45c1-bb87-7368494040eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbca6e0c-155d-49ad-b47e-4a272d0dfc4b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201249-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201249-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201249-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201249-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/581dd42a-b7d2-4b59-9989-2cfbe6f4ae2c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "581dd42a-b7d2-4b59-9989-2cfbe6f4ae2c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3365f547-3ed0-43ed-9f2e-a0a71561d19e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9d6e2401-a61b-4301-8c77-d7ad4a32a019> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9d6e2401-a61b-4301-8c77-d7ad4a32a019";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e>.
+
+  <http://redpencil.data.gift/id/task/8f122ee4-4dd2-432c-802e-d98f71bc96aa> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8f122ee4-4dd2-432c-802e-d98f71bc96aa";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/581dd42a-b7d2-4b59-9989-2cfbe6f4ae2c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9d6e2401-a61b-4301-8c77-d7ad4a32a019>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/6853d088-faa2-4cb1-b0af-20b2de0f508b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6853d088-faa2-4cb1-b0af-20b2de0f508b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6853d088-faa2-4cb1-b0af-20b2de0f508b>.
+    
+<http://data.lblod.info/id/remote-data-objects/860f370a-2d7c-4a6a-b397-bc6c05db99b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "860f370a-2d7c-4a6a-b397-bc6c05db99b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/860f370a-2d7c-4a6a-b397-bc6c05db99b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/47601123-cf9f-4807-b633-8990cdcfe55e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47601123-cf9f-4807-b633-8990cdcfe55e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47601123-cf9f-4807-b633-8990cdcfe55e>.
+    
+<http://data.lblod.info/id/remote-data-objects/be3e6af9-b903-454f-a1cd-b75a80944123> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be3e6af9-b903-454f-a1cd-b75a80944123";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be3e6af9-b903-454f-a1cd-b75a80944123>.
+    
+<http://data.lblod.info/id/remote-data-objects/06f70f45-ed61-4e9b-8a89-a6d61d923cbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06f70f45-ed61-4e9b-8a89-a6d61d923cbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06f70f45-ed61-4e9b-8a89-a6d61d923cbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/887cd41b-865f-4ea1-9911-342aa6263824> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "887cd41b-865f-4ea1-9911-342aa6263824";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/887cd41b-865f-4ea1-9911-342aa6263824>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1323677-48d5-4a04-83de-7fd8b06c4fe2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1323677-48d5-4a04-83de-7fd8b06c4fe2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1323677-48d5-4a04-83de-7fd8b06c4fe2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4d4f019-82a5-4cb0-bfb4-c7ec6e53a045> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4d4f019-82a5-4cb0-bfb4-c7ec6e53a045";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4d4f019-82a5-4cb0-bfb4-c7ec6e53a045>.
+    
+<http://data.lblod.info/id/remote-data-objects/5291732a-cdff-42d6-a803-90c980fa8b2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5291732a-cdff-42d6-a803-90c980fa8b2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5291732a-cdff-42d6-a803-90c980fa8b2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbf43c7c-279a-456d-a9bc-332c3a969fa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbf43c7c-279a-456d-a9bc-332c3a969fa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbf43c7c-279a-456d-a9bc-332c3a969fa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7864b1fd-9516-4482-87b3-6783ad87ba2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7864b1fd-9516-4482-87b3-6783ad87ba2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7864b1fd-9516-4482-87b3-6783ad87ba2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f431a444-7544-4f70-95f3-4c77460ca372> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f431a444-7544-4f70-95f3-4c77460ca372";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f431a444-7544-4f70-95f3-4c77460ca372>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf0a1c14-5472-4e3c-9e26-0704cd359272> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf0a1c14-5472-4e3c-9e26-0704cd359272";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf0a1c14-5472-4e3c-9e26-0704cd359272>.
+    
+<http://data.lblod.info/id/remote-data-objects/17ee0b50-6d3c-4ef8-a76a-061d62f7a4c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17ee0b50-6d3c-4ef8-a76a-061d62f7a4c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17ee0b50-6d3c-4ef8-a76a-061d62f7a4c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb5a589c-7ff5-4add-855b-b846dbb17cd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb5a589c-7ff5-4add-855b-b846dbb17cd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb5a589c-7ff5-4add-855b-b846dbb17cd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/acd68945-7aac-48f6-9aaa-41bd1ee605ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acd68945-7aac-48f6-9aaa-41bd1ee605ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acd68945-7aac-48f6-9aaa-41bd1ee605ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a73b8b6-4ae6-47e6-95f6-3d531c64eca5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a73b8b6-4ae6-47e6-95f6-3d531c64eca5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a73b8b6-4ae6-47e6-95f6-3d531c64eca5>.
+    
+<http://data.lblod.info/id/remote-data-objects/76373a07-cedc-4f08-9d19-71c84a8abc0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76373a07-cedc-4f08-9d19-71c84a8abc0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76373a07-cedc-4f08-9d19-71c84a8abc0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/baad86e5-74ec-4dc3-a056-7aae3cde2acf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "baad86e5-74ec-4dc3-a056-7aae3cde2acf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/baad86e5-74ec-4dc3-a056-7aae3cde2acf>.
+    
+<http://data.lblod.info/id/remote-data-objects/97ecc003-ddc0-4220-a6b8-4486e013d51d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97ecc003-ddc0-4220-a6b8-4486e013d51d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97ecc003-ddc0-4220-a6b8-4486e013d51d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c72c30ba-20fd-48a7-9b0c-d4162754e288> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c72c30ba-20fd-48a7-9b0c-d4162754e288";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Uittreksels_20-12-2021_20505.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c72c30ba-20fd-48a7-9b0c-d4162754e288>.
+    
+<http://data.lblod.info/id/remote-data-objects/df75c394-0f24-4f9a-b39f-99a300171a05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df75c394-0f24-4f9a-b39f-99a300171a05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Uittreksels_20-12-2021_21143.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df75c394-0f24-4f9a-b39f-99a300171a05>.
+    
+<http://data.lblod.info/id/remote-data-objects/b751e267-5b94-4199-b185-cd89c42e570c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b751e267-5b94-4199-b185-cd89c42e570c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Uittreksels_22-11-2021_21000.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b751e267-5b94-4199-b185-cd89c42e570c>.
+    
+<http://data.lblod.info/id/remote-data-objects/86ae9596-c82a-4b3b-ab1f-7f9b0a367591> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86ae9596-c82a-4b3b-ab1f-7f9b0a367591";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Uittreksels_23-05-2022_22205.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86ae9596-c82a-4b3b-ab1f-7f9b0a367591>.
+    
+<http://data.lblod.info/id/remote-data-objects/50ab8b3e-9b61-4765-9e7c-f59bac361414> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50ab8b3e-9b61-4765-9e7c-f59bac361414";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Uittreksels_25-04-2022_22469.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50ab8b3e-9b61-4765-9e7c-f59bac361414>.
+    
+<http://data.lblod.info/id/remote-data-objects/59061258-dc71-451a-bd5b-0957039d2327> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59061258-dc71-451a-bd5b-0957039d2327";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/27175c2982473642c336240be0b283db86f11863d4cc94ae1e1eb985fd5c6753/GetPublication?filename=Uittreksels_25-10-2021_20484.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59061258-dc71-451a-bd5b-0957039d2327>.
+    
+<http://data.lblod.info/id/remote-data-objects/18ea9120-50da-41d7-a179-f763026051d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18ea9120-50da-41d7-a179-f763026051d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Agenda_Gemeenteraad_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18ea9120-50da-41d7-a179-f763026051d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/689114af-5481-4133-9e93-05b32b0f93b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "689114af-5481-4133-9e93-05b32b0f93b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Agenda_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/689114af-5481-4133-9e93-05b32b0f93b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/116b08e0-7a55-432b-9cc8-053ac1f9ab4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "116b08e0-7a55-432b-9cc8-053ac1f9ab4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Agenda_Gemeenteraad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/116b08e0-7a55-432b-9cc8-053ac1f9ab4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/892415ff-12fd-4a5f-b82e-98fa0661a429> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "892415ff-12fd-4a5f-b82e-98fa0661a429";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Agenda_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/892415ff-12fd-4a5f-b82e-98fa0661a429>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6511c00-7cec-4292-9d98-848e0e52bb85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6511c00-7cec-4292-9d98-848e0e52bb85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Agenda_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6511c00-7cec-4292-9d98-848e0e52bb85>.
+    
+<http://data.lblod.info/id/remote-data-objects/455a5640-b7b0-4049-9bd3-725fa99da890> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "455a5640-b7b0-4049-9bd3-725fa99da890";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Agenda_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/455a5640-b7b0-4049-9bd3-725fa99da890>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7a86c87-8093-41e6-a4c7-85bd34631203> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7a86c87-8093-41e6-a4c7-85bd34631203";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Agenda_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7a86c87-8093-41e6-a4c7-85bd34631203>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6aa08b9-7e5f-462d-937d-b51063cf5c49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6aa08b9-7e5f-462d-937d-b51063cf5c49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Agenda_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6aa08b9-7e5f-462d-937d-b51063cf5c49>.
+    
+<http://data.lblod.info/id/remote-data-objects/791b3702-72f0-46e6-9aaf-722c5b30918c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "791b3702-72f0-46e6-9aaf-722c5b30918c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/791b3702-72f0-46e6-9aaf-722c5b30918c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e426e5d-1460-456e-b091-795f085a4442> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e426e5d-1460-456e-b091-795f085a4442";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e426e5d-1460-456e-b091-795f085a4442>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb9dbd62-1107-4ae9-b18e-c21624ed0104> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb9dbd62-1107-4ae9-b18e-c21624ed0104";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb9dbd62-1107-4ae9-b18e-c21624ed0104>.
+    
+<http://data.lblod.info/id/remote-data-objects/340f02cf-adc4-40d1-900d-1746357fe1ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "340f02cf-adc4-40d1-900d-1746357fe1ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/340f02cf-adc4-40d1-900d-1746357fe1ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/779321f7-be7e-4644-a5d7-26665fa27043> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "779321f7-be7e-4644-a5d7-26665fa27043";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/779321f7-be7e-4644-a5d7-26665fa27043>.
+    
+<http://data.lblod.info/id/remote-data-objects/b84ac136-1e48-4140-bce4-fa6d606c4b7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b84ac136-1e48-4140-bce4-fa6d606c4b7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b84ac136-1e48-4140-bce4-fa6d606c4b7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/16a704e5-315d-4f16-9f81-3314c6b2d536> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16a704e5-315d-4f16-9f81-3314c6b2d536";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16a704e5-315d-4f16-9f81-3314c6b2d536>.
+    
+<http://data.lblod.info/id/remote-data-objects/b307696e-0499-41b1-aea1-8015c760b0fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b307696e-0499-41b1-aea1-8015c760b0fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b307696e-0499-41b1-aea1-8015c760b0fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/363b5adf-4105-444f-abab-6505a7d929b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "363b5adf-4105-444f-abab-6505a7d929b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Notulen_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/363b5adf-4105-444f-abab-6505a7d929b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e85bf15e-b1ad-4b16-afca-7c99e135f180> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e85bf15e-b1ad-4b16-afca-7c99e135f180";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Notulen_Gemeenteraad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e85bf15e-b1ad-4b16-afca-7c99e135f180>.
+    
+<http://data.lblod.info/id/remote-data-objects/e25c1af3-603a-4aba-982a-5f5359b42bd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e25c1af3-603a-4aba-982a-5f5359b42bd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Notulen_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e25c1af3-603a-4aba-982a-5f5359b42bd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/239777a9-b1ba-44ad-8126-73ba1ed625df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "239777a9-b1ba-44ad-8126-73ba1ed625df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Notulen_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/239777a9-b1ba-44ad-8126-73ba1ed625df>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab0cf4a3-484e-4454-ac74-e7ce3fa0c5bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab0cf4a3-484e-4454-ac74-e7ce3fa0c5bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Notulen_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab0cf4a3-484e-4454-ac74-e7ce3fa0c5bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/4327f85e-e017-40f5-9e91-86bc83fbba56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4327f85e-e017-40f5-9e91-86bc83fbba56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Notulen_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4327f85e-e017-40f5-9e91-86bc83fbba56>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ade8023-170f-4542-a972-a1e48d468e14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ade8023-170f-4542-a972-a1e48d468e14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_14-03-2022_22216.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ade8023-170f-4542-a972-a1e48d468e14>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c24b305-d52e-4c0f-9aa0-f6077d87c661> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c24b305-d52e-4c0f-9aa0-f6077d87c661";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_14-03-2022_22217.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3365f547-3ed0-43ed-9f2e-a0a71561d19e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c24b305-d52e-4c0f-9aa0-f6077d87c661>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201250-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201250-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201250-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201250-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a00c649c-a376-4fe3-95d0-21db7e34e0d1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a00c649c-a376-4fe3-95d0-21db7e34e0d1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "88a873fb-b61b-4877-8bd7-66d18db94879";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e6e2e3e5-d12b-4066-b7e9-33d4b0631505> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e6e2e3e5-d12b-4066-b7e9-33d4b0631505";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879>.
+
+  <http://redpencil.data.gift/id/task/2fb55772-682d-47df-ba04-baf2a43f7073> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2fb55772-682d-47df-ba04-baf2a43f7073";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a00c649c-a376-4fe3-95d0-21db7e34e0d1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e6e2e3e5-d12b-4066-b7e9-33d4b0631505>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/57b21f8c-12cd-435b-b353-918f7a823502> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57b21f8c-12cd-435b-b353-918f7a823502";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_20-12-2021_20504.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57b21f8c-12cd-435b-b353-918f7a823502>.
+    
+<http://data.lblod.info/id/remote-data-objects/82464766-76e4-49c8-bd8e-137071ea6d3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82464766-76e4-49c8-bd8e-137071ea6d3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_20-12-2021_21425.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82464766-76e4-49c8-bd8e-137071ea6d3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/07e37fbb-33bc-4fb2-8777-84bd97a49939> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07e37fbb-33bc-4fb2-8777-84bd97a49939";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_20-12-2021_21543.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07e37fbb-33bc-4fb2-8777-84bd97a49939>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b40976f-1664-4f8e-9104-181710c84f49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b40976f-1664-4f8e-9104-181710c84f49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_20-12-2021_21561.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b40976f-1664-4f8e-9104-181710c84f49>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c5c9702-88f9-453f-a8b3-fb5c9b12f853> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c5c9702-88f9-453f-a8b3-fb5c9b12f853";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_22-11-2021_20443.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c5c9702-88f9-453f-a8b3-fb5c9b12f853>.
+    
+<http://data.lblod.info/id/remote-data-objects/d93d7330-8788-475d-8d93-cf8408fb904a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d93d7330-8788-475d-8d93-cf8408fb904a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_22-11-2021_21013.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d93d7330-8788-475d-8d93-cf8408fb904a>.
+    
+<http://data.lblod.info/id/remote-data-objects/949fde64-df46-475e-8201-4665217238c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "949fde64-df46-475e-8201-4665217238c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_22-11-2021_21014.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/949fde64-df46-475e-8201-4665217238c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f328aaab-930f-45af-9da8-e8d52a6c3e8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f328aaab-930f-45af-9da8-e8d52a6c3e8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_22-11-2021_21015.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f328aaab-930f-45af-9da8-e8d52a6c3e8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd547d41-8f0b-47ef-ac71-e9b68853dfaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd547d41-8f0b-47ef-ac71-e9b68853dfaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_22-11-2021_21017.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd547d41-8f0b-47ef-ac71-e9b68853dfaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/c63032f9-d8cd-45bb-9982-b362ff6d153e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c63032f9-d8cd-45bb-9982-b362ff6d153e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_22-11-2021_21019.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c63032f9-d8cd-45bb-9982-b362ff6d153e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f51270f-48d8-41fd-b197-3df2214732a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f51270f-48d8-41fd-b197-3df2214732a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_22-11-2021_21020.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f51270f-48d8-41fd-b197-3df2214732a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3e00223-d48d-4ba1-a88c-bbfe2307b1fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3e00223-d48d-4ba1-a88c-bbfe2307b1fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_23-05-2022_22203.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3e00223-d48d-4ba1-a88c-bbfe2307b1fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6eb0759-03f5-4d8f-ba44-493e2785ef46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6eb0759-03f5-4d8f-ba44-493e2785ef46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_23-05-2022_22204.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6eb0759-03f5-4d8f-ba44-493e2785ef46>.
+    
+<http://data.lblod.info/id/remote-data-objects/abef5c0a-8197-4e62-b57a-c5069f8345dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abef5c0a-8197-4e62-b57a-c5069f8345dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_23-05-2022_23050.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abef5c0a-8197-4e62-b57a-c5069f8345dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/352df76f-9a10-4d44-b32c-0dbea68c2404> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "352df76f-9a10-4d44-b32c-0dbea68c2404";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_25-04-2022_22022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/352df76f-9a10-4d44-b32c-0dbea68c2404>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5b3167d-9da4-4ecb-a703-ee17ac543a36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5b3167d-9da4-4ecb-a703-ee17ac543a36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_25-04-2022_22487.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5b3167d-9da4-4ecb-a703-ee17ac543a36>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf65c1ce-53b9-4df5-8e9f-52bea8d85622> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf65c1ce-53b9-4df5-8e9f-52bea8d85622";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_25-04-2022_22488.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf65c1ce-53b9-4df5-8e9f-52bea8d85622>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e418c53-9042-4cc1-b247-ee224b5085fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e418c53-9042-4cc1-b247-ee224b5085fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_25-04-2022_22489.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e418c53-9042-4cc1-b247-ee224b5085fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/46da28d7-cee1-4e1a-b9a2-79ce19c9d528> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46da28d7-cee1-4e1a-b9a2-79ce19c9d528";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_25-04-2022_22711.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46da28d7-cee1-4e1a-b9a2-79ce19c9d528>.
+    
+<http://data.lblod.info/id/remote-data-objects/825dea04-dad2-4891-9239-b435e70fde08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "825dea04-dad2-4891-9239-b435e70fde08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_25-10-2021_18588.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/825dea04-dad2-4891-9239-b435e70fde08>.
+    
+<http://data.lblod.info/id/remote-data-objects/0753bdef-a007-4f4f-b1d0-a9765979e38f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0753bdef-a007-4f4f-b1d0-a9765979e38f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_27-06-2022_23333.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0753bdef-a007-4f4f-b1d0-a9765979e38f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d800b316-94c1-448d-b31c-65f4eeab8573> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d800b316-94c1-448d-b31c-65f4eeab8573";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/973c71eed73abf56d871a2ededab7878337c40b203c38d2a297ed20f18b0ddc4/GetPublication?filename=Uittreksels_31-01-2022_21800.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d800b316-94c1-448d-b31c-65f4eeab8573>.
+    
+<http://data.lblod.info/id/remote-data-objects/43b63f9d-ef98-4dfd-aee1-06fa64296cd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43b63f9d-ef98-4dfd-aee1-06fa64296cd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43b63f9d-ef98-4dfd-aee1-06fa64296cd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b9c461a-3ba2-421f-9d5e-88f9c7c0a5de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b9c461a-3ba2-421f-9d5e-88f9c7c0a5de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b9c461a-3ba2-421f-9d5e-88f9c7c0a5de>.
+    
+<http://data.lblod.info/id/remote-data-objects/58d5dfb3-7627-4984-b1c8-0031ba8cb3e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58d5dfb3-7627-4984-b1c8-0031ba8cb3e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58d5dfb3-7627-4984-b1c8-0031ba8cb3e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/9153f8bd-f1bd-4745-ae1b-f787c6f312c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9153f8bd-f1bd-4745-ae1b-f787c6f312c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9153f8bd-f1bd-4745-ae1b-f787c6f312c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c49a00ce-1d89-4338-a5b7-7f82b60c199c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c49a00ce-1d89-4338-a5b7-7f82b60c199c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c49a00ce-1d89-4338-a5b7-7f82b60c199c>.
+    
+<http://data.lblod.info/id/remote-data-objects/49f3fdfc-261d-431f-af8c-dd1a0b4e1e5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49f3fdfc-261d-431f-af8c-dd1a0b4e1e5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49f3fdfc-261d-431f-af8c-dd1a0b4e1e5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfe1e5f8-25ef-4bd7-8aaa-f38dfb1ceabd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfe1e5f8-25ef-4bd7-8aaa-f38dfb1ceabd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfe1e5f8-25ef-4bd7-8aaa-f38dfb1ceabd>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a92aaa7-ca3e-4fcb-a047-c12dc8ac14ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a92aaa7-ca3e-4fcb-a047-c12dc8ac14ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a92aaa7-ca3e-4fcb-a047-c12dc8ac14ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/6679ba78-2695-4e66-8982-4eef7a928ee0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6679ba78-2695-4e66-8982-4eef7a928ee0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6679ba78-2695-4e66-8982-4eef7a928ee0>.
+    
+<http://data.lblod.info/id/remote-data-objects/8385f376-0751-4e99-820f-41f5103c2be3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8385f376-0751-4e99-820f-41f5103c2be3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8385f376-0751-4e99-820f-41f5103c2be3>.
+    
+<http://data.lblod.info/id/remote-data-objects/48475325-fb57-4191-92d3-8d09215bd797> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48475325-fb57-4191-92d3-8d09215bd797";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48475325-fb57-4191-92d3-8d09215bd797>.
+    
+<http://data.lblod.info/id/remote-data-objects/d80a0521-30b0-49a3-9582-ce4c2647b68f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d80a0521-30b0-49a3-9582-ce4c2647b68f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d80a0521-30b0-49a3-9582-ce4c2647b68f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1daa498-539e-4e16-b441-bfc52ea08a6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1daa498-539e-4e16-b441-bfc52ea08a6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1daa498-539e-4e16-b441-bfc52ea08a6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e03b7553-2965-4997-9b98-0c77d76b8bcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e03b7553-2965-4997-9b98-0c77d76b8bcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e03b7553-2965-4997-9b98-0c77d76b8bcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7be85612-f16e-402b-bdf3-14402399aa8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7be85612-f16e-402b-bdf3-14402399aa8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7be85612-f16e-402b-bdf3-14402399aa8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d20d9b1-a6b6-44de-b0a3-7fa113e595b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d20d9b1-a6b6-44de-b0a3-7fa113e595b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d20d9b1-a6b6-44de-b0a3-7fa113e595b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/96a83d7a-02e5-4a4d-a3c3-d2d99f3f974d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96a83d7a-02e5-4a4d-a3c3-d2d99f3f974d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96a83d7a-02e5-4a4d-a3c3-d2d99f3f974d>.
+    
+<http://data.lblod.info/id/remote-data-objects/95b718c2-05b6-4706-b677-7fd0b2944226> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95b718c2-05b6-4706-b677-7fd0b2944226";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95b718c2-05b6-4706-b677-7fd0b2944226>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab4ab9de-2b9b-46db-a985-cc14aa59a206> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab4ab9de-2b9b-46db-a985-cc14aa59a206";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab4ab9de-2b9b-46db-a985-cc14aa59a206>.
+    
+<http://data.lblod.info/id/remote-data-objects/013f43e9-45cb-40ec-bbbc-e6c82cbed6d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "013f43e9-45cb-40ec-bbbc-e6c82cbed6d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/013f43e9-45cb-40ec-bbbc-e6c82cbed6d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/71db747c-3b36-42a6-a736-a9650fb2b3ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71db747c-3b36-42a6-a736-a9650fb2b3ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71db747c-3b36-42a6-a736-a9650fb2b3ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a21ea78-03a8-48a4-800a-c5323b2d929b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a21ea78-03a8-48a4-800a-c5323b2d929b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a21ea78-03a8-48a4-800a-c5323b2d929b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6879bbef-1567-4907-8d5f-372501a29278> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6879bbef-1567-4907-8d5f-372501a29278";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6879bbef-1567-4907-8d5f-372501a29278>.
+    
+<http://data.lblod.info/id/remote-data-objects/20bb0a3a-7e58-4156-af6e-21550307dd3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20bb0a3a-7e58-4156-af6e-21550307dd3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20bb0a3a-7e58-4156-af6e-21550307dd3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f0a7bae-a228-4ede-876e-f9f0d3d4ecbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f0a7bae-a228-4ede-876e-f9f0d3d4ecbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f0a7bae-a228-4ede-876e-f9f0d3d4ecbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/107d280a-954d-4a7d-8da2-7d29927bbc12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "107d280a-954d-4a7d-8da2-7d29927bbc12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/107d280a-954d-4a7d-8da2-7d29927bbc12>.
+    
+<http://data.lblod.info/id/remote-data-objects/bebcda33-3f1b-46f7-a5c9-67cb84c97f2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bebcda33-3f1b-46f7-a5c9-67cb84c97f2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bebcda33-3f1b-46f7-a5c9-67cb84c97f2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d63a2076-ff97-46e6-a0d3-9df33f0b26a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d63a2076-ff97-46e6-a0d3-9df33f0b26a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a873fb-b61b-4877-8bd7-66d18db94879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d63a2076-ff97-46e6-a0d3-9df33f0b26a0>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201251-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201251-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201251-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201251-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e0b81d3b-dbfd-4f5b-937a-a3aa4ad82bf3> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e0b81d3b-dbfd-4f5b-937a-a3aa4ad82bf3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6b599a82-91f6-46bd-b188-5cb95ada36a0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6113d29d-0b66-4017-8e39-7ebc0d233c5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6113d29d-0b66-4017-8e39-7ebc0d233c5b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0>.
+
+  <http://redpencil.data.gift/id/task/f599a55b-7db1-413a-87d4-91e10b61d255> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f599a55b-7db1-413a-87d4-91e10b61d255";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e0b81d3b-dbfd-4f5b-937a-a3aa4ad82bf3>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6113d29d-0b66-4017-8e39-7ebc0d233c5b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e7ec0a2f-f7f2-4040-9fa1-70941de01fbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7ec0a2f-f7f2-4040-9fa1-70941de01fbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7ec0a2f-f7f2-4040-9fa1-70941de01fbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ab53df8-1d50-4dcb-9a93-f281aab2894f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ab53df8-1d50-4dcb-9a93-f281aab2894f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ab53df8-1d50-4dcb-9a93-f281aab2894f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0953dba-da61-4b81-b385-308b624cd171> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0953dba-da61-4b81-b385-308b624cd171";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0953dba-da61-4b81-b385-308b624cd171>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f07df33-602b-4449-a0b8-2adae7271b08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f07df33-602b-4449-a0b8-2adae7271b08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f07df33-602b-4449-a0b8-2adae7271b08>.
+    
+<http://data.lblod.info/id/remote-data-objects/e57bb83a-642b-421c-b42a-29d0e043bc87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e57bb83a-642b-421c-b42a-29d0e043bc87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e57bb83a-642b-421c-b42a-29d0e043bc87>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ba2be2b-c796-4846-bc0c-337097015534> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ba2be2b-c796-4846-bc0c-337097015534";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ba2be2b-c796-4846-bc0c-337097015534>.
+    
+<http://data.lblod.info/id/remote-data-objects/efc3db41-3580-4727-bd2b-93e6ec77056b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efc3db41-3580-4727-bd2b-93e6ec77056b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efc3db41-3580-4727-bd2b-93e6ec77056b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a300a418-49ef-4e6d-a287-fc15d52f11ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a300a418-49ef-4e6d-a287-fc15d52f11ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a300a418-49ef-4e6d-a287-fc15d52f11ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/917bf1ea-7e10-44f1-b2f6-4d6a8ca7b5f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "917bf1ea-7e10-44f1-b2f6-4d6a8ca7b5f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/917bf1ea-7e10-44f1-b2f6-4d6a8ca7b5f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/792a20c8-8795-4831-a46d-439e062af18c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "792a20c8-8795-4831-a46d-439e062af18c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/792a20c8-8795-4831-a46d-439e062af18c>.
+    
+<http://data.lblod.info/id/remote-data-objects/193c5ceb-b17d-4ba3-9361-09bd71b5772f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "193c5ceb-b17d-4ba3-9361-09bd71b5772f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/193c5ceb-b17d-4ba3-9361-09bd71b5772f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d92f0703-490e-41dd-b6c3-3f4cf8438d8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d92f0703-490e-41dd-b6c3-3f4cf8438d8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_01-03-2022_22225.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d92f0703-490e-41dd-b6c3-3f4cf8438d8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9e7d89e-2f9e-4e3d-be5a-b8e180f07cbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9e7d89e-2f9e-4e3d-be5a-b8e180f07cbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_01-03-2022_22258.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9e7d89e-2f9e-4e3d-be5a-b8e180f07cbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/59cbd0eb-e75c-4ff4-9f7c-c27589f0d307> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59cbd0eb-e75c-4ff4-9f7c-c27589f0d307";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_01-03-2022_22260.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59cbd0eb-e75c-4ff4-9f7c-c27589f0d307>.
+    
+<http://data.lblod.info/id/remote-data-objects/16a16b2c-4480-47db-af99-cefb421a16cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16a16b2c-4480-47db-af99-cefb421a16cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_01-03-2022_22261.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16a16b2c-4480-47db-af99-cefb421a16cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/05a38c1a-aeaf-4f28-805f-f725f3c20ab4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05a38c1a-aeaf-4f28-805f-f725f3c20ab4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_03-05-2022_22960.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05a38c1a-aeaf-4f28-805f-f725f3c20ab4>.
+    
+<http://data.lblod.info/id/remote-data-objects/639014b4-dd73-49ac-9a1c-43e41024d2c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "639014b4-dd73-49ac-9a1c-43e41024d2c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_04-01-2022_21715.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/639014b4-dd73-49ac-9a1c-43e41024d2c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c0af581-8c6d-4f61-8c2a-17dd1ad65c46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c0af581-8c6d-4f61-8c2a-17dd1ad65c46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_04-01-2022_21740.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c0af581-8c6d-4f61-8c2a-17dd1ad65c46>.
+    
+<http://data.lblod.info/id/remote-data-objects/da1a5ffc-355d-4529-8039-42cdc12d1876> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da1a5ffc-355d-4529-8039-42cdc12d1876";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_05-04-2022_22568.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da1a5ffc-355d-4529-8039-42cdc12d1876>.
+    
+<http://data.lblod.info/id/remote-data-objects/80814e5f-7406-431b-a0e5-e160983ebe94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80814e5f-7406-431b-a0e5-e160983ebe94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_05-04-2022_22581.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80814e5f-7406-431b-a0e5-e160983ebe94>.
+    
+<http://data.lblod.info/id/remote-data-objects/e134fe77-9564-4d25-8237-8f26135667df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e134fe77-9564-4d25-8237-8f26135667df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_05-07-2022_23501.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e134fe77-9564-4d25-8237-8f26135667df>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef5da551-b9dd-45b7-889a-3a784ef57a18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef5da551-b9dd-45b7-889a-3a784ef57a18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_05-10-2021_20660.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef5da551-b9dd-45b7-889a-3a784ef57a18>.
+    
+<http://data.lblod.info/id/remote-data-objects/99d0cf30-3769-4913-8c56-6174bb0c5a59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99d0cf30-3769-4913-8c56-6174bb0c5a59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_07-06-2022_23287.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99d0cf30-3769-4913-8c56-6174bb0c5a59>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ead5c3d-0f9c-408d-94c8-7a47e71e2453> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ead5c3d-0f9c-408d-94c8-7a47e71e2453";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_07-12-2021_21560.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ead5c3d-0f9c-408d-94c8-7a47e71e2453>.
+    
+<http://data.lblod.info/id/remote-data-objects/a287c2d0-1ca9-46f5-b332-51b3371b6800> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a287c2d0-1ca9-46f5-b332-51b3371b6800";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_08-03-2022_22319.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a287c2d0-1ca9-46f5-b332-51b3371b6800>.
+    
+<http://data.lblod.info/id/remote-data-objects/998b0f9b-f98d-4c54-aad5-be9be0580855> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "998b0f9b-f98d-4c54-aad5-be9be0580855";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_09-11-2021_21006.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/998b0f9b-f98d-4c54-aad5-be9be0580855>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e1fd78e-359b-4ef2-a87e-8a22ea27444a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e1fd78e-359b-4ef2-a87e-8a22ea27444a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_09-11-2021_21009.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e1fd78e-359b-4ef2-a87e-8a22ea27444a>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb1d5c43-c970-4d33-8ae5-5b5a595a20ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb1d5c43-c970-4d33-8ae5-5b5a595a20ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_10-05-2022_23049.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb1d5c43-c970-4d33-8ae5-5b5a595a20ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/3877a04c-433c-450f-9bc3-41b4833ffcfe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3877a04c-433c-450f-9bc3-41b4833ffcfe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_12-07-2022_23544.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3877a04c-433c-450f-9bc3-41b4833ffcfe>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b8abba7-307f-40b6-bf9b-721de549ab20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b8abba7-307f-40b6-bf9b-721de549ab20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_12-10-2021_20704.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b8abba7-307f-40b6-bf9b-721de549ab20>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1e5fd93-145a-4c11-a6ab-73daebecf3db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1e5fd93-145a-4c11-a6ab-73daebecf3db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_12-10-2021_20705.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1e5fd93-145a-4c11-a6ab-73daebecf3db>.
+    
+<http://data.lblod.info/id/remote-data-objects/7847783f-2a61-406c-94c9-735e849665d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7847783f-2a61-406c-94c9-735e849665d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_14-06-2022_23327.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7847783f-2a61-406c-94c9-735e849665d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/77436248-f80b-4dba-9fa2-f971cebb178c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77436248-f80b-4dba-9fa2-f971cebb178c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_14-06-2022_23350.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77436248-f80b-4dba-9fa2-f971cebb178c>.
+    
+<http://data.lblod.info/id/remote-data-objects/462b4487-7e61-459d-b9cf-b47b1cac2555> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "462b4487-7e61-459d-b9cf-b47b1cac2555";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_14-12-2021_21614.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/462b4487-7e61-459d-b9cf-b47b1cac2555>.
+    
+<http://data.lblod.info/id/remote-data-objects/288f1593-6a6a-4d71-a163-b91bb5a87743> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "288f1593-6a6a-4d71-a163-b91bb5a87743";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_15-02-2022_22060.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/288f1593-6a6a-4d71-a163-b91bb5a87743>.
+    
+<http://data.lblod.info/id/remote-data-objects/88a50ecf-232e-43d4-8e77-765184290d69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88a50ecf-232e-43d4-8e77-765184290d69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_15-03-2022_22368.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88a50ecf-232e-43d4-8e77-765184290d69>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d32b528-9cbe-452c-bbc8-99b54a43106f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d32b528-9cbe-452c-bbc8-99b54a43106f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_15-03-2022_22409.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d32b528-9cbe-452c-bbc8-99b54a43106f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bb29d27-0924-4878-add0-c14806ebcdab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bb29d27-0924-4878-add0-c14806ebcdab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_17-05-2022_23075.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bb29d27-0924-4878-add0-c14806ebcdab>.
+    
+<http://data.lblod.info/id/remote-data-objects/1dfba90f-fdb7-4289-956e-8357f55eecee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1dfba90f-fdb7-4289-956e-8357f55eecee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_18-01-2022_21808.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1dfba90f-fdb7-4289-956e-8357f55eecee>.
+    
+<http://data.lblod.info/id/remote-data-objects/d991b1e1-c250-4364-b195-12fac94571b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d991b1e1-c250-4364-b195-12fac94571b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_19-04-2022_22745.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d991b1e1-c250-4364-b195-12fac94571b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7da253e3-43c6-4e18-8583-c9b0751a1756> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7da253e3-43c6-4e18-8583-c9b0751a1756";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_19-04-2022_22834.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7da253e3-43c6-4e18-8583-c9b0751a1756>.
+    
+<http://data.lblod.info/id/remote-data-objects/538529b1-6373-4609-96bc-3f5078abed68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "538529b1-6373-4609-96bc-3f5078abed68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_19-04-2022_22837.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/538529b1-6373-4609-96bc-3f5078abed68>.
+    
+<http://data.lblod.info/id/remote-data-objects/38520cad-a7e4-47f5-8469-124402abf30d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38520cad-a7e4-47f5-8469-124402abf30d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_19-04-2022_22853.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38520cad-a7e4-47f5-8469-124402abf30d>.
+    
+<http://data.lblod.info/id/remote-data-objects/898d0477-c1d5-481a-95d8-a2f353110fdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "898d0477-c1d5-481a-95d8-a2f353110fdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_19-04-2022_22854.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/898d0477-c1d5-481a-95d8-a2f353110fdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/c11e70bd-48e1-4070-bde4-1f8d74aa5f27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c11e70bd-48e1-4070-bde4-1f8d74aa5f27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_19-10-2021_20865.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c11e70bd-48e1-4070-bde4-1f8d74aa5f27>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e9e9c5b-ca6c-4ce9-a661-21795b8419bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e9e9c5b-ca6c-4ce9-a661-21795b8419bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_21-06-2022_23382.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e9e9c5b-ca6c-4ce9-a661-21795b8419bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/72242f0e-ab9d-40cf-a799-695ef3a601c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72242f0e-ab9d-40cf-a799-695ef3a601c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_21-12-2021_21646.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72242f0e-ab9d-40cf-a799-695ef3a601c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f37a33e7-a6ea-4034-9854-ce388de726c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f37a33e7-a6ea-4034-9854-ce388de726c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_21-12-2021_21680.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f37a33e7-a6ea-4034-9854-ce388de726c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a6a8838-3f5f-40e1-a932-578e10412d8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a6a8838-3f5f-40e1-a932-578e10412d8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_21-12-2021_21701.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a6a8838-3f5f-40e1-a932-578e10412d8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9329331a-00d8-4cdd-96a2-13e7b4c33d2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9329331a-00d8-4cdd-96a2-13e7b4c33d2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_22-02-2022_22064.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b599a82-91f6-46bd-b188-5cb95ada36a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9329331a-00d8-4cdd-96a2-13e7b4c33d2f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201252-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201252-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201252-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201252-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b75564e0-ce2a-4b00-846b-1fe7bcbbc4d9> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b75564e0-ce2a-4b00-846b-1fe7bcbbc4d9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "382acb62-1d18-4c0b-beb6-2879329e0215";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d7a12e29-9b48-453b-8672-6e2867bbdf76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d7a12e29-9b48-453b-8672-6e2867bbdf76";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215>.
+
+  <http://redpencil.data.gift/id/task/e3c3524a-bef3-4aaf-b55b-31028a51adde> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e3c3524a-bef3-4aaf-b55b-31028a51adde";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b75564e0-ce2a-4b00-846b-1fe7bcbbc4d9>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d7a12e29-9b48-453b-8672-6e2867bbdf76>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/135e42b4-e97f-44ae-b871-40065d8a0549> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "135e42b4-e97f-44ae-b871-40065d8a0549";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_22-02-2022_22198.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/135e42b4-e97f-44ae-b871-40065d8a0549>.
+    
+<http://data.lblod.info/id/remote-data-objects/44e424d0-d60f-447a-81d0-2bec83893af4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44e424d0-d60f-447a-81d0-2bec83893af4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_22-03-2022_22417.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44e424d0-d60f-447a-81d0-2bec83893af4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0a5d5b0-7886-4223-a369-270e73383a3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0a5d5b0-7886-4223-a369-270e73383a3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_24-05-2022_23181.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0a5d5b0-7886-4223-a369-270e73383a3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e8a299e-a609-47ac-ad80-121950820d69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e8a299e-a609-47ac-ad80-121950820d69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_24-05-2022_23208.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e8a299e-a609-47ac-ad80-121950820d69>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fddbc22-94ef-42da-bdbf-053c7949c864> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fddbc22-94ef-42da-bdbf-053c7949c864";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_25-01-2022_21847.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fddbc22-94ef-42da-bdbf-053c7949c864>.
+    
+<http://data.lblod.info/id/remote-data-objects/e27aabce-b930-4fa2-ab84-ec04790c9204> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e27aabce-b930-4fa2-ab84-ec04790c9204";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_25-01-2022_21875.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e27aabce-b930-4fa2-ab84-ec04790c9204>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb2a194e-de83-407f-a366-b7f0b1713c57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb2a194e-de83-407f-a366-b7f0b1713c57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_28-06-2022_23462.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb2a194e-de83-407f-a366-b7f0b1713c57>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dac8b12-3a0f-40ba-af45-614f1aee19b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dac8b12-3a0f-40ba-af45-614f1aee19b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_28-06-2022_23485.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dac8b12-3a0f-40ba-af45-614f1aee19b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/df5cc3e0-ad8a-430c-aa01-5684dcb99d72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df5cc3e0-ad8a-430c-aa01-5684dcb99d72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_28-06-2022_23486.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df5cc3e0-ad8a-430c-aa01-5684dcb99d72>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bc17363-7fcf-484a-b98e-05cce8f728ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bc17363-7fcf-484a-b98e-05cce8f728ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/9e5b3ffff9c1ad8cfb57e6bae86494f9de9faa38d362e983c60d26b79777deed/GetPublication?filename=Uittreksels_29-03-2022_22515.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bc17363-7fcf-484a-b98e-05cce8f728ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ff7bdef-6798-4890-98e5-49fbc06df740> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ff7bdef-6798-4890-98e5-49fbc06df740";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ff7bdef-6798-4890-98e5-49fbc06df740>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddd356da-0696-4653-92f9-90591d45659b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddd356da-0696-4653-92f9-90591d45659b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddd356da-0696-4653-92f9-90591d45659b>.
+    
+<http://data.lblod.info/id/remote-data-objects/29fabdbb-3749-43cf-a375-16616c5b6687> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29fabdbb-3749-43cf-a375-16616c5b6687";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29fabdbb-3749-43cf-a375-16616c5b6687>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0d678d7-f8b5-414e-bf9a-04dc6be91d54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0d678d7-f8b5-414e-bf9a-04dc6be91d54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0d678d7-f8b5-414e-bf9a-04dc6be91d54>.
+    
+<http://data.lblod.info/id/remote-data-objects/e24d988f-713c-4793-be5f-ae71ae17623f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e24d988f-713c-4793-be5f-ae71ae17623f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e24d988f-713c-4793-be5f-ae71ae17623f>.
+    
+<http://data.lblod.info/id/remote-data-objects/84ffddc4-c925-4417-9018-17473e2fb03f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84ffddc4-c925-4417-9018-17473e2fb03f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84ffddc4-c925-4417-9018-17473e2fb03f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a93a5280-2c81-490e-ab2d-499e7dae9aec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a93a5280-2c81-490e-ab2d-499e7dae9aec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a93a5280-2c81-490e-ab2d-499e7dae9aec>.
+    
+<http://data.lblod.info/id/remote-data-objects/6adfa5b0-1ed0-42b4-9b14-5d7b81804c15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6adfa5b0-1ed0-42b4-9b14-5d7b81804c15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6adfa5b0-1ed0-42b4-9b14-5d7b81804c15>.
+    
+<http://data.lblod.info/id/remote-data-objects/54b7b8ad-1bca-4130-90ac-9352fd1b60a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54b7b8ad-1bca-4130-90ac-9352fd1b60a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54b7b8ad-1bca-4130-90ac-9352fd1b60a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e6394c9-ec1c-4dd4-b84d-ac99b0b578a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e6394c9-ec1c-4dd4-b84d-ac99b0b578a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e6394c9-ec1c-4dd4-b84d-ac99b0b578a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/02ce1952-d27a-4cf9-985d-28cfb595dede> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02ce1952-d27a-4cf9-985d-28cfb595dede";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02ce1952-d27a-4cf9-985d-28cfb595dede>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6c35e91-fd06-49bb-86fe-474c747a8d55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6c35e91-fd06-49bb-86fe-474c747a8d55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6c35e91-fd06-49bb-86fe-474c747a8d55>.
+    
+<http://data.lblod.info/id/remote-data-objects/59b6591b-7fd1-4b56-845e-12b751ec4ef5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59b6591b-7fd1-4b56-845e-12b751ec4ef5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59b6591b-7fd1-4b56-845e-12b751ec4ef5>.
+    
+<http://data.lblod.info/id/remote-data-objects/08c9c432-64aa-4293-9251-59290fe9d972> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08c9c432-64aa-4293-9251-59290fe9d972";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08c9c432-64aa-4293-9251-59290fe9d972>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ab0fa18-1398-4c05-a75f-1d7412d2cd91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ab0fa18-1398-4c05-a75f-1d7412d2cd91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ab0fa18-1398-4c05-a75f-1d7412d2cd91>.
+    
+<http://data.lblod.info/id/remote-data-objects/074196cd-cc68-4b11-b064-7e4739e01d5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "074196cd-cc68-4b11-b064-7e4739e01d5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/074196cd-cc68-4b11-b064-7e4739e01d5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d49ea04b-1d7d-4ea5-969e-e8b0f5d42096> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d49ea04b-1d7d-4ea5-969e-e8b0f5d42096";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d49ea04b-1d7d-4ea5-969e-e8b0f5d42096>.
+    
+<http://data.lblod.info/id/remote-data-objects/cff8e90b-001b-4db5-aa8a-23dca421dfd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cff8e90b-001b-4db5-aa8a-23dca421dfd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cff8e90b-001b-4db5-aa8a-23dca421dfd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0c8368f-0d58-4016-a799-7faea648751f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0c8368f-0d58-4016-a799-7faea648751f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0c8368f-0d58-4016-a799-7faea648751f>.
+    
+<http://data.lblod.info/id/remote-data-objects/87bf8c6a-a85c-4e89-8034-14ca3e090c08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87bf8c6a-a85c-4e89-8034-14ca3e090c08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87bf8c6a-a85c-4e89-8034-14ca3e090c08>.
+    
+<http://data.lblod.info/id/remote-data-objects/7730aa07-77b1-4ac2-893b-7a4d7dfb30ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7730aa07-77b1-4ac2-893b-7a4d7dfb30ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7730aa07-77b1-4ac2-893b-7a4d7dfb30ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/27c69861-23a5-48d4-aab9-3ac150fbdff8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27c69861-23a5-48d4-aab9-3ac150fbdff8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27c69861-23a5-48d4-aab9-3ac150fbdff8>.
+    
+<http://data.lblod.info/id/remote-data-objects/6564581d-4988-4cd2-9a68-005c31b0155b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6564581d-4988-4cd2-9a68-005c31b0155b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6564581d-4988-4cd2-9a68-005c31b0155b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5eca946-5ba6-465d-9d44-8e12dc5f5745> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5eca946-5ba6-465d-9d44-8e12dc5f5745";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5eca946-5ba6-465d-9d44-8e12dc5f5745>.
+    
+<http://data.lblod.info/id/remote-data-objects/49abcdc7-a98a-43f8-9fad-1bab5bdcee72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49abcdc7-a98a-43f8-9fad-1bab5bdcee72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49abcdc7-a98a-43f8-9fad-1bab5bdcee72>.
+    
+<http://data.lblod.info/id/remote-data-objects/d38f33bc-3016-4f70-9a89-82627a08e43e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d38f33bc-3016-4f70-9a89-82627a08e43e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d38f33bc-3016-4f70-9a89-82627a08e43e>.
+    
+<http://data.lblod.info/id/remote-data-objects/66f29d11-3d69-48fa-bef7-6953b8583d34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66f29d11-3d69-48fa-bef7-6953b8583d34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66f29d11-3d69-48fa-bef7-6953b8583d34>.
+    
+<http://data.lblod.info/id/remote-data-objects/4242922c-5017-407a-b352-409c266d5f21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4242922c-5017-407a-b352-409c266d5f21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4242922c-5017-407a-b352-409c266d5f21>.
+    
+<http://data.lblod.info/id/remote-data-objects/809b1ae9-5902-4a28-957d-1b2f3cbdf870> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "809b1ae9-5902-4a28-957d-1b2f3cbdf870";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/809b1ae9-5902-4a28-957d-1b2f3cbdf870>.
+    
+<http://data.lblod.info/id/remote-data-objects/91cdcada-3a56-47d7-98f9-1c8fede1bb11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91cdcada-3a56-47d7-98f9-1c8fede1bb11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91cdcada-3a56-47d7-98f9-1c8fede1bb11>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c4e5280-3110-4333-85c2-be6214c93f45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c4e5280-3110-4333-85c2-be6214c93f45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c4e5280-3110-4333-85c2-be6214c93f45>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ea4d207-f331-4990-bdc4-51f31347a70c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ea4d207-f331-4990-bdc4-51f31347a70c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ea4d207-f331-4990-bdc4-51f31347a70c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0542db50-a42a-4c6b-9e7b-d34891f1e075> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0542db50-a42a-4c6b-9e7b-d34891f1e075";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0542db50-a42a-4c6b-9e7b-d34891f1e075>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc6446f3-1ed0-4802-bf51-96b8db616bda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc6446f3-1ed0-4802-bf51-96b8db616bda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc6446f3-1ed0-4802-bf51-96b8db616bda>.
+    
+<http://data.lblod.info/id/remote-data-objects/a48ac5af-18fc-4ec6-925d-c8cb89ae38bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a48ac5af-18fc-4ec6-925d-c8cb89ae38bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a48ac5af-18fc-4ec6-925d-c8cb89ae38bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec93d5a9-1851-4d8e-9d9e-67bc8f985e9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec93d5a9-1851-4d8e-9d9e-67bc8f985e9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec93d5a9-1851-4d8e-9d9e-67bc8f985e9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1154b3bd-5cb4-47cb-bb91-8b0551c8ba25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1154b3bd-5cb4-47cb-bb91-8b0551c8ba25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1154b3bd-5cb4-47cb-bb91-8b0551c8ba25>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d332679-8ca6-4500-a5bd-ff3b57b5068b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d332679-8ca6-4500-a5bd-ff3b57b5068b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d332679-8ca6-4500-a5bd-ff3b57b5068b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a086c4d-ce05-44ed-a1c8-9653195e8b9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a086c4d-ce05-44ed-a1c8-9653195e8b9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.avelgem.be/LBLODWeb/Home/Overzicht/bedf9a23-76fa-4ce7-837d-909526f4a9ae/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a086c4d-ce05-44ed-a1c8-9653195e8b9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/00c6f3cb-d15d-4472-bc01-e36fbde21f55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00c6f3cb-d15d-4472-bc01-e36fbde21f55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/382acb62-1d18-4c0b-beb6-2879329e0215> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00c6f3cb-d15d-4472-bc01-e36fbde21f55>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201253-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201253-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201253-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201253-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/4337940e-4799-41c2-aa3a-cd2d17db170e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4337940e-4799-41c2-aa3a-cd2d17db170e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f312f0c6-f262-41f6-b08a-8e2b53bd569a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/89b46cce-d074-47e0-9d35-b0be23344ce6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "89b46cce-d074-47e0-9d35-b0be23344ce6";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a>.
+
+  <http://redpencil.data.gift/id/task/4cb84544-844a-4485-a208-3bbb15caa126> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4cb84544-844a-4485-a208-3bbb15caa126";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/4337940e-4799-41c2-aa3a-cd2d17db170e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/89b46cce-d074-47e0-9d35-b0be23344ce6>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/2bc9ee43-55d6-4609-b1d6-91b79bb7b167> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bc9ee43-55d6-4609-b1d6-91b79bb7b167";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bc9ee43-55d6-4609-b1d6-91b79bb7b167>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b17b0fc-279e-4755-b92a-92993fbe66fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b17b0fc-279e-4755-b92a-92993fbe66fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b17b0fc-279e-4755-b92a-92993fbe66fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ba2fe57-7fe3-4301-ad77-1adcfcf0a1bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ba2fe57-7fe3-4301-ad77-1adcfcf0a1bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ba2fe57-7fe3-4301-ad77-1adcfcf0a1bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b9c6ed4-6e0d-4cb6-a5a3-c386bb988fcb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b9c6ed4-6e0d-4cb6-a5a3-c386bb988fcb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b9c6ed4-6e0d-4cb6-a5a3-c386bb988fcb>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fbbf568-4ce2-4c8a-9295-d17164428715> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fbbf568-4ce2-4c8a-9295-d17164428715";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fbbf568-4ce2-4c8a-9295-d17164428715>.
+    
+<http://data.lblod.info/id/remote-data-objects/550f75ae-2825-43e0-8997-938803abe6b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "550f75ae-2825-43e0-8997-938803abe6b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/550f75ae-2825-43e0-8997-938803abe6b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e2b6939-83a6-4b55-ad6d-7028b5e38a4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e2b6939-83a6-4b55-ad6d-7028b5e38a4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e2b6939-83a6-4b55-ad6d-7028b5e38a4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b02a9d36-fc32-4bff-9a00-4c81c1839922> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b02a9d36-fc32-4bff-9a00-4c81c1839922";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b02a9d36-fc32-4bff-9a00-4c81c1839922>.
+    
+<http://data.lblod.info/id/remote-data-objects/92292bc2-8377-49ab-9346-848d6313db21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92292bc2-8377-49ab-9346-848d6313db21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92292bc2-8377-49ab-9346-848d6313db21>.
+    
+<http://data.lblod.info/id/remote-data-objects/077ad134-0da2-45e8-95e8-c1ef9e8fde75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "077ad134-0da2-45e8-95e8-c1ef9e8fde75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/077ad134-0da2-45e8-95e8-c1ef9e8fde75>.
+    
+<http://data.lblod.info/id/remote-data-objects/f39c1003-f2b6-44f3-9f8d-3c8a45932e12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f39c1003-f2b6-44f3-9f8d-3c8a45932e12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f39c1003-f2b6-44f3-9f8d-3c8a45932e12>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ec7faae-f4cd-4771-a47a-dd51bcdc8032> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ec7faae-f4cd-4771-a47a-dd51bcdc8032";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ec7faae-f4cd-4771-a47a-dd51bcdc8032>.
+    
+<http://data.lblod.info/id/remote-data-objects/963405bc-18a8-4fee-9778-686d54d84b02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "963405bc-18a8-4fee-9778-686d54d84b02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/963405bc-18a8-4fee-9778-686d54d84b02>.
+    
+<http://data.lblod.info/id/remote-data-objects/46d127c9-b269-4714-9db1-8738054e84a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46d127c9-b269-4714-9db1-8738054e84a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46d127c9-b269-4714-9db1-8738054e84a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/9106d8e3-5fe1-4d11-a701-70bceb2eed31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9106d8e3-5fe1-4d11-a701-70bceb2eed31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9106d8e3-5fe1-4d11-a701-70bceb2eed31>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae47f163-5e13-45b5-8e8e-7b524d48dfcb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae47f163-5e13-45b5-8e8e-7b524d48dfcb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae47f163-5e13-45b5-8e8e-7b524d48dfcb>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad7ed09c-a209-49c0-b42e-f7d38e43d505> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad7ed09c-a209-49c0-b42e-f7d38e43d505";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad7ed09c-a209-49c0-b42e-f7d38e43d505>.
+    
+<http://data.lblod.info/id/remote-data-objects/9df878a2-5ed2-4d31-b1bd-38581c87387a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9df878a2-5ed2-4d31-b1bd-38581c87387a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9df878a2-5ed2-4d31-b1bd-38581c87387a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c59912c-45e0-4602-a938-2ad63ffa69d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c59912c-45e0-4602-a938-2ad63ffa69d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c59912c-45e0-4602-a938-2ad63ffa69d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e8b85df-9f5f-4639-b279-ff1414268355> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e8b85df-9f5f-4639-b279-ff1414268355";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e8b85df-9f5f-4639-b279-ff1414268355>.
+    
+<http://data.lblod.info/id/remote-data-objects/5034d1f9-ada0-4e55-ba7f-d7b8c0d74bb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5034d1f9-ada0-4e55-ba7f-d7b8c0d74bb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5034d1f9-ada0-4e55-ba7f-d7b8c0d74bb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/8febaa08-512f-494b-857d-a2e10f33089f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8febaa08-512f-494b-857d-a2e10f33089f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8febaa08-512f-494b-857d-a2e10f33089f>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfc27b06-84e7-49ee-b224-0fc6be233607> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfc27b06-84e7-49ee-b224-0fc6be233607";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfc27b06-84e7-49ee-b224-0fc6be233607>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3379039-e79d-4457-95c7-5268001cde03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3379039-e79d-4457-95c7-5268001cde03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3379039-e79d-4457-95c7-5268001cde03>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ae2939b-9075-413b-a1b6-88e837208815> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ae2939b-9075-413b-a1b6-88e837208815";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ae2939b-9075-413b-a1b6-88e837208815>.
+    
+<http://data.lblod.info/id/remote-data-objects/55c43562-d13f-4bec-910c-e4b9a2e0c552> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55c43562-d13f-4bec-910c-e4b9a2e0c552";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55c43562-d13f-4bec-910c-e4b9a2e0c552>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ba412ff-6601-4552-9e5d-e00ce61e7315> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ba412ff-6601-4552-9e5d-e00ce61e7315";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Uittreksels_04-07-2022_48902.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ba412ff-6601-4552-9e5d-e00ce61e7315>.
+    
+<http://data.lblod.info/id/remote-data-objects/135756b0-67b8-4a57-8780-280ee636702b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "135756b0-67b8-4a57-8780-280ee636702b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Uittreksels_04-07-2022_48976.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/135756b0-67b8-4a57-8780-280ee636702b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6a8e8c7-64c4-4eca-8fb6-f7d40bb296b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6a8e8c7-64c4-4eca-8fb6-f7d40bb296b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Uittreksels_13-12-2021_47017.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6a8e8c7-64c4-4eca-8fb6-f7d40bb296b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/0984b503-c686-4344-a023-11695942f5e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0984b503-c686-4344-a023-11695942f5e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/57fa67e4f6296d400289b56dc9c715c84a3387441ac03ae05b59a6df1bfc1a91/GetPublication?filename=Uittreksels_21-02-2022_47817.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0984b503-c686-4344-a023-11695942f5e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dafbff2-3eeb-409f-9b21-7fc72b1bbd3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dafbff2-3eeb-409f-9b21-7fc72b1bbd3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_02-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dafbff2-3eeb-409f-9b21-7fc72b1bbd3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc925156-927e-4924-a7c9-584c926273e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc925156-927e-4924-a7c9-584c926273e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc925156-927e-4924-a7c9-584c926273e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9d373f1-93f0-444c-9c7f-1a9d98b29723> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9d373f1-93f0-444c-9c7f-1a9d98b29723";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9d373f1-93f0-444c-9c7f-1a9d98b29723>.
+    
+<http://data.lblod.info/id/remote-data-objects/86b471d1-4ee3-4bc4-a019-efbaf47c70a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86b471d1-4ee3-4bc4-a019-efbaf47c70a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_04-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86b471d1-4ee3-4bc4-a019-efbaf47c70a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1ad9ad1-d30c-46bf-b00d-895cebdb04d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1ad9ad1-d30c-46bf-b00d-895cebdb04d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1ad9ad1-d30c-46bf-b00d-895cebdb04d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/12573821-bdbb-4994-b7b3-07b030c88aae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12573821-bdbb-4994-b7b3-07b030c88aae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_04-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12573821-bdbb-4994-b7b3-07b030c88aae>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ae30d6c-db46-4b57-9974-56e7e8c9ee53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ae30d6c-db46-4b57-9974-56e7e8c9ee53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ae30d6c-db46-4b57-9974-56e7e8c9ee53>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca2ff8d0-8455-451b-a7f4-816cb4b400ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca2ff8d0-8455-451b-a7f4-816cb4b400ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca2ff8d0-8455-451b-a7f4-816cb4b400ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/78f94dc1-873d-4c81-8a56-6bf79dd3e2ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78f94dc1-873d-4c81-8a56-6bf79dd3e2ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78f94dc1-873d-4c81-8a56-6bf79dd3e2ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/57f56043-406a-4c56-b89a-8d9a2036a653> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57f56043-406a-4c56-b89a-8d9a2036a653";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57f56043-406a-4c56-b89a-8d9a2036a653>.
+    
+<http://data.lblod.info/id/remote-data-objects/165d396c-89b3-4cad-ab48-7ada0a4d7e08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "165d396c-89b3-4cad-ab48-7ada0a4d7e08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/165d396c-89b3-4cad-ab48-7ada0a4d7e08>.
+    
+<http://data.lblod.info/id/remote-data-objects/75343354-8239-496d-8d48-4df3a83483d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75343354-8239-496d-8d48-4df3a83483d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75343354-8239-496d-8d48-4df3a83483d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c33eca18-d4ca-487c-b943-ba3b12c9a682> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c33eca18-d4ca-487c-b943-ba3b12c9a682";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c33eca18-d4ca-487c-b943-ba3b12c9a682>.
+    
+<http://data.lblod.info/id/remote-data-objects/401cd0ca-8c96-4202-9db3-6fc86b99403f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "401cd0ca-8c96-4202-9db3-6fc86b99403f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/401cd0ca-8c96-4202-9db3-6fc86b99403f>.
+    
+<http://data.lblod.info/id/remote-data-objects/cac4517d-5260-4f32-8e7d-8764d181c75f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cac4517d-5260-4f32-8e7d-8764d181c75f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cac4517d-5260-4f32-8e7d-8764d181c75f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6593cb3-bceb-4242-ae99-6ee7184920ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6593cb3-bceb-4242-ae99-6ee7184920ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6593cb3-bceb-4242-ae99-6ee7184920ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/276d5c88-29b4-44df-b714-f57c03e6088c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "276d5c88-29b4-44df-b714-f57c03e6088c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/276d5c88-29b4-44df-b714-f57c03e6088c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a039ac69-6e3f-4375-9f7b-6400547b05d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a039ac69-6e3f-4375-9f7b-6400547b05d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a039ac69-6e3f-4375-9f7b-6400547b05d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c5e0d50-3736-4fab-aacd-8a0d2873afdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c5e0d50-3736-4fab-aacd-8a0d2873afdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c5e0d50-3736-4fab-aacd-8a0d2873afdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/62f559cf-b6fb-47ea-a87b-ef346971cc3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62f559cf-b6fb-47ea-a87b-ef346971cc3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f312f0c6-f262-41f6-b08a-8e2b53bd569a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62f559cf-b6fb-47ea-a87b-ef346971cc3f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201255-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201255-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201255-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201255-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b76b4e87-b1a5-4d29-9f17-68dfc2de26f2> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b76b4e87-b1a5-4d29-9f17-68dfc2de26f2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cef15deb-9b1b-4b28-8d5b-7ad820dce062";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/8e1d0b1d-7550-4e4e-9c93-710404836d13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8e1d0b1d-7550-4e4e-9c93-710404836d13";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062>.
+
+  <http://redpencil.data.gift/id/task/a8a83e4c-c9b9-4fbd-b86c-3f48c2490e5d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a8a83e4c-c9b9-4fbd-b86c-3f48c2490e5d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b76b4e87-b1a5-4d29-9f17-68dfc2de26f2>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/8e1d0b1d-7550-4e4e-9c93-710404836d13>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/bc84a888-db6e-4a0e-a319-6df1b813c982> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc84a888-db6e-4a0e-a319-6df1b813c982";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc84a888-db6e-4a0e-a319-6df1b813c982>.
+    
+<http://data.lblod.info/id/remote-data-objects/1afd812c-36f6-432a-adf2-adcb69a0fd3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1afd812c-36f6-432a-adf2-adcb69a0fd3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1afd812c-36f6-432a-adf2-adcb69a0fd3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc5d36aa-90ef-4416-adae-b72b0292bec5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc5d36aa-90ef-4416-adae-b72b0292bec5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc5d36aa-90ef-4416-adae-b72b0292bec5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e43c917e-10cc-4767-85e4-c32cfc375567> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e43c917e-10cc-4767-85e4-c32cfc375567";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e43c917e-10cc-4767-85e4-c32cfc375567>.
+    
+<http://data.lblod.info/id/remote-data-objects/069cd820-979b-488c-b826-7e6a9dee4e60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "069cd820-979b-488c-b826-7e6a9dee4e60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/069cd820-979b-488c-b826-7e6a9dee4e60>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c2b5864-4cac-460b-9c9c-71a39b061ff5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c2b5864-4cac-460b-9c9c-71a39b061ff5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c2b5864-4cac-460b-9c9c-71a39b061ff5>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4f2097d-8601-4b95-a54d-5ae14bfeb8f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4f2097d-8601-4b95-a54d-5ae14bfeb8f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4f2097d-8601-4b95-a54d-5ae14bfeb8f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/583ff7d5-20af-4aaa-adb9-b36e071b3836> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "583ff7d5-20af-4aaa-adb9-b36e071b3836";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=BesluitenLijst_Burgemeester_29-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/583ff7d5-20af-4aaa-adb9-b36e071b3836>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c026caa-04e4-43a1-a406-32520ba5ba74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c026caa-04e4-43a1-a406-32520ba5ba74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=Uittreksels_10-11-2021_46894.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c026caa-04e4-43a1-a406-32520ba5ba74>.
+    
+<http://data.lblod.info/id/remote-data-objects/75842edc-9b3a-431a-b26c-3c3b0a20238f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75842edc-9b3a-431a-b26c-3c3b0a20238f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=Uittreksels_22-06-2022_49015.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75842edc-9b3a-431a-b26c-3c3b0a20238f>.
+    
+<http://data.lblod.info/id/remote-data-objects/de8ad80a-ca2d-48b6-b6c6-2109293a94f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de8ad80a-ca2d-48b6-b6c6-2109293a94f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=Uittreksels_23-06-2022_49040.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de8ad80a-ca2d-48b6-b6c6-2109293a94f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dbb697f-2878-41f2-95d5-450af8e11020> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dbb697f-2878-41f2-95d5-450af8e11020";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=Uittreksels_23-06-2022_49041.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dbb697f-2878-41f2-95d5-450af8e11020>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebd3a511-61b2-4d23-8c51-a351ad5a8ac0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebd3a511-61b2-4d23-8c51-a351ad5a8ac0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/d6c591f4ee139737b90333f668397fff9204d57a27c383c6095543c4c3cf67e0/GetPublication?filename=Uittreksels_28-01-2022_47573.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebd3a511-61b2-4d23-8c51-a351ad5a8ac0>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfdde87d-7e8b-4736-b89a-54c86e4d0833> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfdde87d-7e8b-4736-b89a-54c86e4d0833";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfdde87d-7e8b-4736-b89a-54c86e4d0833>.
+    
+<http://data.lblod.info/id/remote-data-objects/83ca8b6c-0f8b-4976-8480-39390fa44ddc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83ca8b6c-0f8b-4976-8480-39390fa44ddc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83ca8b6c-0f8b-4976-8480-39390fa44ddc>.
+    
+<http://data.lblod.info/id/remote-data-objects/e26c8efe-149e-4f1d-ad60-ae680bdda578> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e26c8efe-149e-4f1d-ad60-ae680bdda578";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_01-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e26c8efe-149e-4f1d-ad60-ae680bdda578>.
+    
+<http://data.lblod.info/id/remote-data-objects/a67973bd-4cac-48d3-bc7e-65d8856d1d61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a67973bd-4cac-48d3-bc7e-65d8856d1d61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_02-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a67973bd-4cac-48d3-bc7e-65d8856d1d61>.
+    
+<http://data.lblod.info/id/remote-data-objects/68f18d89-c8af-4227-8d9b-5030d279a75a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68f18d89-c8af-4227-8d9b-5030d279a75a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_02-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68f18d89-c8af-4227-8d9b-5030d279a75a>.
+    
+<http://data.lblod.info/id/remote-data-objects/648b5858-5c92-4569-a61e-f81921c88a0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "648b5858-5c92-4569-a61e-f81921c88a0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/648b5858-5c92-4569-a61e-f81921c88a0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfd17082-b9c0-4970-a5eb-0abb550cc082> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfd17082-b9c0-4970-a5eb-0abb550cc082";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfd17082-b9c0-4970-a5eb-0abb550cc082>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f2319b5-e10e-450e-8d8f-7ad5d41a5a33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f2319b5-e10e-450e-8d8f-7ad5d41a5a33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f2319b5-e10e-450e-8d8f-7ad5d41a5a33>.
+    
+<http://data.lblod.info/id/remote-data-objects/298af6cf-856b-464e-9277-1530b1ab22ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "298af6cf-856b-464e-9277-1530b1ab22ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/298af6cf-856b-464e-9277-1530b1ab22ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/1367770e-e1c4-47e1-a81a-efbbbe5355b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1367770e-e1c4-47e1-a81a-efbbbe5355b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_06-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1367770e-e1c4-47e1-a81a-efbbbe5355b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/118b6b61-5af8-4970-9947-0267ea31775a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "118b6b61-5af8-4970-9947-0267ea31775a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/118b6b61-5af8-4970-9947-0267ea31775a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5bbe30f-1cf6-4e98-9744-aa32aea6dfeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5bbe30f-1cf6-4e98-9744-aa32aea6dfeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5bbe30f-1cf6-4e98-9744-aa32aea6dfeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/6819251e-f92c-4d31-9c37-4b276acbfbde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6819251e-f92c-4d31-9c37-4b276acbfbde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6819251e-f92c-4d31-9c37-4b276acbfbde>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0f3f507-ec82-4dbc-8b0f-56851a3f18c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0f3f507-ec82-4dbc-8b0f-56851a3f18c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0f3f507-ec82-4dbc-8b0f-56851a3f18c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9651bdb8-fb81-475c-b4c2-7751b4df4ec6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9651bdb8-fb81-475c-b4c2-7751b4df4ec6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9651bdb8-fb81-475c-b4c2-7751b4df4ec6>.
+    
+<http://data.lblod.info/id/remote-data-objects/89fa30ca-e673-48bc-beae-825a73b9f8d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89fa30ca-e673-48bc-beae-825a73b9f8d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89fa30ca-e673-48bc-beae-825a73b9f8d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c439d985-a4af-42dd-8521-8e28fb42844f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c439d985-a4af-42dd-8521-8e28fb42844f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_12-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c439d985-a4af-42dd-8521-8e28fb42844f>.
+    
+<http://data.lblod.info/id/remote-data-objects/da1b0e79-ff32-42cc-acf3-eb9013d1b721> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da1b0e79-ff32-42cc-acf3-eb9013d1b721";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_13-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da1b0e79-ff32-42cc-acf3-eb9013d1b721>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9760d76-78e8-4467-93d0-5937a68e3957> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9760d76-78e8-4467-93d0-5937a68e3957";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9760d76-78e8-4467-93d0-5937a68e3957>.
+    
+<http://data.lblod.info/id/remote-data-objects/c17e3c16-bf7d-44fb-80e5-ae1a49b85070> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c17e3c16-bf7d-44fb-80e5-ae1a49b85070";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c17e3c16-bf7d-44fb-80e5-ae1a49b85070>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a31323a-5203-4d9e-8de9-9ac74f81eef5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a31323a-5203-4d9e-8de9-9ac74f81eef5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a31323a-5203-4d9e-8de9-9ac74f81eef5>.
+    
+<http://data.lblod.info/id/remote-data-objects/81c84fe5-5ea1-4722-98f1-522c7c037091> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81c84fe5-5ea1-4722-98f1-522c7c037091";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81c84fe5-5ea1-4722-98f1-522c7c037091>.
+    
+<http://data.lblod.info/id/remote-data-objects/58050843-9809-4160-9ade-dfcb869a57d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58050843-9809-4160-9ade-dfcb869a57d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58050843-9809-4160-9ade-dfcb869a57d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0aab109-472f-4abb-ab88-d68fc581041a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0aab109-472f-4abb-ab88-d68fc581041a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_16-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0aab109-472f-4abb-ab88-d68fc581041a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0481677c-9657-4a65-88d8-6ed4a36b1471> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0481677c-9657-4a65-88d8-6ed4a36b1471";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_16-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0481677c-9657-4a65-88d8-6ed4a36b1471>.
+    
+<http://data.lblod.info/id/remote-data-objects/01a93bc6-6dfe-49f2-a53c-ee92a418341b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01a93bc6-6dfe-49f2-a53c-ee92a418341b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01a93bc6-6dfe-49f2-a53c-ee92a418341b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3838884-efb0-41f3-9aba-239b14f07f80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3838884-efb0-41f3-9aba-239b14f07f80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3838884-efb0-41f3-9aba-239b14f07f80>.
+    
+<http://data.lblod.info/id/remote-data-objects/42683a1c-cb37-48de-aa28-2239ed1072b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42683a1c-cb37-48de-aa28-2239ed1072b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_19-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42683a1c-cb37-48de-aa28-2239ed1072b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f10f0ecf-4e1b-4b1c-b874-5a46115afd2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f10f0ecf-4e1b-4b1c-b874-5a46115afd2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f10f0ecf-4e1b-4b1c-b874-5a46115afd2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a9519d5-b168-4787-a20c-0ea5dbd9efa5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a9519d5-b168-4787-a20c-0ea5dbd9efa5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_20-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a9519d5-b168-4787-a20c-0ea5dbd9efa5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a33be2d-2917-4eef-8639-f33459fe64a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a33be2d-2917-4eef-8639-f33459fe64a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_20-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a33be2d-2917-4eef-8639-f33459fe64a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/23cfdf68-9cff-41ca-b3d6-799ac7017394> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23cfdf68-9cff-41ca-b3d6-799ac7017394";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23cfdf68-9cff-41ca-b3d6-799ac7017394>.
+    
+<http://data.lblod.info/id/remote-data-objects/a01a2493-bc50-4f5d-a9d1-cb8ec204c4bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a01a2493-bc50-4f5d-a9d1-cb8ec204c4bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a01a2493-bc50-4f5d-a9d1-cb8ec204c4bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a4866b4-b285-47c7-ad77-ee455b915f57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a4866b4-b285-47c7-ad77-ee455b915f57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a4866b4-b285-47c7-ad77-ee455b915f57>.
+    
+<http://data.lblod.info/id/remote-data-objects/58952c29-84a4-44aa-b182-a3b5156afe91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58952c29-84a4-44aa-b182-a3b5156afe91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58952c29-84a4-44aa-b182-a3b5156afe91>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5a719de-5931-45ea-917c-799839dede5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5a719de-5931-45ea-917c-799839dede5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5a719de-5931-45ea-917c-799839dede5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/47476290-6e24-4bc0-86fd-68a33e25b5ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47476290-6e24-4bc0-86fd-68a33e25b5ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cef15deb-9b1b-4b28-8d5b-7ad820dce062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47476290-6e24-4bc0-86fd-68a33e25b5ef>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201256-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201256-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201256-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201256-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b9fd7a9f-057f-4ce5-b833-858b1fec94e9> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b9fd7a9f-057f-4ce5-b833-858b1fec94e9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "959a427c-c399-49b2-8973-4b80712ecde8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ca42b6d4-6e8d-4400-99aa-060849f2b19c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ca42b6d4-6e8d-4400-99aa-060849f2b19c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8>.
+
+  <http://redpencil.data.gift/id/task/551a1bad-0043-452f-84ed-57b2b5233870> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "551a1bad-0043-452f-84ed-57b2b5233870";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b9fd7a9f-057f-4ce5-b833-858b1fec94e9>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ca42b6d4-6e8d-4400-99aa-060849f2b19c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/bad11c28-15ab-438b-a31a-754cba81760c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bad11c28-15ab-438b-a31a-754cba81760c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bad11c28-15ab-438b-a31a-754cba81760c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e92cc5c-5cc5-453f-becb-7490d0b6f4a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e92cc5c-5cc5-453f-becb-7490d0b6f4a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e92cc5c-5cc5-453f-becb-7490d0b6f4a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/814d4a99-fcde-43a7-9d6d-2afa4aa75d3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "814d4a99-fcde-43a7-9d6d-2afa4aa75d3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/814d4a99-fcde-43a7-9d6d-2afa4aa75d3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/66334f93-920b-4b3a-b756-5a0fb13ca3a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66334f93-920b-4b3a-b756-5a0fb13ca3a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66334f93-920b-4b3a-b756-5a0fb13ca3a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/eba3e159-0b24-4a9a-a979-5c4cdc840fa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eba3e159-0b24-4a9a-a979-5c4cdc840fa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_29-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eba3e159-0b24-4a9a-a979-5c4cdc840fa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/041dc2af-c82a-432a-9bc8-cca210f71343> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "041dc2af-c82a-432a-9bc8-cca210f71343";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/041dc2af-c82a-432a-9bc8-cca210f71343>.
+    
+<http://data.lblod.info/id/remote-data-objects/16d72510-0e54-4908-add0-746d1ebf4671> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16d72510-0e54-4908-add0-746d1ebf4671";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_06-07-2022_49129.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16d72510-0e54-4908-add0-746d1ebf4671>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b2ca4aa-0d74-40b2-ab8d-503e14532cda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b2ca4aa-0d74-40b2-ab8d-503e14532cda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_10-11-2021_46796.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b2ca4aa-0d74-40b2-ab8d-503e14532cda>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc508d7b-bcbf-4d18-b37e-5c330adb6c40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc508d7b-bcbf-4d18-b37e-5c330adb6c40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_10-11-2021_46797.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc508d7b-bcbf-4d18-b37e-5c330adb6c40>.
+    
+<http://data.lblod.info/id/remote-data-objects/03dfe3b4-e091-4237-849e-56f613dc807f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03dfe3b4-e091-4237-849e-56f613dc807f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_13-07-2022_48036.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03dfe3b4-e091-4237-849e-56f613dc807f>.
+    
+<http://data.lblod.info/id/remote-data-objects/988ad8a7-6552-4849-b254-1438e86335a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "988ad8a7-6552-4849-b254-1438e86335a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_13-07-2022_48037.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/988ad8a7-6552-4849-b254-1438e86335a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad3211d7-7418-4487-838a-f1fac404b666> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad3211d7-7418-4487-838a-f1fac404b666";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_13-07-2022_48040.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad3211d7-7418-4487-838a-f1fac404b666>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f7b021e-dfe6-40e9-86ee-ae92e801cddb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f7b021e-dfe6-40e9-86ee-ae92e801cddb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_13-07-2022_48872.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f7b021e-dfe6-40e9-86ee-ae92e801cddb>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdbc0cc4-2e7d-4bc5-b7c6-76e671593aa5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdbc0cc4-2e7d-4bc5-b7c6-76e671593aa5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_13-07-2022_48904.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdbc0cc4-2e7d-4bc5-b7c6-76e671593aa5>.
+    
+<http://data.lblod.info/id/remote-data-objects/49b3bcfc-47ff-4e9f-9345-a44004283af7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49b3bcfc-47ff-4e9f-9345-a44004283af7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_13-07-2022_48966.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49b3bcfc-47ff-4e9f-9345-a44004283af7>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd313994-ba6f-416b-b829-f5d7bee33520> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd313994-ba6f-416b-b829-f5d7bee33520";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_13-07-2022_49028.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd313994-ba6f-416b-b829-f5d7bee33520>.
+    
+<http://data.lblod.info/id/remote-data-objects/94f6eb99-3ba0-47f7-b359-25fba499d162> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94f6eb99-3ba0-47f7-b359-25fba499d162";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_13-07-2022_49128.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94f6eb99-3ba0-47f7-b359-25fba499d162>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a752417-9a97-4324-baf1-325826dfd573> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a752417-9a97-4324-baf1-325826dfd573";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_20-07-2022_47672.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a752417-9a97-4324-baf1-325826dfd573>.
+    
+<http://data.lblod.info/id/remote-data-objects/23b56359-cdc4-430c-bc9c-42ae0753c0eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23b56359-cdc4-430c-bc9c-42ae0753c0eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_20-07-2022_47673.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23b56359-cdc4-430c-bc9c-42ae0753c0eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdc18e3e-03e9-4f34-a8f7-a530e9711d53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdc18e3e-03e9-4f34-a8f7-a530e9711d53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_20-07-2022_47675.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdc18e3e-03e9-4f34-a8f7-a530e9711d53>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5dc6b37-4a90-4fcf-a66c-27a84c0772b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5dc6b37-4a90-4fcf-a66c-27a84c0772b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_20-07-2022_47676.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5dc6b37-4a90-4fcf-a66c-27a84c0772b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2c5ec52-452c-48c4-8970-816ace886bd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2c5ec52-452c-48c4-8970-816ace886bd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_20-07-2022_49080.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2c5ec52-452c-48c4-8970-816ace886bd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad4ab61d-e62e-44a1-a48a-3b403eab7f4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad4ab61d-e62e-44a1-a48a-3b403eab7f4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_22-06-2022_48752.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad4ab61d-e62e-44a1-a48a-3b403eab7f4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/622ac319-3980-406f-8310-9ef10898dc93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "622ac319-3980-406f-8310-9ef10898dc93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_22-06-2022_48814.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/622ac319-3980-406f-8310-9ef10898dc93>.
+    
+<http://data.lblod.info/id/remote-data-objects/c767d36e-f9be-45e8-8e70-71c326196421> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c767d36e-f9be-45e8-8e70-71c326196421";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_22-06-2022_48883.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c767d36e-f9be-45e8-8e70-71c326196421>.
+    
+<http://data.lblod.info/id/remote-data-objects/90e352de-357a-4262-b3d3-85be69bb81cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90e352de-357a-4262-b3d3-85be69bb81cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/dda5158c5e789f673a7e691cb36f104fff856215aba2f2bdf621d81964bd2800/GetPublication?filename=Uittreksels_23-03-2022_48192.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90e352de-357a-4262-b3d3-85be69bb81cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac164e9a-61d8-48a7-91b9-ce8ef6dd7077> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac164e9a-61d8-48a7-91b9-ce8ef6dd7077";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac164e9a-61d8-48a7-91b9-ce8ef6dd7077>.
+    
+<http://data.lblod.info/id/remote-data-objects/a560406a-2bd8-4a7e-90e8-0238d8548e3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a560406a-2bd8-4a7e-90e8-0238d8548e3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a560406a-2bd8-4a7e-90e8-0238d8548e3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/385f0495-0f98-41d7-8d70-1615ac87a837> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "385f0495-0f98-41d7-8d70-1615ac87a837";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_01-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/385f0495-0f98-41d7-8d70-1615ac87a837>.
+    
+<http://data.lblod.info/id/remote-data-objects/675d7c18-1922-4689-b781-7e35ae69bf99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "675d7c18-1922-4689-b781-7e35ae69bf99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_02-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/675d7c18-1922-4689-b781-7e35ae69bf99>.
+    
+<http://data.lblod.info/id/remote-data-objects/8033df27-1484-4adf-b51f-dd787a2173cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8033df27-1484-4adf-b51f-dd787a2173cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_02-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8033df27-1484-4adf-b51f-dd787a2173cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/fde398e5-75d7-4840-86d2-acbedbcc56f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fde398e5-75d7-4840-86d2-acbedbcc56f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fde398e5-75d7-4840-86d2-acbedbcc56f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/0665456e-f31b-41ad-8ff9-92e5b2e17313> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0665456e-f31b-41ad-8ff9-92e5b2e17313";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0665456e-f31b-41ad-8ff9-92e5b2e17313>.
+    
+<http://data.lblod.info/id/remote-data-objects/58342b2b-105d-426c-b378-f28a02d7485c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58342b2b-105d-426c-b378-f28a02d7485c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58342b2b-105d-426c-b378-f28a02d7485c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7613b918-5285-454d-9a00-dd54023e65dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7613b918-5285-454d-9a00-dd54023e65dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7613b918-5285-454d-9a00-dd54023e65dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcb33bde-e4be-4f47-be92-4aaed3717ae0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcb33bde-e4be-4f47-be92-4aaed3717ae0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcb33bde-e4be-4f47-be92-4aaed3717ae0>.
+    
+<http://data.lblod.info/id/remote-data-objects/230a8504-e121-494e-bd7f-05795cbbeb77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "230a8504-e121-494e-bd7f-05795cbbeb77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/230a8504-e121-494e-bd7f-05795cbbeb77>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8c91498-a596-45ed-8d49-eec5562b8212> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8c91498-a596-45ed-8d49-eec5562b8212";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8c91498-a596-45ed-8d49-eec5562b8212>.
+    
+<http://data.lblod.info/id/remote-data-objects/e78d7ee8-c8ae-4e3f-8cbd-300ca7419bc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e78d7ee8-c8ae-4e3f-8cbd-300ca7419bc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_12-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e78d7ee8-c8ae-4e3f-8cbd-300ca7419bc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/24b8e6d1-5804-4894-99aa-0687ea0ad764> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24b8e6d1-5804-4894-99aa-0687ea0ad764";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24b8e6d1-5804-4894-99aa-0687ea0ad764>.
+    
+<http://data.lblod.info/id/remote-data-objects/e34d5a98-1f4a-4c0e-9f1f-c5a20ba09d87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e34d5a98-1f4a-4c0e-9f1f-c5a20ba09d87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e34d5a98-1f4a-4c0e-9f1f-c5a20ba09d87>.
+    
+<http://data.lblod.info/id/remote-data-objects/a773ae53-b7d5-455d-b062-b4f9948609c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a773ae53-b7d5-455d-b062-b4f9948609c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a773ae53-b7d5-455d-b062-b4f9948609c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3b7578a-12db-408d-8919-0c36ace9ff98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3b7578a-12db-408d-8919-0c36ace9ff98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3b7578a-12db-408d-8919-0c36ace9ff98>.
+    
+<http://data.lblod.info/id/remote-data-objects/53455cc1-ecb3-4541-a8e7-1a0a8a013ca0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53455cc1-ecb3-4541-a8e7-1a0a8a013ca0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53455cc1-ecb3-4541-a8e7-1a0a8a013ca0>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b98d0f7-07e3-492e-8c7c-a5de88428eb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b98d0f7-07e3-492e-8c7c-a5de88428eb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b98d0f7-07e3-492e-8c7c-a5de88428eb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f89f42a6-4044-4e3a-9c3b-462deedaa74d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f89f42a6-4044-4e3a-9c3b-462deedaa74d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_19-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f89f42a6-4044-4e3a-9c3b-462deedaa74d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e357391c-9a5d-4b12-8d2d-eb94124ddd2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e357391c-9a5d-4b12-8d2d-eb94124ddd2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e357391c-9a5d-4b12-8d2d-eb94124ddd2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d5ccb4d-2ae2-45e7-a40c-5af9148bb216> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d5ccb4d-2ae2-45e7-a40c-5af9148bb216";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d5ccb4d-2ae2-45e7-a40c-5af9148bb216>.
+    
+<http://data.lblod.info/id/remote-data-objects/e557ea1e-98e1-41e9-9401-1aea223db054> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e557ea1e-98e1-41e9-9401-1aea223db054";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e557ea1e-98e1-41e9-9401-1aea223db054>.
+    
+<http://data.lblod.info/id/remote-data-objects/85603d97-667c-4448-8458-8764d320ef80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85603d97-667c-4448-8458-8764d320ef80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/959a427c-c399-49b2-8973-4b80712ecde8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85603d97-667c-4448-8458-8764d320ef80>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201257-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201257-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201257-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201257-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/8f12a524-bb2a-4fe8-9476-e9049acdefcf> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8f12a524-bb2a-4fe8-9476-e9049acdefcf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "89ab10af-ace9-48aa-97b4-137955f3af64";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a122d4b2-3932-4472-bed3-5ee674ddd05a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a122d4b2-3932-4472-bed3-5ee674ddd05a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64>.
+
+  <http://redpencil.data.gift/id/task/eff1ff4c-fad5-4bec-ba47-f32a335db7a8> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "eff1ff4c-fad5-4bec-ba47-f32a335db7a8";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/8f12a524-bb2a-4fe8-9476-e9049acdefcf>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a122d4b2-3932-4472-bed3-5ee674ddd05a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/ab987db8-7e08-4e05-a397-2f5254bbd056> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab987db8-7e08-4e05-a397-2f5254bbd056";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab987db8-7e08-4e05-a397-2f5254bbd056>.
+    
+<http://data.lblod.info/id/remote-data-objects/3572c41c-bf34-4d42-ae1c-031a4a7eaf77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3572c41c-bf34-4d42-ae1c-031a4a7eaf77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3572c41c-bf34-4d42-ae1c-031a4a7eaf77>.
+    
+<http://data.lblod.info/id/remote-data-objects/81258c92-8736-4ae2-aa61-794c34b8b51e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81258c92-8736-4ae2-aa61-794c34b8b51e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81258c92-8736-4ae2-aa61-794c34b8b51e>.
+    
+<http://data.lblod.info/id/remote-data-objects/46222c56-dfc6-4841-a6b4-0c1bc45047a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46222c56-dfc6-4841-a6b4-0c1bc45047a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46222c56-dfc6-4841-a6b4-0c1bc45047a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/db91861b-ab82-4f81-affc-becad8721b4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db91861b-ab82-4f81-affc-becad8721b4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db91861b-ab82-4f81-affc-becad8721b4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/cde01a8e-4aaf-42e8-96ae-087fac598fc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cde01a8e-4aaf-42e8-96ae-087fac598fc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cde01a8e-4aaf-42e8-96ae-087fac598fc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2eea914-8cf2-47d7-935c-3af12fb0d04e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2eea914-8cf2-47d7-935c-3af12fb0d04e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2eea914-8cf2-47d7-935c-3af12fb0d04e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2388ba8-c11d-4ddd-bdf4-659d912670c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2388ba8-c11d-4ddd-bdf4-659d912670c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2388ba8-c11d-4ddd-bdf4-659d912670c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2eec4bd-326b-48be-ba70-7812e91c5f7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2eec4bd-326b-48be-ba70-7812e91c5f7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=BesluitenLijst_Vast%20Bureau_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2eec4bd-326b-48be-ba70-7812e91c5f7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5892d057-10fa-4985-b504-c6dccc81d582> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5892d057-10fa-4985-b504-c6dccc81d582";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=Uittreksels_10-11-2021_46873.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5892d057-10fa-4985-b504-c6dccc81d582>.
+    
+<http://data.lblod.info/id/remote-data-objects/0421aa5d-676e-46e2-a94f-a075edefb990> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0421aa5d-676e-46e2-a94f-a075edefb990";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=Uittreksels_10-11-2021_46874.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0421aa5d-676e-46e2-a94f-a075edefb990>.
+    
+<http://data.lblod.info/id/remote-data-objects/e718e51a-63d4-446a-8619-93b564090130> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e718e51a-63d4-446a-8619-93b564090130";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f09c00e84deceb820fdd123563dc718c655168a2aea3c02629812ca1b41a3aeb/GetPublication?filename=Uittreksels_23-03-2022_48194.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e718e51a-63d4-446a-8619-93b564090130>.
+    
+<http://data.lblod.info/id/remote-data-objects/b37348d3-9ffd-45f2-82fb-8b904dba1a09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b37348d3-9ffd-45f2-82fb-8b904dba1a09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Agenda_Gemeenteraad_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b37348d3-9ffd-45f2-82fb-8b904dba1a09>.
+    
+<http://data.lblod.info/id/remote-data-objects/93183149-fd9e-4855-a2b9-7e49b1647090> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93183149-fd9e-4855-a2b9-7e49b1647090";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Agenda_Gemeenteraad_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93183149-fd9e-4855-a2b9-7e49b1647090>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b64b7c1-1e11-4d5c-956b-5bba2f6468d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b64b7c1-1e11-4d5c-956b-5bba2f6468d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Agenda_Gemeenteraad_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b64b7c1-1e11-4d5c-956b-5bba2f6468d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb725447-a715-4486-ab72-e83d65baded5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb725447-a715-4486-ab72-e83d65baded5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Agenda_Gemeenteraad_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb725447-a715-4486-ab72-e83d65baded5>.
+    
+<http://data.lblod.info/id/remote-data-objects/300aa138-c5b9-4d19-aefc-1b6e974f609a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "300aa138-c5b9-4d19-aefc-1b6e974f609a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Agenda_Gemeenteraad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/300aa138-c5b9-4d19-aefc-1b6e974f609a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e65c85af-88ec-433a-89c6-0a464d5f115e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e65c85af-88ec-433a-89c6-0a464d5f115e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Agenda_Gemeenteraad_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e65c85af-88ec-433a-89c6-0a464d5f115e>.
+    
+<http://data.lblod.info/id/remote-data-objects/29ccafe5-5ab7-4f1c-b277-0d59e2cc4b54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29ccafe5-5ab7-4f1c-b277-0d59e2cc4b54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Agenda_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29ccafe5-5ab7-4f1c-b277-0d59e2cc4b54>.
+    
+<http://data.lblod.info/id/remote-data-objects/1399f51d-665d-4830-9e71-c7f0a69557fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1399f51d-665d-4830-9e71-c7f0a69557fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Agenda_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1399f51d-665d-4830-9e71-c7f0a69557fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/15f24d2c-818d-4092-bc20-8cca3b4923e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15f24d2c-818d-4092-bc20-8cca3b4923e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Agenda_Gemeenteraad_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15f24d2c-818d-4092-bc20-8cca3b4923e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7a92fed-dce3-4315-bb45-f850e4269228> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7a92fed-dce3-4315-bb45-f850e4269228";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Agenda_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7a92fed-dce3-4315-bb45-f850e4269228>.
+    
+<http://data.lblod.info/id/remote-data-objects/895091fd-9c89-4823-8872-0890210251ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "895091fd-9c89-4823-8872-0890210251ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=BesluitenLijst_Gemeenteraad_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/895091fd-9c89-4823-8872-0890210251ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/54355ffb-ade4-4a33-baa3-0db8d0475019> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54355ffb-ade4-4a33-baa3-0db8d0475019";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=BesluitenLijst_Gemeenteraad_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54355ffb-ade4-4a33-baa3-0db8d0475019>.
+    
+<http://data.lblod.info/id/remote-data-objects/32ff9d02-1416-49ac-bf21-2ff44309b3da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32ff9d02-1416-49ac-bf21-2ff44309b3da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=BesluitenLijst_Gemeenteraad_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32ff9d02-1416-49ac-bf21-2ff44309b3da>.
+    
+<http://data.lblod.info/id/remote-data-objects/7527da1b-b7ec-451b-a8fb-7e3d874c6e2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7527da1b-b7ec-451b-a8fb-7e3d874c6e2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=BesluitenLijst_Gemeenteraad_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7527da1b-b7ec-451b-a8fb-7e3d874c6e2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/efe294b7-96ab-43b2-8a58-2c5a5602fb82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efe294b7-96ab-43b2-8a58-2c5a5602fb82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=BesluitenLijst_Gemeenteraad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efe294b7-96ab-43b2-8a58-2c5a5602fb82>.
+    
+<http://data.lblod.info/id/remote-data-objects/be9fe39b-4df6-463a-aaa4-04d838391df9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be9fe39b-4df6-463a-aaa4-04d838391df9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=BesluitenLijst_Gemeenteraad_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be9fe39b-4df6-463a-aaa4-04d838391df9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0a50e95-c1c5-4546-a2f8-ad0ea4099131> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0a50e95-c1c5-4546-a2f8-ad0ea4099131";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0a50e95-c1c5-4546-a2f8-ad0ea4099131>.
+    
+<http://data.lblod.info/id/remote-data-objects/679ac3fe-2ee4-420d-a3d5-3e4c71d50ae8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "679ac3fe-2ee4-420d-a3d5-3e4c71d50ae8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/679ac3fe-2ee4-420d-a3d5-3e4c71d50ae8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1144a283-28f6-4255-93d1-e2f3b50a6d97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1144a283-28f6-4255-93d1-e2f3b50a6d97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=BesluitenLijst_Gemeenteraad_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1144a283-28f6-4255-93d1-e2f3b50a6d97>.
+    
+<http://data.lblod.info/id/remote-data-objects/740c760d-cb39-4346-9bb2-7d682ec9ba8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "740c760d-cb39-4346-9bb2-7d682ec9ba8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=BesluitenLijst_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/740c760d-cb39-4346-9bb2-7d682ec9ba8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/37179bd2-c088-40bc-b704-dda52bbd0160> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37179bd2-c088-40bc-b704-dda52bbd0160";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Notulen_Gemeenteraad_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37179bd2-c088-40bc-b704-dda52bbd0160>.
+    
+<http://data.lblod.info/id/remote-data-objects/e91b0164-1d4b-4011-bcff-5dcc33b6194d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e91b0164-1d4b-4011-bcff-5dcc33b6194d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Notulen_Gemeenteraad_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e91b0164-1d4b-4011-bcff-5dcc33b6194d>.
+    
+<http://data.lblod.info/id/remote-data-objects/30dcce0b-84f4-4767-b2fb-28ac10cadfe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30dcce0b-84f4-4767-b2fb-28ac10cadfe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Notulen_Gemeenteraad_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30dcce0b-84f4-4767-b2fb-28ac10cadfe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e804b1f-9148-4bf9-8e7d-322bf62147d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e804b1f-9148-4bf9-8e7d-322bf62147d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Notulen_Gemeenteraad_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e804b1f-9148-4bf9-8e7d-322bf62147d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/62342380-3555-41e5-a47b-bfb669990570> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62342380-3555-41e5-a47b-bfb669990570";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Notulen_Gemeenteraad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62342380-3555-41e5-a47b-bfb669990570>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac18e02b-a045-4669-974b-81623bbb6278> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac18e02b-a045-4669-974b-81623bbb6278";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Notulen_Gemeenteraad_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac18e02b-a045-4669-974b-81623bbb6278>.
+    
+<http://data.lblod.info/id/remote-data-objects/8108c309-a630-4bf4-a314-75de130fb7ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8108c309-a630-4bf4-a314-75de130fb7ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Notulen_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8108c309-a630-4bf4-a314-75de130fb7ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/97985257-e7c4-48ac-a0eb-453ff6535871> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97985257-e7c4-48ac-a0eb-453ff6535871";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Notulen_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97985257-e7c4-48ac-a0eb-453ff6535871>.
+    
+<http://data.lblod.info/id/remote-data-objects/92cea06f-d162-4d51-9fa9-de6a168209dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92cea06f-d162-4d51-9fa9-de6a168209dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Notulen_Gemeenteraad_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92cea06f-d162-4d51-9fa9-de6a168209dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ebc3ae0-cb1e-4b18-ae84-2c0fbaa4b10e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ebc3ae0-cb1e-4b18-ae84-2c0fbaa4b10e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Notulen_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ebc3ae0-cb1e-4b18-ae84-2c0fbaa4b10e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3f3e9f3-d6ed-4ea2-8079-8ba1ea1dff2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3f3e9f3-d6ed-4ea2-8079-8ba1ea1dff2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_04-07-2022_48914.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3f3e9f3-d6ed-4ea2-8079-8ba1ea1dff2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/de1724a1-4319-4dc6-b555-06c78ac5b6f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de1724a1-4319-4dc6-b555-06c78ac5b6f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_04-07-2022_48915.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de1724a1-4319-4dc6-b555-06c78ac5b6f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/7209a462-c868-45ef-b85a-954fa2200a33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7209a462-c868-45ef-b85a-954fa2200a33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_04-07-2022_48928.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7209a462-c868-45ef-b85a-954fa2200a33>.
+    
+<http://data.lblod.info/id/remote-data-objects/60179835-6d47-4dc3-9975-6dda1637d536> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60179835-6d47-4dc3-9975-6dda1637d536";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_04-07-2022_48970.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60179835-6d47-4dc3-9975-6dda1637d536>.
+    
+<http://data.lblod.info/id/remote-data-objects/4594a9c4-afaf-4314-989c-609bb50d42b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4594a9c4-afaf-4314-989c-609bb50d42b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_04-07-2022_48974.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4594a9c4-afaf-4314-989c-609bb50d42b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/565138e8-0a76-4ffa-a02e-6a41776b6203> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "565138e8-0a76-4ffa-a02e-6a41776b6203";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_04-07-2022_48975.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/565138e8-0a76-4ffa-a02e-6a41776b6203>.
+    
+<http://data.lblod.info/id/remote-data-objects/811562f4-7b9f-487d-9176-0c13a0180c23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "811562f4-7b9f-487d-9176-0c13a0180c23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_04-07-2022_49018.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/811562f4-7b9f-487d-9176-0c13a0180c23>.
+    
+<http://data.lblod.info/id/remote-data-objects/23cbcf8c-88b1-4ca6-beed-9251d2b418de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23cbcf8c-88b1-4ca6-beed-9251d2b418de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_09-05-2022_48285.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89ab10af-ace9-48aa-97b4-137955f3af64> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23cbcf8c-88b1-4ca6-beed-9251d2b418de>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201258-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201258-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201258-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201258-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/70d176dd-7063-4f66-a4fc-16cfdd63fbf1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "70d176dd-7063-4f66-a4fc-16cfdd63fbf1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b725b27b-f7e0-4848-8f7f-9c145f331a29";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/20657082-814c-4300-b68a-ef03a7ab047d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "20657082-814c-4300-b68a-ef03a7ab047d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29>.
+
+  <http://redpencil.data.gift/id/task/6a6957b3-aac5-45dc-9449-b95c70fb7b64> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6a6957b3-aac5-45dc-9449-b95c70fb7b64";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/70d176dd-7063-4f66-a4fc-16cfdd63fbf1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/20657082-814c-4300-b68a-ef03a7ab047d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5fc3ad48-2dca-4f9a-af25-e42ad5d667af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fc3ad48-2dca-4f9a-af25-e42ad5d667af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_09-05-2022_48338.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fc3ad48-2dca-4f9a-af25-e42ad5d667af>.
+    
+<http://data.lblod.info/id/remote-data-objects/6698dce9-2fed-49ca-a82f-534cfb672fd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6698dce9-2fed-49ca-a82f-534cfb672fd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_09-05-2022_48376.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6698dce9-2fed-49ca-a82f-534cfb672fd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ba41ece-83bc-4cab-89d9-b66dd944b266> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ba41ece-83bc-4cab-89d9-b66dd944b266";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_09-05-2022_48390.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ba41ece-83bc-4cab-89d9-b66dd944b266>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1487ec5-96ab-402f-9839-73548a7e54a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1487ec5-96ab-402f-9839-73548a7e54a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_11-10-2021_41660.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1487ec5-96ab-402f-9839-73548a7e54a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5fd03e7-65f1-4438-837f-d29d1ee94b16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5fd03e7-65f1-4438-837f-d29d1ee94b16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_11-10-2021_41661.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5fd03e7-65f1-4438-837f-d29d1ee94b16>.
+    
+<http://data.lblod.info/id/remote-data-objects/597503c7-3c3b-49b1-9b0c-57899ced8560> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "597503c7-3c3b-49b1-9b0c-57899ced8560";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_11-10-2021_41665.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/597503c7-3c3b-49b1-9b0c-57899ced8560>.
+    
+<http://data.lblod.info/id/remote-data-objects/91ac9766-b950-4c4e-a356-cc2a2a185c4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91ac9766-b950-4c4e-a356-cc2a2a185c4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-06-2022_48557.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91ac9766-b950-4c4e-a356-cc2a2a185c4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/097a8db9-041f-4d39-b04d-50b1416cc06f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "097a8db9-041f-4d39-b04d-50b1416cc06f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-06-2022_48591.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/097a8db9-041f-4d39-b04d-50b1416cc06f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a567c45-4c3b-4278-8acd-a928f5e38190> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a567c45-4c3b-4278-8acd-a928f5e38190";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-06-2022_48710.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a567c45-4c3b-4278-8acd-a928f5e38190>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3d5f4d2-6778-46c1-834b-e7016493f6e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3d5f4d2-6778-46c1-834b-e7016493f6e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-06-2022_48746.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3d5f4d2-6778-46c1-834b-e7016493f6e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1bef9ec-c0ad-4616-8900-a91c0ef7efe1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1bef9ec-c0ad-4616-8900-a91c0ef7efe1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-06-2022_48790.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1bef9ec-c0ad-4616-8900-a91c0ef7efe1>.
+    
+<http://data.lblod.info/id/remote-data-objects/cae12292-28b6-4b67-b755-6c36284b4b53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cae12292-28b6-4b67-b755-6c36284b4b53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-06-2022_48791.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cae12292-28b6-4b67-b755-6c36284b4b53>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfae7ffe-529d-4ca7-b5b9-6014b0adc8b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfae7ffe-529d-4ca7-b5b9-6014b0adc8b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-06-2022_48792.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfae7ffe-529d-4ca7-b5b9-6014b0adc8b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/81b9422d-d363-49d2-81dc-b96292e0d93a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81b9422d-d363-49d2-81dc-b96292e0d93a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-06-2022_48827.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81b9422d-d363-49d2-81dc-b96292e0d93a>.
+    
+<http://data.lblod.info/id/remote-data-objects/032af761-6bf9-49c6-a78b-5883e15cc0ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "032af761-6bf9-49c6-a78b-5883e15cc0ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-12-2021_46632.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/032af761-6bf9-49c6-a78b-5883e15cc0ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/3044d3c6-c99a-4869-96a2-a90918fcc582> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3044d3c6-c99a-4869-96a2-a90918fcc582";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-12-2021_46701.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3044d3c6-c99a-4869-96a2-a90918fcc582>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1b8dc4d-6e2a-4f42-9cb5-0f332b7f4c5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1b8dc4d-6e2a-4f42-9cb5-0f332b7f4c5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-12-2021_46704.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1b8dc4d-6e2a-4f42-9cb5-0f332b7f4c5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c3e921f-b221-475f-80d3-d5323ded874b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c3e921f-b221-475f-80d3-d5323ded874b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-12-2021_46706.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c3e921f-b221-475f-80d3-d5323ded874b>.
+    
+<http://data.lblod.info/id/remote-data-objects/850d84c7-2f01-4655-9d4f-88d4e840b237> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "850d84c7-2f01-4655-9d4f-88d4e840b237";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-12-2021_47009.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/850d84c7-2f01-4655-9d4f-88d4e840b237>.
+    
+<http://data.lblod.info/id/remote-data-objects/64ae201e-440f-493a-b2ea-023730631a7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64ae201e-440f-493a-b2ea-023730631a7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-12-2021_47010.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64ae201e-440f-493a-b2ea-023730631a7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/70d3fc56-509d-4119-97e6-c57bb5ae42b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70d3fc56-509d-4119-97e6-c57bb5ae42b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-12-2021_47015.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70d3fc56-509d-4119-97e6-c57bb5ae42b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a11bd2c-500b-4918-874b-c5cf44510f19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a11bd2c-500b-4918-874b-c5cf44510f19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-12-2021_47016.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a11bd2c-500b-4918-874b-c5cf44510f19>.
+    
+<http://data.lblod.info/id/remote-data-objects/69ad394c-1db0-4ca8-8cfd-7139ecd65ee1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69ad394c-1db0-4ca8-8cfd-7139ecd65ee1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-12-2021_47021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69ad394c-1db0-4ca8-8cfd-7139ecd65ee1>.
+    
+<http://data.lblod.info/id/remote-data-objects/80111167-7a59-4514-9d1c-288cafdd5aa9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80111167-7a59-4514-9d1c-288cafdd5aa9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_13-12-2021_47022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80111167-7a59-4514-9d1c-288cafdd5aa9>.
+    
+<http://data.lblod.info/id/remote-data-objects/02e4e3d5-9d17-4234-b0a6-409d9e94009b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02e4e3d5-9d17-4234-b0a6-409d9e94009b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_15-11-2021_38209.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02e4e3d5-9d17-4234-b0a6-409d9e94009b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3de13ada-db89-4187-9274-f83e4188da5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3de13ada-db89-4187-9274-f83e4188da5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_15-11-2021_41700.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3de13ada-db89-4187-9274-f83e4188da5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a335f25a-a526-4f5d-9f5c-31529cc23e88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a335f25a-a526-4f5d-9f5c-31529cc23e88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_15-11-2021_41705.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a335f25a-a526-4f5d-9f5c-31529cc23e88>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecef27ed-c6ff-4d3e-946d-a709fb296ec5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecef27ed-c6ff-4d3e-946d-a709fb296ec5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_15-11-2021_46615.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecef27ed-c6ff-4d3e-946d-a709fb296ec5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cd226b6-42a3-486f-b191-d6c8f8a8633a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cd226b6-42a3-486f-b191-d6c8f8a8633a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_15-11-2021_46827.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cd226b6-42a3-486f-b191-d6c8f8a8633a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2219ec2-e3ed-482c-828b-3ea903d97a94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2219ec2-e3ed-482c-828b-3ea903d97a94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_15-11-2021_46896.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2219ec2-e3ed-482c-828b-3ea903d97a94>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef770d59-2dfa-43ee-bb1c-03075cf22e00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef770d59-2dfa-43ee-bb1c-03075cf22e00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_21-02-2022_47667.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef770d59-2dfa-43ee-bb1c-03075cf22e00>.
+    
+<http://data.lblod.info/id/remote-data-objects/17f079f8-baa4-4074-a22b-b2bea86b8356> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17f079f8-baa4-4074-a22b-b2bea86b8356";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_21-02-2022_47748.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17f079f8-baa4-4074-a22b-b2bea86b8356>.
+    
+<http://data.lblod.info/id/remote-data-objects/321da440-8f87-4bc5-a724-c9cd744783e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "321da440-8f87-4bc5-a724-c9cd744783e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_28-03-2022_47782.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/321da440-8f87-4bc5-a724-c9cd744783e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd994f8a-8070-40c7-a71d-6f406114fa23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd994f8a-8070-40c7-a71d-6f406114fa23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_31-01-2022_40601.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd994f8a-8070-40c7-a71d-6f406114fa23>.
+    
+<http://data.lblod.info/id/remote-data-objects/96ae36fb-6923-4a8e-a2c8-daa571a139d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96ae36fb-6923-4a8e-a2c8-daa571a139d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_31-01-2022_47489.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96ae36fb-6923-4a8e-a2c8-daa571a139d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/eef537e9-6564-435f-8288-41ddf72b1fb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eef537e9-6564-435f-8288-41ddf72b1fb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_31-01-2022_47540.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eef537e9-6564-435f-8288-41ddf72b1fb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/faf2fefe-d770-4617-a202-87e74215c424> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "faf2fefe-d770-4617-a202-87e74215c424";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.berlare.be/LBLODWeb/Home/Overzicht/f93148504465f5aa906c7bec4fbb426facbd50eb6c0ecc386d946eed8337a63f/GetPublication?filename=Uittreksels_31-01-2022_47650.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/faf2fefe-d770-4617-a202-87e74215c424>.
+    
+<http://data.lblod.info/id/remote-data-objects/27596f3c-9f01-46da-94d0-0565a3209c4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27596f3c-9f01-46da-94d0-0565a3209c4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27596f3c-9f01-46da-94d0-0565a3209c4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8cd5cba-6e54-4039-b731-09b11cba2ddf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8cd5cba-6e54-4039-b731-09b11cba2ddf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8cd5cba-6e54-4039-b731-09b11cba2ddf>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3362f45-00ef-4a62-a198-8dd04557dc73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3362f45-00ef-4a62-a198-8dd04557dc73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3362f45-00ef-4a62-a198-8dd04557dc73>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec611101-0676-422b-8774-52bff3e91862> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec611101-0676-422b-8774-52bff3e91862";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_03-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec611101-0676-422b-8774-52bff3e91862>.
+    
+<http://data.lblod.info/id/remote-data-objects/1543f5a5-4b54-4261-a895-cbb2d4b43a80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1543f5a5-4b54-4261-a895-cbb2d4b43a80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1543f5a5-4b54-4261-a895-cbb2d4b43a80>.
+    
+<http://data.lblod.info/id/remote-data-objects/6814d3b2-c22a-4627-ae37-afb6a6f4535d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6814d3b2-c22a-4627-ae37-afb6a6f4535d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6814d3b2-c22a-4627-ae37-afb6a6f4535d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0fc92a7-674c-443a-89f2-5a7226610b44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0fc92a7-674c-443a-89f2-5a7226610b44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0fc92a7-674c-443a-89f2-5a7226610b44>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0f1fbc8-239e-4190-a683-4d5d2127166a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0f1fbc8-239e-4190-a683-4d5d2127166a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0f1fbc8-239e-4190-a683-4d5d2127166a>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa156e4e-25b4-4140-aaf7-2b7f464a9590> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa156e4e-25b4-4140-aaf7-2b7f464a9590";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_10-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa156e4e-25b4-4140-aaf7-2b7f464a9590>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3759509-d257-4b81-a6a1-a0a53b074da2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3759509-d257-4b81-a6a1-a0a53b074da2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_10-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3759509-d257-4b81-a6a1-a0a53b074da2>.
+    
+<http://data.lblod.info/id/remote-data-objects/884a1f39-1690-4b92-9b33-9eac88233d45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "884a1f39-1690-4b92-9b33-9eac88233d45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/884a1f39-1690-4b92-9b33-9eac88233d45>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8a25b86-eacd-4ad3-b52a-1ca208b57dde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8a25b86-eacd-4ad3-b52a-1ca208b57dde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8a25b86-eacd-4ad3-b52a-1ca208b57dde>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff57c4ed-2c49-474b-a853-e789e42b1fbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff57c4ed-2c49-474b-a853-e789e42b1fbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:12:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b725b27b-f7e0-4848-8f7f-9c145f331a29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff57c4ed-2c49-474b-a853-e789e42b1fbb>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201300-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201300-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201300-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201300-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/aaadcfd7-c8d0-4df1-9168-4c419d26f562> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "aaadcfd7-c8d0-4df1-9168-4c419d26f562";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3868aa10-1a13-4781-9f11-e0c57cc723d1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/efd2d8de-6eb2-4b90-8193-0b1ab2047365> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "efd2d8de-6eb2-4b90-8193-0b1ab2047365";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1>.
+
+  <http://redpencil.data.gift/id/task/f1f13c51-199d-4e39-be34-4a66e7ee03d2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f1f13c51-199d-4e39-be34-4a66e7ee03d2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/aaadcfd7-c8d0-4df1-9168-4c419d26f562>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/efd2d8de-6eb2-4b90-8193-0b1ab2047365>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/bdc999c9-e3ca-43b8-81cb-5c03cbb0ab90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdc999c9-e3ca-43b8-81cb-5c03cbb0ab90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdc999c9-e3ca-43b8-81cb-5c03cbb0ab90>.
+    
+<http://data.lblod.info/id/remote-data-objects/f44f9af9-a81a-4d58-aa9b-06d34c405583> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f44f9af9-a81a-4d58-aa9b-06d34c405583";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f44f9af9-a81a-4d58-aa9b-06d34c405583>.
+    
+<http://data.lblod.info/id/remote-data-objects/25d657d2-b448-4470-a34a-d31d89e69bbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25d657d2-b448-4470-a34a-d31d89e69bbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25d657d2-b448-4470-a34a-d31d89e69bbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d7714ca-6748-4f5c-a1df-e6dfaa37bdcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d7714ca-6748-4f5c-a1df-e6dfaa37bdcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d7714ca-6748-4f5c-a1df-e6dfaa37bdcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddb83532-5046-40aa-bf27-5534617f171f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddb83532-5046-40aa-bf27-5534617f171f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddb83532-5046-40aa-bf27-5534617f171f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9b6e9ed-8c52-486a-a26e-cd3ede9f86d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9b6e9ed-8c52-486a-a26e-cd3ede9f86d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9b6e9ed-8c52-486a-a26e-cd3ede9f86d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5bb720a-77e1-4b68-ad68-84d9a5b9e6f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5bb720a-77e1-4b68-ad68-84d9a5b9e6f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5bb720a-77e1-4b68-ad68-84d9a5b9e6f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a02bd8f-471e-41b9-b65f-2aee92b73aa0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a02bd8f-471e-41b9-b65f-2aee92b73aa0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a02bd8f-471e-41b9-b65f-2aee92b73aa0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a73cfbaa-cf21-47d0-8478-ac4ab83acaba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a73cfbaa-cf21-47d0-8478-ac4ab83acaba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a73cfbaa-cf21-47d0-8478-ac4ab83acaba>.
+    
+<http://data.lblod.info/id/remote-data-objects/17d2e48d-9759-468c-af1b-df473c3eb7a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17d2e48d-9759-468c-af1b-df473c3eb7a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17d2e48d-9759-468c-af1b-df473c3eb7a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a39c8fc7-9d27-4f1e-ba61-bdf8dff09d52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a39c8fc7-9d27-4f1e-ba61-bdf8dff09d52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a39c8fc7-9d27-4f1e-ba61-bdf8dff09d52>.
+    
+<http://data.lblod.info/id/remote-data-objects/fed71d3b-8575-4c98-90a0-4e6a755d3ddb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fed71d3b-8575-4c98-90a0-4e6a755d3ddb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fed71d3b-8575-4c98-90a0-4e6a755d3ddb>.
+    
+<http://data.lblod.info/id/remote-data-objects/84aefbb8-3291-4f6b-b757-8bdb990d036a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84aefbb8-3291-4f6b-b757-8bdb990d036a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84aefbb8-3291-4f6b-b757-8bdb990d036a>.
+    
+<http://data.lblod.info/id/remote-data-objects/84ab19cd-4333-4813-82f6-afdf91172603> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84ab19cd-4333-4813-82f6-afdf91172603";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84ab19cd-4333-4813-82f6-afdf91172603>.
+    
+<http://data.lblod.info/id/remote-data-objects/13fd2fb5-152b-455c-b816-fdda06bed7f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13fd2fb5-152b-455c-b816-fdda06bed7f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_24-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13fd2fb5-152b-455c-b816-fdda06bed7f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ac4acbb-7e8a-4926-b4b8-865d2c08c877> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ac4acbb-7e8a-4926-b4b8-865d2c08c877";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ac4acbb-7e8a-4926-b4b8-865d2c08c877>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdf5710b-a706-472c-8ad8-f6fb4fd22c41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdf5710b-a706-472c-8ad8-f6fb4fd22c41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdf5710b-a706-472c-8ad8-f6fb4fd22c41>.
+    
+<http://data.lblod.info/id/remote-data-objects/52475294-aa4f-40f8-b7de-24e9208999e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52475294-aa4f-40f8-b7de-24e9208999e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_26-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52475294-aa4f-40f8-b7de-24e9208999e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/12406bd3-30e4-489d-b288-d1b5187bcde3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12406bd3-30e4-489d-b288-d1b5187bcde3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12406bd3-30e4-489d-b288-d1b5187bcde3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e5bdf25-97a8-4765-99c5-fc05c6d56f26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e5bdf25-97a8-4765-99c5-fc05c6d56f26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e5bdf25-97a8-4765-99c5-fc05c6d56f26>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4dc6614-40bb-4fda-9a7a-ded10d82762f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4dc6614-40bb-4fda-9a7a-ded10d82762f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/02237bbd-7ab4-4e16-90b2-b39cc79fa0f5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4dc6614-40bb-4fda-9a7a-ded10d82762f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1bc4d1a-4d55-4c87-b48a-3cf75c6b6b0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1bc4d1a-4d55-4c87-b48a-3cf75c6b6b0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1bc4d1a-4d55-4c87-b48a-3cf75c6b6b0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0803d99-522e-43fd-a97f-f5f2eb32e574> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0803d99-522e-43fd-a97f-f5f2eb32e574";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0803d99-522e-43fd-a97f-f5f2eb32e574>.
+    
+<http://data.lblod.info/id/remote-data-objects/08032c20-a40c-4df5-8ab9-bc330ed8ab77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08032c20-a40c-4df5-8ab9-bc330ed8ab77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08032c20-a40c-4df5-8ab9-bc330ed8ab77>.
+    
+<http://data.lblod.info/id/remote-data-objects/81cf2b8e-9acc-4306-b4af-8f20df46d155> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81cf2b8e-9acc-4306-b4af-8f20df46d155";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81cf2b8e-9acc-4306-b4af-8f20df46d155>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e948f36-9f3d-4a0e-8ff6-dffae834890f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e948f36-9f3d-4a0e-8ff6-dffae834890f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e948f36-9f3d-4a0e-8ff6-dffae834890f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e52cb52b-4d86-4f6c-a3a7-5183ad342ad7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e52cb52b-4d86-4f6c-a3a7-5183ad342ad7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e52cb52b-4d86-4f6c-a3a7-5183ad342ad7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e2493a1-603f-42e7-958d-6bb81b78bcc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e2493a1-603f-42e7-958d-6bb81b78bcc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e2493a1-603f-42e7-958d-6bb81b78bcc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4e8ffe1-410a-462e-83e1-aca9e5dd73ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4e8ffe1-410a-462e-83e1-aca9e5dd73ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4e8ffe1-410a-462e-83e1-aca9e5dd73ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/67f8a313-e61c-4370-a811-422d0eb85bdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67f8a313-e61c-4370-a811-422d0eb85bdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67f8a313-e61c-4370-a811-422d0eb85bdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/63064e78-b032-400e-8f31-04ca89e98701> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63064e78-b032-400e-8f31-04ca89e98701";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63064e78-b032-400e-8f31-04ca89e98701>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce304d25-957a-45ed-84e2-035cbe6b70aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce304d25-957a-45ed-84e2-035cbe6b70aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce304d25-957a-45ed-84e2-035cbe6b70aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e0de8fb-0651-4c26-8b43-2441431dcfb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e0de8fb-0651-4c26-8b43-2441431dcfb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e0de8fb-0651-4c26-8b43-2441431dcfb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/976eea94-b4ff-4d7e-9cc4-256a5cc3c6aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "976eea94-b4ff-4d7e-9cc4-256a5cc3c6aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/976eea94-b4ff-4d7e-9cc4-256a5cc3c6aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8dc7adf-a6aa-4ca1-94ba-dcaa96b2ac25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8dc7adf-a6aa-4ca1-94ba-dcaa96b2ac25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8dc7adf-a6aa-4ca1-94ba-dcaa96b2ac25>.
+    
+<http://data.lblod.info/id/remote-data-objects/e95bfe9a-bc3c-4d45-9dfd-1f88747046a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e95bfe9a-bc3c-4d45-9dfd-1f88747046a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e95bfe9a-bc3c-4d45-9dfd-1f88747046a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c94ea28-44d1-431c-857b-239a4a8a86a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c94ea28-44d1-431c-857b-239a4a8a86a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c94ea28-44d1-431c-857b-239a4a8a86a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e16060ae-401d-47db-90eb-82b53d81320c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e16060ae-401d-47db-90eb-82b53d81320c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e16060ae-401d-47db-90eb-82b53d81320c>.
+    
+<http://data.lblod.info/id/remote-data-objects/42d437e7-5663-4612-abfd-5524953ca377> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42d437e7-5663-4612-abfd-5524953ca377";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42d437e7-5663-4612-abfd-5524953ca377>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e89be2e-49a9-4ba2-afdb-be106f3c2119> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e89be2e-49a9-4ba2-afdb-be106f3c2119";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e89be2e-49a9-4ba2-afdb-be106f3c2119>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe412d3b-f888-4d26-b759-68a816b11ed9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe412d3b-f888-4d26-b759-68a816b11ed9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe412d3b-f888-4d26-b759-68a816b11ed9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1670b080-f32e-4c85-92c1-4338ae849364> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1670b080-f32e-4c85-92c1-4338ae849364";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1670b080-f32e-4c85-92c1-4338ae849364>.
+    
+<http://data.lblod.info/id/remote-data-objects/83ca622b-bdfc-4c7a-a04a-058508b3ecba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83ca622b-bdfc-4c7a-a04a-058508b3ecba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83ca622b-bdfc-4c7a-a04a-058508b3ecba>.
+    
+<http://data.lblod.info/id/remote-data-objects/b822f32c-ccd7-4b31-ac6c-389921290feb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b822f32c-ccd7-4b31-ac6c-389921290feb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b822f32c-ccd7-4b31-ac6c-389921290feb>.
+    
+<http://data.lblod.info/id/remote-data-objects/f132fca7-77aa-472a-87f5-923adbbf47fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f132fca7-77aa-472a-87f5-923adbbf47fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f132fca7-77aa-472a-87f5-923adbbf47fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/d90f460b-a154-453d-b2bd-e271af5a4f43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d90f460b-a154-453d-b2bd-e271af5a4f43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d90f460b-a154-453d-b2bd-e271af5a4f43>.
+    
+<http://data.lblod.info/id/remote-data-objects/0753be43-8dd0-4c86-acf8-3029e3296696> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0753be43-8dd0-4c86-acf8-3029e3296696";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0753be43-8dd0-4c86-acf8-3029e3296696>.
+    
+<http://data.lblod.info/id/remote-data-objects/37469802-9386-439c-a9a9-3a428a39fd47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37469802-9386-439c-a9a9-3a428a39fd47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=ToegevoegdeAgenda_Raad%20voor%20Maatschappelijk%20Welzijn_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37469802-9386-439c-a9a9-3a428a39fd47>.
+    
+<http://data.lblod.info/id/remote-data-objects/d63c3e6d-ba7a-40ce-838a-e94e24f234fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d63c3e6d-ba7a-40ce-838a-e94e24f234fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=ToegevoegdeAgenda_Raad%20voor%20Maatschappelijk%20Welzijn_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d63c3e6d-ba7a-40ce-838a-e94e24f234fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/24091888-24db-4df5-8e6b-a8214750d306> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24091888-24db-4df5-8e6b-a8214750d306";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=ToegevoegdeAgenda_Raad%20voor%20Maatschappelijk%20Welzijn_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3868aa10-1a13-4781-9f11-e0c57cc723d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24091888-24db-4df5-8e6b-a8214750d306>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201301-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201301-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201301-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201301-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/19b1d3d3-47f6-47ba-9198-fa23e43fa6a5> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "19b1d3d3-47f6-47ba-9198-fa23e43fa6a5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5331d8a9-af2d-4a5e-8414-fab12a5a2bd5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6250660a-16a6-4773-b2e3-eb70095d1e00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6250660a-16a6-4773-b2e3-eb70095d1e00";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5>.
+
+  <http://redpencil.data.gift/id/task/263730e4-2095-4cb7-bf9d-a78a16f29fb1> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "263730e4-2095-4cb7-bf9d-a78a16f29fb1";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/19b1d3d3-47f6-47ba-9198-fa23e43fa6a5>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6250660a-16a6-4773-b2e3-eb70095d1e00>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a0a0a87f-853f-4ed6-8832-675d82522c91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0a0a87f-853f-4ed6-8832-675d82522c91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=ToegevoegdeAgenda_Raad%20voor%20Maatschappelijk%20Welzijn_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0a0a87f-853f-4ed6-8832-675d82522c91>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d039a40-ee6b-436a-b3a8-14ebec057afc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d039a40-ee6b-436a-b3a8-14ebec057afc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=ToegevoegdeAgenda_Raad%20voor%20Maatschappelijk%20Welzijn_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d039a40-ee6b-436a-b3a8-14ebec057afc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9c0bd25-57d1-40fb-b42c-a61d5ba85f82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9c0bd25-57d1-40fb-b42c-a61d5ba85f82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Uittreksels_14-12-2021_51844.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9c0bd25-57d1-40fb-b42c-a61d5ba85f82>.
+    
+<http://data.lblod.info/id/remote-data-objects/85a623b8-2709-4997-90df-6147108ae011> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85a623b8-2709-4997-90df-6147108ae011";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Uittreksels_14-12-2021_52043.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85a623b8-2709-4997-90df-6147108ae011>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a1259aa-5302-4883-b2b4-3a6ebf754d1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a1259aa-5302-4883-b2b4-3a6ebf754d1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/2171fbdffa3379c1e61702a4c3fa00a62824f13bb2709f5649230977d08462b2/GetPublication?filename=Uittreksels_21-06-2022_62118.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a1259aa-5302-4883-b2b4-3a6ebf754d1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dc33cf1-715d-4788-bedd-5adeb587302e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dc33cf1-715d-4788-bedd-5adeb587302e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Agenda_Gemeenteraad_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dc33cf1-715d-4788-bedd-5adeb587302e>.
+    
+<http://data.lblod.info/id/remote-data-objects/67830b0b-15d2-4064-a5ae-5310275525ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67830b0b-15d2-4064-a5ae-5310275525ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Agenda_Gemeenteraad_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67830b0b-15d2-4064-a5ae-5310275525ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbda0823-5c84-4494-a083-fac8a17daa7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbda0823-5c84-4494-a083-fac8a17daa7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Agenda_Gemeenteraad_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbda0823-5c84-4494-a083-fac8a17daa7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8e8a0d2-78bb-47c5-b9dd-5a4a59e5d428> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8e8a0d2-78bb-47c5-b9dd-5a4a59e5d428";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Agenda_Gemeenteraad_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8e8a0d2-78bb-47c5-b9dd-5a4a59e5d428>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7bf118f-159d-48e7-a490-ddbf8dafee09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7bf118f-159d-48e7-a490-ddbf8dafee09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Agenda_Gemeenteraad_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7bf118f-159d-48e7-a490-ddbf8dafee09>.
+    
+<http://data.lblod.info/id/remote-data-objects/45886053-36c3-4067-8086-7ae58b54c81b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45886053-36c3-4067-8086-7ae58b54c81b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Agenda_Gemeenteraad_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45886053-36c3-4067-8086-7ae58b54c81b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5329a0f2-ee76-4090-80d5-c03914eac4f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5329a0f2-ee76-4090-80d5-c03914eac4f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Agenda_Gemeenteraad_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5329a0f2-ee76-4090-80d5-c03914eac4f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/27d11d03-4a88-46ce-b877-cb47e598196d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27d11d03-4a88-46ce-b877-cb47e598196d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Agenda_Gemeenteraad_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27d11d03-4a88-46ce-b877-cb47e598196d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5526fe07-355f-466b-9786-378d18b19987> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5526fe07-355f-466b-9786-378d18b19987";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Agenda_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5526fe07-355f-466b-9786-378d18b19987>.
+    
+<http://data.lblod.info/id/remote-data-objects/df091891-3617-489c-97e2-c322840d36c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df091891-3617-489c-97e2-c322840d36c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df091891-3617-489c-97e2-c322840d36c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4f013dd-75aa-481f-b2c8-b4389f18ce82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4f013dd-75aa-481f-b2c8-b4389f18ce82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4f013dd-75aa-481f-b2c8-b4389f18ce82>.
+    
+<http://data.lblod.info/id/remote-data-objects/c48d12ec-9de2-4167-8dae-96d31743e1b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c48d12ec-9de2-4167-8dae-96d31743e1b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c48d12ec-9de2-4167-8dae-96d31743e1b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/bef746ac-b26e-45bf-ac22-67c998197811> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bef746ac-b26e-45bf-ac22-67c998197811";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bef746ac-b26e-45bf-ac22-67c998197811>.
+    
+<http://data.lblod.info/id/remote-data-objects/475e7da6-b5b3-4488-9aab-38e97401ecf4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "475e7da6-b5b3-4488-9aab-38e97401ecf4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/475e7da6-b5b3-4488-9aab-38e97401ecf4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8743442-b235-4be4-a9ae-090dd5f08181> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8743442-b235-4be4-a9ae-090dd5f08181";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8743442-b235-4be4-a9ae-090dd5f08181>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2a8a658-faa3-4103-bf09-b38e3c387ff8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2a8a658-faa3-4103-bf09-b38e3c387ff8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2a8a658-faa3-4103-bf09-b38e3c387ff8>.
+    
+<http://data.lblod.info/id/remote-data-objects/11dbe2cc-c696-42a8-9974-ed4a7bd11d52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11dbe2cc-c696-42a8-9974-ed4a7bd11d52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11dbe2cc-c696-42a8-9974-ed4a7bd11d52>.
+    
+<http://data.lblod.info/id/remote-data-objects/2951df5b-4f73-4bea-88f4-8660076c2071> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2951df5b-4f73-4bea-88f4-8660076c2071";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2951df5b-4f73-4bea-88f4-8660076c2071>.
+    
+<http://data.lblod.info/id/remote-data-objects/113dd4df-a71b-4af3-86ff-fa2afb09d823> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "113dd4df-a71b-4af3-86ff-fa2afb09d823";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Notulen_Gemeenteraad_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/113dd4df-a71b-4af3-86ff-fa2afb09d823>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecf1a0f6-fad2-4f17-9a3d-6b0c141cabcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecf1a0f6-fad2-4f17-9a3d-6b0c141cabcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Notulen_Gemeenteraad_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecf1a0f6-fad2-4f17-9a3d-6b0c141cabcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/54c29e1b-6a26-42d2-b1ba-4915808ece0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54c29e1b-6a26-42d2-b1ba-4915808ece0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Notulen_Gemeenteraad_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54c29e1b-6a26-42d2-b1ba-4915808ece0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/458f076d-555d-4b2b-8b53-2046f561d824> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "458f076d-555d-4b2b-8b53-2046f561d824";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Notulen_Gemeenteraad_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/458f076d-555d-4b2b-8b53-2046f561d824>.
+    
+<http://data.lblod.info/id/remote-data-objects/14c244fa-0ea6-405b-9d82-9316247bd2ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14c244fa-0ea6-405b-9d82-9316247bd2ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Notulen_Gemeenteraad_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14c244fa-0ea6-405b-9d82-9316247bd2ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a91679a-3d40-4cff-bcd0-f53a3620f759> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a91679a-3d40-4cff-bcd0-f53a3620f759";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Notulen_Gemeenteraad_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a91679a-3d40-4cff-bcd0-f53a3620f759>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ea64e66-5791-443a-be2c-3ede8b39917f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ea64e66-5791-443a-be2c-3ede8b39917f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Notulen_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ea64e66-5791-443a-be2c-3ede8b39917f>.
+    
+<http://data.lblod.info/id/remote-data-objects/132df896-b11f-4d60-80d2-1927b9696b32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "132df896-b11f-4d60-80d2-1927b9696b32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/132df896-b11f-4d60-80d2-1927b9696b32>.
+    
+<http://data.lblod.info/id/remote-data-objects/809da580-1aa8-465c-bae7-a66134b9fb57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "809da580-1aa8-465c-bae7-a66134b9fb57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/809da580-1aa8-465c-bae7-a66134b9fb57>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c596024-6d88-4436-b5c0-a8bf8574b3eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c596024-6d88-4436-b5c0-a8bf8574b3eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c596024-6d88-4436-b5c0-a8bf8574b3eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/436e78db-d690-4c76-aad6-06558141665c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "436e78db-d690-4c76-aad6-06558141665c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/436e78db-d690-4c76-aad6-06558141665c>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcb0a12b-cc06-4925-90c2-b78a635b9be6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcb0a12b-cc06-4925-90c2-b78a635b9be6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcb0a12b-cc06-4925-90c2-b78a635b9be6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8cf2309-38a6-4f66-9a16-0ec84022f76e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8cf2309-38a6-4f66-9a16-0ec84022f76e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_09-11-2021_49395.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8cf2309-38a6-4f66-9a16-0ec84022f76e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d12bc09-45d2-4cc8-9098-a320e9ba4cb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d12bc09-45d2-4cc8-9098-a320e9ba4cb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_09-11-2021_49396.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d12bc09-45d2-4cc8-9098-a320e9ba4cb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/56ce38d7-f410-40b0-b7a4-85a01244df02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56ce38d7-f410-40b0-b7a4-85a01244df02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_11-01-2022_52212.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56ce38d7-f410-40b0-b7a4-85a01244df02>.
+    
+<http://data.lblod.info/id/remote-data-objects/887a93eb-cb7c-457a-a906-d415ecaddffd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "887a93eb-cb7c-457a-a906-d415ecaddffd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_11-01-2022_53463.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/887a93eb-cb7c-457a-a906-d415ecaddffd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d92c710f-3fa1-4f83-92f8-518b38a444d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d92c710f-3fa1-4f83-92f8-518b38a444d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_11-01-2022_53639.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d92c710f-3fa1-4f83-92f8-518b38a444d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/4256eae3-5197-4dac-9dc5-5b77614a3a5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4256eae3-5197-4dac-9dc5-5b77614a3a5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_14-12-2021_51945.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4256eae3-5197-4dac-9dc5-5b77614a3a5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/87375def-8cc1-498e-bb58-510d747cfbce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87375def-8cc1-498e-bb58-510d747cfbce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_14-12-2021_52039.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87375def-8cc1-498e-bb58-510d747cfbce>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a98cb6c-62a1-4c02-a57e-f4522f8cae43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a98cb6c-62a1-4c02-a57e-f4522f8cae43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_15-03-2022_55015.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a98cb6c-62a1-4c02-a57e-f4522f8cae43>.
+    
+<http://data.lblod.info/id/remote-data-objects/db94a845-7ef3-4127-b519-b51a0c0c5957> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db94a845-7ef3-4127-b519-b51a0c0c5957";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_15-03-2022_56426.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db94a845-7ef3-4127-b519-b51a0c0c5957>.
+    
+<http://data.lblod.info/id/remote-data-objects/79846290-303a-4aeb-b3e0-b615d8feffa8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79846290-303a-4aeb-b3e0-b615d8feffa8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_15-03-2022_56593.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79846290-303a-4aeb-b3e0-b615d8feffa8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d71d7bd-1385-4592-9c0d-e7796c9f0edb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d71d7bd-1385-4592-9c0d-e7796c9f0edb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_15-03-2022_56609.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d71d7bd-1385-4592-9c0d-e7796c9f0edb>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd1ea806-a0bf-48b8-859b-24ab75d538bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd1ea806-a0bf-48b8-859b-24ab75d538bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_15-03-2022_56780.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd1ea806-a0bf-48b8-859b-24ab75d538bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/7eb20e00-3d13-4789-ba78-ea5fd7cda57e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7eb20e00-3d13-4789-ba78-ea5fd7cda57e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_17-05-2022_58259.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7eb20e00-3d13-4789-ba78-ea5fd7cda57e>.
+    
+<http://data.lblod.info/id/remote-data-objects/548c26e8-5ae7-43b8-8e53-422f9c6df3da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "548c26e8-5ae7-43b8-8e53-422f9c6df3da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_17-05-2022_59689.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/548c26e8-5ae7-43b8-8e53-422f9c6df3da>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d186273-9a29-4a67-8268-2472c2ad29e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d186273-9a29-4a67-8268-2472c2ad29e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_17-05-2022_59690.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5331d8a9-af2d-4a5e-8414-fab12a5a2bd5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d186273-9a29-4a67-8268-2472c2ad29e2>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201302-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201302-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201302-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201302-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/48f85c4e-5d40-406a-8d21-7dacf4a03461> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "48f85c4e-5d40-406a-8d21-7dacf4a03461";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9862900c-dddf-46b0-8827-95ccd8761151";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/629c6175-6f40-4af7-85f8-3fe33eba788f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "629c6175-6f40-4af7-85f8-3fe33eba788f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151>.
+
+  <http://redpencil.data.gift/id/task/5dd72e1d-313d-4712-9ee6-0f2bd4185b76> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5dd72e1d-313d-4712-9ee6-0f2bd4185b76";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/48f85c4e-5d40-406a-8d21-7dacf4a03461>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/629c6175-6f40-4af7-85f8-3fe33eba788f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7d12b7a0-eee0-4992-8208-aad9a94bb9f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d12b7a0-eee0-4992-8208-aad9a94bb9f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_17-05-2022_60733.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d12b7a0-eee0-4992-8208-aad9a94bb9f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8351d5c-1a3d-475b-b434-fb25af94ae4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8351d5c-1a3d-475b-b434-fb25af94ae4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_21-06-2022_59522.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8351d5c-1a3d-475b-b434-fb25af94ae4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6247531d-bd88-460b-9314-fe75fd7dd2cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6247531d-bd88-460b-9314-fe75fd7dd2cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_21-06-2022_60828.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6247531d-bd88-460b-9314-fe75fd7dd2cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffddf6db-8526-4b44-9e75-e0c17e5e8c51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffddf6db-8526-4b44-9e75-e0c17e5e8c51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_21-06-2022_61964.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffddf6db-8526-4b44-9e75-e0c17e5e8c51>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7840aee-79ee-4286-9919-796b221479cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7840aee-79ee-4286-9919-796b221479cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_21-06-2022_61976.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7840aee-79ee-4286-9919-796b221479cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f2300f6-6b42-4e96-837a-a283a45b4a68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f2300f6-6b42-4e96-837a-a283a45b4a68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_21-06-2022_62068.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f2300f6-6b42-4e96-837a-a283a45b4a68>.
+    
+<http://data.lblod.info/id/remote-data-objects/577e5a82-efbf-4b66-9d94-c0ac206a0a38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "577e5a82-efbf-4b66-9d94-c0ac206a0a38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_21-06-2022_62074.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/577e5a82-efbf-4b66-9d94-c0ac206a0a38>.
+    
+<http://data.lblod.info/id/remote-data-objects/d95fcf08-d827-4afc-a437-bd55b237820c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d95fcf08-d827-4afc-a437-bd55b237820c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_21-06-2022_62109.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d95fcf08-d827-4afc-a437-bd55b237820c>.
+    
+<http://data.lblod.info/id/remote-data-objects/70f730cf-8ae5-4f10-921e-e831099e0cea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70f730cf-8ae5-4f10-921e-e831099e0cea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_21-06-2022_62121.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70f730cf-8ae5-4f10-921e-e831099e0cea>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8d7fb14-fb33-4443-a998-31a77badfe01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8d7fb14-fb33-4443-a998-31a77badfe01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_21-06-2022_62124.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8d7fb14-fb33-4443-a998-31a77badfe01>.
+    
+<http://data.lblod.info/id/remote-data-objects/54459d66-d7be-44f3-9141-2e61d399d9a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54459d66-d7be-44f3-9141-2e61d399d9a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_21-06-2022_62226.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54459d66-d7be-44f3-9141-2e61d399d9a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fd98225-7470-4fab-8f74-2aee46871f88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fd98225-7470-4fab-8f74-2aee46871f88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_21-06-2022_62243.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fd98225-7470-4fab-8f74-2aee46871f88>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a50bd69-7eaf-4833-b3b8-c39bdf717eab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a50bd69-7eaf-4833-b3b8-c39bdf717eab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/57df5f1fecb1bf7153511033f27f995126aab99c20d1dd8de2ca2970e447c2f1/GetPublication?filename=Uittreksels_26-04-2022_58121.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a50bd69-7eaf-4833-b3b8-c39bdf717eab>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f146766-9be4-41a5-99a2-d68da720fbd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f146766-9be4-41a5-99a2-d68da720fbd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/d19acd69b15ad4b8a1385a1642010667138271c1e6f5b1402d97e531c1404e64/GetPublication?filename=BesluitenLijst_Beslissingen%20burgemeester_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f146766-9be4-41a5-99a2-d68da720fbd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d6e2e95-fa7b-4776-81e3-4670c94b075a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d6e2e95-fa7b-4776-81e3-4670c94b075a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/d19acd69b15ad4b8a1385a1642010667138271c1e6f5b1402d97e531c1404e64/GetPublication?filename=BesluitenLijst_Beslissingen%20burgemeester_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d6e2e95-fa7b-4776-81e3-4670c94b075a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a29d9878-ead3-434b-b1fc-3bd4e01f3b07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a29d9878-ead3-434b-b1fc-3bd4e01f3b07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/d19acd69b15ad4b8a1385a1642010667138271c1e6f5b1402d97e531c1404e64/GetPublication?filename=BesluitenLijst_Beslissingen%20burgemeester_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a29d9878-ead3-434b-b1fc-3bd4e01f3b07>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf843b18-d3e3-47eb-9c0f-33521d231962> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf843b18-d3e3-47eb-9c0f-33521d231962";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/d19acd69b15ad4b8a1385a1642010667138271c1e6f5b1402d97e531c1404e64/GetPublication?filename=BesluitenLijst_Beslissingen%20burgemeester_28-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf843b18-d3e3-47eb-9c0f-33521d231962>.
+    
+<http://data.lblod.info/id/remote-data-objects/72b62d05-8a87-4e59-bc39-28b70a262924> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72b62d05-8a87-4e59-bc39-28b70a262924";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/d19acd69b15ad4b8a1385a1642010667138271c1e6f5b1402d97e531c1404e64/GetPublication?filename=BesluitenLijst_Beslissingen%20burgemeester_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72b62d05-8a87-4e59-bc39-28b70a262924>.
+    
+<http://data.lblod.info/id/remote-data-objects/56aac68f-73df-484f-b5d8-d151456b4681> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56aac68f-73df-484f-b5d8-d151456b4681";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/d19acd69b15ad4b8a1385a1642010667138271c1e6f5b1402d97e531c1404e64/GetPublication?filename=BesluitenLijst_Beslissingen%20burgemeester_29-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56aac68f-73df-484f-b5d8-d151456b4681>.
+    
+<http://data.lblod.info/id/remote-data-objects/fed4d950-fa25-448d-97f2-893396dfdcb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fed4d950-fa25-448d-97f2-893396dfdcb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/d19acd69b15ad4b8a1385a1642010667138271c1e6f5b1402d97e531c1404e64/GetPublication?filename=Uittreksels_02-12-2021_52133.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fed4d950-fa25-448d-97f2-893396dfdcb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0836ecfe-6c50-4433-ba32-53095d04a371> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0836ecfe-6c50-4433-ba32-53095d04a371";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/d19acd69b15ad4b8a1385a1642010667138271c1e6f5b1402d97e531c1404e64/GetPublication?filename=Uittreksels_16-12-2021_53410.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0836ecfe-6c50-4433-ba32-53095d04a371>.
+    
+<http://data.lblod.info/id/remote-data-objects/964d1ef3-46d9-4101-a3f9-0e8c4ede5073> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "964d1ef3-46d9-4101-a3f9-0e8c4ede5073";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/d19acd69b15ad4b8a1385a1642010667138271c1e6f5b1402d97e531c1404e64/GetPublication?filename=Uittreksels_19-11-2021_51946.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/964d1ef3-46d9-4101-a3f9-0e8c4ede5073>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d38e36a-2618-480c-a6a5-783e7404d966> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d38e36a-2618-480c-a6a5-783e7404d966";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/d19acd69b15ad4b8a1385a1642010667138271c1e6f5b1402d97e531c1404e64/GetPublication?filename=Uittreksels_24-06-2022_62708.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d38e36a-2618-480c-a6a5-783e7404d966>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb03b3b2-982f-4363-bc93-caec3732e8af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb03b3b2-982f-4363-bc93-caec3732e8af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/d19acd69b15ad4b8a1385a1642010667138271c1e6f5b1402d97e531c1404e64/GetPublication?filename=Uittreksels_24-11-2021_52031.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb03b3b2-982f-4363-bc93-caec3732e8af>.
+    
+<http://data.lblod.info/id/remote-data-objects/36d2f3cd-281d-479e-be3f-d96c888d30cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36d2f3cd-281d-479e-be3f-d96c888d30cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/d19acd69b15ad4b8a1385a1642010667138271c1e6f5b1402d97e531c1404e64/GetPublication?filename=Uittreksels_28-01-2022_55109.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36d2f3cd-281d-479e-be3f-d96c888d30cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/68790796-9021-48b0-b6cb-f1434b32d4be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68790796-9021-48b0-b6cb-f1434b32d4be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/d19acd69b15ad4b8a1385a1642010667138271c1e6f5b1402d97e531c1404e64/GetPublication?filename=Uittreksels_29-12-2021_53641.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68790796-9021-48b0-b6cb-f1434b32d4be>.
+    
+<http://data.lblod.info/id/remote-data-objects/82df28c6-9e77-4af0-b7a5-f54e6bb67196> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82df28c6-9e77-4af0-b7a5-f54e6bb67196";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82df28c6-9e77-4af0-b7a5-f54e6bb67196>.
+    
+<http://data.lblod.info/id/remote-data-objects/802ce511-7680-422e-b0b0-bf3357ffbcee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "802ce511-7680-422e-b0b0-bf3357ffbcee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/802ce511-7680-422e-b0b0-bf3357ffbcee>.
+    
+<http://data.lblod.info/id/remote-data-objects/14380fc1-915b-4397-96b7-6c0369433304> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14380fc1-915b-4397-96b7-6c0369433304";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14380fc1-915b-4397-96b7-6c0369433304>.
+    
+<http://data.lblod.info/id/remote-data-objects/faa0f6c1-692f-4389-897c-44bc1d719b77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "faa0f6c1-692f-4389-897c-44bc1d719b77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_03-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/faa0f6c1-692f-4389-897c-44bc1d719b77>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba768d43-222b-4ac7-b742-b326663828cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba768d43-222b-4ac7-b742-b326663828cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba768d43-222b-4ac7-b742-b326663828cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/e12bbe2f-183d-43b9-bc29-5e7742a2b306> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e12bbe2f-183d-43b9-bc29-5e7742a2b306";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e12bbe2f-183d-43b9-bc29-5e7742a2b306>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa4a58ac-36e1-4a1f-892f-66ab02640051> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa4a58ac-36e1-4a1f-892f-66ab02640051";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa4a58ac-36e1-4a1f-892f-66ab02640051>.
+    
+<http://data.lblod.info/id/remote-data-objects/53684e4f-b8b9-4c2b-b132-f1fb636acb3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53684e4f-b8b9-4c2b-b132-f1fb636acb3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_08-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53684e4f-b8b9-4c2b-b132-f1fb636acb3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab4d4c4d-dad3-4c23-a144-2c57270c3a0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab4d4c4d-dad3-4c23-a144-2c57270c3a0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab4d4c4d-dad3-4c23-a144-2c57270c3a0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d45d41a9-68ea-4be5-ba65-85b1fc25a485> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d45d41a9-68ea-4be5-ba65-85b1fc25a485";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_10-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d45d41a9-68ea-4be5-ba65-85b1fc25a485>.
+    
+<http://data.lblod.info/id/remote-data-objects/79348947-1db0-4ecd-9bfa-4a160945b443> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79348947-1db0-4ecd-9bfa-4a160945b443";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_10-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79348947-1db0-4ecd-9bfa-4a160945b443>.
+    
+<http://data.lblod.info/id/remote-data-objects/f39ee7ed-2ef9-492b-abfd-f63f86f874ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f39ee7ed-2ef9-492b-abfd-f63f86f874ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_11-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f39ee7ed-2ef9-492b-abfd-f63f86f874ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/001288cd-ca0a-4aa8-897a-2d2c5f22da50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "001288cd-ca0a-4aa8-897a-2d2c5f22da50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_11-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/001288cd-ca0a-4aa8-897a-2d2c5f22da50>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c386a5b-200b-407a-9a6f-7e08e65ff625> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c386a5b-200b-407a-9a6f-7e08e65ff625";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_12-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c386a5b-200b-407a-9a6f-7e08e65ff625>.
+    
+<http://data.lblod.info/id/remote-data-objects/54fb4905-9012-457d-b4e3-9ce9a32d866f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54fb4905-9012-457d-b4e3-9ce9a32d866f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54fb4905-9012-457d-b4e3-9ce9a32d866f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f34aea1c-6a7e-4b96-aa16-ae434a02f894> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f34aea1c-6a7e-4b96-aa16-ae434a02f894";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_14-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f34aea1c-6a7e-4b96-aa16-ae434a02f894>.
+    
+<http://data.lblod.info/id/remote-data-objects/e64eb2a0-9007-4fa5-a9ce-7bb076ba2588> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e64eb2a0-9007-4fa5-a9ce-7bb076ba2588";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e64eb2a0-9007-4fa5-a9ce-7bb076ba2588>.
+    
+<http://data.lblod.info/id/remote-data-objects/77e834ed-949c-41ea-9874-5a1e7b42b34e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77e834ed-949c-41ea-9874-5a1e7b42b34e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77e834ed-949c-41ea-9874-5a1e7b42b34e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7cca236-01e1-43a1-af9d-bba8517203a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7cca236-01e1-43a1-af9d-bba8517203a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_17-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7cca236-01e1-43a1-af9d-bba8517203a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e024c9a-1b62-40f8-9c70-54e86fad7f5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e024c9a-1b62-40f8-9c70-54e86fad7f5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_17-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e024c9a-1b62-40f8-9c70-54e86fad7f5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1898c1c-2b57-409e-a30b-27bccdb5c3f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1898c1c-2b57-409e-a30b-27bccdb5c3f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1898c1c-2b57-409e-a30b-27bccdb5c3f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dc8c173-43b1-4d54-98f1-e29cb1f71f10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dc8c173-43b1-4d54-98f1-e29cb1f71f10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_18-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dc8c173-43b1-4d54-98f1-e29cb1f71f10>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed87f1b2-b7f8-4fa3-9d16-254cb7973d61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed87f1b2-b7f8-4fa3-9d16-254cb7973d61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed87f1b2-b7f8-4fa3-9d16-254cb7973d61>.
+    
+<http://data.lblod.info/id/remote-data-objects/443be6ae-a372-4ca2-bec0-b0cf3a33032f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "443be6ae-a372-4ca2-bec0-b0cf3a33032f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9862900c-dddf-46b0-8827-95ccd8761151> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/443be6ae-a372-4ca2-bec0-b0cf3a33032f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201303-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201303-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201303-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201303-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/0b2573e6-da42-42ca-b7b4-0cb0eb318226> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0b2573e6-da42-42ca-b7b4-0cb0eb318226";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a7232440-5787-405d-a6ac-6da289ceb244";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/fc46dbf5-9e91-49eb-b0d0-6158522bc81e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fc46dbf5-9e91-49eb-b0d0-6158522bc81e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244>.
+
+  <http://redpencil.data.gift/id/task/bd40d917-30fe-4168-b60e-c40f16051795> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bd40d917-30fe-4168-b60e-c40f16051795";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/0b2573e6-da42-42ca-b7b4-0cb0eb318226>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/fc46dbf5-9e91-49eb-b0d0-6158522bc81e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c6121c1a-5e8d-48d2-9f9a-9860cfa0c348> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6121c1a-5e8d-48d2-9f9a-9860cfa0c348";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_21-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6121c1a-5e8d-48d2-9f9a-9860cfa0c348>.
+    
+<http://data.lblod.info/id/remote-data-objects/6343835e-ea79-4e38-8655-416037a022e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6343835e-ea79-4e38-8655-416037a022e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_22-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6343835e-ea79-4e38-8655-416037a022e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0a7dfb7-93f4-42b4-8293-194992c87781> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0a7dfb7-93f4-42b4-8293-194992c87781";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_22-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0a7dfb7-93f4-42b4-8293-194992c87781>.
+    
+<http://data.lblod.info/id/remote-data-objects/e124df14-8fee-4f07-b891-ab8c97780b9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e124df14-8fee-4f07-b891-ab8c97780b9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_22-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e124df14-8fee-4f07-b891-ab8c97780b9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/08e814fe-e033-4413-b49f-e65dbadde963> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08e814fe-e033-4413-b49f-e65dbadde963";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08e814fe-e033-4413-b49f-e65dbadde963>.
+    
+<http://data.lblod.info/id/remote-data-objects/eac8a503-f972-4882-9260-fa9dd72b6f5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eac8a503-f972-4882-9260-fa9dd72b6f5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_24-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eac8a503-f972-4882-9260-fa9dd72b6f5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/88e2eaf9-c617-4b20-9432-2b220d8f14de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88e2eaf9-c617-4b20-9432-2b220d8f14de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_25-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88e2eaf9-c617-4b20-9432-2b220d8f14de>.
+    
+<http://data.lblod.info/id/remote-data-objects/16362e44-7318-4118-a487-91f3f91575f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16362e44-7318-4118-a487-91f3f91575f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_25-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16362e44-7318-4118-a487-91f3f91575f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc204f4c-0eae-4f34-9ea8-5a9da08ce334> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc204f4c-0eae-4f34-9ea8-5a9da08ce334";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_26-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc204f4c-0eae-4f34-9ea8-5a9da08ce334>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebb1051b-feb7-42b4-bbe7-9512df613915> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebb1051b-feb7-42b4-bbe7-9512df613915";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebb1051b-feb7-42b4-bbe7-9512df613915>.
+    
+<http://data.lblod.info/id/remote-data-objects/8dcb340d-55d7-41e1-822f-0d95d64899d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8dcb340d-55d7-41e1-822f-0d95d64899d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8dcb340d-55d7-41e1-822f-0d95d64899d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/496c54b4-8569-4f7b-be60-c42cec42181b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "496c54b4-8569-4f7b-be60-c42cec42181b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/496c54b4-8569-4f7b-be60-c42cec42181b>.
+    
+<http://data.lblod.info/id/remote-data-objects/18d0cc77-843f-407e-b583-2d3851f2a9b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18d0cc77-843f-407e-b583-2d3851f2a9b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=Uittreksels_13-05-2022_60788.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18d0cc77-843f-407e-b583-2d3851f2a9b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff1c9d7e-34b5-4eb6-940a-54c77c5f923e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff1c9d7e-34b5-4eb6-940a-54c77c5f923e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=Uittreksels_22-07-2022_64948.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff1c9d7e-34b5-4eb6-940a-54c77c5f923e>.
+    
+<http://data.lblod.info/id/remote-data-objects/cadb3fc1-bcbf-4c9a-b14d-33a0ff563329> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cadb3fc1-bcbf-4c9a-b14d-33a0ff563329";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=Uittreksels_24-12-2021_53542.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cadb3fc1-bcbf-4c9a-b14d-33a0ff563329>.
+    
+<http://data.lblod.info/id/remote-data-objects/09643459-5a01-41ed-9e76-c5b065911d08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09643459-5a01-41ed-9e76-c5b065911d08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.blankenberge.be/LBLODWeb/Home/Overzicht/fd67148999a8b062a7e08b91f319ed184c6ff5c8a019d11a6d6b24ada8b1f85e/GetPublication?filename=Uittreksels_25-02-2022_56598.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09643459-5a01-41ed-9e76-c5b065911d08>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd619b94-9284-4265-852f-aa1e8381fa60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd619b94-9284-4265-852f-aa1e8381fa60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd619b94-9284-4265-852f-aa1e8381fa60>.
+    
+<http://data.lblod.info/id/remote-data-objects/8948cdd4-f54e-48be-a069-39bbe5858235> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8948cdd4-f54e-48be-a069-39bbe5858235";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8948cdd4-f54e-48be-a069-39bbe5858235>.
+    
+<http://data.lblod.info/id/remote-data-objects/331eea46-2df4-444f-bb0c-eda506ca5340> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "331eea46-2df4-444f-bb0c-eda506ca5340";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/331eea46-2df4-444f-bb0c-eda506ca5340>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b3dd764-d45a-4e4e-ae94-9f09bdac222a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b3dd764-d45a-4e4e-ae94-9f09bdac222a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b3dd764-d45a-4e4e-ae94-9f09bdac222a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c771e324-093d-4834-965a-cd62a9d211ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c771e324-093d-4834-965a-cd62a9d211ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c771e324-093d-4834-965a-cd62a9d211ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/24fd3096-3848-4f17-8a58-22a365ba7e78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24fd3096-3848-4f17-8a58-22a365ba7e78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24fd3096-3848-4f17-8a58-22a365ba7e78>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e03784d-9ecb-4a39-a29b-dcfae4efc1a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e03784d-9ecb-4a39-a29b-dcfae4efc1a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e03784d-9ecb-4a39-a29b-dcfae4efc1a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/4aaa56c4-4ed9-4c0b-9341-981cce7f43e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4aaa56c4-4ed9-4c0b-9341-981cce7f43e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4aaa56c4-4ed9-4c0b-9341-981cce7f43e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/06759e0b-f9a7-4b9d-bdab-dcf253f0025a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06759e0b-f9a7-4b9d-bdab-dcf253f0025a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06759e0b-f9a7-4b9d-bdab-dcf253f0025a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e91372a-3b50-4ec3-a91a-10c718e104f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e91372a-3b50-4ec3-a91a-10c718e104f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e91372a-3b50-4ec3-a91a-10c718e104f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/beba494a-b1ed-42c5-bec6-182de83c6c6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "beba494a-b1ed-42c5-bec6-182de83c6c6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/beba494a-b1ed-42c5-bec6-182de83c6c6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/db8a228c-6738-424d-92bf-d87560224885> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db8a228c-6738-424d-92bf-d87560224885";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=Notulen_OCMW-raad_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db8a228c-6738-424d-92bf-d87560224885>.
+    
+<http://data.lblod.info/id/remote-data-objects/99c9817d-de9d-497a-a51e-bacdcc6a15bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99c9817d-de9d-497a-a51e-bacdcc6a15bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=Notulen_OCMW-raad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99c9817d-de9d-497a-a51e-bacdcc6a15bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8706ed7-4fa2-4e86-be59-0de28d656680> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8706ed7-4fa2-4e86-be59-0de28d656680";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=Notulen_OCMW-raad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8706ed7-4fa2-4e86-be59-0de28d656680>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec88fbf2-e8df-4c0f-b6b4-8860b9087017> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec88fbf2-e8df-4c0f-b6b4-8860b9087017";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=Notulen_OCMW-raad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec88fbf2-e8df-4c0f-b6b4-8860b9087017>.
+    
+<http://data.lblod.info/id/remote-data-objects/22fca2d9-6e85-40f8-8766-5f99b872f0c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22fca2d9-6e85-40f8-8766-5f99b872f0c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=Notulen_OCMW-raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22fca2d9-6e85-40f8-8766-5f99b872f0c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecea2fb6-51d0-4f41-8d3b-ca72c1ce5fd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecea2fb6-51d0-4f41-8d3b-ca72c1ce5fd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=Notulen_OCMW-raad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecea2fb6-51d0-4f41-8d3b-ca72c1ce5fd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1652fd74-26a8-4338-9e0f-c158385cb1a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1652fd74-26a8-4338-9e0f-c158385cb1a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=Notulen_OCMW-raad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1652fd74-26a8-4338-9e0f-c158385cb1a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f23d6257-b2ab-43d7-b145-f8f47bb96ed2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f23d6257-b2ab-43d7-b145-f8f47bb96ed2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=Notulen_OCMW-raad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f23d6257-b2ab-43d7-b145-f8f47bb96ed2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f812dc49-16d8-4f0d-b510-b0acdb4edb02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f812dc49-16d8-4f0d-b510-b0acdb4edb02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=Notulen_OCMW-raad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f812dc49-16d8-4f0d-b510-b0acdb4edb02>.
+    
+<http://data.lblod.info/id/remote-data-objects/c44d4553-5232-48fd-aeb7-8961dc39ac15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c44d4553-5232-48fd-aeb7-8961dc39ac15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=Notulen_OCMW-raad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c44d4553-5232-48fd-aeb7-8961dc39ac15>.
+    
+<http://data.lblod.info/id/remote-data-objects/f53a8426-7cac-443b-bfe7-833dadce36f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f53a8426-7cac-443b-bfe7-833dadce36f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=Uittreksels_12-07-2022_48876.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f53a8426-7cac-443b-bfe7-833dadce36f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/42b5e49b-3b4b-4758-9af1-79d2a691b7d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42b5e49b-3b4b-4758-9af1-79d2a691b7d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=Uittreksels_12-07-2022_48877.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42b5e49b-3b4b-4758-9af1-79d2a691b7d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b6d5c37-92b3-43c9-bce6-584df846c441> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b6d5c37-92b3-43c9-bce6-584df846c441";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=Uittreksels_20-12-2021_45903.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b6d5c37-92b3-43c9-bce6-584df846c441>.
+    
+<http://data.lblod.info/id/remote-data-objects/1caa9a94-614e-4959-9db7-838d13f1396c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1caa9a94-614e-4959-9db7-838d13f1396c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=Uittreksels_20-12-2021_45919.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1caa9a94-614e-4959-9db7-838d13f1396c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7355c5c3-3eb9-441b-b647-dfaf6b2dcc53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7355c5c3-3eb9-441b-b647-dfaf6b2dcc53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=Uittreksels_25-10-2021_45106.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7355c5c3-3eb9-441b-b647-dfaf6b2dcc53>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b754ef7-ec3e-45fb-9313-3859ad71e64d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b754ef7-ec3e-45fb-9313-3859ad71e64d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/079c62c3c9a5fe661f62f2833bb02c8c5bfe646ec97a2c1ba6055df3ba04013d/GetPublication?filename=Uittreksels_28-03-2022_47422.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b754ef7-ec3e-45fb-9313-3859ad71e64d>.
+    
+<http://data.lblod.info/id/remote-data-objects/744b2271-54fa-467e-b215-ad4407fdeae3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "744b2271-54fa-467e-b215-ad4407fdeae3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/744b2271-54fa-467e-b215-ad4407fdeae3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab90cf24-042e-403a-b2fd-4bbb00f03e6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab90cf24-042e-403a-b2fd-4bbb00f03e6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab90cf24-042e-403a-b2fd-4bbb00f03e6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/abb5bc59-54d6-425b-9f26-fc58f96eb1d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abb5bc59-54d6-425b-9f26-fc58f96eb1d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abb5bc59-54d6-425b-9f26-fc58f96eb1d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f6959a0-29b0-4a33-ba7e-5f4f8b22547a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f6959a0-29b0-4a33-ba7e-5f4f8b22547a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f6959a0-29b0-4a33-ba7e-5f4f8b22547a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6d921b5-9fa8-46be-aab0-1045e72de36a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6d921b5-9fa8-46be-aab0-1045e72de36a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6d921b5-9fa8-46be-aab0-1045e72de36a>.
+    
+<http://data.lblod.info/id/remote-data-objects/92948939-f240-43a1-9a9f-ef36f0983c82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92948939-f240-43a1-9a9f-ef36f0983c82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92948939-f240-43a1-9a9f-ef36f0983c82>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cc191c7-c5c9-4054-89f7-981256460e2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cc191c7-c5c9-4054-89f7-981256460e2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a7232440-5787-405d-a6ac-6da289ceb244> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cc191c7-c5c9-4054-89f7-981256460e2b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201305-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201305-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201305-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201305-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/392bd685-42aa-4ec0-a26d-48e5179156f6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "392bd685-42aa-4ec0-a26d-48e5179156f6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a4a78532-0257-40b9-b7d6-8ba18be494cf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/53311fbd-8fe8-4c29-8389-540390145a83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "53311fbd-8fe8-4c29-8389-540390145a83";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf>.
+
+  <http://redpencil.data.gift/id/task/9c57609c-c82e-40cd-9b39-b21f03378df5> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9c57609c-c82e-40cd-9b39-b21f03378df5";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/392bd685-42aa-4ec0-a26d-48e5179156f6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/53311fbd-8fe8-4c29-8389-540390145a83>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b2f675b9-d1dd-47b8-be9e-8a27d54a5fb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2f675b9-d1dd-47b8-be9e-8a27d54a5fb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2f675b9-d1dd-47b8-be9e-8a27d54a5fb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf705510-b839-4ef4-a746-1513894117b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf705510-b839-4ef4-a746-1513894117b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf705510-b839-4ef4-a746-1513894117b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/09c9a04d-7ba4-4e63-a68f-1c1f35f39550> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09c9a04d-7ba4-4e63-a68f-1c1f35f39550";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09c9a04d-7ba4-4e63-a68f-1c1f35f39550>.
+    
+<http://data.lblod.info/id/remote-data-objects/652d25fa-8ad3-4faf-ad9a-7bd2e841bc09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "652d25fa-8ad3-4faf-ad9a-7bd2e841bc09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/652d25fa-8ad3-4faf-ad9a-7bd2e841bc09>.
+    
+<http://data.lblod.info/id/remote-data-objects/59b840fa-1a00-47c6-b9f0-e4cc35d8fa02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59b840fa-1a00-47c6-b9f0-e4cc35d8fa02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59b840fa-1a00-47c6-b9f0-e4cc35d8fa02>.
+    
+<http://data.lblod.info/id/remote-data-objects/104bffaa-cb0c-46a4-b7e5-c1c722e6ac1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "104bffaa-cb0c-46a4-b7e5-c1c722e6ac1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/104bffaa-cb0c-46a4-b7e5-c1c722e6ac1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca87f4d9-cda8-46ef-a097-b1e9e5e6b891> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca87f4d9-cda8-46ef-a097-b1e9e5e6b891";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca87f4d9-cda8-46ef-a097-b1e9e5e6b891>.
+    
+<http://data.lblod.info/id/remote-data-objects/68d3fe5c-f2d0-44cd-9578-e022857f1883> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68d3fe5c-f2d0-44cd-9578-e022857f1883";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68d3fe5c-f2d0-44cd-9578-e022857f1883>.
+    
+<http://data.lblod.info/id/remote-data-objects/821a804a-8a44-439c-8451-8d70d5f7716c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "821a804a-8a44-439c-8451-8d70d5f7716c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/821a804a-8a44-439c-8451-8d70d5f7716c>.
+    
+<http://data.lblod.info/id/remote-data-objects/84a1e68b-4207-4023-8b5d-2fd1f6cd723e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84a1e68b-4207-4023-8b5d-2fd1f6cd723e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84a1e68b-4207-4023-8b5d-2fd1f6cd723e>.
+    
+<http://data.lblod.info/id/remote-data-objects/77d01529-6fc6-451d-bddc-869e2206594c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77d01529-6fc6-451d-bddc-869e2206594c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77d01529-6fc6-451d-bddc-869e2206594c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c690ab9e-936f-4dd6-b65c-7d0086614fe0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c690ab9e-936f-4dd6-b65c-7d0086614fe0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c690ab9e-936f-4dd6-b65c-7d0086614fe0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c04e556e-59ce-4248-aa7b-5e96223cd067> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c04e556e-59ce-4248-aa7b-5e96223cd067";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c04e556e-59ce-4248-aa7b-5e96223cd067>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5a7ee04-8411-4810-9c30-c8661fb59313> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5a7ee04-8411-4810-9c30-c8661fb59313";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5a7ee04-8411-4810-9c30-c8661fb59313>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0363ae4-c457-4149-abfd-9599f61e609e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0363ae4-c457-4149-abfd-9599f61e609e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0363ae4-c457-4149-abfd-9599f61e609e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff5785e8-276f-4b5d-bb76-41257138b5bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff5785e8-276f-4b5d-bb76-41257138b5bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff5785e8-276f-4b5d-bb76-41257138b5bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/47b29b40-ac85-40a9-9f47-78602f186383> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47b29b40-ac85-40a9-9f47-78602f186383";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47b29b40-ac85-40a9-9f47-78602f186383>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca404df6-1890-485b-90f7-23ad7828eb1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca404df6-1890-485b-90f7-23ad7828eb1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca404df6-1890-485b-90f7-23ad7828eb1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c1d7449-2abf-42c6-8799-d999178d8377> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c1d7449-2abf-42c6-8799-d999178d8377";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c1d7449-2abf-42c6-8799-d999178d8377>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b8de403-0aa2-4066-aa20-59a62ac75a87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b8de403-0aa2-4066-aa20-59a62ac75a87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b8de403-0aa2-4066-aa20-59a62ac75a87>.
+    
+<http://data.lblod.info/id/remote-data-objects/89a6c1ac-f7ae-43db-8c1e-874af0b6346d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89a6c1ac-f7ae-43db-8c1e-874af0b6346d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89a6c1ac-f7ae-43db-8c1e-874af0b6346d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fd05aff-20e2-4270-a466-6a92157d344c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fd05aff-20e2-4270-a466-6a92157d344c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fd05aff-20e2-4270-a466-6a92157d344c>.
+    
+<http://data.lblod.info/id/remote-data-objects/85a747e5-2e20-418b-a954-690e23c53219> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85a747e5-2e20-418b-a954-690e23c53219";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85a747e5-2e20-418b-a954-690e23c53219>.
+    
+<http://data.lblod.info/id/remote-data-objects/28bd733a-904e-49df-b6f5-9d3ba50659b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28bd733a-904e-49df-b6f5-9d3ba50659b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28bd733a-904e-49df-b6f5-9d3ba50659b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/30ec14a6-d6f6-4259-951a-4c64f59cfe84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30ec14a6-d6f6-4259-951a-4c64f59cfe84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30ec14a6-d6f6-4259-951a-4c64f59cfe84>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca920756-1b8d-4989-a014-48dcf9e4409d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca920756-1b8d-4989-a014-48dcf9e4409d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca920756-1b8d-4989-a014-48dcf9e4409d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7774eac-78ae-43c8-8d9a-76bcd96bc2fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7774eac-78ae-43c8-8d9a-76bcd96bc2fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7774eac-78ae-43c8-8d9a-76bcd96bc2fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c671b84-5910-4e48-9e5c-c32bf8f75384> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c671b84-5910-4e48-9e5c-c32bf8f75384";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c671b84-5910-4e48-9e5c-c32bf8f75384>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2f8b1b5-92a2-45c5-9ea1-ff3d6810748e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2f8b1b5-92a2-45c5-9ea1-ff3d6810748e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2f8b1b5-92a2-45c5-9ea1-ff3d6810748e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b408110b-77f6-4ed9-9afe-ef8467ca81c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b408110b-77f6-4ed9-9afe-ef8467ca81c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b408110b-77f6-4ed9-9afe-ef8467ca81c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bca6b4f-d82e-422b-adbc-d4e6a4f978cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bca6b4f-d82e-422b-adbc-d4e6a4f978cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bca6b4f-d82e-422b-adbc-d4e6a4f978cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2b3e1ad-80ca-4ce8-b5ab-8d0cb133f047> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2b3e1ad-80ca-4ce8-b5ab-8d0cb133f047";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2b3e1ad-80ca-4ce8-b5ab-8d0cb133f047>.
+    
+<http://data.lblod.info/id/remote-data-objects/60ba09de-e116-457a-a326-aff376fdb993> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60ba09de-e116-457a-a326-aff376fdb993";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60ba09de-e116-457a-a326-aff376fdb993>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cd1117c-7b68-45b3-998f-30649ce0f7c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cd1117c-7b68-45b3-998f-30649ce0f7c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cd1117c-7b68-45b3-998f-30649ce0f7c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/da1edd27-a8d8-4d83-a7a0-2d4e2f46f221> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da1edd27-a8d8-4d83-a7a0-2d4e2f46f221";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/1e0f80a44088a9ccef39e66430e7afbae99f5354365a62abb2ee3cc4878433a7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da1edd27-a8d8-4d83-a7a0-2d4e2f46f221>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5473dbb-693d-4d10-abec-1a6ede406475> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5473dbb-693d-4d10-abec-1a6ede406475";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5473dbb-693d-4d10-abec-1a6ede406475>.
+    
+<http://data.lblod.info/id/remote-data-objects/eabd6a45-540a-4f41-8f09-e837c999d329> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eabd6a45-540a-4f41-8f09-e837c999d329";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eabd6a45-540a-4f41-8f09-e837c999d329>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7748b80-c5b1-46b5-aba2-7ca11300e9ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7748b80-c5b1-46b5-aba2-7ca11300e9ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7748b80-c5b1-46b5-aba2-7ca11300e9ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/10b490d3-5675-485c-84b1-a9867fbeb57c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10b490d3-5675-485c-84b1-a9867fbeb57c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10b490d3-5675-485c-84b1-a9867fbeb57c>.
+    
+<http://data.lblod.info/id/remote-data-objects/752f5d83-39f9-40c7-b1b1-8055f6ff0807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "752f5d83-39f9-40c7-b1b1-8055f6ff0807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/752f5d83-39f9-40c7-b1b1-8055f6ff0807>.
+    
+<http://data.lblod.info/id/remote-data-objects/b510bc6c-744b-4b22-b43a-1969a8cd0cc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b510bc6c-744b-4b22-b43a-1969a8cd0cc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b510bc6c-744b-4b22-b43a-1969a8cd0cc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7aa68994-be71-44dc-8f96-f5d76aeafe63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7aa68994-be71-44dc-8f96-f5d76aeafe63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7aa68994-be71-44dc-8f96-f5d76aeafe63>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a69d848-9b00-41a8-97b5-3aefc46de0f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a69d848-9b00-41a8-97b5-3aefc46de0f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a69d848-9b00-41a8-97b5-3aefc46de0f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d11bc0f-deb5-41d8-9582-fbc458e24f55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d11bc0f-deb5-41d8-9582-fbc458e24f55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d11bc0f-deb5-41d8-9582-fbc458e24f55>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4a52cfb-4632-4c73-95fe-d3f591549cea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4a52cfb-4632-4c73-95fe-d3f591549cea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4a52cfb-4632-4c73-95fe-d3f591549cea>.
+    
+<http://data.lblod.info/id/remote-data-objects/33cbc3bb-8e82-45b9-aaa5-717adefbeb8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33cbc3bb-8e82-45b9-aaa5-717adefbeb8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33cbc3bb-8e82-45b9-aaa5-717adefbeb8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c364a3a4-aa4b-4f71-8b5f-cb9baa8d8c72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c364a3a4-aa4b-4f71-8b5f-cb9baa8d8c72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c364a3a4-aa4b-4f71-8b5f-cb9baa8d8c72>.
+    
+<http://data.lblod.info/id/remote-data-objects/55c60118-1447-4994-ac43-ffb73fab2537> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55c60118-1447-4994-ac43-ffb73fab2537";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55c60118-1447-4994-ac43-ffb73fab2537>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf1249d2-8342-4b77-a895-747739671261> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf1249d2-8342-4b77-a895-747739671261";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf1249d2-8342-4b77-a895-747739671261>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bd4fab6-7276-47b2-801d-fc43fbdf8a5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bd4fab6-7276-47b2-801d-fc43fbdf8a5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4a78532-0257-40b9-b7d6-8ba18be494cf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bd4fab6-7276-47b2-801d-fc43fbdf8a5a>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201306-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201306-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201306-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201306-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/4e7d18ea-8cbe-4e08-83ff-13126a352364> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4e7d18ea-8cbe-4e08-83ff-13126a352364";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cbe08aaa-23e7-4346-8344-1e9769efb2d6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f3ac13c5-5c5e-482c-b22a-0056d0516d7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f3ac13c5-5c5e-482c-b22a-0056d0516d7a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6>.
+
+  <http://redpencil.data.gift/id/task/f62ebf51-2873-40c2-b071-0187b5783752> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f62ebf51-2873-40c2-b071-0187b5783752";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/4e7d18ea-8cbe-4e08-83ff-13126a352364>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f3ac13c5-5c5e-482c-b22a-0056d0516d7a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/f812ac14-596a-4cab-aac7-7662ea96358a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f812ac14-596a-4cab-aac7-7662ea96358a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f812ac14-596a-4cab-aac7-7662ea96358a>.
+    
+<http://data.lblod.info/id/remote-data-objects/535a4f42-6a05-4556-b63d-55bf50bf6822> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "535a4f42-6a05-4556-b63d-55bf50bf6822";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/535a4f42-6a05-4556-b63d-55bf50bf6822>.
+    
+<http://data.lblod.info/id/remote-data-objects/f053fa23-ea7a-4db7-8b27-637db6d45683> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f053fa23-ea7a-4db7-8b27-637db6d45683";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f053fa23-ea7a-4db7-8b27-637db6d45683>.
+    
+<http://data.lblod.info/id/remote-data-objects/05b15b70-55f8-4e3f-983c-69cedc2071b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05b15b70-55f8-4e3f-983c-69cedc2071b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05b15b70-55f8-4e3f-983c-69cedc2071b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/595f642f-ebc1-4b54-8471-2369a2443772> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "595f642f-ebc1-4b54-8471-2369a2443772";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/595f642f-ebc1-4b54-8471-2369a2443772>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ad1e2c5-b6ac-4a5e-a034-720294ae20e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ad1e2c5-b6ac-4a5e-a034-720294ae20e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ad1e2c5-b6ac-4a5e-a034-720294ae20e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/37286fd3-a4df-4e1c-afc3-b2f09b4113e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37286fd3-a4df-4e1c-afc3-b2f09b4113e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37286fd3-a4df-4e1c-afc3-b2f09b4113e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/478b60c2-b528-4d64-b83d-08c9588e0db1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "478b60c2-b528-4d64-b83d-08c9588e0db1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/478b60c2-b528-4d64-b83d-08c9588e0db1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e72b6197-3172-4032-876f-dd1ca3414370> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e72b6197-3172-4032-876f-dd1ca3414370";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e72b6197-3172-4032-876f-dd1ca3414370>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9f75258-c222-4419-8b97-237f4635cc2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9f75258-c222-4419-8b97-237f4635cc2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9f75258-c222-4419-8b97-237f4635cc2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a51ff7c0-53aa-4ba7-97dd-17a8342ea5ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a51ff7c0-53aa-4ba7-97dd-17a8342ea5ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a51ff7c0-53aa-4ba7-97dd-17a8342ea5ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/faf80ec4-4d20-416b-8484-971bb4253433> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "faf80ec4-4d20-416b-8484-971bb4253433";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/faf80ec4-4d20-416b-8484-971bb4253433>.
+    
+<http://data.lblod.info/id/remote-data-objects/38cb2ba3-3c0b-4e91-b891-1723a3f22835> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38cb2ba3-3c0b-4e91-b891-1723a3f22835";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38cb2ba3-3c0b-4e91-b891-1723a3f22835>.
+    
+<http://data.lblod.info/id/remote-data-objects/64f5e6ed-f705-48c3-bff2-6509af96b806> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64f5e6ed-f705-48c3-bff2-6509af96b806";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64f5e6ed-f705-48c3-bff2-6509af96b806>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdf87ddf-4c30-46e4-a705-a8ec3c0a3ca2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdf87ddf-4c30-46e4-a705-a8ec3c0a3ca2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdf87ddf-4c30-46e4-a705-a8ec3c0a3ca2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8760fa76-e1b9-4af7-872d-170df2056f73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8760fa76-e1b9-4af7-872d-170df2056f73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8760fa76-e1b9-4af7-872d-170df2056f73>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8624c59-424d-4326-aa2e-192376a32db2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8624c59-424d-4326-aa2e-192376a32db2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8624c59-424d-4326-aa2e-192376a32db2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5f03846-e73a-44d8-864b-013bb49f3434> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5f03846-e73a-44d8-864b-013bb49f3434";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5f03846-e73a-44d8-864b-013bb49f3434>.
+    
+<http://data.lblod.info/id/remote-data-objects/140418d8-e41f-424c-981b-a0d4626d6329> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "140418d8-e41f-424c-981b-a0d4626d6329";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/140418d8-e41f-424c-981b-a0d4626d6329>.
+    
+<http://data.lblod.info/id/remote-data-objects/680ec491-6320-473e-b99f-f266e1c72024> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "680ec491-6320-473e-b99f-f266e1c72024";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/680ec491-6320-473e-b99f-f266e1c72024>.
+    
+<http://data.lblod.info/id/remote-data-objects/0348ee54-8028-484f-a848-d6a51c41010c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0348ee54-8028-484f-a848-d6a51c41010c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0348ee54-8028-484f-a848-d6a51c41010c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7538aa8c-1e95-455f-be68-7f8b667b886a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7538aa8c-1e95-455f-be68-7f8b667b886a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7538aa8c-1e95-455f-be68-7f8b667b886a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9bc9225-cf87-4390-beb3-adfad0b1ef06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9bc9225-cf87-4390-beb3-adfad0b1ef06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9bc9225-cf87-4390-beb3-adfad0b1ef06>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8556225-dffd-49bd-ab49-cebae6cdcf4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8556225-dffd-49bd-ab49-cebae6cdcf4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8556225-dffd-49bd-ab49-cebae6cdcf4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/40f9874f-9816-4724-9567-8eb044557c86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40f9874f-9816-4724-9567-8eb044557c86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40f9874f-9816-4724-9567-8eb044557c86>.
+    
+<http://data.lblod.info/id/remote-data-objects/a388d2b0-01a6-492a-b9e0-02330de6c56c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a388d2b0-01a6-492a-b9e0-02330de6c56c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/76266720797710da26bdd7bc38e57ad94558c134691d41a8067be12477b0c794/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a388d2b0-01a6-492a-b9e0-02330de6c56c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cabd5b3-7066-42e7-9989-84a0548e409f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cabd5b3-7066-42e7-9989-84a0548e409f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/ad961bbd94c5f34103bdc9a44524ba32369513811d0f52ea5b35ac194cc45d1a/GetPublication?filename=BesluitenLijstUitspraak_Beslissing%20burgemeester_01-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cabd5b3-7066-42e7-9989-84a0548e409f>.
+    
+<http://data.lblod.info/id/remote-data-objects/94e50da9-8e66-417c-b8e9-df03da121569> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94e50da9-8e66-417c-b8e9-df03da121569";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/ad961bbd94c5f34103bdc9a44524ba32369513811d0f52ea5b35ac194cc45d1a/GetPublication?filename=BesluitenLijstUitspraak_Beslissing%20burgemeester_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94e50da9-8e66-417c-b8e9-df03da121569>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cbbec7f-148e-47f3-aabb-4c3167afb6dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cbbec7f-148e-47f3-aabb-4c3167afb6dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/ad961bbd94c5f34103bdc9a44524ba32369513811d0f52ea5b35ac194cc45d1a/GetPublication?filename=BesluitenLijstUitspraak_Beslissing%20burgemeester_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cbbec7f-148e-47f3-aabb-4c3167afb6dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b260601-d1b9-4666-b742-27efd43561d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b260601-d1b9-4666-b742-27efd43561d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/ad961bbd94c5f34103bdc9a44524ba32369513811d0f52ea5b35ac194cc45d1a/GetPublication?filename=BesluitenLijstUitspraak_Beslissing%20burgemeester_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b260601-d1b9-4666-b742-27efd43561d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/457bd993-2700-4237-8b32-9b00e2fc1316> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "457bd993-2700-4237-8b32-9b00e2fc1316";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/ad961bbd94c5f34103bdc9a44524ba32369513811d0f52ea5b35ac194cc45d1a/GetPublication?filename=BesluitenLijstUitspraak_Beslissing%20burgemeester_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/457bd993-2700-4237-8b32-9b00e2fc1316>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea583dad-e857-4942-824c-1738e8fc32c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea583dad-e857-4942-824c-1738e8fc32c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/ad961bbd94c5f34103bdc9a44524ba32369513811d0f52ea5b35ac194cc45d1a/GetPublication?filename=BesluitenLijstUitspraak_Beslissing%20burgemeester_01-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea583dad-e857-4942-824c-1738e8fc32c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/75e72df7-7897-4f1e-96b1-66b206925252> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75e72df7-7897-4f1e-96b1-66b206925252";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/ad961bbd94c5f34103bdc9a44524ba32369513811d0f52ea5b35ac194cc45d1a/GetPublication?filename=BesluitenLijstUitspraak_Beslissing%20burgemeester_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75e72df7-7897-4f1e-96b1-66b206925252>.
+    
+<http://data.lblod.info/id/remote-data-objects/90bde3f5-bbce-4ded-a872-603a8af0b67a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90bde3f5-bbce-4ded-a872-603a8af0b67a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/ad961bbd94c5f34103bdc9a44524ba32369513811d0f52ea5b35ac194cc45d1a/GetPublication?filename=BesluitenLijstUitspraak_Beslissing%20burgemeester_01-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90bde3f5-bbce-4ded-a872-603a8af0b67a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf764423-b7e9-444e-9b77-0d8f8d5600d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf764423-b7e9-444e-9b77-0d8f8d5600d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/ad961bbd94c5f34103bdc9a44524ba32369513811d0f52ea5b35ac194cc45d1a/GetPublication?filename=BesluitenLijstUitspraak_Beslissing%20burgemeester_01-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf764423-b7e9-444e-9b77-0d8f8d5600d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/3899c446-d109-4f41-a937-ddf0d30c9f5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3899c446-d109-4f41-a937-ddf0d30c9f5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3899c446-d109-4f41-a937-ddf0d30c9f5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d140686-59ef-4a9c-9af6-f39bb25da307> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d140686-59ef-4a9c-9af6-f39bb25da307";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d140686-59ef-4a9c-9af6-f39bb25da307>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff4c1b43-d55f-4fdf-ac6c-3a01c62fa8a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff4c1b43-d55f-4fdf-ac6c-3a01c62fa8a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_18-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff4c1b43-d55f-4fdf-ac6c-3a01c62fa8a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4db3acc-9e5b-4ebf-9749-0cbf87e96876> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4db3acc-9e5b-4ebf-9749-0cbf87e96876";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4db3acc-9e5b-4ebf-9749-0cbf87e96876>.
+    
+<http://data.lblod.info/id/remote-data-objects/801b8c9d-47b0-4abf-ac22-ee1c28755ed6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "801b8c9d-47b0-4abf-ac22-ee1c28755ed6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/801b8c9d-47b0-4abf-ac22-ee1c28755ed6>.
+    
+<http://data.lblod.info/id/remote-data-objects/76d8372e-f71a-4fe8-be8c-693fd5326e80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76d8372e-f71a-4fe8-be8c-693fd5326e80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76d8372e-f71a-4fe8-be8c-693fd5326e80>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a991dab-a431-41da-8e4b-8fa63b5fdc5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a991dab-a431-41da-8e4b-8fa63b5fdc5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a991dab-a431-41da-8e4b-8fa63b5fdc5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/cff4f18a-a39c-41ba-bfc6-4685a60e63d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cff4f18a-a39c-41ba-bfc6-4685a60e63d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cff4f18a-a39c-41ba-bfc6-4685a60e63d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec3522e1-d246-4914-8fdf-b9fe26f2e373> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec3522e1-d246-4914-8fdf-b9fe26f2e373";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec3522e1-d246-4914-8fdf-b9fe26f2e373>.
+    
+<http://data.lblod.info/id/remote-data-objects/9def43ae-3e01-4cf0-9f20-0a18e4bc2aeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9def43ae-3e01-4cf0-9f20-0a18e4bc2aeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9def43ae-3e01-4cf0-9f20-0a18e4bc2aeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/31dd0b4e-64af-4201-bfec-381cfa47ec31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31dd0b4e-64af-4201-bfec-381cfa47ec31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31dd0b4e-64af-4201-bfec-381cfa47ec31>.
+    
+<http://data.lblod.info/id/remote-data-objects/69f8865a-0e50-4874-9ca7-1a2289f7787d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69f8865a-0e50-4874-9ca7-1a2289f7787d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69f8865a-0e50-4874-9ca7-1a2289f7787d>.
+    
+<http://data.lblod.info/id/remote-data-objects/974f59ee-1d12-49ce-875a-c6d5c95e9a4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "974f59ee-1d12-49ce-875a-c6d5c95e9a4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Notulen_Gemeenteraad_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/974f59ee-1d12-49ce-875a-c6d5c95e9a4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/82c291a1-557d-4256-8522-7a6db247ae65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82c291a1-557d-4256-8522-7a6db247ae65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Notulen_Gemeenteraad_18-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82c291a1-557d-4256-8522-7a6db247ae65>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bb5003a-0861-4d7f-a18c-301f2a77350e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bb5003a-0861-4d7f-a18c-301f2a77350e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Notulen_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbe08aaa-23e7-4346-8344-1e9769efb2d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bb5003a-0861-4d7f-a18c-301f2a77350e>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201307-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201307-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201307-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201307-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/97d52fde-f368-439e-89be-2f2edc3eeb56> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "97d52fde-f368-439e-89be-2f2edc3eeb56";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5ba3a80a-aae0-4923-94a7-b022e8ea0bb6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/702dba99-9aac-48a5-ae68-45fbb35a9b8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "702dba99-9aac-48a5-ae68-45fbb35a9b8b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6>.
+
+  <http://redpencil.data.gift/id/task/f474c0df-e17f-4e8f-a2e8-2e53fdc29bd7> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f474c0df-e17f-4e8f-a2e8-2e53fdc29bd7";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/97d52fde-f368-439e-89be-2f2edc3eeb56>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/702dba99-9aac-48a5-ae68-45fbb35a9b8b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/dafa2f77-9f7d-471c-ab96-1246b4deade2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dafa2f77-9f7d-471c-ab96-1246b4deade2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Notulen_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dafa2f77-9f7d-471c-ab96-1246b4deade2>.
+    
+<http://data.lblod.info/id/remote-data-objects/bddd4d11-885c-42be-a22c-d7bd8b693ce9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bddd4d11-885c-42be-a22c-d7bd8b693ce9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Notulen_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bddd4d11-885c-42be-a22c-d7bd8b693ce9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1244afb8-cc1c-445d-9ac8-b4bf2186f8e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1244afb8-cc1c-445d-9ac8-b4bf2186f8e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Notulen_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1244afb8-cc1c-445d-9ac8-b4bf2186f8e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e69ccdb-3384-4aec-8783-7047cf2b4cdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e69ccdb-3384-4aec-8783-7047cf2b4cdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Notulen_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e69ccdb-3384-4aec-8783-7047cf2b4cdf>.
+    
+<http://data.lblod.info/id/remote-data-objects/5eb24ac3-a569-4a43-992c-ac283101ea63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5eb24ac3-a569-4a43-992c-ac283101ea63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Notulen_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5eb24ac3-a569-4a43-992c-ac283101ea63>.
+    
+<http://data.lblod.info/id/remote-data-objects/620d54a2-2404-4652-b46b-8b477912bced> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "620d54a2-2404-4652-b46b-8b477912bced";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Notulen_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/620d54a2-2404-4652-b46b-8b477912bced>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfa724a4-97c5-4942-9405-f0691e5bc314> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfa724a4-97c5-4942-9405-f0691e5bc314";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Notulen_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfa724a4-97c5-4942-9405-f0691e5bc314>.
+    
+<http://data.lblod.info/id/remote-data-objects/c04e65a8-97c3-41e7-95f0-261a78c77c7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c04e65a8-97c3-41e7-95f0-261a78c77c7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Notulen_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c04e65a8-97c3-41e7-95f0-261a78c77c7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/624da2a9-1547-4adc-942e-472b08fa42d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "624da2a9-1547-4adc-942e-472b08fa42d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_12-07-2022_48656.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/624da2a9-1547-4adc-942e-472b08fa42d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdf8e136-d8c1-4a1e-b520-0e13e574ab24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdf8e136-d8c1-4a1e-b520-0e13e574ab24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_12-07-2022_48659.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdf8e136-d8c1-4a1e-b520-0e13e574ab24>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c953f1c-7610-455f-865e-acfaabd1342f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c953f1c-7610-455f-865e-acfaabd1342f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_12-07-2022_48661.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c953f1c-7610-455f-865e-acfaabd1342f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4347c7b7-ea59-4590-8781-034643d33242> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4347c7b7-ea59-4590-8781-034643d33242";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_12-07-2022_48880.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4347c7b7-ea59-4590-8781-034643d33242>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bd4c11e-4ae2-4e47-8014-681cd7871027> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bd4c11e-4ae2-4e47-8014-681cd7871027";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_12-07-2022_48891.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bd4c11e-4ae2-4e47-8014-681cd7871027>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ef99349-1f27-4216-b278-37fe8de74656> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ef99349-1f27-4216-b278-37fe8de74656";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_12-07-2022_48909.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ef99349-1f27-4216-b278-37fe8de74656>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ca6d5dc-4478-4d21-8b27-50ed69df4936> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ca6d5dc-4478-4d21-8b27-50ed69df4936";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_12-07-2022_48945.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ca6d5dc-4478-4d21-8b27-50ed69df4936>.
+    
+<http://data.lblod.info/id/remote-data-objects/813aafe7-72d3-444c-b7a5-f65ca8157b5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "813aafe7-72d3-444c-b7a5-f65ca8157b5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_20-12-2021_45371.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/813aafe7-72d3-444c-b7a5-f65ca8157b5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/aac24062-d187-4ec6-8505-037a3c1e6986> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aac24062-d187-4ec6-8505-037a3c1e6986";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_20-12-2021_45372.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aac24062-d187-4ec6-8505-037a3c1e6986>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4363781-9413-4026-b169-3c756b7ed04e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4363781-9413-4026-b169-3c756b7ed04e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_20-12-2021_45639.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4363781-9413-4026-b169-3c756b7ed04e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6779241c-52c6-468a-ad4c-607ad2b9a753> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6779241c-52c6-468a-ad4c-607ad2b9a753";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_20-12-2021_45665.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6779241c-52c6-468a-ad4c-607ad2b9a753>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd340899-b23b-403c-b44b-2b196e8d4c0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd340899-b23b-403c-b44b-2b196e8d4c0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_20-12-2021_45666.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd340899-b23b-403c-b44b-2b196e8d4c0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d68c47e-d257-41dd-b48d-b9dbd42d9313> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d68c47e-d257-41dd-b48d-b9dbd42d9313";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_20-12-2021_45851.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d68c47e-d257-41dd-b48d-b9dbd42d9313>.
+    
+<http://data.lblod.info/id/remote-data-objects/08240aaf-32ef-4b29-8cb9-2621540f794c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08240aaf-32ef-4b29-8cb9-2621540f794c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_20-12-2021_45852.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08240aaf-32ef-4b29-8cb9-2621540f794c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fa079fd-5675-4d0c-93f9-8ba69d7a9677> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fa079fd-5675-4d0c-93f9-8ba69d7a9677";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_20-12-2021_45853.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fa079fd-5675-4d0c-93f9-8ba69d7a9677>.
+    
+<http://data.lblod.info/id/remote-data-objects/bff37dc3-915c-4bac-89f5-92f85b208087> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bff37dc3-915c-4bac-89f5-92f85b208087";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_20-12-2021_45854.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bff37dc3-915c-4bac-89f5-92f85b208087>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b16f24d-d581-4a05-98a6-2d2a008114e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b16f24d-d581-4a05-98a6-2d2a008114e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_20-12-2021_45855.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b16f24d-d581-4a05-98a6-2d2a008114e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fd23337-7f8d-4aa2-addf-b04424a5e5eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fd23337-7f8d-4aa2-addf-b04424a5e5eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_20-12-2021_45856.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fd23337-7f8d-4aa2-addf-b04424a5e5eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/32ef2f9e-603c-4306-8857-a3edb78670a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32ef2f9e-603c-4306-8857-a3edb78670a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_20-12-2021_45858.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32ef2f9e-603c-4306-8857-a3edb78670a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f83ae05-46f8-46a3-b013-878874c35155> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f83ae05-46f8-46a3-b013-878874c35155";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_20-12-2021_45859.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f83ae05-46f8-46a3-b013-878874c35155>.
+    
+<http://data.lblod.info/id/remote-data-objects/e49adda6-a709-4a6c-9dcd-48700fe8528f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e49adda6-a709-4a6c-9dcd-48700fe8528f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_20-12-2021_45901.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e49adda6-a709-4a6c-9dcd-48700fe8528f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6257659-9f53-4e75-a6d5-836e353cb940> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6257659-9f53-4e75-a6d5-836e353cb940";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_20-12-2021_45904.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6257659-9f53-4e75-a6d5-836e353cb940>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf365944-566f-40e3-bdf3-2c4b8ab5b93e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf365944-566f-40e3-bdf3-2c4b8ab5b93e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_20-12-2021_45918.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf365944-566f-40e3-bdf3-2c4b8ab5b93e>.
+    
+<http://data.lblod.info/id/remote-data-objects/22fb1cd2-1417-4be1-af03-fb48306af804> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22fb1cd2-1417-4be1-af03-fb48306af804";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_21-02-2022_46260.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22fb1cd2-1417-4be1-af03-fb48306af804>.
+    
+<http://data.lblod.info/id/remote-data-objects/55bb74e5-c8ec-42df-8d67-41e9ef0cfd9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55bb74e5-c8ec-42df-8d67-41e9ef0cfd9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_21-02-2022_46262.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55bb74e5-c8ec-42df-8d67-41e9ef0cfd9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce131c96-844b-4a59-ac03-47fa1a18d766> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce131c96-844b-4a59-ac03-47fa1a18d766";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_21-02-2022_46490.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce131c96-844b-4a59-ac03-47fa1a18d766>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf92dc5c-90b3-4410-b8eb-b67bf58fafe8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf92dc5c-90b3-4410-b8eb-b67bf58fafe8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_21-02-2022_46514.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf92dc5c-90b3-4410-b8eb-b67bf58fafe8>.
+    
+<http://data.lblod.info/id/remote-data-objects/826dcde3-0aa3-4a36-8217-69d5fd7319af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "826dcde3-0aa3-4a36-8217-69d5fd7319af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_21-02-2022_46550.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/826dcde3-0aa3-4a36-8217-69d5fd7319af>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dcdd1a5-df96-4a7f-a887-055a7ec28c35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dcdd1a5-df96-4a7f-a887-055a7ec28c35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_21-02-2022_46552.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dcdd1a5-df96-4a7f-a887-055a7ec28c35>.
+    
+<http://data.lblod.info/id/remote-data-objects/278cdf3d-127c-4495-bd06-9022507b73aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "278cdf3d-127c-4495-bd06-9022507b73aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_21-02-2022_46553.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/278cdf3d-127c-4495-bd06-9022507b73aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/73fbe982-c46e-4a03-a847-4afaeca25428> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73fbe982-c46e-4a03-a847-4afaeca25428";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_21-02-2022_46595.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73fbe982-c46e-4a03-a847-4afaeca25428>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ec4230c-6730-4a4e-9a14-465874b3cc95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ec4230c-6730-4a4e-9a14-465874b3cc95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_21-02-2022_46596.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ec4230c-6730-4a4e-9a14-465874b3cc95>.
+    
+<http://data.lblod.info/id/remote-data-objects/6db5a8d3-9393-4db2-a6d1-e0df7c1dbfe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6db5a8d3-9393-4db2-a6d1-e0df7c1dbfe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_21-02-2022_46602.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6db5a8d3-9393-4db2-a6d1-e0df7c1dbfe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b5b43d7-7b11-4f14-86ae-5c87fd3a3d30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b5b43d7-7b11-4f14-86ae-5c87fd3a3d30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_21-02-2022_46698.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b5b43d7-7b11-4f14-86ae-5c87fd3a3d30>.
+    
+<http://data.lblod.info/id/remote-data-objects/9823adab-8b48-4461-85a1-a02c427ebd3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9823adab-8b48-4461-85a1-a02c427ebd3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_21-02-2022_46701.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9823adab-8b48-4461-85a1-a02c427ebd3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/09b876e7-c407-4fd9-af40-5bfb2f78fd86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09b876e7-c407-4fd9-af40-5bfb2f78fd86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_25-04-2022_47504.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09b876e7-c407-4fd9-af40-5bfb2f78fd86>.
+    
+<http://data.lblod.info/id/remote-data-objects/04d3262d-9be4-4177-8240-32c8e3b093f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04d3262d-9be4-4177-8240-32c8e3b093f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_25-04-2022_47506.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04d3262d-9be4-4177-8240-32c8e3b093f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/562d1abd-a164-49d6-960f-0eff49ed7b3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "562d1abd-a164-49d6-960f-0eff49ed7b3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_25-04-2022_47759.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/562d1abd-a164-49d6-960f-0eff49ed7b3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/194f538e-ebfe-4195-8426-d7191d6136f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "194f538e-ebfe-4195-8426-d7191d6136f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_25-04-2022_47798.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/194f538e-ebfe-4195-8426-d7191d6136f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9ba4e27-054f-4f23-85f8-7eb3fb10527c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9ba4e27-054f-4f23-85f8-7eb3fb10527c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_25-04-2022_47799.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9ba4e27-054f-4f23-85f8-7eb3fb10527c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2da83ffd-78f4-4101-89ea-1d8f05ca8911> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2da83ffd-78f4-4101-89ea-1d8f05ca8911";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_25-10-2021_45124.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2da83ffd-78f4-4101-89ea-1d8f05ca8911>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b80afa4-19a2-41af-9368-e95e0e61c4ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b80afa4-19a2-41af-9368-e95e0e61c4ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_27-06-2022_47176.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5ba3a80a-aae0-4923-94a7-b022e8ea0bb6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b80afa4-19a2-41af-9368-e95e0e61c4ff>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201308-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201308-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201308-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201308-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/cffcd82c-505e-4247-afd6-cdcf7123abf6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cffcd82c-505e-4247-afd6-cdcf7123abf6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d774bf67-9a06-4732-8e6c-b0b8d5e4b74d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d774bf67-9a06-4732-8e6c-b0b8d5e4b74d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd>.
+
+  <http://redpencil.data.gift/id/task/340d8c46-a646-4a54-97eb-631ec23abcf6> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "340d8c46-a646-4a54-97eb-631ec23abcf6";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/cffcd82c-505e-4247-afd6-cdcf7123abf6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d774bf67-9a06-4732-8e6c-b0b8d5e4b74d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/dd50492f-baf3-443e-879f-846fe0482877> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd50492f-baf3-443e-879f-846fe0482877";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_27-06-2022_47185.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd50492f-baf3-443e-879f-846fe0482877>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1ca7efc-caf5-40a6-a0ba-3f45100100f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1ca7efc-caf5-40a6-a0ba-3f45100100f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_27-06-2022_47808.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1ca7efc-caf5-40a6-a0ba-3f45100100f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b3bdd9d-9bba-410a-bda6-4e9625f407a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b3bdd9d-9bba-410a-bda6-4e9625f407a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_27-06-2022_47810.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b3bdd9d-9bba-410a-bda6-4e9625f407a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/72d4f056-2ebd-4eb8-ae39-97b1fd273982> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72d4f056-2ebd-4eb8-ae39-97b1fd273982";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_27-06-2022_48392.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72d4f056-2ebd-4eb8-ae39-97b1fd273982>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9c49d27-f77b-4987-ba72-b9990ef5867d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9c49d27-f77b-4987-ba72-b9990ef5867d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_27-06-2022_48393.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9c49d27-f77b-4987-ba72-b9990ef5867d>.
+    
+<http://data.lblod.info/id/remote-data-objects/607e9c13-6268-4948-8815-654642cc492c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "607e9c13-6268-4948-8815-654642cc492c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_27-06-2022_48654.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/607e9c13-6268-4948-8815-654642cc492c>.
+    
+<http://data.lblod.info/id/remote-data-objects/36c9118f-bb36-44a5-9642-84f5b3b32510> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36c9118f-bb36-44a5-9642-84f5b3b32510";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_28-03-2022_47320.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36c9118f-bb36-44a5-9642-84f5b3b32510>.
+    
+<http://data.lblod.info/id/remote-data-objects/82075eb2-b345-4796-8799-b081d7337054> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82075eb2-b345-4796-8799-b081d7337054";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_28-03-2022_47423.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82075eb2-b345-4796-8799-b081d7337054>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e1218c5-059f-44fb-af62-25ec20c1794d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e1218c5-059f-44fb-af62-25ec20c1794d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_28-03-2022_47424.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e1218c5-059f-44fb-af62-25ec20c1794d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ce70a5a-c994-4b69-921f-dd91602d1fa0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ce70a5a-c994-4b69-921f-dd91602d1fa0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_29-11-2021_45512.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ce70a5a-c994-4b69-921f-dd91602d1fa0>.
+    
+<http://data.lblod.info/id/remote-data-objects/83e2ce8b-d0e3-41a9-8641-f0bb013cc23a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83e2ce8b-d0e3-41a9-8641-f0bb013cc23a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_31-01-2022_46239.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83e2ce8b-d0e3-41a9-8641-f0bb013cc23a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8139af00-a36f-43cb-aefc-045dc44a95a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8139af00-a36f-43cb-aefc-045dc44a95a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.bredene.be/LBLODWeb/Home/Overzicht/fb8313e714fe1aee8d6c27ff876ce2fc3096d25fccd25dbebcb244f2cfee7c69/GetPublication?filename=Uittreksels_31-01-2022_46477.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8139af00-a36f-43cb-aefc-045dc44a95a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/45e05530-c1f6-4f4d-9b4a-ea63d27360e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45e05530-c1f6-4f4d-9b4a-ea63d27360e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Agenda_gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45e05530-c1f6-4f4d-9b4a-ea63d27360e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8978517-4c02-4810-b4c3-9770f79384d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8978517-4c02-4810-b4c3-9770f79384d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Agenda_gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8978517-4c02-4810-b4c3-9770f79384d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ce5f543-0d84-40f7-98b2-c93c4af6ddae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ce5f543-0d84-40f7-98b2-c93c4af6ddae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Agenda_gemeenteraad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ce5f543-0d84-40f7-98b2-c93c4af6ddae>.
+    
+<http://data.lblod.info/id/remote-data-objects/29b464ae-11be-4219-a465-00b922e49a4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29b464ae-11be-4219-a465-00b922e49a4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Agenda_gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29b464ae-11be-4219-a465-00b922e49a4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8165bd4-78d4-4672-8cea-a0ffcef66d49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8165bd4-78d4-4672-8cea-a0ffcef66d49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Agenda_gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8165bd4-78d4-4672-8cea-a0ffcef66d49>.
+    
+<http://data.lblod.info/id/remote-data-objects/deb4a01d-c725-4d18-a9c2-fe84daf2bcfb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "deb4a01d-c725-4d18-a9c2-fe84daf2bcfb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Agenda_gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/deb4a01d-c725-4d18-a9c2-fe84daf2bcfb>.
+    
+<http://data.lblod.info/id/remote-data-objects/91b9d29d-92e6-4c8f-b850-6a13f0761432> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91b9d29d-92e6-4c8f-b850-6a13f0761432";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Agenda_gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91b9d29d-92e6-4c8f-b850-6a13f0761432>.
+    
+<http://data.lblod.info/id/remote-data-objects/257ebfa5-c64b-461f-a895-834462e57003> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "257ebfa5-c64b-461f-a895-834462e57003";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Agenda_gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/257ebfa5-c64b-461f-a895-834462e57003>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c9aa0db-e3e3-4fed-85a3-babf304c0c40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c9aa0db-e3e3-4fed-85a3-babf304c0c40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Agenda_gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c9aa0db-e3e3-4fed-85a3-babf304c0c40>.
+    
+<http://data.lblod.info/id/remote-data-objects/61867ab2-6685-4dc5-b65a-ec7fce6a800f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61867ab2-6685-4dc5-b65a-ec7fce6a800f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=BesluitenLijst_gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61867ab2-6685-4dc5-b65a-ec7fce6a800f>.
+    
+<http://data.lblod.info/id/remote-data-objects/929b21f8-8f1a-4004-b4ce-8e37f3503533> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "929b21f8-8f1a-4004-b4ce-8e37f3503533";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=BesluitenLijst_gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/929b21f8-8f1a-4004-b4ce-8e37f3503533>.
+    
+<http://data.lblod.info/id/remote-data-objects/671a242f-d1d5-434a-8e3d-cb223b2cf7c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "671a242f-d1d5-434a-8e3d-cb223b2cf7c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=BesluitenLijst_gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/671a242f-d1d5-434a-8e3d-cb223b2cf7c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/300a94c7-ea7b-4dc7-9096-f3cc1ecc43ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "300a94c7-ea7b-4dc7-9096-f3cc1ecc43ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=BesluitenLijst_gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/300a94c7-ea7b-4dc7-9096-f3cc1ecc43ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/16b6bd2b-e012-423c-b005-04b9d4e1d2b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16b6bd2b-e012-423c-b005-04b9d4e1d2b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=BesluitenLijst_gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16b6bd2b-e012-423c-b005-04b9d4e1d2b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2aceb9b-9786-48f8-ac63-40929818a576> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2aceb9b-9786-48f8-ac63-40929818a576";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2aceb9b-9786-48f8-ac63-40929818a576>.
+    
+<http://data.lblod.info/id/remote-data-objects/228c947f-6ac8-41a3-ae47-1d3cfa661945> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "228c947f-6ac8-41a3-ae47-1d3cfa661945";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/228c947f-6ac8-41a3-ae47-1d3cfa661945>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc06e148-eed2-43a8-ae6a-dfcf794effc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc06e148-eed2-43a8-ae6a-dfcf794effc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc06e148-eed2-43a8-ae6a-dfcf794effc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/039544d8-1912-48ae-821a-6972159dabd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "039544d8-1912-48ae-821a-6972159dabd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/039544d8-1912-48ae-821a-6972159dabd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a338019d-0bbe-4403-88e4-8ac57b8658d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a338019d-0bbe-4403-88e4-8ac57b8658d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Notulen_gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a338019d-0bbe-4403-88e4-8ac57b8658d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff4ac62f-1572-4d74-b4a7-ca09e4c0796b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff4ac62f-1572-4d74-b4a7-ca09e4c0796b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Notulen_gemeenteraad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff4ac62f-1572-4d74-b4a7-ca09e4c0796b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1b04655-b221-43c9-9834-8df23e663613> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1b04655-b221-43c9-9834-8df23e663613";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Notulen_gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1b04655-b221-43c9-9834-8df23e663613>.
+    
+<http://data.lblod.info/id/remote-data-objects/3998093c-add2-4fcf-a432-65c352e97231> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3998093c-add2-4fcf-a432-65c352e97231";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Notulen_gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3998093c-add2-4fcf-a432-65c352e97231>.
+    
+<http://data.lblod.info/id/remote-data-objects/614b65e4-05d5-4948-9306-f8367296b3c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "614b65e4-05d5-4948-9306-f8367296b3c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Notulen_gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/614b65e4-05d5-4948-9306-f8367296b3c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e95f07d-6366-4698-8809-0e5db05c741f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e95f07d-6366-4698-8809-0e5db05c741f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Notulen_gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e95f07d-6366-4698-8809-0e5db05c741f>.
+    
+<http://data.lblod.info/id/remote-data-objects/683e32f0-a0d6-4446-9764-3cf3f440a94f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "683e32f0-a0d6-4446-9764-3cf3f440a94f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Notulen_gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/683e32f0-a0d6-4446-9764-3cf3f440a94f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2aaaacc7-19d4-4cb7-ab9d-355a1a363702> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2aaaacc7-19d4-4cb7-ab9d-355a1a363702";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Notulen_gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2aaaacc7-19d4-4cb7-ab9d-355a1a363702>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa14b0a2-507a-4e4c-8e1e-8c45a36efbc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa14b0a2-507a-4e4c-8e1e-8c45a36efbc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=ToegevoegdeAgenda_gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa14b0a2-507a-4e4c-8e1e-8c45a36efbc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbc42ea4-9279-48a6-b022-56d0c6236046> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbc42ea4-9279-48a6-b022-56d0c6236046";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=ToegevoegdeAgenda_gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbc42ea4-9279-48a6-b022-56d0c6236046>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd7ba184-9728-483a-b80d-4ebf4aa17747> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd7ba184-9728-483a-b80d-4ebf4aa17747";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=ToegevoegdeAgenda_gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd7ba184-9728-483a-b80d-4ebf4aa17747>.
+    
+<http://data.lblod.info/id/remote-data-objects/e60e240d-2aa7-4704-9902-bae4085a11ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e60e240d-2aa7-4704-9902-bae4085a11ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=ToegevoegdeAgenda_gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e60e240d-2aa7-4704-9902-bae4085a11ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/84048e97-ad62-49f8-8b01-1184cc8f6ba3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84048e97-ad62-49f8-8b01-1184cc8f6ba3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_19-05-2022_39545.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84048e97-ad62-49f8-8b01-1184cc8f6ba3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2b0856a-6b34-4894-86e5-8bf9372150c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2b0856a-6b34-4894-86e5-8bf9372150c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_19-05-2022_39548.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2b0856a-6b34-4894-86e5-8bf9372150c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c783081-d8b2-49d9-b5a5-b9170960416e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c783081-d8b2-49d9-b5a5-b9170960416e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_19-05-2022_39674.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c783081-d8b2-49d9-b5a5-b9170960416e>.
+    
+<http://data.lblod.info/id/remote-data-objects/996b6b5f-3526-4592-b1ff-d042559e281e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "996b6b5f-3526-4592-b1ff-d042559e281e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-06-2022_39704.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/996b6b5f-3526-4592-b1ff-d042559e281e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b9a511e-c2a0-4e70-84b6-e8b930e403f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b9a511e-c2a0-4e70-84b6-e8b930e403f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-06-2022_39855.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b9a511e-c2a0-4e70-84b6-e8b930e403f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c6f3870-0b8a-4bde-9b5d-b1ff13e98397> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c6f3870-0b8a-4bde-9b5d-b1ff13e98397";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-06-2022_39908.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c6f3870-0b8a-4bde-9b5d-b1ff13e98397>.
+    
+<http://data.lblod.info/id/remote-data-objects/77b88c7c-021b-472f-9540-4772d97fc22a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77b88c7c-021b-472f-9540-4772d97fc22a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-06-2022_39911.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77b88c7c-021b-472f-9540-4772d97fc22a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cca84f1-f7f5-440d-b01a-f9cd11ddee06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cca84f1-f7f5-440d-b01a-f9cd11ddee06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-06-2022_39912.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cf7a1cb-a844-4f8f-a9ca-19dcd1295bdd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cca84f1-f7f5-440d-b01a-f9cd11ddee06>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201309-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201309-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201309-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201309-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/5e9391e9-57f9-4e90-883f-25d7b7bfa0da> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5e9391e9-57f9-4e90-883f-25d7b7bfa0da";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7532811a-592e-4ec5-9d57-2afcb39c8b9f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9360484e-dbff-49e6-9c20-7ec015b67456> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9360484e-dbff-49e6-9c20-7ec015b67456";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f>.
+
+  <http://redpencil.data.gift/id/task/03666026-6f91-41b9-a73d-4bfe53a7d8d7> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "03666026-6f91-41b9-a73d-4bfe53a7d8d7";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/5e9391e9-57f9-4e90-883f-25d7b7bfa0da>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9360484e-dbff-49e6-9c20-7ec015b67456>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/92e25a38-3d55-4448-ab57-13c4eb5d9fe4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92e25a38-3d55-4448-ab57-13c4eb5d9fe4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-06-2022_40172.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92e25a38-3d55-4448-ab57-13c4eb5d9fe4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fd0fda7-7282-4947-991c-1ecd442e4d8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fd0fda7-7282-4947-991c-1ecd442e4d8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-06-2022_40188.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fd0fda7-7282-4947-991c-1ecd442e4d8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ca3d3a0-9273-4d8b-9c29-e4e8b01bd330> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ca3d3a0-9273-4d8b-9c29-e4e8b01bd330";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-06-2022_40191.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ca3d3a0-9273-4d8b-9c29-e4e8b01bd330>.
+    
+<http://data.lblod.info/id/remote-data-objects/197844d3-ea5b-499a-bf7e-009219cbc2d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "197844d3-ea5b-499a-bf7e-009219cbc2d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-06-2022_40192.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/197844d3-ea5b-499a-bf7e-009219cbc2d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/48c9dc21-5401-4f7f-8ce6-b1dfb58e0dc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48c9dc21-5401-4f7f-8ce6-b1dfb58e0dc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-06-2022_40240.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48c9dc21-5401-4f7f-8ce6-b1dfb58e0dc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f65ddc15-f49b-4905-9d6c-e0e5b7494f0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f65ddc15-f49b-4905-9d6c-e0e5b7494f0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-12-2021_36655.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f65ddc15-f49b-4905-9d6c-e0e5b7494f0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb687b8e-0f42-48d8-8ac3-1f8ea4e93db2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb687b8e-0f42-48d8-8ac3-1f8ea4e93db2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-12-2021_36656.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb687b8e-0f42-48d8-8ac3-1f8ea4e93db2>.
+    
+<http://data.lblod.info/id/remote-data-objects/494bb97e-8751-4f63-8e0d-f9aac3cb668b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "494bb97e-8751-4f63-8e0d-f9aac3cb668b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-12-2021_36659.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/494bb97e-8751-4f63-8e0d-f9aac3cb668b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2081daac-4359-4dbc-915c-57a62607bbd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2081daac-4359-4dbc-915c-57a62607bbd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-12-2021_36662.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2081daac-4359-4dbc-915c-57a62607bbd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d7b80fd-f0b9-4a34-8f33-0c28658720e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d7b80fd-f0b9-4a34-8f33-0c28658720e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-12-2021_36663.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d7b80fd-f0b9-4a34-8f33-0c28658720e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e236622c-45ec-4633-8ed9-68394623a9af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e236622c-45ec-4633-8ed9-68394623a9af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-12-2021_36665.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e236622c-45ec-4633-8ed9-68394623a9af>.
+    
+<http://data.lblod.info/id/remote-data-objects/99f5595f-4ab0-4b04-b738-222f5ba2e56b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99f5595f-4ab0-4b04-b738-222f5ba2e56b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-12-2021_36666.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99f5595f-4ab0-4b04-b738-222f5ba2e56b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b302a831-e4ea-44a7-9269-6829a840ee51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b302a831-e4ea-44a7-9269-6829a840ee51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-12-2021_36667.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b302a831-e4ea-44a7-9269-6829a840ee51>.
+    
+<http://data.lblod.info/id/remote-data-objects/a068b05e-e74b-473c-9d32-42d7c231c7d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a068b05e-e74b-473c-9d32-42d7c231c7d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-12-2021_36669.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a068b05e-e74b-473c-9d32-42d7c231c7d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2102e93-3005-447c-b36f-412613ec7f8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2102e93-3005-447c-b36f-412613ec7f8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-12-2021_36994.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2102e93-3005-447c-b36f-412613ec7f8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/94db4ce6-5f27-412a-9ff5-bb425d21ee04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94db4ce6-5f27-412a-9ff5-bb425d21ee04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-12-2021_37000.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94db4ce6-5f27-412a-9ff5-bb425d21ee04>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4242337-f199-47cc-b69a-dec7a18eddd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4242337-f199-47cc-b69a-dec7a18eddd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-12-2021_37006.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4242337-f199-47cc-b69a-dec7a18eddd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/08dd0778-4895-4107-a6a1-0dd258e821e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08dd0778-4895-4107-a6a1-0dd258e821e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-12-2021_37027.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08dd0778-4895-4107-a6a1-0dd258e821e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4174b3e7-8553-412d-b661-dcb43b33cc82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4174b3e7-8553-412d-b661-dcb43b33cc82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-12-2021_37119.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4174b3e7-8553-412d-b661-dcb43b33cc82>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ec665ce-dec3-4276-9d06-b00a53709375> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ec665ce-dec3-4276-9d06-b00a53709375";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-12-2021_37296.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ec665ce-dec3-4276-9d06-b00a53709375>.
+    
+<http://data.lblod.info/id/remote-data-objects/75a843df-b7de-4f50-8e96-7a3aa5eb49b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75a843df-b7de-4f50-8e96-7a3aa5eb49b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_23-12-2021_37405.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75a843df-b7de-4f50-8e96-7a3aa5eb49b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7160cf5-cdb3-458f-8b00-34da536db0b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7160cf5-cdb3-458f-8b00-34da536db0b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_24-02-2022_37993.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7160cf5-cdb3-458f-8b00-34da536db0b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/114ad167-2ca5-4de6-87e8-fe58a4f21661> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "114ad167-2ca5-4de6-87e8-fe58a4f21661";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_24-02-2022_38185.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/114ad167-2ca5-4de6-87e8-fe58a4f21661>.
+    
+<http://data.lblod.info/id/remote-data-objects/044f6f6a-bbab-46f7-a3f8-5ae138baa866> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "044f6f6a-bbab-46f7-a3f8-5ae138baa866";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_24-03-2022_38315.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/044f6f6a-bbab-46f7-a3f8-5ae138baa866>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2015892-1aeb-4a79-8cb7-05c629decefa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2015892-1aeb-4a79-8cb7-05c629decefa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_24-03-2022_38764.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2015892-1aeb-4a79-8cb7-05c629decefa>.
+    
+<http://data.lblod.info/id/remote-data-objects/61c6b5b4-6662-4e56-9768-acb218d9d249> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61c6b5b4-6662-4e56-9768-acb218d9d249";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_25-11-2021_36180.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61c6b5b4-6662-4e56-9768-acb218d9d249>.
+    
+<http://data.lblod.info/id/remote-data-objects/4401c5c0-0cba-4424-b0bf-855b3a3b0e98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4401c5c0-0cba-4424-b0bf-855b3a3b0e98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_25-11-2021_36572.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4401c5c0-0cba-4424-b0bf-855b3a3b0e98>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c287d43-d862-48fd-a3f3-2c6c1e4b6830> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c287d43-d862-48fd-a3f3-2c6c1e4b6830";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_25-11-2021_36647.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c287d43-d862-48fd-a3f3-2c6c1e4b6830>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f6677ea-967d-4b32-9002-14b4ef764359> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f6677ea-967d-4b32-9002-14b4ef764359";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_25-11-2021_36650.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f6677ea-967d-4b32-9002-14b4ef764359>.
+    
+<http://data.lblod.info/id/remote-data-objects/95426573-fdb3-44c2-81f9-feff4628f66b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95426573-fdb3-44c2-81f9-feff4628f66b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_25-11-2021_36813.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95426573-fdb3-44c2-81f9-feff4628f66b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c02eceb5-9b7a-4849-8f53-9fa67b56e026> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c02eceb5-9b7a-4849-8f53-9fa67b56e026";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_27-01-2022_37589.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c02eceb5-9b7a-4849-8f53-9fa67b56e026>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c11a182-0490-46d7-a1c4-a8a541f56fe7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c11a182-0490-46d7-a1c4-a8a541f56fe7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_27-01-2022_37669.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c11a182-0490-46d7-a1c4-a8a541f56fe7>.
+    
+<http://data.lblod.info/id/remote-data-objects/5169a489-3e8e-47dc-b2a6-34f9a6b7b5d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5169a489-3e8e-47dc-b2a6-34f9a6b7b5d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_28-04-2022_39164.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5169a489-3e8e-47dc-b2a6-34f9a6b7b5d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/88e1e65d-6e34-44fd-942e-a7d0c90660de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88e1e65d-6e34-44fd-942e-a7d0c90660de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_28-04-2022_39345.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88e1e65d-6e34-44fd-942e-a7d0c90660de>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a6b9f1a-997c-41c0-86a9-5ee7631ef6e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a6b9f1a-997c-41c0-86a9-5ee7631ef6e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_28-04-2022_39371.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a6b9f1a-997c-41c0-86a9-5ee7631ef6e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/49dec3e6-f293-4218-9e6f-3509d4749ace> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49dec3e6-f293-4218-9e6f-3509d4749ace";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_28-04-2022_39373.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49dec3e6-f293-4218-9e6f-3509d4749ace>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b0ee0d5-4537-4e8c-8f77-705ba51d7f01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b0ee0d5-4537-4e8c-8f77-705ba51d7f01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_28-10-2021_29416.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b0ee0d5-4537-4e8c-8f77-705ba51d7f01>.
+    
+<http://data.lblod.info/id/remote-data-objects/3418b8c5-7682-4a20-aa53-02ba5d452815> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3418b8c5-7682-4a20-aa53-02ba5d452815";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_28-10-2021_36008.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3418b8c5-7682-4a20-aa53-02ba5d452815>.
+    
+<http://data.lblod.info/id/remote-data-objects/889d59fe-7ae3-48f4-85b6-72509960d085> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "889d59fe-7ae3-48f4-85b6-72509960d085";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_28-10-2021_36038.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/889d59fe-7ae3-48f4-85b6-72509960d085>.
+    
+<http://data.lblod.info/id/remote-data-objects/cea7e063-5a86-436c-84fe-2a9c2aa08966> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cea7e063-5a86-436c-84fe-2a9c2aa08966";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_28-10-2021_36068.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cea7e063-5a86-436c-84fe-2a9c2aa08966>.
+    
+<http://data.lblod.info/id/remote-data-objects/33282202-5cf4-4f03-adcf-c30be9d71e40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33282202-5cf4-4f03-adcf-c30be9d71e40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/0b6f3318fba1b7394ae8d4e8a0d06683796ae6b87f5dcdcf2c9cba2840b5b84e/GetPublication?filename=Uittreksels_28-10-2021_36310.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33282202-5cf4-4f03-adcf-c30be9d71e40>.
+    
+<http://data.lblod.info/id/remote-data-objects/1554a391-028f-448c-9b72-eaa041d663e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1554a391-028f-448c-9b72-eaa041d663e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1554a391-028f-448c-9b72-eaa041d663e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/30b5e2a9-bb02-4c67-b26c-ab324c2a4345> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30b5e2a9-bb02-4c67-b26c-ab324c2a4345";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30b5e2a9-bb02-4c67-b26c-ab324c2a4345>.
+    
+<http://data.lblod.info/id/remote-data-objects/6848b179-2107-49a1-85ce-58017b7d9960> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6848b179-2107-49a1-85ce-58017b7d9960";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6848b179-2107-49a1-85ce-58017b7d9960>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b7e7cbf-efcc-4108-8660-c0f972e317b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b7e7cbf-efcc-4108-8660-c0f972e317b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b7e7cbf-efcc-4108-8660-c0f972e317b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5db5224-add4-4359-9d06-cc2c7aafe7c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5db5224-add4-4359-9d06-cc2c7aafe7c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5db5224-add4-4359-9d06-cc2c7aafe7c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ad1865c-d094-4428-8ad1-9b940ec5fbe6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ad1865c-d094-4428-8ad1-9b940ec5fbe6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ad1865c-d094-4428-8ad1-9b940ec5fbe6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d3070fd-04d3-4015-ae43-2ae673e91b11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d3070fd-04d3-4015-ae43-2ae673e91b11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d3070fd-04d3-4015-ae43-2ae673e91b11>.
+    
+<http://data.lblod.info/id/remote-data-objects/606bdd7b-44c9-4702-9435-469cbde19e52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "606bdd7b-44c9-4702-9435-469cbde19e52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/606bdd7b-44c9-4702-9435-469cbde19e52>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c2e39ef-d207-426f-9f4c-c23a5e4da1de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c2e39ef-d207-426f-9f4c-c23a5e4da1de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7532811a-592e-4ec5-9d57-2afcb39c8b9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c2e39ef-d207-426f-9f4c-c23a5e4da1de>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201311-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201311-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201311-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201311-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/ec15c736-6ae9-4ef2-8e61-82f501a20188> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ec15c736-6ae9-4ef2-8e61-82f501a20188";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "774bf547-f188-4312-9c5f-8916f0dc4895";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b0c54406-1b93-4de4-9043-0056ddc2d3cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b0c54406-1b93-4de4-9043-0056ddc2d3cc";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895>.
+
+  <http://redpencil.data.gift/id/task/590328d7-a785-4043-bc42-3aee4062842c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "590328d7-a785-4043-bc42-3aee4062842c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/ec15c736-6ae9-4ef2-8e61-82f501a20188>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b0c54406-1b93-4de4-9043-0056ddc2d3cc>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e8e666ef-cac9-4659-911c-e7596fed3af0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8e666ef-cac9-4659-911c-e7596fed3af0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8e666ef-cac9-4659-911c-e7596fed3af0>.
+    
+<http://data.lblod.info/id/remote-data-objects/49a21198-66a9-4291-a85e-a5986fd3f792> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49a21198-66a9-4291-a85e-a5986fd3f792";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49a21198-66a9-4291-a85e-a5986fd3f792>.
+    
+<http://data.lblod.info/id/remote-data-objects/a68c947f-9a47-4824-82ff-1a722e487531> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a68c947f-9a47-4824-82ff-1a722e487531";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a68c947f-9a47-4824-82ff-1a722e487531>.
+    
+<http://data.lblod.info/id/remote-data-objects/36c0c2ca-aa01-47b5-99a5-8d5e1f2ead5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36c0c2ca-aa01-47b5-99a5-8d5e1f2ead5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36c0c2ca-aa01-47b5-99a5-8d5e1f2ead5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a93ec915-0daa-4095-93dc-1a1f430dd626> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a93ec915-0daa-4095-93dc-1a1f430dd626";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a93ec915-0daa-4095-93dc-1a1f430dd626>.
+    
+<http://data.lblod.info/id/remote-data-objects/451fd21a-1fa6-4cf7-8b91-700acdc0ab42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "451fd21a-1fa6-4cf7-8b91-700acdc0ab42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/451fd21a-1fa6-4cf7-8b91-700acdc0ab42>.
+    
+<http://data.lblod.info/id/remote-data-objects/5415e4c5-5a36-45d2-9c07-2166ef5e82a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5415e4c5-5a36-45d2-9c07-2166ef5e82a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5415e4c5-5a36-45d2-9c07-2166ef5e82a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9e06622-e39c-4f2d-a9a0-30dfafca3fa7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9e06622-e39c-4f2d-a9a0-30dfafca3fa7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9e06622-e39c-4f2d-a9a0-30dfafca3fa7>.
+    
+<http://data.lblod.info/id/remote-data-objects/db018657-a426-4555-8437-05f1ba9eaa31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db018657-a426-4555-8437-05f1ba9eaa31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db018657-a426-4555-8437-05f1ba9eaa31>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e87dae0-0f00-45d2-9675-c5bd3ffea07d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e87dae0-0f00-45d2-9675-c5bd3ffea07d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e87dae0-0f00-45d2-9675-c5bd3ffea07d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3b24fb5-48a9-445c-959c-e686e708df48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3b24fb5-48a9-445c-959c-e686e708df48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_26-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3b24fb5-48a9-445c-959c-e686e708df48>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddaf2b6a-f619-4450-a006-1192f8c744ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddaf2b6a-f619-4450-a006-1192f8c744ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddaf2b6a-f619-4450-a006-1192f8c744ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee7011ce-73d4-4ba1-9ad2-e9c4ffeb4457> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee7011ce-73d4-4ba1-9ad2-e9c4ffeb4457";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee7011ce-73d4-4ba1-9ad2-e9c4ffeb4457>.
+    
+<http://data.lblod.info/id/remote-data-objects/d51a1478-08b2-4386-99b9-0d6777dff082> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d51a1478-08b2-4386-99b9-0d6777dff082";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijst_college%20van%20Burgemeester%20en%20Schepenen_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d51a1478-08b2-4386-99b9-0d6777dff082>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe89e1ed-5552-43a8-9496-4725401eb6b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe89e1ed-5552-43a8-9496-4725401eb6b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe89e1ed-5552-43a8-9496-4725401eb6b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c83e838-33d3-4cc2-9e13-9bcac1858c03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c83e838-33d3-4cc2-9e13-9bcac1858c03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c83e838-33d3-4cc2-9e13-9bcac1858c03>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2525d34-85b1-40ee-8c8b-1e48d51fc691> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2525d34-85b1-40ee-8c8b-1e48d51fc691";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2525d34-85b1-40ee-8c8b-1e48d51fc691>.
+    
+<http://data.lblod.info/id/remote-data-objects/b181f743-37e8-4e9d-b516-d1fee8d7d805> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b181f743-37e8-4e9d-b516-d1fee8d7d805";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b181f743-37e8-4e9d-b516-d1fee8d7d805>.
+    
+<http://data.lblod.info/id/remote-data-objects/81cc8480-1545-4e53-8965-d84c9b1ed425> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81cc8480-1545-4e53-8965-d84c9b1ed425";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81cc8480-1545-4e53-8965-d84c9b1ed425>.
+    
+<http://data.lblod.info/id/remote-data-objects/3346cd5f-f93f-41af-a2f1-9ec2ec38cf0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3346cd5f-f93f-41af-a2f1-9ec2ec38cf0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3346cd5f-f93f-41af-a2f1-9ec2ec38cf0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9df3c881-bfdf-4ea4-9018-7ba63c952c71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9df3c881-bfdf-4ea4-9018-7ba63c952c71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9df3c881-bfdf-4ea4-9018-7ba63c952c71>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2a88ec5-18e7-44ee-868c-07d96fd4ff45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2a88ec5-18e7-44ee-868c-07d96fd4ff45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2a88ec5-18e7-44ee-868c-07d96fd4ff45>.
+    
+<http://data.lblod.info/id/remote-data-objects/905e4e35-0b8b-4107-9421-9ec6d29768d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "905e4e35-0b8b-4107-9421-9ec6d29768d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/905e4e35-0b8b-4107-9421-9ec6d29768d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab47819e-2141-44fe-84e8-beaf7d5163c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab47819e-2141-44fe-84e8-beaf7d5163c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab47819e-2141-44fe-84e8-beaf7d5163c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec57ff3a-8143-4dc6-8bca-a1f7ee1bacfd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec57ff3a-8143-4dc6-8bca-a1f7ee1bacfd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec57ff3a-8143-4dc6-8bca-a1f7ee1bacfd>.
+    
+<http://data.lblod.info/id/remote-data-objects/30223a83-0c20-4637-a868-a1522fc0f88f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30223a83-0c20-4637-a868-a1522fc0f88f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30223a83-0c20-4637-a868-a1522fc0f88f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ed47862-5b9a-4660-af86-8b21a205ebbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ed47862-5b9a-4660-af86-8b21a205ebbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ed47862-5b9a-4660-af86-8b21a205ebbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc4db9e7-6566-4e78-8354-71d2a91a9d50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc4db9e7-6566-4e78-8354-71d2a91a9d50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc4db9e7-6566-4e78-8354-71d2a91a9d50>.
+    
+<http://data.lblod.info/id/remote-data-objects/87f047e1-7a85-434d-838f-2dc3b5b63fdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87f047e1-7a85-434d-838f-2dc3b5b63fdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87f047e1-7a85-434d-838f-2dc3b5b63fdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/21cf9529-80a6-4545-ab01-ce4285cc0449> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21cf9529-80a6-4545-ab01-ce4285cc0449";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21cf9529-80a6-4545-ab01-ce4285cc0449>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd2fc590-ef59-4a5f-b497-3b88ff725b01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd2fc590-ef59-4a5f-b497-3b88ff725b01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd2fc590-ef59-4a5f-b497-3b88ff725b01>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7dc28ee-a76a-4587-b8b3-c8be77627a65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7dc28ee-a76a-4587-b8b3-c8be77627a65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_28-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7dc28ee-a76a-4587-b8b3-c8be77627a65>.
+    
+<http://data.lblod.info/id/remote-data-objects/7065f1c0-f7b1-4534-a209-8a45c21d99fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7065f1c0-f7b1-4534-a209-8a45c21d99fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20Burgemeester%20en%20Schepenen_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7065f1c0-f7b1-4534-a209-8a45c21d99fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e597c59-6437-443c-9440-b2ad39b0cc66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e597c59-6437-443c-9440-b2ad39b0cc66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_01-02-2022_37985.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e597c59-6437-443c-9440-b2ad39b0cc66>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d685955-9c61-4664-892e-d10f7aee9514> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d685955-9c61-4664-892e-d10f7aee9514";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_01-03-2022_38565.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d685955-9c61-4664-892e-d10f7aee9514>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f154304-f8a8-4c5e-a0d7-34f788f8c4d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f154304-f8a8-4c5e-a0d7-34f788f8c4d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_01-03-2022_38753.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f154304-f8a8-4c5e-a0d7-34f788f8c4d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9b188b5-1e91-4dfc-a24b-89e09be3cd8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9b188b5-1e91-4dfc-a24b-89e09be3cd8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_03-05-2022_39707.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9b188b5-1e91-4dfc-a24b-89e09be3cd8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c82be0c4-22ba-48a4-838f-aa992b8db5a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c82be0c4-22ba-48a4-838f-aa992b8db5a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_05-04-2022_39272.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c82be0c4-22ba-48a4-838f-aa992b8db5a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ab985d1-8084-4384-9b43-54e92180f6dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ab985d1-8084-4384-9b43-54e92180f6dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_05-04-2022_39289.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ab985d1-8084-4384-9b43-54e92180f6dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebf402fb-b4a1-4bfc-a03e-e07a99403111> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebf402fb-b4a1-4bfc-a03e-e07a99403111";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_05-04-2022_39333.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebf402fb-b4a1-4bfc-a03e-e07a99403111>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfb2e662-a8b6-4572-98cd-369ae5ec0678> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfb2e662-a8b6-4572-98cd-369ae5ec0678";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_05-10-2021_35946.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfb2e662-a8b6-4572-98cd-369ae5ec0678>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef14b3a6-a951-4790-bb39-7bdad6fafe1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef14b3a6-a951-4790-bb39-7bdad6fafe1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_05-10-2021_35947.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef14b3a6-a951-4790-bb39-7bdad6fafe1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5782528a-805a-437d-8091-c67488962df8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5782528a-805a-437d-8091-c67488962df8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_07-06-2022_40222.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5782528a-805a-437d-8091-c67488962df8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fda9c73-7524-4434-9a0b-2b3bb065da24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fda9c73-7524-4434-9a0b-2b3bb065da24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_07-06-2022_40230.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fda9c73-7524-4434-9a0b-2b3bb065da24>.
+    
+<http://data.lblod.info/id/remote-data-objects/85b8b65f-6cb5-40ea-b589-e2c3cd079b91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85b8b65f-6cb5-40ea-b589-e2c3cd079b91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_07-12-2021_37122.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85b8b65f-6cb5-40ea-b589-e2c3cd079b91>.
+    
+<http://data.lblod.info/id/remote-data-objects/83b156bb-a7e2-46a0-ad41-4976731bf16a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83b156bb-a7e2-46a0-ad41-4976731bf16a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_08-02-2022_38182.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83b156bb-a7e2-46a0-ad41-4976731bf16a>.
+    
+<http://data.lblod.info/id/remote-data-objects/31c3c353-12b5-475b-89df-509dd9b190b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31c3c353-12b5-475b-89df-509dd9b190b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_08-02-2022_38187.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31c3c353-12b5-475b-89df-509dd9b190b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/d28c435a-7206-47e0-b541-0eb4e0e56703> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d28c435a-7206-47e0-b541-0eb4e0e56703";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_08-02-2022_38188.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d28c435a-7206-47e0-b541-0eb4e0e56703>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb61c1c9-facd-4eff-8c67-9df384e38d43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb61c1c9-facd-4eff-8c67-9df384e38d43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_08-03-2022_38299.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb61c1c9-facd-4eff-8c67-9df384e38d43>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cc29735-9227-453e-b5d0-f109c4e19d8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cc29735-9227-453e-b5d0-f109c4e19d8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_09-11-2021_36701.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/774bf547-f188-4312-9c5f-8916f0dc4895> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cc29735-9227-453e-b5d0-f109c4e19d8b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201312-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201312-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201312-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201312-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/1e9d6113-d388-4bd4-b230-bebfd7ef77b4> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1e9d6113-d388-4bd4-b230-bebfd7ef77b4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e1dd8b62-b0af-480e-858f-d2971499b6dd";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/433f3fda-3607-453a-9530-c1c56d33daec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "433f3fda-3607-453a-9530-c1c56d33daec";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd>.
+
+  <http://redpencil.data.gift/id/task/ef834fa2-6747-473d-aa2c-db8a0327f0a5> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ef834fa2-6747-473d-aa2c-db8a0327f0a5";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/1e9d6113-d388-4bd4-b230-bebfd7ef77b4>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/433f3fda-3607-453a-9530-c1c56d33daec>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b79666bd-4eec-416b-895b-a262a29d9e8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b79666bd-4eec-416b-895b-a262a29d9e8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_09-11-2021_36709.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b79666bd-4eec-416b-895b-a262a29d9e8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f731dc8c-f29d-4438-8699-89c1a343e5b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f731dc8c-f29d-4438-8699-89c1a343e5b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_09-11-2021_36710.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f731dc8c-f29d-4438-8699-89c1a343e5b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c95ce079-e8e5-4677-81e3-9fdb2f2360d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c95ce079-e8e5-4677-81e3-9fdb2f2360d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_09-11-2021_36714.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c95ce079-e8e5-4677-81e3-9fdb2f2360d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/56b4d8b6-22fd-4992-8bce-790584f8a7cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56b4d8b6-22fd-4992-8bce-790584f8a7cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_10-05-2022_39822.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56b4d8b6-22fd-4992-8bce-790584f8a7cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fbc78dd-140a-4d11-ab9d-6ce56d78acef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fbc78dd-140a-4d11-ab9d-6ce56d78acef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_10-05-2022_39826.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fbc78dd-140a-4d11-ab9d-6ce56d78acef>.
+    
+<http://data.lblod.info/id/remote-data-objects/3551dfef-aaa4-466e-933d-6154c31d7acc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3551dfef-aaa4-466e-933d-6154c31d7acc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_10-05-2022_39834.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3551dfef-aaa4-466e-933d-6154c31d7acc>.
+    
+<http://data.lblod.info/id/remote-data-objects/728a1dae-ae33-45ce-a45b-decebb70bb75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "728a1dae-ae33-45ce-a45b-decebb70bb75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_12-07-2022_40751.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/728a1dae-ae33-45ce-a45b-decebb70bb75>.
+    
+<http://data.lblod.info/id/remote-data-objects/6149177c-abea-4826-92ac-3f4eca8fc90e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6149177c-abea-4826-92ac-3f4eca8fc90e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_12-07-2022_40753.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6149177c-abea-4826-92ac-3f4eca8fc90e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e71cc942-3e3f-40f6-b705-86e5dc924cc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e71cc942-3e3f-40f6-b705-86e5dc924cc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_12-07-2022_40754.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e71cc942-3e3f-40f6-b705-86e5dc924cc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/be496419-ec08-4eab-b846-348cc5584886> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be496419-ec08-4eab-b846-348cc5584886";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_12-07-2022_40759.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be496419-ec08-4eab-b846-348cc5584886>.
+    
+<http://data.lblod.info/id/remote-data-objects/45ecfc1f-b0e6-46f9-82ad-be9d7d3bdb80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45ecfc1f-b0e6-46f9-82ad-be9d7d3bdb80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_14-12-2021_37353.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45ecfc1f-b0e6-46f9-82ad-be9d7d3bdb80>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c8dcecd-8faf-41cd-a822-592676e844d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c8dcecd-8faf-41cd-a822-592676e844d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_14-12-2021_37354.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c8dcecd-8faf-41cd-a822-592676e844d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/78af8c5f-052a-41f3-a80c-c84741630c37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78af8c5f-052a-41f3-a80c-c84741630c37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_15-02-2022_38297.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78af8c5f-052a-41f3-a80c-c84741630c37>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e64153f-7bae-47de-ad18-303b3a87f753> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e64153f-7bae-47de-ad18-303b3a87f753";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_15-02-2022_38306.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e64153f-7bae-47de-ad18-303b3a87f753>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d05209b-411c-477c-a484-ff42ee7157dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d05209b-411c-477c-a484-ff42ee7157dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_15-03-2022_38945.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d05209b-411c-477c-a484-ff42ee7157dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/1800e240-2099-4472-b501-f3cffbb35b0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1800e240-2099-4472-b501-f3cffbb35b0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_16-11-2021_36808.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1800e240-2099-4472-b501-f3cffbb35b0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5cd9306-7de0-4315-9980-3e1264f0d97c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5cd9306-7de0-4315-9980-3e1264f0d97c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_17-05-2022_39956.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5cd9306-7de0-4315-9980-3e1264f0d97c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8014ead8-4443-4e6c-a0e3-a2e9f0c91a16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8014ead8-4443-4e6c-a0e3-a2e9f0c91a16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_18-01-2022_37775.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8014ead8-4443-4e6c-a0e3-a2e9f0c91a16>.
+    
+<http://data.lblod.info/id/remote-data-objects/aaa27b07-d4b2-488c-b94f-8cc396bf2d82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aaa27b07-d4b2-488c-b94f-8cc396bf2d82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_19-07-2022_40811.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aaa27b07-d4b2-488c-b94f-8cc396bf2d82>.
+    
+<http://data.lblod.info/id/remote-data-objects/d379f2fb-e70b-4440-97fa-6a013a3b34dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d379f2fb-e70b-4440-97fa-6a013a3b34dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_19-10-2021_36222.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d379f2fb-e70b-4440-97fa-6a013a3b34dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed7caf99-e133-451b-8bc1-e963a2b87b34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed7caf99-e133-451b-8bc1-e963a2b87b34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_19-10-2021_36223.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed7caf99-e133-451b-8bc1-e963a2b87b34>.
+    
+<http://data.lblod.info/id/remote-data-objects/88b21a21-f909-4223-9f9d-d0b768036b5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88b21a21-f909-4223-9f9d-d0b768036b5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_19-10-2021_36226.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88b21a21-f909-4223-9f9d-d0b768036b5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/633c6c05-815a-4e29-94b4-9ea1a9862545> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "633c6c05-815a-4e29-94b4-9ea1a9862545";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_21-06-2022_40388.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/633c6c05-815a-4e29-94b4-9ea1a9862545>.
+    
+<http://data.lblod.info/id/remote-data-objects/cee660c7-655c-4638-b965-634d4d78fafa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cee660c7-655c-4638-b965-634d4d78fafa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_21-06-2022_40481.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cee660c7-655c-4638-b965-634d4d78fafa>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9ea9786-2c61-47c5-b671-34c64ccdd796> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9ea9786-2c61-47c5-b671-34c64ccdd796";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_22-02-2022_38561.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9ea9786-2c61-47c5-b671-34c64ccdd796>.
+    
+<http://data.lblod.info/id/remote-data-objects/11335f20-7d0e-4336-bc77-e0f743575396> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11335f20-7d0e-4336-bc77-e0f743575396";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_22-02-2022_38567.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11335f20-7d0e-4336-bc77-e0f743575396>.
+    
+<http://data.lblod.info/id/remote-data-objects/f857f74e-45a5-4a57-bf26-23a506c61802> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f857f74e-45a5-4a57-bf26-23a506c61802";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_22-02-2022_38568.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f857f74e-45a5-4a57-bf26-23a506c61802>.
+    
+<http://data.lblod.info/id/remote-data-objects/d06f60de-24bf-4990-9b77-c1bbf2a9d3b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d06f60de-24bf-4990-9b77-c1bbf2a9d3b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_22-03-2022_39039.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d06f60de-24bf-4990-9b77-c1bbf2a9d3b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/79dc7683-30cf-40a4-865c-e3be11a08a5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79dc7683-30cf-40a4-865c-e3be11a08a5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_25-01-2022_37882.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79dc7683-30cf-40a4-865c-e3be11a08a5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a035949a-7db5-42f3-b5e7-4b101c831be6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a035949a-7db5-42f3-b5e7-4b101c831be6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_26-10-2021_36513.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a035949a-7db5-42f3-b5e7-4b101c831be6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3516067-3887-498f-b1c0-91cf241e261f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3516067-3887-498f-b1c0-91cf241e261f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_28-06-2022_40561.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3516067-3887-498f-b1c0-91cf241e261f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b26e6670-e532-4063-9dca-6b43a65912d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b26e6670-e532-4063-9dca-6b43a65912d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_28-06-2022_40567.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b26e6670-e532-4063-9dca-6b43a65912d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f6b000f-4f45-44bb-9980-606d2dae7588> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f6b000f-4f45-44bb-9980-606d2dae7588";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_28-06-2022_40569.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f6b000f-4f45-44bb-9980-606d2dae7588>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cdf2392-dfda-41e9-9680-8d8ec58d34f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cdf2392-dfda-41e9-9680-8d8ec58d34f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_28-06-2022_40573.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cdf2392-dfda-41e9-9680-8d8ec58d34f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0d66708-8da1-4e9e-b1fa-d0da419b348d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0d66708-8da1-4e9e-b1fa-d0da419b348d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_28-06-2022_40574.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0d66708-8da1-4e9e-b1fa-d0da419b348d>.
+    
+<http://data.lblod.info/id/remote-data-objects/caee6c29-823f-496e-a4c5-c2a3dbdc08f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "caee6c29-823f-496e-a4c5-c2a3dbdc08f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_29-03-2022_39261.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/caee6c29-823f-496e-a4c5-c2a3dbdc08f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f617af22-4e41-4393-b168-80428b121090> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f617af22-4e41-4393-b168-80428b121090";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_30-11-2021_36979.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f617af22-4e41-4393-b168-80428b121090>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e1f0fb3-f7d4-44db-a918-92bff95e221b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e1f0fb3-f7d4-44db-a918-92bff95e221b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_30-11-2021_36980.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e1f0fb3-f7d4-44db-a918-92bff95e221b>.
+    
+<http://data.lblod.info/id/remote-data-objects/65b9e13e-48f9-436d-8e11-236ccb20a360> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65b9e13e-48f9-436d-8e11-236ccb20a360";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/3eb6c6aca511dc49cc4b884ec6a2df86dfdfffab96b0c522883b02055f50da86/GetPublication?filename=Uittreksels_31-05-2022_40137.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65b9e13e-48f9-436d-8e11-236ccb20a360>.
+    
+<http://data.lblod.info/id/remote-data-objects/98a256d2-09b0-40a6-bb2c-02d478fccf91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98a256d2-09b0-40a6-bb2c-02d478fccf91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/4b7c38cf47f7d08d525ba37cc26cd4d400616a1690af30ad91a6cc6130460b71/GetPublication?filename=BesluitenLijst_besluiten%20van%20de%20burgemeester_01-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98a256d2-09b0-40a6-bb2c-02d478fccf91>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ba7bd7a-fbb3-41ef-b701-7bca1d8d5284> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ba7bd7a-fbb3-41ef-b701-7bca1d8d5284";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ba7bd7a-fbb3-41ef-b701-7bca1d8d5284>.
+    
+<http://data.lblod.info/id/remote-data-objects/48f3222b-1abc-4b73-af2b-04d6248478a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48f3222b-1abc-4b73-af2b-04d6248478a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48f3222b-1abc-4b73-af2b-04d6248478a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/24d5ddda-265b-4f50-bb78-c9f7ed4af9a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24d5ddda-265b-4f50-bb78-c9f7ed4af9a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24d5ddda-265b-4f50-bb78-c9f7ed4af9a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e66f8472-94b3-4d6d-af48-d836540d3f7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e66f8472-94b3-4d6d-af48-d836540d3f7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e66f8472-94b3-4d6d-af48-d836540d3f7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b325f75-b018-43de-b901-8dfb887b3e3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b325f75-b018-43de-b901-8dfb887b3e3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b325f75-b018-43de-b901-8dfb887b3e3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a54c5df-67fa-4022-87cd-ec6cee041913> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a54c5df-67fa-4022-87cd-ec6cee041913";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a54c5df-67fa-4022-87cd-ec6cee041913>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3e3d5c3-3abf-4840-a62f-3a86dd327303> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3e3d5c3-3abf-4840-a62f-3a86dd327303";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3e3d5c3-3abf-4840-a62f-3a86dd327303>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc4a3cc2-7187-4377-8f36-e007ea8954a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc4a3cc2-7187-4377-8f36-e007ea8954a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc4a3cc2-7187-4377-8f36-e007ea8954a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/346f0572-efba-4719-9980-b60e37a45adf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "346f0572-efba-4719-9980-b60e37a45adf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/346f0572-efba-4719-9980-b60e37a45adf>.
+    
+<http://data.lblod.info/id/remote-data-objects/9625c029-8624-42c5-a782-1bdd41c3c58c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9625c029-8624-42c5-a782-1bdd41c3c58c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e1dd8b62-b0af-480e-858f-d2971499b6dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9625c029-8624-42c5-a782-1bdd41c3c58c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201313-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201313-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201313-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201313-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/5b22f552-3f5f-46c0-b58c-6423f24370e4> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5b22f552-3f5f-46c0-b58c-6423f24370e4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5c3f7306-373e-43a5-8ea4-74b76fc197f0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e888f8ca-24a3-4225-afb6-7fda47b5b65e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e888f8ca-24a3-4225-afb6-7fda47b5b65e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0>.
+
+  <http://redpencil.data.gift/id/task/eaef32b8-5e76-403d-bb32-face584d6a10> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "eaef32b8-5e76-403d-bb32-face584d6a10";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/5b22f552-3f5f-46c0-b58c-6423f24370e4>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e888f8ca-24a3-4225-afb6-7fda47b5b65e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/0c57ca9b-81c8-46ba-89e6-e9093b472479> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c57ca9b-81c8-46ba-89e6-e9093b472479";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c57ca9b-81c8-46ba-89e6-e9093b472479>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e891a40-cf43-4d94-979c-8b6931f27961> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e891a40-cf43-4d94-979c-8b6931f27961";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e891a40-cf43-4d94-979c-8b6931f27961>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5772421-ee42-4da1-88d6-fd38cc643d1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5772421-ee42-4da1-88d6-fd38cc643d1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5772421-ee42-4da1-88d6-fd38cc643d1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd650008-0f29-48ff-a647-1f696c8e42c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd650008-0f29-48ff-a647-1f696c8e42c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd650008-0f29-48ff-a647-1f696c8e42c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ad4b74f-02a1-45b2-8116-69a6d461e83d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ad4b74f-02a1-45b2-8116-69a6d461e83d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ad4b74f-02a1-45b2-8116-69a6d461e83d>.
+    
+<http://data.lblod.info/id/remote-data-objects/85073571-4b92-4ffc-9a60-c8b99279fca5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85073571-4b92-4ffc-9a60-c8b99279fca5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85073571-4b92-4ffc-9a60-c8b99279fca5>.
+    
+<http://data.lblod.info/id/remote-data-objects/eaecebc5-ac38-4f47-9ce1-080440258531> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eaecebc5-ac38-4f47-9ce1-080440258531";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eaecebc5-ac38-4f47-9ce1-080440258531>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc6eff79-9f91-4804-8e65-111aabf9be04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc6eff79-9f91-4804-8e65-111aabf9be04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc6eff79-9f91-4804-8e65-111aabf9be04>.
+    
+<http://data.lblod.info/id/remote-data-objects/4aabcba1-e7d6-4827-a36e-56a6b94d5819> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4aabcba1-e7d6-4827-a36e-56a6b94d5819";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4aabcba1-e7d6-4827-a36e-56a6b94d5819>.
+    
+<http://data.lblod.info/id/remote-data-objects/0869ac70-9b92-4f4a-a0aa-e5df4740bcd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0869ac70-9b92-4f4a-a0aa-e5df4740bcd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0869ac70-9b92-4f4a-a0aa-e5df4740bcd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4e6d08e-0c69-438f-9a50-e9e706fbfbb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4e6d08e-0c69-438f-9a50-e9e706fbfbb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4e6d08e-0c69-438f-9a50-e9e706fbfbb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/824e28c5-e1a7-4cdb-b8e3-83ad9c3a919f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "824e28c5-e1a7-4cdb-b8e3-83ad9c3a919f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/824e28c5-e1a7-4cdb-b8e3-83ad9c3a919f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2eb460e4-b710-48ef-b21d-88b3ad584279> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2eb460e4-b710-48ef-b21d-88b3ad584279";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2eb460e4-b710-48ef-b21d-88b3ad584279>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b3f5730-e7b6-4c3f-acf4-bcdaeb927cbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b3f5730-e7b6-4c3f-acf4-bcdaeb927cbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b3f5730-e7b6-4c3f-acf4-bcdaeb927cbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f1678cc-cc77-4182-a380-e67ee6b3986d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f1678cc-cc77-4182-a380-e67ee6b3986d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f1678cc-cc77-4182-a380-e67ee6b3986d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7197e6de-7556-4ee0-963f-5d8d4942cbfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7197e6de-7556-4ee0-963f-5d8d4942cbfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7197e6de-7556-4ee0-963f-5d8d4942cbfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/eed309ba-9eaf-46d5-8df6-4e9dbf1660f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eed309ba-9eaf-46d5-8df6-4e9dbf1660f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Uittreksels_19-05-2022_39804.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eed309ba-9eaf-46d5-8df6-4e9dbf1660f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/87fa92b7-de43-4e87-86d7-035754ad7316> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87fa92b7-de43-4e87-86d7-035754ad7316";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Uittreksels_23-06-2022_39913.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87fa92b7-de43-4e87-86d7-035754ad7316>.
+    
+<http://data.lblod.info/id/remote-data-objects/e667ea8b-8c0f-4194-a16a-0845dba4c7be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e667ea8b-8c0f-4194-a16a-0845dba4c7be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Uittreksels_23-06-2022_40174.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e667ea8b-8c0f-4194-a16a-0845dba4c7be>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7654e9a-de54-4249-bb70-2fd8ae7c3d0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7654e9a-de54-4249-bb70-2fd8ae7c3d0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Uittreksels_23-12-2021_37007.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7654e9a-de54-4249-bb70-2fd8ae7c3d0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f47b3f5e-ffa1-4cd3-9316-d553a37298bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f47b3f5e-ffa1-4cd3-9316-d553a37298bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Uittreksels_24-02-2022_38184.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f47b3f5e-ffa1-4cd3-9316-d553a37298bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3001296-b4ff-4f83-a99b-8641810d4e90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3001296-b4ff-4f83-a99b-8641810d4e90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Uittreksels_24-03-2022_38763.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3001296-b4ff-4f83-a99b-8641810d4e90>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7649658-2da0-4245-a3cb-e6a1a9d51df3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7649658-2da0-4245-a3cb-e6a1a9d51df3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Uittreksels_25-11-2021_36814.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7649658-2da0-4245-a3cb-e6a1a9d51df3>.
+    
+<http://data.lblod.info/id/remote-data-objects/322e1439-c2f9-4357-847e-6050e1e5cb24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "322e1439-c2f9-4357-847e-6050e1e5cb24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Uittreksels_28-04-2022_37988.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/322e1439-c2f9-4357-847e-6050e1e5cb24>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c546702-11e8-485d-98e0-65c578031780> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c546702-11e8-485d-98e0-65c578031780";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/75aa22033361d86fc8f476c7e84b20f7ca9102361f92673e485507bcb150353b/GetPublication?filename=Uittreksels_28-04-2022_39365.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c546702-11e8-485d-98e0-65c578031780>.
+    
+<http://data.lblod.info/id/remote-data-objects/db76c9cc-e420-4ed4-97f6-b68b5736b0a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db76c9cc-e420-4ed4-97f6-b68b5736b0a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_Vast%20Bureau_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db76c9cc-e420-4ed4-97f6-b68b5736b0a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d47af4e3-5344-44b9-9c1a-aadf88ceac0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d47af4e3-5344-44b9-9c1a-aadf88ceac0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_vast%20bureau_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d47af4e3-5344-44b9-9c1a-aadf88ceac0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9d82ca3-bbae-403d-9ef1-81735b5dbc0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9d82ca3-bbae-403d-9ef1-81735b5dbc0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_Vast%20Bureau_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9d82ca3-bbae-403d-9ef1-81735b5dbc0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdfc8e2a-329a-4b20-983d-4343bff6bcea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdfc8e2a-329a-4b20-983d-4343bff6bcea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_vast%20bureau_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdfc8e2a-329a-4b20-983d-4343bff6bcea>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7f092a3-7c75-4f11-93a1-a3ad03e2cec1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7f092a3-7c75-4f11-93a1-a3ad03e2cec1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_vast%20bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7f092a3-7c75-4f11-93a1-a3ad03e2cec1>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e6b0896-3bc4-4bdf-a7de-ec160c058880> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e6b0896-3bc4-4bdf-a7de-ec160c058880";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e6b0896-3bc4-4bdf-a7de-ec160c058880>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac796e5f-e9a7-4e57-bd6d-5b488c350461> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac796e5f-e9a7-4e57-bd6d-5b488c350461";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_vast%20bureau_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac796e5f-e9a7-4e57-bd6d-5b488c350461>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4665e87-a01f-49d2-bfa2-3190c00e5ed4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4665e87-a01f-49d2-bfa2-3190c00e5ed4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_Vast%20Bureau_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4665e87-a01f-49d2-bfa2-3190c00e5ed4>.
+    
+<http://data.lblod.info/id/remote-data-objects/964401bb-d1f4-4c65-975d-8c9b85e8a817> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "964401bb-d1f4-4c65-975d-8c9b85e8a817";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_vast%20bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/964401bb-d1f4-4c65-975d-8c9b85e8a817>.
+    
+<http://data.lblod.info/id/remote-data-objects/0983946f-acfc-42f2-b092-50559d15628a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0983946f-acfc-42f2-b092-50559d15628a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_vast%20bureau_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0983946f-acfc-42f2-b092-50559d15628a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6a709a7-0f1e-4ae0-ae88-1d8062526126> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6a709a7-0f1e-4ae0-ae88-1d8062526126";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_Vast%20Bureau_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6a709a7-0f1e-4ae0-ae88-1d8062526126>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d4ee506-7b33-4ca7-a0eb-7b32f0c55103> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d4ee506-7b33-4ca7-a0eb-7b32f0c55103";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_vast%20bureau_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d4ee506-7b33-4ca7-a0eb-7b32f0c55103>.
+    
+<http://data.lblod.info/id/remote-data-objects/15f36033-7e03-4856-82ab-f9bc6b942c8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15f36033-7e03-4856-82ab-f9bc6b942c8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_Vast%20Bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15f36033-7e03-4856-82ab-f9bc6b942c8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/96ec753b-c4a5-4ec5-87d3-1f4e5da17bd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96ec753b-c4a5-4ec5-87d3-1f4e5da17bd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_vast%20bureau_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96ec753b-c4a5-4ec5-87d3-1f4e5da17bd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8d38e77-913b-4d70-9262-c88744da6245> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8d38e77-913b-4d70-9262-c88744da6245";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_vast%20bureau_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8d38e77-913b-4d70-9262-c88744da6245>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5943ab8-85eb-4c9c-88e5-f51e9a97af7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5943ab8-85eb-4c9c-88e5-f51e9a97af7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5943ab8-85eb-4c9c-88e5-f51e9a97af7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5e83263-75cf-4738-952d-b1940231eff7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5e83263-75cf-4738-952d-b1940231eff7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5e83263-75cf-4738-952d-b1940231eff7>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a13dec3-ad57-42cb-97f7-016f776335f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a13dec3-ad57-42cb-97f7-016f776335f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_vast%20bureau_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a13dec3-ad57-42cb-97f7-016f776335f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/22598c69-6c46-455a-8f2f-33d682da2e33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22598c69-6c46-455a-8f2f-33d682da2e33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_vast%20bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22598c69-6c46-455a-8f2f-33d682da2e33>.
+    
+<http://data.lblod.info/id/remote-data-objects/39d11737-6079-4b23-93fc-7449365036dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39d11737-6079-4b23-93fc-7449365036dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_vast%20bureau_26-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39d11737-6079-4b23-93fc-7449365036dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2d85f14-bd34-4835-9b3c-f8911f778cce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2d85f14-bd34-4835-9b3c-f8911f778cce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_vast%20bureau_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2d85f14-bd34-4835-9b3c-f8911f778cce>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6778544-81a6-48ee-a0ba-195423630c51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6778544-81a6-48ee-a0ba-195423630c51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6778544-81a6-48ee-a0ba-195423630c51>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d4c320f-5782-4fbf-b5f0-bac0142b87d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d4c320f-5782-4fbf-b5f0-bac0142b87d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijst_vast%20bureau_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d4c320f-5782-4fbf-b5f0-bac0142b87d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cd1ddf3-6949-48ad-9062-9a684b3ba067> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cd1ddf3-6949-48ad-9062-9a684b3ba067";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cd1ddf3-6949-48ad-9062-9a684b3ba067>.
+    
+<http://data.lblod.info/id/remote-data-objects/667786d4-ea82-4a78-978c-da249d91e087> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "667786d4-ea82-4a78-978c-da249d91e087";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5c3f7306-373e-43a5-8ea4-74b76fc197f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/667786d4-ea82-4a78-978c-da249d91e087>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201314-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201314-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201314-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201314-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b36af843-a62f-4f6e-aa1a-c4336bd46917> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b36af843-a62f-4f6e-aa1a-c4336bd46917";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1a2a0a01-018a-4ebe-8c59-534cb5b9fb95";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/5b112bf6-7853-4eb3-97b4-a3b29f033909> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5b112bf6-7853-4eb3-97b4-a3b29f033909";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95>.
+
+  <http://redpencil.data.gift/id/task/19d356e2-e0d9-43f9-bd34-06e27604a78e> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "19d356e2-e0d9-43f9-bd34-06e27604a78e";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b36af843-a62f-4f6e-aa1a-c4336bd46917>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/5b112bf6-7853-4eb3-97b4-a3b29f033909>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/68542831-d7e8-45b6-a22e-ee015a7c436f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68542831-d7e8-45b6-a22e-ee015a7c436f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68542831-d7e8-45b6-a22e-ee015a7c436f>.
+    
+<http://data.lblod.info/id/remote-data-objects/40d5450c-5377-4dab-8eca-334c2c279cd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40d5450c-5377-4dab-8eca-334c2c279cd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40d5450c-5377-4dab-8eca-334c2c279cd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/191be4ef-44eb-4882-83cb-aabe0a998da1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "191be4ef-44eb-4882-83cb-aabe0a998da1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/191be4ef-44eb-4882-83cb-aabe0a998da1>.
+    
+<http://data.lblod.info/id/remote-data-objects/33350f74-749f-416c-a140-17b368588f42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33350f74-749f-416c-a140-17b368588f42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33350f74-749f-416c-a140-17b368588f42>.
+    
+<http://data.lblod.info/id/remote-data-objects/134ea225-1e2c-4215-9343-126c566fcf1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "134ea225-1e2c-4215-9343-126c566fcf1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/134ea225-1e2c-4215-9343-126c566fcf1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8aef00b-9743-45d3-b9f6-eed34718826a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8aef00b-9743-45d3-b9f6-eed34718826a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8aef00b-9743-45d3-b9f6-eed34718826a>.
+    
+<http://data.lblod.info/id/remote-data-objects/89e2eef9-7e8d-4144-806f-1c4ae88450ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89e2eef9-7e8d-4144-806f-1c4ae88450ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89e2eef9-7e8d-4144-806f-1c4ae88450ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c40f7fb-6a16-412b-815e-6677b42d9453> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c40f7fb-6a16-412b-815e-6677b42d9453";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c40f7fb-6a16-412b-815e-6677b42d9453>.
+    
+<http://data.lblod.info/id/remote-data-objects/b50f0f7d-cff2-43c0-87f6-3e36b9d0294f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b50f0f7d-cff2-43c0-87f6-3e36b9d0294f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b50f0f7d-cff2-43c0-87f6-3e36b9d0294f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdd82e56-1a5c-4d3f-8683-bd4aa2a1a8ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdd82e56-1a5c-4d3f-8683-bd4aa2a1a8ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdd82e56-1a5c-4d3f-8683-bd4aa2a1a8ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/d75c6e39-2af0-49f7-bad5-91e978ba27a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d75c6e39-2af0-49f7-bad5-91e978ba27a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d75c6e39-2af0-49f7-bad5-91e978ba27a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/88af7d51-47d5-435a-a55e-14f5b1c0b894> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88af7d51-47d5-435a-a55e-14f5b1c0b894";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88af7d51-47d5-435a-a55e-14f5b1c0b894>.
+    
+<http://data.lblod.info/id/remote-data-objects/b06bb5e0-7c07-4171-839c-2f30fc0044eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b06bb5e0-7c07-4171-839c-2f30fc0044eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b06bb5e0-7c07-4171-839c-2f30fc0044eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/e625604c-da26-44ee-8622-e2880b9c3ec0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e625604c-da26-44ee-8622-e2880b9c3ec0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e625604c-da26-44ee-8622-e2880b9c3ec0>.
+    
+<http://data.lblod.info/id/remote-data-objects/94e4369e-cf73-4979-8f7e-089799e80cd4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94e4369e-cf73-4979-8f7e-089799e80cd4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94e4369e-cf73-4979-8f7e-089799e80cd4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a071e176-3825-4731-bd71-8d5c0e173c3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a071e176-3825-4731-bd71-8d5c0e173c3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a071e176-3825-4731-bd71-8d5c0e173c3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/34767f67-2047-41bd-86f3-022970d5ab87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34767f67-2047-41bd-86f3-022970d5ab87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.buggenhout.be/LBLODWeb/Home/Overzicht/9add8682739afb8c87ae26c5bf0b96904c6c5bd42549a5d9fe7c9e9b1bf91d0b/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34767f67-2047-41bd-86f3-022970d5ab87>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fcb5ce9-54f1-4019-9bed-4d972489c859> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fcb5ce9-54f1-4019-9bed-4d972489c859";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fcb5ce9-54f1-4019-9bed-4d972489c859>.
+    
+<http://data.lblod.info/id/remote-data-objects/66d0d6de-d592-4c18-a58c-403ee74cb6ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66d0d6de-d592-4c18-a58c-403ee74cb6ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66d0d6de-d592-4c18-a58c-403ee74cb6ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/6827a669-fa45-4da9-8004-2745dcb7a27c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6827a669-fa45-4da9-8004-2745dcb7a27c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6827a669-fa45-4da9-8004-2745dcb7a27c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b70cc842-0b5a-4446-a1cd-f33cf3537978> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b70cc842-0b5a-4446-a1cd-f33cf3537978";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b70cc842-0b5a-4446-a1cd-f33cf3537978>.
+    
+<http://data.lblod.info/id/remote-data-objects/703642ab-30b4-4af4-9953-01b24344a9aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "703642ab-30b4-4af4-9953-01b24344a9aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/703642ab-30b4-4af4-9953-01b24344a9aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e08f54d-d3ee-4062-8ad8-a168ae28a66d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e08f54d-d3ee-4062-8ad8-a168ae28a66d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e08f54d-d3ee-4062-8ad8-a168ae28a66d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7defeabd-2f97-4970-8e51-cd51212d459e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7defeabd-2f97-4970-8e51-cd51212d459e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7defeabd-2f97-4970-8e51-cd51212d459e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0eb572f3-a608-4e64-9bd4-917cd033cf1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0eb572f3-a608-4e64-9bd4-917cd033cf1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0eb572f3-a608-4e64-9bd4-917cd033cf1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/69ec9c56-ac1e-406b-bf06-b06d6df7f443> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69ec9c56-ac1e-406b-bf06-b06d6df7f443";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=Uittreksels_23-06-2022_14099.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69ec9c56-ac1e-406b-bf06-b06d6df7f443>.
+    
+<http://data.lblod.info/id/remote-data-objects/c66248af-1796-451e-abdf-70e784dcc0c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c66248af-1796-451e-abdf-70e784dcc0c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=Uittreksels_23-06-2022_14241.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c66248af-1796-451e-abdf-70e784dcc0c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a3aa8b4-444e-43a0-817e-6342b9afd89f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a3aa8b4-444e-43a0-817e-6342b9afd89f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=Uittreksels_23-06-2022_14242.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a3aa8b4-444e-43a0-817e-6342b9afd89f>.
+    
+<http://data.lblod.info/id/remote-data-objects/267ce3d4-e971-4890-a879-9acbde441e34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "267ce3d4-e971-4890-a879-9acbde441e34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=Uittreksels_23-12-2021_11742.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/267ce3d4-e971-4890-a879-9acbde441e34>.
+    
+<http://data.lblod.info/id/remote-data-objects/e36316dc-f006-41a1-af1b-57b05f332fe3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e36316dc-f006-41a1-af1b-57b05f332fe3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=Uittreksels_24-03-2022_13024.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e36316dc-f006-41a1-af1b-57b05f332fe3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5f00ac1-490a-4426-b944-02f01701ade9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5f00ac1-490a-4426-b944-02f01701ade9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=Uittreksels_24-03-2022_13305.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5f00ac1-490a-4426-b944-02f01701ade9>.
+    
+<http://data.lblod.info/id/remote-data-objects/006c7088-a272-4ef1-aa60-ab0f68f14aa8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "006c7088-a272-4ef1-aa60-ab0f68f14aa8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=Uittreksels_25-11-2021_11485.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/006c7088-a272-4ef1-aa60-ab0f68f14aa8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0188ecc9-4756-4e75-bec4-ce4ee7a0463f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0188ecc9-4756-4e75-bec4-ce4ee7a0463f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=Uittreksels_25-11-2021_11724.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0188ecc9-4756-4e75-bec4-ce4ee7a0463f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee386cf7-8fc9-4aef-9492-a5c048c8f8f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee386cf7-8fc9-4aef-9492-a5c048c8f8f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=Uittreksels_27-01-2022_12597.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee386cf7-8fc9-4aef-9492-a5c048c8f8f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/95742b78-bfa7-4890-ab95-bcde78f02f32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95742b78-bfa7-4890-ab95-bcde78f02f32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=Uittreksels_27-01-2022_12644.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95742b78-bfa7-4890-ab95-bcde78f02f32>.
+    
+<http://data.lblod.info/id/remote-data-objects/72c60e79-7262-4caf-ac32-f6e2facc1383> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72c60e79-7262-4caf-ac32-f6e2facc1383";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=Uittreksels_27-01-2022_12645.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72c60e79-7262-4caf-ac32-f6e2facc1383>.
+    
+<http://data.lblod.info/id/remote-data-objects/59b0b276-b9f7-4cf0-8ca7-f6770d074461> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59b0b276-b9f7-4cf0-8ca7-f6770d074461";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=Uittreksels_27-01-2022_12649.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59b0b276-b9f7-4cf0-8ca7-f6770d074461>.
+    
+<http://data.lblod.info/id/remote-data-objects/4595d45b-eda2-41ed-9d62-22ad44556df4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4595d45b-eda2-41ed-9d62-22ad44556df4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=Uittreksels_28-04-2022_13538.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4595d45b-eda2-41ed-9d62-22ad44556df4>.
+    
+<http://data.lblod.info/id/remote-data-objects/f96f469c-b31f-4e47-a72d-ca6cd0383b19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f96f469c-b31f-4e47-a72d-ca6cd0383b19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=Uittreksels_28-04-2022_13703.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f96f469c-b31f-4e47-a72d-ca6cd0383b19>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ed00dd2-fb87-4d7d-9c8a-e3aa3d406d6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ed00dd2-fb87-4d7d-9c8a-e3aa3d406d6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/3b08d8da89dd60c0442d0bc3c77f7ce9bef27a24468a2ef255b03c07ca69e10c/GetPublication?filename=Uittreksels_28-10-2021_11494.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ed00dd2-fb87-4d7d-9c8a-e3aa3d406d6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/120940d8-1296-44f9-8ee3-3927c43cdaf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "120940d8-1296-44f9-8ee3-3927c43cdaf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/826e6198cbc95fd5703edfbe2261285063f774451c7fd326358ca04afcd876a8/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/120940d8-1296-44f9-8ee3-3927c43cdaf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7d07103-4346-4f9d-a9f2-507441406de8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7d07103-4346-4f9d-a9f2-507441406de8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/826e6198cbc95fd5703edfbe2261285063f774451c7fd326358ca04afcd876a8/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7d07103-4346-4f9d-a9f2-507441406de8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed554802-667b-4bba-bea5-c158f7b1f731> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed554802-667b-4bba-bea5-c158f7b1f731";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/826e6198cbc95fd5703edfbe2261285063f774451c7fd326358ca04afcd876a8/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed554802-667b-4bba-bea5-c158f7b1f731>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c60c343-eac9-4162-9f13-95cd53019f2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c60c343-eac9-4162-9f13-95cd53019f2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/826e6198cbc95fd5703edfbe2261285063f774451c7fd326358ca04afcd876a8/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c60c343-eac9-4162-9f13-95cd53019f2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f9959d3-1a61-4d4c-8e11-ee354b2b8e41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f9959d3-1a61-4d4c-8e11-ee354b2b8e41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/826e6198cbc95fd5703edfbe2261285063f774451c7fd326358ca04afcd876a8/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f9959d3-1a61-4d4c-8e11-ee354b2b8e41>.
+    
+<http://data.lblod.info/id/remote-data-objects/2380ac66-1a61-4cae-8b98-70d3a1818e61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2380ac66-1a61-4cae-8b98-70d3a1818e61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/826e6198cbc95fd5703edfbe2261285063f774451c7fd326358ca04afcd876a8/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2380ac66-1a61-4cae-8b98-70d3a1818e61>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bf140fb-6266-4967-93e4-4b0b5b0215e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bf140fb-6266-4967-93e4-4b0b5b0215e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/826e6198cbc95fd5703edfbe2261285063f774451c7fd326358ca04afcd876a8/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bf140fb-6266-4967-93e4-4b0b5b0215e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/805e7be3-ca4d-4ecd-ad03-bfe8b37f1948> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "805e7be3-ca4d-4ecd-ad03-bfe8b37f1948";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/826e6198cbc95fd5703edfbe2261285063f774451c7fd326358ca04afcd876a8/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/805e7be3-ca4d-4ecd-ad03-bfe8b37f1948>.
+    
+<http://data.lblod.info/id/remote-data-objects/64629969-6bd0-42fb-8a77-ecd814c7299a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64629969-6bd0-42fb-8a77-ecd814c7299a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/826e6198cbc95fd5703edfbe2261285063f774451c7fd326358ca04afcd876a8/GetPublication?filename=Uittreksels_23-12-2021_11741.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64629969-6bd0-42fb-8a77-ecd814c7299a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9a9676d-ae3c-4ae5-bdea-4d0f38ca1eca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9a9676d-ae3c-4ae5-bdea-4d0f38ca1eca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/826e6198cbc95fd5703edfbe2261285063f774451c7fd326358ca04afcd876a8/GetPublication?filename=Uittreksels_28-04-2022_13539.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a2a0a01-018a-4ebe-8c59-534cb5b9fb95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9a9676d-ae3c-4ae5-bdea-4d0f38ca1eca>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201316-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201316-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201316-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201316-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/1cf587e5-4dfb-41b2-a0d5-52de6358700e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1cf587e5-4dfb-41b2-a0d5-52de6358700e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ac693eae-0461-4e37-8c27-b043bc51f05a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9ef77ee0-f9ca-4af4-99e3-9c2fc420e5ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9ef77ee0-f9ca-4af4-99e3-9c2fc420e5ac";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a>.
+
+  <http://redpencil.data.gift/id/task/a4c6a080-3a18-4766-881f-eb2499c19d81> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a4c6a080-3a18-4766-881f-eb2499c19d81";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/1cf587e5-4dfb-41b2-a0d5-52de6358700e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9ef77ee0-f9ca-4af4-99e3-9c2fc420e5ac>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/6d7e3cea-60b3-4007-a51c-af6871e40e24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d7e3cea-60b3-4007-a51c-af6871e40e24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/8a5f476a531dc98c115c00ea02e81002aee73c860991231317f57ed32c8d11f8/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d7e3cea-60b3-4007-a51c-af6871e40e24>.
+    
+<http://data.lblod.info/id/remote-data-objects/c809c011-2cc8-4155-9b3d-eba77aea5d1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c809c011-2cc8-4155-9b3d-eba77aea5d1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/8a5f476a531dc98c115c00ea02e81002aee73c860991231317f57ed32c8d11f8/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c809c011-2cc8-4155-9b3d-eba77aea5d1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5018519a-aa5f-48ef-8a05-0d4bc5249149> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5018519a-aa5f-48ef-8a05-0d4bc5249149";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/8a5f476a531dc98c115c00ea02e81002aee73c860991231317f57ed32c8d11f8/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_20-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5018519a-aa5f-48ef-8a05-0d4bc5249149>.
+    
+<http://data.lblod.info/id/remote-data-objects/af5218b8-7de7-41a8-8f47-8b0a1df31e96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af5218b8-7de7-41a8-8f47-8b0a1df31e96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/8a5f476a531dc98c115c00ea02e81002aee73c860991231317f57ed32c8d11f8/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af5218b8-7de7-41a8-8f47-8b0a1df31e96>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d246d9b-d514-4909-a9be-0339dd21719a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d246d9b-d514-4909-a9be-0339dd21719a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/8a5f476a531dc98c115c00ea02e81002aee73c860991231317f57ed32c8d11f8/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_27-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d246d9b-d514-4909-a9be-0339dd21719a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5abd4d72-414d-45a6-9a7f-f42ad09b7d80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5abd4d72-414d-45a6-9a7f-f42ad09b7d80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/8a5f476a531dc98c115c00ea02e81002aee73c860991231317f57ed32c8d11f8/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5abd4d72-414d-45a6-9a7f-f42ad09b7d80>.
+    
+<http://data.lblod.info/id/remote-data-objects/5224c727-642c-4424-97d6-516307a17a3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5224c727-642c-4424-97d6-516307a17a3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5224c727-642c-4424-97d6-516307a17a3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/39e2a67f-2c20-4623-bb10-fcaf4a97cea3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39e2a67f-2c20-4623-bb10-fcaf4a97cea3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39e2a67f-2c20-4623-bb10-fcaf4a97cea3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2cddea4-b669-439f-8ac2-9838fd776e56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2cddea4-b669-439f-8ac2-9838fd776e56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_02-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2cddea4-b669-439f-8ac2-9838fd776e56>.
+    
+<http://data.lblod.info/id/remote-data-objects/3deb7522-f6ed-44c3-be0f-b7a656391a3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3deb7522-f6ed-44c3-be0f-b7a656391a3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3deb7522-f6ed-44c3-be0f-b7a656391a3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9776f82-346d-4ded-8b56-4207d014c513> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9776f82-346d-4ded-8b56-4207d014c513";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9776f82-346d-4ded-8b56-4207d014c513>.
+    
+<http://data.lblod.info/id/remote-data-objects/e57ec6df-16f8-4cf2-8a59-859a54590340> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e57ec6df-16f8-4cf2-8a59-859a54590340";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e57ec6df-16f8-4cf2-8a59-859a54590340>.
+    
+<http://data.lblod.info/id/remote-data-objects/6024ef11-bdcb-4a58-9dde-55103e82892e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6024ef11-bdcb-4a58-9dde-55103e82892e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6024ef11-bdcb-4a58-9dde-55103e82892e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6645ff3-085a-4697-81ff-2d69e2f39da6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6645ff3-085a-4697-81ff-2d69e2f39da6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6645ff3-085a-4697-81ff-2d69e2f39da6>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa6087f8-40eb-4e7e-a055-e75d79996f77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa6087f8-40eb-4e7e-a055-e75d79996f77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_06-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa6087f8-40eb-4e7e-a055-e75d79996f77>.
+    
+<http://data.lblod.info/id/remote-data-objects/be45f02b-5746-4545-a76c-74dc3f9481cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be45f02b-5746-4545-a76c-74dc3f9481cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be45f02b-5746-4545-a76c-74dc3f9481cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f985ac4-805b-4ac5-80d9-9ae79cd109c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f985ac4-805b-4ac5-80d9-9ae79cd109c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f985ac4-805b-4ac5-80d9-9ae79cd109c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/b33581e4-6f8c-45b8-b6d3-3ac9726aef97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b33581e4-6f8c-45b8-b6d3-3ac9726aef97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b33581e4-6f8c-45b8-b6d3-3ac9726aef97>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cae6a4a-fa40-471a-90e4-a83c6f0cffa0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cae6a4a-fa40-471a-90e4-a83c6f0cffa0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cae6a4a-fa40-471a-90e4-a83c6f0cffa0>.
+    
+<http://data.lblod.info/id/remote-data-objects/303b03b1-fb7b-4f85-92ef-2afd46d1408a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "303b03b1-fb7b-4f85-92ef-2afd46d1408a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/303b03b1-fb7b-4f85-92ef-2afd46d1408a>.
+    
+<http://data.lblod.info/id/remote-data-objects/36ca9d25-d0f5-455f-ae39-3b0827cb63bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36ca9d25-d0f5-455f-ae39-3b0827cb63bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36ca9d25-d0f5-455f-ae39-3b0827cb63bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/52b8521d-8a9b-461a-804d-7019796a3788> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52b8521d-8a9b-461a-804d-7019796a3788";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_12-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52b8521d-8a9b-461a-804d-7019796a3788>.
+    
+<http://data.lblod.info/id/remote-data-objects/65ed7271-1d6b-4ec6-af61-369e7eaa774c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65ed7271-1d6b-4ec6-af61-369e7eaa774c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_13-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65ed7271-1d6b-4ec6-af61-369e7eaa774c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6064a5aa-dbaf-4a82-8f3a-d4cff7e243d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6064a5aa-dbaf-4a82-8f3a-d4cff7e243d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6064a5aa-dbaf-4a82-8f3a-d4cff7e243d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bee9681-4690-49b1-aa84-f0c33a1966c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bee9681-4690-49b1-aa84-f0c33a1966c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bee9681-4690-49b1-aa84-f0c33a1966c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/856e7be6-b9c9-4d86-a183-e28a3880b3af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "856e7be6-b9c9-4d86-a183-e28a3880b3af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/856e7be6-b9c9-4d86-a183-e28a3880b3af>.
+    
+<http://data.lblod.info/id/remote-data-objects/949747b3-0b3b-44f9-9bf1-6b3a0a8fc24a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "949747b3-0b3b-44f9-9bf1-6b3a0a8fc24a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/949747b3-0b3b-44f9-9bf1-6b3a0a8fc24a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1b7604f-5935-4f45-8459-f32d99c288e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1b7604f-5935-4f45-8459-f32d99c288e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_16-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1b7604f-5935-4f45-8459-f32d99c288e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4449c343-105a-492a-8549-5adeb604562f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4449c343-105a-492a-8549-5adeb604562f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_16-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4449c343-105a-492a-8549-5adeb604562f>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb8c69ba-d16f-44c8-8f38-b5d0db340957> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb8c69ba-d16f-44c8-8f38-b5d0db340957";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb8c69ba-d16f-44c8-8f38-b5d0db340957>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec794be1-63d2-4bad-9a6f-b089e75aca8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec794be1-63d2-4bad-9a6f-b089e75aca8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec794be1-63d2-4bad-9a6f-b089e75aca8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4672b983-33f0-4003-8a17-bfa5d3b6cd01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4672b983-33f0-4003-8a17-bfa5d3b6cd01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4672b983-33f0-4003-8a17-bfa5d3b6cd01>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a8aa421-f6c2-4e47-80c2-2361ba00ec93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a8aa421-f6c2-4e47-80c2-2361ba00ec93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a8aa421-f6c2-4e47-80c2-2361ba00ec93>.
+    
+<http://data.lblod.info/id/remote-data-objects/df1dceba-edad-4dfa-b484-29a86af7e32d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df1dceba-edad-4dfa-b484-29a86af7e32d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_20-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df1dceba-edad-4dfa-b484-29a86af7e32d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5607ef73-0f70-445e-8e1e-988cc611bc26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5607ef73-0f70-445e-8e1e-988cc611bc26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5607ef73-0f70-445e-8e1e-988cc611bc26>.
+    
+<http://data.lblod.info/id/remote-data-objects/a78d9853-407e-4854-9610-a4519535d1cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a78d9853-407e-4854-9610-a4519535d1cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a78d9853-407e-4854-9610-a4519535d1cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/857eaa39-eacf-47fe-abe7-443ca0de9d8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "857eaa39-eacf-47fe-abe7-443ca0de9d8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/857eaa39-eacf-47fe-abe7-443ca0de9d8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f2612ca-42c0-4591-829f-f276743ea57d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f2612ca-42c0-4591-829f-f276743ea57d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f2612ca-42c0-4591-829f-f276743ea57d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f68bba9b-173b-4cc4-9223-b5a5d0c6994d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f68bba9b-173b-4cc4-9223-b5a5d0c6994d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f68bba9b-173b-4cc4-9223-b5a5d0c6994d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b69cc12-a1f1-4444-9cc0-60612380e8fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b69cc12-a1f1-4444-9cc0-60612380e8fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b69cc12-a1f1-4444-9cc0-60612380e8fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/db4d4123-a848-4631-be58-c52024f354c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db4d4123-a848-4631-be58-c52024f354c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db4d4123-a848-4631-be58-c52024f354c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c34c5d8-7d2f-40c9-a9bd-1a277804d5ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c34c5d8-7d2f-40c9-a9bd-1a277804d5ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c34c5d8-7d2f-40c9-a9bd-1a277804d5ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/535d97b8-b28b-438e-a5ea-d1dacafa1540> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "535d97b8-b28b-438e-a5ea-d1dacafa1540";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_27-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/535d97b8-b28b-438e-a5ea-d1dacafa1540>.
+    
+<http://data.lblod.info/id/remote-data-objects/5306cb58-faa0-4e76-92cc-bb0957c29927> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5306cb58-faa0-4e76-92cc-bb0957c29927";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5306cb58-faa0-4e76-92cc-bb0957c29927>.
+    
+<http://data.lblod.info/id/remote-data-objects/23f9b66c-8d7a-4fca-a3dd-04ebd2b04787> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23f9b66c-8d7a-4fca-a3dd-04ebd2b04787";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23f9b66c-8d7a-4fca-a3dd-04ebd2b04787>.
+    
+<http://data.lblod.info/id/remote-data-objects/22224092-cff2-4c3d-ad87-e75859bc109b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22224092-cff2-4c3d-ad87-e75859bc109b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/e874e655-0ced-4ecf-a694-f87649e2e376/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22224092-cff2-4c3d-ad87-e75859bc109b>.
+    
+<http://data.lblod.info/id/remote-data-objects/be7553b2-7ecc-4f00-8658-8099fc15b8ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be7553b2-7ecc-4f00-8658-8099fc15b8ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be7553b2-7ecc-4f00-8658-8099fc15b8ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/bae17778-5713-4610-bbf9-a06555309ca8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bae17778-5713-4610-bbf9-a06555309ca8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_01-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bae17778-5713-4610-bbf9-a06555309ca8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4effbfa7-46d6-4695-842f-550796e14af3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4effbfa7-46d6-4695-842f-550796e14af3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_02-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4effbfa7-46d6-4695-842f-550796e14af3>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f022bc8-c3db-45e0-931d-7912d7c87d24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f022bc8-c3db-45e0-931d-7912d7c87d24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ac693eae-0461-4e37-8c27-b043bc51f05a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f022bc8-c3db-45e0-931d-7912d7c87d24>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201317-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201317-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201317-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201317-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e69b814f-1596-40ac-a66e-807c3b261c92> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e69b814f-1596-40ac-a66e-807c3b261c92";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fa319d49-5264-4094-9db8-3e7454a2a2dd";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/7d863e87-f805-4768-bce3-3411c616cf92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7d863e87-f805-4768-bce3-3411c616cf92";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd>.
+
+  <http://redpencil.data.gift/id/task/ea3a171c-592d-42da-9dc5-30413cb14c9a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ea3a171c-592d-42da-9dc5-30413cb14c9a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e69b814f-1596-40ac-a66e-807c3b261c92>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/7d863e87-f805-4768-bce3-3411c616cf92>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/96b88197-fb06-4c88-b4ed-a6138ef31186> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96b88197-fb06-4c88-b4ed-a6138ef31186";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96b88197-fb06-4c88-b4ed-a6138ef31186>.
+    
+<http://data.lblod.info/id/remote-data-objects/207af9b3-c6df-4636-ae97-7012e523323f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "207af9b3-c6df-4636-ae97-7012e523323f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/207af9b3-c6df-4636-ae97-7012e523323f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec9adb3c-0303-4b83-a3fa-99cef3427c1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec9adb3c-0303-4b83-a3fa-99cef3427c1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec9adb3c-0303-4b83-a3fa-99cef3427c1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3b54d4e-a873-4aa0-9b03-fd61c4127158> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3b54d4e-a873-4aa0-9b03-fd61c4127158";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3b54d4e-a873-4aa0-9b03-fd61c4127158>.
+    
+<http://data.lblod.info/id/remote-data-objects/4193de23-2f3c-48ee-85c9-98ad87448634> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4193de23-2f3c-48ee-85c9-98ad87448634";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_06-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4193de23-2f3c-48ee-85c9-98ad87448634>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e2485a1-8e43-4499-99a1-977f9e241645> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e2485a1-8e43-4499-99a1-977f9e241645";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e2485a1-8e43-4499-99a1-977f9e241645>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f48699d-80cd-4bda-a641-0ab9fd4f08ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f48699d-80cd-4bda-a641-0ab9fd4f08ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f48699d-80cd-4bda-a641-0ab9fd4f08ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/b242464b-9088-431e-bd78-3dcdd597120c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b242464b-9088-431e-bd78-3dcdd597120c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b242464b-9088-431e-bd78-3dcdd597120c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c39eed69-e15b-4846-8ea2-00aef4d8bdec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c39eed69-e15b-4846-8ea2-00aef4d8bdec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c39eed69-e15b-4846-8ea2-00aef4d8bdec>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1d69e17-725d-45ba-a07a-149794847cab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1d69e17-725d-45ba-a07a-149794847cab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1d69e17-725d-45ba-a07a-149794847cab>.
+    
+<http://data.lblod.info/id/remote-data-objects/edb5c44b-b52b-408a-a622-375a441682f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edb5c44b-b52b-408a-a622-375a441682f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edb5c44b-b52b-408a-a622-375a441682f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef9c9fd2-4c9f-443e-b71d-404554c9267a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef9c9fd2-4c9f-443e-b71d-404554c9267a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_12-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef9c9fd2-4c9f-443e-b71d-404554c9267a>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd3c9634-d874-48d4-a94c-90a86d37e3b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd3c9634-d874-48d4-a94c-90a86d37e3b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_13-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd3c9634-d874-48d4-a94c-90a86d37e3b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bd465fd-216e-4019-854e-49b90eedff1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bd465fd-216e-4019-854e-49b90eedff1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bd465fd-216e-4019-854e-49b90eedff1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/821f1272-eb45-4ba5-9de9-dd01ba35b450> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "821f1272-eb45-4ba5-9de9-dd01ba35b450";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/821f1272-eb45-4ba5-9de9-dd01ba35b450>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2061cd1-1453-4a54-afa3-16669833e508> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2061cd1-1453-4a54-afa3-16669833e508";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2061cd1-1453-4a54-afa3-16669833e508>.
+    
+<http://data.lblod.info/id/remote-data-objects/c26e7f7c-eba7-47ac-9720-8b3e30d4a653> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c26e7f7c-eba7-47ac-9720-8b3e30d4a653";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c26e7f7c-eba7-47ac-9720-8b3e30d4a653>.
+    
+<http://data.lblod.info/id/remote-data-objects/b124506a-367c-43cd-a6a1-d309bce34f46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b124506a-367c-43cd-a6a1-d309bce34f46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_16-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b124506a-367c-43cd-a6a1-d309bce34f46>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e77c105-8fde-410a-9728-12acd5e7d870> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e77c105-8fde-410a-9728-12acd5e7d870";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_16-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e77c105-8fde-410a-9728-12acd5e7d870>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c6ba55e-3940-4064-a504-837053cd51ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c6ba55e-3940-4064-a504-837053cd51ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c6ba55e-3940-4064-a504-837053cd51ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/6011e72d-2ae3-4313-97c5-dc545d53be05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6011e72d-2ae3-4313-97c5-dc545d53be05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6011e72d-2ae3-4313-97c5-dc545d53be05>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e707e24-1985-4ec0-83b9-355bb5e9d0ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e707e24-1985-4ec0-83b9-355bb5e9d0ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_19-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e707e24-1985-4ec0-83b9-355bb5e9d0ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/8594a5ca-d164-4927-9515-e2a11d7636eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8594a5ca-d164-4927-9515-e2a11d7636eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8594a5ca-d164-4927-9515-e2a11d7636eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/7775d705-8de9-4a7e-bac2-c8fdb7b8d2d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7775d705-8de9-4a7e-bac2-c8fdb7b8d2d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_20-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7775d705-8de9-4a7e-bac2-c8fdb7b8d2d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a82a088d-bfb6-4d23-8042-1d798480b396> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a82a088d-bfb6-4d23-8042-1d798480b396";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a82a088d-bfb6-4d23-8042-1d798480b396>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8fa88fb-a413-4da5-953c-eed00a56d6c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8fa88fb-a413-4da5-953c-eed00a56d6c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8fa88fb-a413-4da5-953c-eed00a56d6c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d165d62-b282-48fe-b10a-0463b961a731> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d165d62-b282-48fe-b10a-0463b961a731";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d165d62-b282-48fe-b10a-0463b961a731>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1bd8890-c16a-48e2-8755-6b6309378eb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1bd8890-c16a-48e2-8755-6b6309378eb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1bd8890-c16a-48e2-8755-6b6309378eb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/17d4265b-0d10-4b59-882c-cd5c0023b5ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17d4265b-0d10-4b59-882c-cd5c0023b5ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17d4265b-0d10-4b59-882c-cd5c0023b5ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/778fb21b-2be4-4fd7-9d46-e11f4b4c0523> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "778fb21b-2be4-4fd7-9d46-e11f4b4c0523";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/778fb21b-2be4-4fd7-9d46-e11f4b4c0523>.
+    
+<http://data.lblod.info/id/remote-data-objects/d68995dd-8e43-49ae-8ddb-ccc9bbcc77e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d68995dd-8e43-49ae-8ddb-ccc9bbcc77e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d68995dd-8e43-49ae-8ddb-ccc9bbcc77e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/9265dd52-b054-45b4-a5e1-f5a10fa76bdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9265dd52-b054-45b4-a5e1-f5a10fa76bdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9265dd52-b054-45b4-a5e1-f5a10fa76bdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/990c7415-a9ab-4cbd-89ea-d780c1628faf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "990c7415-a9ab-4cbd-89ea-d780c1628faf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_27-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/990c7415-a9ab-4cbd-89ea-d780c1628faf>.
+    
+<http://data.lblod.info/id/remote-data-objects/76fd74ea-7473-4934-bfdd-3b650ec83bbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76fd74ea-7473-4934-bfdd-3b650ec83bbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76fd74ea-7473-4934-bfdd-3b650ec83bbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/84ce7570-4b15-477b-afab-1b47e34ee094> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84ce7570-4b15-477b-afab-1b47e34ee094";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84ce7570-4b15-477b-afab-1b47e34ee094>.
+    
+<http://data.lblod.info/id/remote-data-objects/239a5645-bfff-4bc5-b993-6ee8788ed36d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "239a5645-bfff-4bc5-b993-6ee8788ed36d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.damme.be/LBLODWeb/Home/Overzicht/fb1c1b73c53d42d489a9678ba0c2f042e09fa48e3fcdd1b40be4aedaab1d08f6/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/239a5645-bfff-4bc5-b993-6ee8788ed36d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a94885bb-a42a-4b1f-9616-1ce7527c03f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a94885bb-a42a-4b1f-9616-1ce7527c03f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Agenda_Gemeenteraad_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a94885bb-a42a-4b1f-9616-1ce7527c03f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d057bc8-7ec7-4130-8bdf-796f6d40a9e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d057bc8-7ec7-4130-8bdf-796f6d40a9e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Agenda_Gemeenteraad_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d057bc8-7ec7-4130-8bdf-796f6d40a9e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed21f541-1628-4fc9-9a54-74fbfae4af19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed21f541-1628-4fc9-9a54-74fbfae4af19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Agenda_Gemeenteraad_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed21f541-1628-4fc9-9a54-74fbfae4af19>.
+    
+<http://data.lblod.info/id/remote-data-objects/41550698-24f9-447a-9bc6-6c6be6ae03e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41550698-24f9-447a-9bc6-6c6be6ae03e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Agenda_Gemeenteraad_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41550698-24f9-447a-9bc6-6c6be6ae03e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/774ad093-5610-4c61-a344-aa75317f0758> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "774ad093-5610-4c61-a344-aa75317f0758";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Agenda_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/774ad093-5610-4c61-a344-aa75317f0758>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ef858be-ac55-4c4f-b64d-bffb5343ef4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ef858be-ac55-4c4f-b64d-bffb5343ef4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Agenda_Gemeenteraad_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ef858be-ac55-4c4f-b64d-bffb5343ef4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c7bd067-a65d-45f2-8920-71d2079f5fee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c7bd067-a65d-45f2-8920-71d2079f5fee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Agenda_Gemeenteraad_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c7bd067-a65d-45f2-8920-71d2079f5fee>.
+    
+<http://data.lblod.info/id/remote-data-objects/2961ddd8-340f-46ca-9b87-d0bf8741b00e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2961ddd8-340f-46ca-9b87-d0bf8741b00e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Agenda_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2961ddd8-340f-46ca-9b87-d0bf8741b00e>.
+    
+<http://data.lblod.info/id/remote-data-objects/870fcfca-eeb9-440d-8f81-5dc5c2bba5dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "870fcfca-eeb9-440d-8f81-5dc5c2bba5dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Agenda_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/870fcfca-eeb9-440d-8f81-5dc5c2bba5dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc447b21-5ba1-4062-9af0-b174e65e1b9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc447b21-5ba1-4062-9af0-b174e65e1b9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc447b21-5ba1-4062-9af0-b174e65e1b9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/25a46ea1-e4df-4014-addc-278cc2e3487c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25a46ea1-e4df-4014-addc-278cc2e3487c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25a46ea1-e4df-4014-addc-278cc2e3487c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc468d39-3d49-429b-9c67-53fe21c2186d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc468d39-3d49-429b-9c67-53fe21c2186d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc468d39-3d49-429b-9c67-53fe21c2186d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d19a0895-4907-4fdc-a78b-3e383ba41612> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d19a0895-4907-4fdc-a78b-3e383ba41612";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d19a0895-4907-4fdc-a78b-3e383ba41612>.
+    
+<http://data.lblod.info/id/remote-data-objects/9565998f-3c12-45cd-989b-cb9406b9b522> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9565998f-3c12-45cd-989b-cb9406b9b522";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fa319d49-5264-4094-9db8-3e7454a2a2dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9565998f-3c12-45cd-989b-cb9406b9b522>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201318-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201318-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201318-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201318-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/0dd1633e-7df8-43bd-b5c3-d01dbc2bccb6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0dd1633e-7df8-43bd-b5c3-d01dbc2bccb6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "85d7928b-f67c-4ce3-a4a1-a01c3d145fe8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ae5bd9fc-d18c-4069-9552-ecb1d06e0da7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ae5bd9fc-d18c-4069-9552-ecb1d06e0da7";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8>.
+
+  <http://redpencil.data.gift/id/task/c26f7032-d0fe-4a21-88e5-755aa0d8e7c9> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c26f7032-d0fe-4a21-88e5-755aa0d8e7c9";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/0dd1633e-7df8-43bd-b5c3-d01dbc2bccb6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ae5bd9fc-d18c-4069-9552-ecb1d06e0da7>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a51a6291-d49a-4952-8f1e-2ec449f77f2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a51a6291-d49a-4952-8f1e-2ec449f77f2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a51a6291-d49a-4952-8f1e-2ec449f77f2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b04258fe-5a52-4a49-b2ba-cd5dfc4b9fb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b04258fe-5a52-4a49-b2ba-cd5dfc4b9fb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b04258fe-5a52-4a49-b2ba-cd5dfc4b9fb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/abba6300-15f4-4f5b-9b32-42c91b24e75e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abba6300-15f4-4f5b-9b32-42c91b24e75e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abba6300-15f4-4f5b-9b32-42c91b24e75e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d9199ff-d7e2-4947-aba7-f5edc5566c99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d9199ff-d7e2-4947-aba7-f5edc5566c99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d9199ff-d7e2-4947-aba7-f5edc5566c99>.
+    
+<http://data.lblod.info/id/remote-data-objects/71d607fb-bb9f-41a4-970f-fd9b742aee67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71d607fb-bb9f-41a4-970f-fd9b742aee67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Notulen_Gemeenteraad_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71d607fb-bb9f-41a4-970f-fd9b742aee67>.
+    
+<http://data.lblod.info/id/remote-data-objects/97191c03-91e5-414b-8fe9-091dd59677c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97191c03-91e5-414b-8fe9-091dd59677c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Notulen_Gemeenteraad_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97191c03-91e5-414b-8fe9-091dd59677c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1c5fa83-b6a4-4ede-8776-a8d0d59b8507> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1c5fa83-b6a4-4ede-8776-a8d0d59b8507";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Notulen_Gemeenteraad_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1c5fa83-b6a4-4ede-8776-a8d0d59b8507>.
+    
+<http://data.lblod.info/id/remote-data-objects/59ee7a98-e037-47ba-b897-24399192f573> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59ee7a98-e037-47ba-b897-24399192f573";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Notulen_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59ee7a98-e037-47ba-b897-24399192f573>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c930b82-7449-45cf-831f-c0e7aadb9f0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c930b82-7449-45cf-831f-c0e7aadb9f0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Notulen_Gemeenteraad_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c930b82-7449-45cf-831f-c0e7aadb9f0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/40ee5cf4-4ccd-467f-bc86-973b3331b411> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40ee5cf4-4ccd-467f-bc86-973b3331b411";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Notulen_Gemeenteraad_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40ee5cf4-4ccd-467f-bc86-973b3331b411>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e8e6e97-b529-452d-a318-0322195988f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e8e6e97-b529-452d-a318-0322195988f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Notulen_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e8e6e97-b529-452d-a318-0322195988f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8f6e2ed-c045-4970-b081-aaf1108a41cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8f6e2ed-c045-4970-b081-aaf1108a41cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Notulen_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8f6e2ed-c045-4970-b081-aaf1108a41cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/1081d02b-4765-4c65-b53a-514ecce52d5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1081d02b-4765-4c65-b53a-514ecce52d5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Uittreksels_16-06-2022_24446.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1081d02b-4765-4c65-b53a-514ecce52d5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/21d729f7-8d9a-48f4-8c58-50fa2c3c44bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21d729f7-8d9a-48f4-8c58-50fa2c3c44bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Uittreksels_16-06-2022_24447.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21d729f7-8d9a-48f4-8c58-50fa2c3c44bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/72ef3e0b-86f2-460b-99d6-f30d96a0867d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72ef3e0b-86f2-460b-99d6-f30d96a0867d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Uittreksels_16-06-2022_24544.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72ef3e0b-86f2-460b-99d6-f30d96a0867d>.
+    
+<http://data.lblod.info/id/remote-data-objects/18b9c50c-e834-450e-806b-bfd71fa12d8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18b9c50c-e834-450e-806b-bfd71fa12d8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Uittreksels_16-06-2022_24622.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18b9c50c-e834-450e-806b-bfd71fa12d8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad5b5dd3-28c5-45e9-b267-f2d0d6c8e80a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad5b5dd3-28c5-45e9-b267-f2d0d6c8e80a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Uittreksels_16-12-2021_20645.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad5b5dd3-28c5-45e9-b267-f2d0d6c8e80a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4811a3f0-9a07-445d-a1e3-d2a23356bd28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4811a3f0-9a07-445d-a1e3-d2a23356bd28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Uittreksels_16-12-2021_20646.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4811a3f0-9a07-445d-a1e3-d2a23356bd28>.
+    
+<http://data.lblod.info/id/remote-data-objects/574db4c2-4c2c-4b2b-ae00-349fef35d33e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "574db4c2-4c2c-4b2b-ae00-349fef35d33e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Uittreksels_16-12-2021_22003.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/574db4c2-4c2c-4b2b-ae00-349fef35d33e>.
+    
+<http://data.lblod.info/id/remote-data-objects/44ea7161-50f0-46c3-8a02-aa3f65e181bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44ea7161-50f0-46c3-8a02-aa3f65e181bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Uittreksels_16-12-2021_22005.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44ea7161-50f0-46c3-8a02-aa3f65e181bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b020da8-7c48-4a95-a9c7-e411256c3fd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b020da8-7c48-4a95-a9c7-e411256c3fd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Uittreksels_16-12-2021_22006.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b020da8-7c48-4a95-a9c7-e411256c3fd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/cee6bff4-bbc6-4dd2-be93-bc38c25ae966> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cee6bff4-bbc6-4dd2-be93-bc38c25ae966";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Uittreksels_16-12-2021_22008.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cee6bff4-bbc6-4dd2-be93-bc38c25ae966>.
+    
+<http://data.lblod.info/id/remote-data-objects/9bd1634c-0ead-43c7-b3dc-a776b04b7d6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9bd1634c-0ead-43c7-b3dc-a776b04b7d6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Uittreksels_16-12-2021_22010.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9bd1634c-0ead-43c7-b3dc-a776b04b7d6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/296f843a-d3d1-4317-94f8-5aeff5a481cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "296f843a-d3d1-4317-94f8-5aeff5a481cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Uittreksels_16-12-2021_22012.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/296f843a-d3d1-4317-94f8-5aeff5a481cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/27f96f04-90c1-4eed-bbe0-2a5ca0f92529> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27f96f04-90c1-4eed-bbe0-2a5ca0f92529";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Uittreksels_17-02-2022_22670.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27f96f04-90c1-4eed-bbe0-2a5ca0f92529>.
+    
+<http://data.lblod.info/id/remote-data-objects/db375e54-375c-4d6d-8a4e-7cb36b0b1771> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db375e54-375c-4d6d-8a4e-7cb36b0b1771";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/3abf6d8eec0db6e70ae6e21b246449df5d197293696b20c7871a620a032adcfd/GetPublication?filename=Uittreksels_28-04-2022_23923.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db375e54-375c-4d6d-8a4e-7cb36b0b1771>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cf3383d-a8e4-4979-a27e-f9b504b4ddf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cf3383d-a8e4-4979-a27e-f9b504b4ddf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cf3383d-a8e4-4979-a27e-f9b504b4ddf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ce61b50-a22b-4c46-b8f8-81fc0b07b359> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ce61b50-a22b-4c46-b8f8-81fc0b07b359";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ce61b50-a22b-4c46-b8f8-81fc0b07b359>.
+    
+<http://data.lblod.info/id/remote-data-objects/49dafc52-e893-459e-9033-66847fc07205> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49dafc52-e893-459e-9033-66847fc07205";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49dafc52-e893-459e-9033-66847fc07205>.
+    
+<http://data.lblod.info/id/remote-data-objects/23615e03-bc21-46e7-b202-b1723bd01569> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23615e03-bc21-46e7-b202-b1723bd01569";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23615e03-bc21-46e7-b202-b1723bd01569>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c0f37d2-7476-492f-a39d-9b680207af89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c0f37d2-7476-492f-a39d-9b680207af89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c0f37d2-7476-492f-a39d-9b680207af89>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a5c3453-ba23-48fc-9a44-59d21a2be9ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a5c3453-ba23-48fc-9a44-59d21a2be9ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a5c3453-ba23-48fc-9a44-59d21a2be9ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/419cc2eb-395a-4acd-8e87-028d6fd44e42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "419cc2eb-395a-4acd-8e87-028d6fd44e42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/419cc2eb-395a-4acd-8e87-028d6fd44e42>.
+    
+<http://data.lblod.info/id/remote-data-objects/693382fa-33b3-4475-8ce9-a17a46e96bc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "693382fa-33b3-4475-8ce9-a17a46e96bc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/693382fa-33b3-4475-8ce9-a17a46e96bc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ea2ed85-c9c9-4e4c-a36f-3744d16b9a31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ea2ed85-c9c9-4e4c-a36f-3744d16b9a31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ea2ed85-c9c9-4e4c-a36f-3744d16b9a31>.
+    
+<http://data.lblod.info/id/remote-data-objects/92af2274-8e08-4ccb-be79-139c0fa53814> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92af2274-8e08-4ccb-be79-139c0fa53814";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92af2274-8e08-4ccb-be79-139c0fa53814>.
+    
+<http://data.lblod.info/id/remote-data-objects/24e4e56c-eb04-467e-a28c-fab6974ff36e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24e4e56c-eb04-467e-a28c-fab6974ff36e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24e4e56c-eb04-467e-a28c-fab6974ff36e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fb18ab2-ea73-4f7b-94cc-18258c67012a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fb18ab2-ea73-4f7b-94cc-18258c67012a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fb18ab2-ea73-4f7b-94cc-18258c67012a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bb6f9b2-ca9d-45ad-9bbb-7bc3fcc759a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bb6f9b2-ca9d-45ad-9bbb-7bc3fcc759a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bb6f9b2-ca9d-45ad-9bbb-7bc3fcc759a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/30df4062-1a2b-4238-8cf4-f2c415cf05ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30df4062-1a2b-4238-8cf4-f2c415cf05ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_10-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30df4062-1a2b-4238-8cf4-f2c415cf05ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/528d8082-e8c7-4bdf-844f-f3ea6f3bec56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "528d8082-e8c7-4bdf-844f-f3ea6f3bec56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/528d8082-e8c7-4bdf-844f-f3ea6f3bec56>.
+    
+<http://data.lblod.info/id/remote-data-objects/11c34e1a-54f9-449e-be76-0e17eff6693f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11c34e1a-54f9-449e-be76-0e17eff6693f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11c34e1a-54f9-449e-be76-0e17eff6693f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e042d3e2-cc15-4468-975d-8f3317cd8acd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e042d3e2-cc15-4468-975d-8f3317cd8acd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e042d3e2-cc15-4468-975d-8f3317cd8acd>.
+    
+<http://data.lblod.info/id/remote-data-objects/85097b05-5992-4e98-bba7-9dbff7c13b52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85097b05-5992-4e98-bba7-9dbff7c13b52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_12-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85097b05-5992-4e98-bba7-9dbff7c13b52>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cfc0e1a-8cbe-46ad-9dd2-17b234cf8cc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cfc0e1a-8cbe-46ad-9dd2-17b234cf8cc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cfc0e1a-8cbe-46ad-9dd2-17b234cf8cc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b90fea7c-1b93-419f-8cc9-02da12bd4bdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b90fea7c-1b93-419f-8cc9-02da12bd4bdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b90fea7c-1b93-419f-8cc9-02da12bd4bdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ba2f2c5-a672-4ce4-b3d6-60b95bb5ae6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ba2f2c5-a672-4ce4-b3d6-60b95bb5ae6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ba2f2c5-a672-4ce4-b3d6-60b95bb5ae6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5c83418-34b4-4f6d-a020-48764ecb958c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5c83418-34b4-4f6d-a020-48764ecb958c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5c83418-34b4-4f6d-a020-48764ecb958c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e5d4555-646b-4181-823a-52b09d974625> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e5d4555-646b-4181-823a-52b09d974625";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e5d4555-646b-4181-823a-52b09d974625>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1f5be70-e157-417f-9767-da8cc67eca83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1f5be70-e157-417f-9767-da8cc67eca83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/85d7928b-f67c-4ce3-a4a1-a01c3d145fe8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1f5be70-e157-417f-9767-da8cc67eca83>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201319-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201319-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201319-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201319-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/bd3e4d15-4f87-45c0-9512-65ec4f232113> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bd3e4d15-4f87-45c0-9512-65ec4f232113";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3ee8f953-5cba-4d2c-90e4-c0b0e93da905";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4d6afc8f-eb5a-4b13-a1db-c16db7e42c0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4d6afc8f-eb5a-4b13-a1db-c16db7e42c0e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905>.
+
+  <http://redpencil.data.gift/id/task/bba912f4-9b7b-4556-92c0-8cb363906501> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bba912f4-9b7b-4556-92c0-8cb363906501";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/bd3e4d15-4f87-45c0-9512-65ec4f232113>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4d6afc8f-eb5a-4b13-a1db-c16db7e42c0e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a8a4e658-67e5-4156-a0d3-b9c7e34ed8c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8a4e658-67e5-4156-a0d3-b9c7e34ed8c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8a4e658-67e5-4156-a0d3-b9c7e34ed8c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb81b319-2e5a-4557-a320-f7b230f5f218> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb81b319-2e5a-4557-a320-f7b230f5f218";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb81b319-2e5a-4557-a320-f7b230f5f218>.
+    
+<http://data.lblod.info/id/remote-data-objects/97a31013-c2e9-4fcf-9a5c-eb712946d9d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97a31013-c2e9-4fcf-9a5c-eb712946d9d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97a31013-c2e9-4fcf-9a5c-eb712946d9d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b813da2-34da-43c4-819b-95b3d14e7a98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b813da2-34da-43c4-819b-95b3d14e7a98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b813da2-34da-43c4-819b-95b3d14e7a98>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa07ebbf-bbad-4118-9b05-413f731f292b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa07ebbf-bbad-4118-9b05-413f731f292b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa07ebbf-bbad-4118-9b05-413f731f292b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5235a340-469f-4b68-9482-860692b6d10d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5235a340-469f-4b68-9482-860692b6d10d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5235a340-469f-4b68-9482-860692b6d10d>.
+    
+<http://data.lblod.info/id/remote-data-objects/09148051-1b27-496e-9cca-ba44cb35028a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09148051-1b27-496e-9cca-ba44cb35028a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09148051-1b27-496e-9cca-ba44cb35028a>.
+    
+<http://data.lblod.info/id/remote-data-objects/dee260c0-1af2-4fb9-8530-1d59b8126b39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dee260c0-1af2-4fb9-8530-1d59b8126b39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dee260c0-1af2-4fb9-8530-1d59b8126b39>.
+    
+<http://data.lblod.info/id/remote-data-objects/15e1aa9d-17f7-4ee7-812f-435150a86471> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15e1aa9d-17f7-4ee7-812f-435150a86471";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15e1aa9d-17f7-4ee7-812f-435150a86471>.
+    
+<http://data.lblod.info/id/remote-data-objects/889771d2-b03c-45cf-812a-cf3b1f6dd0d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "889771d2-b03c-45cf-812a-cf3b1f6dd0d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/889771d2-b03c-45cf-812a-cf3b1f6dd0d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/30692908-18fb-4e51-9d5a-fe11386fcd22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30692908-18fb-4e51-9d5a-fe11386fcd22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30692908-18fb-4e51-9d5a-fe11386fcd22>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5f48ab6-25df-45eb-8b89-cbf262c8495e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5f48ab6-25df-45eb-8b89-cbf262c8495e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5f48ab6-25df-45eb-8b89-cbf262c8495e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee1bea5b-289c-45d1-ac74-612a79e803f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee1bea5b-289c-45d1-ac74-612a79e803f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee1bea5b-289c-45d1-ac74-612a79e803f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/17c16f44-4b2d-4c89-874c-de2d4d3d1328> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17c16f44-4b2d-4c89-874c-de2d4d3d1328";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_26-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17c16f44-4b2d-4c89-874c-de2d4d3d1328>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d501cb1-65d8-44c3-88da-4f0a9b9f9f2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d501cb1-65d8-44c3-88da-4f0a9b9f9f2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d501cb1-65d8-44c3-88da-4f0a9b9f9f2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5fcc494-9dd4-4da6-a947-b10f232b4a5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5fcc494-9dd4-4da6-a947-b10f232b4a5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5fcc494-9dd4-4da6-a947-b10f232b4a5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d186f3ff-b304-425a-a7b1-5ca4aae33521> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d186f3ff-b304-425a-a7b1-5ca4aae33521";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d186f3ff-b304-425a-a7b1-5ca4aae33521>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc8c1027-23f3-4dd5-a91c-a19c0bdc1178> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc8c1027-23f3-4dd5-a91c-a19c0bdc1178";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc8c1027-23f3-4dd5-a91c-a19c0bdc1178>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d691c38-d350-46b2-85d1-6f5c96609bc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d691c38-d350-46b2-85d1-6f5c96609bc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d691c38-d350-46b2-85d1-6f5c96609bc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/13560715-07a4-4171-a145-1bc5f470f3d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13560715-07a4-4171-a145-1bc5f470f3d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/497a4db7c9d5fbee2dc81961b19c0e02cd43ecbd1242ddf04fafe005f3b42729/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13560715-07a4-4171-a145-1bc5f470f3d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/6171fc97-3eef-42b4-96c1-a7fa576d1db7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6171fc97-3eef-42b4-96c1-a7fa576d1db7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6171fc97-3eef-42b4-96c1-a7fa576d1db7>.
+    
+<http://data.lblod.info/id/remote-data-objects/21059a88-b882-4caf-915a-36407c8b6223> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21059a88-b882-4caf-915a-36407c8b6223";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21059a88-b882-4caf-915a-36407c8b6223>.
+    
+<http://data.lblod.info/id/remote-data-objects/560204c3-d918-438b-822b-63339833867e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "560204c3-d918-438b-822b-63339833867e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/560204c3-d918-438b-822b-63339833867e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b96b448-8f17-4b8a-9dff-9d1a41f379ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b96b448-8f17-4b8a-9dff-9d1a41f379ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b96b448-8f17-4b8a-9dff-9d1a41f379ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/55128312-572c-432b-874b-919fe7459eee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55128312-572c-432b-874b-919fe7459eee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55128312-572c-432b-874b-919fe7459eee>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ff7e34f-1abf-4b2a-bce2-9f6a07c4cd41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ff7e34f-1abf-4b2a-bce2-9f6a07c4cd41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ff7e34f-1abf-4b2a-bce2-9f6a07c4cd41>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ba5d596-38c1-4a88-845a-bba102a9afe0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ba5d596-38c1-4a88-845a-bba102a9afe0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_04-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ba5d596-38c1-4a88-845a-bba102a9afe0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6ef278e-52bf-405f-ab12-215956b56d92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6ef278e-52bf-405f-ab12-215956b56d92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6ef278e-52bf-405f-ab12-215956b56d92>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bfc26e1-6802-4936-8df0-a6b4126c4db9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bfc26e1-6802-4936-8df0-a6b4126c4db9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bfc26e1-6802-4936-8df0-a6b4126c4db9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0b5300b-3299-4b08-845c-8b7d696b2a77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0b5300b-3299-4b08-845c-8b7d696b2a77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_07-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0b5300b-3299-4b08-845c-8b7d696b2a77>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae4544ab-4def-47f1-9939-cae23c9751f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae4544ab-4def-47f1-9939-cae23c9751f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae4544ab-4def-47f1-9939-cae23c9751f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/36cc1e1a-8f06-4110-ab3c-48f4d2512850> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36cc1e1a-8f06-4110-ab3c-48f4d2512850";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36cc1e1a-8f06-4110-ab3c-48f4d2512850>.
+    
+<http://data.lblod.info/id/remote-data-objects/8af30c36-b689-435c-a3f4-3781cce69800> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8af30c36-b689-435c-a3f4-3781cce69800";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_08-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8af30c36-b689-435c-a3f4-3781cce69800>.
+    
+<http://data.lblod.info/id/remote-data-objects/3916fcaf-e9e5-4849-8d36-6c0812874db8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3916fcaf-e9e5-4849-8d36-6c0812874db8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3916fcaf-e9e5-4849-8d36-6c0812874db8>.
+    
+<http://data.lblod.info/id/remote-data-objects/11b6c6ed-2019-43a2-9e1e-700ed54c17a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11b6c6ed-2019-43a2-9e1e-700ed54c17a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_10-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11b6c6ed-2019-43a2-9e1e-700ed54c17a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/9457e238-f717-4686-bc93-d593defb92ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9457e238-f717-4686-bc93-d593defb92ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_11-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9457e238-f717-4686-bc93-d593defb92ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/71c355fb-f935-48b8-a157-c1e74034c99f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71c355fb-f935-48b8-a157-c1e74034c99f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_11-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71c355fb-f935-48b8-a157-c1e74034c99f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0463bde7-dbb1-4907-beae-669b8459d105> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0463bde7-dbb1-4907-beae-669b8459d105";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0463bde7-dbb1-4907-beae-669b8459d105>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b28c979-0f6a-4101-8db2-ce49fa35f057> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b28c979-0f6a-4101-8db2-ce49fa35f057";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_12-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b28c979-0f6a-4101-8db2-ce49fa35f057>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a4449d1-cc60-4ee0-9176-d0e5c41e5458> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a4449d1-cc60-4ee0-9176-d0e5c41e5458";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_14-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a4449d1-cc60-4ee0-9176-d0e5c41e5458>.
+    
+<http://data.lblod.info/id/remote-data-objects/82eed453-16ca-4078-bcab-58aef5eb7f57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82eed453-16ca-4078-bcab-58aef5eb7f57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82eed453-16ca-4078-bcab-58aef5eb7f57>.
+    
+<http://data.lblod.info/id/remote-data-objects/bae382a9-a7d0-4c3d-a656-86ed73e27fef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bae382a9-a7d0-4c3d-a656-86ed73e27fef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bae382a9-a7d0-4c3d-a656-86ed73e27fef>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f77fb6a-691c-438c-8b4a-01bd66718624> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f77fb6a-691c-438c-8b4a-01bd66718624";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f77fb6a-691c-438c-8b4a-01bd66718624>.
+    
+<http://data.lblod.info/id/remote-data-objects/5be0a7fa-c8b2-4016-8ce6-9e7a20799305> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5be0a7fa-c8b2-4016-8ce6-9e7a20799305";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5be0a7fa-c8b2-4016-8ce6-9e7a20799305>.
+    
+<http://data.lblod.info/id/remote-data-objects/a14fb433-68d1-4354-826a-162ef0d17729> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a14fb433-68d1-4354-826a-162ef0d17729";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a14fb433-68d1-4354-826a-162ef0d17729>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b586258-0802-42dc-bb6d-e8f2085e3e59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b586258-0802-42dc-bb6d-e8f2085e3e59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_17-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b586258-0802-42dc-bb6d-e8f2085e3e59>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d14fdbe-5f31-4821-8315-b3450295d346> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d14fdbe-5f31-4821-8315-b3450295d346";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_18-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d14fdbe-5f31-4821-8315-b3450295d346>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fe77939-2e4e-4fbd-ada1-46c623762f92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fe77939-2e4e-4fbd-ada1-46c623762f92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fe77939-2e4e-4fbd-ada1-46c623762f92>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6660ef6-df86-4fc7-a2a1-6c11734b0e85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6660ef6-df86-4fc7-a2a1-6c11734b0e85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6660ef6-df86-4fc7-a2a1-6c11734b0e85>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3bf2af4-d08e-41bc-8393-816a100febca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3bf2af4-d08e-41bc-8393-816a100febca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ee8f953-5cba-4d2c-90e4-c0b0e93da905> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3bf2af4-d08e-41bc-8393-816a100febca>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201321-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201321-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201321-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201321-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/022e2e28-986e-451b-ab83-474e0e990c8f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "022e2e28-986e-451b-ab83-474e0e990c8f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4e7dc119-75c7-40ff-b376-45ca6afa3e6c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/8aee237d-271a-4c4d-86d1-842a8dea6fbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8aee237d-271a-4c4d-86d1-842a8dea6fbd";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c>.
+
+  <http://redpencil.data.gift/id/task/41f172ec-51b8-4a77-89b4-bc34787c38d8> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "41f172ec-51b8-4a77-89b4-bc34787c38d8";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/022e2e28-986e-451b-ab83-474e0e990c8f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/8aee237d-271a-4c4d-86d1-842a8dea6fbd>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/bd283359-723e-466e-9f57-811b83234070> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd283359-723e-466e-9f57-811b83234070";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_22-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd283359-723e-466e-9f57-811b83234070>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bcad0fc-f6e2-491e-9818-7497cfe285a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bcad0fc-f6e2-491e-9818-7497cfe285a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_22-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bcad0fc-f6e2-491e-9818-7497cfe285a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/42c63181-6298-4bf3-86eb-572e609432fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42c63181-6298-4bf3-86eb-572e609432fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_22-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42c63181-6298-4bf3-86eb-572e609432fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/b254bcac-619d-4341-b251-1e9ef3095270> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b254bcac-619d-4341-b251-1e9ef3095270";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b254bcac-619d-4341-b251-1e9ef3095270>.
+    
+<http://data.lblod.info/id/remote-data-objects/84ea0b82-04a9-44d2-a2ba-796ddfa145e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84ea0b82-04a9-44d2-a2ba-796ddfa145e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84ea0b82-04a9-44d2-a2ba-796ddfa145e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3db00183-a4f0-49fe-af23-3806eae9bbaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3db00183-a4f0-49fe-af23-3806eae9bbaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3db00183-a4f0-49fe-af23-3806eae9bbaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9f922a5-8a01-4027-8f72-a3e4bb4b1aea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9f922a5-8a01-4027-8f72-a3e4bb4b1aea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_25-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9f922a5-8a01-4027-8f72-a3e4bb4b1aea>.
+    
+<http://data.lblod.info/id/remote-data-objects/acc295eb-e4aa-445e-9706-2cc234828620> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acc295eb-e4aa-445e-9706-2cc234828620";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acc295eb-e4aa-445e-9706-2cc234828620>.
+    
+<http://data.lblod.info/id/remote-data-objects/02db39eb-9561-4361-8f86-547e3a691228> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02db39eb-9561-4361-8f86-547e3a691228";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_26-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02db39eb-9561-4361-8f86-547e3a691228>.
+    
+<http://data.lblod.info/id/remote-data-objects/89845714-f02f-4a0b-94bd-328c63166374> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89845714-f02f-4a0b-94bd-328c63166374";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89845714-f02f-4a0b-94bd-328c63166374>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8a858f9-d4d7-4d28-992c-2d5d747b0eab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8a858f9-d4d7-4d28-992c-2d5d747b0eab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_28-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8a858f9-d4d7-4d28-992c-2d5d747b0eab>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c9ab176-8b6d-4346-86b4-54758fe87e2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c9ab176-8b6d-4346-86b4-54758fe87e2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c9ab176-8b6d-4346-86b4-54758fe87e2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d67b09ce-28cd-4499-85cb-0b0bb28aa83b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d67b09ce-28cd-4499-85cb-0b0bb28aa83b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d67b09ce-28cd-4499-85cb-0b0bb28aa83b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d513d25-552f-4b62-a99c-4ef4b55b0b12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d513d25-552f-4b62-a99c-4ef4b55b0b12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d513d25-552f-4b62-a99c-4ef4b55b0b12>.
+    
+<http://data.lblod.info/id/remote-data-objects/27aa6220-41f1-469e-99ff-64ea59cbb08c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27aa6220-41f1-469e-99ff-64ea59cbb08c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=BesluitenLijstUitspraak_College_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27aa6220-41f1-469e-99ff-64ea59cbb08c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0175650b-55c6-4f60-9b39-b4f4687d8210> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0175650b-55c6-4f60-9b39-b4f4687d8210";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_01-04-2022_23854.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0175650b-55c6-4f60-9b39-b4f4687d8210>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f59279f-7d67-460a-a70b-0aebc67c7e45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f59279f-7d67-460a-a70b-0aebc67c7e45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_01-04-2022_23861.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f59279f-7d67-460a-a70b-0aebc67c7e45>.
+    
+<http://data.lblod.info/id/remote-data-objects/398fa720-b578-4667-8b81-d35407aea01e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "398fa720-b578-4667-8b81-d35407aea01e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_01-10-2021_20268.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/398fa720-b578-4667-8b81-d35407aea01e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca5dbdcb-bca6-4156-b05e-fad123270bb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca5dbdcb-bca6-4156-b05e-fad123270bb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_01-10-2021_20275.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca5dbdcb-bca6-4156-b05e-fad123270bb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a538a8ce-fa41-4e06-95fe-e7dc53dcff47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a538a8ce-fa41-4e06-95fe-e7dc53dcff47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_01-10-2021_20297.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a538a8ce-fa41-4e06-95fe-e7dc53dcff47>.
+    
+<http://data.lblod.info/id/remote-data-objects/4adbd34a-21fb-49c7-a0c1-a96839f8bfaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4adbd34a-21fb-49c7-a0c1-a96839f8bfaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_02-12-2021_21990.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4adbd34a-21fb-49c7-a0c1-a96839f8bfaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/f53c29a8-2aab-4f66-b0c1-40a4bd095d0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f53c29a8-2aab-4f66-b0c1-40a4bd095d0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_03-02-2022_23020.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f53c29a8-2aab-4f66-b0c1-40a4bd095d0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a981a08f-95f6-43d7-ba2b-3b5ec8c19926> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a981a08f-95f6-43d7-ba2b-3b5ec8c19926";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_03-02-2022_23021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a981a08f-95f6-43d7-ba2b-3b5ec8c19926>.
+    
+<http://data.lblod.info/id/remote-data-objects/982fcd7c-6686-4519-a151-0741da9b4cab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "982fcd7c-6686-4519-a151-0741da9b4cab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_03-02-2022_23039.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/982fcd7c-6686-4519-a151-0741da9b4cab>.
+    
+<http://data.lblod.info/id/remote-data-objects/16cc5cf1-8be2-438e-aa6b-06b10cf56b7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16cc5cf1-8be2-438e-aa6b-06b10cf56b7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_03-03-2022_23272.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16cc5cf1-8be2-438e-aa6b-06b10cf56b7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5718eee-91b3-4a62-8f39-29ddf06301b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5718eee-91b3-4a62-8f39-29ddf06301b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_03-03-2022_23440.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5718eee-91b3-4a62-8f39-29ddf06301b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d6dfa12-88dd-4d4d-97c7-827eadd77c57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d6dfa12-88dd-4d4d-97c7-827eadd77c57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_06-01-2022_22442.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d6dfa12-88dd-4d4d-97c7-827eadd77c57>.
+    
+<http://data.lblod.info/id/remote-data-objects/26c5fb93-3620-4c00-a21d-a30c4f9d27ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26c5fb93-3620-4c00-a21d-a30c4f9d27ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_06-05-2022_24255.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26c5fb93-3620-4c00-a21d-a30c4f9d27ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/955b163f-7586-40fc-ae8b-5f3141b0fad2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "955b163f-7586-40fc-ae8b-5f3141b0fad2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_06-05-2022_24309.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/955b163f-7586-40fc-ae8b-5f3141b0fad2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d234c9f-6586-4a46-8a41-c2fd10bad78b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d234c9f-6586-4a46-8a41-c2fd10bad78b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_07-04-2022_23927.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d234c9f-6586-4a46-8a41-c2fd10bad78b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d4dcaca-f73c-45c0-9e86-4306947597c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d4dcaca-f73c-45c0-9e86-4306947597c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_07-10-2021_20451.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d4dcaca-f73c-45c0-9e86-4306947597c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/abf04919-f415-4cf2-b804-33554c10055d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abf04919-f415-4cf2-b804-33554c10055d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_09-12-2021_22091.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abf04919-f415-4cf2-b804-33554c10055d>.
+    
+<http://data.lblod.info/id/remote-data-objects/16e1ec2a-f167-456a-8c71-87b76ead2539> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16e1ec2a-f167-456a-8c71-87b76ead2539";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_09-12-2021_22094.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16e1ec2a-f167-456a-8c71-87b76ead2539>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab8fdeab-58d2-418b-ac1e-0ffb06b591f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab8fdeab-58d2-418b-ac1e-0ffb06b591f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_11-02-2022_23087.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab8fdeab-58d2-418b-ac1e-0ffb06b591f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e05a82af-811f-4c5a-a067-704eb3fa5751> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e05a82af-811f-4c5a-a067-704eb3fa5751";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_11-02-2022_23121.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e05a82af-811f-4c5a-a067-704eb3fa5751>.
+    
+<http://data.lblod.info/id/remote-data-objects/53489407-9ff2-42b3-88a8-fa9c1844429c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53489407-9ff2-42b3-88a8-fa9c1844429c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_11-02-2022_23123.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53489407-9ff2-42b3-88a8-fa9c1844429c>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd083b0d-ce4f-4311-9dfb-13604dd293da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd083b0d-ce4f-4311-9dfb-13604dd293da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_11-03-2022_23539.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd083b0d-ce4f-4311-9dfb-13604dd293da>.
+    
+<http://data.lblod.info/id/remote-data-objects/27e6989c-ebb2-43d5-8a8c-f7c12eeb60b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27e6989c-ebb2-43d5-8a8c-f7c12eeb60b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_11-03-2022_23562.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27e6989c-ebb2-43d5-8a8c-f7c12eeb60b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/750842ca-4ef1-4d76-b72f-3f6b47559800> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "750842ca-4ef1-4d76-b72f-3f6b47559800";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_12-05-2022_24334.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/750842ca-4ef1-4d76-b72f-3f6b47559800>.
+    
+<http://data.lblod.info/id/remote-data-objects/f231ba48-5ec7-4bf7-b93b-8b66ed034f0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f231ba48-5ec7-4bf7-b93b-8b66ed034f0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_12-11-2021_20776.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f231ba48-5ec7-4bf7-b93b-8b66ed034f0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ef8f37a-b959-475e-a87f-71afe6661222> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ef8f37a-b959-475e-a87f-71afe6661222";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_15-10-2021_20534.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ef8f37a-b959-475e-a87f-71afe6661222>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5d42b13-3d5d-4b0b-a4f1-13b536728fb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5d42b13-3d5d-4b0b-a4f1-13b536728fb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_15-10-2021_20542.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5d42b13-3d5d-4b0b-a4f1-13b536728fb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/b00a28af-f077-4507-8916-da2cd5b0004f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b00a28af-f077-4507-8916-da2cd5b0004f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_15-10-2021_20555.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b00a28af-f077-4507-8916-da2cd5b0004f>.
+    
+<http://data.lblod.info/id/remote-data-objects/61167f16-abaa-4847-98d1-cad76672405c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61167f16-abaa-4847-98d1-cad76672405c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_16-06-2022_24349.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61167f16-abaa-4847-98d1-cad76672405c>.
+    
+<http://data.lblod.info/id/remote-data-objects/426bdd65-f7bd-483d-b49c-3892186ad065> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "426bdd65-f7bd-483d-b49c-3892186ad065";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_16-06-2022_24814.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/426bdd65-f7bd-483d-b49c-3892186ad065>.
+    
+<http://data.lblod.info/id/remote-data-objects/326d0890-2a82-449f-9ad9-20bd029da5c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "326d0890-2a82-449f-9ad9-20bd029da5c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_17-02-2022_23169.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/326d0890-2a82-449f-9ad9-20bd029da5c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/9afb549e-3f3f-400d-9902-d1a3968612d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9afb549e-3f3f-400d-9902-d1a3968612d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_17-12-2021_22192.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9afb549e-3f3f-400d-9902-d1a3968612d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c4cdb49-e4eb-4139-b42e-fdcc4a9de49d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c4cdb49-e4eb-4139-b42e-fdcc4a9de49d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_17-12-2021_22194.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c4cdb49-e4eb-4139-b42e-fdcc4a9de49d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1de0580-4abf-4cf6-899d-ee05909f78f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1de0580-4abf-4cf6-899d-ee05909f78f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_17-12-2021_22200.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1de0580-4abf-4cf6-899d-ee05909f78f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e18d6da7-635d-4d73-a042-6ddf25695b11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e18d6da7-635d-4d73-a042-6ddf25695b11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_17-12-2021_22202.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4e7dc119-75c7-40ff-b376-45ca6afa3e6c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e18d6da7-635d-4d73-a042-6ddf25695b11>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201322-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201322-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201322-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201322-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b19d2128-fa00-4945-bf05-6a92154102d6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b19d2128-fa00-4945-bf05-6a92154102d6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c423d12f-ab99-4ed9-beea-e03699d95a32";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b8808176-652e-4cd6-aae0-d4e503d14c0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b8808176-652e-4cd6-aae0-d4e503d14c0b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32>.
+
+  <http://redpencil.data.gift/id/task/0790c57d-aebc-4dba-88ac-360ed2074f17> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0790c57d-aebc-4dba-88ac-360ed2074f17";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b19d2128-fa00-4945-bf05-6a92154102d6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b8808176-652e-4cd6-aae0-d4e503d14c0b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/8ba666b0-203e-49f7-a32d-b9f1ddac7a4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ba666b0-203e-49f7-a32d-b9f1ddac7a4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_17-12-2021_22203.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ba666b0-203e-49f7-a32d-b9f1ddac7a4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1926a723-f781-4739-8795-061b2fb432c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1926a723-f781-4739-8795-061b2fb432c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_17-12-2021_22204.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1926a723-f781-4739-8795-061b2fb432c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fa704d4-9a44-40d9-be32-f41774b83083> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fa704d4-9a44-40d9-be32-f41774b83083";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_17-12-2021_22205.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fa704d4-9a44-40d9-be32-f41774b83083>.
+    
+<http://data.lblod.info/id/remote-data-objects/017664d7-0793-4ede-9733-ee34373b4fdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "017664d7-0793-4ede-9733-ee34373b4fdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_17-12-2021_22207.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/017664d7-0793-4ede-9733-ee34373b4fdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ce0fefd-e231-4a66-9a17-cf03a965560d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ce0fefd-e231-4a66-9a17-cf03a965560d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_17-12-2021_22209.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ce0fefd-e231-4a66-9a17-cf03a965560d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9e61147-15d8-4033-84e1-5014f9fe9ae7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9e61147-15d8-4033-84e1-5014f9fe9ae7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_17-12-2021_22210.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9e61147-15d8-4033-84e1-5014f9fe9ae7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6939dd97-ea65-4280-b887-571e9db5bf21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6939dd97-ea65-4280-b887-571e9db5bf21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_17-12-2021_22211.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6939dd97-ea65-4280-b887-571e9db5bf21>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9668da7-91e3-482f-9c0f-e543674332c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9668da7-91e3-482f-9c0f-e543674332c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_17-12-2021_22212.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9668da7-91e3-482f-9c0f-e543674332c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a347d7a9-fdf8-4b28-875f-c2b4fc8a9642> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a347d7a9-fdf8-4b28-875f-c2b4fc8a9642";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_18-03-2022_23624.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a347d7a9-fdf8-4b28-875f-c2b4fc8a9642>.
+    
+<http://data.lblod.info/id/remote-data-objects/1010e32a-6f87-426d-84f9-793faccbfa51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1010e32a-6f87-426d-84f9-793faccbfa51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_18-03-2022_23625.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1010e32a-6f87-426d-84f9-793faccbfa51>.
+    
+<http://data.lblod.info/id/remote-data-objects/8023f13a-bece-49c8-bd27-e5806dbd5b94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8023f13a-bece-49c8-bd27-e5806dbd5b94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_18-03-2022_23626.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8023f13a-bece-49c8-bd27-e5806dbd5b94>.
+    
+<http://data.lblod.info/id/remote-data-objects/76f60838-88f4-4b09-ab08-1afdda34651a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76f60838-88f4-4b09-ab08-1afdda34651a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_18-03-2022_23627.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76f60838-88f4-4b09-ab08-1afdda34651a>.
+    
+<http://data.lblod.info/id/remote-data-objects/629eea2d-e457-459c-ac60-2489a4570a09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "629eea2d-e457-459c-ac60-2489a4570a09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_19-05-2022_24414.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/629eea2d-e457-459c-ac60-2489a4570a09>.
+    
+<http://data.lblod.info/id/remote-data-objects/50169a12-9ec2-423d-a1d8-cb68802e0178> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50169a12-9ec2-423d-a1d8-cb68802e0178";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_19-05-2022_24415.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50169a12-9ec2-423d-a1d8-cb68802e0178>.
+    
+<http://data.lblod.info/id/remote-data-objects/08dee30a-af4c-411c-b1e8-3110112c83be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08dee30a-af4c-411c-b1e8-3110112c83be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_19-05-2022_24417.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08dee30a-af4c-411c-b1e8-3110112c83be>.
+    
+<http://data.lblod.info/id/remote-data-objects/1472f193-3df6-4537-a29d-5befd54642fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1472f193-3df6-4537-a29d-5befd54642fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_20-01-2022_22613.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1472f193-3df6-4537-a29d-5befd54642fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/60a2c0a9-3a02-4174-badc-5b336d559b54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60a2c0a9-3a02-4174-badc-5b336d559b54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_20-01-2022_22619.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60a2c0a9-3a02-4174-badc-5b336d559b54>.
+    
+<http://data.lblod.info/id/remote-data-objects/fea87777-6bdc-4d1d-9925-cdc0cc382c5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fea87777-6bdc-4d1d-9925-cdc0cc382c5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_20-01-2022_22620.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fea87777-6bdc-4d1d-9925-cdc0cc382c5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/67859316-4db0-46fb-9cc7-6098f8bca78b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67859316-4db0-46fb-9cc7-6098f8bca78b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_22-07-2022_25185.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67859316-4db0-46fb-9cc7-6098f8bca78b>.
+    
+<http://data.lblod.info/id/remote-data-objects/71c7506a-d006-4d8b-b910-b46926146f5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71c7506a-d006-4d8b-b910-b46926146f5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_22-07-2022_25188.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71c7506a-d006-4d8b-b910-b46926146f5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e78ff2f1-d2bf-43d8-bdeb-a0d31867af5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e78ff2f1-d2bf-43d8-bdeb-a0d31867af5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_24-06-2022_24852.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e78ff2f1-d2bf-43d8-bdeb-a0d31867af5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5147cc4-c6fa-41fc-a218-806d8ea1e74a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5147cc4-c6fa-41fc-a218-806d8ea1e74a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_25-03-2022_23695.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5147cc4-c6fa-41fc-a218-806d8ea1e74a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fb521bf-89ec-4890-9779-8c173d3887fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fb521bf-89ec-4890-9779-8c173d3887fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_25-03-2022_23718.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fb521bf-89ec-4890-9779-8c173d3887fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6ae758a-7cd7-4d95-af5d-62557a900866> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6ae758a-7cd7-4d95-af5d-62557a900866";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_29-04-2022_24202.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6ae758a-7cd7-4d95-af5d-62557a900866>.
+    
+<http://data.lblod.info/id/remote-data-objects/150a6ec8-598d-4ba2-a4c2-18fcf8b6c23f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "150a6ec8-598d-4ba2-a4c2-18fcf8b6c23f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_30-06-2022_24988.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/150a6ec8-598d-4ba2-a4c2-18fcf8b6c23f>.
+    
+<http://data.lblod.info/id/remote-data-objects/be894465-fb8e-400a-adab-ff78cbc47b9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be894465-fb8e-400a-adab-ff78cbc47b9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/737293ac3bfed244c8804a753cbdfa6848a19225ecf9d6ee77859c21b04e3466/GetPublication?filename=Uittreksels_30-06-2022_25033.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be894465-fb8e-400a-adab-ff78cbc47b9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e432a6a4-4cc4-4840-b0af-1c57022874e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e432a6a4-4cc4-4840-b0af-1c57022874e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e432a6a4-4cc4-4840-b0af-1c57022874e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b2fc302-28b2-4452-ba84-0899314b607e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b2fc302-28b2-4452-ba84-0899314b607e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b2fc302-28b2-4452-ba84-0899314b607e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1046f824-5eb9-4b45-bb3d-a214293f9870> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1046f824-5eb9-4b45-bb3d-a214293f9870";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1046f824-5eb9-4b45-bb3d-a214293f9870>.
+    
+<http://data.lblod.info/id/remote-data-objects/261d60c4-6e9d-4bca-bc4f-58a5ca88a51a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "261d60c4-6e9d-4bca-bc4f-58a5ca88a51a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/261d60c4-6e9d-4bca-bc4f-58a5ca88a51a>.
+    
+<http://data.lblod.info/id/remote-data-objects/055f9168-e969-4758-8556-d55be8d69f33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "055f9168-e969-4758-8556-d55be8d69f33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/055f9168-e969-4758-8556-d55be8d69f33>.
+    
+<http://data.lblod.info/id/remote-data-objects/f24bae23-5ac1-432e-b691-574e59c0d02b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f24bae23-5ac1-432e-b691-574e59c0d02b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f24bae23-5ac1-432e-b691-574e59c0d02b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c557346-1589-4d96-ba81-171ae0aa9ecc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c557346-1589-4d96-ba81-171ae0aa9ecc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c557346-1589-4d96-ba81-171ae0aa9ecc>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9f37a96-9313-4c29-9afe-2e0094616d8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9f37a96-9313-4c29-9afe-2e0094616d8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9f37a96-9313-4c29-9afe-2e0094616d8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4482d4fc-d4e6-4610-8fa7-e29d86cb56de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4482d4fc-d4e6-4610-8fa7-e29d86cb56de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4482d4fc-d4e6-4610-8fa7-e29d86cb56de>.
+    
+<http://data.lblod.info/id/remote-data-objects/067796aa-7711-4f9f-887c-8f57e12de1f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "067796aa-7711-4f9f-887c-8f57e12de1f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/067796aa-7711-4f9f-887c-8f57e12de1f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc0eba82-7f50-42b0-8f7d-65a156d3a874> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc0eba82-7f50-42b0-8f7d-65a156d3a874";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc0eba82-7f50-42b0-8f7d-65a156d3a874>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6123983-8b98-4f01-8276-d8ddd9cbb90c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6123983-8b98-4f01-8276-d8ddd9cbb90c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6123983-8b98-4f01-8276-d8ddd9cbb90c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d95ffb2b-0bd0-4541-86ae-166e5396a628> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d95ffb2b-0bd0-4541-86ae-166e5396a628";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d95ffb2b-0bd0-4541-86ae-166e5396a628>.
+    
+<http://data.lblod.info/id/remote-data-objects/07df9c3c-a536-4bb9-8334-e3bb8125d93b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07df9c3c-a536-4bb9-8334-e3bb8125d93b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07df9c3c-a536-4bb9-8334-e3bb8125d93b>.
+    
+<http://data.lblod.info/id/remote-data-objects/55833f91-ecaa-4eef-ac23-7d61cfbc3741> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55833f91-ecaa-4eef-ac23-7d61cfbc3741";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55833f91-ecaa-4eef-ac23-7d61cfbc3741>.
+    
+<http://data.lblod.info/id/remote-data-objects/e56c3ea9-e7f1-45c4-9e84-2fbdda07e8c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e56c3ea9-e7f1-45c4-9e84-2fbdda07e8c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e56c3ea9-e7f1-45c4-9e84-2fbdda07e8c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb6b1c01-4052-47cc-b2bc-6fb3f754398e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb6b1c01-4052-47cc-b2bc-6fb3f754398e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb6b1c01-4052-47cc-b2bc-6fb3f754398e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ba5e847-a01a-44c2-9b4a-811618562e80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ba5e847-a01a-44c2-9b4a-811618562e80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=Uittreksels_16-06-2022_24455.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ba5e847-a01a-44c2-9b4a-811618562e80>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b1aa864-2156-4b94-be24-04ec7f071d9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b1aa864-2156-4b94-be24-04ec7f071d9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=Uittreksels_16-12-2021_21994.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b1aa864-2156-4b94-be24-04ec7f071d9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba6df967-788f-4584-b093-a6be2c386236> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba6df967-788f-4584-b093-a6be2c386236";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/f8e99bc23715c726411b182d6fd92b676a03973a5b5ddab314d443eed5852957/GetPublication?filename=Uittreksels_16-12-2021_22028.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba6df967-788f-4584-b093-a6be2c386236>.
+    
+<http://data.lblod.info/id/remote-data-objects/6927a25d-0820-4f86-8a6a-4b8be0ee6fc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6927a25d-0820-4f86-8a6a-4b8be0ee6fc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/fec53312650c6b2a34b64dac18a875a6f48b3c6bda12d7f048ba09c7087f5737/GetPublication?filename=BesluitenLijstUitspraak_Beslissingen%20burgemeester_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6927a25d-0820-4f86-8a6a-4b8be0ee6fc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/326ef2d3-1079-4d34-bc30-113286472c0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "326ef2d3-1079-4d34-bc30-113286472c0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/fec53312650c6b2a34b64dac18a875a6f48b3c6bda12d7f048ba09c7087f5737/GetPublication?filename=BesluitenLijstUitspraak_Beslissingen%20burgemeester_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/326ef2d3-1079-4d34-bc30-113286472c0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/00aabab5-5425-4f98-8fdb-d15c9383346d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00aabab5-5425-4f98-8fdb-d15c9383346d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/fec53312650c6b2a34b64dac18a875a6f48b3c6bda12d7f048ba09c7087f5737/GetPublication?filename=BesluitenLijstUitspraak_Beslissingen%20burgemeester_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00aabab5-5425-4f98-8fdb-d15c9383346d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bf96477-35f3-4702-ad41-5e6bdd8dd0bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bf96477-35f3-4702-ad41-5e6bdd8dd0bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/fec53312650c6b2a34b64dac18a875a6f48b3c6bda12d7f048ba09c7087f5737/GetPublication?filename=BesluitenLijstUitspraak_Beslissingen%20burgemeester_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c423d12f-ab99-4ed9-beea-e03699d95a32> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bf96477-35f3-4702-ad41-5e6bdd8dd0bf>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201323-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201323-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201323-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201323-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/893a1d30-e16b-4a8d-9570-0249a912131e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "893a1d30-e16b-4a8d-9570-0249a912131e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/95b8b67b-b327-435b-ba52-d7a4453663af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "95b8b67b-b327-435b-ba52-d7a4453663af";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7>.
+
+  <http://redpencil.data.gift/id/task/4e11b9c7-8d75-436a-bfda-a1557ab06c5d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4e11b9c7-8d75-436a-bfda-a1557ab06c5d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/893a1d30-e16b-4a8d-9570-0249a912131e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/95b8b67b-b327-435b-ba52-d7a4453663af>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/870ca7bc-babe-44fd-b1bf-9ca20992e4c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "870ca7bc-babe-44fd-b1bf-9ca20992e4c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/fec53312650c6b2a34b64dac18a875a6f48b3c6bda12d7f048ba09c7087f5737/GetPublication?filename=BesluitenLijstUitspraak_Beslissingen%20burgemeester_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/870ca7bc-babe-44fd-b1bf-9ca20992e4c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e49ebb8-1696-4abb-aa7b-0117799c147c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e49ebb8-1696-4abb-aa7b-0117799c147c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/fec53312650c6b2a34b64dac18a875a6f48b3c6bda12d7f048ba09c7087f5737/GetPublication?filename=BesluitenLijstUitspraak_Beslissingen%20burgemeester_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e49ebb8-1696-4abb-aa7b-0117799c147c>.
+    
+<http://data.lblod.info/id/remote-data-objects/77ed91bd-d02a-4495-a59d-0242cb2bef63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77ed91bd-d02a-4495-a59d-0242cb2bef63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/fec53312650c6b2a34b64dac18a875a6f48b3c6bda12d7f048ba09c7087f5737/GetPublication?filename=BesluitenLijstUitspraak_Beslissingen%20burgemeester_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77ed91bd-d02a-4495-a59d-0242cb2bef63>.
+    
+<http://data.lblod.info/id/remote-data-objects/fabd506d-f9be-4920-9e79-3ac58be2bb68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fabd506d-f9be-4920-9e79-3ac58be2bb68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/fec53312650c6b2a34b64dac18a875a6f48b3c6bda12d7f048ba09c7087f5737/GetPublication?filename=BesluitenLijstUitspraak_Beslissingen%20burgemeester_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fabd506d-f9be-4920-9e79-3ac58be2bb68>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ecf96e7-fcd9-4a59-b0fb-3f5024490823> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ecf96e7-fcd9-4a59-b0fb-3f5024490823";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dehaan.be/LBLODWeb/Home/Overzicht/fec53312650c6b2a34b64dac18a875a6f48b3c6bda12d7f048ba09c7087f5737/GetPublication?filename=BesluitenLijstUitspraak_Beslissingen%20burgemeester_31-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ecf96e7-fcd9-4a59-b0fb-3f5024490823>.
+    
+<http://data.lblod.info/id/remote-data-objects/efc072a3-124d-4655-91da-6e7b644847a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efc072a3-124d-4655-91da-6e7b644847a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Agenda_gemeenteraad_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efc072a3-124d-4655-91da-6e7b644847a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/52462b7d-9efb-4bc5-9b28-28b5d796812a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52462b7d-9efb-4bc5-9b28-28b5d796812a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Agenda_gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52462b7d-9efb-4bc5-9b28-28b5d796812a>.
+    
+<http://data.lblod.info/id/remote-data-objects/30ed8054-de68-465c-b47c-ae2725e521a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30ed8054-de68-465c-b47c-ae2725e521a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Agenda_gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30ed8054-de68-465c-b47c-ae2725e521a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/05d8f364-49eb-4ceb-995c-ba6c2883bb51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05d8f364-49eb-4ceb-995c-ba6c2883bb51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Agenda_gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05d8f364-49eb-4ceb-995c-ba6c2883bb51>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ad9d328-23cd-4110-a10b-df8543c7b0ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ad9d328-23cd-4110-a10b-df8543c7b0ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Agenda_gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ad9d328-23cd-4110-a10b-df8543c7b0ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/05b78929-9a82-4de3-b642-a02b547cbc34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05b78929-9a82-4de3-b642-a02b547cbc34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Agenda_gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05b78929-9a82-4de3-b642-a02b547cbc34>.
+    
+<http://data.lblod.info/id/remote-data-objects/57477d9d-4dba-4b49-b8f1-dddc526c8fe2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57477d9d-4dba-4b49-b8f1-dddc526c8fe2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Agenda_gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57477d9d-4dba-4b49-b8f1-dddc526c8fe2>.
+    
+<http://data.lblod.info/id/remote-data-objects/92a49aba-8f03-4dcd-b7e6-a7876366cd83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92a49aba-8f03-4dcd-b7e6-a7876366cd83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Agenda_gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92a49aba-8f03-4dcd-b7e6-a7876366cd83>.
+    
+<http://data.lblod.info/id/remote-data-objects/b22745b3-2d5f-4a88-a2fd-0ab8b7940d6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b22745b3-2d5f-4a88-a2fd-0ab8b7940d6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Agenda_gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b22745b3-2d5f-4a88-a2fd-0ab8b7940d6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e8e4b71-5a68-4c33-8e32-df8b13aa6275> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e8e4b71-5a68-4c33-8e32-df8b13aa6275";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=BesluitenLijst_gemeenteraad_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e8e4b71-5a68-4c33-8e32-df8b13aa6275>.
+    
+<http://data.lblod.info/id/remote-data-objects/d96607df-adbe-4e43-a7ff-bebce4887505> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d96607df-adbe-4e43-a7ff-bebce4887505";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=BesluitenLijst_gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d96607df-adbe-4e43-a7ff-bebce4887505>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9f4a0e6-7c83-45d8-9e20-255c68f155cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9f4a0e6-7c83-45d8-9e20-255c68f155cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=BesluitenLijst_gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9f4a0e6-7c83-45d8-9e20-255c68f155cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/865dee6f-d17d-4dd7-a5a1-ec98ae75ba14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "865dee6f-d17d-4dd7-a5a1-ec98ae75ba14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=BesluitenLijst_gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/865dee6f-d17d-4dd7-a5a1-ec98ae75ba14>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1a7b70b-887e-4afa-bac8-62df994c4297> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1a7b70b-887e-4afa-bac8-62df994c4297";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=BesluitenLijst_gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1a7b70b-887e-4afa-bac8-62df994c4297>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bd6003f-e1e1-403b-93fa-314f5ec74f75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bd6003f-e1e1-403b-93fa-314f5ec74f75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=BesluitenLijst_gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bd6003f-e1e1-403b-93fa-314f5ec74f75>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb9ecf18-7db8-40dc-85be-c28da460f3ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb9ecf18-7db8-40dc-85be-c28da460f3ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=BesluitenLijst_gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb9ecf18-7db8-40dc-85be-c28da460f3ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/c853a9c3-e899-4922-8d64-7908cbe9424d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c853a9c3-e899-4922-8d64-7908cbe9424d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=BesluitenLijst_gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c853a9c3-e899-4922-8d64-7908cbe9424d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a555c04-8c0d-47f4-814f-7ba24526d884> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a555c04-8c0d-47f4-814f-7ba24526d884";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=BesluitenLijst_gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a555c04-8c0d-47f4-814f-7ba24526d884>.
+    
+<http://data.lblod.info/id/remote-data-objects/46d2a948-2974-4026-b808-8432975a6330> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46d2a948-2974-4026-b808-8432975a6330";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Notulen_gemeenteraad_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46d2a948-2974-4026-b808-8432975a6330>.
+    
+<http://data.lblod.info/id/remote-data-objects/38e550f1-03f9-4525-86f7-3b36e8d1f037> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38e550f1-03f9-4525-86f7-3b36e8d1f037";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Notulen_gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38e550f1-03f9-4525-86f7-3b36e8d1f037>.
+    
+<http://data.lblod.info/id/remote-data-objects/24b854b5-853e-4aba-850a-ef91249c29a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24b854b5-853e-4aba-850a-ef91249c29a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Notulen_gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24b854b5-853e-4aba-850a-ef91249c29a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d939ac6-250b-4fd3-bb59-165fb103eb6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d939ac6-250b-4fd3-bb59-165fb103eb6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Notulen_gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d939ac6-250b-4fd3-bb59-165fb103eb6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/31e68902-7e0d-49a8-ab7b-06146f9197cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31e68902-7e0d-49a8-ab7b-06146f9197cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Notulen_gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31e68902-7e0d-49a8-ab7b-06146f9197cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/b01c4be5-0395-4a1e-a2b6-a0c78cbccd6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b01c4be5-0395-4a1e-a2b6-a0c78cbccd6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Notulen_gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b01c4be5-0395-4a1e-a2b6-a0c78cbccd6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e8e51db-5eed-41cc-bd66-bc02ac6e4c61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e8e51db-5eed-41cc-bd66-bc02ac6e4c61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Notulen_gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e8e51db-5eed-41cc-bd66-bc02ac6e4c61>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ce0c1d1-5bb9-4c64-98bc-869185fdaba4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ce0c1d1-5bb9-4c64-98bc-869185fdaba4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Notulen_gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ce0c1d1-5bb9-4c64-98bc-869185fdaba4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a219417-3f92-4c53-880c-46f37931abe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a219417-3f92-4c53-880c-46f37931abe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=ToegevoegdeAgenda_gemeenteraad_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a219417-3f92-4c53-880c-46f37931abe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c8b0daf-87ac-4b76-843c-0539c0bd2af6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c8b0daf-87ac-4b76-843c-0539c0bd2af6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=ToegevoegdeAgenda_gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c8b0daf-87ac-4b76-843c-0539c0bd2af6>.
+    
+<http://data.lblod.info/id/remote-data-objects/96cea147-8a90-4a79-9b60-88bf91f8fd19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96cea147-8a90-4a79-9b60-88bf91f8fd19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=ToegevoegdeAgenda_gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96cea147-8a90-4a79-9b60-88bf91f8fd19>.
+    
+<http://data.lblod.info/id/remote-data-objects/60830839-b8ae-43e1-9436-6bb8aba19e84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60830839-b8ae-43e1-9436-6bb8aba19e84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_05-05-2022_24104.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60830839-b8ae-43e1-9436-6bb8aba19e84>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd407ac7-cc54-4a8a-9022-e262e6434104> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd407ac7-cc54-4a8a-9022-e262e6434104";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_05-05-2022_24241.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd407ac7-cc54-4a8a-9022-e262e6434104>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fe9b8cc-5efa-4253-a21f-07dcd6e6c364> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fe9b8cc-5efa-4253-a21f-07dcd6e6c364";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_05-05-2022_24355.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fe9b8cc-5efa-4253-a21f-07dcd6e6c364>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc3b4745-24c1-42f4-9f41-33a9b4fc09fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc3b4745-24c1-42f4-9f41-33a9b4fc09fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_05-05-2022_24360.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc3b4745-24c1-42f4-9f41-33a9b4fc09fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/31b955f2-ee88-4701-adc9-72f8f37dd388> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31b955f2-ee88-4701-adc9-72f8f37dd388";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_05-05-2022_24363.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31b955f2-ee88-4701-adc9-72f8f37dd388>.
+    
+<http://data.lblod.info/id/remote-data-objects/a89f0aa6-b318-420d-8a1f-69960c9dbada> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a89f0aa6-b318-420d-8a1f-69960c9dbada";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_05-05-2022_24364.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a89f0aa6-b318-420d-8a1f-69960c9dbada>.
+    
+<http://data.lblod.info/id/remote-data-objects/3600c2e3-fd9b-4001-9da6-02b73c687233> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3600c2e3-fd9b-4001-9da6-02b73c687233";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_05-05-2022_24365.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3600c2e3-fd9b-4001-9da6-02b73c687233>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b3db45c-63c2-444f-8b00-4791d7935d1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b3db45c-63c2-444f-8b00-4791d7935d1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_05-05-2022_24366.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b3db45c-63c2-444f-8b00-4791d7935d1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/257378a4-d0f5-43f8-adb4-2d1da19ac598> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "257378a4-d0f5-43f8-adb4-2d1da19ac598";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_05-05-2022_24367.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/257378a4-d0f5-43f8-adb4-2d1da19ac598>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ea93777-72fe-4be8-8fdd-e62c8750e008> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ea93777-72fe-4be8-8fdd-e62c8750e008";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_05-05-2022_24368.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ea93777-72fe-4be8-8fdd-e62c8750e008>.
+    
+<http://data.lblod.info/id/remote-data-objects/16449fa5-18e5-4824-85bb-64808dc850a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16449fa5-18e5-4824-85bb-64808dc850a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_05-05-2022_24369.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16449fa5-18e5-4824-85bb-64808dc850a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b088ecbc-d60d-499a-bf9f-de1c3b53476d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b088ecbc-d60d-499a-bf9f-de1c3b53476d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_05-05-2022_24370.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b088ecbc-d60d-499a-bf9f-de1c3b53476d>.
+    
+<http://data.lblod.info/id/remote-data-objects/881e91a5-d14f-4f77-a1a3-b6ef68206017> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "881e91a5-d14f-4f77-a1a3-b6ef68206017";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_21-12-2021_22663.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/881e91a5-d14f-4f77-a1a3-b6ef68206017>.
+    
+<http://data.lblod.info/id/remote-data-objects/80a6d46d-1834-4259-9ba9-bf8d2924f3ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80a6d46d-1834-4259-9ba9-bf8d2924f3ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_21-12-2021_22664.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80a6d46d-1834-4259-9ba9-bf8d2924f3ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb333a67-1716-41ba-9e55-dc6e028d368b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb333a67-1716-41ba-9e55-dc6e028d368b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_23-06-2022_24863.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb333a67-1716-41ba-9e55-dc6e028d368b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e654bbc-c477-44b9-8a14-b96dba7076f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e654bbc-c477-44b9-8a14-b96dba7076f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_23-06-2022_24968.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea94b8d6-cfcb-483a-8b09-0b225f5ae8e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e654bbc-c477-44b9-8a14-b96dba7076f7>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201324-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201324-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201324-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201324-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c42dee3e-c7f6-4753-9296-f6e9bb713f7a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c42dee3e-c7f6-4753-9296-f6e9bb713f7a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "280c82b8-242e-49cd-9d02-f79287af9b08";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b2a6a3cc-f1aa-4025-8944-503a9b416699> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b2a6a3cc-f1aa-4025-8944-503a9b416699";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08>.
+
+  <http://redpencil.data.gift/id/task/4ced0655-d2d2-41cc-99cc-39120c982a36> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4ced0655-d2d2-41cc-99cc-39120c982a36";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c42dee3e-c7f6-4753-9296-f6e9bb713f7a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b2a6a3cc-f1aa-4025-8944-503a9b416699>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/25b79346-ed49-42a5-89ec-ddf13172b007> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25b79346-ed49-42a5-89ec-ddf13172b007";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_23-06-2022_24970.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25b79346-ed49-42a5-89ec-ddf13172b007>.
+    
+<http://data.lblod.info/id/remote-data-objects/53406900-fad0-4cd6-a6e6-7dc6217861ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53406900-fad0-4cd6-a6e6-7dc6217861ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_23-06-2022_24971.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53406900-fad0-4cd6-a6e6-7dc6217861ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/7be898f0-16ea-49b0-8a0a-b5e5e04fe09e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7be898f0-16ea-49b0-8a0a-b5e5e04fe09e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_24-02-2022_23268.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7be898f0-16ea-49b0-8a0a-b5e5e04fe09e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a35bdb6e-af25-46b8-bfb3-cb72d80a9697> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a35bdb6e-af25-46b8-bfb3-cb72d80a9697";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_24-02-2022_23460.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a35bdb6e-af25-46b8-bfb3-cb72d80a9697>.
+    
+<http://data.lblod.info/id/remote-data-objects/03dfdc8a-c085-4f32-bd87-9b447275b9dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03dfdc8a-c085-4f32-bd87-9b447275b9dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_24-02-2022_23537.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03dfdc8a-c085-4f32-bd87-9b447275b9dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/21342ddb-dd6b-4801-b533-35e37118af55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21342ddb-dd6b-4801-b533-35e37118af55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_24-02-2022_23538.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21342ddb-dd6b-4801-b533-35e37118af55>.
+    
+<http://data.lblod.info/id/remote-data-objects/7229101e-440a-4a28-9269-84cad1d21d5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7229101e-440a-4a28-9269-84cad1d21d5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_25-11-2021_22468.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7229101e-440a-4a28-9269-84cad1d21d5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/66b481bd-9f5c-455e-9b47-17ede6710e67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66b481bd-9f5c-455e-9b47-17ede6710e67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_27-01-2022_23185.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66b481bd-9f5c-455e-9b47-17ede6710e67>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9f567c9-7ef1-4102-ade0-46ffa9f70341> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9f567c9-7ef1-4102-ade0-46ffa9f70341";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_28-10-2021_20906.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9f567c9-7ef1-4102-ade0-46ffa9f70341>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae6f53a1-d672-42cb-adfa-b11627ac114e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae6f53a1-d672-42cb-adfa-b11627ac114e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_28-10-2021_21983.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae6f53a1-d672-42cb-adfa-b11627ac114e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b2e6f4b-ebc1-4738-8d32-3ade0cc345f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b2e6f4b-ebc1-4738-8d32-3ade0cc345f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_28-10-2021_22175.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b2e6f4b-ebc1-4738-8d32-3ade0cc345f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/7795a6b6-ad60-4af7-8c41-f66b28690521> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7795a6b6-ad60-4af7-8c41-f66b28690521";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_31-03-2022_23640.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7795a6b6-ad60-4af7-8c41-f66b28690521>.
+    
+<http://data.lblod.info/id/remote-data-objects/adeae4d8-62df-49b8-a0d3-6bc911d11cef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "adeae4d8-62df-49b8-a0d3-6bc911d11cef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_31-03-2022_23723.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/adeae4d8-62df-49b8-a0d3-6bc911d11cef>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed54d60a-af1e-48ad-ad8c-b2ac38535444> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed54d60a-af1e-48ad-ad8c-b2ac38535444";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_31-03-2022_23724.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed54d60a-af1e-48ad-ad8c-b2ac38535444>.
+    
+<http://data.lblod.info/id/remote-data-objects/be51df6b-612a-446c-b147-f99f0db739fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be51df6b-612a-446c-b147-f99f0db739fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_31-03-2022_23787.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be51df6b-612a-446c-b147-f99f0db739fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7edffee1-4328-46c7-ae03-398da56ffdba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7edffee1-4328-46c7-ae03-398da56ffdba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/1250ce033a9b2c384badc83a107fa676f38c24cac5a3ebe2aabed3390ab7a376/GetPublication?filename=Uittreksels_31-03-2022_23942.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7edffee1-4328-46c7-ae03-398da56ffdba>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2355d29-1220-4735-851b-74a908e6b693> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2355d29-1220-4735-851b-74a908e6b693";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2355d29-1220-4735-851b-74a908e6b693>.
+    
+<http://data.lblod.info/id/remote-data-objects/df88ddfc-a501-4fd5-b3fc-4cc1cec5e0eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df88ddfc-a501-4fd5-b3fc-4cc1cec5e0eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df88ddfc-a501-4fd5-b3fc-4cc1cec5e0eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c75340d2-9599-4c14-b745-d99d8b319c9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c75340d2-9599-4c14-b745-d99d8b319c9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c75340d2-9599-4c14-b745-d99d8b319c9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ba574b1-2b44-401e-9ac8-5fdcfaf064aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ba574b1-2b44-401e-9ac8-5fdcfaf064aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ba574b1-2b44-401e-9ac8-5fdcfaf064aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/eca1b2f0-ac32-4c74-86bd-38fe152441ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eca1b2f0-ac32-4c74-86bd-38fe152441ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eca1b2f0-ac32-4c74-86bd-38fe152441ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/59405309-a7dc-4d73-984a-89443c183828> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59405309-a7dc-4d73-984a-89443c183828";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59405309-a7dc-4d73-984a-89443c183828>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bd08ef4-a137-42e3-aeb4-aac4c280a829> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bd08ef4-a137-42e3-aeb4-aac4c280a829";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bd08ef4-a137-42e3-aeb4-aac4c280a829>.
+    
+<http://data.lblod.info/id/remote-data-objects/9409f808-89bb-48ee-806f-c3f4037634c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9409f808-89bb-48ee-806f-c3f4037634c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9409f808-89bb-48ee-806f-c3f4037634c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec47b680-d905-4fc2-87aa-8cf0796a8391> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec47b680-d905-4fc2-87aa-8cf0796a8391";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec47b680-d905-4fc2-87aa-8cf0796a8391>.
+    
+<http://data.lblod.info/id/remote-data-objects/e05de8cb-488e-4b55-a945-c2a8dfe7d265> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e05de8cb-488e-4b55-a945-c2a8dfe7d265";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e05de8cb-488e-4b55-a945-c2a8dfe7d265>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5d2dbf6-ab3e-44e4-b50b-a3a4e2f37cfb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5d2dbf6-ab3e-44e4-b50b-a3a4e2f37cfb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5d2dbf6-ab3e-44e4-b50b-a3a4e2f37cfb>.
+    
+<http://data.lblod.info/id/remote-data-objects/55b01535-8dde-43bb-9985-68de5ff4072a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55b01535-8dde-43bb-9985-68de5ff4072a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55b01535-8dde-43bb-9985-68de5ff4072a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c63339d6-6a93-4b29-a146-88bbec91a325> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c63339d6-6a93-4b29-a146-88bbec91a325";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c63339d6-6a93-4b29-a146-88bbec91a325>.
+    
+<http://data.lblod.info/id/remote-data-objects/7159d92a-eeac-4c6d-b5ae-fff9f0c2f60f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7159d92a-eeac-4c6d-b5ae-fff9f0c2f60f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7159d92a-eeac-4c6d-b5ae-fff9f0c2f60f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bb00c29-c8ce-4b42-b465-9b6509812b38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bb00c29-c8ce-4b42-b465-9b6509812b38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bb00c29-c8ce-4b42-b465-9b6509812b38>.
+    
+<http://data.lblod.info/id/remote-data-objects/100763a0-9dd1-4f6b-bfb2-837ac28bec1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "100763a0-9dd1-4f6b-bfb2-837ac28bec1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/100763a0-9dd1-4f6b-bfb2-837ac28bec1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd3de0bc-3b11-42a7-a3b9-56d794f50971> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd3de0bc-3b11-42a7-a3b9-56d794f50971";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd3de0bc-3b11-42a7-a3b9-56d794f50971>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd948af6-a9e9-48e5-a481-c88b1d13a69b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd948af6-a9e9-48e5-a481-c88b1d13a69b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd948af6-a9e9-48e5-a481-c88b1d13a69b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f711210e-0680-4383-ab27-ce851b6e9219> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f711210e-0680-4383-ab27-ce851b6e9219";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f711210e-0680-4383-ab27-ce851b6e9219>.
+    
+<http://data.lblod.info/id/remote-data-objects/b89c473a-2150-4da3-809d-2b52b4c9507e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b89c473a-2150-4da3-809d-2b52b4c9507e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b89c473a-2150-4da3-809d-2b52b4c9507e>.
+    
+<http://data.lblod.info/id/remote-data-objects/53215caf-c6df-4932-9506-c0537652f7db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53215caf-c6df-4932-9506-c0537652f7db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Uittreksels_05-05-2022_24350.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53215caf-c6df-4932-9506-c0537652f7db>.
+    
+<http://data.lblod.info/id/remote-data-objects/1436be3e-8c2a-4a8d-a63a-40ea8b101310> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1436be3e-8c2a-4a8d-a63a-40ea8b101310";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Uittreksels_05-05-2022_24351.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1436be3e-8c2a-4a8d-a63a-40ea8b101310>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9578a96-86c5-4931-b78a-ba0a5d114a85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9578a96-86c5-4931-b78a-ba0a5d114a85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Uittreksels_21-12-2021_22662.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9578a96-86c5-4931-b78a-ba0a5d114a85>.
+    
+<http://data.lblod.info/id/remote-data-objects/e37d8f2a-dacb-4888-8fb8-1eb661559d71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e37d8f2a-dacb-4888-8fb8-1eb661559d71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Uittreksels_28-10-2021_22181.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e37d8f2a-dacb-4888-8fb8-1eb661559d71>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f4f01f5-89db-4498-9bcc-d2a7ac78fd20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f4f01f5-89db-4498-9bcc-d2a7ac78fd20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/39423cdccbce6ff187eb4cbf565560edca8e59e6f34ad09c72900c5aa46b0a2e/GetPublication?filename=Uittreksels_31-03-2022_23849.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f4f01f5-89db-4498-9bcc-d2a7ac78fd20>.
+    
+<http://data.lblod.info/id/remote-data-objects/c31b57b3-b678-44bf-bbc5-210b08ebbabe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c31b57b3-b678-44bf-bbc5-210b08ebbabe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c31b57b3-b678-44bf-bbc5-210b08ebbabe>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea261765-6105-492e-a695-08059f508999> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea261765-6105-492e-a695-08059f508999";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea261765-6105-492e-a695-08059f508999>.
+    
+<http://data.lblod.info/id/remote-data-objects/be4c10a3-5556-43bc-b39a-40135bb912cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be4c10a3-5556-43bc-b39a-40135bb912cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be4c10a3-5556-43bc-b39a-40135bb912cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/db9976c2-6534-4a75-a9be-7d2058a84d1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db9976c2-6534-4a75-a9be-7d2058a84d1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db9976c2-6534-4a75-a9be-7d2058a84d1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/94bcf6ec-0a5b-4fc1-8b14-4f45b8839d7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94bcf6ec-0a5b-4fc1-8b14-4f45b8839d7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94bcf6ec-0a5b-4fc1-8b14-4f45b8839d7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/75926df2-6dc6-4018-9de8-93716327fd43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75926df2-6dc6-4018-9de8-93716327fd43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75926df2-6dc6-4018-9de8-93716327fd43>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4bd4db1-806f-4a5a-8c8d-1e331c62291b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4bd4db1-806f-4a5a-8c8d-1e331c62291b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4bd4db1-806f-4a5a-8c8d-1e331c62291b>.
+    
+<http://data.lblod.info/id/remote-data-objects/577d6efb-1b5c-47e8-aec6-9e86dca7c1e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "577d6efb-1b5c-47e8-aec6-9e86dca7c1e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/577d6efb-1b5c-47e8-aec6-9e86dca7c1e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca4a3786-3c63-491e-9e9b-7dc73c45cafd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca4a3786-3c63-491e-9e9b-7dc73c45cafd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/280c82b8-242e-49cd-9d02-f79287af9b08> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca4a3786-3c63-491e-9e9b-7dc73c45cafd>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201326-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201326-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201326-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201326-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c8440b55-d120-4a42-a002-e008bea14175> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c8440b55-d120-4a42-a002-e008bea14175";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2df49607-fbf3-4243-b5a5-24ecce1eb356";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/09a8dfca-5a7d-4083-9684-5a29b85347f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "09a8dfca-5a7d-4083-9684-5a29b85347f0";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356>.
+
+  <http://redpencil.data.gift/id/task/f87e4f4d-8740-46aa-a7a4-32703df3ad7c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f87e4f4d-8740-46aa-a7a4-32703df3ad7c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c8440b55-d120-4a42-a002-e008bea14175>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/09a8dfca-5a7d-4083-9684-5a29b85347f0>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/24776577-46ba-4b52-bf41-0c270550cded> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24776577-46ba-4b52-bf41-0c270550cded";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24776577-46ba-4b52-bf41-0c270550cded>.
+    
+<http://data.lblod.info/id/remote-data-objects/6786d223-5b3a-4319-8d65-713c65b12bb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6786d223-5b3a-4319-8d65-713c65b12bb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6786d223-5b3a-4319-8d65-713c65b12bb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b6fe8ae-01e2-4f91-beec-b881bd08d089> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b6fe8ae-01e2-4f91-beec-b881bd08d089";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b6fe8ae-01e2-4f91-beec-b881bd08d089>.
+    
+<http://data.lblod.info/id/remote-data-objects/5603e2a1-f502-4d4a-a298-30cf7781d1f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5603e2a1-f502-4d4a-a298-30cf7781d1f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5603e2a1-f502-4d4a-a298-30cf7781d1f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/95caba97-3171-40bc-801d-6a6d3b2282f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95caba97-3171-40bc-801d-6a6d3b2282f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95caba97-3171-40bc-801d-6a6d3b2282f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ce3f978-c329-4f3d-9efb-c951e534e9e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ce3f978-c329-4f3d-9efb-c951e534e9e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ce3f978-c329-4f3d-9efb-c951e534e9e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/27a86150-6e4a-40a4-9eba-2ae007982457> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27a86150-6e4a-40a4-9eba-2ae007982457";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27a86150-6e4a-40a4-9eba-2ae007982457>.
+    
+<http://data.lblod.info/id/remote-data-objects/d688fcf6-7a96-4fe7-af3f-dd200e4b23f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d688fcf6-7a96-4fe7-af3f-dd200e4b23f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d688fcf6-7a96-4fe7-af3f-dd200e4b23f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d73a901-e706-4577-804f-0d4216ef1373> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d73a901-e706-4577-804f-0d4216ef1373";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d73a901-e706-4577-804f-0d4216ef1373>.
+    
+<http://data.lblod.info/id/remote-data-objects/20879130-e8d3-4e57-a409-2d625c03d335> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20879130-e8d3-4e57-a409-2d625c03d335";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20879130-e8d3-4e57-a409-2d625c03d335>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcdff254-7e64-4231-affd-916ce9d3affe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcdff254-7e64-4231-affd-916ce9d3affe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcdff254-7e64-4231-affd-916ce9d3affe>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1b9be60-192e-4884-be75-78e11b17de08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1b9be60-192e-4884-be75-78e11b17de08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1b9be60-192e-4884-be75-78e11b17de08>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d1a0545-fda0-43ce-8c0a-0d61456e0865> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d1a0545-fda0-43ce-8c0a-0d61456e0865";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d1a0545-fda0-43ce-8c0a-0d61456e0865>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ca257b7-28a5-43ae-a874-f0b46f81002e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ca257b7-28a5-43ae-a874-f0b46f81002e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ca257b7-28a5-43ae-a874-f0b46f81002e>.
+    
+<http://data.lblod.info/id/remote-data-objects/00d2a36d-4c79-43a9-b8d8-242cf2992b63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00d2a36d-4c79-43a9-b8d8-242cf2992b63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00d2a36d-4c79-43a9-b8d8-242cf2992b63>.
+    
+<http://data.lblod.info/id/remote-data-objects/de5e5167-15c5-416c-932d-93ef73e55469> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de5e5167-15c5-416c-932d-93ef73e55469";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de5e5167-15c5-416c-932d-93ef73e55469>.
+    
+<http://data.lblod.info/id/remote-data-objects/17adefba-bc73-4873-b9d0-370c361fe0d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17adefba-bc73-4873-b9d0-370c361fe0d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17adefba-bc73-4873-b9d0-370c361fe0d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/2564e499-cf1f-4705-84d0-583184f14a5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2564e499-cf1f-4705-84d0-583184f14a5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2564e499-cf1f-4705-84d0-583184f14a5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4047f6d-eb43-4876-a6ce-95982cfcf163> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4047f6d-eb43-4876-a6ce-95982cfcf163";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4047f6d-eb43-4876-a6ce-95982cfcf163>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ed9351f-82e5-4c82-88d0-7d235fe7d09a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ed9351f-82e5-4c82-88d0-7d235fe7d09a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ed9351f-82e5-4c82-88d0-7d235fe7d09a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8a7977d-9848-4931-97e4-0e37b0c62e3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8a7977d-9848-4931-97e4-0e37b0c62e3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8a7977d-9848-4931-97e4-0e37b0c62e3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/53d44f1a-3b72-425e-87f9-b1ae6f11b470> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53d44f1a-3b72-425e-87f9-b1ae6f11b470";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53d44f1a-3b72-425e-87f9-b1ae6f11b470>.
+    
+<http://data.lblod.info/id/remote-data-objects/354890a7-dd65-4fca-a55e-8c514bbef367> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "354890a7-dd65-4fca-a55e-8c514bbef367";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/354890a7-dd65-4fca-a55e-8c514bbef367>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f90725a-7467-48d6-a9cd-a18189d125ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f90725a-7467-48d6-a9cd-a18189d125ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f90725a-7467-48d6-a9cd-a18189d125ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/42f8b5e6-ddc9-4371-a81c-1f716ec2f8f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42f8b5e6-ddc9-4371-a81c-1f716ec2f8f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42f8b5e6-ddc9-4371-a81c-1f716ec2f8f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec616835-dc53-43d5-84db-5761266328ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec616835-dc53-43d5-84db-5761266328ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec616835-dc53-43d5-84db-5761266328ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/8630b9d1-207c-4daf-8b1f-236b6cb032eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8630b9d1-207c-4daf-8b1f-236b6cb032eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=BesluitenLijst_vast%20bureau_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8630b9d1-207c-4daf-8b1f-236b6cb032eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/4adfa4b5-88d9-4f67-a4f7-74f5feb6a1b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4adfa4b5-88d9-4f67-a4f7-74f5feb6a1b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=Uittreksels_08-02-2022_23340.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4adfa4b5-88d9-4f67-a4f7-74f5feb6a1b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7d46774-a902-4dae-aafd-a8cd6af25baf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7d46774-a902-4dae-aafd-a8cd6af25baf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=Uittreksels_14-12-2021_22738.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7d46774-a902-4dae-aafd-a8cd6af25baf>.
+    
+<http://data.lblod.info/id/remote-data-objects/7581cb6d-9148-49e3-a4ba-044a8d555ead> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7581cb6d-9148-49e3-a4ba-044a8d555ead";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/6176a403113835e37462fd2cb10536049be2c819d0be5f94ec569df12a389eea/GetPublication?filename=Uittreksels_29-03-2022_24058.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7581cb6d-9148-49e3-a4ba-044a8d555ead>.
+    
+<http://data.lblod.info/id/remote-data-objects/a48048b3-0923-401f-9fff-ce6b0a2a63d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a48048b3-0923-401f-9fff-ce6b0a2a63d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_01-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a48048b3-0923-401f-9fff-ce6b0a2a63d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/50598cb3-7247-4c24-9b61-ecfaa95c70e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50598cb3-7247-4c24-9b61-ecfaa95c70e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50598cb3-7247-4c24-9b61-ecfaa95c70e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7c1146a-f5ca-43c1-bea5-3724d7e05930> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7c1146a-f5ca-43c1-bea5-3724d7e05930";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7c1146a-f5ca-43c1-bea5-3724d7e05930>.
+    
+<http://data.lblod.info/id/remote-data-objects/ece9684c-f8e0-4cea-b8ae-db6d20a89934> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ece9684c-f8e0-4cea-b8ae-db6d20a89934";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_06-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ece9684c-f8e0-4cea-b8ae-db6d20a89934>.
+    
+<http://data.lblod.info/id/remote-data-objects/86f57d14-ff4b-4532-b856-1d45fb48a14b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86f57d14-ff4b-4532-b856-1d45fb48a14b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86f57d14-ff4b-4532-b856-1d45fb48a14b>.
+    
+<http://data.lblod.info/id/remote-data-objects/513d9c71-ca8d-440c-b845-b96be6191510> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "513d9c71-ca8d-440c-b845-b96be6191510";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/513d9c71-ca8d-440c-b845-b96be6191510>.
+    
+<http://data.lblod.info/id/remote-data-objects/44ab2d90-0f3b-4841-a302-389923e824fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44ab2d90-0f3b-4841-a302-389923e824fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44ab2d90-0f3b-4841-a302-389923e824fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dff492c-cc77-47d7-9630-ad5cc6056290> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dff492c-cc77-47d7-9630-ad5cc6056290";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dff492c-cc77-47d7-9630-ad5cc6056290>.
+    
+<http://data.lblod.info/id/remote-data-objects/be347965-1928-4550-8293-990b481fe200> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be347965-1928-4550-8293-990b481fe200";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be347965-1928-4550-8293-990b481fe200>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfd2c9ba-9e2d-4085-b76a-36c819c010ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfd2c9ba-9e2d-4085-b76a-36c819c010ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfd2c9ba-9e2d-4085-b76a-36c819c010ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a7387da-5874-4d5b-99b6-25ff93c5c6b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a7387da-5874-4d5b-99b6-25ff93c5c6b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a7387da-5874-4d5b-99b6-25ff93c5c6b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d005b237-dd08-4101-bc91-0118e92cb084> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d005b237-dd08-4101-bc91-0118e92cb084";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d005b237-dd08-4101-bc91-0118e92cb084>.
+    
+<http://data.lblod.info/id/remote-data-objects/22e69b74-f698-4e89-9809-93d5695fb91c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22e69b74-f698-4e89-9809-93d5695fb91c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22e69b74-f698-4e89-9809-93d5695fb91c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a34e032b-a7a6-4ea7-91e0-e013b3c1f72c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a34e032b-a7a6-4ea7-91e0-e013b3c1f72c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a34e032b-a7a6-4ea7-91e0-e013b3c1f72c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fea19c05-5869-4a49-b479-65e94407618b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fea19c05-5869-4a49-b479-65e94407618b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fea19c05-5869-4a49-b479-65e94407618b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b041db7c-d79a-42d4-a7fd-4d6788ef5fc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b041db7c-d79a-42d4-a7fd-4d6788ef5fc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b041db7c-d79a-42d4-a7fd-4d6788ef5fc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9b60d4d-95a6-419b-b87f-2bdf0f264413> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9b60d4d-95a6-419b-b87f-2bdf0f264413";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9b60d4d-95a6-419b-b87f-2bdf0f264413>.
+    
+<http://data.lblod.info/id/remote-data-objects/4027a77c-1633-415f-b70d-716e564712df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4027a77c-1633-415f-b70d-716e564712df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4027a77c-1633-415f-b70d-716e564712df>.
+    
+<http://data.lblod.info/id/remote-data-objects/df3edfdb-d2cb-4481-8a6a-7f761ed141ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df3edfdb-d2cb-4481-8a6a-7f761ed141ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df3edfdb-d2cb-4481-8a6a-7f761ed141ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcb86779-0e1a-40e1-84f4-72e590280c04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcb86779-0e1a-40e1-84f4-72e590280c04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2df49607-fbf3-4243-b5a5-24ecce1eb356> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcb86779-0e1a-40e1-84f4-72e590280c04>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201327-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201327-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201327-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201327-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/6cdbe131-8cd4-4b45-94e5-b8b238f90cd6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6cdbe131-8cd4-4b45-94e5-b8b238f90cd6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d0152d9f-5392-471d-a288-9b5aec251e1f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a1c35a46-d94b-4dfc-a712-fb7dab67da27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a1c35a46-d94b-4dfc-a712-fb7dab67da27";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f>.
+
+  <http://redpencil.data.gift/id/task/0645b117-4059-462c-9798-24d91a6723a8> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0645b117-4059-462c-9798-24d91a6723a8";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/6cdbe131-8cd4-4b45-94e5-b8b238f90cd6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a1c35a46-d94b-4dfc-a712-fb7dab67da27>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/57bf184f-176b-43c1-a0dd-29b62d04144e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57bf184f-176b-43c1-a0dd-29b62d04144e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57bf184f-176b-43c1-a0dd-29b62d04144e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ee2e90f-370e-49f8-a679-ea9af7bb9bbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ee2e90f-370e-49f8-a679-ea9af7bb9bbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_27-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ee2e90f-370e-49f8-a679-ea9af7bb9bbb>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c2ba26d-becb-404d-9a7d-8cdce79f9f29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c2ba26d-becb-404d-9a7d-8cdce79f9f29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c2ba26d-becb-404d-9a7d-8cdce79f9f29>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdbce8ed-4e50-4ac2-82b8-00e2471aaeff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdbce8ed-4e50-4ac2-82b8-00e2471aaeff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdbce8ed-4e50-4ac2-82b8-00e2471aaeff>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ab93e77-49d8-400c-a9c6-5ea08983680a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ab93e77-49d8-400c-a9c6-5ea08983680a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ab93e77-49d8-400c-a9c6-5ea08983680a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b6104c8-ea2a-4472-844b-9ec4e1c61b45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b6104c8-ea2a-4472-844b-9ec4e1c61b45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b6104c8-ea2a-4472-844b-9ec4e1c61b45>.
+    
+<http://data.lblod.info/id/remote-data-objects/58fb3fcc-9a67-40ae-bf3b-c0d8dec739ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58fb3fcc-9a67-40ae-bf3b-c0d8dec739ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=BesluitenLijst_besluit%20burgemeester_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58fb3fcc-9a67-40ae-bf3b-c0d8dec739ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/3796f6f9-e929-49bd-a89d-c2bc1da579b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3796f6f9-e929-49bd-a89d-c2bc1da579b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=Uittreksels_04-05-2022_24467.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3796f6f9-e929-49bd-a89d-c2bc1da579b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee59fda8-d0ae-4e85-8ad7-b81364c2599f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee59fda8-d0ae-4e85-8ad7-b81364c2599f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/c8ffb29e3a47d7b1bd356cb80b4caf052170e4b691376967c89e882cb81df23a/GetPublication?filename=Uittreksels_06-10-2021_21984.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee59fda8-d0ae-4e85-8ad7-b81364c2599f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f3122db-9394-4191-a0ab-c55bb545d82c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f3122db-9394-4191-a0ab-c55bb545d82c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f3122db-9394-4191-a0ab-c55bb545d82c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef43d282-1bb3-44d9-a9f3-f62dc4695ca8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef43d282-1bb3-44d9-a9f3-f62dc4695ca8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef43d282-1bb3-44d9-a9f3-f62dc4695ca8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3985ecc8-3651-4efe-8f92-317e453f97dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3985ecc8-3651-4efe-8f92-317e453f97dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3985ecc8-3651-4efe-8f92-317e453f97dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/b013b5b6-78d9-4b1a-aeca-449864dc1ee2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b013b5b6-78d9-4b1a-aeca-449864dc1ee2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b013b5b6-78d9-4b1a-aeca-449864dc1ee2>.
+    
+<http://data.lblod.info/id/remote-data-objects/85b8ef58-0dae-4d42-8634-c3eaad69e55b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85b8ef58-0dae-4d42-8634-c3eaad69e55b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85b8ef58-0dae-4d42-8634-c3eaad69e55b>.
+    
+<http://data.lblod.info/id/remote-data-objects/64889a70-5d2d-4a64-8800-fb11e6b565ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64889a70-5d2d-4a64-8800-fb11e6b565ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64889a70-5d2d-4a64-8800-fb11e6b565ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/47629892-c972-4f90-bd1f-8c4ee6653315> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47629892-c972-4f90-bd1f-8c4ee6653315";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47629892-c972-4f90-bd1f-8c4ee6653315>.
+    
+<http://data.lblod.info/id/remote-data-objects/a31b4f29-dc52-4744-aae9-f2a012aece28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a31b4f29-dc52-4744-aae9-f2a012aece28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a31b4f29-dc52-4744-aae9-f2a012aece28>.
+    
+<http://data.lblod.info/id/remote-data-objects/90932e93-a121-4f50-b8e5-74a94cae097a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90932e93-a121-4f50-b8e5-74a94cae097a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90932e93-a121-4f50-b8e5-74a94cae097a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b71feb94-3dab-46d1-9c6a-0e9a38bee732> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b71feb94-3dab-46d1-9c6a-0e9a38bee732";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b71feb94-3dab-46d1-9c6a-0e9a38bee732>.
+    
+<http://data.lblod.info/id/remote-data-objects/65c28e65-3d3d-4add-83ac-4548b87c18cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65c28e65-3d3d-4add-83ac-4548b87c18cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65c28e65-3d3d-4add-83ac-4548b87c18cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2b168ad-29a6-48d0-9419-6089e4e9f4f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2b168ad-29a6-48d0-9419-6089e4e9f4f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2b168ad-29a6-48d0-9419-6089e4e9f4f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bf37b00-c930-46da-8d66-58dc7c46220b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bf37b00-c930-46da-8d66-58dc7c46220b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bf37b00-c930-46da-8d66-58dc7c46220b>.
+    
+<http://data.lblod.info/id/remote-data-objects/89007828-8a2d-4e41-82ce-061c19fe2290> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89007828-8a2d-4e41-82ce-061c19fe2290";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89007828-8a2d-4e41-82ce-061c19fe2290>.
+    
+<http://data.lblod.info/id/remote-data-objects/eff801ce-845e-4c84-b68f-b795d212cffe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eff801ce-845e-4c84-b68f-b795d212cffe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eff801ce-845e-4c84-b68f-b795d212cffe>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4290709-3b31-40a8-bab5-8eaa046dd59e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4290709-3b31-40a8-bab5-8eaa046dd59e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4290709-3b31-40a8-bab5-8eaa046dd59e>.
+    
+<http://data.lblod.info/id/remote-data-objects/02e58d93-f766-4842-9af5-569f62dd574b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02e58d93-f766-4842-9af5-569f62dd574b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02e58d93-f766-4842-9af5-569f62dd574b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5abe50b9-37f0-41a5-bb88-6cdcd49a636c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5abe50b9-37f0-41a5-bb88-6cdcd49a636c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5abe50b9-37f0-41a5-bb88-6cdcd49a636c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c46a924-cf41-48e1-b1cf-b6026916be70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c46a924-cf41-48e1-b1cf-b6026916be70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c46a924-cf41-48e1-b1cf-b6026916be70>.
+    
+<http://data.lblod.info/id/remote-data-objects/16592180-35b7-4811-8e4f-2a2841e8a0e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16592180-35b7-4811-8e4f-2a2841e8a0e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16592180-35b7-4811-8e4f-2a2841e8a0e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6b4eb39-3e79-4557-9fe5-28f2ac2cf79f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6b4eb39-3e79-4557-9fe5-28f2ac2cf79f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6b4eb39-3e79-4557-9fe5-28f2ac2cf79f>.
+    
+<http://data.lblod.info/id/remote-data-objects/98ea6cf3-3eaa-45f0-ae32-2d952f331530> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98ea6cf3-3eaa-45f0-ae32-2d952f331530";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98ea6cf3-3eaa-45f0-ae32-2d952f331530>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9dd50d6-1f3c-4efd-93d8-e31acbdb9bca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9dd50d6-1f3c-4efd-93d8-e31acbdb9bca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9dd50d6-1f3c-4efd-93d8-e31acbdb9bca>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c65461a-c5ce-4118-8a15-33435a96d6a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c65461a-c5ce-4118-8a15-33435a96d6a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c65461a-c5ce-4118-8a15-33435a96d6a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b28d9d6-ac62-41ce-9c50-ebf62300fc76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b28d9d6-ac62-41ce-9c50-ebf62300fc76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b28d9d6-ac62-41ce-9c50-ebf62300fc76>.
+    
+<http://data.lblod.info/id/remote-data-objects/a49ba545-85e5-4882-b56f-cf68a63eb312> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a49ba545-85e5-4882-b56f-cf68a63eb312";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a49ba545-85e5-4882-b56f-cf68a63eb312>.
+    
+<http://data.lblod.info/id/remote-data-objects/372ff6c7-e864-4de3-9df3-9db0b618c515> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "372ff6c7-e864-4de3-9df3-9db0b618c515";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/372ff6c7-e864-4de3-9df3-9db0b618c515>.
+    
+<http://data.lblod.info/id/remote-data-objects/840bf2ad-3523-45dc-acc4-1f9b890d39e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "840bf2ad-3523-45dc-acc4-1f9b890d39e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/840bf2ad-3523-45dc-acc4-1f9b890d39e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5513806-dcd9-4c99-9698-494068dc52fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5513806-dcd9-4c99-9698-494068dc52fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5513806-dcd9-4c99-9698-494068dc52fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/4199749f-24df-4ebd-9e48-86e568f59fba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4199749f-24df-4ebd-9e48-86e568f59fba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4199749f-24df-4ebd-9e48-86e568f59fba>.
+    
+<http://data.lblod.info/id/remote-data-objects/4116b143-2b7e-4a5c-9869-1caf2d10bf29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4116b143-2b7e-4a5c-9869-1caf2d10bf29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4116b143-2b7e-4a5c-9869-1caf2d10bf29>.
+    
+<http://data.lblod.info/id/remote-data-objects/4803e3ac-68d9-47bc-948f-e1ff80e3b7b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4803e3ac-68d9-47bc-948f-e1ff80e3b7b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4803e3ac-68d9-47bc-948f-e1ff80e3b7b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/efbd9c84-42ad-4d1b-96df-565066e2ff00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efbd9c84-42ad-4d1b-96df-565066e2ff00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efbd9c84-42ad-4d1b-96df-565066e2ff00>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7ae1b3b-1ca8-4849-a766-5f65677ce4c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7ae1b3b-1ca8-4849-a766-5f65677ce4c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7ae1b3b-1ca8-4849-a766-5f65677ce4c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/193670c9-592b-46a4-8a3a-eedab4c5edf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "193670c9-592b-46a4-8a3a-eedab4c5edf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/193670c9-592b-46a4-8a3a-eedab4c5edf9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f6c3fd2-2bb0-4f90-bdaa-adca62acbf8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f6c3fd2-2bb0-4f90-bdaa-adca62acbf8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f6c3fd2-2bb0-4f90-bdaa-adca62acbf8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0a24191-7102-4368-a4c2-75956805374f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0a24191-7102-4368-a4c2-75956805374f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0a24191-7102-4368-a4c2-75956805374f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f865f74-9a36-44ae-a972-b227f382a571> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f865f74-9a36-44ae-a972-b227f382a571";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_01-03-2022_23670.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f865f74-9a36-44ae-a972-b227f382a571>.
+    
+<http://data.lblod.info/id/remote-data-objects/01b6dd88-8d9c-46ef-bb4d-27a2f28cce7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01b6dd88-8d9c-46ef-bb4d-27a2f28cce7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_01-03-2022_23672.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01b6dd88-8d9c-46ef-bb4d-27a2f28cce7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f97638b-afb6-4ce1-8965-5f5edb3b4e46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f97638b-afb6-4ce1-8965-5f5edb3b4e46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_01-03-2022_23677.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f97638b-afb6-4ce1-8965-5f5edb3b4e46>.
+    
+<http://data.lblod.info/id/remote-data-objects/0849544c-2c6b-4d89-8131-e7e73be342f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0849544c-2c6b-4d89-8131-e7e73be342f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_03-05-2022_24380.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0152d9f-5392-471d-a288-9b5aec251e1f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0849544c-2c6b-4d89-8131-e7e73be342f0>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201328-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201328-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201328-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201328-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/41e2cfac-3f51-4aaa-b562-894fc976bf2c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "41e2cfac-3f51-4aaa-b562-894fc976bf2c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "31efc3d7-0ab0-460b-a36f-7a144db27bf1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9b3778ca-f3c5-4179-8f77-73edcf0ae08d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9b3778ca-f3c5-4179-8f77-73edcf0ae08d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1>.
+
+  <http://redpencil.data.gift/id/task/37724027-78c7-4ca0-a6ea-43579dacfc13> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "37724027-78c7-4ca0-a6ea-43579dacfc13";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/41e2cfac-3f51-4aaa-b562-894fc976bf2c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9b3778ca-f3c5-4179-8f77-73edcf0ae08d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b5a7d202-d508-46b3-b41d-beb53c1c8108> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5a7d202-d508-46b3-b41d-beb53c1c8108";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_03-05-2022_24390.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5a7d202-d508-46b3-b41d-beb53c1c8108>.
+    
+<http://data.lblod.info/id/remote-data-objects/9566aeb8-bb6b-4255-a533-8633b98e6c49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9566aeb8-bb6b-4255-a533-8633b98e6c49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_03-05-2022_24393.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9566aeb8-bb6b-4255-a533-8633b98e6c49>.
+    
+<http://data.lblod.info/id/remote-data-objects/2671c4b1-b167-4fd9-804d-ca7825998c03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2671c4b1-b167-4fd9-804d-ca7825998c03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_03-11-2021_22262.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2671c4b1-b167-4fd9-804d-ca7825998c03>.
+    
+<http://data.lblod.info/id/remote-data-objects/e12a97cd-2e03-4315-9ae5-8a2ab9356278> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e12a97cd-2e03-4315-9ae5-8a2ab9356278";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_03-11-2021_22263.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e12a97cd-2e03-4315-9ae5-8a2ab9356278>.
+    
+<http://data.lblod.info/id/remote-data-objects/32d8c63c-eab8-4dc4-aac4-939aa6fc28b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32d8c63c-eab8-4dc4-aac4-939aa6fc28b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_05-04-2022_24042.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32d8c63c-eab8-4dc4-aac4-939aa6fc28b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a1cb74a-7ada-47ee-a85b-9419d86eb7d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a1cb74a-7ada-47ee-a85b-9419d86eb7d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_05-04-2022_24043.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a1cb74a-7ada-47ee-a85b-9419d86eb7d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b116030f-1e5c-4906-8a3d-d35615839be7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b116030f-1e5c-4906-8a3d-d35615839be7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_05-04-2022_24046.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b116030f-1e5c-4906-8a3d-d35615839be7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0628e5e-8a19-4f60-b467-177968d7fd77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0628e5e-8a19-4f60-b467-177968d7fd77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_05-04-2022_24047.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0628e5e-8a19-4f60-b467-177968d7fd77>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8d85de5-ded4-4cef-b7d3-4c76e650ced1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8d85de5-ded4-4cef-b7d3-4c76e650ced1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_05-04-2022_24048.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8d85de5-ded4-4cef-b7d3-4c76e650ced1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e36b8aed-a011-48af-a48d-7e4edcecc1ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e36b8aed-a011-48af-a48d-7e4edcecc1ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_05-04-2022_24088.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e36b8aed-a011-48af-a48d-7e4edcecc1ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/51db0e62-5b25-4703-853e-97ef06b1a13a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51db0e62-5b25-4703-853e-97ef06b1a13a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_05-07-2022_24748.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51db0e62-5b25-4703-853e-97ef06b1a13a>.
+    
+<http://data.lblod.info/id/remote-data-objects/69e60a61-5374-4e87-8e4b-1819fc37c14a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69e60a61-5374-4e87-8e4b-1819fc37c14a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_05-07-2022_25170.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69e60a61-5374-4e87-8e4b-1819fc37c14a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7131ebb-457c-4611-b1dd-bd00b1dcdf1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7131ebb-457c-4611-b1dd-bd00b1dcdf1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_05-07-2022_25176.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7131ebb-457c-4611-b1dd-bd00b1dcdf1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2a03d44-fe13-45b6-80e6-c904eb8a7b9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2a03d44-fe13-45b6-80e6-c904eb8a7b9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_05-07-2022_25181.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2a03d44-fe13-45b6-80e6-c904eb8a7b9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/19211ba6-da25-4874-b726-1ef91f8f0f79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19211ba6-da25-4874-b726-1ef91f8f0f79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_05-07-2022_25199.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19211ba6-da25-4874-b726-1ef91f8f0f79>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4540eff-655c-485f-87ee-e78dd24c82d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4540eff-655c-485f-87ee-e78dd24c82d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_05-07-2022_25207.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4540eff-655c-485f-87ee-e78dd24c82d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/725d7488-60ee-4bd0-a149-256671d2aead> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "725d7488-60ee-4bd0-a149-256671d2aead";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_05-10-2021_20910.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/725d7488-60ee-4bd0-a149-256671d2aead>.
+    
+<http://data.lblod.info/id/remote-data-objects/cefc991b-8bc5-42c8-a997-5b58967dd620> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cefc991b-8bc5-42c8-a997-5b58967dd620";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_05-10-2021_21959.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cefc991b-8bc5-42c8-a997-5b58967dd620>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d3947d2-64c9-4898-9443-4874d4ded8f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d3947d2-64c9-4898-9443-4874d4ded8f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_07-06-2022_24799.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d3947d2-64c9-4898-9443-4874d4ded8f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9d0d6a9-c141-41ab-a234-dbdce622d8c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9d0d6a9-c141-41ab-a234-dbdce622d8c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_07-06-2022_24801.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9d0d6a9-c141-41ab-a234-dbdce622d8c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e069ac27-ae99-4999-b741-1ecb24ee4554> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e069ac27-ae99-4999-b741-1ecb24ee4554";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_07-06-2022_24815.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e069ac27-ae99-4999-b741-1ecb24ee4554>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e68341b-bcd8-40ed-8fb4-2cc34ce7f8dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e68341b-bcd8-40ed-8fb4-2cc34ce7f8dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_07-12-2021_22638.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e68341b-bcd8-40ed-8fb4-2cc34ce7f8dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d03e984-cba1-49cf-bc79-ca4b97ef5b85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d03e984-cba1-49cf-bc79-ca4b97ef5b85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_08-02-2022_23329.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d03e984-cba1-49cf-bc79-ca4b97ef5b85>.
+    
+<http://data.lblod.info/id/remote-data-objects/81064148-e37a-4467-ab28-d2b11f7bf749> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81064148-e37a-4467-ab28-d2b11f7bf749";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_09-11-2021_22337.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81064148-e37a-4467-ab28-d2b11f7bf749>.
+    
+<http://data.lblod.info/id/remote-data-objects/26feaa59-1590-4c8e-a3d1-c2370eb95e92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26feaa59-1590-4c8e-a3d1-c2370eb95e92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_09-11-2021_22345.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26feaa59-1590-4c8e-a3d1-c2370eb95e92>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee7450d6-d89b-42b5-9a45-dccf7d1dddcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee7450d6-d89b-42b5-9a45-dccf7d1dddcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_12-10-2021_20770.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee7450d6-d89b-42b5-9a45-dccf7d1dddcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/81e6979c-358e-434e-8656-5609d431dfd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81e6979c-358e-434e-8656-5609d431dfd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_14-06-2022_24879.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81e6979c-358e-434e-8656-5609d431dfd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/432a61b4-506c-4abd-b7a8-0daddfe87be2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "432a61b4-506c-4abd-b7a8-0daddfe87be2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_14-06-2022_24880.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/432a61b4-506c-4abd-b7a8-0daddfe87be2>.
+    
+<http://data.lblod.info/id/remote-data-objects/64dff3ed-fb81-4ef0-88e6-8d96baf652c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64dff3ed-fb81-4ef0-88e6-8d96baf652c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_14-06-2022_24884.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64dff3ed-fb81-4ef0-88e6-8d96baf652c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a395340-6724-4825-b83a-80c649d5f6ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a395340-6724-4825-b83a-80c649d5f6ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_14-06-2022_24913.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a395340-6724-4825-b83a-80c649d5f6ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/96dc4653-0af4-4895-be29-02abd4b9c4f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96dc4653-0af4-4895-be29-02abd4b9c4f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_14-12-2021_22737.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96dc4653-0af4-4895-be29-02abd4b9c4f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/08159218-539f-47d7-85f6-674ae0dd5511> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08159218-539f-47d7-85f6-674ae0dd5511";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_15-02-2022_23463.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08159218-539f-47d7-85f6-674ae0dd5511>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3e230ba-9aa1-4b2c-b798-da3ee67e3ee6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3e230ba-9aa1-4b2c-b798-da3ee67e3ee6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_15-03-2022_23789.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3e230ba-9aa1-4b2c-b798-da3ee67e3ee6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d13a6be6-834d-463d-82e2-4b9eb3b3b469> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d13a6be6-834d-463d-82e2-4b9eb3b3b469";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_17-05-2022_24593.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d13a6be6-834d-463d-82e2-4b9eb3b3b469>.
+    
+<http://data.lblod.info/id/remote-data-objects/48adbacb-cda7-4ba9-8757-6ba564e85708> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48adbacb-cda7-4ba9-8757-6ba564e85708";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_19-04-2022_24089.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48adbacb-cda7-4ba9-8757-6ba564e85708>.
+    
+<http://data.lblod.info/id/remote-data-objects/105558a7-64fd-4436-9af0-68afa8aaa83c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "105558a7-64fd-4436-9af0-68afa8aaa83c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_19-04-2022_24183.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/105558a7-64fd-4436-9af0-68afa8aaa83c>.
+    
+<http://data.lblod.info/id/remote-data-objects/57e9f17c-d3e0-4bd2-9da9-cfa3728873cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57e9f17c-d3e0-4bd2-9da9-cfa3728873cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_19-10-2021_22120.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57e9f17c-d3e0-4bd2-9da9-cfa3728873cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7f98cd5-7256-4bd5-a235-c32259847f62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7f98cd5-7256-4bd5-a235-c32259847f62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_21-06-2022_25004.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7f98cd5-7256-4bd5-a235-c32259847f62>.
+    
+<http://data.lblod.info/id/remote-data-objects/f06ce901-1d79-4a7c-a5b5-fef449e5a452> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f06ce901-1d79-4a7c-a5b5-fef449e5a452";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_21-06-2022_25007.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f06ce901-1d79-4a7c-a5b5-fef449e5a452>.
+    
+<http://data.lblod.info/id/remote-data-objects/d075132e-7b81-438c-9d68-c6b9afa3d019> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d075132e-7b81-438c-9d68-c6b9afa3d019";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_21-06-2022_25008.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d075132e-7b81-438c-9d68-c6b9afa3d019>.
+    
+<http://data.lblod.info/id/remote-data-objects/5370034c-2170-4daa-9b7d-1a130bd2b973> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5370034c-2170-4daa-9b7d-1a130bd2b973";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_21-06-2022_25017.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5370034c-2170-4daa-9b7d-1a130bd2b973>.
+    
+<http://data.lblod.info/id/remote-data-objects/5dc00786-c8de-4e32-81cf-8b87f250da74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5dc00786-c8de-4e32-81cf-8b87f250da74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_22-02-2022_23563.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5dc00786-c8de-4e32-81cf-8b87f250da74>.
+    
+<http://data.lblod.info/id/remote-data-objects/b20cbe80-4a23-417c-8a82-2921c1a63723> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b20cbe80-4a23-417c-8a82-2921c1a63723";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_23-11-2021_22428.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b20cbe80-4a23-417c-8a82-2921c1a63723>.
+    
+<http://data.lblod.info/id/remote-data-objects/a90be36c-fd75-45af-927a-245576fd0655> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a90be36c-fd75-45af-927a-245576fd0655";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_23-11-2021_22429.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a90be36c-fd75-45af-927a-245576fd0655>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f54c4c8-5285-4ca0-96b5-8a3196000fb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f54c4c8-5285-4ca0-96b5-8a3196000fb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_23-11-2021_22485.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f54c4c8-5285-4ca0-96b5-8a3196000fb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/65a838f8-2652-46da-af5e-6953f935021a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65a838f8-2652-46da-af5e-6953f935021a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_23-11-2021_22486.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65a838f8-2652-46da-af5e-6953f935021a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5fef8f5-30c9-4e4f-8f86-89990823219b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5fef8f5-30c9-4e4f-8f86-89990823219b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_24-05-2022_24672.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5fef8f5-30c9-4e4f-8f86-89990823219b>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfba0532-2bb9-496b-a4c1-3ea36d6c0c90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfba0532-2bb9-496b-a4c1-3ea36d6c0c90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_25-01-2022_23148.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfba0532-2bb9-496b-a4c1-3ea36d6c0c90>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a8e867e-a785-46e1-9356-e63cc76991ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a8e867e-a785-46e1-9356-e63cc76991ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_25-01-2022_23166.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a8e867e-a785-46e1-9356-e63cc76991ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/242b21bd-31a4-4fb0-a347-9cc546862578> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "242b21bd-31a4-4fb0-a347-9cc546862578";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_25-01-2022_23181.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/31efc3d7-0ab0-460b-a36f-7a144db27bf1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/242b21bd-31a4-4fb0-a347-9cc546862578>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201329-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201329-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201329-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201329-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e6cc015f-5e68-4bd8-b856-1514bf124db3> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e6cc015f-5e68-4bd8-b856-1514bf124db3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4131b3f8-05a1-4618-bd74-99379ae00d9f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a3143a3f-1371-4793-8686-0aa6e86b62d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a3143a3f-1371-4793-8686-0aa6e86b62d3";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f>.
+
+  <http://redpencil.data.gift/id/task/e6096c0a-b36a-4b00-a6c6-b25715d592c2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e6096c0a-b36a-4b00-a6c6-b25715d592c2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e6cc015f-5e68-4bd8-b856-1514bf124db3>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a3143a3f-1371-4793-8686-0aa6e86b62d3>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/bd2c27d8-df6b-4fe1-b5eb-2e79ff448f0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd2c27d8-df6b-4fe1-b5eb-2e79ff448f0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_26-04-2022_24275.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd2c27d8-df6b-4fe1-b5eb-2e79ff448f0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b35c7e9d-e2d2-4ce9-8f21-91757e570ffc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b35c7e9d-e2d2-4ce9-8f21-91757e570ffc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_26-04-2022_24281.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b35c7e9d-e2d2-4ce9-8f21-91757e570ffc>.
+    
+<http://data.lblod.info/id/remote-data-objects/b378771f-4f52-4a6b-b988-85485fce1219> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b378771f-4f52-4a6b-b988-85485fce1219";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_26-04-2022_24282.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b378771f-4f52-4a6b-b988-85485fce1219>.
+    
+<http://data.lblod.info/id/remote-data-objects/bea18df9-3985-4880-b8fe-24149fa56351> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bea18df9-3985-4880-b8fe-24149fa56351";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_26-04-2022_24283.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bea18df9-3985-4880-b8fe-24149fa56351>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ecbef5b-b81e-4cb3-9f04-7c7211b0eb17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ecbef5b-b81e-4cb3-9f04-7c7211b0eb17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_26-10-2021_22132.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ecbef5b-b81e-4cb3-9f04-7c7211b0eb17>.
+    
+<http://data.lblod.info/id/remote-data-objects/1af161c4-92fb-4423-9770-d377ee39f5c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1af161c4-92fb-4423-9770-d377ee39f5c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_26-10-2021_22133.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1af161c4-92fb-4423-9770-d377ee39f5c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/52ed6df2-4d50-4cae-b096-6497779c4786> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52ed6df2-4d50-4cae-b096-6497779c4786";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_26-10-2021_22141.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52ed6df2-4d50-4cae-b096-6497779c4786>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b424221-0703-4c19-b591-6050e47b12fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b424221-0703-4c19-b591-6050e47b12fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_26-10-2021_22206.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b424221-0703-4c19-b591-6050e47b12fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/03184bbe-0606-4fea-af73-84e789b8368c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03184bbe-0606-4fea-af73-84e789b8368c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_26-10-2021_22220.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03184bbe-0606-4fea-af73-84e789b8368c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1338abe-dfae-480f-9850-e621d68151ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1338abe-dfae-480f-9850-e621d68151ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_26-10-2021_22223.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1338abe-dfae-480f-9850-e621d68151ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/584a6ccc-4ed8-43dc-a204-5a317cb57d8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "584a6ccc-4ed8-43dc-a204-5a317cb57d8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_28-06-2022_25041.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/584a6ccc-4ed8-43dc-a204-5a317cb57d8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab4c5cc9-35a6-4277-beb2-37fbb9831d6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab4c5cc9-35a6-4277-beb2-37fbb9831d6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_29-03-2022_23949.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab4c5cc9-35a6-4277-beb2-37fbb9831d6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9558f22a-cfe8-4ff9-aa94-3dfcbd492b1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9558f22a-cfe8-4ff9-aa94-3dfcbd492b1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_29-03-2022_24030.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9558f22a-cfe8-4ff9-aa94-3dfcbd492b1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/59c24ae8-0f3e-4afd-a719-d6552e16789c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59c24ae8-0f3e-4afd-a719-d6552e16789c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_30-11-2021_22586.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59c24ae8-0f3e-4afd-a719-d6552e16789c>.
+    
+<http://data.lblod.info/id/remote-data-objects/80c31425-c0e7-4963-b467-c15a599a4014> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80c31425-c0e7-4963-b467-c15a599a4014";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_30-11-2021_22600.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80c31425-c0e7-4963-b467-c15a599a4014>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e88625e-ee91-4388-8cfd-91c4a163efd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e88625e-ee91-4388-8cfd-91c4a163efd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_31-05-2022_24709.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e88625e-ee91-4388-8cfd-91c4a163efd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb4a6eed-4123-4ff8-b8a4-6c56812cdf69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb4a6eed-4123-4ff8-b8a4-6c56812cdf69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_31-05-2022_24727.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb4a6eed-4123-4ff8-b8a4-6c56812cdf69>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc5a5f34-6c6c-4b80-ac50-a59b86319259> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc5a5f34-6c6c-4b80-ac50-a59b86319259";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.denderleeuw.be/LBLODWeb/Home/Overzicht/dab5130473c7101cf0b1863e8aef97215998baa46226c19ae54c0087e54c00cb/GetPublication?filename=Uittreksels_31-05-2022_24730.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc5a5f34-6c6c-4b80-ac50-a59b86319259>.
+    
+<http://data.lblod.info/id/remote-data-objects/f66cc13e-abcf-445e-b002-fbcdc8c1b804> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f66cc13e-abcf-445e-b002-fbcdc8c1b804";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/1f5cdb5ef5dfe49177becb6fadad7fda5f6891a1d79c71c44de93792c7905961/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f66cc13e-abcf-445e-b002-fbcdc8c1b804>.
+    
+<http://data.lblod.info/id/remote-data-objects/da749866-d74c-4c59-952d-1db8f4094ba7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da749866-d74c-4c59-952d-1db8f4094ba7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/1f5cdb5ef5dfe49177becb6fadad7fda5f6891a1d79c71c44de93792c7905961/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da749866-d74c-4c59-952d-1db8f4094ba7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7f8b454-0243-4528-bcd2-b660f0b317b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7f8b454-0243-4528-bcd2-b660f0b317b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/1f5cdb5ef5dfe49177becb6fadad7fda5f6891a1d79c71c44de93792c7905961/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7f8b454-0243-4528-bcd2-b660f0b317b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e03b7653-480b-442b-8435-b7b1f331d86d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e03b7653-480b-442b-8435-b7b1f331d86d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/1f5cdb5ef5dfe49177becb6fadad7fda5f6891a1d79c71c44de93792c7905961/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e03b7653-480b-442b-8435-b7b1f331d86d>.
+    
+<http://data.lblod.info/id/remote-data-objects/09e866a0-eaf5-47f2-9030-c2752786ab87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09e866a0-eaf5-47f2-9030-c2752786ab87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/1f5cdb5ef5dfe49177becb6fadad7fda5f6891a1d79c71c44de93792c7905961/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09e866a0-eaf5-47f2-9030-c2752786ab87>.
+    
+<http://data.lblod.info/id/remote-data-objects/16666ef1-e853-42ec-aa4a-0bf8eeded172> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16666ef1-e853-42ec-aa4a-0bf8eeded172";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/1f5cdb5ef5dfe49177becb6fadad7fda5f6891a1d79c71c44de93792c7905961/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16666ef1-e853-42ec-aa4a-0bf8eeded172>.
+    
+<http://data.lblod.info/id/remote-data-objects/f045ffc8-08fd-4fb4-9c66-f64800ee19dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f045ffc8-08fd-4fb4-9c66-f64800ee19dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/1f5cdb5ef5dfe49177becb6fadad7fda5f6891a1d79c71c44de93792c7905961/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f045ffc8-08fd-4fb4-9c66-f64800ee19dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cec3a3a-33ee-4fae-9517-97f2dedf4bca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cec3a3a-33ee-4fae-9517-97f2dedf4bca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/1f5cdb5ef5dfe49177becb6fadad7fda5f6891a1d79c71c44de93792c7905961/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cec3a3a-33ee-4fae-9517-97f2dedf4bca>.
+    
+<http://data.lblod.info/id/remote-data-objects/af5d8fa2-18af-407e-9269-992f9572392e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af5d8fa2-18af-407e-9269-992f9572392e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/1f5cdb5ef5dfe49177becb6fadad7fda5f6891a1d79c71c44de93792c7905961/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af5d8fa2-18af-407e-9269-992f9572392e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef8e0b0d-0935-4da3-9774-f7207216586b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef8e0b0d-0935-4da3-9774-f7207216586b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/1f5cdb5ef5dfe49177becb6fadad7fda5f6891a1d79c71c44de93792c7905961/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef8e0b0d-0935-4da3-9774-f7207216586b>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb3384b6-9d91-44e3-a0ed-d47b266aa8d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb3384b6-9d91-44e3-a0ed-d47b266aa8d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/1f5cdb5ef5dfe49177becb6fadad7fda5f6891a1d79c71c44de93792c7905961/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb3384b6-9d91-44e3-a0ed-d47b266aa8d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fdb0ff1-11b6-41c3-8de7-6bd558f28c03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fdb0ff1-11b6-41c3-8de7-6bd558f28c03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/1f5cdb5ef5dfe49177becb6fadad7fda5f6891a1d79c71c44de93792c7905961/GetPublication?filename=Uittreksels_14-06-2022_73760.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fdb0ff1-11b6-41c3-8de7-6bd558f28c03>.
+    
+<http://data.lblod.info/id/remote-data-objects/11a7997c-a968-4afe-a4a6-15a44bf2abea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11a7997c-a968-4afe-a4a6-15a44bf2abea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/1f5cdb5ef5dfe49177becb6fadad7fda5f6891a1d79c71c44de93792c7905961/GetPublication?filename=Uittreksels_14-06-2022_76889.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11a7997c-a968-4afe-a4a6-15a44bf2abea>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fa47dab-7776-4ab1-84d4-161e98c2c9f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fa47dab-7776-4ab1-84d4-161e98c2c9f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/1f5cdb5ef5dfe49177becb6fadad7fda5f6891a1d79c71c44de93792c7905961/GetPublication?filename=Uittreksels_19-04-2022_75085.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fa47dab-7776-4ab1-84d4-161e98c2c9f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0da10834-808a-420d-aed8-00ca68353863> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0da10834-808a-420d-aed8-00ca68353863";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0da10834-808a-420d-aed8-00ca68353863>.
+    
+<http://data.lblod.info/id/remote-data-objects/bee88c79-7581-4c14-9881-6a518dce122c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bee88c79-7581-4c14-9881-6a518dce122c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bee88c79-7581-4c14-9881-6a518dce122c>.
+    
+<http://data.lblod.info/id/remote-data-objects/14a8efcf-e425-4a79-8cdb-a5f045828746> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14a8efcf-e425-4a79-8cdb-a5f045828746";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14a8efcf-e425-4a79-8cdb-a5f045828746>.
+    
+<http://data.lblod.info/id/remote-data-objects/96a8b1e5-e938-456f-8b53-734638eee069> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96a8b1e5-e938-456f-8b53-734638eee069";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96a8b1e5-e938-456f-8b53-734638eee069>.
+    
+<http://data.lblod.info/id/remote-data-objects/46fbce2b-74b8-4906-96d8-ef37b7c2f59d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46fbce2b-74b8-4906-96d8-ef37b7c2f59d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46fbce2b-74b8-4906-96d8-ef37b7c2f59d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8863adfb-9c02-4f55-9b06-655b04de7a79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8863adfb-9c02-4f55-9b06-655b04de7a79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8863adfb-9c02-4f55-9b06-655b04de7a79>.
+    
+<http://data.lblod.info/id/remote-data-objects/035250c4-5934-4f7c-b379-9675012fa2df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "035250c4-5934-4f7c-b379-9675012fa2df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/035250c4-5934-4f7c-b379-9675012fa2df>.
+    
+<http://data.lblod.info/id/remote-data-objects/155974ee-b79d-4f1d-a25d-a9f4bb208c99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "155974ee-b79d-4f1d-a25d-a9f4bb208c99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/155974ee-b79d-4f1d-a25d-a9f4bb208c99>.
+    
+<http://data.lblod.info/id/remote-data-objects/418a42d4-173a-407f-acda-dfaeb120aed1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "418a42d4-173a-407f-acda-dfaeb120aed1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/418a42d4-173a-407f-acda-dfaeb120aed1>.
+    
+<http://data.lblod.info/id/remote-data-objects/3be2d6b0-bc42-4c8a-a658-cfebe89887c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3be2d6b0-bc42-4c8a-a658-cfebe89887c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3be2d6b0-bc42-4c8a-a658-cfebe89887c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/94810306-eb73-4fec-8b28-4578bce3cebd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94810306-eb73-4fec-8b28-4578bce3cebd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94810306-eb73-4fec-8b28-4578bce3cebd>.
+    
+<http://data.lblod.info/id/remote-data-objects/e37b56a1-f7d9-47b2-85c8-08204b45eccd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e37b56a1-f7d9-47b2-85c8-08204b45eccd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e37b56a1-f7d9-47b2-85c8-08204b45eccd>.
+    
+<http://data.lblod.info/id/remote-data-objects/38e40b2d-9040-4ca5-87a7-c28fb3dd5395> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38e40b2d-9040-4ca5-87a7-c28fb3dd5395";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38e40b2d-9040-4ca5-87a7-c28fb3dd5395>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0a4a207-ad4a-435c-a06c-9aad47831c71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0a4a207-ad4a-435c-a06c-9aad47831c71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0a4a207-ad4a-435c-a06c-9aad47831c71>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8288029-8d20-4776-8682-db29a6461656> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8288029-8d20-4776-8682-db29a6461656";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8288029-8d20-4776-8682-db29a6461656>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fa63aad-49b5-4412-b88f-98db0a0bdb88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fa63aad-49b5-4412-b88f-98db0a0bdb88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fa63aad-49b5-4412-b88f-98db0a0bdb88>.
+    
+<http://data.lblod.info/id/remote-data-objects/0abf2879-7580-4629-976a-fa9e83bd9b81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0abf2879-7580-4629-976a-fa9e83bd9b81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0abf2879-7580-4629-976a-fa9e83bd9b81>.
+    
+<http://data.lblod.info/id/remote-data-objects/7401b13f-a2ef-45a9-aee1-a1bdbb09ef54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7401b13f-a2ef-45a9-aee1-a1bdbb09ef54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4131b3f8-05a1-4618-bd74-99379ae00d9f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7401b13f-a2ef-45a9-aee1-a1bdbb09ef54>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201330-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201330-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201330-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201330-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/4e7c6e8d-0b86-4da9-a16e-d29b99b8be19> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4e7c6e8d-0b86-4da9-a16e-d29b99b8be19";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "67a1c17b-da34-497b-9bf0-4bbfc0f02bc5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/44c2df25-6105-4ebb-8eb2-d511e11908d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "44c2df25-6105-4ebb-8eb2-d511e11908d3";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5>.
+
+  <http://redpencil.data.gift/id/task/1e6f4ae9-d55e-4d3e-8f92-9da8fec5faa1> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1e6f4ae9-d55e-4d3e-8f92-9da8fec5faa1";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/4e7c6e8d-0b86-4da9-a16e-d29b99b8be19>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/44c2df25-6105-4ebb-8eb2-d511e11908d3>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/9785977c-b04e-4357-a2d8-1d7f4348b9ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9785977c-b04e-4357-a2d8-1d7f4348b9ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9785977c-b04e-4357-a2d8-1d7f4348b9ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e1ed573-37e4-4723-be4c-9016166ac0f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e1ed573-37e4-4723-be4c-9016166ac0f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e1ed573-37e4-4723-be4c-9016166ac0f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f5cd5da-d787-46a2-b865-4b8f1225bb8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f5cd5da-d787-46a2-b865-4b8f1225bb8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f5cd5da-d787-46a2-b865-4b8f1225bb8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5db08974-76a8-4c3d-a173-050b658915dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5db08974-76a8-4c3d-a173-050b658915dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5db08974-76a8-4c3d-a173-050b658915dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9629889-fac4-4d9b-a99f-3026dd9a3f72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9629889-fac4-4d9b-a99f-3026dd9a3f72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9629889-fac4-4d9b-a99f-3026dd9a3f72>.
+    
+<http://data.lblod.info/id/remote-data-objects/c45f35ce-5b9c-4c3e-91a8-75ead65db131> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c45f35ce-5b9c-4c3e-91a8-75ead65db131";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c45f35ce-5b9c-4c3e-91a8-75ead65db131>.
+    
+<http://data.lblod.info/id/remote-data-objects/3984f08e-71e6-44eb-a2bd-c1b10001bce3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3984f08e-71e6-44eb-a2bd-c1b10001bce3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3984f08e-71e6-44eb-a2bd-c1b10001bce3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b1138e6-a46e-4cd0-b2ff-5c7fb9741435> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b1138e6-a46e-4cd0-b2ff-5c7fb9741435";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b1138e6-a46e-4cd0-b2ff-5c7fb9741435>.
+    
+<http://data.lblod.info/id/remote-data-objects/e252c9d6-c115-47d9-961f-fe0ea6183c6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e252c9d6-c115-47d9-961f-fe0ea6183c6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e252c9d6-c115-47d9-961f-fe0ea6183c6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/05451a75-433d-47d7-9dc9-48043ee473b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05451a75-433d-47d7-9dc9-48043ee473b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05451a75-433d-47d7-9dc9-48043ee473b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/44f2a826-518c-441c-8830-7343eb597421> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44f2a826-518c-441c-8830-7343eb597421";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44f2a826-518c-441c-8830-7343eb597421>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a2d65ca-1028-4473-b95c-d68325d92b24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a2d65ca-1028-4473-b95c-d68325d92b24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_26-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a2d65ca-1028-4473-b95c-d68325d92b24>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba3b53bd-0e2c-4ee9-8ef4-c3c80e1f0f9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba3b53bd-0e2c-4ee9-8ef4-c3c80e1f0f9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba3b53bd-0e2c-4ee9-8ef4-c3c80e1f0f9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/255db3ec-06dc-4caf-b804-82a364ef23b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "255db3ec-06dc-4caf-b804-82a364ef23b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/255db3ec-06dc-4caf-b804-82a364ef23b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9962cc3e-af04-4418-a28d-ef38ad8ec1e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9962cc3e-af04-4418-a28d-ef38ad8ec1e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9962cc3e-af04-4418-a28d-ef38ad8ec1e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc21cec3-7904-423f-b655-6bf263d95dbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc21cec3-7904-423f-b655-6bf263d95dbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc21cec3-7904-423f-b655-6bf263d95dbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/072de60a-cd4d-44d4-9e97-1910c98573fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "072de60a-cd4d-44d4-9e97-1910c98573fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/072de60a-cd4d-44d4-9e97-1910c98573fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d00559b6-fab6-49f2-8698-ab6c25f99879> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d00559b6-fab6-49f2-8698-ab6c25f99879";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d00559b6-fab6-49f2-8698-ab6c25f99879>.
+    
+<http://data.lblod.info/id/remote-data-objects/8eacaa94-fab9-4ce9-b017-332c96ca1773> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8eacaa94-fab9-4ce9-b017-332c96ca1773";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/28385947879a565db461e6388d19ffff5a470df0fa3580645dcfec283ae5ece4/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8eacaa94-fab9-4ce9-b017-332c96ca1773>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb897833-6123-4a48-9036-fe1e3527f663> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb897833-6123-4a48-9036-fe1e3527f663";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/7449b5330d95d5102fc0e1c7e46166b602a154a257efb9164d4ea92ef1ed9a8a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb897833-6123-4a48-9036-fe1e3527f663>.
+    
+<http://data.lblod.info/id/remote-data-objects/75ce40a6-2c1b-4b7d-84f0-192cb184ea65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75ce40a6-2c1b-4b7d-84f0-192cb184ea65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/7449b5330d95d5102fc0e1c7e46166b602a154a257efb9164d4ea92ef1ed9a8a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75ce40a6-2c1b-4b7d-84f0-192cb184ea65>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c02c6de-384a-4e16-add3-11aa2d15cb9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c02c6de-384a-4e16-add3-11aa2d15cb9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/7449b5330d95d5102fc0e1c7e46166b602a154a257efb9164d4ea92ef1ed9a8a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c02c6de-384a-4e16-add3-11aa2d15cb9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/68a1561f-c367-4f82-a342-a7d946d13910> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68a1561f-c367-4f82-a342-a7d946d13910";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/7449b5330d95d5102fc0e1c7e46166b602a154a257efb9164d4ea92ef1ed9a8a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68a1561f-c367-4f82-a342-a7d946d13910>.
+    
+<http://data.lblod.info/id/remote-data-objects/517d3e50-de04-478c-acf7-af49dcd0d013> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "517d3e50-de04-478c-acf7-af49dcd0d013";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/7449b5330d95d5102fc0e1c7e46166b602a154a257efb9164d4ea92ef1ed9a8a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/517d3e50-de04-478c-acf7-af49dcd0d013>.
+    
+<http://data.lblod.info/id/remote-data-objects/636ca586-816e-40aa-8a75-3e707eb2072a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "636ca586-816e-40aa-8a75-3e707eb2072a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/7449b5330d95d5102fc0e1c7e46166b602a154a257efb9164d4ea92ef1ed9a8a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/636ca586-816e-40aa-8a75-3e707eb2072a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9038dab-c2f6-44df-98a1-ab3fbf1f59eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9038dab-c2f6-44df-98a1-ab3fbf1f59eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/7449b5330d95d5102fc0e1c7e46166b602a154a257efb9164d4ea92ef1ed9a8a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9038dab-c2f6-44df-98a1-ab3fbf1f59eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4d4d67f-43b0-4233-aed7-7bc95e3d5d5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4d4d67f-43b0-4233-aed7-7bc95e3d5d5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/7449b5330d95d5102fc0e1c7e46166b602a154a257efb9164d4ea92ef1ed9a8a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4d4d67f-43b0-4233-aed7-7bc95e3d5d5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8d1736c-4c38-4de2-a8d0-ec0b505f29a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8d1736c-4c38-4de2-a8d0-ec0b505f29a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/7449b5330d95d5102fc0e1c7e46166b602a154a257efb9164d4ea92ef1ed9a8a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8d1736c-4c38-4de2-a8d0-ec0b505f29a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ee5af68-e602-43da-86d9-cece937f0bbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ee5af68-e602-43da-86d9-cece937f0bbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/7449b5330d95d5102fc0e1c7e46166b602a154a257efb9164d4ea92ef1ed9a8a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ee5af68-e602-43da-86d9-cece937f0bbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/e679ba6b-f2af-43be-a2c5-935721c5301c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e679ba6b-f2af-43be-a2c5-935721c5301c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/7449b5330d95d5102fc0e1c7e46166b602a154a257efb9164d4ea92ef1ed9a8a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e679ba6b-f2af-43be-a2c5-935721c5301c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f8d840a-db9c-424a-9614-8436a2c494ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f8d840a-db9c-424a-9614-8436a2c494ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f8d840a-db9c-424a-9614-8436a2c494ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/52fad2e1-e847-4c61-ade7-a948fdfc486f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52fad2e1-e847-4c61-ade7-a948fdfc486f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52fad2e1-e847-4c61-ade7-a948fdfc486f>.
+    
+<http://data.lblod.info/id/remote-data-objects/bff8dc18-9d4c-4a0e-b3e3-68c3613ac8e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bff8dc18-9d4c-4a0e-b3e3-68c3613ac8e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bff8dc18-9d4c-4a0e-b3e3-68c3613ac8e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1cbf022-c079-44c9-bbf0-e0e5b1fe5c88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1cbf022-c079-44c9-bbf0-e0e5b1fe5c88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1cbf022-c079-44c9-bbf0-e0e5b1fe5c88>.
+    
+<http://data.lblod.info/id/remote-data-objects/55ab99dc-5d0f-4f58-bef1-47b57b10f838> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55ab99dc-5d0f-4f58-bef1-47b57b10f838";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55ab99dc-5d0f-4f58-bef1-47b57b10f838>.
+    
+<http://data.lblod.info/id/remote-data-objects/312ae54d-f90a-4ce1-9fda-995f13423f2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "312ae54d-f90a-4ce1-9fda-995f13423f2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/312ae54d-f90a-4ce1-9fda-995f13423f2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c666c609-2454-4b24-be44-449c259608ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c666c609-2454-4b24-be44-449c259608ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c666c609-2454-4b24-be44-449c259608ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/6db263e7-9b10-4e30-82fa-49eb43c7228e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6db263e7-9b10-4e30-82fa-49eb43c7228e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6db263e7-9b10-4e30-82fa-49eb43c7228e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1dfd5874-bcca-4167-8166-0525385240cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1dfd5874-bcca-4167-8166-0525385240cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1dfd5874-bcca-4167-8166-0525385240cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b90a9e4-269a-4e81-87a5-b5bbfd260975> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b90a9e4-269a-4e81-87a5-b5bbfd260975";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b90a9e4-269a-4e81-87a5-b5bbfd260975>.
+    
+<http://data.lblod.info/id/remote-data-objects/afa1ddc6-fd97-4a53-8030-33101d0bfed1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afa1ddc6-fd97-4a53-8030-33101d0bfed1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afa1ddc6-fd97-4a53-8030-33101d0bfed1>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb94eae9-835b-492b-b110-69cc40db71de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb94eae9-835b-492b-b110-69cc40db71de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb94eae9-835b-492b-b110-69cc40db71de>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfac1656-a4af-4383-9f3f-537d097dc837> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfac1656-a4af-4383-9f3f-537d097dc837";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfac1656-a4af-4383-9f3f-537d097dc837>.
+    
+<http://data.lblod.info/id/remote-data-objects/9acbecbe-d922-4e2c-a14b-539d4dc91664> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9acbecbe-d922-4e2c-a14b-539d4dc91664";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9acbecbe-d922-4e2c-a14b-539d4dc91664>.
+    
+<http://data.lblod.info/id/remote-data-objects/515f2341-2e15-4780-ad55-3911a4d6db48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "515f2341-2e15-4780-ad55-3911a4d6db48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/515f2341-2e15-4780-ad55-3911a4d6db48>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a2c971c-6d27-4958-9e9c-8436a437ba4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a2c971c-6d27-4958-9e9c-8436a437ba4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a2c971c-6d27-4958-9e9c-8436a437ba4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3e9434f-d952-4605-ae33-bff1079ee44e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3e9434f-d952-4605-ae33-bff1079ee44e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3e9434f-d952-4605-ae33-bff1079ee44e>.
+    
+<http://data.lblod.info/id/remote-data-objects/94eaa98f-627b-4e49-aded-301d5f178ce6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94eaa98f-627b-4e49-aded-301d5f178ce6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94eaa98f-627b-4e49-aded-301d5f178ce6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c695d76c-a436-4eae-81e2-55e83e7cf1a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c695d76c-a436-4eae-81e2-55e83e7cf1a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c695d76c-a436-4eae-81e2-55e83e7cf1a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8cb45d2-92a0-43e2-8580-c8f5dd5c1812> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8cb45d2-92a0-43e2-8580-c8f5dd5c1812";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67a1c17b-da34-497b-9bf0-4bbfc0f02bc5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8cb45d2-92a0-43e2-8580-c8f5dd5c1812>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201332-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201332-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201332-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201332-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/775b0a57-3291-4fa5-93e7-cd0909a158d1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "775b0a57-3291-4fa5-93e7-cd0909a158d1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d852ec40-be82-4391-9f43-bc31259365a1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/eb3539c3-3eed-4518-95ce-0799efb91df9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "eb3539c3-3eed-4518-95ce-0799efb91df9";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1>.
+
+  <http://redpencil.data.gift/id/task/a1a656cc-158c-4c90-a5ce-3c3fbd6a8a7d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a1a656cc-158c-4c90-a5ce-3c3fbd6a8a7d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/775b0a57-3291-4fa5-93e7-cd0909a158d1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/eb3539c3-3eed-4518-95ce-0799efb91df9>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/9a11e3e6-a3d2-43a9-a294-235bca9ff64e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a11e3e6-a3d2-43a9-a294-235bca9ff64e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a11e3e6-a3d2-43a9-a294-235bca9ff64e>.
+    
+<http://data.lblod.info/id/remote-data-objects/59bec2e8-9d6d-45dd-a4e8-d5c3222bf8a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59bec2e8-9d6d-45dd-a4e8-d5c3222bf8a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59bec2e8-9d6d-45dd-a4e8-d5c3222bf8a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd34a28b-fd5d-4cff-9b8a-a52c4b99377a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd34a28b-fd5d-4cff-9b8a-a52c4b99377a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd34a28b-fd5d-4cff-9b8a-a52c4b99377a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b32ae5e8-b11f-417e-8329-46b89b719563> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b32ae5e8-b11f-417e-8329-46b89b719563";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b32ae5e8-b11f-417e-8329-46b89b719563>.
+    
+<http://data.lblod.info/id/remote-data-objects/75e6e952-5eba-42d2-be65-0cc66bcfd17a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75e6e952-5eba-42d2-be65-0cc66bcfd17a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75e6e952-5eba-42d2-be65-0cc66bcfd17a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c782c8b-3662-4a66-acd0-ade5812bd61b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c782c8b-3662-4a66-acd0-ade5812bd61b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c782c8b-3662-4a66-acd0-ade5812bd61b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4436ebf-7c1e-4d35-94f9-7ce511560350> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4436ebf-7c1e-4d35-94f9-7ce511560350";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4436ebf-7c1e-4d35-94f9-7ce511560350>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0c2cc31-1fc4-4bcc-87d2-a10c641670db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0c2cc31-1fc4-4bcc-87d2-a10c641670db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0c2cc31-1fc4-4bcc-87d2-a10c641670db>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd3021bb-701b-4c95-843a-08321c0b3b7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd3021bb-701b-4c95-843a-08321c0b3b7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_26-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd3021bb-701b-4c95-843a-08321c0b3b7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/76580abb-0c5d-45ba-b8d9-d0bd68b9dcd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76580abb-0c5d-45ba-b8d9-d0bd68b9dcd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76580abb-0c5d-45ba-b8d9-d0bd68b9dcd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/85a0dc62-8d2d-49a9-a170-295bd1527386> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85a0dc62-8d2d-49a9-a170-295bd1527386";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85a0dc62-8d2d-49a9-a170-295bd1527386>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc5e2f8c-a854-4b2a-82c1-6c65bffe99c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc5e2f8c-a854-4b2a-82c1-6c65bffe99c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc5e2f8c-a854-4b2a-82c1-6c65bffe99c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/281eece6-5b8f-4e08-a958-ce5f62493e2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "281eece6-5b8f-4e08-a958-ce5f62493e2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/281eece6-5b8f-4e08-a958-ce5f62493e2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0752f74d-0cb9-44c8-8f29-99e979e4988e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0752f74d-0cb9-44c8-8f29-99e979e4988e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0752f74d-0cb9-44c8-8f29-99e979e4988e>.
+    
+<http://data.lblod.info/id/remote-data-objects/38374274-6bb8-4bbc-9579-4a1beb034d9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38374274-6bb8-4bbc-9579-4a1beb034d9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38374274-6bb8-4bbc-9579-4a1beb034d9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/19fde4d7-4716-4af9-8409-e33fabd012fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19fde4d7-4716-4af9-8409-e33fabd012fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.dendermonde.be/LBLODWeb/Home/Overzicht/983498b2cd107128a34a390ce51a2362c6192245a098352a9584f2b6f7582173/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19fde4d7-4716-4af9-8409-e33fabd012fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/b992e94e-da6d-4f7b-b9d3-d816b60e2e5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b992e94e-da6d-4f7b-b9d3-d816b60e2e5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Agenda_OCMW-raad_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b992e94e-da6d-4f7b-b9d3-d816b60e2e5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d39cfa77-defb-4fe8-9e90-f23b7047e7c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d39cfa77-defb-4fe8-9e90-f23b7047e7c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Agenda_OCMW-raad_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d39cfa77-defb-4fe8-9e90-f23b7047e7c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2df8401-9e0a-4fae-9048-f4893c62e4a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2df8401-9e0a-4fae-9048-f4893c62e4a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Agenda_OCMW-raad_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2df8401-9e0a-4fae-9048-f4893c62e4a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fbb4168-0885-4a73-a485-838ee8557196> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fbb4168-0885-4a73-a485-838ee8557196";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Agenda_OCMW-raad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fbb4168-0885-4a73-a485-838ee8557196>.
+    
+<http://data.lblod.info/id/remote-data-objects/52e8387f-52a3-4bc4-add2-db1f66caf1ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52e8387f-52a3-4bc4-add2-db1f66caf1ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Agenda_OCMW-raad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52e8387f-52a3-4bc4-add2-db1f66caf1ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff9bf3da-5ee5-4ca4-9ff9-c026580e7def> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff9bf3da-5ee5-4ca4-9ff9-c026580e7def";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Agenda_OCMW-raad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff9bf3da-5ee5-4ca4-9ff9-c026580e7def>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb0030cd-2fee-4ea9-b9b9-0468a7a421ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb0030cd-2fee-4ea9-b9b9-0468a7a421ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=BesluitenLijst_OCMW-raad_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb0030cd-2fee-4ea9-b9b9-0468a7a421ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b0b3abf-cccc-43ac-81d8-efa64d86cc99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b0b3abf-cccc-43ac-81d8-efa64d86cc99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=BesluitenLijst_OCMW-raad_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b0b3abf-cccc-43ac-81d8-efa64d86cc99>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b595e1a-9863-44cc-a068-4cee09de0cad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b595e1a-9863-44cc-a068-4cee09de0cad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=BesluitenLijst_OCMW-raad_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b595e1a-9863-44cc-a068-4cee09de0cad>.
+    
+<http://data.lblod.info/id/remote-data-objects/bda03093-55cb-43fc-915b-6294393075f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bda03093-55cb-43fc-915b-6294393075f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=BesluitenLijst_OCMW-raad_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bda03093-55cb-43fc-915b-6294393075f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca9b41a1-de39-4eeb-848e-2026bdb6daa0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca9b41a1-de39-4eeb-848e-2026bdb6daa0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=BesluitenLijst_OCMW-raad_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca9b41a1-de39-4eeb-848e-2026bdb6daa0>.
+    
+<http://data.lblod.info/id/remote-data-objects/49ce40eb-6344-4dac-97f9-5a64be8b7906> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49ce40eb-6344-4dac-97f9-5a64be8b7906";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=BesluitenLijst_OCMW-raad_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49ce40eb-6344-4dac-97f9-5a64be8b7906>.
+    
+<http://data.lblod.info/id/remote-data-objects/895ad04f-bca8-4ca1-8513-d726ba389e4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "895ad04f-bca8-4ca1-8513-d726ba389e4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=BesluitenLijst_OCMW-raad_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/895ad04f-bca8-4ca1-8513-d726ba389e4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/52df203c-30d7-441b-ba9a-3a8fe84e78bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52df203c-30d7-441b-ba9a-3a8fe84e78bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=BesluitenLijst_OCMW-raad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52df203c-30d7-441b-ba9a-3a8fe84e78bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/edb4b9a1-3c95-4c94-a6a9-f4401bada488> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edb4b9a1-3c95-4c94-a6a9-f4401bada488";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=BesluitenLijst_OCMW-raad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edb4b9a1-3c95-4c94-a6a9-f4401bada488>.
+    
+<http://data.lblod.info/id/remote-data-objects/11ebf71e-54ae-4cdc-94cb-f100d515e084> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11ebf71e-54ae-4cdc-94cb-f100d515e084";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=BesluitenLijst_OCMW-raad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11ebf71e-54ae-4cdc-94cb-f100d515e084>.
+    
+<http://data.lblod.info/id/remote-data-objects/e279e678-dc95-4f3e-b3f7-60850701c9f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e279e678-dc95-4f3e-b3f7-60850701c9f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Notulen_OCMW-raad_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e279e678-dc95-4f3e-b3f7-60850701c9f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3113ec38-6bf2-47ba-9ecd-3e46211dfa41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3113ec38-6bf2-47ba-9ecd-3e46211dfa41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Notulen_OCMW-raad_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3113ec38-6bf2-47ba-9ecd-3e46211dfa41>.
+    
+<http://data.lblod.info/id/remote-data-objects/388d4b96-1982-40aa-9b49-60dfe44deb3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "388d4b96-1982-40aa-9b49-60dfe44deb3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Notulen_OCMW-raad_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/388d4b96-1982-40aa-9b49-60dfe44deb3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0debaafe-effc-468b-9842-1b81ca5c5e2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0debaafe-effc-468b-9842-1b81ca5c5e2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Notulen_OCMW-raad_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0debaafe-effc-468b-9842-1b81ca5c5e2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/caa11d04-b20f-4c08-8d53-77b7a9d3a4e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "caa11d04-b20f-4c08-8d53-77b7a9d3a4e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Notulen_OCMW-raad_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/caa11d04-b20f-4c08-8d53-77b7a9d3a4e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/797f5a47-82b8-46d8-b0f2-5afd5f6f5c4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "797f5a47-82b8-46d8-b0f2-5afd5f6f5c4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Notulen_OCMW-raad_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/797f5a47-82b8-46d8-b0f2-5afd5f6f5c4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/867a740f-7a34-4037-95be-782c8374eb85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "867a740f-7a34-4037-95be-782c8374eb85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Notulen_OCMW-raad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/867a740f-7a34-4037-95be-782c8374eb85>.
+    
+<http://data.lblod.info/id/remote-data-objects/aab257bf-0af8-43a1-8d2d-c4b2b230462d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aab257bf-0af8-43a1-8d2d-c4b2b230462d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Notulen_OCMW-raad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aab257bf-0af8-43a1-8d2d-c4b2b230462d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c22894d-94e9-4402-bab0-505cdc7befc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c22894d-94e9-4402-bab0-505cdc7befc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Notulen_OCMW-raad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c22894d-94e9-4402-bab0-505cdc7befc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce58aa73-90e3-4431-9817-58666b8c277a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce58aa73-90e3-4431-9817-58666b8c277a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Uittreksels_08-11-2021_64914.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce58aa73-90e3-4431-9817-58666b8c277a>.
+    
+<http://data.lblod.info/id/remote-data-objects/be757ab3-cb3f-44f7-9c38-4fe3bf463f67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be757ab3-cb3f-44f7-9c38-4fe3bf463f67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Uittreksels_08-11-2021_65054.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be757ab3-cb3f-44f7-9c38-4fe3bf463f67>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ffc49d6-57e5-4211-96f0-be4b989924fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ffc49d6-57e5-4211-96f0-be4b989924fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Uittreksels_19-04-2022_69980.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ffc49d6-57e5-4211-96f0-be4b989924fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/017972b8-ba84-485d-b1fc-a1b3a02995db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "017972b8-ba84-485d-b1fc-a1b3a02995db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Uittreksels_20-06-2022_70916.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/017972b8-ba84-485d-b1fc-a1b3a02995db>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd89c0a7-3233-40dd-8ce3-c7d6964b8083> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd89c0a7-3233-40dd-8ce3-c7d6964b8083";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/02077be6ab153dd0a633c506c4476b5d85df40dcf87d0c8dd84ba1242d08eb97/GetPublication?filename=Uittreksels_21-03-2022_69426.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd89c0a7-3233-40dd-8ce3-c7d6964b8083>.
+    
+<http://data.lblod.info/id/remote-data-objects/f18e99d6-c50a-4545-a61c-e6fe5aa3b4e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f18e99d6-c50a-4545-a61c-e6fe5aa3b4e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f18e99d6-c50a-4545-a61c-e6fe5aa3b4e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc6dcacb-f03f-4883-803c-5bd5edfe635d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc6dcacb-f03f-4883-803c-5bd5edfe635d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc6dcacb-f03f-4883-803c-5bd5edfe635d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bec174d2-3b57-435e-8abb-f69f4493374e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bec174d2-3b57-435e-8abb-f69f4493374e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bec174d2-3b57-435e-8abb-f69f4493374e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4ede238-e4fe-42ca-87ac-881fe713a949> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4ede238-e4fe-42ca-87ac-881fe713a949";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d852ec40-be82-4391-9f43-bc31259365a1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4ede238-e4fe-42ca-87ac-881fe713a949>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201333-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201333-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201333-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201333-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/bb7c6636-d1c1-44d2-b094-54aaab981a2f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bb7c6636-d1c1-44d2-b094-54aaab981a2f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6d2a8f48-6f56-4677-b855-b28d9a5464b5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/cbcfc4ca-10a8-4c04-8285-776bd89382db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cbcfc4ca-10a8-4c04-8285-776bd89382db";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5>.
+
+  <http://redpencil.data.gift/id/task/4f585b66-9cf6-46a3-a8d3-bad2b2ae218a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4f585b66-9cf6-46a3-a8d3-bad2b2ae218a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/bb7c6636-d1c1-44d2-b094-54aaab981a2f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/cbcfc4ca-10a8-4c04-8285-776bd89382db>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a2831060-e6c2-444d-8df2-9127696c46c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2831060-e6c2-444d-8df2-9127696c46c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2831060-e6c2-444d-8df2-9127696c46c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1321d063-63c4-4440-ba48-005c1169f3f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1321d063-63c4-4440-ba48-005c1169f3f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1321d063-63c4-4440-ba48-005c1169f3f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a513cb6e-6ee6-4c8d-a978-f41b15922af0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a513cb6e-6ee6-4c8d-a978-f41b15922af0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a513cb6e-6ee6-4c8d-a978-f41b15922af0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c830fc3b-bc47-47cf-a572-0d74dfcb60ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c830fc3b-bc47-47cf-a572-0d74dfcb60ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c830fc3b-bc47-47cf-a572-0d74dfcb60ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/a835c1a6-c4f1-4e51-a1dc-41b79e6c2ba2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a835c1a6-c4f1-4e51-a1dc-41b79e6c2ba2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a835c1a6-c4f1-4e51-a1dc-41b79e6c2ba2>.
+    
+<http://data.lblod.info/id/remote-data-objects/334d40f5-1b1e-4d5d-b27a-52097d12e503> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "334d40f5-1b1e-4d5d-b27a-52097d12e503";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_09-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/334d40f5-1b1e-4d5d-b27a-52097d12e503>.
+    
+<http://data.lblod.info/id/remote-data-objects/67b48609-ce50-4069-a768-0a1ecdf7813f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67b48609-ce50-4069-a768-0a1ecdf7813f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67b48609-ce50-4069-a768-0a1ecdf7813f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cd16314-df02-4847-bbf5-8a5359539473> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cd16314-df02-4847-bbf5-8a5359539473";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cd16314-df02-4847-bbf5-8a5359539473>.
+    
+<http://data.lblod.info/id/remote-data-objects/446def63-2e39-4af9-b182-c05176cc4434> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "446def63-2e39-4af9-b182-c05176cc4434";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/446def63-2e39-4af9-b182-c05176cc4434>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ae4d691-b1d5-4aee-8803-4c23a6b9dae6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ae4d691-b1d5-4aee-8803-4c23a6b9dae6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ae4d691-b1d5-4aee-8803-4c23a6b9dae6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b5272b0-eb6c-47d1-963b-92cdb6100a16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b5272b0-eb6c-47d1-963b-92cdb6100a16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b5272b0-eb6c-47d1-963b-92cdb6100a16>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c5bfd04-7f33-4fdd-bcad-56a5af289e81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c5bfd04-7f33-4fdd-bcad-56a5af289e81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c5bfd04-7f33-4fdd-bcad-56a5af289e81>.
+    
+<http://data.lblod.info/id/remote-data-objects/745a31c1-0e93-4fbd-a985-a8a3ff54e475> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "745a31c1-0e93-4fbd-a985-a8a3ff54e475";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/745a31c1-0e93-4fbd-a985-a8a3ff54e475>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cfda26e-1c57-4a21-bb6c-eec55519ada5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cfda26e-1c57-4a21-bb6c-eec55519ada5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cfda26e-1c57-4a21-bb6c-eec55519ada5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5485e6e8-2f30-4e68-9fb1-0fdd0fa75861> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5485e6e8-2f30-4e68-9fb1-0fdd0fa75861";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5485e6e8-2f30-4e68-9fb1-0fdd0fa75861>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5dcb64e-645c-4f51-9b5b-5f8959aecb1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5dcb64e-645c-4f51-9b5b-5f8959aecb1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5dcb64e-645c-4f51-9b5b-5f8959aecb1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb5df7a7-9609-46fc-b38d-337f090e32e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb5df7a7-9609-46fc-b38d-337f090e32e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb5df7a7-9609-46fc-b38d-337f090e32e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a72f91d5-936f-4811-859b-235874510c2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a72f91d5-936f-4811-859b-235874510c2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a72f91d5-936f-4811-859b-235874510c2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/097d06d2-1f97-4d0d-9eb4-3e16ca01615c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "097d06d2-1f97-4d0d-9eb4-3e16ca01615c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/097d06d2-1f97-4d0d-9eb4-3e16ca01615c>.
+    
+<http://data.lblod.info/id/remote-data-objects/de972611-fdba-4518-9da5-996d6c0e8953> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de972611-fdba-4518-9da5-996d6c0e8953";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de972611-fdba-4518-9da5-996d6c0e8953>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e5601ea-a993-40f5-b6ca-d5694c0f6dc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e5601ea-a993-40f5-b6ca-d5694c0f6dc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e5601ea-a993-40f5-b6ca-d5694c0f6dc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6a10006-2f45-454b-b72b-5017445bc386> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6a10006-2f45-454b-b72b-5017445bc386";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6a10006-2f45-454b-b72b-5017445bc386>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5efd596-4d95-4693-802b-333246e7b11c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5efd596-4d95-4693-802b-333246e7b11c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5efd596-4d95-4693-802b-333246e7b11c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e71433c9-05ed-43cb-a69d-9190f0e8d2d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e71433c9-05ed-43cb-a69d-9190f0e8d2d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e71433c9-05ed-43cb-a69d-9190f0e8d2d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d70dde26-dca1-4d57-ac4c-47db595bfb3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d70dde26-dca1-4d57-ac4c-47db595bfb3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d70dde26-dca1-4d57-ac4c-47db595bfb3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c57fdb52-d9c1-4b35-bced-02d46322d220> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c57fdb52-d9c1-4b35-bced-02d46322d220";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c57fdb52-d9c1-4b35-bced-02d46322d220>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fac8368-dbd5-4f59-bab8-3b8ea45ee032> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fac8368-dbd5-4f59-bab8-3b8ea45ee032";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fac8368-dbd5-4f59-bab8-3b8ea45ee032>.
+    
+<http://data.lblod.info/id/remote-data-objects/e01fd107-8abc-4c58-9b62-cc6304697837> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e01fd107-8abc-4c58-9b62-cc6304697837";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e01fd107-8abc-4c58-9b62-cc6304697837>.
+    
+<http://data.lblod.info/id/remote-data-objects/587afca0-64f7-4dcd-9550-5a183da68ae1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "587afca0-64f7-4dcd-9550-5a183da68ae1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/587afca0-64f7-4dcd-9550-5a183da68ae1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1e5dca9-8bc9-4588-b55a-405f869736b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1e5dca9-8bc9-4588-b55a-405f869736b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=BesluitenLijst_Schepencollege_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1e5dca9-8bc9-4588-b55a-405f869736b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/5278d153-5958-4a4c-a379-20afd976fa67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5278d153-5958-4a4c-a379-20afd976fa67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_02-05-2022_69966.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5278d153-5958-4a4c-a379-20afd976fa67>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce2f69f2-b4d3-49a5-bfcb-ef536670bf5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce2f69f2-b4d3-49a5-bfcb-ef536670bf5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_02-05-2022_70281.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce2f69f2-b4d3-49a5-bfcb-ef536670bf5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cdcf470-66e5-439c-a1f5-80eca0af5a1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cdcf470-66e5-439c-a1f5-80eca0af5a1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_04-04-2022_69879.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cdcf470-66e5-439c-a1f5-80eca0af5a1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/550f00d6-c590-4b42-85e1-15a432f42b79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "550f00d6-c590-4b42-85e1-15a432f42b79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_04-07-2022_71362.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/550f00d6-c590-4b42-85e1-15a432f42b79>.
+    
+<http://data.lblod.info/id/remote-data-objects/754ca2a9-eef9-46b2-990d-a1cf6d206f54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "754ca2a9-eef9-46b2-990d-a1cf6d206f54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_07-03-2022_68234.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/754ca2a9-eef9-46b2-990d-a1cf6d206f54>.
+    
+<http://data.lblod.info/id/remote-data-objects/a75408b1-2b7c-49fa-9eae-5924d0f028e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a75408b1-2b7c-49fa-9eae-5924d0f028e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_07-03-2022_68238.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a75408b1-2b7c-49fa-9eae-5924d0f028e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/60cc840e-1ff2-4bad-aac8-b2924a181d86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60cc840e-1ff2-4bad-aac8-b2924a181d86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_07-03-2022_68241.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60cc840e-1ff2-4bad-aac8-b2924a181d86>.
+    
+<http://data.lblod.info/id/remote-data-objects/b35853e7-f14c-4b2b-9666-dfcfb96fa8b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b35853e7-f14c-4b2b-9666-dfcfb96fa8b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_07-03-2022_68302.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b35853e7-f14c-4b2b-9666-dfcfb96fa8b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/326d894e-c854-458b-a218-0ba66d5eed8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "326d894e-c854-458b-a218-0ba66d5eed8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_08-11-2021_64921.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/326d894e-c854-458b-a218-0ba66d5eed8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/af69ff53-04ff-4dbe-ba12-0bd8db6389d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af69ff53-04ff-4dbe-ba12-0bd8db6389d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_08-11-2021_65207.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af69ff53-04ff-4dbe-ba12-0bd8db6389d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/062361d2-8556-4165-aa30-f2e833868873> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "062361d2-8556-4165-aa30-f2e833868873";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_09-05-2022_70353.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/062361d2-8556-4165-aa30-f2e833868873>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cf972bf-117d-47b1-b0ca-98b8d9341baa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cf972bf-117d-47b1-b0ca-98b8d9341baa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_09-05-2022_70424.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cf972bf-117d-47b1-b0ca-98b8d9341baa>.
+    
+<http://data.lblod.info/id/remote-data-objects/c51e03ce-00a4-45a2-b8f8-ec9057370102> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c51e03ce-00a4-45a2-b8f8-ec9057370102";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_09-05-2022_70425.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c51e03ce-00a4-45a2-b8f8-ec9057370102>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d287813-47d9-41c6-ac67-ac1835f5396d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d287813-47d9-41c6-ac67-ac1835f5396d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_09-06-2022_70803.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d287813-47d9-41c6-ac67-ac1835f5396d>.
+    
+<http://data.lblod.info/id/remote-data-objects/25dbc588-1cc5-4799-83ab-b42f3513880b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25dbc588-1cc5-4799-83ab-b42f3513880b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_14-02-2022_66760.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25dbc588-1cc5-4799-83ab-b42f3513880b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0133cd4d-3757-4f05-a714-88b45d6ba878> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0133cd4d-3757-4f05-a714-88b45d6ba878";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_16-05-2022_70493.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0133cd4d-3757-4f05-a714-88b45d6ba878>.
+    
+<http://data.lblod.info/id/remote-data-objects/af77c9ee-3d3f-4260-bf2a-15610104dbbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af77c9ee-3d3f-4260-bf2a-15610104dbbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_18-10-2021_64640.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af77c9ee-3d3f-4260-bf2a-15610104dbbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f84ffff-fe25-4b0b-9c4d-dabc70c6eaf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f84ffff-fe25-4b0b-9c4d-dabc70c6eaf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_19-04-2022_69920.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f84ffff-fe25-4b0b-9c4d-dabc70c6eaf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5e9eeeb-a4b0-4d1f-bc2c-4ca159447703> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5e9eeeb-a4b0-4d1f-bc2c-4ca159447703";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_19-04-2022_69970.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5e9eeeb-a4b0-4d1f-bc2c-4ca159447703>.
+    
+<http://data.lblod.info/id/remote-data-objects/75b31db4-5110-4df4-baaa-33b37320b0f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75b31db4-5110-4df4-baaa-33b37320b0f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_19-04-2022_70037.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d2a8f48-6f56-4677-b855-b28d9a5464b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75b31db4-5110-4df4-baaa-33b37320b0f1>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201334-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201334-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201334-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201334-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/eeeacaa6-067a-416f-8f96-717bbe1e14ff> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "eeeacaa6-067a-416f-8f96-717bbe1e14ff";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c1f97b09-81d7-4064-ad8a-2bffb9ebd375> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c1f97b09-81d7-4064-ad8a-2bffb9ebd375";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced>.
+
+  <http://redpencil.data.gift/id/task/91cb2242-c172-4e9f-9592-87c56b22d894> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "91cb2242-c172-4e9f-9592-87c56b22d894";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/eeeacaa6-067a-416f-8f96-717bbe1e14ff>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c1f97b09-81d7-4064-ad8a-2bffb9ebd375>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/2fbdfd62-5dbe-43bc-9b5f-2c0dddaacf47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fbdfd62-5dbe-43bc-9b5f-2c0dddaacf47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_22-11-2021_65300.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fbdfd62-5dbe-43bc-9b5f-2c0dddaacf47>.
+    
+<http://data.lblod.info/id/remote-data-objects/92077f34-f333-458b-a677-a3e0b11675d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92077f34-f333-458b-a677-a3e0b11675d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_23-05-2022_70639.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92077f34-f333-458b-a677-a3e0b11675d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/39bd96e1-379c-4e05-bdf3-5c0c49b9d707> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39bd96e1-379c-4e05-bdf3-5c0c49b9d707";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_23-05-2022_70677.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39bd96e1-379c-4e05-bdf3-5c0c49b9d707>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e14b17b-ac00-4ed7-b3cd-92437fae6e07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e14b17b-ac00-4ed7-b3cd-92437fae6e07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_23-05-2022_70694.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e14b17b-ac00-4ed7-b3cd-92437fae6e07>.
+    
+<http://data.lblod.info/id/remote-data-objects/cddfd4b0-5cd7-4102-b691-9112fa25fa3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cddfd4b0-5cd7-4102-b691-9112fa25fa3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_25-10-2021_64902.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cddfd4b0-5cd7-4102-b691-9112fa25fa3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5ddd1b5-fa42-47d3-9d90-9397534d1471> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5ddd1b5-fa42-47d3-9d90-9397534d1471";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_25-10-2021_64904.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5ddd1b5-fa42-47d3-9d90-9397534d1471>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f250955-89fc-4254-b3bb-26e66ee5fdd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f250955-89fc-4254-b3bb-26e66ee5fdd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_30-05-2022_70708.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f250955-89fc-4254-b3bb-26e66ee5fdd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/141346b1-7c93-4446-bb81-54fb4ccafc39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "141346b1-7c93-4446-bb81-54fb4ccafc39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2eae0c74aa3948ccdad14c47a25657ca7a9ffc86a618cf940af54d123ed30dd7/GetPublication?filename=Uittreksels_31-01-2022_66598.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/141346b1-7c93-4446-bb81-54fb4ccafc39>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ae33596-ff44-41a6-b6be-682d83c47201> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ae33596-ff44-41a6-b6be-682d83c47201";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ae33596-ff44-41a6-b6be-682d83c47201>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c56a85c-49ee-4215-b1f4-8d6643cefede> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c56a85c-49ee-4215-b1f4-8d6643cefede";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c56a85c-49ee-4215-b1f4-8d6643cefede>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffcafbf0-8018-4a2a-94fd-83bb15dfcdcb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffcafbf0-8018-4a2a-94fd-83bb15dfcdcb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffcafbf0-8018-4a2a-94fd-83bb15dfcdcb>.
+    
+<http://data.lblod.info/id/remote-data-objects/53634ef0-3995-4565-8a56-c4302dab1d08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53634ef0-3995-4565-8a56-c4302dab1d08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53634ef0-3995-4565-8a56-c4302dab1d08>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1b0e9a7-a513-45bb-80d9-58c596f90fe4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1b0e9a7-a513-45bb-80d9-58c596f90fe4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1b0e9a7-a513-45bb-80d9-58c596f90fe4>.
+    
+<http://data.lblod.info/id/remote-data-objects/54c1bec5-b37f-4092-ad2a-01f157606395> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54c1bec5-b37f-4092-ad2a-01f157606395";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54c1bec5-b37f-4092-ad2a-01f157606395>.
+    
+<http://data.lblod.info/id/remote-data-objects/9566607f-4285-4eba-a370-b9fd3b42c893> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9566607f-4285-4eba-a370-b9fd3b42c893";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9566607f-4285-4eba-a370-b9fd3b42c893>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4a04c68-871e-4047-a13b-0f6fb8ce079d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4a04c68-871e-4047-a13b-0f6fb8ce079d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4a04c68-871e-4047-a13b-0f6fb8ce079d>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f7842c3-36d5-477b-a6d4-2e0ff50c69ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f7842c3-36d5-477b-a6d4-2e0ff50c69ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f7842c3-36d5-477b-a6d4-2e0ff50c69ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/78db3fa2-015b-4181-8fcf-6679612750e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78db3fa2-015b-4181-8fcf-6679612750e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78db3fa2-015b-4181-8fcf-6679612750e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/41608eb1-20f2-4774-89a4-56db019d0fd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41608eb1-20f2-4774-89a4-56db019d0fd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41608eb1-20f2-4774-89a4-56db019d0fd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/90eec65e-ed66-445d-bb50-dba035a4c456> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90eec65e-ed66-445d-bb50-dba035a4c456";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90eec65e-ed66-445d-bb50-dba035a4c456>.
+    
+<http://data.lblod.info/id/remote-data-objects/d67c0ebe-cf20-4e8c-ae15-c27b6a11e7d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d67c0ebe-cf20-4e8c-ae15-c27b6a11e7d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d67c0ebe-cf20-4e8c-ae15-c27b6a11e7d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/906ce473-3e7d-4f0f-9385-3a8d7daa298d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "906ce473-3e7d-4f0f-9385-3a8d7daa298d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/906ce473-3e7d-4f0f-9385-3a8d7daa298d>.
+    
+<http://data.lblod.info/id/remote-data-objects/50e208c9-f889-421c-8621-209240803ddc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50e208c9-f889-421c-8621-209240803ddc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50e208c9-f889-421c-8621-209240803ddc>.
+    
+<http://data.lblod.info/id/remote-data-objects/a38e7016-833a-4653-9d32-42423347260a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a38e7016-833a-4653-9d32-42423347260a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a38e7016-833a-4653-9d32-42423347260a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bbdf06a-dccd-43bb-95d5-5b86601abf1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bbdf06a-dccd-43bb-95d5-5b86601abf1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bbdf06a-dccd-43bb-95d5-5b86601abf1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/37c0ada3-5f22-424b-9fba-335b3be36bd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37c0ada3-5f22-424b-9fba-335b3be36bd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37c0ada3-5f22-424b-9fba-335b3be36bd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d891ecf-1b56-4e94-bcea-0071b31e68ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d891ecf-1b56-4e94-bcea-0071b31e68ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d891ecf-1b56-4e94-bcea-0071b31e68ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac01299f-7a36-4d43-a239-350ce341e3b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac01299f-7a36-4d43-a239-350ce341e3b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac01299f-7a36-4d43-a239-350ce341e3b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/358a73ea-aced-4915-b38c-bcbd0ec1cdcf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "358a73ea-aced-4915-b38c-bcbd0ec1cdcf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/358a73ea-aced-4915-b38c-bcbd0ec1cdcf>.
+    
+<http://data.lblod.info/id/remote-data-objects/f42821e4-ddfa-41f5-876e-813bd9372b5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f42821e4-ddfa-41f5-876e-813bd9372b5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f42821e4-ddfa-41f5-876e-813bd9372b5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8639d022-c9f8-488a-ba76-71a72e562f58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8639d022-c9f8-488a-ba76-71a72e562f58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8639d022-c9f8-488a-ba76-71a72e562f58>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccd57de0-891e-4cbd-bb9d-a00d2a844975> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccd57de0-891e-4cbd-bb9d-a00d2a844975";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccd57de0-891e-4cbd-bb9d-a00d2a844975>.
+    
+<http://data.lblod.info/id/remote-data-objects/25a9f74c-ee3f-4a72-95cb-b3df35ec6a1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25a9f74c-ee3f-4a72-95cb-b3df35ec6a1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25a9f74c-ee3f-4a72-95cb-b3df35ec6a1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/65092531-d4df-4ac5-b76f-d7eabb4ad4cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65092531-d4df-4ac5-b76f-d7eabb4ad4cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65092531-d4df-4ac5-b76f-d7eabb4ad4cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3574b5e-b8a6-424c-834e-5414985be568> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3574b5e-b8a6-424c-834e-5414985be568";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3574b5e-b8a6-424c-834e-5414985be568>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e75540d-eed2-4a39-a54f-db08bb6f662f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e75540d-eed2-4a39-a54f-db08bb6f662f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e75540d-eed2-4a39-a54f-db08bb6f662f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cc50c0c-af7a-44a8-a4d2-f601e59e224e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cc50c0c-af7a-44a8-a4d2-f601e59e224e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cc50c0c-af7a-44a8-a4d2-f601e59e224e>.
+    
+<http://data.lblod.info/id/remote-data-objects/94857f14-22fa-4c34-a14d-1ab941d8c888> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94857f14-22fa-4c34-a14d-1ab941d8c888";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94857f14-22fa-4c34-a14d-1ab941d8c888>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0ad9210-191f-482a-be1d-0c20aab86a8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0ad9210-191f-482a-be1d-0c20aab86a8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0ad9210-191f-482a-be1d-0c20aab86a8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4d9651d-bee0-4fc0-a18d-bd18ce43c926> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4d9651d-bee0-4fc0-a18d-bd18ce43c926";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4d9651d-bee0-4fc0-a18d-bd18ce43c926>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f6cab4a-449d-49ee-a26f-20c689f9e54c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f6cab4a-449d-49ee-a26f-20c689f9e54c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f6cab4a-449d-49ee-a26f-20c689f9e54c>.
+    
+<http://data.lblod.info/id/remote-data-objects/db60681c-3e8d-4379-b7f0-b3d323269e6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db60681c-3e8d-4379-b7f0-b3d323269e6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db60681c-3e8d-4379-b7f0-b3d323269e6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc44ac24-53e4-4be5-9841-9310a44af805> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc44ac24-53e4-4be5-9841-9310a44af805";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/2fcd024b-e3c1-4e9b-ad4a-7cec8f594850/GetPublication?filename=BesluitenLijst_Vast%20Bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc44ac24-53e4-4be5-9841-9310a44af805>.
+    
+<http://data.lblod.info/id/remote-data-objects/cefa33cd-1159-4f57-a9fb-09b2b5c0ae38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cefa33cd-1159-4f57-a9fb-09b2b5c0ae38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Agenda_Gemeenteraad_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cefa33cd-1159-4f57-a9fb-09b2b5c0ae38>.
+    
+<http://data.lblod.info/id/remote-data-objects/05589372-55f9-4828-a010-087a1d643229> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05589372-55f9-4828-a010-087a1d643229";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Agenda_Gemeenteraad_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05589372-55f9-4828-a010-087a1d643229>.
+    
+<http://data.lblod.info/id/remote-data-objects/7244f7af-60f3-48b2-ae2f-d4259d1e9d06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7244f7af-60f3-48b2-ae2f-d4259d1e9d06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Agenda_Gemeenteraad_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7244f7af-60f3-48b2-ae2f-d4259d1e9d06>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4ad2d4f-a581-45bb-a19c-bff3291800a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4ad2d4f-a581-45bb-a19c-bff3291800a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Agenda_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4ad2d4f-a581-45bb-a19c-bff3291800a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/25d92730-9445-4923-aaa6-146fc17fb1b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25d92730-9445-4923-aaa6-146fc17fb1b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Agenda_Gemeenteraad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25d92730-9445-4923-aaa6-146fc17fb1b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee276151-2319-4d67-b6b1-452bd2106728> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee276151-2319-4d67-b6b1-452bd2106728";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Agenda_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee276151-2319-4d67-b6b1-452bd2106728>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5bcf1e0-37fd-49b8-9698-5f7cd55bc026> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5bcf1e0-37fd-49b8-9698-5f7cd55bc026";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=BesluitenLijst_Gemeenteraad_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4a2af513-d9fe-4a28-87b6-a2fc1dfe7ced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5bcf1e0-37fd-49b8-9698-5f7cd55bc026>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201335-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201335-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201335-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201335-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/5837313e-724e-4710-a45d-ca7d542ab184> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5837313e-724e-4710-a45d-ca7d542ab184";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4fb8828e-ab36-448f-a8f9-a353e1358c37";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/0a2eb87b-c19e-450e-bb73-8b4909a37a5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0a2eb87b-c19e-450e-bb73-8b4909a37a5a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37>.
+
+  <http://redpencil.data.gift/id/task/c4b1875c-bd5f-4889-b497-c516f50e8470> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c4b1875c-bd5f-4889-b497-c516f50e8470";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/5837313e-724e-4710-a45d-ca7d542ab184>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/0a2eb87b-c19e-450e-bb73-8b4909a37a5a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a1d7de3f-0125-41c5-99e7-4537b9525e90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1d7de3f-0125-41c5-99e7-4537b9525e90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=BesluitenLijst_Gemeenteraad_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1d7de3f-0125-41c5-99e7-4537b9525e90>.
+    
+<http://data.lblod.info/id/remote-data-objects/219b0dbf-d42b-41d8-8da7-8cf4209dd38e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "219b0dbf-d42b-41d8-8da7-8cf4209dd38e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=BesluitenLijst_Gemeenteraad_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/219b0dbf-d42b-41d8-8da7-8cf4209dd38e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a23394b-f1d8-4e8e-b90e-33cd921e1a94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a23394b-f1d8-4e8e-b90e-33cd921e1a94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=BesluitenLijst_Gemeenteraad_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a23394b-f1d8-4e8e-b90e-33cd921e1a94>.
+    
+<http://data.lblod.info/id/remote-data-objects/93028f43-82c4-4180-b098-0366aaa6e831> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93028f43-82c4-4180-b098-0366aaa6e831";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=BesluitenLijst_Gemeenteraad_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93028f43-82c4-4180-b098-0366aaa6e831>.
+    
+<http://data.lblod.info/id/remote-data-objects/44206160-41e7-4de4-857d-7048017a2cc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44206160-41e7-4de4-857d-7048017a2cc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=BesluitenLijst_Gemeenteraad_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44206160-41e7-4de4-857d-7048017a2cc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c34b8daa-9dd1-400d-90db-6f14a1222e8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c34b8daa-9dd1-400d-90db-6f14a1222e8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=BesluitenLijst_Gemeenteraad_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c34b8daa-9dd1-400d-90db-6f14a1222e8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a76f7be1-6c74-42c9-87d7-9e04e75b8e40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a76f7be1-6c74-42c9-87d7-9e04e75b8e40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a76f7be1-6c74-42c9-87d7-9e04e75b8e40>.
+    
+<http://data.lblod.info/id/remote-data-objects/4be80941-85e9-440d-8e5a-859a7a02efe4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4be80941-85e9-440d-8e5a-859a7a02efe4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4be80941-85e9-440d-8e5a-859a7a02efe4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c599b6a6-b125-485c-a4dd-98cb32440339> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c599b6a6-b125-485c-a4dd-98cb32440339";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c599b6a6-b125-485c-a4dd-98cb32440339>.
+    
+<http://data.lblod.info/id/remote-data-objects/bca4115b-eed1-4b7c-8985-709ee9162128> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bca4115b-eed1-4b7c-8985-709ee9162128";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Notulen_Gemeenteraad_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bca4115b-eed1-4b7c-8985-709ee9162128>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a75f974-363f-42c7-a6e8-842e027562eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a75f974-363f-42c7-a6e8-842e027562eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Notulen_Gemeenteraad_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a75f974-363f-42c7-a6e8-842e027562eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/33c31d7b-ee3c-4ec0-8ce5-e568907c96ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33c31d7b-ee3c-4ec0-8ce5-e568907c96ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Notulen_Gemeenteraad_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33c31d7b-ee3c-4ec0-8ce5-e568907c96ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a3202a1-e183-4104-85b4-192c54241de0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a3202a1-e183-4104-85b4-192c54241de0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Notulen_Gemeenteraad_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a3202a1-e183-4104-85b4-192c54241de0>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d9e0fe4-2db1-4e9d-967c-372a9e53a661> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d9e0fe4-2db1-4e9d-967c-372a9e53a661";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Notulen_Gemeenteraad_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d9e0fe4-2db1-4e9d-967c-372a9e53a661>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e93957c-aa3d-46b3-b9e4-db8fcaeb2a16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e93957c-aa3d-46b3-b9e4-db8fcaeb2a16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Notulen_Gemeenteraad_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e93957c-aa3d-46b3-b9e4-db8fcaeb2a16>.
+    
+<http://data.lblod.info/id/remote-data-objects/748bb388-e580-437f-a36d-262d22f5532c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "748bb388-e580-437f-a36d-262d22f5532c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Notulen_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/748bb388-e580-437f-a36d-262d22f5532c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2eaa24f6-da24-45d7-9c46-d42458ee3ab3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2eaa24f6-da24-45d7-9c46-d42458ee3ab3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Notulen_Gemeenteraad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2eaa24f6-da24-45d7-9c46-d42458ee3ab3>.
+    
+<http://data.lblod.info/id/remote-data-objects/08cacb78-61f7-4468-b20a-f0716df906c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08cacb78-61f7-4468-b20a-f0716df906c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Notulen_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08cacb78-61f7-4468-b20a-f0716df906c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c294e66-d403-424d-afd1-038b029fd59b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c294e66-d403-424d-afd1-038b029fd59b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_06-12-2021_65528.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c294e66-d403-424d-afd1-038b029fd59b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e97326c-e0ac-4db2-ba00-2f828d0fa0dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e97326c-e0ac-4db2-ba00-2f828d0fa0dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_06-12-2021_65539.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e97326c-e0ac-4db2-ba00-2f828d0fa0dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f44b9e28-7723-445a-9ddf-3b2d0d42c1b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f44b9e28-7723-445a-9ddf-3b2d0d42c1b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_06-12-2021_65540.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f44b9e28-7723-445a-9ddf-3b2d0d42c1b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/713ac295-10b5-4bd4-87e8-c014c26b2750> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "713ac295-10b5-4bd4-87e8-c014c26b2750";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_06-12-2021_65541.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/713ac295-10b5-4bd4-87e8-c014c26b2750>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bdd506a-169c-4f62-bf18-576619804ace> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bdd506a-169c-4f62-bf18-576619804ace";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_06-12-2021_65542.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bdd506a-169c-4f62-bf18-576619804ace>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e7f80c9-0853-4e6c-9df2-c70604ca000c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e7f80c9-0853-4e6c-9df2-c70604ca000c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_06-12-2021_65544.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e7f80c9-0853-4e6c-9df2-c70604ca000c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ea78cbf-60c4-4117-89bf-7b6a847aa6c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ea78cbf-60c4-4117-89bf-7b6a847aa6c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_06-12-2021_65546.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ea78cbf-60c4-4117-89bf-7b6a847aa6c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec5facb6-648f-4b60-a154-738802b0855d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec5facb6-648f-4b60-a154-738802b0855d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_06-12-2021_65550.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec5facb6-648f-4b60-a154-738802b0855d>.
+    
+<http://data.lblod.info/id/remote-data-objects/56cc351c-c3f3-4059-9a2f-b8be9ecda864> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56cc351c-c3f3-4059-9a2f-b8be9ecda864";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_08-11-2021_64915.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56cc351c-c3f3-4059-9a2f-b8be9ecda864>.
+    
+<http://data.lblod.info/id/remote-data-objects/8be372c3-6696-4d60-b58e-de39a13a8a56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8be372c3-6696-4d60-b58e-de39a13a8a56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_08-11-2021_64916.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8be372c3-6696-4d60-b58e-de39a13a8a56>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcad3cc5-46ba-4b0f-8843-3ad11c644b4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcad3cc5-46ba-4b0f-8843-3ad11c644b4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_08-11-2021_65068.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcad3cc5-46ba-4b0f-8843-3ad11c644b4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e472cb56-f4cd-4d52-9b1d-f56961b9cf1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e472cb56-f4cd-4d52-9b1d-f56961b9cf1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_08-11-2021_65069.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e472cb56-f4cd-4d52-9b1d-f56961b9cf1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac8c520c-f779-435a-9026-68bf18a8663b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac8c520c-f779-435a-9026-68bf18a8663b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_08-11-2021_65073.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac8c520c-f779-435a-9026-68bf18a8663b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e38fe0e-41be-4cb6-a1c3-d7c12fb9f426> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e38fe0e-41be-4cb6-a1c3-d7c12fb9f426";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_08-11-2021_65078.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e38fe0e-41be-4cb6-a1c3-d7c12fb9f426>.
+    
+<http://data.lblod.info/id/remote-data-objects/58859b6c-21b3-49ce-8cf2-ab01f49cc5f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58859b6c-21b3-49ce-8cf2-ab01f49cc5f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_08-11-2021_65079.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58859b6c-21b3-49ce-8cf2-ab01f49cc5f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/10179eea-367f-4b70-9066-ccedff47e619> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10179eea-367f-4b70-9066-ccedff47e619";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_14-07-2022_71421.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10179eea-367f-4b70-9066-ccedff47e619>.
+    
+<http://data.lblod.info/id/remote-data-objects/44b14560-9bcb-4399-ae75-c829b67e3607> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44b14560-9bcb-4399-ae75-c829b67e3607";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_14-07-2022_71423.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44b14560-9bcb-4399-ae75-c829b67e3607>.
+    
+<http://data.lblod.info/id/remote-data-objects/99aee5f3-0fd3-4346-ae76-8441766525b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99aee5f3-0fd3-4346-ae76-8441766525b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_14-07-2022_71425.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99aee5f3-0fd3-4346-ae76-8441766525b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a86c3edd-6c0d-4d37-bca6-33e8069f32cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a86c3edd-6c0d-4d37-bca6-33e8069f32cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_14-07-2022_71427.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a86c3edd-6c0d-4d37-bca6-33e8069f32cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/688568eb-e033-4b65-bed2-9f6e3d10724e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "688568eb-e033-4b65-bed2-9f6e3d10724e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_17-01-2022_66129.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/688568eb-e033-4b65-bed2-9f6e3d10724e>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf955f59-3afd-46ad-891f-8bf029f17e76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf955f59-3afd-46ad-891f-8bf029f17e76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_17-01-2022_66130.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf955f59-3afd-46ad-891f-8bf029f17e76>.
+    
+<http://data.lblod.info/id/remote-data-objects/29570692-decd-461d-94cd-c044b51309cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29570692-decd-461d-94cd-c044b51309cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_17-01-2022_66131.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29570692-decd-461d-94cd-c044b51309cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ee1c63c-87b8-496e-a4d9-46ec386efdc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ee1c63c-87b8-496e-a4d9-46ec386efdc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_17-01-2022_66132.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ee1c63c-87b8-496e-a4d9-46ec386efdc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d30b21fb-4bd4-4fa7-b145-025d04163e05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d30b21fb-4bd4-4fa7-b145-025d04163e05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_17-01-2022_66138.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d30b21fb-4bd4-4fa7-b145-025d04163e05>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a72f817-b7f7-4732-b4e3-194d2c94e961> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a72f817-b7f7-4732-b4e3-194d2c94e961";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_17-01-2022_66139.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a72f817-b7f7-4732-b4e3-194d2c94e961>.
+    
+<http://data.lblod.info/id/remote-data-objects/6631befe-5a16-4bd8-be05-375fc9705be5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6631befe-5a16-4bd8-be05-375fc9705be5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_18-10-2021_64431.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6631befe-5a16-4bd8-be05-375fc9705be5>.
+    
+<http://data.lblod.info/id/remote-data-objects/71f01a27-cee3-4614-b6f9-7cf743bc2d0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71f01a27-cee3-4614-b6f9-7cf743bc2d0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_19-04-2022_69987.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71f01a27-cee3-4614-b6f9-7cf743bc2d0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/766ffa70-b773-45d5-8491-9e822c27c649> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "766ffa70-b773-45d5-8491-9e822c27c649";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_19-04-2022_69988.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/766ffa70-b773-45d5-8491-9e822c27c649>.
+    
+<http://data.lblod.info/id/remote-data-objects/74c2396c-16a8-4c48-9ccb-10d48fe8991f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74c2396c-16a8-4c48-9ccb-10d48fe8991f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_19-04-2022_69994.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74c2396c-16a8-4c48-9ccb-10d48fe8991f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fc07744-f42a-4a63-8a8d-37282c320b68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fc07744-f42a-4a63-8a8d-37282c320b68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_20-06-2022_70914.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fc07744-f42a-4a63-8a8d-37282c320b68>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4972592-8d16-4303-8a99-deb718a07b4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4972592-8d16-4303-8a99-deb718a07b4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_20-06-2022_71000.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4972592-8d16-4303-8a99-deb718a07b4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d4d7f08-3c32-4df5-936e-563ba7ae640d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d4d7f08-3c32-4df5-936e-563ba7ae640d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_20-06-2022_71006.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fb8828e-ab36-448f-a8f9-a353e1358c37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d4d7f08-3c32-4df5-936e-563ba7ae640d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201337-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201337-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201337-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201337-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/27470478-fd9f-4729-bb65-fe97a00908a8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "27470478-fd9f-4729-bb65-fe97a00908a8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/66f68211-6b27-4bcd-a36e-a611a1f4d061> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "66f68211-6b27-4bcd-a36e-a611a1f4d061";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd>.
+
+  <http://redpencil.data.gift/id/task/11711681-1953-4e4e-977b-3db6ae680e07> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "11711681-1953-4e4e-977b-3db6ae680e07";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/27470478-fd9f-4729-bb65-fe97a00908a8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/66f68211-6b27-4bcd-a36e-a611a1f4d061>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/8747a8f0-57b8-4526-9512-c8feee5d6108> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8747a8f0-57b8-4526-9512-c8feee5d6108";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_21-02-2022_66831.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8747a8f0-57b8-4526-9512-c8feee5d6108>.
+    
+<http://data.lblod.info/id/remote-data-objects/45c39ff6-c2e9-4f4d-8658-b46ceacbf44d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45c39ff6-c2e9-4f4d-8658-b46ceacbf44d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_21-02-2022_66834.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45c39ff6-c2e9-4f4d-8658-b46ceacbf44d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c811f2e1-c8a2-4b0d-919c-3aa4ad709c00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c811f2e1-c8a2-4b0d-919c-3aa4ad709c00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_21-02-2022_66836.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c811f2e1-c8a2-4b0d-919c-3aa4ad709c00>.
+    
+<http://data.lblod.info/id/remote-data-objects/d86fdae6-be75-4f73-9609-a33386456787> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d86fdae6-be75-4f73-9609-a33386456787";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_21-02-2022_66838.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d86fdae6-be75-4f73-9609-a33386456787>.
+    
+<http://data.lblod.info/id/remote-data-objects/d59f3246-2199-4018-b943-30aca9161a14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d59f3246-2199-4018-b943-30aca9161a14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_21-02-2022_66846.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d59f3246-2199-4018-b943-30aca9161a14>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0a31c1b-13ed-48a5-9378-7cb25044da5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0a31c1b-13ed-48a5-9378-7cb25044da5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_21-02-2022_66849.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0a31c1b-13ed-48a5-9378-7cb25044da5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/675cf412-a118-4b2e-8aa0-da75b6fd652f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "675cf412-a118-4b2e-8aa0-da75b6fd652f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_21-02-2022_66850.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/675cf412-a118-4b2e-8aa0-da75b6fd652f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a98248b4-3ce7-4bd8-9099-e66bd5e85dd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a98248b4-3ce7-4bd8-9099-e66bd5e85dd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_21-03-2022_69450.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a98248b4-3ce7-4bd8-9099-e66bd5e85dd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/49892870-36f0-481a-92f5-35176b6460a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49892870-36f0-481a-92f5-35176b6460a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_21-03-2022_69452.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49892870-36f0-481a-92f5-35176b6460a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a7aa0eb-001a-4961-9f79-2ff2cc928684> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a7aa0eb-001a-4961-9f79-2ff2cc928684";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/5c80471b90e518d0911765f596b29755cb306f598c3da2893b3b3c45bc4406ee/GetPublication?filename=Uittreksels_21-03-2022_69453.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a7aa0eb-001a-4961-9f79-2ff2cc928684>.
+    
+<http://data.lblod.info/id/remote-data-objects/edcff841-29dc-4abd-a0be-74c43d3dd795> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edcff841-29dc-4abd-a0be-74c43d3dd795";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_01-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edcff841-29dc-4abd-a0be-74c43d3dd795>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c562121-68df-4872-82cb-415edfc334aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c562121-68df-4872-82cb-415edfc334aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c562121-68df-4872-82cb-415edfc334aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/7735eab5-376d-4264-8edb-c429f9563889> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7735eab5-376d-4264-8edb-c429f9563889";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_03-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7735eab5-376d-4264-8edb-c429f9563889>.
+    
+<http://data.lblod.info/id/remote-data-objects/542b84c2-77c4-42f6-a1c6-afb4ccc8b25a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "542b84c2-77c4-42f6-a1c6-afb4ccc8b25a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/542b84c2-77c4-42f6-a1c6-afb4ccc8b25a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cf3d95a-09f4-40a8-b2b2-06ecc87d9c1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cf3d95a-09f4-40a8-b2b2-06ecc87d9c1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_05-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cf3d95a-09f4-40a8-b2b2-06ecc87d9c1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/065e5134-4ee1-4ff4-9227-de1afb8a1901> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "065e5134-4ee1-4ff4-9227-de1afb8a1901";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/065e5134-4ee1-4ff4-9227-de1afb8a1901>.
+    
+<http://data.lblod.info/id/remote-data-objects/c86d3de5-07c3-43d2-b36e-7b5a8e372cb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c86d3de5-07c3-43d2-b36e-7b5a8e372cb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c86d3de5-07c3-43d2-b36e-7b5a8e372cb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/57ac7dda-ac5a-4163-a9ee-e57373552489> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57ac7dda-ac5a-4163-a9ee-e57373552489";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_10-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57ac7dda-ac5a-4163-a9ee-e57373552489>.
+    
+<http://data.lblod.info/id/remote-data-objects/e18ab00d-eb3b-4bb9-b89c-de58a06992d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e18ab00d-eb3b-4bb9-b89c-de58a06992d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_11-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e18ab00d-eb3b-4bb9-b89c-de58a06992d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e12903e4-8219-4cd3-ac1e-b9fc095cf3a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e12903e4-8219-4cd3-ac1e-b9fc095cf3a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e12903e4-8219-4cd3-ac1e-b9fc095cf3a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9adf787-78c2-4597-88e3-cf6d403b38eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9adf787-78c2-4597-88e3-cf6d403b38eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9adf787-78c2-4597-88e3-cf6d403b38eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b30b4fd-c860-4f9d-a727-7861c6d66104> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b30b4fd-c860-4f9d-a727-7861c6d66104";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_15-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b30b4fd-c860-4f9d-a727-7861c6d66104>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3e6fa80-51d0-43b4-aa76-a234ef90573a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3e6fa80-51d0-43b4-aa76-a234ef90573a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3e6fa80-51d0-43b4-aa76-a234ef90573a>.
+    
+<http://data.lblod.info/id/remote-data-objects/29f70ed3-99e6-41f7-ac12-9696e8203aae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29f70ed3-99e6-41f7-ac12-9696e8203aae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_17-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29f70ed3-99e6-41f7-ac12-9696e8203aae>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1aa5403-2c53-484b-8e13-4fe0e124477a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1aa5403-2c53-484b-8e13-4fe0e124477a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_17-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1aa5403-2c53-484b-8e13-4fe0e124477a>.
+    
+<http://data.lblod.info/id/remote-data-objects/22ca4674-6e4a-4198-b5ff-4834442256c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22ca4674-6e4a-4198-b5ff-4834442256c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22ca4674-6e4a-4198-b5ff-4834442256c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b0d09eb-3326-476d-afc5-6c747fcf5c24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b0d09eb-3326-476d-afc5-6c747fcf5c24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_18-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b0d09eb-3326-476d-afc5-6c747fcf5c24>.
+    
+<http://data.lblod.info/id/remote-data-objects/98111b1e-c94d-4030-a941-e7efe12cf562> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98111b1e-c94d-4030-a941-e7efe12cf562";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98111b1e-c94d-4030-a941-e7efe12cf562>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e1a911a-b13a-45fa-884a-2776505bb1c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e1a911a-b13a-45fa-884a-2776505bb1c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_22-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e1a911a-b13a-45fa-884a-2776505bb1c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8391ddd8-c063-4ed5-83f5-216b87da0037> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8391ddd8-c063-4ed5-83f5-216b87da0037";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_22-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8391ddd8-c063-4ed5-83f5-216b87da0037>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b12fd4f-8340-4558-9f37-7e805f2f14b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b12fd4f-8340-4558-9f37-7e805f2f14b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b12fd4f-8340-4558-9f37-7e805f2f14b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/68705e33-bddb-4ec3-ae00-c812e39e4a38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68705e33-bddb-4ec3-ae00-c812e39e4a38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68705e33-bddb-4ec3-ae00-c812e39e4a38>.
+    
+<http://data.lblod.info/id/remote-data-objects/a97da2b9-972c-4d3e-a064-91a5b47c278c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a97da2b9-972c-4d3e-a064-91a5b47c278c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a97da2b9-972c-4d3e-a064-91a5b47c278c>.
+    
+<http://data.lblod.info/id/remote-data-objects/03a15302-1dc9-4a0d-9b7a-c1576fac4e8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03a15302-1dc9-4a0d-9b7a-c1576fac4e8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03a15302-1dc9-4a0d-9b7a-c1576fac4e8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3a542b7-0f65-400b-8f70-f2ee4e23147a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3a542b7-0f65-400b-8f70-f2ee4e23147a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.depanne.be/LBLODWeb/Home/Overzicht/a4e4b214bcca0c10be072e7389a454af1d38d5b48588be85e771bfae045aa6f7/GetPublication?filename=BesluitenLijst_Burgemeester_29-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3a542b7-0f65-400b-8f70-f2ee4e23147a>.
+    
+<http://data.lblod.info/id/remote-data-objects/67f36eb1-8a86-4ac1-9852-bfa0f93ba7b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67f36eb1-8a86-4ac1-9852-bfa0f93ba7b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Agenda_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67f36eb1-8a86-4ac1-9852-bfa0f93ba7b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d25e07af-7195-4545-9e0c-2b350142bdc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d25e07af-7195-4545-9e0c-2b350142bdc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Agenda_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d25e07af-7195-4545-9e0c-2b350142bdc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f1b1179-4977-4241-93d6-1b947f2c372d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f1b1179-4977-4241-93d6-1b947f2c372d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=BesluitenLijst_Gemeenteraad_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f1b1179-4977-4241-93d6-1b947f2c372d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e25771bd-5758-4dad-8253-1b5e1ebac260> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e25771bd-5758-4dad-8253-1b5e1ebac260";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=BesluitenLijst_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e25771bd-5758-4dad-8253-1b5e1ebac260>.
+    
+<http://data.lblod.info/id/remote-data-objects/57f3ace3-ae23-4a58-8eb1-6a43d1fbf379> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57f3ace3-ae23-4a58-8eb1-6a43d1fbf379";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57f3ace3-ae23-4a58-8eb1-6a43d1fbf379>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfa33652-2b9c-4e6f-a45f-236531d7215d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfa33652-2b9c-4e6f-a45f-236531d7215d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfa33652-2b9c-4e6f-a45f-236531d7215d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8778a87e-44c1-4298-ae63-d3923ddf2304> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8778a87e-44c1-4298-ae63-d3923ddf2304";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8778a87e-44c1-4298-ae63-d3923ddf2304>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b6a7edc-04ab-4d94-8fdb-6426daa94a60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b6a7edc-04ab-4d94-8fdb-6426daa94a60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b6a7edc-04ab-4d94-8fdb-6426daa94a60>.
+    
+<http://data.lblod.info/id/remote-data-objects/2438e5ad-3ecd-4be3-a026-07c2bdbfdea4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2438e5ad-3ecd-4be3-a026-07c2bdbfdea4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2438e5ad-3ecd-4be3-a026-07c2bdbfdea4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fb0fe84-eb69-457d-9c9b-4efc63980da7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fb0fe84-eb69-457d-9c9b-4efc63980da7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=BesluitenLijst_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fb0fe84-eb69-457d-9c9b-4efc63980da7>.
+    
+<http://data.lblod.info/id/remote-data-objects/74e5f740-e28b-47ad-90af-5b1374a41081> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74e5f740-e28b-47ad-90af-5b1374a41081";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=BesluitenLijst_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74e5f740-e28b-47ad-90af-5b1374a41081>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a0d33a4-81be-450b-9f24-de8f3a145677> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a0d33a4-81be-450b-9f24-de8f3a145677";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_04-07-2022_75345.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a0d33a4-81be-450b-9f24-de8f3a145677>.
+    
+<http://data.lblod.info/id/remote-data-objects/02c524ce-bf54-4b0d-a3b2-e88e1b44ec5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02c524ce-bf54-4b0d-a3b2-e88e1b44ec5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_04-07-2022_75716.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02c524ce-bf54-4b0d-a3b2-e88e1b44ec5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/02c170b6-9bb8-4887-bd82-69086e821c90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02c170b6-9bb8-4887-bd82-69086e821c90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_04-07-2022_76103.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02c170b6-9bb8-4887-bd82-69086e821c90>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba6d59ef-dcfb-476b-b313-abc37a91932c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba6d59ef-dcfb-476b-b313-abc37a91932c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_04-07-2022_76217.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b63bc6d9-cdef-40cf-a0d1-a66ee38e25dd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba6d59ef-dcfb-476b-b313-abc37a91932c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201338-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201338-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201338-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201338-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/8d0e49d9-d85f-4acf-8950-3447af51c2ea> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8d0e49d9-d85f-4acf-8950-3447af51c2ea";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2f29bcc2-ce97-4331-b692-c2780dedc09d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/01a0f55b-58f3-49cb-a983-f7598bad9315> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "01a0f55b-58f3-49cb-a983-f7598bad9315";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d>.
+
+  <http://redpencil.data.gift/id/task/987d00f7-d682-4e42-accf-0deb6f6f0159> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "987d00f7-d682-4e42-accf-0deb6f6f0159";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/8d0e49d9-d85f-4acf-8950-3447af51c2ea>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/01a0f55b-58f3-49cb-a983-f7598bad9315>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/eda2b1a2-bda0-4bfa-b061-0275fd72ebcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eda2b1a2-bda0-4bfa-b061-0275fd72ebcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_23-05-2022_75427.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eda2b1a2-bda0-4bfa-b061-0275fd72ebcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/c09f9264-699d-46ef-8d9e-e1a17c0e546d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c09f9264-699d-46ef-8d9e-e1a17c0e546d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_23-05-2022_75444.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c09f9264-699d-46ef-8d9e-e1a17c0e546d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cfcd9d4-5eb4-4acf-b280-ded8152c90b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cfcd9d4-5eb4-4acf-b280-ded8152c90b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_23-05-2022_75448.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cfcd9d4-5eb4-4acf-b280-ded8152c90b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/49a77768-9004-48f7-92d7-dabb4cfb8786> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49a77768-9004-48f7-92d7-dabb4cfb8786";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_23-05-2022_75478.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49a77768-9004-48f7-92d7-dabb4cfb8786>.
+    
+<http://data.lblod.info/id/remote-data-objects/cef3e7cc-5786-4bb5-9875-e54f01dbbf38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cef3e7cc-5786-4bb5-9875-e54f01dbbf38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_25-04-2022_74889.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cef3e7cc-5786-4bb5-9875-e54f01dbbf38>.
+    
+<http://data.lblod.info/id/remote-data-objects/a69947ec-567c-4c1e-8e04-c90b0283a231> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a69947ec-567c-4c1e-8e04-c90b0283a231";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_25-04-2022_74967.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a69947ec-567c-4c1e-8e04-c90b0283a231>.
+    
+<http://data.lblod.info/id/remote-data-objects/9829ae42-fe64-476d-afac-a76a8eca08dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9829ae42-fe64-476d-afac-a76a8eca08dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_25-10-2021_72234.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9829ae42-fe64-476d-afac-a76a8eca08dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/95d94959-ea78-4934-9f08-8b19ef5844b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95d94959-ea78-4934-9f08-8b19ef5844b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_28-03-2022_74579.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95d94959-ea78-4934-9f08-8b19ef5844b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0244529-ef5b-460d-abdd-386dff38204f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0244529-ef5b-460d-abdd-386dff38204f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_28-03-2022_74758.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0244529-ef5b-460d-abdd-386dff38204f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a610955b-2d6d-4eb8-a88e-a87fa00dc4f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a610955b-2d6d-4eb8-a88e-a87fa00dc4f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_28-03-2022_74759.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a610955b-2d6d-4eb8-a88e-a87fa00dc4f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9e7ffb7-74c9-4a76-9fe4-7dec3b1293f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9e7ffb7-74c9-4a76-9fe4-7dec3b1293f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_29-11-2021_72646.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9e7ffb7-74c9-4a76-9fe4-7dec3b1293f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/57431445-332c-4713-b1a4-b183c6715417> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57431445-332c-4713-b1a4-b183c6715417";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_29-11-2021_72647.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57431445-332c-4713-b1a4-b183c6715417>.
+    
+<http://data.lblod.info/id/remote-data-objects/1654e2e5-285f-4167-80fc-070bd4ecace2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1654e2e5-285f-4167-80fc-070bd4ecace2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/01ac53e76002f96cd17761c3ae6a7ce7f8999b1992c25d55ef95c7162608b605/GetPublication?filename=Uittreksels_29-11-2021_72859.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1654e2e5-285f-4167-80fc-070bd4ecace2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b732521e-e111-41f2-b93e-f658dbbd56dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b732521e-e111-41f2-b93e-f658dbbd56dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/bf1c69d611a5744883769c851bcd70fa4ac44e8278e81a55c7addf6ec12e3638/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b732521e-e111-41f2-b93e-f658dbbd56dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/be6a12fa-1f70-49b4-b9e0-d522d95fd318> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be6a12fa-1f70-49b4-b9e0-d522d95fd318";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/bf1c69d611a5744883769c851bcd70fa4ac44e8278e81a55c7addf6ec12e3638/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be6a12fa-1f70-49b4-b9e0-d522d95fd318>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ada2429-93d6-4119-8260-115d6fd9aca7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ada2429-93d6-4119-8260-115d6fd9aca7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/bf1c69d611a5744883769c851bcd70fa4ac44e8278e81a55c7addf6ec12e3638/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ada2429-93d6-4119-8260-115d6fd9aca7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba5a0eb8-ac83-4160-8785-98e02eec02c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba5a0eb8-ac83-4160-8785-98e02eec02c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/bf1c69d611a5744883769c851bcd70fa4ac44e8278e81a55c7addf6ec12e3638/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba5a0eb8-ac83-4160-8785-98e02eec02c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3b8b437-e2b2-436c-8fec-5f7ab40fa709> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3b8b437-e2b2-436c-8fec-5f7ab40fa709";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/bf1c69d611a5744883769c851bcd70fa4ac44e8278e81a55c7addf6ec12e3638/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3b8b437-e2b2-436c-8fec-5f7ab40fa709>.
+    
+<http://data.lblod.info/id/remote-data-objects/fead458d-ae9c-40cf-9f1d-f1cf76911023> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fead458d-ae9c-40cf-9f1d-f1cf76911023";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/bf1c69d611a5744883769c851bcd70fa4ac44e8278e81a55c7addf6ec12e3638/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fead458d-ae9c-40cf-9f1d-f1cf76911023>.
+    
+<http://data.lblod.info/id/remote-data-objects/917bae76-92ab-4a8a-a776-d7d1b002d6c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "917bae76-92ab-4a8a-a776-d7d1b002d6c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/bf1c69d611a5744883769c851bcd70fa4ac44e8278e81a55c7addf6ec12e3638/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/917bae76-92ab-4a8a-a776-d7d1b002d6c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba99dddd-9a2c-45ca-8215-553b1348d387> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba99dddd-9a2c-45ca-8215-553b1348d387";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/bf1c69d611a5744883769c851bcd70fa4ac44e8278e81a55c7addf6ec12e3638/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba99dddd-9a2c-45ca-8215-553b1348d387>.
+    
+<http://data.lblod.info/id/remote-data-objects/2592d553-7d23-4e02-8586-09142e4769ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2592d553-7d23-4e02-8586-09142e4769ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/bf1c69d611a5744883769c851bcd70fa4ac44e8278e81a55c7addf6ec12e3638/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2592d553-7d23-4e02-8586-09142e4769ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3960c20-9400-4a6c-b4ea-40bf34ccf17d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3960c20-9400-4a6c-b4ea-40bf34ccf17d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/bf1c69d611a5744883769c851bcd70fa4ac44e8278e81a55c7addf6ec12e3638/GetPublication?filename=Uittreksels_04-07-2022_76109.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3960c20-9400-4a6c-b4ea-40bf34ccf17d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b4bc2cd-efd2-4cbd-b5ea-00942228a08f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b4bc2cd-efd2-4cbd-b5ea-00942228a08f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/bf1c69d611a5744883769c851bcd70fa4ac44e8278e81a55c7addf6ec12e3638/GetPublication?filename=Uittreksels_04-07-2022_76218.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b4bc2cd-efd2-4cbd-b5ea-00942228a08f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e39a3e9f-43ee-445a-a8d2-235791f7b9d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e39a3e9f-43ee-445a-a8d2-235791f7b9d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/bf1c69d611a5744883769c851bcd70fa4ac44e8278e81a55c7addf6ec12e3638/GetPublication?filename=Uittreksels_23-05-2022_75462.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e39a3e9f-43ee-445a-a8d2-235791f7b9d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d563784-3302-4b77-ae6c-e8b8374b8b9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d563784-3302-4b77-ae6c-e8b8374b8b9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/bf1c69d611a5744883769c851bcd70fa4ac44e8278e81a55c7addf6ec12e3638/GetPublication?filename=Uittreksels_28-03-2022_74261.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d563784-3302-4b77-ae6c-e8b8374b8b9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8608189-a8d7-41c9-a969-f6992334782b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8608189-a8d7-41c9-a969-f6992334782b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/bf1c69d611a5744883769c851bcd70fa4ac44e8278e81a55c7addf6ec12e3638/GetPublication?filename=Uittreksels_29-11-2021_72714.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8608189-a8d7-41c9-a969-f6992334782b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec23af1e-9b22-4d44-8c69-eeb689e8c6f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec23af1e-9b22-4d44-8c69-eeb689e8c6f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/bf1c69d611a5744883769c851bcd70fa4ac44e8278e81a55c7addf6ec12e3638/GetPublication?filename=Uittreksels_29-11-2021_72715.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec23af1e-9b22-4d44-8c69-eeb689e8c6f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cb19258-e943-4cb9-8d53-6f38afb1f153> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cb19258-e943-4cb9-8d53-6f38afb1f153";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.diksmuide.be/LBLODWeb/Home/Overzicht/bf1c69d611a5744883769c851bcd70fa4ac44e8278e81a55c7addf6ec12e3638/GetPublication?filename=Uittreksels_29-11-2021_72860.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cb19258-e943-4cb9-8d53-6f38afb1f153>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e504987-fa8f-44e4-9b27-9be91a06281f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e504987-fa8f-44e4-9b27-9be91a06281f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e504987-fa8f-44e4-9b27-9be91a06281f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c35b67d7-ba0c-4209-80da-d5d669679fc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c35b67d7-ba0c-4209-80da-d5d669679fc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c35b67d7-ba0c-4209-80da-d5d669679fc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0da792a-1b7b-4a5b-a0f3-6094771302bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0da792a-1b7b-4a5b-a0f3-6094771302bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0da792a-1b7b-4a5b-a0f3-6094771302bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/87584993-abe5-4e76-8c44-c5ed97c7dc98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87584993-abe5-4e76-8c44-c5ed97c7dc98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87584993-abe5-4e76-8c44-c5ed97c7dc98>.
+    
+<http://data.lblod.info/id/remote-data-objects/33120827-f8c2-4fce-962c-ab9d4603fc08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33120827-f8c2-4fce-962c-ab9d4603fc08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33120827-f8c2-4fce-962c-ab9d4603fc08>.
+    
+<http://data.lblod.info/id/remote-data-objects/c027f1e6-7268-4060-bdcb-f40717ec2090> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c027f1e6-7268-4060-bdcb-f40717ec2090";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c027f1e6-7268-4060-bdcb-f40717ec2090>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4761a41-8a8d-418d-83b8-a7b9c4be4093> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4761a41-8a8d-418d-83b8-a7b9c4be4093";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4761a41-8a8d-418d-83b8-a7b9c4be4093>.
+    
+<http://data.lblod.info/id/remote-data-objects/884ecaa7-65bb-4e27-ad7a-4d6a8e20fb46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "884ecaa7-65bb-4e27-ad7a-4d6a8e20fb46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/884ecaa7-65bb-4e27-ad7a-4d6a8e20fb46>.
+    
+<http://data.lblod.info/id/remote-data-objects/da3369bf-4abc-423f-9277-464e0d02fa3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da3369bf-4abc-423f-9277-464e0d02fa3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da3369bf-4abc-423f-9277-464e0d02fa3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e2bb1ce-c022-44b2-957f-f5fb937242b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e2bb1ce-c022-44b2-957f-f5fb937242b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e2bb1ce-c022-44b2-957f-f5fb937242b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1239b935-a90e-477a-870f-35f85ec0e2dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1239b935-a90e-477a-870f-35f85ec0e2dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1239b935-a90e-477a-870f-35f85ec0e2dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa820b0a-b76f-4c6e-8566-500c8ac90ad7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa820b0a-b76f-4c6e-8566-500c8ac90ad7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa820b0a-b76f-4c6e-8566-500c8ac90ad7>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcd9cada-8d75-4036-85c1-28df2b776d78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcd9cada-8d75-4036-85c1-28df2b776d78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcd9cada-8d75-4036-85c1-28df2b776d78>.
+    
+<http://data.lblod.info/id/remote-data-objects/092d9197-fc90-4d36-8e4d-ecd48ce7edb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "092d9197-fc90-4d36-8e4d-ecd48ce7edb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/092d9197-fc90-4d36-8e4d-ecd48ce7edb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/daee43d5-249b-40fc-b542-588c6fbfe8fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "daee43d5-249b-40fc-b542-588c6fbfe8fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/daee43d5-249b-40fc-b542-588c6fbfe8fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5a25fcd-775d-4c07-8557-ebea1afb09d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5a25fcd-775d-4c07-8557-ebea1afb09d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5a25fcd-775d-4c07-8557-ebea1afb09d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e3bd22a-e491-449e-9331-41f3dbe16e5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e3bd22a-e491-449e-9331-41f3dbe16e5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e3bd22a-e491-449e-9331-41f3dbe16e5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/61f63418-3415-48b8-83a4-03ef89732d7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61f63418-3415-48b8-83a4-03ef89732d7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61f63418-3415-48b8-83a4-03ef89732d7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/64ee1bbc-f042-498a-9037-e1ce5fb28a99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64ee1bbc-f042-498a-9037-e1ce5fb28a99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64ee1bbc-f042-498a-9037-e1ce5fb28a99>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa23b390-c704-4833-9f58-454647c1cb40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa23b390-c704-4833-9f58-454647c1cb40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa23b390-c704-4833-9f58-454647c1cb40>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1db73aa-4a59-4425-824b-61accef366e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1db73aa-4a59-4425-824b-61accef366e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f29bcc2-ce97-4331-b692-c2780dedc09d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1db73aa-4a59-4425-824b-61accef366e8>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201339-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201339-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201339-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201339-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/091dd461-507f-4d42-915d-499547f68c8f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "091dd461-507f-4d42-915d-499547f68c8f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "674d45e3-0062-48da-a1bf-ace18ed0cba4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/361986e4-9d56-4b16-934a-5cac95639068> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "361986e4-9d56-4b16-934a-5cac95639068";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4>.
+
+  <http://redpencil.data.gift/id/task/2e9765f8-cdd4-44c5-8206-e4604dce8603> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2e9765f8-cdd4-44c5-8206-e4604dce8603";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/091dd461-507f-4d42-915d-499547f68c8f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/361986e4-9d56-4b16-934a-5cac95639068>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/0a56f238-dc79-4620-8b64-b9bf2926ef20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a56f238-dc79-4620-8b64-b9bf2926ef20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a56f238-dc79-4620-8b64-b9bf2926ef20>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cbd7d71-e993-45d3-aa4d-e6e36a0de221> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cbd7d71-e993-45d3-aa4d-e6e36a0de221";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cbd7d71-e993-45d3-aa4d-e6e36a0de221>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebcb8a42-5d03-4984-9264-61e5ed60a992> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebcb8a42-5d03-4984-9264-61e5ed60a992";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebcb8a42-5d03-4984-9264-61e5ed60a992>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf2404d6-b461-4c45-8ae0-c8f56d5119bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf2404d6-b461-4c45-8ae0-c8f56d5119bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf2404d6-b461-4c45-8ae0-c8f56d5119bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8f70431-a30a-4985-ac31-ff5f190febb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8f70431-a30a-4985-ac31-ff5f190febb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8f70431-a30a-4985-ac31-ff5f190febb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/975bb3a0-881d-4577-83b2-56a35716caf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "975bb3a0-881d-4577-83b2-56a35716caf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/975bb3a0-881d-4577-83b2-56a35716caf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c123929-7f8d-4f14-9dfd-d9b590060d7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c123929-7f8d-4f14-9dfd-d9b590060d7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c123929-7f8d-4f14-9dfd-d9b590060d7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/733389c0-fa3d-4acf-b5f2-88b914e4561e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "733389c0-fa3d-4acf-b5f2-88b914e4561e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/733389c0-fa3d-4acf-b5f2-88b914e4561e>.
+    
+<http://data.lblod.info/id/remote-data-objects/880af0f0-3c49-413e-9154-92f90e8f50f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "880af0f0-3c49-413e-9154-92f90e8f50f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/880af0f0-3c49-413e-9154-92f90e8f50f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/429b30b9-b5d0-49ef-bb06-e12b73b158b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "429b30b9-b5d0-49ef-bb06-e12b73b158b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/429b30b9-b5d0-49ef-bb06-e12b73b158b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/aaf816f6-8f60-431a-9c51-da4e5561ec91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aaf816f6-8f60-431a-9c51-da4e5561ec91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aaf816f6-8f60-431a-9c51-da4e5561ec91>.
+    
+<http://data.lblod.info/id/remote-data-objects/f703c18d-2f7c-4364-b5ca-d55874a82e6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f703c18d-2f7c-4364-b5ca-d55874a82e6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f703c18d-2f7c-4364-b5ca-d55874a82e6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b420d72-3169-4e18-9fff-dc1335785075> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b420d72-3169-4e18-9fff-dc1335785075";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b420d72-3169-4e18-9fff-dc1335785075>.
+    
+<http://data.lblod.info/id/remote-data-objects/152e357a-0c68-4aec-a8e2-a1083294c979> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "152e357a-0c68-4aec-a8e2-a1083294c979";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/152e357a-0c68-4aec-a8e2-a1083294c979>.
+    
+<http://data.lblod.info/id/remote-data-objects/c41aff34-02f8-49f9-96e4-dccda91f4a5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c41aff34-02f8-49f9-96e4-dccda91f4a5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c41aff34-02f8-49f9-96e4-dccda91f4a5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b200322b-bdea-4384-9126-b8bc2eef1566> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b200322b-bdea-4384-9126-b8bc2eef1566";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b200322b-bdea-4384-9126-b8bc2eef1566>.
+    
+<http://data.lblod.info/id/remote-data-objects/d15b0198-5c3a-493d-9ffc-0a4fd6a944a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d15b0198-5c3a-493d-9ffc-0a4fd6a944a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d15b0198-5c3a-493d-9ffc-0a4fd6a944a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/20b12ff8-776e-4bf8-89aa-892022339409> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20b12ff8-776e-4bf8-89aa-892022339409";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20b12ff8-776e-4bf8-89aa-892022339409>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4e6ac1e-ece6-4bfb-90b8-2b67b71dfc30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4e6ac1e-ece6-4bfb-90b8-2b67b71dfc30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4e6ac1e-ece6-4bfb-90b8-2b67b71dfc30>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d51b1d2-3c42-410d-8dd2-4eae0e0a4d49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d51b1d2-3c42-410d-8dd2-4eae0e0a4d49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d51b1d2-3c42-410d-8dd2-4eae0e0a4d49>.
+    
+<http://data.lblod.info/id/remote-data-objects/81bf97ed-26c8-4138-bc43-8a49d7b792c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81bf97ed-26c8-4138-bc43-8a49d7b792c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_01-02-2022_48415.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81bf97ed-26c8-4138-bc43-8a49d7b792c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f07ead0-d988-4ba3-89a1-205c1a4c836d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f07ead0-d988-4ba3-89a1-205c1a4c836d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_01-03-2022_48828.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f07ead0-d988-4ba3-89a1-205c1a4c836d>.
+    
+<http://data.lblod.info/id/remote-data-objects/900086af-9e63-4f2b-baf0-742b9bbcd9a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "900086af-9e63-4f2b-baf0-742b9bbcd9a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_01-03-2022_48835.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/900086af-9e63-4f2b-baf0-742b9bbcd9a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fc67cca-cab6-4081-b296-949e93cfe27b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fc67cca-cab6-4081-b296-949e93cfe27b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_03-05-2022_49782.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fc67cca-cab6-4081-b296-949e93cfe27b>.
+    
+<http://data.lblod.info/id/remote-data-objects/215a53a7-f704-4011-8ad4-d0406690b20e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "215a53a7-f704-4011-8ad4-d0406690b20e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_03-05-2022_49849.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/215a53a7-f704-4011-8ad4-d0406690b20e>.
+    
+<http://data.lblod.info/id/remote-data-objects/00164261-ac53-4d09-94f3-e0280c41f5d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00164261-ac53-4d09-94f3-e0280c41f5d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_05-04-2022_49382.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00164261-ac53-4d09-94f3-e0280c41f5d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d06ec4f-3da1-4c17-b7f3-dbe10cfafa45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d06ec4f-3da1-4c17-b7f3-dbe10cfafa45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_05-04-2022_49396.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d06ec4f-3da1-4c17-b7f3-dbe10cfafa45>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbedec4c-6354-426a-9f84-9810f78fb4b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbedec4c-6354-426a-9f84-9810f78fb4b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_05-04-2022_49421.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbedec4c-6354-426a-9f84-9810f78fb4b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d66b3c4b-3727-46e0-b9d6-cf9bb6643274> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d66b3c4b-3727-46e0-b9d6-cf9bb6643274";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_05-04-2022_49422.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d66b3c4b-3727-46e0-b9d6-cf9bb6643274>.
+    
+<http://data.lblod.info/id/remote-data-objects/04456c8d-1526-4c61-8f6d-acce2237023e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04456c8d-1526-4c61-8f6d-acce2237023e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_05-07-2022_50692.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04456c8d-1526-4c61-8f6d-acce2237023e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d08ef8b-b29e-4271-8e5f-51dad26ac678> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d08ef8b-b29e-4271-8e5f-51dad26ac678";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_05-07-2022_50696.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d08ef8b-b29e-4271-8e5f-51dad26ac678>.
+    
+<http://data.lblod.info/id/remote-data-objects/2070e600-9c02-4b42-91d1-9e25ba06bd82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2070e600-9c02-4b42-91d1-9e25ba06bd82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_05-07-2022_50776.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2070e600-9c02-4b42-91d1-9e25ba06bd82>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cbef64f-03ed-4251-910c-d4d31c679011> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cbef64f-03ed-4251-910c-d4d31c679011";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_05-07-2022_50784.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cbef64f-03ed-4251-910c-d4d31c679011>.
+    
+<http://data.lblod.info/id/remote-data-objects/7eeadfee-8b24-41a6-8bd2-c6f695039605> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7eeadfee-8b24-41a6-8bd2-c6f695039605";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_05-07-2022_50789.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7eeadfee-8b24-41a6-8bd2-c6f695039605>.
+    
+<http://data.lblod.info/id/remote-data-objects/7385bdf8-5fdd-4550-8e8a-74d349895cd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7385bdf8-5fdd-4550-8e8a-74d349895cd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_05-07-2022_50798.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7385bdf8-5fdd-4550-8e8a-74d349895cd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce2c4387-29f1-46f5-9ff9-f15eac74d0d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce2c4387-29f1-46f5-9ff9-f15eac74d0d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_05-07-2022_50801.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce2c4387-29f1-46f5-9ff9-f15eac74d0d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d651213d-c44c-461d-953c-04771be1999d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d651213d-c44c-461d-953c-04771be1999d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_07-12-2021_47533.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d651213d-c44c-461d-953c-04771be1999d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fea616e-8a4f-4c43-9059-4be3eacdaaa2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fea616e-8a4f-4c43-9059-4be3eacdaaa2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_07-12-2021_47534.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fea616e-8a4f-4c43-9059-4be3eacdaaa2>.
+    
+<http://data.lblod.info/id/remote-data-objects/beda5c66-bdd3-4c50-8366-b7090cb2dd63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "beda5c66-bdd3-4c50-8366-b7090cb2dd63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_07-12-2021_47535.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/beda5c66-bdd3-4c50-8366-b7090cb2dd63>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ea939bb-4be2-414b-824a-4ceb4521b20b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ea939bb-4be2-414b-824a-4ceb4521b20b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_07-12-2021_47537.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ea939bb-4be2-414b-824a-4ceb4521b20b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f095c257-2b39-42a6-80e3-3c49f0d4a136> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f095c257-2b39-42a6-80e3-3c49f0d4a136";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_07-12-2021_47575.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f095c257-2b39-42a6-80e3-3c49f0d4a136>.
+    
+<http://data.lblod.info/id/remote-data-objects/a19cab31-6739-469e-9edf-1598fb097451> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a19cab31-6739-469e-9edf-1598fb097451";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_08-02-2022_48478.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a19cab31-6739-469e-9edf-1598fb097451>.
+    
+<http://data.lblod.info/id/remote-data-objects/871637be-a5d6-435a-a2e1-c21181b6160b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "871637be-a5d6-435a-a2e1-c21181b6160b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_08-02-2022_48497.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/871637be-a5d6-435a-a2e1-c21181b6160b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1b1302b-c151-4b9e-ad4e-839124ba18e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1b1302b-c151-4b9e-ad4e-839124ba18e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_08-02-2022_48536.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1b1302b-c151-4b9e-ad4e-839124ba18e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d4552bd-0c99-4190-a494-3fb99790e668> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d4552bd-0c99-4190-a494-3fb99790e668";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_08-03-2022_49028.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d4552bd-0c99-4190-a494-3fb99790e668>.
+    
+<http://data.lblod.info/id/remote-data-objects/46add7a1-f25d-42ab-aa50-6e57e1feb9b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46add7a1-f25d-42ab-aa50-6e57e1feb9b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_10-05-2022_49902.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46add7a1-f25d-42ab-aa50-6e57e1feb9b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3430a0a2-4bb0-43f0-ab14-b246a41f18d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3430a0a2-4bb0-43f0-ab14-b246a41f18d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_10-05-2022_49988.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3430a0a2-4bb0-43f0-ab14-b246a41f18d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8185b994-4af8-4ca1-8dcc-98e600cd96ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8185b994-4af8-4ca1-8dcc-98e600cd96ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_11-01-2022_48112.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8185b994-4af8-4ca1-8dcc-98e600cd96ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/88a95849-57e6-4b3a-a333-df4b84132ded> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88a95849-57e6-4b3a-a333-df4b84132ded";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_11-01-2022_48113.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88a95849-57e6-4b3a-a333-df4b84132ded>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef5008e3-77a7-4863-820a-054c21bb9c48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef5008e3-77a7-4863-820a-054c21bb9c48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_12-10-2021_46664.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/674d45e3-0062-48da-a1bf-ace18ed0cba4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef5008e3-77a7-4863-820a-054c21bb9c48>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201340-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201340-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201340-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201340-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/0fb71f27-0ec5-4d0f-8af2-497ec341094e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0fb71f27-0ec5-4d0f-8af2-497ec341094e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "687fdb78-2847-40fb-875b-031f41059648";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/169d765d-5a09-46e7-9615-84cd8f79393d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "169d765d-5a09-46e7-9615-84cd8f79393d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648>.
+
+  <http://redpencil.data.gift/id/task/51bbbcd5-2177-48e3-948f-851301e53861> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "51bbbcd5-2177-48e3-948f-851301e53861";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/0fb71f27-0ec5-4d0f-8af2-497ec341094e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/169d765d-5a09-46e7-9615-84cd8f79393d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/20acffa8-d6d1-4bb2-85d1-9bdcc11f88cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20acffa8-d6d1-4bb2-85d1-9bdcc11f88cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_14-06-2022_50393.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20acffa8-d6d1-4bb2-85d1-9bdcc11f88cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/df247d46-726b-4328-98ca-2b0f3ea590e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df247d46-726b-4328-98ca-2b0f3ea590e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_14-06-2022_50404.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df247d46-726b-4328-98ca-2b0f3ea590e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0d0899a-475c-4602-ba59-ad3e48154ba1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0d0899a-475c-4602-ba59-ad3e48154ba1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_14-06-2022_50407.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0d0899a-475c-4602-ba59-ad3e48154ba1>.
+    
+<http://data.lblod.info/id/remote-data-objects/92064f5f-8078-4a6e-a991-d6ac80503b2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92064f5f-8078-4a6e-a991-d6ac80503b2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_14-06-2022_50434.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92064f5f-8078-4a6e-a991-d6ac80503b2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/03ab3baf-6c57-4a44-b083-275f18945ee9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03ab3baf-6c57-4a44-b083-275f18945ee9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_14-06-2022_50435.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03ab3baf-6c57-4a44-b083-275f18945ee9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4ada426-f575-40f3-84b0-7e5c10c1d3fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4ada426-f575-40f3-84b0-7e5c10c1d3fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_14-06-2022_50442.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4ada426-f575-40f3-84b0-7e5c10c1d3fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e98d5c4-d23a-4952-982b-03137fb1b7a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e98d5c4-d23a-4952-982b-03137fb1b7a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_14-06-2022_50457.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e98d5c4-d23a-4952-982b-03137fb1b7a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7271b79a-737f-4756-8a52-304fa8981cae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7271b79a-737f-4756-8a52-304fa8981cae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_14-06-2022_50461.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7271b79a-737f-4756-8a52-304fa8981cae>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba9efb74-b0c3-42b9-a5b5-bf10fd53b311> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba9efb74-b0c3-42b9-a5b5-bf10fd53b311";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_15-02-2022_48265.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba9efb74-b0c3-42b9-a5b5-bf10fd53b311>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e97beef-8e4f-4f31-af45-15245cd5cc80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e97beef-8e4f-4f31-af45-15245cd5cc80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_15-02-2022_48617.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e97beef-8e4f-4f31-af45-15245cd5cc80>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c10f5bd-dc55-46d4-bcbd-eb3399ce1c9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c10f5bd-dc55-46d4-bcbd-eb3399ce1c9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_15-02-2022_48692.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c10f5bd-dc55-46d4-bcbd-eb3399ce1c9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6057bce1-ed1e-4540-a738-ce47a981c3e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6057bce1-ed1e-4540-a738-ce47a981c3e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_15-02-2022_48701.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6057bce1-ed1e-4540-a738-ce47a981c3e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e54a1e8-55ce-48b6-8fe9-febd81a57e9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e54a1e8-55ce-48b6-8fe9-febd81a57e9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_15-03-2022_48810.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e54a1e8-55ce-48b6-8fe9-febd81a57e9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a383c557-a2cb-44ed-b9d4-6c9b1e8fa9d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a383c557-a2cb-44ed-b9d4-6c9b1e8fa9d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_17-05-2022_50021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a383c557-a2cb-44ed-b9d4-6c9b1e8fa9d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c602a1d1-5da8-4498-a776-6e6441f95cb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c602a1d1-5da8-4498-a776-6e6441f95cb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_19-04-2022_49639.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c602a1d1-5da8-4498-a776-6e6441f95cb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a91e82cc-ae2a-48d8-beb1-ebfff96ea398> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a91e82cc-ae2a-48d8-beb1-ebfff96ea398";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_19-04-2022_49675.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a91e82cc-ae2a-48d8-beb1-ebfff96ea398>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdfd0661-0e06-4df3-8944-8580381e53bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdfd0661-0e06-4df3-8944-8580381e53bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_19-07-2022_50919.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdfd0661-0e06-4df3-8944-8580381e53bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/b71b0956-5b6a-48b4-8a49-62aaabe4e38f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b71b0956-5b6a-48b4-8a49-62aaabe4e38f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_19-07-2022_50959.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b71b0956-5b6a-48b4-8a49-62aaabe4e38f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fad1e390-2530-4903-b25b-0e6b7034de7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fad1e390-2530-4903-b25b-0e6b7034de7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_19-07-2022_50964.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fad1e390-2530-4903-b25b-0e6b7034de7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/873e42fe-5015-4477-991d-a74ee5c52fbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "873e42fe-5015-4477-991d-a74ee5c52fbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_19-07-2022_50966.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/873e42fe-5015-4477-991d-a74ee5c52fbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/d63bed36-b438-472c-9d1a-b82e0a9e3ef9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d63bed36-b438-472c-9d1a-b82e0a9e3ef9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_19-07-2022_50975.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d63bed36-b438-472c-9d1a-b82e0a9e3ef9>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ad8a8fe-3654-4b3c-9f10-2e675ee8b7cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ad8a8fe-3654-4b3c-9f10-2e675ee8b7cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_19-07-2022_50983.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ad8a8fe-3654-4b3c-9f10-2e675ee8b7cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ac38c72-9bd3-44d6-8e75-c07eb3e871d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ac38c72-9bd3-44d6-8e75-c07eb3e871d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_21-12-2021_47759.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ac38c72-9bd3-44d6-8e75-c07eb3e871d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a6e7412-4ef0-419e-9f88-bfa44055bf6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a6e7412-4ef0-419e-9f88-bfa44055bf6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_21-12-2021_47760.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a6e7412-4ef0-419e-9f88-bfa44055bf6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/54581340-f72d-44b6-b913-860fc42ccfb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54581340-f72d-44b6-b913-860fc42ccfb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_22-02-2022_48766.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54581340-f72d-44b6-b913-860fc42ccfb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/10790f84-9725-4022-8ddb-b7fad5c23067> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10790f84-9725-4022-8ddb-b7fad5c23067";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_22-03-2022_49229.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10790f84-9725-4022-8ddb-b7fad5c23067>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb45b098-bf94-48a4-9ec6-a3ac31c6b78c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb45b098-bf94-48a4-9ec6-a3ac31c6b78c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_24-05-2022_50085.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb45b098-bf94-48a4-9ec6-a3ac31c6b78c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f4a3488-0188-4247-90d0-af9943b2f429> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f4a3488-0188-4247-90d0-af9943b2f429";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_24-05-2022_50086.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f4a3488-0188-4247-90d0-af9943b2f429>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecf0b0f0-a3cd-4917-bda8-a7d59ed57358> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecf0b0f0-a3cd-4917-bda8-a7d59ed57358";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_24-05-2022_50160.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecf0b0f0-a3cd-4917-bda8-a7d59ed57358>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f41b81f-890b-4f2c-b41d-faf989766482> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f41b81f-890b-4f2c-b41d-faf989766482";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_26-04-2022_49696.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f41b81f-890b-4f2c-b41d-faf989766482>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7b29b9c-f086-47ab-8615-64aa9daa3e27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7b29b9c-f086-47ab-8615-64aa9daa3e27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_28-06-2022_50621.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7b29b9c-f086-47ab-8615-64aa9daa3e27>.
+    
+<http://data.lblod.info/id/remote-data-objects/00ff0cbe-6bdc-4913-97a5-dfb0500f648b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00ff0cbe-6bdc-4913-97a5-dfb0500f648b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_28-06-2022_50623.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00ff0cbe-6bdc-4913-97a5-dfb0500f648b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c442e0b-e34f-40c2-b971-094258d1bde2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c442e0b-e34f-40c2-b971-094258d1bde2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_31-05-2022_50187.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c442e0b-e34f-40c2-b971-094258d1bde2>.
+    
+<http://data.lblod.info/id/remote-data-objects/75095c08-3c94-4faf-8f85-bf4f5d39175e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75095c08-3c94-4faf-8f85-bf4f5d39175e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_31-05-2022_50207.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75095c08-3c94-4faf-8f85-bf4f5d39175e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a14bc19f-263c-4143-b9cf-cde4a57a471e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a14bc19f-263c-4143-b9cf-cde4a57a471e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_31-05-2022_50239.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a14bc19f-263c-4143-b9cf-cde4a57a471e>.
+    
+<http://data.lblod.info/id/remote-data-objects/451902d0-2d5f-42a2-867b-11bf7a18500d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "451902d0-2d5f-42a2-867b-11bf7a18500d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/514ed3fe675ab1c1d96bbea34678987b47f137240e8589af5ad01932118f4dc0/GetPublication?filename=Uittreksels_31-05-2022_50249.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/451902d0-2d5f-42a2-867b-11bf7a18500d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c482a79-751a-465c-bb9e-ea1c8ef1cd59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c482a79-751a-465c-bb9e-ea1c8ef1cd59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c482a79-751a-465c-bb9e-ea1c8ef1cd59>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b5b153c-96be-4e35-af81-ec710851756d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b5b153c-96be-4e35-af81-ec710851756d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b5b153c-96be-4e35-af81-ec710851756d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b11c0877-df45-41d6-a5a5-72e776bca117> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b11c0877-df45-41d6-a5a5-72e776bca117";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b11c0877-df45-41d6-a5a5-72e776bca117>.
+    
+<http://data.lblod.info/id/remote-data-objects/f122ae09-b652-4ac6-b15c-7ba3059349d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f122ae09-b652-4ac6-b15c-7ba3059349d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f122ae09-b652-4ac6-b15c-7ba3059349d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/38810f4b-999b-482c-9c2b-c9cfd7389408> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38810f4b-999b-482c-9c2b-c9cfd7389408";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38810f4b-999b-482c-9c2b-c9cfd7389408>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b238a94-270a-48ab-98b4-74a07d1cc280> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b238a94-270a-48ab-98b4-74a07d1cc280";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b238a94-270a-48ab-98b4-74a07d1cc280>.
+    
+<http://data.lblod.info/id/remote-data-objects/373ff752-7916-4cfb-b83f-1bb3ad7d2c99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "373ff752-7916-4cfb-b83f-1bb3ad7d2c99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/373ff752-7916-4cfb-b83f-1bb3ad7d2c99>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ebd68c1-cdde-482d-acfc-a93818c142bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ebd68c1-cdde-482d-acfc-a93818c142bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ebd68c1-cdde-482d-acfc-a93818c142bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf047148-1ed6-48d8-9175-4559de5d922b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf047148-1ed6-48d8-9175-4559de5d922b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf047148-1ed6-48d8-9175-4559de5d922b>.
+    
+<http://data.lblod.info/id/remote-data-objects/56807fef-920b-45f3-b540-2e88ffbb43cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56807fef-920b-45f3-b540-2e88ffbb43cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56807fef-920b-45f3-b540-2e88ffbb43cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/f13d2c5a-7205-4262-86a2-e20ba600a84d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f13d2c5a-7205-4262-86a2-e20ba600a84d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f13d2c5a-7205-4262-86a2-e20ba600a84d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4e71f02-7e8b-4742-8e47-43d96cf1a4b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4e71f02-7e8b-4742-8e47-43d96cf1a4b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4e71f02-7e8b-4742-8e47-43d96cf1a4b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad6ce364-757f-463a-a4da-8a1ff9d8043e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad6ce364-757f-463a-a4da-8a1ff9d8043e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad6ce364-757f-463a-a4da-8a1ff9d8043e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5082d587-a3ea-43a1-86e5-c7f6334922c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5082d587-a3ea-43a1-86e5-c7f6334922c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/687fdb78-2847-40fb-875b-031f41059648> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5082d587-a3ea-43a1-86e5-c7f6334922c2>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201342-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201342-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201342-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201342-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/1b3f159c-e7e1-44a2-8856-0e1fff2e09c2> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1b3f159c-e7e1-44a2-8856-0e1fff2e09c2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cb61c731-320b-40d0-9e11-fd4ad114dced";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c2354590-2ae1-4ef0-b0ce-fa59b4414b35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c2354590-2ae1-4ef0-b0ce-fa59b4414b35";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced>.
+
+  <http://redpencil.data.gift/id/task/31a8e384-e19e-4339-87f7-9f435d52c514> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "31a8e384-e19e-4339-87f7-9f435d52c514";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/1b3f159c-e7e1-44a2-8856-0e1fff2e09c2>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c2354590-2ae1-4ef0-b0ce-fa59b4414b35>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/3c103b1e-71c3-4060-b046-334e681fada8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c103b1e-71c3-4060-b046-334e681fada8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c103b1e-71c3-4060-b046-334e681fada8>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa243678-aefb-4439-ae99-44b2c4688292> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa243678-aefb-4439-ae99-44b2c4688292";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa243678-aefb-4439-ae99-44b2c4688292>.
+    
+<http://data.lblod.info/id/remote-data-objects/50baedf3-b541-46b8-b355-070a40527695> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50baedf3-b541-46b8-b355-070a40527695";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50baedf3-b541-46b8-b355-070a40527695>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b2f3e46-f916-4eac-9db3-5d9df8755948> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b2f3e46-f916-4eac-9db3-5d9df8755948";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b2f3e46-f916-4eac-9db3-5d9df8755948>.
+    
+<http://data.lblod.info/id/remote-data-objects/f166e668-f125-4d2d-85aa-f94b2d380437> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f166e668-f125-4d2d-85aa-f94b2d380437";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f166e668-f125-4d2d-85aa-f94b2d380437>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f7ec420-7702-4e6e-ad69-2b7573481b43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f7ec420-7702-4e6e-ad69-2b7573481b43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_28-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f7ec420-7702-4e6e-ad69-2b7573481b43>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6677503-8777-4ac2-bd91-725a8f59554b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6677503-8777-4ac2-bd91-725a8f59554b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6677503-8777-4ac2-bd91-725a8f59554b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd8a9d15-b3f6-4db0-9723-07e9b7a8ce1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd8a9d15-b3f6-4db0-9723-07e9b7a8ce1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd8a9d15-b3f6-4db0-9723-07e9b7a8ce1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5301418c-003e-47d5-9960-923046978ff6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5301418c-003e-47d5-9960-923046978ff6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=BesluitenLijst_Burgemeester_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5301418c-003e-47d5-9960-923046978ff6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c076e0a-6246-4e41-a824-2a69f6ed8fc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c076e0a-6246-4e41-a824-2a69f6ed8fc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=Uittreksels_04-01-2022_48065.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c076e0a-6246-4e41-a824-2a69f6ed8fc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/14ed7949-0c0a-437e-9670-df5d45fe2067> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14ed7949-0c0a-437e-9670-df5d45fe2067";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=Uittreksels_17-01-2022_48245.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14ed7949-0c0a-437e-9670-df5d45fe2067>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b5a56f1-cf75-4f2d-959a-17198028391d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b5a56f1-cf75-4f2d-959a-17198028391d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/72f280fc84edc3fb814939d5235574b163c47fd9bc846ea714922d81aac54993/GetPublication?filename=Uittreksels_20-01-2022_48309.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b5a56f1-cf75-4f2d-959a-17198028391d>.
+    
+<http://data.lblod.info/id/remote-data-objects/47ea26e5-26b7-4848-8d26-d2ed9a8b5543> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47ea26e5-26b7-4848-8d26-d2ed9a8b5543";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47ea26e5-26b7-4848-8d26-d2ed9a8b5543>.
+    
+<http://data.lblod.info/id/remote-data-objects/59a7083c-a016-4fbf-8063-896799cd963a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59a7083c-a016-4fbf-8063-896799cd963a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59a7083c-a016-4fbf-8063-896799cd963a>.
+    
+<http://data.lblod.info/id/remote-data-objects/66803412-594e-400d-824e-eec6c81d028e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66803412-594e-400d-824e-eec6c81d028e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66803412-594e-400d-824e-eec6c81d028e>.
+    
+<http://data.lblod.info/id/remote-data-objects/160f7832-7af4-4790-9f9e-2ad130f82b8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "160f7832-7af4-4790-9f9e-2ad130f82b8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/160f7832-7af4-4790-9f9e-2ad130f82b8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee480bd9-8c62-412f-8df1-178da2c4334b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee480bd9-8c62-412f-8df1-178da2c4334b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee480bd9-8c62-412f-8df1-178da2c4334b>.
+    
+<http://data.lblod.info/id/remote-data-objects/22e286c1-987a-4d54-9073-b6c79acc3363> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22e286c1-987a-4d54-9073-b6c79acc3363";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22e286c1-987a-4d54-9073-b6c79acc3363>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc7afc5d-0802-4272-b5d5-b2a17043cb25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc7afc5d-0802-4272-b5d5-b2a17043cb25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc7afc5d-0802-4272-b5d5-b2a17043cb25>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6fc046f-9bf1-4e35-9a9b-765007314c4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6fc046f-9bf1-4e35-9a9b-765007314c4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6fc046f-9bf1-4e35-9a9b-765007314c4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c8136c7-f89c-4966-bdb2-e6b85322ba49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c8136c7-f89c-4966-bdb2-e6b85322ba49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c8136c7-f89c-4966-bdb2-e6b85322ba49>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bb2212e-d986-4d16-8c22-55431c1f266d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bb2212e-d986-4d16-8c22-55431c1f266d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bb2212e-d986-4d16-8c22-55431c1f266d>.
+    
+<http://data.lblod.info/id/remote-data-objects/24892837-77b1-4610-8cbc-bd1e9eb7059f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24892837-77b1-4610-8cbc-bd1e9eb7059f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24892837-77b1-4610-8cbc-bd1e9eb7059f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5d3b605-b4fb-4bd5-8940-529204924acb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5d3b605-b4fb-4bd5-8940-529204924acb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5d3b605-b4fb-4bd5-8940-529204924acb>.
+    
+<http://data.lblod.info/id/remote-data-objects/2094323c-3dc7-45d7-b842-115b147ace7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2094323c-3dc7-45d7-b842-115b147ace7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2094323c-3dc7-45d7-b842-115b147ace7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d423f06-64f3-4342-8db8-b57f3f15d0cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d423f06-64f3-4342-8db8-b57f3f15d0cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d423f06-64f3-4342-8db8-b57f3f15d0cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb776329-332a-49ba-87dd-99b0ccdfb78d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb776329-332a-49ba-87dd-99b0ccdfb78d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb776329-332a-49ba-87dd-99b0ccdfb78d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e200fdb4-2c41-4867-82a6-eb81649f6536> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e200fdb4-2c41-4867-82a6-eb81649f6536";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e200fdb4-2c41-4867-82a6-eb81649f6536>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dadac6b-a11b-4c5e-a8cf-922e2f62859c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dadac6b-a11b-4c5e-a8cf-922e2f62859c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dadac6b-a11b-4c5e-a8cf-922e2f62859c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4340427f-3bd0-4009-a024-8aa9fbbe8e78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4340427f-3bd0-4009-a024-8aa9fbbe8e78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4340427f-3bd0-4009-a024-8aa9fbbe8e78>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d5dc488-9e9f-470e-8f3c-267ad8decd11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d5dc488-9e9f-470e-8f3c-267ad8decd11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d5dc488-9e9f-470e-8f3c-267ad8decd11>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ce33bbc-2bed-4b77-bbf1-84e20f4d2543> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ce33bbc-2bed-4b77-bbf1-84e20f4d2543";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ce33bbc-2bed-4b77-bbf1-84e20f4d2543>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0ae5565-b405-47c7-8a8a-730e5dee3ccb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0ae5565-b405-47c7-8a8a-730e5dee3ccb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0ae5565-b405-47c7-8a8a-730e5dee3ccb>.
+    
+<http://data.lblod.info/id/remote-data-objects/e447e529-a696-4879-84d4-a60a26209ddf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e447e529-a696-4879-84d4-a60a26209ddf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e447e529-a696-4879-84d4-a60a26209ddf>.
+    
+<http://data.lblod.info/id/remote-data-objects/028d600d-6e76-40b8-a45d-73e2e376905a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "028d600d-6e76-40b8-a45d-73e2e376905a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/028d600d-6e76-40b8-a45d-73e2e376905a>.
+    
+<http://data.lblod.info/id/remote-data-objects/aaf05969-ae9d-47b8-9385-115d5eb8afe1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aaf05969-ae9d-47b8-9385-115d5eb8afe1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aaf05969-ae9d-47b8-9385-115d5eb8afe1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fef2899-ea97-4b1c-a1c2-b2e5e578877f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fef2899-ea97-4b1c-a1c2-b2e5e578877f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fef2899-ea97-4b1c-a1c2-b2e5e578877f>.
+    
+<http://data.lblod.info/id/remote-data-objects/10e73b14-351c-446e-81e1-d876669641e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10e73b14-351c-446e-81e1-d876669641e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10e73b14-351c-446e-81e1-d876669641e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a051cf79-881d-4dc1-8a0d-849267c42715> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a051cf79-881d-4dc1-8a0d-849267c42715";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a051cf79-881d-4dc1-8a0d-849267c42715>.
+    
+<http://data.lblod.info/id/remote-data-objects/d672dae3-2337-4867-8a9d-f40c6bf36723> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d672dae3-2337-4867-8a9d-f40c6bf36723";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d672dae3-2337-4867-8a9d-f40c6bf36723>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a4a4f43-9fe6-401c-afc9-23bf73053911> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a4a4f43-9fe6-401c-afc9-23bf73053911";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a4a4f43-9fe6-401c-afc9-23bf73053911>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2d8dbb2-9e7c-46a7-a4b0-f35964458535> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2d8dbb2-9e7c-46a7-a4b0-f35964458535";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2d8dbb2-9e7c-46a7-a4b0-f35964458535>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb469663-e70d-47fd-ab88-fc3dca1c4d86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb469663-e70d-47fd-ab88-fc3dca1c4d86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb469663-e70d-47fd-ab88-fc3dca1c4d86>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0bef844-3454-4240-b83c-de64fa008016> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0bef844-3454-4240-b83c-de64fa008016";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0bef844-3454-4240-b83c-de64fa008016>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d2c0f55-7d24-47cc-a50b-d86598d8e410> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d2c0f55-7d24-47cc-a50b-d86598d8e410";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d2c0f55-7d24-47cc-a50b-d86598d8e410>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8d70ee9-0190-4a26-bf01-99f37461044f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8d70ee9-0190-4a26-bf01-99f37461044f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8d70ee9-0190-4a26-bf01-99f37461044f>.
+    
+<http://data.lblod.info/id/remote-data-objects/efe868c3-785b-4655-8e46-74de495d1539> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efe868c3-785b-4655-8e46-74de495d1539";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efe868c3-785b-4655-8e46-74de495d1539>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a45f022-1729-4c95-8957-88e32262268f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a45f022-1729-4c95-8957-88e32262268f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a45f022-1729-4c95-8957-88e32262268f>.
+    
+<http://data.lblod.info/id/remote-data-objects/04d36fff-d99c-48a0-b097-a96679608044> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04d36fff-d99c-48a0-b097-a96679608044";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04d36fff-d99c-48a0-b097-a96679608044>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1f33870-1046-4adc-8f17-2622d4d5a9fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1f33870-1046-4adc-8f17-2622d4d5a9fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb61c731-320b-40d0-9e11-fd4ad114dced> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1f33870-1046-4adc-8f17-2622d4d5a9fd>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201343-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201343-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201343-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201343-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/961be557-0b29-4520-b242-02636dfa1c10> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "961be557-0b29-4520-b242-02636dfa1c10";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "87a495d6-9922-4699-b8c1-998222317ca4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c297cb4c-7b33-48eb-833c-1c719f2c22a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c297cb4c-7b33-48eb-833c-1c719f2c22a6";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4>.
+
+  <http://redpencil.data.gift/id/task/db4c38e6-1444-4a31-a47e-8bf65ed467c0> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "db4c38e6-1444-4a31-a47e-8bf65ed467c0";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/961be557-0b29-4520-b242-02636dfa1c10>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c297cb4c-7b33-48eb-833c-1c719f2c22a6>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/86740e2f-a42d-4d5b-a4c1-ef1e05303a1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86740e2f-a42d-4d5b-a4c1-ef1e05303a1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86740e2f-a42d-4d5b-a4c1-ef1e05303a1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d72ca1cd-3738-4c79-885d-7853d58b29e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d72ca1cd-3738-4c79-885d-7853d58b29e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d72ca1cd-3738-4c79-885d-7853d58b29e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a381b3e5-b1ce-40be-b10a-c57d0573e7db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a381b3e5-b1ce-40be-b10a-c57d0573e7db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/82f481bf1d34dfc7b2521fa03f72296533045a067324e1313c1336a838ebd2f1/GetPublication?filename=BesluitenLijst_Vast%20bureau_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a381b3e5-b1ce-40be-b10a-c57d0573e7db>.
+    
+<http://data.lblod.info/id/remote-data-objects/1804c198-ee8d-48a5-931e-9f61c41ad0c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1804c198-ee8d-48a5-931e-9f61c41ad0c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Agenda_OCMW%20raad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1804c198-ee8d-48a5-931e-9f61c41ad0c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a8997a1-eb29-4b04-97a5-1534a779685e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a8997a1-eb29-4b04-97a5-1534a779685e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Agenda_OCMW%20raad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a8997a1-eb29-4b04-97a5-1534a779685e>.
+    
+<http://data.lblod.info/id/remote-data-objects/957dd3b4-fab7-427c-9c24-357ef06da77c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "957dd3b4-fab7-427c-9c24-357ef06da77c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Agenda_OCMW%20raad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/957dd3b4-fab7-427c-9c24-357ef06da77c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a49e4b73-7059-4a6f-bfe1-71b7b6c70622> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a49e4b73-7059-4a6f-bfe1-71b7b6c70622";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Agenda_OCMW%20raad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a49e4b73-7059-4a6f-bfe1-71b7b6c70622>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c4da4df-1b6b-4212-b55a-3183dbc33891> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c4da4df-1b6b-4212-b55a-3183dbc33891";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Agenda_OCMW%20raad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c4da4df-1b6b-4212-b55a-3183dbc33891>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c96eba4-9bf4-48dd-b155-ba8d932d9bcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c96eba4-9bf4-48dd-b155-ba8d932d9bcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Agenda_OCMW%20raad_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c96eba4-9bf4-48dd-b155-ba8d932d9bcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d457af3-fddd-4d37-907e-0bbd15706ba1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d457af3-fddd-4d37-907e-0bbd15706ba1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Agenda_OCMW%20raad_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d457af3-fddd-4d37-907e-0bbd15706ba1>.
+    
+<http://data.lblod.info/id/remote-data-objects/29fabc52-97be-4d97-a301-891831f14b86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29fabc52-97be-4d97-a301-891831f14b86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Agenda_OCMW%20raad_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29fabc52-97be-4d97-a301-891831f14b86>.
+    
+<http://data.lblod.info/id/remote-data-objects/050c5cd5-9408-49b1-b65b-6d01871b0c06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "050c5cd5-9408-49b1-b65b-6d01871b0c06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Agenda_OCMW%20raad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/050c5cd5-9408-49b1-b65b-6d01871b0c06>.
+    
+<http://data.lblod.info/id/remote-data-objects/f71a67b8-1fc7-4f4e-8f50-d93c5bb45f89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f71a67b8-1fc7-4f4e-8f50-d93c5bb45f89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=BesluitenLijst_OCMW%20raad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f71a67b8-1fc7-4f4e-8f50-d93c5bb45f89>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9b48b0c-da58-4f58-9775-a2934a371ff4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9b48b0c-da58-4f58-9775-a2934a371ff4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=BesluitenLijst_OCMW%20raad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9b48b0c-da58-4f58-9775-a2934a371ff4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4023dff9-f8f4-493b-96af-fc14ae5ff6d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4023dff9-f8f4-493b-96af-fc14ae5ff6d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=BesluitenLijst_OCMW%20raad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4023dff9-f8f4-493b-96af-fc14ae5ff6d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2c04a35-91bf-4fb2-be24-ca4ef585ce47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2c04a35-91bf-4fb2-be24-ca4ef585ce47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=BesluitenLijst_OCMW%20raad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2c04a35-91bf-4fb2-be24-ca4ef585ce47>.
+    
+<http://data.lblod.info/id/remote-data-objects/01b891f9-1373-4cd0-b933-e22f6fc62c32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01b891f9-1373-4cd0-b933-e22f6fc62c32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=BesluitenLijst_OCMW%20raad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01b891f9-1373-4cd0-b933-e22f6fc62c32>.
+    
+<http://data.lblod.info/id/remote-data-objects/70eecf85-b05a-4b2c-ab2c-cb7cec5b7d45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70eecf85-b05a-4b2c-ab2c-cb7cec5b7d45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=BesluitenLijst_OCMW%20raad_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70eecf85-b05a-4b2c-ab2c-cb7cec5b7d45>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b1b9709-80df-4d18-91cd-ad62250139c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b1b9709-80df-4d18-91cd-ad62250139c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=BesluitenLijst_OCMW%20raad_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b1b9709-80df-4d18-91cd-ad62250139c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/89afca0f-5ac3-4267-ab4f-e9d76f20ae3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89afca0f-5ac3-4267-ab4f-e9d76f20ae3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=BesluitenLijst_OCMW%20raad_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89afca0f-5ac3-4267-ab4f-e9d76f20ae3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/918a248f-b315-4b7a-adef-3f1373d2b81f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "918a248f-b315-4b7a-adef-3f1373d2b81f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=BesluitenLijst_OCMW%20raad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/918a248f-b315-4b7a-adef-3f1373d2b81f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c288dcc-186b-48a1-9783-aa8e8b91641d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c288dcc-186b-48a1-9783-aa8e8b91641d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Notulen_OCMW%20raad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c288dcc-186b-48a1-9783-aa8e8b91641d>.
+    
+<http://data.lblod.info/id/remote-data-objects/842784a6-c522-41a0-86e7-3d26675a5ce1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "842784a6-c522-41a0-86e7-3d26675a5ce1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Notulen_OCMW%20raad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/842784a6-c522-41a0-86e7-3d26675a5ce1>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe10a101-fb92-4c09-b15f-a575299dc757> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe10a101-fb92-4c09-b15f-a575299dc757";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Notulen_OCMW%20raad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe10a101-fb92-4c09-b15f-a575299dc757>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e776048-75fe-49e8-a6d7-f6c31444d094> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e776048-75fe-49e8-a6d7-f6c31444d094";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Notulen_OCMW%20raad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e776048-75fe-49e8-a6d7-f6c31444d094>.
+    
+<http://data.lblod.info/id/remote-data-objects/aff7ee8e-afad-4ead-8ac3-a410cc0a6270> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aff7ee8e-afad-4ead-8ac3-a410cc0a6270";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Notulen_OCMW%20raad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aff7ee8e-afad-4ead-8ac3-a410cc0a6270>.
+    
+<http://data.lblod.info/id/remote-data-objects/a02836cb-4c12-490a-b755-dd3b9fb4fee4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a02836cb-4c12-490a-b755-dd3b9fb4fee4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Notulen_OCMW%20raad_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a02836cb-4c12-490a-b755-dd3b9fb4fee4>.
+    
+<http://data.lblod.info/id/remote-data-objects/091804fe-16e3-412d-8618-1d81e40e9e4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "091804fe-16e3-412d-8618-1d81e40e9e4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Notulen_OCMW%20raad_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/091804fe-16e3-412d-8618-1d81e40e9e4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fa6aefb-ddeb-4cf5-b3c5-c5674cef873b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fa6aefb-ddeb-4cf5-b3c5-c5674cef873b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Notulen_OCMW%20raad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fa6aefb-ddeb-4cf5-b3c5-c5674cef873b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e1d629b-2287-49ea-b04b-0717dce338cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e1d629b-2287-49ea-b04b-0717dce338cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Uittreksels_21-12-2021_47410.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e1d629b-2287-49ea-b04b-0717dce338cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/3aaac185-20af-4e3d-b320-126d90022a8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3aaac185-20af-4e3d-b320-126d90022a8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Uittreksels_22-02-2022_48384.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3aaac185-20af-4e3d-b320-126d90022a8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/15820fcf-6020-4373-8506-4005053d0788> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15820fcf-6020-4373-8506-4005053d0788";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Uittreksels_29-03-2022_48761.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15820fcf-6020-4373-8506-4005053d0788>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6e87403-8f1c-4da8-968a-a694232e537c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6e87403-8f1c-4da8-968a-a694232e537c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Uittreksels_29-03-2022_48842.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6e87403-8f1c-4da8-968a-a694232e537c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d76d91d7-81a3-4184-a9d2-e1cef325615f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d76d91d7-81a3-4184-a9d2-e1cef325615f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/96b9b4aaca5d3d29cde6a1c2a8e2860348f1a3124afc281c7c079cc98e8a5050/GetPublication?filename=Uittreksels_31-05-2022_50081.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d76d91d7-81a3-4184-a9d2-e1cef325615f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7d8dfeb-d9fe-48fa-8dfb-f813fa96c150> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7d8dfeb-d9fe-48fa-8dfb-f813fa96c150";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Agenda_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7d8dfeb-d9fe-48fa-8dfb-f813fa96c150>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0a5ef30-9d3b-4773-ae5c-c59dc3913c43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0a5ef30-9d3b-4773-ae5c-c59dc3913c43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Agenda_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0a5ef30-9d3b-4773-ae5c-c59dc3913c43>.
+    
+<http://data.lblod.info/id/remote-data-objects/908109b8-739f-4484-aa53-6daa8dc686cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "908109b8-739f-4484-aa53-6daa8dc686cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Agenda_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/908109b8-739f-4484-aa53-6daa8dc686cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/be94abe5-89ab-4d6c-8fb2-63e931263f98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be94abe5-89ab-4d6c-8fb2-63e931263f98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Agenda_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be94abe5-89ab-4d6c-8fb2-63e931263f98>.
+    
+<http://data.lblod.info/id/remote-data-objects/748fe934-c7a2-4de7-9e95-b343a6eca61c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "748fe934-c7a2-4de7-9e95-b343a6eca61c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Agenda_Gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/748fe934-c7a2-4de7-9e95-b343a6eca61c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0986228d-752e-42b5-96ad-8b77f2aa90ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0986228d-752e-42b5-96ad-8b77f2aa90ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Agenda_Gemeenteraad_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0986228d-752e-42b5-96ad-8b77f2aa90ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/99438299-6855-4233-83da-39aae79251b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99438299-6855-4233-83da-39aae79251b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Agenda_Gemeenteraad_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99438299-6855-4233-83da-39aae79251b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/09012f12-4b2d-4221-9a14-79ebc8d476e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09012f12-4b2d-4221-9a14-79ebc8d476e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Agenda_Gemeenteraad_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09012f12-4b2d-4221-9a14-79ebc8d476e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/0514217c-bd6f-4be2-9614-ad6640126a85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0514217c-bd6f-4be2-9614-ad6640126a85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Agenda_Gemeenteraad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0514217c-bd6f-4be2-9614-ad6640126a85>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f5204f0-f4c1-4047-ad03-6e1320bfc395> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f5204f0-f4c1-4047-ad03-6e1320bfc395";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f5204f0-f4c1-4047-ad03-6e1320bfc395>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8bfad5c-a48b-4e20-a579-5fbcda7d6893> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8bfad5c-a48b-4e20-a579-5fbcda7d6893";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=BesluitenLijst_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8bfad5c-a48b-4e20-a579-5fbcda7d6893>.
+    
+<http://data.lblod.info/id/remote-data-objects/38329bfb-fe69-4350-b0f9-d98238d2c8e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38329bfb-fe69-4350-b0f9-d98238d2c8e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38329bfb-fe69-4350-b0f9-d98238d2c8e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/268aa8ac-d589-4b89-8350-4e15fb628263> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "268aa8ac-d589-4b89-8350-4e15fb628263";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=BesluitenLijst_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/268aa8ac-d589-4b89-8350-4e15fb628263>.
+    
+<http://data.lblod.info/id/remote-data-objects/823b66a9-45f7-45fc-9583-04b0008a7d66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "823b66a9-45f7-45fc-9583-04b0008a7d66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=BesluitenLijst_Gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/823b66a9-45f7-45fc-9583-04b0008a7d66>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b295134-2a45-4a9e-986b-ce1d3f78d1f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b295134-2a45-4a9e-986b-ce1d3f78d1f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b295134-2a45-4a9e-986b-ce1d3f78d1f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a5f5174-312e-4392-80e1-1cdb828e91b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a5f5174-312e-4392-80e1-1cdb828e91b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=BesluitenLijst_Gemeenteraad_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/87a495d6-9922-4699-b8c1-998222317ca4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a5f5174-312e-4392-80e1-1cdb828e91b6>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201344-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201344-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201344-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201344-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/492e1f47-c239-47ff-88c4-d0f75b2b3d3d> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "492e1f47-c239-47ff-88c4-d0f75b2b3d3d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "54ec5f5f-e270-49e1-8416-41cd16e81f3c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/0416a9c1-4d58-419a-8189-c2efce307189> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0416a9c1-4d58-419a-8189-c2efce307189";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c>.
+
+  <http://redpencil.data.gift/id/task/548bd352-437e-4520-a53c-4161a199ad43> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "548bd352-437e-4520-a53c-4161a199ad43";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/492e1f47-c239-47ff-88c4-d0f75b2b3d3d>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/0416a9c1-4d58-419a-8189-c2efce307189>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/012d5cab-00c5-4d3d-abbd-ad2decb14862> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "012d5cab-00c5-4d3d-abbd-ad2decb14862";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=BesluitenLijst_Gemeenteraad_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/012d5cab-00c5-4d3d-abbd-ad2decb14862>.
+    
+<http://data.lblod.info/id/remote-data-objects/37f8fbb3-be88-460e-bd79-e66daf3a4787> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37f8fbb3-be88-460e-bd79-e66daf3a4787";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=BesluitenLijst_Gemeenteraad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37f8fbb3-be88-460e-bd79-e66daf3a4787>.
+    
+<http://data.lblod.info/id/remote-data-objects/eef0445c-8d92-4938-b987-c979013e8a9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eef0445c-8d92-4938-b987-c979013e8a9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Notulen_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eef0445c-8d92-4938-b987-c979013e8a9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6aa1d3a8-8060-4529-979b-05f9ee58097c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6aa1d3a8-8060-4529-979b-05f9ee58097c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Notulen_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6aa1d3a8-8060-4529-979b-05f9ee58097c>.
+    
+<http://data.lblod.info/id/remote-data-objects/db20032a-8bd5-4d1a-861f-c0868bbc7265> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db20032a-8bd5-4d1a-861f-c0868bbc7265";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Notulen_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db20032a-8bd5-4d1a-861f-c0868bbc7265>.
+    
+<http://data.lblod.info/id/remote-data-objects/1741c9db-c9a9-48a4-8f38-da454f5395e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1741c9db-c9a9-48a4-8f38-da454f5395e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Notulen_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1741c9db-c9a9-48a4-8f38-da454f5395e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe00b33c-e9bb-4bb1-a954-0caeedba7205> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe00b33c-e9bb-4bb1-a954-0caeedba7205";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Notulen_Gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe00b33c-e9bb-4bb1-a954-0caeedba7205>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b83ed31-b31b-44c4-84d2-fd7fd43c16df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b83ed31-b31b-44c4-84d2-fd7fd43c16df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Notulen_Gemeenteraad_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b83ed31-b31b-44c4-84d2-fd7fd43c16df>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7a0643a-854c-4e8e-8f06-d47af54d5da7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7a0643a-854c-4e8e-8f06-d47af54d5da7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Notulen_Gemeenteraad_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7a0643a-854c-4e8e-8f06-d47af54d5da7>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc2ba91f-b278-4e5e-b3a5-07a708f52cb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc2ba91f-b278-4e5e-b3a5-07a708f52cb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Notulen_Gemeenteraad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc2ba91f-b278-4e5e-b3a5-07a708f52cb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d371ff7-453c-4581-ad04-4843a34abb49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d371ff7-453c-4581-ad04-4843a34abb49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_45643.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d371ff7-453c-4581-ad04-4843a34abb49>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2f01fd1-b452-460a-9f70-c78468a71ef2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2f01fd1-b452-460a-9f70-c78468a71ef2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_45644.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2f01fd1-b452-460a-9f70-c78468a71ef2>.
+    
+<http://data.lblod.info/id/remote-data-objects/973d3bbf-c5fb-4810-b19a-0d3d33afcde9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "973d3bbf-c5fb-4810-b19a-0d3d33afcde9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_45645.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/973d3bbf-c5fb-4810-b19a-0d3d33afcde9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d51770d4-1579-4a50-afab-7e7fbdd38806> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d51770d4-1579-4a50-afab-7e7fbdd38806";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_45646.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d51770d4-1579-4a50-afab-7e7fbdd38806>.
+    
+<http://data.lblod.info/id/remote-data-objects/99d04073-f375-4693-8b1a-b0aa54a1e7c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99d04073-f375-4693-8b1a-b0aa54a1e7c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_45647.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99d04073-f375-4693-8b1a-b0aa54a1e7c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0f86543-016c-4fba-a6d3-abd976a37b31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0f86543-016c-4fba-a6d3-abd976a37b31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_45652.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0f86543-016c-4fba-a6d3-abd976a37b31>.
+    
+<http://data.lblod.info/id/remote-data-objects/520454d8-dd6a-4e01-a0de-8bd547ce0b29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "520454d8-dd6a-4e01-a0de-8bd547ce0b29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_45655.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/520454d8-dd6a-4e01-a0de-8bd547ce0b29>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5074b50-a124-4077-be61-15e254a2e757> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5074b50-a124-4077-be61-15e254a2e757";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_46559.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5074b50-a124-4077-be61-15e254a2e757>.
+    
+<http://data.lblod.info/id/remote-data-objects/81bb66b4-94ef-4241-a1ef-15e03daf9a22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81bb66b4-94ef-4241-a1ef-15e03daf9a22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_47092.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81bb66b4-94ef-4241-a1ef-15e03daf9a22>.
+    
+<http://data.lblod.info/id/remote-data-objects/5685ff4c-ee69-4007-aadd-6b93a2ff0423> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5685ff4c-ee69-4007-aadd-6b93a2ff0423";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_47243.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5685ff4c-ee69-4007-aadd-6b93a2ff0423>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8e5e950-916e-4f1e-8a5f-9149bc52b8d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8e5e950-916e-4f1e-8a5f-9149bc52b8d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_47351.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8e5e950-916e-4f1e-8a5f-9149bc52b8d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a42934fc-1d3f-413b-aa95-b30acd6b61f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a42934fc-1d3f-413b-aa95-b30acd6b61f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_47353.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a42934fc-1d3f-413b-aa95-b30acd6b61f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4c698b7-4f8b-4dda-bd96-9ba852b977da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4c698b7-4f8b-4dda-bd96-9ba852b977da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_47358.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4c698b7-4f8b-4dda-bd96-9ba852b977da>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d784a1c-1fa6-48d0-9d9b-64ff931c938f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d784a1c-1fa6-48d0-9d9b-64ff931c938f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_47404.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d784a1c-1fa6-48d0-9d9b-64ff931c938f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1674e6ad-aa85-4537-ba6d-b5199e638fb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1674e6ad-aa85-4537-ba6d-b5199e638fb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_47406.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1674e6ad-aa85-4537-ba6d-b5199e638fb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/50df1ee6-e687-4efb-9adf-89174743cbd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50df1ee6-e687-4efb-9adf-89174743cbd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_47584.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50df1ee6-e687-4efb-9adf-89174743cbd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1eff8ed-c860-4fad-b9ea-39fc806ca6a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1eff8ed-c860-4fad-b9ea-39fc806ca6a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_21-12-2021_47623.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1eff8ed-c860-4fad-b9ea-39fc806ca6a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f97ca05-fc82-44d0-bc31-d35aa487d249> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f97ca05-fc82-44d0-bc31-d35aa487d249";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_22-02-2022_48157.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f97ca05-fc82-44d0-bc31-d35aa487d249>.
+    
+<http://data.lblod.info/id/remote-data-objects/22288bd5-5356-42ba-96dc-34a90912142d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22288bd5-5356-42ba-96dc-34a90912142d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_25-01-2022_48227.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22288bd5-5356-42ba-96dc-34a90912142d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a28b2f8e-e280-4d0f-9d6d-56b6353c898b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a28b2f8e-e280-4d0f-9d6d-56b6353c898b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_26-10-2021_46132.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a28b2f8e-e280-4d0f-9d6d-56b6353c898b>.
+    
+<http://data.lblod.info/id/remote-data-objects/30ff033f-df4e-47fe-aa61-c204540746fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30ff033f-df4e-47fe-aa61-c204540746fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_26-10-2021_46474.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30ff033f-df4e-47fe-aa61-c204540746fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc464069-7a45-411f-8e03-f520bdfea773> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc464069-7a45-411f-8e03-f520bdfea773";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_26-10-2021_46690.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc464069-7a45-411f-8e03-f520bdfea773>.
+    
+<http://data.lblod.info/id/remote-data-objects/55b0ab9b-69df-44cc-b7ef-a0b9adeaf167> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55b0ab9b-69df-44cc-b7ef-a0b9adeaf167";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_28-06-2022_49889.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55b0ab9b-69df-44cc-b7ef-a0b9adeaf167>.
+    
+<http://data.lblod.info/id/remote-data-objects/53656db2-0dd5-49b9-83d1-d6ced625afec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53656db2-0dd5-49b9-83d1-d6ced625afec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_28-06-2022_50519.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53656db2-0dd5-49b9-83d1-d6ced625afec>.
+    
+<http://data.lblod.info/id/remote-data-objects/be07c276-5cab-4830-832d-2772f2f96d0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be07c276-5cab-4830-832d-2772f2f96d0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_29-03-2022_48841.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be07c276-5cab-4830-832d-2772f2f96d0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/bedadc79-2303-45dc-baec-f17d6ca51caa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bedadc79-2303-45dc-baec-f17d6ca51caa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_29-03-2022_49092.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bedadc79-2303-45dc-baec-f17d6ca51caa>.
+    
+<http://data.lblod.info/id/remote-data-objects/27211de9-7a3f-4a9b-b46f-f46806a63d23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27211de9-7a3f-4a9b-b46f-f46806a63d23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_30-11-2021_45979.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27211de9-7a3f-4a9b-b46f-f46806a63d23>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cac054e-5c7f-455d-9fc4-183d6b97c296> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cac054e-5c7f-455d-9fc4-183d6b97c296";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_30-11-2021_46843.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cac054e-5c7f-455d-9fc4-183d6b97c296>.
+    
+<http://data.lblod.info/id/remote-data-objects/932c67e7-ffd9-4dc4-95a7-25405ed0e0c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "932c67e7-ffd9-4dc4-95a7-25405ed0e0c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_30-11-2021_47096.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/932c67e7-ffd9-4dc4-95a7-25405ed0e0c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c261ecd5-0b3d-4a9b-8681-57298b5b5d58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c261ecd5-0b3d-4a9b-8681-57298b5b5d58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_30-11-2021_47188.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c261ecd5-0b3d-4a9b-8681-57298b5b5d58>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1e63d9e-5219-4c84-b1e8-e902b3e54b91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1e63d9e-5219-4c84-b1e8-e902b3e54b91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_30-11-2021_47193.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1e63d9e-5219-4c84-b1e8-e902b3e54b91>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ef203a8-0aca-4023-a421-ffd5ca00d28d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ef203a8-0aca-4023-a421-ffd5ca00d28d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_30-11-2021_47223.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ef203a8-0aca-4023-a421-ffd5ca00d28d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f67a2882-8973-4922-981b-a513092a962e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f67a2882-8973-4922-981b-a513092a962e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_30-11-2021_47224.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f67a2882-8973-4922-981b-a513092a962e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b49a4013-242f-4ea6-a8f9-06ec800cac08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b49a4013-242f-4ea6-a8f9-06ec800cac08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_31-05-2022_48464.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b49a4013-242f-4ea6-a8f9-06ec800cac08>.
+    
+<http://data.lblod.info/id/remote-data-objects/7980d9ab-f2a1-4a0d-bd22-567f3a603605> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7980d9ab-f2a1-4a0d-bd22-567f3a603605";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_31-05-2022_49803.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7980d9ab-f2a1-4a0d-bd22-567f3a603605>.
+    
+<http://data.lblod.info/id/remote-data-objects/1109c77a-55de-4cac-bced-0e59ca59f76d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1109c77a-55de-4cac-bced-0e59ca59f76d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_31-05-2022_49829.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1109c77a-55de-4cac-bced-0e59ca59f76d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6ee1872-389d-433e-ab1d-a7dc9de04f13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6ee1872-389d-433e-ab1d-a7dc9de04f13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_31-05-2022_49851.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6ee1872-389d-433e-ab1d-a7dc9de04f13>.
+    
+<http://data.lblod.info/id/remote-data-objects/5af4e4a4-b7f0-4e2a-9412-85c14f7e400b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5af4e4a4-b7f0-4e2a-9412-85c14f7e400b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_31-05-2022_49897.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5af4e4a4-b7f0-4e2a-9412-85c14f7e400b>.
+    
+<http://data.lblod.info/id/remote-data-objects/712e18d4-7d4d-43ca-905f-6cd39a27fc00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "712e18d4-7d4d-43ca-905f-6cd39a27fc00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_31-05-2022_50073.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/712e18d4-7d4d-43ca-905f-6cd39a27fc00>.
+    
+<http://data.lblod.info/id/remote-data-objects/96e2bfc7-1db1-433a-9e78-28cb08da18e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96e2bfc7-1db1-433a-9e78-28cb08da18e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_31-05-2022_50079.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/54ec5f5f-e270-49e1-8416-41cd16e81f3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96e2bfc7-1db1-433a-9e78-28cb08da18e9>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201345-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201345-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201345-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201345-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/942d3173-702b-4f88-857a-a5f8fa1f3894> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "942d3173-702b-4f88-857a-a5f8fa1f3894";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "07438276-c685-4502-afdd-0e068a1dccf7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/80d17dfe-4775-45c0-82cb-63f38084444c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "80d17dfe-4775-45c0-82cb-63f38084444c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7>.
+
+  <http://redpencil.data.gift/id/task/c6d09087-721e-451e-b41e-c16784c3f528> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c6d09087-721e-451e-b41e-c16784c3f528";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/942d3173-702b-4f88-857a-a5f8fa1f3894>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/80d17dfe-4775-45c0-82cb-63f38084444c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c1ca14a1-fd72-404d-9729-32334c0398b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1ca14a1-fd72-404d-9729-32334c0398b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.erpe-mere.be/LBLODWeb/Home/Overzicht/f49f676e03473239863aaf4e20c0ee2be86b824f7969dd64cabbe129978f5517/GetPublication?filename=Uittreksels_31-05-2022_50080.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1ca14a1-fd72-404d-9729-32334c0398b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5b706d5-e891-44f8-bd6f-cbdeb3e25c8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5b706d5-e891-44f8-bd6f-cbdeb3e25c8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5b706d5-e891-44f8-bd6f-cbdeb3e25c8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0586bd6-43b8-45e2-b2f7-752cbc1593c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0586bd6-43b8-45e2-b2f7-752cbc1593c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0586bd6-43b8-45e2-b2f7-752cbc1593c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/32b8a40c-bbc3-4d2a-9489-bffa4373020e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32b8a40c-bbc3-4d2a-9489-bffa4373020e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32b8a40c-bbc3-4d2a-9489-bffa4373020e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6abd5884-f965-48b7-af25-8a19946be758> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6abd5884-f965-48b7-af25-8a19946be758";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6abd5884-f965-48b7-af25-8a19946be758>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b1b1762-4d4d-4d7d-964f-20c056dcb8b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b1b1762-4d4d-4d7d-964f-20c056dcb8b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b1b1762-4d4d-4d7d-964f-20c056dcb8b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dd64796-863b-452d-891a-fd95a2d7cc33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dd64796-863b-452d-891a-fd95a2d7cc33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dd64796-863b-452d-891a-fd95a2d7cc33>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c8183b3-d321-4b51-aac6-0bdb0b7d090d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c8183b3-d321-4b51-aac6-0bdb0b7d090d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c8183b3-d321-4b51-aac6-0bdb0b7d090d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e9dcaed-d5e8-409b-a4ae-bee5507e641f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e9dcaed-d5e8-409b-a4ae-bee5507e641f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e9dcaed-d5e8-409b-a4ae-bee5507e641f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f097f1e-27a9-4d79-b35d-4eec77b7ce01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f097f1e-27a9-4d79-b35d-4eec77b7ce01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f097f1e-27a9-4d79-b35d-4eec77b7ce01>.
+    
+<http://data.lblod.info/id/remote-data-objects/77274d87-41da-4402-998f-a68c5fe83d6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77274d87-41da-4402-998f-a68c5fe83d6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77274d87-41da-4402-998f-a68c5fe83d6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/62a5d051-97a0-47e1-bcd8-df92f44f6e4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62a5d051-97a0-47e1-bcd8-df92f44f6e4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62a5d051-97a0-47e1-bcd8-df92f44f6e4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/071a230f-a546-4247-baa4-d2ac00709a74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "071a230f-a546-4247-baa4-d2ac00709a74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/071a230f-a546-4247-baa4-d2ac00709a74>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ab8314a-efcf-4324-999f-5c448e446d69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ab8314a-efcf-4324-999f-5c448e446d69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ab8314a-efcf-4324-999f-5c448e446d69>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b2f3492-5821-413a-9036-c093540d11dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b2f3492-5821-413a-9036-c093540d11dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b2f3492-5821-413a-9036-c093540d11dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/161102a2-0e44-4d86-a3a2-b845ee0706e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "161102a2-0e44-4d86-a3a2-b845ee0706e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/161102a2-0e44-4d86-a3a2-b845ee0706e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bf994bd-7731-4576-bb25-929c1d86a0ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bf994bd-7731-4576-bb25-929c1d86a0ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bf994bd-7731-4576-bb25-929c1d86a0ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/84511a00-19cf-4248-883f-404c87ebcf48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84511a00-19cf-4248-883f-404c87ebcf48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84511a00-19cf-4248-883f-404c87ebcf48>.
+    
+<http://data.lblod.info/id/remote-data-objects/551c1aab-0089-4b37-bd59-da8f0cee07fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "551c1aab-0089-4b37-bd59-da8f0cee07fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=Uittreksels_16-12-2021_99199.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/551c1aab-0089-4b37-bd59-da8f0cee07fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3b3f0b8-0f57-46c8-8454-6bd6af611d0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3b3f0b8-0f57-46c8-8454-6bd6af611d0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=Uittreksels_23-06-2022_103830.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3b3f0b8-0f57-46c8-8454-6bd6af611d0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/75e41690-3373-404b-91b4-7eae220be0c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75e41690-3373-404b-91b4-7eae220be0c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=Uittreksels_23-06-2022_103895.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75e41690-3373-404b-91b4-7eae220be0c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/548aa834-58f0-4322-8d3c-710c34689a79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "548aa834-58f0-4322-8d3c-710c34689a79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=Uittreksels_24-02-2022_100733.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/548aa834-58f0-4322-8d3c-710c34689a79>.
+    
+<http://data.lblod.info/id/remote-data-objects/15a43317-c54b-4b04-94fe-ac56dbb2aa94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15a43317-c54b-4b04-94fe-ac56dbb2aa94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=Uittreksels_24-02-2022_101070.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15a43317-c54b-4b04-94fe-ac56dbb2aa94>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f7dc7e7-168a-46fa-8a1d-fd8c82095f72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f7dc7e7-168a-46fa-8a1d-fd8c82095f72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=Uittreksels_25-11-2021_98740.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f7dc7e7-168a-46fa-8a1d-fd8c82095f72>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d9b2769-e840-4753-8b81-dfb18d9b33a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d9b2769-e840-4753-8b81-dfb18d9b33a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/ce4a8cf0f69a4414c18570be81ee5c58087f9d3a1c60cef64b889d62fb0efdb9/GetPublication?filename=Uittreksels_27-01-2022_100378.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d9b2769-e840-4753-8b81-dfb18d9b33a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3902530-0fb9-4004-ba5e-952531421b5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3902530-0fb9-4004-ba5e-952531421b5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Agenda_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3902530-0fb9-4004-ba5e-952531421b5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f46b151-1f61-4618-bd7a-6dbe6c6739e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f46b151-1f61-4618-bd7a-6dbe6c6739e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Agenda_Gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f46b151-1f61-4618-bd7a-6dbe6c6739e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fc0abc0-d4b2-4fcb-a9f6-cfbd9de145bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fc0abc0-d4b2-4fcb-a9f6-cfbd9de145bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Agenda_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fc0abc0-d4b2-4fcb-a9f6-cfbd9de145bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d449138-772d-436d-8e79-43b0025e4f52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d449138-772d-436d-8e79-43b0025e4f52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Agenda_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d449138-772d-436d-8e79-43b0025e4f52>.
+    
+<http://data.lblod.info/id/remote-data-objects/1486fc15-f626-409e-879f-ec8b471d9b7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1486fc15-f626-409e-879f-ec8b471d9b7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Agenda_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1486fc15-f626-409e-879f-ec8b471d9b7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/036423bc-5320-40cb-9742-99b526556c7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "036423bc-5320-40cb-9742-99b526556c7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Agenda_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/036423bc-5320-40cb-9742-99b526556c7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4322409d-751a-476e-bdf9-5278a71f3fed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4322409d-751a-476e-bdf9-5278a71f3fed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Agenda_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4322409d-751a-476e-bdf9-5278a71f3fed>.
+    
+<http://data.lblod.info/id/remote-data-objects/94138ebe-7e29-4083-86fd-33bb23872ecb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94138ebe-7e29-4083-86fd-33bb23872ecb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Agenda_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94138ebe-7e29-4083-86fd-33bb23872ecb>.
+    
+<http://data.lblod.info/id/remote-data-objects/23d56947-0eaa-4fe1-9790-593f7896c79c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23d56947-0eaa-4fe1-9790-593f7896c79c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=BesluitenLijst_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23d56947-0eaa-4fe1-9790-593f7896c79c>.
+    
+<http://data.lblod.info/id/remote-data-objects/27b03fcc-b6ec-47c2-8c33-54ff7e28333d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27b03fcc-b6ec-47c2-8c33-54ff7e28333d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=BesluitenLijst_Gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27b03fcc-b6ec-47c2-8c33-54ff7e28333d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad2f444c-4df4-4d9b-a017-9d61df6673fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad2f444c-4df4-4d9b-a017-9d61df6673fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad2f444c-4df4-4d9b-a017-9d61df6673fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/984bec78-731c-4f07-aaa0-14ee67a3700f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "984bec78-731c-4f07-aaa0-14ee67a3700f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/984bec78-731c-4f07-aaa0-14ee67a3700f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c50b4e73-74bd-4bbe-b828-8becd37e267c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c50b4e73-74bd-4bbe-b828-8becd37e267c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c50b4e73-74bd-4bbe-b828-8becd37e267c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a0c59c8-f332-47da-a9ba-c23c689ac379> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a0c59c8-f332-47da-a9ba-c23c689ac379";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a0c59c8-f332-47da-a9ba-c23c689ac379>.
+    
+<http://data.lblod.info/id/remote-data-objects/e858c6c7-ada6-4918-89af-102541d12dde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e858c6c7-ada6-4918-89af-102541d12dde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e858c6c7-ada6-4918-89af-102541d12dde>.
+    
+<http://data.lblod.info/id/remote-data-objects/50214776-3886-467f-84c1-175758c27c95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50214776-3886-467f-84c1-175758c27c95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50214776-3886-467f-84c1-175758c27c95>.
+    
+<http://data.lblod.info/id/remote-data-objects/75802213-6aa0-48c7-997f-4381c348f119> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75802213-6aa0-48c7-997f-4381c348f119";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75802213-6aa0-48c7-997f-4381c348f119>.
+    
+<http://data.lblod.info/id/remote-data-objects/096bf25c-4057-4f80-9de6-51a188053bf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "096bf25c-4057-4f80-9de6-51a188053bf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Notulen_Gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/096bf25c-4057-4f80-9de6-51a188053bf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a789401-e2c8-467d-979c-6edbc132b437> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a789401-e2c8-467d-979c-6edbc132b437";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Notulen_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a789401-e2c8-467d-979c-6edbc132b437>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c6f715f-b8ab-4d07-9cfa-0e061144f391> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c6f715f-b8ab-4d07-9cfa-0e061144f391";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Notulen_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c6f715f-b8ab-4d07-9cfa-0e061144f391>.
+    
+<http://data.lblod.info/id/remote-data-objects/71839213-4afc-45ac-89fd-8a48b005e616> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71839213-4afc-45ac-89fd-8a48b005e616";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Notulen_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71839213-4afc-45ac-89fd-8a48b005e616>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fe8a56d-7b21-49fb-9447-6b66dd6806e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fe8a56d-7b21-49fb-9447-6b66dd6806e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Notulen_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fe8a56d-7b21-49fb-9447-6b66dd6806e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d345e91-f500-4b38-ac11-8ef536fdf42e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d345e91-f500-4b38-ac11-8ef536fdf42e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_16-12-2021_99198.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d345e91-f500-4b38-ac11-8ef536fdf42e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e6b85e3-dfdc-4734-af3d-0af10a9f86c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e6b85e3-dfdc-4734-af3d-0af10a9f86c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_16-12-2021_99201.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e6b85e3-dfdc-4734-af3d-0af10a9f86c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c8c2d4d-03f6-4a34-9e85-52b21b4c0aaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c8c2d4d-03f6-4a34-9e85-52b21b4c0aaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_16-12-2021_99202.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/07438276-c685-4502-afdd-0e068a1dccf7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c8c2d4d-03f6-4a34-9e85-52b21b4c0aaa>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201346-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201346-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201346-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201346-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3a6f9887-fe2f-4a6d-b786-6239a3649ef4> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3a6f9887-fe2f-4a6d-b786-6239a3649ef4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "de5ccf9a-d7e7-4d2e-b631-7b160f9e5789";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d393cc96-0de2-478c-9202-19bd9e7d4d19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d393cc96-0de2-478c-9202-19bd9e7d4d19";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789>.
+
+  <http://redpencil.data.gift/id/task/09b95f70-c4f8-4ebd-8550-5bf8d333e9f4> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "09b95f70-c4f8-4ebd-8550-5bf8d333e9f4";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3a6f9887-fe2f-4a6d-b786-6239a3649ef4>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d393cc96-0de2-478c-9202-19bd9e7d4d19>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/54899c57-a348-4dfa-ac4c-891eeac38229> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54899c57-a348-4dfa-ac4c-891eeac38229";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_23-06-2022_103897.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54899c57-a348-4dfa-ac4c-891eeac38229>.
+    
+<http://data.lblod.info/id/remote-data-objects/336816d2-4ef5-4cec-8497-2f0426f1f43d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "336816d2-4ef5-4cec-8497-2f0426f1f43d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_23-06-2022_103899.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/336816d2-4ef5-4cec-8497-2f0426f1f43d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3598a3d8-00d4-4585-b947-32cf4f07f02a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3598a3d8-00d4-4585-b947-32cf4f07f02a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_23-06-2022_103900.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3598a3d8-00d4-4585-b947-32cf4f07f02a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7006dfc3-7a75-4347-b6bb-309751be65a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7006dfc3-7a75-4347-b6bb-309751be65a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_23-06-2022_104009.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7006dfc3-7a75-4347-b6bb-309751be65a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/950ccae4-a2a9-455e-865e-43af8dff0031> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "950ccae4-a2a9-455e-865e-43af8dff0031";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_23-06-2022_104328.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/950ccae4-a2a9-455e-865e-43af8dff0031>.
+    
+<http://data.lblod.info/id/remote-data-objects/d97836d2-8943-4f63-b198-4b85c191aa54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d97836d2-8943-4f63-b198-4b85c191aa54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_23-06-2022_104796.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d97836d2-8943-4f63-b198-4b85c191aa54>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2ea22b5-d9d4-410b-9502-86226fdebddb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2ea22b5-d9d4-410b-9502-86226fdebddb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_24-02-2022_100752.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2ea22b5-d9d4-410b-9502-86226fdebddb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4bcf590-3992-4a7c-8386-ff5e3c6bf6de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4bcf590-3992-4a7c-8386-ff5e3c6bf6de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_24-02-2022_101071.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4bcf590-3992-4a7c-8386-ff5e3c6bf6de>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d172735-ceed-4c9c-bd8b-eaf35d7fd27e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d172735-ceed-4c9c-bd8b-eaf35d7fd27e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_24-02-2022_101340.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d172735-ceed-4c9c-bd8b-eaf35d7fd27e>.
+    
+<http://data.lblod.info/id/remote-data-objects/801e1580-3094-405f-9ef3-8b4c6887cb5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "801e1580-3094-405f-9ef3-8b4c6887cb5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_24-02-2022_101392.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/801e1580-3094-405f-9ef3-8b4c6887cb5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/33fba19a-4e3c-482a-9c2a-d3158341439d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33fba19a-4e3c-482a-9c2a-d3158341439d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_24-03-2022_101918.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33fba19a-4e3c-482a-9c2a-d3158341439d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dade1da-97e2-48bf-b961-9580820e7dac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dade1da-97e2-48bf-b961-9580820e7dac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_25-11-2021_98662.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dade1da-97e2-48bf-b961-9580820e7dac>.
+    
+<http://data.lblod.info/id/remote-data-objects/58431621-b947-4187-ac7c-90e5b3fca947> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58431621-b947-4187-ac7c-90e5b3fca947";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_25-11-2021_98663.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58431621-b947-4187-ac7c-90e5b3fca947>.
+    
+<http://data.lblod.info/id/remote-data-objects/76f14292-056b-44ff-a7c2-c7f0d0c230b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76f14292-056b-44ff-a7c2-c7f0d0c230b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_25-11-2021_98726.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76f14292-056b-44ff-a7c2-c7f0d0c230b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c5746c7-ad75-4bf7-be3b-ea6058f7a4ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c5746c7-ad75-4bf7-be3b-ea6058f7a4ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_25-11-2021_98803.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c5746c7-ad75-4bf7-be3b-ea6058f7a4ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6c81f72-366a-43a8-8f74-acd703878a85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6c81f72-366a-43a8-8f74-acd703878a85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.evergem.be/LBLODWeb/Home/Overzicht/d91a8bafc8feeee5e60dda4184be7d1e0743f123cde12e3479dd2bbd3f1769ca/GetPublication?filename=Uittreksels_28-04-2022_102720.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6c81f72-366a-43a8-8f74-acd703878a85>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ebca1ea-e486-4861-8085-db58c473dd8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ebca1ea-e486-4861-8085-db58c473dd8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ebca1ea-e486-4861-8085-db58c473dd8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/423d2217-9af3-4642-96f6-ccb0f8402092> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "423d2217-9af3-4642-96f6-ccb0f8402092";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/423d2217-9af3-4642-96f6-ccb0f8402092>.
+    
+<http://data.lblod.info/id/remote-data-objects/52ca8073-112a-4723-a2c5-f0805a915650> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52ca8073-112a-4723-a2c5-f0805a915650";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52ca8073-112a-4723-a2c5-f0805a915650>.
+    
+<http://data.lblod.info/id/remote-data-objects/45a85175-c127-4a9f-8463-82a3aa9c2556> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45a85175-c127-4a9f-8463-82a3aa9c2556";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45a85175-c127-4a9f-8463-82a3aa9c2556>.
+    
+<http://data.lblod.info/id/remote-data-objects/326bd993-5e16-4cda-9d23-fd8865c82f8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "326bd993-5e16-4cda-9d23-fd8865c82f8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/326bd993-5e16-4cda-9d23-fd8865c82f8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/56a6af6e-bc82-40ed-9108-178fd3de75e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56a6af6e-bc82-40ed-9108-178fd3de75e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56a6af6e-bc82-40ed-9108-178fd3de75e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/47a97b65-e8bb-4e1b-a87f-c355b1f83829> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47a97b65-e8bb-4e1b-a87f-c355b1f83829";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47a97b65-e8bb-4e1b-a87f-c355b1f83829>.
+    
+<http://data.lblod.info/id/remote-data-objects/a80e7fdb-2fe9-495f-a4e1-219849f4ca43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a80e7fdb-2fe9-495f-a4e1-219849f4ca43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a80e7fdb-2fe9-495f-a4e1-219849f4ca43>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfc06988-7617-46d7-b0e0-eecdd6426d2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfc06988-7617-46d7-b0e0-eecdd6426d2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfc06988-7617-46d7-b0e0-eecdd6426d2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/07bd166d-7c3e-46d8-a7f4-4e38e23d8782> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07bd166d-7c3e-46d8-a7f4-4e38e23d8782";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07bd166d-7c3e-46d8-a7f4-4e38e23d8782>.
+    
+<http://data.lblod.info/id/remote-data-objects/43fb2510-fb97-4434-9dd5-df0ea53b258f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43fb2510-fb97-4434-9dd5-df0ea53b258f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43fb2510-fb97-4434-9dd5-df0ea53b258f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b05f29d8-c1ba-4daf-8847-5a746a820737> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b05f29d8-c1ba-4daf-8847-5a746a820737";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b05f29d8-c1ba-4daf-8847-5a746a820737>.
+    
+<http://data.lblod.info/id/remote-data-objects/35d3b984-04d8-46a8-9d7a-a58a7e6e0ae8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35d3b984-04d8-46a8-9d7a-a58a7e6e0ae8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35d3b984-04d8-46a8-9d7a-a58a7e6e0ae8>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d057201-cc65-4b19-b108-6e288de28be1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d057201-cc65-4b19-b108-6e288de28be1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d057201-cc65-4b19-b108-6e288de28be1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a754880-92b2-4977-b828-aee74f6a9776> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a754880-92b2-4977-b828-aee74f6a9776";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a754880-92b2-4977-b828-aee74f6a9776>.
+    
+<http://data.lblod.info/id/remote-data-objects/483205ac-ff8d-4fcb-9b00-07f504b2f6e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "483205ac-ff8d-4fcb-9b00-07f504b2f6e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/483205ac-ff8d-4fcb-9b00-07f504b2f6e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ccc73df-026b-473e-b6c7-1976cef7cfbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ccc73df-026b-473e-b6c7-1976cef7cfbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ccc73df-026b-473e-b6c7-1976cef7cfbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/762e52ae-0d5d-4b52-8a64-7b7dabdb5c8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "762e52ae-0d5d-4b52-8a64-7b7dabdb5c8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_26-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/762e52ae-0d5d-4b52-8a64-7b7dabdb5c8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/db1dad97-fff9-4b6e-a47e-e1901e71701a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db1dad97-fff9-4b6e-a47e-e1901e71701a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db1dad97-fff9-4b6e-a47e-e1901e71701a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ba6c2d9-f342-400e-930e-ca023a2da84a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ba6c2d9-f342-400e-930e-ca023a2da84a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ba6c2d9-f342-400e-930e-ca023a2da84a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8be8a14e-3363-42d7-bbbf-b4841a2344f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8be8a14e-3363-42d7-bbbf-b4841a2344f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/6b85664a-f3a6-46be-92f5-bea8440d6a6d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8be8a14e-3363-42d7-bbbf-b4841a2344f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/85a7cd35-078d-497a-986e-cbcd40a6fa6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85a7cd35-078d-497a-986e-cbcd40a6fa6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Agenda_Gemeenteraad_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85a7cd35-078d-497a-986e-cbcd40a6fa6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d60782a-0061-4dc9-8f83-f4fb508008bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d60782a-0061-4dc9-8f83-f4fb508008bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Agenda_Gemeenteraad_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d60782a-0061-4dc9-8f83-f4fb508008bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c0c52db-cee1-494c-9444-abd91e069ae5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c0c52db-cee1-494c-9444-abd91e069ae5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Agenda_Gemeenteraad_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c0c52db-cee1-494c-9444-abd91e069ae5>.
+    
+<http://data.lblod.info/id/remote-data-objects/909cce50-5397-4ee2-af12-ff6e7a6a161a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "909cce50-5397-4ee2-af12-ff6e7a6a161a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Agenda_Gemeenteraad_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/909cce50-5397-4ee2-af12-ff6e7a6a161a>.
+    
+<http://data.lblod.info/id/remote-data-objects/165144e4-a75f-4a1f-bada-82b5de9b9929> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "165144e4-a75f-4a1f-bada-82b5de9b9929";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Agenda_Gemeenteraad_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/165144e4-a75f-4a1f-bada-82b5de9b9929>.
+    
+<http://data.lblod.info/id/remote-data-objects/50112b7f-2ed3-4db5-abf2-b870bc0e9263> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50112b7f-2ed3-4db5-abf2-b870bc0e9263";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Agenda_Gemeenteraad_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50112b7f-2ed3-4db5-abf2-b870bc0e9263>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce135f45-f0b0-471b-8e8c-bad7a590e622> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce135f45-f0b0-471b-8e8c-bad7a590e622";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Agenda_Gemeenteraad_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce135f45-f0b0-471b-8e8c-bad7a590e622>.
+    
+<http://data.lblod.info/id/remote-data-objects/238c72a3-de9c-40ad-a130-34669eea8a33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "238c72a3-de9c-40ad-a130-34669eea8a33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Agenda_Gemeenteraad_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/238c72a3-de9c-40ad-a130-34669eea8a33>.
+    
+<http://data.lblod.info/id/remote-data-objects/84f22ebb-e735-4678-a2ac-92fff45110c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84f22ebb-e735-4678-a2ac-92fff45110c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Agenda_Gemeenteraad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84f22ebb-e735-4678-a2ac-92fff45110c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/07d6c795-44d1-4105-aa4a-f067a6394c1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07d6c795-44d1-4105-aa4a-f067a6394c1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=BesluitenLijst_Gemeenteraad_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07d6c795-44d1-4105-aa4a-f067a6394c1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e21ce75a-5da9-49eb-9585-e1898db023e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e21ce75a-5da9-49eb-9585-e1898db023e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=BesluitenLijst_Gemeenteraad_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e21ce75a-5da9-49eb-9585-e1898db023e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3aef6fd-90ed-43e5-bbf9-e869dc2f97a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3aef6fd-90ed-43e5-bbf9-e869dc2f97a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=BesluitenLijst_Gemeenteraad_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3aef6fd-90ed-43e5-bbf9-e869dc2f97a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b273e090-423d-438d-b72d-0b347a2d8a9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b273e090-423d-438d-b72d-0b347a2d8a9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=BesluitenLijst_Gemeenteraad_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de5ccf9a-d7e7-4d2e-b631-7b160f9e5789> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b273e090-423d-438d-b72d-0b347a2d8a9d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201348-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201348-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201348-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201348-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/5482f3b1-be2e-4042-886c-2ebace20d913> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5482f3b1-be2e-4042-886c-2ebace20d913";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7bcf3e78-8ff6-4834-81ac-34e62322a70c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/0a8a86d6-cb4e-4ce1-88f3-ed1ceeeb22dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0a8a86d6-cb4e-4ce1-88f3-ed1ceeeb22dd";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c>.
+
+  <http://redpencil.data.gift/id/task/0f5eb141-dee6-4d57-a69e-37aa8d98d80c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0f5eb141-dee6-4d57-a69e-37aa8d98d80c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/5482f3b1-be2e-4042-886c-2ebace20d913>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/0a8a86d6-cb4e-4ce1-88f3-ed1ceeeb22dd>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a96f9783-7366-4991-95e1-27e72b7ca796> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a96f9783-7366-4991-95e1-27e72b7ca796";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=BesluitenLijst_Gemeenteraad_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a96f9783-7366-4991-95e1-27e72b7ca796>.
+    
+<http://data.lblod.info/id/remote-data-objects/2746e731-a2ee-40c1-a3d1-1d572fcf0b8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2746e731-a2ee-40c1-a3d1-1d572fcf0b8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=BesluitenLijst_Gemeenteraad_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2746e731-a2ee-40c1-a3d1-1d572fcf0b8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d15b5e57-d081-472c-8a52-bdda6e07385a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d15b5e57-d081-472c-8a52-bdda6e07385a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=BesluitenLijst_Gemeenteraad_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d15b5e57-d081-472c-8a52-bdda6e07385a>.
+    
+<http://data.lblod.info/id/remote-data-objects/67b60b51-a516-4cf3-ae1b-805b5650ec4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67b60b51-a516-4cf3-ae1b-805b5650ec4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=BesluitenLijst_Gemeenteraad_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67b60b51-a516-4cf3-ae1b-805b5650ec4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0046dfc1-6b44-416b-849a-962e3e634a26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0046dfc1-6b44-416b-849a-962e3e634a26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0046dfc1-6b44-416b-849a-962e3e634a26>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9952a6b-602b-4934-8715-fcf08397eee7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9952a6b-602b-4934-8715-fcf08397eee7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Notulen_Gemeenteraad_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9952a6b-602b-4934-8715-fcf08397eee7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f28c7be1-6bd6-4dbe-af30-c91e6d7e4773> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f28c7be1-6bd6-4dbe-af30-c91e6d7e4773";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Notulen_Gemeenteraad_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f28c7be1-6bd6-4dbe-af30-c91e6d7e4773>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed428e3b-1256-41bd-b364-af019651fe01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed428e3b-1256-41bd-b364-af019651fe01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Notulen_Gemeenteraad_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed428e3b-1256-41bd-b364-af019651fe01>.
+    
+<http://data.lblod.info/id/remote-data-objects/3eb1c824-f377-4bcf-b569-253d4a6ff1f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3eb1c824-f377-4bcf-b569-253d4a6ff1f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Notulen_Gemeenteraad_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3eb1c824-f377-4bcf-b569-253d4a6ff1f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/165e9680-f8cd-4636-856f-aee94311bab3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "165e9680-f8cd-4636-856f-aee94311bab3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Notulen_Gemeenteraad_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/165e9680-f8cd-4636-856f-aee94311bab3>.
+    
+<http://data.lblod.info/id/remote-data-objects/93b6934f-72de-404f-b99a-71eed19620ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93b6934f-72de-404f-b99a-71eed19620ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Notulen_Gemeenteraad_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93b6934f-72de-404f-b99a-71eed19620ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9a30480-1bf3-4239-be3d-9ef7e6560b5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9a30480-1bf3-4239-be3d-9ef7e6560b5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Notulen_Gemeenteraad_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9a30480-1bf3-4239-be3d-9ef7e6560b5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a8c61c8-0195-4c36-900d-40d789b12c29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a8c61c8-0195-4c36-900d-40d789b12c29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Notulen_Gemeenteraad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a8c61c8-0195-4c36-900d-40d789b12c29>.
+    
+<http://data.lblod.info/id/remote-data-objects/82930b13-0205-457e-9196-88e600bb9157> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82930b13-0205-457e-9196-88e600bb9157";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_02-06-2022_68411.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82930b13-0205-457e-9196-88e600bb9157>.
+    
+<http://data.lblod.info/id/remote-data-objects/25d55ae5-cfec-4f73-9109-e5957ca3fc49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25d55ae5-cfec-4f73-9109-e5957ca3fc49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_02-06-2022_69358.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25d55ae5-cfec-4f73-9109-e5957ca3fc49>.
+    
+<http://data.lblod.info/id/remote-data-objects/61843700-d7e9-4926-90b9-00da06be6509> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61843700-d7e9-4926-90b9-00da06be6509";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_02-06-2022_69359.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61843700-d7e9-4926-90b9-00da06be6509>.
+    
+<http://data.lblod.info/id/remote-data-objects/190e75a7-9a5a-4738-9188-707ac064689f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "190e75a7-9a5a-4738-9188-707ac064689f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_02-06-2022_69360.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/190e75a7-9a5a-4738-9188-707ac064689f>.
+    
+<http://data.lblod.info/id/remote-data-objects/90b4cfb8-447a-4702-9ca6-cf4ee31b39a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90b4cfb8-447a-4702-9ca6-cf4ee31b39a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_02-06-2022_69361.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90b4cfb8-447a-4702-9ca6-cf4ee31b39a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4956352a-aa3e-42bc-984a-b0c0efb94410> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4956352a-aa3e-42bc-984a-b0c0efb94410";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_02-06-2022_69633.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4956352a-aa3e-42bc-984a-b0c0efb94410>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0917f25-d149-4768-9a3d-dad014ad634d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0917f25-d149-4768-9a3d-dad014ad634d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_02-06-2022_69636.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0917f25-d149-4768-9a3d-dad014ad634d>.
+    
+<http://data.lblod.info/id/remote-data-objects/92cfeee1-42d1-45ac-b257-b04325c215a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92cfeee1-42d1-45ac-b257-b04325c215a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_03-02-2022_67853.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92cfeee1-42d1-45ac-b257-b04325c215a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7e34fcf-be6f-47f3-9d8f-3ed43d9ca109> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7e34fcf-be6f-47f3-9d8f-3ed43d9ca109";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_03-02-2022_68162.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7e34fcf-be6f-47f3-9d8f-3ed43d9ca109>.
+    
+<http://data.lblod.info/id/remote-data-objects/903aeba5-99e3-4824-b72f-a44b07ec45f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "903aeba5-99e3-4824-b72f-a44b07ec45f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_03-02-2022_68163.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/903aeba5-99e3-4824-b72f-a44b07ec45f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/84c440bb-f1f1-4a7b-9755-56e0b571cc81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84c440bb-f1f1-4a7b-9755-56e0b571cc81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_07-07-2022_70143.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84c440bb-f1f1-4a7b-9755-56e0b571cc81>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc6c22b4-bb5c-4b27-ad24-9299b1c13012> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc6c22b4-bb5c-4b27-ad24-9299b1c13012";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_07-10-2021_65266.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc6c22b4-bb5c-4b27-ad24-9299b1c13012>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4bb663d-4f32-4348-b3a1-9b2468db05ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4bb663d-4f32-4348-b3a1-9b2468db05ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_07-10-2021_65267.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4bb663d-4f32-4348-b3a1-9b2468db05ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa7ab02b-632d-4346-9ce5-b51d8626b132> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa7ab02b-632d-4346-9ce5-b51d8626b132";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_07-10-2021_65377.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa7ab02b-632d-4346-9ce5-b51d8626b132>.
+    
+<http://data.lblod.info/id/remote-data-objects/20d207ee-36c4-4a4d-91f2-6abc3249f182> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20d207ee-36c4-4a4d-91f2-6abc3249f182";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_07-10-2021_65472.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20d207ee-36c4-4a4d-91f2-6abc3249f182>.
+    
+<http://data.lblod.info/id/remote-data-objects/81607625-c300-4fa6-9b2d-e646c0bb798e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81607625-c300-4fa6-9b2d-e646c0bb798e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_10-03-2022_68443.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81607625-c300-4fa6-9b2d-e646c0bb798e>.
+    
+<http://data.lblod.info/id/remote-data-objects/14de56d2-8db3-4cb8-9dec-33c27bc646fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14de56d2-8db3-4cb8-9dec-33c27bc646fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_10-03-2022_68478.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14de56d2-8db3-4cb8-9dec-33c27bc646fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3fcf13e-1d95-41df-bda0-716eb2631038> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3fcf13e-1d95-41df-bda0-716eb2631038";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_13-01-2022_67636.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3fcf13e-1d95-41df-bda0-716eb2631038>.
+    
+<http://data.lblod.info/id/remote-data-objects/c61b00f9-e494-4c77-90c3-3ffadd44f603> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c61b00f9-e494-4c77-90c3-3ffadd44f603";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_18-11-2021_65635.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c61b00f9-e494-4c77-90c3-3ffadd44f603>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6dc8f71-b1bd-4120-8744-87139df3e9e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6dc8f71-b1bd-4120-8744-87139df3e9e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_18-11-2021_65636.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6dc8f71-b1bd-4120-8744-87139df3e9e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/77cd7acc-58d4-4297-a86e-cd617e87145d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77cd7acc-58d4-4297-a86e-cd617e87145d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_18-11-2021_65637.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77cd7acc-58d4-4297-a86e-cd617e87145d>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d204b79-2992-43f1-979d-e0d6e0c369e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d204b79-2992-43f1-979d-e0d6e0c369e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_18-11-2021_65638.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d204b79-2992-43f1-979d-e0d6e0c369e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f933fdba-fdc7-47f1-8507-3e80d8adb6c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f933fdba-fdc7-47f1-8507-3e80d8adb6c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_18-11-2021_65640.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f933fdba-fdc7-47f1-8507-3e80d8adb6c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/fba67e68-bb83-4433-88ee-22974ca7ea29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fba67e68-bb83-4433-88ee-22974ca7ea29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_18-11-2021_65657.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fba67e68-bb83-4433-88ee-22974ca7ea29>.
+    
+<http://data.lblod.info/id/remote-data-objects/e003abf8-98f8-4c80-a1d3-68ef795168a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e003abf8-98f8-4c80-a1d3-68ef795168a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_18-11-2021_65885.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e003abf8-98f8-4c80-a1d3-68ef795168a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2f30e72-edc6-4cab-81eb-d1da2c4b843c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2f30e72-edc6-4cab-81eb-d1da2c4b843c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_23-12-2021_65874.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2f30e72-edc6-4cab-81eb-d1da2c4b843c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ab83be1-f357-48b8-a6a3-c3171fe4ac1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ab83be1-f357-48b8-a6a3-c3171fe4ac1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_23-12-2021_66054.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ab83be1-f357-48b8-a6a3-c3171fe4ac1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7cacffa-fc35-407e-a28f-5610cc6cfd9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7cacffa-fc35-407e-a28f-5610cc6cfd9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_23-12-2021_67187.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7cacffa-fc35-407e-a28f-5610cc6cfd9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d59d812-3a68-4921-b4a8-10d6f033e4e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d59d812-3a68-4921-b4a8-10d6f033e4e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_23-12-2021_67437.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d59d812-3a68-4921-b4a8-10d6f033e4e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/326d7e09-6a63-44b1-9b5b-f329ae7539f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "326d7e09-6a63-44b1-9b5b-f329ae7539f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_23-12-2021_67450.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/326d7e09-6a63-44b1-9b5b-f329ae7539f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0a21dd1-7753-4625-9c96-6b33f05ac4ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0a21dd1-7753-4625-9c96-6b33f05ac4ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/71e796ea15c7b8a7b47a4376e386a9f400d7a78a2a4d7bda075451a2e7228308/GetPublication?filename=Uittreksels_23-12-2021_67487.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0a21dd1-7753-4625-9c96-6b33f05ac4ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2e883f4-ba16-4f22-8ced-38f6c64d7b1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2e883f4-ba16-4f22-8ced-38f6c64d7b1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2e883f4-ba16-4f22-8ced-38f6c64d7b1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/41579cfb-6223-4c0c-b653-e1e28507cec5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41579cfb-6223-4c0c-b653-e1e28507cec5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41579cfb-6223-4c0c-b653-e1e28507cec5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a411edc3-476b-4cb1-bd4a-8a50bf9a8009> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a411edc3-476b-4cb1-bd4a-8a50bf9a8009";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a411edc3-476b-4cb1-bd4a-8a50bf9a8009>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a4fb071-2fc5-4f03-990b-eee1cdd48cda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a4fb071-2fc5-4f03-990b-eee1cdd48cda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a4fb071-2fc5-4f03-990b-eee1cdd48cda>.
+    
+<http://data.lblod.info/id/remote-data-objects/daeafb22-0188-4a70-9c17-7047ce96f8e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "daeafb22-0188-4a70-9c17-7047ce96f8e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/daeafb22-0188-4a70-9c17-7047ce96f8e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a14496f0-ac20-4159-ba9f-c032bc2877cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a14496f0-ac20-4159-ba9f-c032bc2877cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7bcf3e78-8ff6-4834-81ac-34e62322a70c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a14496f0-ac20-4159-ba9f-c032bc2877cb>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201349-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201349-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201349-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201349-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e34edb12-b30f-45cb-9928-a46b133456a1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e34edb12-b30f-45cb-9928-a46b133456a1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7dcee7d8-36d8-40e8-b014-3e2e671987d1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/5e0bfd8c-bbc9-4a33-894c-23c41c4a5177> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5e0bfd8c-bbc9-4a33-894c-23c41c4a5177";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1>.
+
+  <http://redpencil.data.gift/id/task/152c9c70-4af6-4af6-8121-edb1c46ff294> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "152c9c70-4af6-4af6-8121-edb1c46ff294";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e34edb12-b30f-45cb-9928-a46b133456a1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/5e0bfd8c-bbc9-4a33-894c-23c41c4a5177>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7858888b-e944-4755-9327-91b85df2c25d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7858888b-e944-4755-9327-91b85df2c25d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7858888b-e944-4755-9327-91b85df2c25d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bef0f4a9-da89-45a2-8369-4cdd2b109eaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bef0f4a9-da89-45a2-8369-4cdd2b109eaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bef0f4a9-da89-45a2-8369-4cdd2b109eaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bc7938a-1b49-402c-8586-8a42019ef9ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bc7938a-1b49-402c-8586-8a42019ef9ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bc7938a-1b49-402c-8586-8a42019ef9ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/353918d3-4971-4a2f-bf45-ab7ce2464733> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "353918d3-4971-4a2f-bf45-ab7ce2464733";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/353918d3-4971-4a2f-bf45-ab7ce2464733>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea48c34e-7b39-465d-947c-8435930b5869> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea48c34e-7b39-465d-947c-8435930b5869";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea48c34e-7b39-465d-947c-8435930b5869>.
+    
+<http://data.lblod.info/id/remote-data-objects/de7a248a-9e99-4cc6-9391-c48b677a2b8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de7a248a-9e99-4cc6-9391-c48b677a2b8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de7a248a-9e99-4cc6-9391-c48b677a2b8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8716c32c-335c-4a29-a820-64145e48f995> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8716c32c-335c-4a29-a820-64145e48f995";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8716c32c-335c-4a29-a820-64145e48f995>.
+    
+<http://data.lblod.info/id/remote-data-objects/004ec2c4-6984-4f74-83c4-7f247286e759> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "004ec2c4-6984-4f74-83c4-7f247286e759";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/004ec2c4-6984-4f74-83c4-7f247286e759>.
+    
+<http://data.lblod.info/id/remote-data-objects/de202260-7c60-4253-bede-2cc2402aacfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de202260-7c60-4253-bede-2cc2402aacfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de202260-7c60-4253-bede-2cc2402aacfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/5dd68cbe-64eb-430d-b681-adea8547ffd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5dd68cbe-64eb-430d-b681-adea8547ffd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5dd68cbe-64eb-430d-b681-adea8547ffd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/11e4bd34-7a6f-4c49-9b36-bb7f08145458> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11e4bd34-7a6f-4c49-9b36-bb7f08145458";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11e4bd34-7a6f-4c49-9b36-bb7f08145458>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fed5877-852b-4736-92ea-3d98fe373449> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fed5877-852b-4736-92ea-3d98fe373449";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fed5877-852b-4736-92ea-3d98fe373449>.
+    
+<http://data.lblod.info/id/remote-data-objects/6aa80501-c2a0-4f28-8be0-def689da7f20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6aa80501-c2a0-4f28-8be0-def689da7f20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6aa80501-c2a0-4f28-8be0-def689da7f20>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f9397d7-688b-40ea-bde6-881d0e9b8b2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f9397d7-688b-40ea-bde6-881d0e9b8b2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f9397d7-688b-40ea-bde6-881d0e9b8b2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7f195d8-c8c1-433b-9dc9-d6049f6ad97c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7f195d8-c8c1-433b-9dc9-d6049f6ad97c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7f195d8-c8c1-433b-9dc9-d6049f6ad97c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6ba5e54-d7fc-487f-bf1d-773d7bdcee00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6ba5e54-d7fc-487f-bf1d-773d7bdcee00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6ba5e54-d7fc-487f-bf1d-773d7bdcee00>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9b2f15b-95ba-4973-b452-fb101b43ce3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9b2f15b-95ba-4973-b452-fb101b43ce3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9b2f15b-95ba-4973-b452-fb101b43ce3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/18b08df4-16fb-4f5b-bbca-6662a05a9bdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18b08df4-16fb-4f5b-bbca-6662a05a9bdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18b08df4-16fb-4f5b-bbca-6662a05a9bdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6b31f90-d6c4-4c6e-9042-7e655dd3d710> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6b31f90-d6c4-4c6e-9042-7e655dd3d710";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6b31f90-d6c4-4c6e-9042-7e655dd3d710>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbb2a0e8-ff6d-4c9d-8972-77adf6c56a77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbb2a0e8-ff6d-4c9d-8972-77adf6c56a77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbb2a0e8-ff6d-4c9d-8972-77adf6c56a77>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a9dfe1a-f8c4-4ef4-98bf-7c3a6dad3f2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a9dfe1a-f8c4-4ef4-98bf-7c3a6dad3f2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Uittreksels_02-06-2022_68412.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a9dfe1a-f8c4-4ef4-98bf-7c3a6dad3f2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c66bef39-015e-4e49-87ec-c95e809a6f70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c66bef39-015e-4e49-87ec-c95e809a6f70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Uittreksels_02-06-2022_69389.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c66bef39-015e-4e49-87ec-c95e809a6f70>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca0a0e2b-5f13-405b-ab86-b109b827f7f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca0a0e2b-5f13-405b-ab86-b109b827f7f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Uittreksels_03-02-2022_68167.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca0a0e2b-5f13-405b-ab86-b109b827f7f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2788943-f600-4995-9cc1-cdee85ad6414> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2788943-f600-4995-9cc1-cdee85ad6414";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Uittreksels_05-05-2022_69282.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2788943-f600-4995-9cc1-cdee85ad6414>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1489dce-01cf-4584-a5f2-687ad4b6e398> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1489dce-01cf-4584-a5f2-687ad4b6e398";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Uittreksels_07-07-2022_69615.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1489dce-01cf-4584-a5f2-687ad4b6e398>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fb8e1d2-2d98-4f24-9b74-e2366b2aad3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fb8e1d2-2d98-4f24-9b74-e2366b2aad3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Uittreksels_10-03-2022_68394.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fb8e1d2-2d98-4f24-9b74-e2366b2aad3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7051f76-d33b-4c61-909c-7097b6f5f362> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7051f76-d33b-4c61-909c-7097b6f5f362";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Uittreksels_10-03-2022_68445.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7051f76-d33b-4c61-909c-7097b6f5f362>.
+    
+<http://data.lblod.info/id/remote-data-objects/33233d9f-3487-4428-8fea-9e240f64c93b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33233d9f-3487-4428-8fea-9e240f64c93b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Uittreksels_10-03-2022_68492.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33233d9f-3487-4428-8fea-9e240f64c93b>.
+    
+<http://data.lblod.info/id/remote-data-objects/218ef5f9-6aa7-49dc-9f81-cdb663abc3e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "218ef5f9-6aa7-49dc-9f81-cdb663abc3e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Uittreksels_13-01-2022_67731.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/218ef5f9-6aa7-49dc-9f81-cdb663abc3e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d8b816a-f8a2-477a-ba15-6963f8308d4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d8b816a-f8a2-477a-ba15-6963f8308d4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Uittreksels_18-11-2021_65571.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d8b816a-f8a2-477a-ba15-6963f8308d4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5843df5-2fde-4631-bc7f-9f2ca844ad6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5843df5-2fde-4631-bc7f-9f2ca844ad6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Uittreksels_18-11-2021_65581.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5843df5-2fde-4631-bc7f-9f2ca844ad6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fecb9b3a-fd42-4f90-b2ab-3c3226dcb31a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fecb9b3a-fd42-4f90-b2ab-3c3226dcb31a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Uittreksels_18-11-2021_65767.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fecb9b3a-fd42-4f90-b2ab-3c3226dcb31a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cc7fb27-278c-4e7e-ae28-080d0dbcd462> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cc7fb27-278c-4e7e-ae28-080d0dbcd462";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/ac7ba7e17231bf96367da732930ae47b8682ae483e52572207394cf089c70162/GetPublication?filename=Uittreksels_23-12-2021_67439.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cc7fb27-278c-4e7e-ae28-080d0dbcd462>.
+    
+<http://data.lblod.info/id/remote-data-objects/940cd9de-fe35-4f78-991e-f2a008de58c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "940cd9de-fe35-4f78-991e-f2a008de58c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/940cd9de-fe35-4f78-991e-f2a008de58c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/6994286c-234c-47c6-835a-acb3dde5bd43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6994286c-234c-47c6-835a-acb3dde5bd43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6994286c-234c-47c6-835a-acb3dde5bd43>.
+    
+<http://data.lblod.info/id/remote-data-objects/996fbdfe-1ca9-4755-bb0a-5c5da62a162d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "996fbdfe-1ca9-4755-bb0a-5c5da62a162d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/996fbdfe-1ca9-4755-bb0a-5c5da62a162d>.
+    
+<http://data.lblod.info/id/remote-data-objects/47c0c595-a441-4925-a640-993459d5fc64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47c0c595-a441-4925-a640-993459d5fc64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47c0c595-a441-4925-a640-993459d5fc64>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a71681d-2c14-439d-a0b3-55ceafe19834> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a71681d-2c14-439d-a0b3-55ceafe19834";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a71681d-2c14-439d-a0b3-55ceafe19834>.
+    
+<http://data.lblod.info/id/remote-data-objects/ede3c4bb-720d-43b6-ae52-9c310736631c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ede3c4bb-720d-43b6-ae52-9c310736631c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ede3c4bb-720d-43b6-ae52-9c310736631c>.
+    
+<http://data.lblod.info/id/remote-data-objects/772915af-1e1d-409a-bc3e-350938b8ba72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "772915af-1e1d-409a-bc3e-350938b8ba72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/772915af-1e1d-409a-bc3e-350938b8ba72>.
+    
+<http://data.lblod.info/id/remote-data-objects/611098f6-f4cf-4dc7-bb78-b6304298e6aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "611098f6-f4cf-4dc7-bb78-b6304298e6aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/611098f6-f4cf-4dc7-bb78-b6304298e6aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/02e32594-c103-4ee8-bdea-f5a5e1af41ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02e32594-c103-4ee8-bdea-f5a5e1af41ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02e32594-c103-4ee8-bdea-f5a5e1af41ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b47fc87-2c32-4f58-b1a8-9d9498d126c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b47fc87-2c32-4f58-b1a8-9d9498d126c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b47fc87-2c32-4f58-b1a8-9d9498d126c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/65eee258-4808-47a2-98a9-bccfd0717798> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65eee258-4808-47a2-98a9-bccfd0717798";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65eee258-4808-47a2-98a9-bccfd0717798>.
+    
+<http://data.lblod.info/id/remote-data-objects/235c7e8d-2a44-4a9a-8ee9-8ef48e9495b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "235c7e8d-2a44-4a9a-8ee9-8ef48e9495b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/235c7e8d-2a44-4a9a-8ee9-8ef48e9495b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/0640d3a8-7139-4d5d-a465-b746e26f6a68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0640d3a8-7139-4d5d-a465-b746e26f6a68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0640d3a8-7139-4d5d-a465-b746e26f6a68>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c652116-8948-4cf7-a7ea-04cd04e7e173> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c652116-8948-4cf7-a7ea-04cd04e7e173";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c652116-8948-4cf7-a7ea-04cd04e7e173>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb05f0b7-94e2-4948-92d5-245ba6e1c46c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb05f0b7-94e2-4948-92d5-245ba6e1c46c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb05f0b7-94e2-4948-92d5-245ba6e1c46c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d62d7ce0-f39c-4f12-9980-6b7f2c962401> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d62d7ce0-f39c-4f12-9980-6b7f2c962401";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d62d7ce0-f39c-4f12-9980-6b7f2c962401>.
+    
+<http://data.lblod.info/id/remote-data-objects/769104c5-ba20-44ec-82d4-00127468e4c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "769104c5-ba20-44ec-82d4-00127468e4c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7dcee7d8-36d8-40e8-b014-3e2e671987d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/769104c5-ba20-44ec-82d4-00127468e4c2>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201350-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201350-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201350-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201350-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/4e79e1e3-490e-4432-8da6-e0e97bf36919> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4e79e1e3-490e-4432-8da6-e0e97bf36919";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/dafd65c1-768d-413c-869a-6543078d7a21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dafd65c1-768d-413c-869a-6543078d7a21";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5>.
+
+  <http://redpencil.data.gift/id/task/6cea829b-8d30-4d85-85db-f9bb634ea6ed> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6cea829b-8d30-4d85-85db-f9bb634ea6ed";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/4e79e1e3-490e-4432-8da6-e0e97bf36919>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/dafd65c1-768d-413c-869a-6543078d7a21>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/fa4ea9a4-cd68-4062-a6b2-284a5d8a4536> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa4ea9a4-cd68-4062-a6b2-284a5d8a4536";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa4ea9a4-cd68-4062-a6b2-284a5d8a4536>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6585b21-e713-44d2-9bbe-1a4ef17104e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6585b21-e713-44d2-9bbe-1a4ef17104e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6585b21-e713-44d2-9bbe-1a4ef17104e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/04a5463c-f458-4e0c-a19b-17c5ee75878d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04a5463c-f458-4e0c-a19b-17c5ee75878d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04a5463c-f458-4e0c-a19b-17c5ee75878d>.
+    
+<http://data.lblod.info/id/remote-data-objects/947daa0d-bad7-43a1-b399-288edd30c5ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "947daa0d-bad7-43a1-b399-288edd30c5ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/947daa0d-bad7-43a1-b399-288edd30c5ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/69213b3b-a502-4bcc-a556-baaccc563e26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69213b3b-a502-4bcc-a556-baaccc563e26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69213b3b-a502-4bcc-a556-baaccc563e26>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f139b35-ae5f-4f58-95da-725354f7ce24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f139b35-ae5f-4f58-95da-725354f7ce24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f139b35-ae5f-4f58-95da-725354f7ce24>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0ca50dd-8c67-4890-ad5e-68ad685d31bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0ca50dd-8c67-4890-ad5e-68ad685d31bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0ca50dd-8c67-4890-ad5e-68ad685d31bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/96ec0007-0d89-4428-b977-33efd0455a86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96ec0007-0d89-4428-b977-33efd0455a86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96ec0007-0d89-4428-b977-33efd0455a86>.
+    
+<http://data.lblod.info/id/remote-data-objects/859139b9-1f2d-4c84-95d2-c882915e8315> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "859139b9-1f2d-4c84-95d2-c882915e8315";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/859139b9-1f2d-4c84-95d2-c882915e8315>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e62d4a8-4cd5-4d34-ad0c-fbc94fe0f8d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e62d4a8-4cd5-4d34-ad0c-fbc94fe0f8d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e62d4a8-4cd5-4d34-ad0c-fbc94fe0f8d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/45c3e14d-0389-4c1f-a198-1265b3d2f48b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45c3e14d-0389-4c1f-a198-1265b3d2f48b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45c3e14d-0389-4c1f-a198-1265b3d2f48b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c86beef-33d6-4ae1-b34c-f3e6dad3c360> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c86beef-33d6-4ae1-b34c-f3e6dad3c360";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c86beef-33d6-4ae1-b34c-f3e6dad3c360>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9ae7b7f-f5a5-4ca5-a19b-4625614bbf54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9ae7b7f-f5a5-4ca5-a19b-4625614bbf54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9ae7b7f-f5a5-4ca5-a19b-4625614bbf54>.
+    
+<http://data.lblod.info/id/remote-data-objects/85c8581d-e502-4fb3-a484-e7c0c016f74d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85c8581d-e502-4fb3-a484-e7c0c016f74d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85c8581d-e502-4fb3-a484-e7c0c016f74d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b7e0031-ef56-43c6-8afb-a375ce3bf29b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b7e0031-ef56-43c6-8afb-a375ce3bf29b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b7e0031-ef56-43c6-8afb-a375ce3bf29b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5613dc64-8fd0-406c-9393-f5ecb20d2039> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5613dc64-8fd0-406c-9393-f5ecb20d2039";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5613dc64-8fd0-406c-9393-f5ecb20d2039>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8dfa07d-9262-48b2-b4cd-b67c59146162> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8dfa07d-9262-48b2-b4cd-b67c59146162";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8dfa07d-9262-48b2-b4cd-b67c59146162>.
+    
+<http://data.lblod.info/id/remote-data-objects/10e5c366-6427-4ec4-a8b1-4ebaa88e6625> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10e5c366-6427-4ec4-a8b1-4ebaa88e6625";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_26-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10e5c366-6427-4ec4-a8b1-4ebaa88e6625>.
+    
+<http://data.lblod.info/id/remote-data-objects/4aedefbe-3473-4be1-a433-3c9d1408a852> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4aedefbe-3473-4be1-a433-3c9d1408a852";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4aedefbe-3473-4be1-a433-3c9d1408a852>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8d963c5-e46c-43ec-920a-557c5f6f03e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8d963c5-e46c-43ec-920a-557c5f6f03e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8d963c5-e46c-43ec-920a-557c5f6f03e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/abaa8bf3-ddc1-4bd4-ab17-b9389141017b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abaa8bf3-ddc1-4bd4-ab17-b9389141017b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abaa8bf3-ddc1-4bd4-ab17-b9389141017b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d52194e-1b7e-4f49-a7bd-08bae0174435> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d52194e-1b7e-4f49-a7bd-08bae0174435";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d52194e-1b7e-4f49-a7bd-08bae0174435>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff5aa1a5-c79a-4024-9add-47e5d020a08f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff5aa1a5-c79a-4024-9add-47e5d020a08f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff5aa1a5-c79a-4024-9add-47e5d020a08f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9c2026f-e309-4cd5-9018-d61c599dd41b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9c2026f-e309-4cd5-9018-d61c599dd41b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9c2026f-e309-4cd5-9018-d61c599dd41b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f75ced5c-9610-4767-9027-bd55fcb5f12c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f75ced5c-9610-4767-9027-bd55fcb5f12c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.gistel.be/LBLODWeb/Home/Overzicht/c719789501024cbe541b244b8a1b202c8505df6785d1b5687106eed5feb856c6/GetPublication?filename=Notulen_College%20van%20burgemeester%20en%20schepenen_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f75ced5c-9610-4767-9027-bd55fcb5f12c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d73b5f5-dcd1-4de3-9e41-9b3068dc0e24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d73b5f5-dcd1-4de3-9e41-9b3068dc0e24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d73b5f5-dcd1-4de3-9e41-9b3068dc0e24>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e72c1b0-da0f-43d1-92d3-907df4a29d70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e72c1b0-da0f-43d1-92d3-907df4a29d70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e72c1b0-da0f-43d1-92d3-907df4a29d70>.
+    
+<http://data.lblod.info/id/remote-data-objects/b091a10e-c978-45d2-8259-73ca5c129f6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b091a10e-c978-45d2-8259-73ca5c129f6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b091a10e-c978-45d2-8259-73ca5c129f6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa7eafd1-71f0-40db-ab7a-78a9522d66d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa7eafd1-71f0-40db-ab7a-78a9522d66d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa7eafd1-71f0-40db-ab7a-78a9522d66d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/47082c08-c11a-4777-90a3-a05afaf2e96d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47082c08-c11a-4777-90a3-a05afaf2e96d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47082c08-c11a-4777-90a3-a05afaf2e96d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8aacf8e-abc0-45b1-aedb-c9f218f0223a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8aacf8e-abc0-45b1-aedb-c9f218f0223a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8aacf8e-abc0-45b1-aedb-c9f218f0223a>.
+    
+<http://data.lblod.info/id/remote-data-objects/98417370-4067-493a-bec7-c2b48d548db8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98417370-4067-493a-bec7-c2b48d548db8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98417370-4067-493a-bec7-c2b48d548db8>.
+    
+<http://data.lblod.info/id/remote-data-objects/da70449f-0c96-4e5e-b78b-67d201bb25f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da70449f-0c96-4e5e-b78b-67d201bb25f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da70449f-0c96-4e5e-b78b-67d201bb25f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb76d898-00cb-44f5-a277-01e2559fdd99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb76d898-00cb-44f5-a277-01e2559fdd99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb76d898-00cb-44f5-a277-01e2559fdd99>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9281c32-a5ce-4097-8012-42435788c668> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9281c32-a5ce-4097-8012-42435788c668";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9281c32-a5ce-4097-8012-42435788c668>.
+    
+<http://data.lblod.info/id/remote-data-objects/58cc8092-bc1b-4214-af83-5cc6d32f46b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58cc8092-bc1b-4214-af83-5cc6d32f46b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58cc8092-bc1b-4214-af83-5cc6d32f46b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b874b364-df7f-4b7d-bcde-24407738644b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b874b364-df7f-4b7d-bcde-24407738644b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b874b364-df7f-4b7d-bcde-24407738644b>.
+    
+<http://data.lblod.info/id/remote-data-objects/db6feaf8-45f8-407a-baed-4c7f388aeeca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db6feaf8-45f8-407a-baed-4c7f388aeeca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db6feaf8-45f8-407a-baed-4c7f388aeeca>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e4f9476-9a8f-4f65-bd40-375de6fdcdcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e4f9476-9a8f-4f65-bd40-375de6fdcdcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e4f9476-9a8f-4f65-bd40-375de6fdcdcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/eeb5d5d4-675b-45bc-84e9-dc398fc88776> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eeb5d5d4-675b-45bc-84e9-dc398fc88776";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eeb5d5d4-675b-45bc-84e9-dc398fc88776>.
+    
+<http://data.lblod.info/id/remote-data-objects/8aa74f41-ed8f-4ce3-9947-b89923d195db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8aa74f41-ed8f-4ce3-9947-b89923d195db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8aa74f41-ed8f-4ce3-9947-b89923d195db>.
+    
+<http://data.lblod.info/id/remote-data-objects/804652f7-4583-4f10-8997-605781cf6d21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "804652f7-4583-4f10-8997-605781cf6d21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/804652f7-4583-4f10-8997-605781cf6d21>.
+    
+<http://data.lblod.info/id/remote-data-objects/85522941-9d32-4b05-8fb3-daf14c8c4dd4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85522941-9d32-4b05-8fb3-daf14c8c4dd4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85522941-9d32-4b05-8fb3-daf14c8c4dd4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae9bd3c1-7561-4d14-b34f-ff411a32695f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae9bd3c1-7561-4d14-b34f-ff411a32695f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae9bd3c1-7561-4d14-b34f-ff411a32695f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c17f61b-5748-41eb-ace6-f11b36f46f95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c17f61b-5748-41eb-ace6-f11b36f46f95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c17f61b-5748-41eb-ace6-f11b36f46f95>.
+    
+<http://data.lblod.info/id/remote-data-objects/f26102ab-9561-4d59-bba5-4002352c553b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f26102ab-9561-4d59-bba5-4002352c553b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f26102ab-9561-4d59-bba5-4002352c553b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5224c083-03f5-4e7e-9870-e116a2247bf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5224c083-03f5-4e7e-9870-e116a2247bf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5224c083-03f5-4e7e-9870-e116a2247bf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/915eb4cf-4cc8-436f-9665-7434ad257eb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "915eb4cf-4cc8-436f-9665-7434ad257eb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/915eb4cf-4cc8-436f-9665-7434ad257eb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2682098c-fcf3-4bac-94f2-abc00180ced0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2682098c-fcf3-4bac-94f2-abc00180ced0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2682098c-fcf3-4bac-94f2-abc00180ced0>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd7dc99d-1ca2-4687-a939-6183352039e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd7dc99d-1ca2-4687-a939-6183352039e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c8c75a2d-5bb6-4bfa-be99-c3137ee6f1a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd7dc99d-1ca2-4687-a939-6183352039e1>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201351-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201351-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201351-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201351-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/5e293f68-d0fc-4939-9ba8-f366e9c37d48> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5e293f68-d0fc-4939-9ba8-f366e9c37d48";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "392c7346-12b1-4f0b-9585-f68b690fe18b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/7785c60e-7e9a-4f82-9087-91306c140224> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7785c60e-7e9a-4f82-9087-91306c140224";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b>.
+
+  <http://redpencil.data.gift/id/task/99158e96-b145-4b3c-b0f2-b6c9bbbb8971> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "99158e96-b145-4b3c-b0f2-b6c9bbbb8971";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/5e293f68-d0fc-4939-9ba8-f366e9c37d48>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/7785c60e-7e9a-4f82-9087-91306c140224>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/37bf6850-702d-4bd6-a9ff-7f597bb2b51d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37bf6850-702d-4bd6-a9ff-7f597bb2b51d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37bf6850-702d-4bd6-a9ff-7f597bb2b51d>.
+    
+<http://data.lblod.info/id/remote-data-objects/02961e4f-8b1c-4893-8366-8e62083e7d69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02961e4f-8b1c-4893-8366-8e62083e7d69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02961e4f-8b1c-4893-8366-8e62083e7d69>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ce914b7-8c08-4516-ae15-de5ad2c74c08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ce914b7-8c08-4516-ae15-de5ad2c74c08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ce914b7-8c08-4516-ae15-de5ad2c74c08>.
+    
+<http://data.lblod.info/id/remote-data-objects/4133aa5f-5105-406e-8ced-ff14a72e20f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4133aa5f-5105-406e-8ced-ff14a72e20f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4133aa5f-5105-406e-8ced-ff14a72e20f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ead00686-bf8d-44be-8037-7e2599a4f2c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ead00686-bf8d-44be-8037-7e2599a4f2c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ead00686-bf8d-44be-8037-7e2599a4f2c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/7587d1a5-03aa-4d7e-99ee-95658f36d56a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7587d1a5-03aa-4d7e-99ee-95658f36d56a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7587d1a5-03aa-4d7e-99ee-95658f36d56a>.
+    
+<http://data.lblod.info/id/remote-data-objects/21492ddd-3e2f-47f1-a91b-aec36cc710cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21492ddd-3e2f-47f1-a91b-aec36cc710cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21492ddd-3e2f-47f1-a91b-aec36cc710cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c4c7dd4-66d6-4d40-b5d8-7a00f9853333> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c4c7dd4-66d6-4d40-b5d8-7a00f9853333";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c4c7dd4-66d6-4d40-b5d8-7a00f9853333>.
+    
+<http://data.lblod.info/id/remote-data-objects/66bad996-8758-492c-a891-1bb82b8e4451> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66bad996-8758-492c-a891-1bb82b8e4451";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66bad996-8758-492c-a891-1bb82b8e4451>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0613299-3b8e-42c0-abdf-39b45a1b527e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0613299-3b8e-42c0-abdf-39b45a1b527e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0613299-3b8e-42c0-abdf-39b45a1b527e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a7df801-f4db-4f4b-8023-ff565053d573> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a7df801-f4db-4f4b-8023-ff565053d573";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a7df801-f4db-4f4b-8023-ff565053d573>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ad78821-4245-4a01-ae85-9675c2447796> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ad78821-4245-4a01-ae85-9675c2447796";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ad78821-4245-4a01-ae85-9675c2447796>.
+    
+<http://data.lblod.info/id/remote-data-objects/625863ab-de7c-4d6e-8407-c6e27a68b27d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "625863ab-de7c-4d6e-8407-c6e27a68b27d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/625863ab-de7c-4d6e-8407-c6e27a68b27d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c9c548e-8adc-43b1-9b75-7a86853a74ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c9c548e-8adc-43b1-9b75-7a86853a74ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c9c548e-8adc-43b1-9b75-7a86853a74ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/adca2b61-a9a5-44e5-bfb1-3d871ffb73f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "adca2b61-a9a5-44e5-bfb1-3d871ffb73f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=Uittreksels_14-06-2022_82306.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/adca2b61-a9a5-44e5-bfb1-3d871ffb73f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dab6143-06e7-4547-81fc-71fda24072f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dab6143-06e7-4547-81fc-71fda24072f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=Uittreksels_14-06-2022_82307.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dab6143-06e7-4547-81fc-71fda24072f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/913beb46-b840-4194-a153-ddb8404ec521> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "913beb46-b840-4194-a153-ddb8404ec521";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=Uittreksels_14-06-2022_82434.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/913beb46-b840-4194-a153-ddb8404ec521>.
+    
+<http://data.lblod.info/id/remote-data-objects/af3d79cf-06ef-4aff-83d8-1187869aa15d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af3d79cf-06ef-4aff-83d8-1187869aa15d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=Uittreksels_19-10-2021_77057.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af3d79cf-06ef-4aff-83d8-1187869aa15d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f060bedd-e54d-4663-826b-1e77f6c3b69e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f060bedd-e54d-4663-826b-1e77f6c3b69e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=Uittreksels_19-10-2021_77061.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f060bedd-e54d-4663-826b-1e77f6c3b69e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5754203c-beb3-495e-8aee-f4f6cb999f77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5754203c-beb3-495e-8aee-f4f6cb999f77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/2b4720eac2231426d9c018bd196758b202f6c591b96c6c7f970e0ffd64f83051/GetPublication?filename=Uittreksels_21-12-2021_77336.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5754203c-beb3-495e-8aee-f4f6cb999f77>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b0db316-b23e-42f7-a49b-c51978c76a0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b0db316-b23e-42f7-a49b-c51978c76a0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Agenda_Gemeenteraad_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b0db316-b23e-42f7-a49b-c51978c76a0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/62ca62be-65b8-42b3-944b-ede915d9bb90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62ca62be-65b8-42b3-944b-ede915d9bb90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Agenda_Gemeenteraad_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62ca62be-65b8-42b3-944b-ede915d9bb90>.
+    
+<http://data.lblod.info/id/remote-data-objects/a226fb43-94f1-40a6-9686-7b4cf1a8217b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a226fb43-94f1-40a6-9686-7b4cf1a8217b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Agenda_Gemeenteraad_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a226fb43-94f1-40a6-9686-7b4cf1a8217b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c91b1a13-2850-4cd7-896d-0a622e3dc9db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c91b1a13-2850-4cd7-896d-0a622e3dc9db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Agenda_Gemeenteraad_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c91b1a13-2850-4cd7-896d-0a622e3dc9db>.
+    
+<http://data.lblod.info/id/remote-data-objects/850861c4-8d66-4639-856c-915908ded1ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "850861c4-8d66-4639-856c-915908ded1ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Agenda_Gemeenteraad_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/850861c4-8d66-4639-856c-915908ded1ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1d612d1-ef66-47da-90d0-90685785fd72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1d612d1-ef66-47da-90d0-90685785fd72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Agenda_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1d612d1-ef66-47da-90d0-90685785fd72>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5c5baed-190e-4f2c-af39-8c1aee3fa23b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5c5baed-190e-4f2c-af39-8c1aee3fa23b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Agenda_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5c5baed-190e-4f2c-af39-8c1aee3fa23b>.
+    
+<http://data.lblod.info/id/remote-data-objects/caa0e2ae-eb19-490c-a9aa-d87d1242a852> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "caa0e2ae-eb19-490c-a9aa-d87d1242a852";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Agenda_Gemeenteraad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/caa0e2ae-eb19-490c-a9aa-d87d1242a852>.
+    
+<http://data.lblod.info/id/remote-data-objects/560eeb4e-9736-447d-ac37-f10e99d34f4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "560eeb4e-9736-447d-ac37-f10e99d34f4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Agenda_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/560eeb4e-9736-447d-ac37-f10e99d34f4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5af5c011-fdc6-41e9-8a53-bc10623b25cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5af5c011-fdc6-41e9-8a53-bc10623b25cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5af5c011-fdc6-41e9-8a53-bc10623b25cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/edbae488-599a-476f-b513-04fe14cfb6ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edbae488-599a-476f-b513-04fe14cfb6ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edbae488-599a-476f-b513-04fe14cfb6ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/13d09faf-63a0-4e97-ac9f-ce7a2e80a777> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13d09faf-63a0-4e97-ac9f-ce7a2e80a777";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13d09faf-63a0-4e97-ac9f-ce7a2e80a777>.
+    
+<http://data.lblod.info/id/remote-data-objects/38cb2e96-6ee6-4b5c-883d-c31bae9daad9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38cb2e96-6ee6-4b5c-883d-c31bae9daad9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38cb2e96-6ee6-4b5c-883d-c31bae9daad9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e002c1a6-ced0-4ff7-80bf-328ef18e8eed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e002c1a6-ced0-4ff7-80bf-328ef18e8eed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e002c1a6-ced0-4ff7-80bf-328ef18e8eed>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e953f2c-4ca5-409b-a701-bda27fd7c686> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e953f2c-4ca5-409b-a701-bda27fd7c686";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e953f2c-4ca5-409b-a701-bda27fd7c686>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd372b77-08a1-44b5-a400-9e6b9f45118c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd372b77-08a1-44b5-a400-9e6b9f45118c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd372b77-08a1-44b5-a400-9e6b9f45118c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e84b52a-958a-4198-a280-8984d697b0e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e84b52a-958a-4198-a280-8984d697b0e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e84b52a-958a-4198-a280-8984d697b0e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/65655c0f-bad3-4d1d-9305-933a82f90757> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65655c0f-bad3-4d1d-9305-933a82f90757";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65655c0f-bad3-4d1d-9305-933a82f90757>.
+    
+<http://data.lblod.info/id/remote-data-objects/0967be84-2e88-4b17-8f8a-f8a86421fd4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0967be84-2e88-4b17-8f8a-f8a86421fd4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Notulen_Gemeenteraad_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0967be84-2e88-4b17-8f8a-f8a86421fd4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/762e3456-cfa6-4829-a409-589e536d7255> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "762e3456-cfa6-4829-a409-589e536d7255";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Notulen_Gemeenteraad_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/762e3456-cfa6-4829-a409-589e536d7255>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d787ffb-6da8-4512-a7c4-36259a23ddc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d787ffb-6da8-4512-a7c4-36259a23ddc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Notulen_Gemeenteraad_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d787ffb-6da8-4512-a7c4-36259a23ddc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffebc900-b44b-4ead-bdf6-7379feb66718> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffebc900-b44b-4ead-bdf6-7379feb66718";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Notulen_Gemeenteraad_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffebc900-b44b-4ead-bdf6-7379feb66718>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa81712c-a8c1-46d4-a7c1-7bf9893b8533> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa81712c-a8c1-46d4-a7c1-7bf9893b8533";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Notulen_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa81712c-a8c1-46d4-a7c1-7bf9893b8533>.
+    
+<http://data.lblod.info/id/remote-data-objects/e97eee2d-afa8-4c0d-af19-b6caedf8db95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e97eee2d-afa8-4c0d-af19-b6caedf8db95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Notulen_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e97eee2d-afa8-4c0d-af19-b6caedf8db95>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5c66524-03e7-4696-89d0-b973f3e50053> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5c66524-03e7-4696-89d0-b973f3e50053";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Notulen_Gemeenteraad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5c66524-03e7-4696-89d0-b973f3e50053>.
+    
+<http://data.lblod.info/id/remote-data-objects/68e63774-3c4e-467e-98c2-c978af2c4ff9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68e63774-3c4e-467e-98c2-c978af2c4ff9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Notulen_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68e63774-3c4e-467e-98c2-c978af2c4ff9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9aec6f6-7f44-43a7-9dfe-0000b9a51871> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9aec6f6-7f44-43a7-9dfe-0000b9a51871";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_15-11-2021_77158.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9aec6f6-7f44-43a7-9dfe-0000b9a51871>.
+    
+<http://data.lblod.info/id/remote-data-objects/06bb388d-7b3e-4c64-b238-0e7b08c38450> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06bb388d-7b3e-4c64-b238-0e7b08c38450";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_15-11-2021_77166.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06bb388d-7b3e-4c64-b238-0e7b08c38450>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebb8fa8c-5e16-489e-bc99-24ebe94a58aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebb8fa8c-5e16-489e-bc99-24ebe94a58aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_16-05-2022_81809.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebb8fa8c-5e16-489e-bc99-24ebe94a58aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/72753e51-835a-44ac-be0d-a75d21371962> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72753e51-835a-44ac-be0d-a75d21371962";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_16-05-2022_81810.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/392c7346-12b1-4f0b-9585-f68b690fe18b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72753e51-835a-44ac-be0d-a75d21371962>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201353-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201353-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201353-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201353-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/188b0ab9-d27e-4529-ab2b-c6793d9bdd6a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "188b0ab9-d27e-4529-ab2b-c6793d9bdd6a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "91d6b15e-0590-4986-a321-cdd612811e5f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b5d86e98-7e71-4883-a0df-4b6ec4c51712> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b5d86e98-7e71-4883-a0df-4b6ec4c51712";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f>.
+
+  <http://redpencil.data.gift/id/task/0987a04e-adae-4556-adae-9a8bbd5bfeda> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0987a04e-adae-4556-adae-9a8bbd5bfeda";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/188b0ab9-d27e-4529-ab2b-c6793d9bdd6a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b5d86e98-7e71-4883-a0df-4b6ec4c51712>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/3013627a-c3e2-4605-ae73-56e822d749ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3013627a-c3e2-4605-ae73-56e822d749ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_16-05-2022_81815.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3013627a-c3e2-4605-ae73-56e822d749ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/5978e8a3-f966-4068-8cd8-b5f8ac37d85e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5978e8a3-f966-4068-8cd8-b5f8ac37d85e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_16-05-2022_81816.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5978e8a3-f966-4068-8cd8-b5f8ac37d85e>.
+    
+<http://data.lblod.info/id/remote-data-objects/02b56fe0-7438-41ad-a260-5cdb8f1daac2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02b56fe0-7438-41ad-a260-5cdb8f1daac2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_18-07-2022_82721.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02b56fe0-7438-41ad-a260-5cdb8f1daac2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d20e45c-f823-4d2c-927b-7b758aae4203> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d20e45c-f823-4d2c-927b-7b758aae4203";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_18-07-2022_82722.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d20e45c-f823-4d2c-927b-7b758aae4203>.
+    
+<http://data.lblod.info/id/remote-data-objects/469b4a67-8ab1-4135-895f-b4e9ab19db0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "469b4a67-8ab1-4135-895f-b4e9ab19db0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_18-07-2022_82726.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/469b4a67-8ab1-4135-895f-b4e9ab19db0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a121401-b034-4feb-956f-2e46443c978b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a121401-b034-4feb-956f-2e46443c978b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_18-07-2022_82727.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a121401-b034-4feb-956f-2e46443c978b>.
+    
+<http://data.lblod.info/id/remote-data-objects/44ef4b86-e3bb-4d9c-acca-ea1d007cd9f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44ef4b86-e3bb-4d9c-acca-ea1d007cd9f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_18-07-2022_82732.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44ef4b86-e3bb-4d9c-acca-ea1d007cd9f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f16042fe-3eea-46b4-a287-98539aa9786e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f16042fe-3eea-46b4-a287-98539aa9786e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_18-07-2022_82736.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f16042fe-3eea-46b4-a287-98539aa9786e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dc15b8b-773f-4c3c-8a12-405912755680> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dc15b8b-773f-4c3c-8a12-405912755680";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_18-07-2022_82737.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dc15b8b-773f-4c3c-8a12-405912755680>.
+    
+<http://data.lblod.info/id/remote-data-objects/65416176-d7bb-4bf3-847e-b681f6a0b8ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65416176-d7bb-4bf3-847e-b681f6a0b8ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_18-07-2022_82739.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65416176-d7bb-4bf3-847e-b681f6a0b8ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6a06380-f1b1-4677-abb0-87273c4fced5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6a06380-f1b1-4677-abb0-87273c4fced5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_18-10-2021_76806.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6a06380-f1b1-4677-abb0-87273c4fced5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fe30dbe-395f-4e8e-b8de-dd81949a712b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fe30dbe-395f-4e8e-b8de-dd81949a712b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_20-06-2022_82228.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fe30dbe-395f-4e8e-b8de-dd81949a712b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a529b3e-0df5-4181-942f-e44ef3718f51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a529b3e-0df5-4181-942f-e44ef3718f51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_20-06-2022_82234.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a529b3e-0df5-4181-942f-e44ef3718f51>.
+    
+<http://data.lblod.info/id/remote-data-objects/472f4cf6-feeb-4daf-a990-7ffd80419699> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "472f4cf6-feeb-4daf-a990-7ffd80419699";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_20-06-2022_82235.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/472f4cf6-feeb-4daf-a990-7ffd80419699>.
+    
+<http://data.lblod.info/id/remote-data-objects/acf91306-53b6-4157-9d49-ab7bf8b61f7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acf91306-53b6-4157-9d49-ab7bf8b61f7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_20-12-2021_77477.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acf91306-53b6-4157-9d49-ab7bf8b61f7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f21dce1-94a0-4d2e-b185-d9198c1d4910> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f21dce1-94a0-4d2e-b185-d9198c1d4910";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_20-12-2021_77478.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f21dce1-94a0-4d2e-b185-d9198c1d4910>.
+    
+<http://data.lblod.info/id/remote-data-objects/4487c54d-3521-449a-afa1-ad34876b70c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4487c54d-3521-449a-afa1-ad34876b70c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_20-12-2021_77479.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4487c54d-3521-449a-afa1-ad34876b70c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/affffb39-569e-4ecd-b041-0878f5b09bdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "affffb39-569e-4ecd-b041-0878f5b09bdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_20-12-2021_77480.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/affffb39-569e-4ecd-b041-0878f5b09bdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e99c313-c1da-4f08-a497-857adf2db3d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e99c313-c1da-4f08-a497-857adf2db3d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_20-12-2021_77483.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e99c313-c1da-4f08-a497-857adf2db3d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/50e78536-2e0a-482c-be6e-531326630e27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50e78536-2e0a-482c-be6e-531326630e27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_20-12-2021_77484.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50e78536-2e0a-482c-be6e-531326630e27>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e3e05fb-1a7b-446f-a1d3-c791c8183d11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e3e05fb-1a7b-446f-a1d3-c791c8183d11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_20-12-2021_77489.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e3e05fb-1a7b-446f-a1d3-c791c8183d11>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4d39460-f9c3-45d6-b291-611eb4497945> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4d39460-f9c3-45d6-b291-611eb4497945";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_20-12-2021_77490.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4d39460-f9c3-45d6-b291-611eb4497945>.
+    
+<http://data.lblod.info/id/remote-data-objects/08413cae-7a86-4a7a-94aa-a8833158621a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08413cae-7a86-4a7a-94aa-a8833158621a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_20-12-2021_77492.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08413cae-7a86-4a7a-94aa-a8833158621a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7da7cad-51fa-45b5-b2c1-4de33c75b6b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7da7cad-51fa-45b5-b2c1-4de33c75b6b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_21-02-2022_78119.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7da7cad-51fa-45b5-b2c1-4de33c75b6b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bb44fa2-531d-42ea-80e7-848c91c466f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bb44fa2-531d-42ea-80e7-848c91c466f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_21-02-2022_78123.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bb44fa2-531d-42ea-80e7-848c91c466f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9c90a29-bdca-427c-8b1c-5c531ac705f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9c90a29-bdca-427c-8b1c-5c531ac705f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_21-03-2022_78478.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9c90a29-bdca-427c-8b1c-5c531ac705f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0bdd883-1c2e-4e3a-afb8-753c52ef3002> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0bdd883-1c2e-4e3a-afb8-753c52ef3002";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_21-03-2022_78483.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0bdd883-1c2e-4e3a-afb8-753c52ef3002>.
+    
+<http://data.lblod.info/id/remote-data-objects/96f28f8d-01b5-4eb4-ac83-2db621d9d479> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96f28f8d-01b5-4eb4-ac83-2db621d9d479";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_21-03-2022_78528.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96f28f8d-01b5-4eb4-ac83-2db621d9d479>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce77d037-43b1-47c9-a8e2-404c6a4c971f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce77d037-43b1-47c9-a8e2-404c6a4c971f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/31acc83f76449ab1813ef8e0c95eeeb4172c52eab26a469f6e4a3daf4dec247a/GetPublication?filename=Uittreksels_25-04-2022_78853.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce77d037-43b1-47c9-a8e2-404c6a4c971f>.
+    
+<http://data.lblod.info/id/remote-data-objects/598fe6f8-dbab-4946-afd6-86748efe231d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "598fe6f8-dbab-4946-afd6-86748efe231d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/598fe6f8-dbab-4946-afd6-86748efe231d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8ab4f79-603b-43b2-af3c-9d3b6a45799e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8ab4f79-603b-43b2-af3c-9d3b6a45799e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8ab4f79-603b-43b2-af3c-9d3b6a45799e>.
+    
+<http://data.lblod.info/id/remote-data-objects/beed1762-e63c-4b52-9ce8-67099a58c7d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "beed1762-e63c-4b52-9ce8-67099a58c7d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/beed1762-e63c-4b52-9ce8-67099a58c7d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef94b1c2-e7a8-4b57-b565-dc35d6c99e5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef94b1c2-e7a8-4b57-b565-dc35d6c99e5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef94b1c2-e7a8-4b57-b565-dc35d6c99e5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4df9e2bc-b4c2-42f9-8406-47cb87cff44c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4df9e2bc-b4c2-42f9-8406-47cb87cff44c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4df9e2bc-b4c2-42f9-8406-47cb87cff44c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a13466a-db45-45ef-9bc4-3b1fc7bda08b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a13466a-db45-45ef-9bc4-3b1fc7bda08b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a13466a-db45-45ef-9bc4-3b1fc7bda08b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d3c8cf2-3300-4559-83f1-93a89bfb0b09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d3c8cf2-3300-4559-83f1-93a89bfb0b09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d3c8cf2-3300-4559-83f1-93a89bfb0b09>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8c0e1e6-837f-46d1-89a7-45afcc6a2f90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8c0e1e6-837f-46d1-89a7-45afcc6a2f90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8c0e1e6-837f-46d1-89a7-45afcc6a2f90>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c7e9cea-6ac0-49da-9812-fa68bb858c52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c7e9cea-6ac0-49da-9812-fa68bb858c52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c7e9cea-6ac0-49da-9812-fa68bb858c52>.
+    
+<http://data.lblod.info/id/remote-data-objects/07f7deab-a18c-41bc-ab77-c0f65bea3703> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07f7deab-a18c-41bc-ab77-c0f65bea3703";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07f7deab-a18c-41bc-ab77-c0f65bea3703>.
+    
+<http://data.lblod.info/id/remote-data-objects/fde97c38-b328-4d20-bebf-6b43d285669c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fde97c38-b328-4d20-bebf-6b43d285669c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fde97c38-b328-4d20-bebf-6b43d285669c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb552e08-7ac8-4e3d-a57d-b9c29e065a61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb552e08-7ac8-4e3d-a57d-b9c29e065a61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb552e08-7ac8-4e3d-a57d-b9c29e065a61>.
+    
+<http://data.lblod.info/id/remote-data-objects/8316ebd1-a174-47ca-9abf-dfad952dc75f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8316ebd1-a174-47ca-9abf-dfad952dc75f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8316ebd1-a174-47ca-9abf-dfad952dc75f>.
+    
+<http://data.lblod.info/id/remote-data-objects/78703c91-84a2-46fb-9af2-66e673557c2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78703c91-84a2-46fb-9af2-66e673557c2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78703c91-84a2-46fb-9af2-66e673557c2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/78b7e3ad-e974-48d5-b0cb-67578dd1faaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78b7e3ad-e974-48d5-b0cb-67578dd1faaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78b7e3ad-e974-48d5-b0cb-67578dd1faaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/da64ea08-5a8e-42bc-a6a4-dcd13a86182e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da64ea08-5a8e-42bc-a6a4-dcd13a86182e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da64ea08-5a8e-42bc-a6a4-dcd13a86182e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1185f809-dac5-4548-bb4a-2828265597a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1185f809-dac5-4548-bb4a-2828265597a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1185f809-dac5-4548-bb4a-2828265597a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdc53502-d7cc-462d-9cc7-8a032d0d12cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdc53502-d7cc-462d-9cc7-8a032d0d12cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdc53502-d7cc-462d-9cc7-8a032d0d12cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/5aa7446e-1d7a-4f7f-a306-2a3be2320830> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5aa7446e-1d7a-4f7f-a306-2a3be2320830";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5aa7446e-1d7a-4f7f-a306-2a3be2320830>.
+    
+<http://data.lblod.info/id/remote-data-objects/08a967fd-5612-4bf3-886f-cd6436770f4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08a967fd-5612-4bf3-886f-cd6436770f4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08a967fd-5612-4bf3-886f-cd6436770f4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1048513e-b379-4665-8711-45037eb14c01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1048513e-b379-4665-8711-45037eb14c01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91d6b15e-0590-4986-a321-cdd612811e5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1048513e-b379-4665-8711-45037eb14c01>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201354-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201354-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201354-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201354-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f47ac750-03fc-4779-83f0-5ba707f430e2> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f47ac750-03fc-4779-83f0-5ba707f430e2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8068f1ae-bcfa-4771-865c-9bb45604bfe0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/76694a94-2b32-48f5-b6b3-499c506df8b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "76694a94-2b32-48f5-b6b3-499c506df8b7";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0>.
+
+  <http://redpencil.data.gift/id/task/a0258c83-bcbd-4909-9e4b-25441697f9df> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a0258c83-bcbd-4909-9e4b-25441697f9df";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f47ac750-03fc-4779-83f0-5ba707f430e2>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/76694a94-2b32-48f5-b6b3-499c506df8b7>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b1890feb-e85a-46d4-b204-09f8c95dcdc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1890feb-e85a-46d4-b204-09f8c95dcdc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1890feb-e85a-46d4-b204-09f8c95dcdc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d08f5d34-79b7-4944-8657-7d8998e6c8a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d08f5d34-79b7-4944-8657-7d8998e6c8a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d08f5d34-79b7-4944-8657-7d8998e6c8a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1233899-f9de-4150-85bf-8b28cd9cde8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1233899-f9de-4150-85bf-8b28cd9cde8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1233899-f9de-4150-85bf-8b28cd9cde8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f4a2987-e9d3-4ad7-bfa8-51ad4d2c4ba5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f4a2987-e9d3-4ad7-bfa8-51ad4d2c4ba5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f4a2987-e9d3-4ad7-bfa8-51ad4d2c4ba5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4509c869-7e82-4622-89d0-e85f3638d422> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4509c869-7e82-4622-89d0-e85f3638d422";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4509c869-7e82-4622-89d0-e85f3638d422>.
+    
+<http://data.lblod.info/id/remote-data-objects/a78f82c4-18cc-4918-b3e7-a3740674f40c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a78f82c4-18cc-4918-b3e7-a3740674f40c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Uittreksels_16-05-2022_81819.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a78f82c4-18cc-4918-b3e7-a3740674f40c>.
+    
+<http://data.lblod.info/id/remote-data-objects/58ab8ed4-2c32-43d1-a17c-3bcc43fa5d5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58ab8ed4-2c32-43d1-a17c-3bcc43fa5d5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Uittreksels_18-07-2022_82716.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58ab8ed4-2c32-43d1-a17c-3bcc43fa5d5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c0ab5f8-6986-4b8f-a159-d1fa5c6e415f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c0ab5f8-6986-4b8f-a159-d1fa5c6e415f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Uittreksels_18-07-2022_82718.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c0ab5f8-6986-4b8f-a159-d1fa5c6e415f>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa8f531c-4f1c-46d2-9010-f7e0d6934c3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa8f531c-4f1c-46d2-9010-f7e0d6934c3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Uittreksels_18-07-2022_82719.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa8f531c-4f1c-46d2-9010-f7e0d6934c3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbab79b5-59c2-4827-8238-60c1b7b5b428> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbab79b5-59c2-4827-8238-60c1b7b5b428";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Uittreksels_18-07-2022_82720.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbab79b5-59c2-4827-8238-60c1b7b5b428>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cbc0792-729d-4f45-9f07-a15bc933115d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cbc0792-729d-4f45-9f07-a15bc933115d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Uittreksels_20-06-2022_82221.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cbc0792-729d-4f45-9f07-a15bc933115d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fc7827b-fb19-4b75-bd4a-d605c14e2273> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fc7827b-fb19-4b75-bd4a-d605c14e2273";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Uittreksels_20-12-2021_77473.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fc7827b-fb19-4b75-bd4a-d605c14e2273>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f368f7f-7e0e-436d-96ef-9c06398c189f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f368f7f-7e0e-436d-96ef-9c06398c189f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/4799e3ccff8543f074a76a19b7bf9eca166dfff6d4c46f8e1b6c202d504242b3/GetPublication?filename=Uittreksels_20-12-2021_77475.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f368f7f-7e0e-436d-96ef-9c06398c189f>.
+    
+<http://data.lblod.info/id/remote-data-objects/86bb243d-0cd8-4c88-b046-c97be2651b98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86bb243d-0cd8-4c88-b046-c97be2651b98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/7e4f1692c4391571f856ac0eba25e5d83061eb0570900af4d8754859e9857318/GetPublication?filename=BesluitenLijstUitspraak_Besluit%20burgemeester_02-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86bb243d-0cd8-4c88-b046-c97be2651b98>.
+    
+<http://data.lblod.info/id/remote-data-objects/88e6c48e-a46a-46e8-8fc4-f1e3be8e35ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88e6c48e-a46a-46e8-8fc4-f1e3be8e35ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/7e4f1692c4391571f856ac0eba25e5d83061eb0570900af4d8754859e9857318/GetPublication?filename=BesluitenLijstUitspraak_Besluit%20burgemeester_02-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88e6c48e-a46a-46e8-8fc4-f1e3be8e35ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/99a1d4db-06f4-4d73-8f02-8a08d111e778> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99a1d4db-06f4-4d73-8f02-8a08d111e778";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/7e4f1692c4391571f856ac0eba25e5d83061eb0570900af4d8754859e9857318/GetPublication?filename=Uittreksels_02-02-2022_78150.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99a1d4db-06f4-4d73-8f02-8a08d111e778>.
+    
+<http://data.lblod.info/id/remote-data-objects/13c4cce0-f320-4c00-a9bc-749a454afee9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13c4cce0-f320-4c00-a9bc-749a454afee9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/7e4f1692c4391571f856ac0eba25e5d83061eb0570900af4d8754859e9857318/GetPublication?filename=Uittreksels_02-03-2022_78504.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13c4cce0-f320-4c00-a9bc-749a454afee9>.
+    
+<http://data.lblod.info/id/remote-data-objects/611c0071-317c-4e01-b677-65ea8e2e736a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "611c0071-317c-4e01-b677-65ea8e2e736a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/7e4f1692c4391571f856ac0eba25e5d83061eb0570900af4d8754859e9857318/GetPublication?filename=Uittreksels_26-11-2021_77454.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/611c0071-317c-4e01-b677-65ea8e2e736a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba4eadbd-02e6-41ca-9d29-0b2af3ee55ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba4eadbd-02e6-41ca-9d29-0b2af3ee55ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba4eadbd-02e6-41ca-9d29-0b2af3ee55ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff75747c-0fdc-4ec0-956a-39c25cf79780> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff75747c-0fdc-4ec0-956a-39c25cf79780";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff75747c-0fdc-4ec0-956a-39c25cf79780>.
+    
+<http://data.lblod.info/id/remote-data-objects/c094f6fa-ac29-404e-9c87-b74ac9c23cd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c094f6fa-ac29-404e-9c87-b74ac9c23cd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c094f6fa-ac29-404e-9c87-b74ac9c23cd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c3378e9-1009-41b6-be2f-31de64caaecc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c3378e9-1009-41b6-be2f-31de64caaecc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c3378e9-1009-41b6-be2f-31de64caaecc>.
+    
+<http://data.lblod.info/id/remote-data-objects/36f07dbe-c9de-4c3b-a074-60451f65a12c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36f07dbe-c9de-4c3b-a074-60451f65a12c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36f07dbe-c9de-4c3b-a074-60451f65a12c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cf69a3f-afb1-4d05-939f-c2fad5e45a27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cf69a3f-afb1-4d05-939f-c2fad5e45a27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cf69a3f-afb1-4d05-939f-c2fad5e45a27>.
+    
+<http://data.lblod.info/id/remote-data-objects/193466d3-128e-403e-89e6-684ee3b68bda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "193466d3-128e-403e-89e6-684ee3b68bda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/193466d3-128e-403e-89e6-684ee3b68bda>.
+    
+<http://data.lblod.info/id/remote-data-objects/c897991a-b526-4905-b263-8b4663c5a2c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c897991a-b526-4905-b263-8b4663c5a2c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c897991a-b526-4905-b263-8b4663c5a2c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c67c5aae-5d50-40e3-967d-97b276171ce1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c67c5aae-5d50-40e3-967d-97b276171ce1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c67c5aae-5d50-40e3-967d-97b276171ce1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac666a6e-df84-429b-b3ff-9a17de4e06a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac666a6e-df84-429b-b3ff-9a17de4e06a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac666a6e-df84-429b-b3ff-9a17de4e06a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb078ac1-67d4-4d53-9b81-0d590ecbecc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb078ac1-67d4-4d53-9b81-0d590ecbecc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb078ac1-67d4-4d53-9b81-0d590ecbecc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f41a0e3f-e3fd-4e82-b5b2-8335b52863fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f41a0e3f-e3fd-4e82-b5b2-8335b52863fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f41a0e3f-e3fd-4e82-b5b2-8335b52863fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5d256a1-ea62-4df1-941b-ebbcb8186cd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5d256a1-ea62-4df1-941b-ebbcb8186cd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5d256a1-ea62-4df1-941b-ebbcb8186cd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/26fd10f9-8b87-4832-9e58-1d4a5a7e142c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26fd10f9-8b87-4832-9e58-1d4a5a7e142c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26fd10f9-8b87-4832-9e58-1d4a5a7e142c>.
+    
+<http://data.lblod.info/id/remote-data-objects/317f5b5a-abfa-417b-aa18-72c91f4c64fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "317f5b5a-abfa-417b-aa18-72c91f4c64fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/317f5b5a-abfa-417b-aa18-72c91f4c64fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f4d79c4-ada0-40a7-af75-06a8e3e7e658> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f4d79c4-ada0-40a7-af75-06a8e3e7e658";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f4d79c4-ada0-40a7-af75-06a8e3e7e658>.
+    
+<http://data.lblod.info/id/remote-data-objects/add6c4a6-a3ed-4535-b0c6-07eec481ce29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "add6c4a6-a3ed-4535-b0c6-07eec481ce29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/add6c4a6-a3ed-4535-b0c6-07eec481ce29>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab131927-dd77-44a3-a90f-d1d1a1ec6f41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab131927-dd77-44a3-a90f-d1d1a1ec6f41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab131927-dd77-44a3-a90f-d1d1a1ec6f41>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4acf490-343b-4c84-b241-3f1d5d6ac0b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4acf490-343b-4c84-b241-3f1d5d6ac0b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4acf490-343b-4c84-b241-3f1d5d6ac0b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/895f1dee-2a7b-4f60-86b2-f3030c53ed21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "895f1dee-2a7b-4f60-86b2-f3030c53ed21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/895f1dee-2a7b-4f60-86b2-f3030c53ed21>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5537e13-889b-40dc-9438-15a3bdea92c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5537e13-889b-40dc-9438-15a3bdea92c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5537e13-889b-40dc-9438-15a3bdea92c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/06d2a3b6-8404-49fe-8cb3-b437de9855a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06d2a3b6-8404-49fe-8cb3-b437de9855a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06d2a3b6-8404-49fe-8cb3-b437de9855a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca11badf-1d02-4238-bc9a-e1242d2732d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca11badf-1d02-4238-bc9a-e1242d2732d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca11badf-1d02-4238-bc9a-e1242d2732d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/de3da557-71d8-4bcc-9b61-cfea875b431f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de3da557-71d8-4bcc-9b61-cfea875b431f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de3da557-71d8-4bcc-9b61-cfea875b431f>.
+    
+<http://data.lblod.info/id/remote-data-objects/33025760-01cb-4645-afb5-36ba32b95347> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33025760-01cb-4645-afb5-36ba32b95347";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33025760-01cb-4645-afb5-36ba32b95347>.
+    
+<http://data.lblod.info/id/remote-data-objects/73b0060e-d66b-41f8-82b4-447e02825154> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73b0060e-d66b-41f8-82b4-447e02825154";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73b0060e-d66b-41f8-82b4-447e02825154>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0e89658-44e0-49db-b270-54fec5ad2bcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0e89658-44e0-49db-b270-54fec5ad2bcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0e89658-44e0-49db-b270-54fec5ad2bcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d268f0e-395d-4b44-9388-ac98ce2313a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d268f0e-395d-4b44-9388-ac98ce2313a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d268f0e-395d-4b44-9388-ac98ce2313a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/94497f43-a6b9-4f42-97cf-14dafe1ea029> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94497f43-a6b9-4f42-97cf-14dafe1ea029";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94497f43-a6b9-4f42-97cf-14dafe1ea029>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4d0b5a7-a66c-4e88-a798-112dea81e8d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4d0b5a7-a66c-4e88-a798-112dea81e8d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4d0b5a7-a66c-4e88-a798-112dea81e8d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b1610a8-6e3f-47aa-ae0c-c15e3ba877ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b1610a8-6e3f-47aa-ae0c-c15e3ba877ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b1610a8-6e3f-47aa-ae0c-c15e3ba877ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0fd9ee1-a392-4778-8eb5-6ccbf14f8846> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0fd9ee1-a392-4778-8eb5-6ccbf14f8846";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8068f1ae-bcfa-4771-865c-9bb45604bfe0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0fd9ee1-a392-4778-8eb5-6ccbf14f8846>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201355-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201355-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201355-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201355-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2cdd8073-72c7-4427-9773-34ba7b040d35> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2cdd8073-72c7-4427-9773-34ba7b040d35";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a961955d-692e-44da-8fba-accdd12c9f97";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/cb4073c7-be03-4b63-8ec9-15f22f381d7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cb4073c7-be03-4b63-8ec9-15f22f381d7e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97>.
+
+  <http://redpencil.data.gift/id/task/11d06c3c-c53a-41e9-83bc-fe72e39b485b> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "11d06c3c-c53a-41e9-83bc-fe72e39b485b";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2cdd8073-72c7-4427-9773-34ba7b040d35>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/cb4073c7-be03-4b63-8ec9-15f22f381d7e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/dbafcdc0-524f-4ad0-884a-e1f7be8308f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbafcdc0-524f-4ad0-884a-e1f7be8308f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbafcdc0-524f-4ad0-884a-e1f7be8308f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca4f48c1-2f76-4e31-9f63-32383db519e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca4f48c1-2f76-4e31-9f63-32383db519e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca4f48c1-2f76-4e31-9f63-32383db519e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/549ff912-2a02-4e47-a02f-4936d238bb64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "549ff912-2a02-4e47-a02f-4936d238bb64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/549ff912-2a02-4e47-a02f-4936d238bb64>.
+    
+<http://data.lblod.info/id/remote-data-objects/e90b3bb7-04f8-4f33-9832-34ffa59174bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e90b3bb7-04f8-4f33-9832-34ffa59174bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e90b3bb7-04f8-4f33-9832-34ffa59174bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/145a4810-15b9-4eec-b5de-8c5062e91f08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "145a4810-15b9-4eec-b5de-8c5062e91f08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/145a4810-15b9-4eec-b5de-8c5062e91f08>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3b324a2-73c6-4dc2-8a3d-fa853b2f4813> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3b324a2-73c6-4dc2-8a3d-fa853b2f4813";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3b324a2-73c6-4dc2-8a3d-fa853b2f4813>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ec21dd5-1831-4c5e-a082-1b026e7f41d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ec21dd5-1831-4c5e-a082-1b026e7f41d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ec21dd5-1831-4c5e-a082-1b026e7f41d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5a56abe-21d6-4f4b-beb3-142794c40a55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5a56abe-21d6-4f4b-beb3-142794c40a55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_05-10-2021_76774.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5a56abe-21d6-4f4b-beb3-142794c40a55>.
+    
+<http://data.lblod.info/id/remote-data-objects/42d9d22f-d12d-4ffd-9ab7-8e904222c24e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42d9d22f-d12d-4ffd-9ab7-8e904222c24e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_07-06-2022_82338.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42d9d22f-d12d-4ffd-9ab7-8e904222c24e>.
+    
+<http://data.lblod.info/id/remote-data-objects/af989465-1fe3-4e80-8701-bdbb342c6f46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af989465-1fe3-4e80-8701-bdbb342c6f46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_08-03-2022_78509.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af989465-1fe3-4e80-8701-bdbb342c6f46>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4c1359c-41d0-484c-b158-12172b698f2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4c1359c-41d0-484c-b158-12172b698f2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_14-06-2022_82304.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4c1359c-41d0-484c-b158-12172b698f2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4efeebce-1901-44e4-89c5-c61ef6597742> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4efeebce-1901-44e4-89c5-c61ef6597742";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_14-06-2022_82305.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4efeebce-1901-44e4-89c5-c61ef6597742>.
+    
+<http://data.lblod.info/id/remote-data-objects/341a94a2-c144-4ab2-81bf-535e94de92b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "341a94a2-c144-4ab2-81bf-535e94de92b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_14-06-2022_82433.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/341a94a2-c144-4ab2-81bf-535e94de92b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b22c5db-310f-44a0-8cbf-d20551449d0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b22c5db-310f-44a0-8cbf-d20551449d0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_15-03-2022_78558.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b22c5db-310f-44a0-8cbf-d20551449d0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/019f7af2-6622-48a1-95a9-67c01b76c4c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "019f7af2-6622-48a1-95a9-67c01b76c4c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_17-05-2022_82021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/019f7af2-6622-48a1-95a9-67c01b76c4c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a779247f-6124-4d38-acd6-d7038cae266f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a779247f-6124-4d38-acd6-d7038cae266f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_17-05-2022_82025.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a779247f-6124-4d38-acd6-d7038cae266f>.
+    
+<http://data.lblod.info/id/remote-data-objects/80b8b5be-0134-46e6-96fe-4845362a709f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80b8b5be-0134-46e6-96fe-4845362a709f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_17-05-2022_82026.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80b8b5be-0134-46e6-96fe-4845362a709f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bb1db52-00e9-413e-a978-87cedcba904b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bb1db52-00e9-413e-a978-87cedcba904b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_17-05-2022_82029.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bb1db52-00e9-413e-a978-87cedcba904b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae60e3c4-6c25-4ae8-9c22-0dd0f732e5b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae60e3c4-6c25-4ae8-9c22-0dd0f732e5b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_17-05-2022_82031.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae60e3c4-6c25-4ae8-9c22-0dd0f732e5b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4532920-bfc2-4cc7-8b51-ae2113dba54c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4532920-bfc2-4cc7-8b51-ae2113dba54c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_19-07-2022_82971.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4532920-bfc2-4cc7-8b51-ae2113dba54c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1debcab5-365d-4064-b131-187e9ae2f8ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1debcab5-365d-4064-b131-187e9ae2f8ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_19-07-2022_82972.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1debcab5-365d-4064-b131-187e9ae2f8ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/74da91ec-ad17-4416-81ba-92801675bf3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74da91ec-ad17-4416-81ba-92801675bf3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_19-10-2021_76970.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74da91ec-ad17-4416-81ba-92801675bf3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/04f78fa4-347a-466a-94dd-4573a4dc3198> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04f78fa4-347a-466a-94dd-4573a4dc3198";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_19-10-2021_77005.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04f78fa4-347a-466a-94dd-4573a4dc3198>.
+    
+<http://data.lblod.info/id/remote-data-objects/65c1ea97-e901-41c4-b016-437583f25dc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65c1ea97-e901-41c4-b016-437583f25dc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_21-12-2021_77335.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65c1ea97-e901-41c4-b016-437583f25dc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4fcb4ec-5b8d-462e-be08-9dfc850eb999> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4fcb4ec-5b8d-462e-be08-9dfc850eb999";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_22-02-2022_78365.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4fcb4ec-5b8d-462e-be08-9dfc850eb999>.
+    
+<http://data.lblod.info/id/remote-data-objects/09bfbb42-c390-4fab-a09d-3763d8f415c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09bfbb42-c390-4fab-a09d-3763d8f415c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_22-03-2022_78559.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09bfbb42-c390-4fab-a09d-3763d8f415c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/73494e97-d04c-4839-8916-041cd49cdf29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73494e97-d04c-4839-8916-041cd49cdf29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_26-04-2022_81767.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73494e97-d04c-4839-8916-041cd49cdf29>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3a58dc5-a653-4c4c-86ef-6650679ff0cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3a58dc5-a653-4c4c-86ef-6650679ff0cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_28-06-2022_82084.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3a58dc5-a653-4c4c-86ef-6650679ff0cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2d54ad2-af3b-4ad1-bd78-15e77f40f1fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2d54ad2-af3b-4ad1-bd78-15e77f40f1fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_28-06-2022_82575.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2d54ad2-af3b-4ad1-bd78-15e77f40f1fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/b33b01a7-2477-4ae1-a572-72ac2353f489> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b33b01a7-2477-4ae1-a572-72ac2353f489";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_28-06-2022_82576.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b33b01a7-2477-4ae1-a572-72ac2353f489>.
+    
+<http://data.lblod.info/id/remote-data-objects/69d0621c-b6e4-4b1e-b110-9b81a812daba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69d0621c-b6e4-4b1e-b110-9b81a812daba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.harelbeke.be/LBLODWeb/Home/Overzicht/b11b4f99470c85fb73d881b965bd0f24c197c84ffc068d5d6bad94b910763d9c/GetPublication?filename=Uittreksels_28-06-2022_82577.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69d0621c-b6e4-4b1e-b110-9b81a812daba>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b9916c7-f6c7-45af-a4a4-c5450902f790> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b9916c7-f6c7-45af-a4a4-c5450902f790";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Agenda_Gemeenteraad_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b9916c7-f6c7-45af-a4a4-c5450902f790>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb48ee4f-7e37-4d32-8db3-e1d50cc91337> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb48ee4f-7e37-4d32-8db3-e1d50cc91337";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Agenda_Gemeenteraad_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb48ee4f-7e37-4d32-8db3-e1d50cc91337>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c61c2cd-dbd7-4591-8da7-91714c2cd338> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c61c2cd-dbd7-4591-8da7-91714c2cd338";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Agenda_Gemeenteraad_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c61c2cd-dbd7-4591-8da7-91714c2cd338>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff4f0565-3d7e-4086-b2ac-6b1d410251ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff4f0565-3d7e-4086-b2ac-6b1d410251ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Agenda_Gemeenteraad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff4f0565-3d7e-4086-b2ac-6b1d410251ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/642b67b3-26bd-4c47-bae0-14a7025e1422> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "642b67b3-26bd-4c47-bae0-14a7025e1422";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Agenda_Gemeenteraad_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/642b67b3-26bd-4c47-bae0-14a7025e1422>.
+    
+<http://data.lblod.info/id/remote-data-objects/a41de80a-c5dc-43ce-b067-862a77c55ba3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a41de80a-c5dc-43ce-b067-862a77c55ba3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Agenda_Gemeenteraad_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a41de80a-c5dc-43ce-b067-862a77c55ba3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e123ef8c-e2d2-47a1-83ae-286a43cbd810> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e123ef8c-e2d2-47a1-83ae-286a43cbd810";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Agenda_Gemeenteraad_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e123ef8c-e2d2-47a1-83ae-286a43cbd810>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7031587-a9eb-4378-a5ce-65af46768cb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7031587-a9eb-4378-a5ce-65af46768cb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Agenda_Gemeenteraad_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7031587-a9eb-4378-a5ce-65af46768cb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1bf710e-9228-40a6-9b41-c3d94ebf850d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1bf710e-9228-40a6-9b41-c3d94ebf850d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Agenda_Gemeenteraad_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1bf710e-9228-40a6-9b41-c3d94ebf850d>.
+    
+<http://data.lblod.info/id/remote-data-objects/37f660e3-37f2-48d0-b592-34d436481c46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37f660e3-37f2-48d0-b592-34d436481c46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=BesluitenLijst_Gemeenteraad_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37f660e3-37f2-48d0-b592-34d436481c46>.
+    
+<http://data.lblod.info/id/remote-data-objects/19a77742-3e8a-493e-9489-7def21a6e3d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19a77742-3e8a-493e-9489-7def21a6e3d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=BesluitenLijst_Gemeenteraad_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19a77742-3e8a-493e-9489-7def21a6e3d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cae12a9-f4ae-4d0e-a449-5e39afc7ff71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cae12a9-f4ae-4d0e-a449-5e39afc7ff71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=BesluitenLijst_Gemeenteraad_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cae12a9-f4ae-4d0e-a449-5e39afc7ff71>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb08b6fa-2a03-475b-8912-ef7155871035> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb08b6fa-2a03-475b-8912-ef7155871035";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=BesluitenLijst_Gemeenteraad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb08b6fa-2a03-475b-8912-ef7155871035>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e6567d2-8c6f-4cfc-9f45-a82409a3710c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e6567d2-8c6f-4cfc-9f45-a82409a3710c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e6567d2-8c6f-4cfc-9f45-a82409a3710c>.
+    
+<http://data.lblod.info/id/remote-data-objects/69b14802-ba0c-4713-9b4b-776a9f239578> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69b14802-ba0c-4713-9b4b-776a9f239578";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69b14802-ba0c-4713-9b4b-776a9f239578>.
+    
+<http://data.lblod.info/id/remote-data-objects/74d0b9cc-c399-4065-96fd-f39dffbf73ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74d0b9cc-c399-4065-96fd-f39dffbf73ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74d0b9cc-c399-4065-96fd-f39dffbf73ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bc359c8-f35f-4fa7-8119-c8bf14f2487d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bc359c8-f35f-4fa7-8119-c8bf14f2487d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=BesluitenLijst_Gemeenteraad_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bc359c8-f35f-4fa7-8119-c8bf14f2487d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d172a71-68f5-4049-a75e-9bfbb6b762f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d172a71-68f5-4049-a75e-9bfbb6b762f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d172a71-68f5-4049-a75e-9bfbb6b762f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/97a3fa27-ec20-4f49-9f18-015ce8e39c92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97a3fa27-ec20-4f49-9f18-015ce8e39c92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Notulen_Gemeenteraad_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a961955d-692e-44da-8fba-accdd12c9f97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97a3fa27-ec20-4f49-9f18-015ce8e39c92>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201356-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201356-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201356-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201356-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f995b370-0fbb-4537-b392-2d8923eb4216> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f995b370-0fbb-4537-b392-2d8923eb4216";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d2a9b711-8441-4189-96b9-dd35f609388e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6d77f157-e7c8-4c55-ac79-443983aa0c0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6d77f157-e7c8-4c55-ac79-443983aa0c0f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e>.
+
+  <http://redpencil.data.gift/id/task/716b0f89-492e-4ade-8388-66db3238fa98> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "716b0f89-492e-4ade-8388-66db3238fa98";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f995b370-0fbb-4537-b392-2d8923eb4216>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6d77f157-e7c8-4c55-ac79-443983aa0c0f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e25ba203-0e9e-4df7-8775-9a87ca0e3490> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e25ba203-0e9e-4df7-8775-9a87ca0e3490";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_18-05-2022_17478.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e25ba203-0e9e-4df7-8775-9a87ca0e3490>.
+    
+<http://data.lblod.info/id/remote-data-objects/d592dc33-ad98-464b-86c0-2803a8887915> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d592dc33-ad98-464b-86c0-2803a8887915";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_18-05-2022_17483.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d592dc33-ad98-464b-86c0-2803a8887915>.
+    
+<http://data.lblod.info/id/remote-data-objects/751b5b81-c72b-4fe4-b1a4-9ec63b9b12ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "751b5b81-c72b-4fe4-b1a4-9ec63b9b12ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-06-2022_17610.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/751b5b81-c72b-4fe4-b1a4-9ec63b9b12ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/8162080d-2161-42fb-ad23-6c7c8256aa9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8162080d-2161-42fb-ad23-6c7c8256aa9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-06-2022_17624.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8162080d-2161-42fb-ad23-6c7c8256aa9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/168d6ce1-1007-4b1f-b415-803d0654625a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "168d6ce1-1007-4b1f-b415-803d0654625a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-06-2022_17660.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/168d6ce1-1007-4b1f-b415-803d0654625a>.
+    
+<http://data.lblod.info/id/remote-data-objects/89fe9717-5837-4992-80da-67151a51a8e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89fe9717-5837-4992-80da-67151a51a8e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-06-2022_17661.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89fe9717-5837-4992-80da-67151a51a8e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9748820a-6925-4027-9b78-167067e1593d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9748820a-6925-4027-9b78-167067e1593d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-06-2022_17751.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9748820a-6925-4027-9b78-167067e1593d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecff5979-bf30-4996-a9b8-7aa52ef43a6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecff5979-bf30-4996-a9b8-7aa52ef43a6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-06-2022_17829.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecff5979-bf30-4996-a9b8-7aa52ef43a6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/88725dda-e200-4325-8603-98334e012af7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88725dda-e200-4325-8603-98334e012af7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-06-2022_17859.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88725dda-e200-4325-8603-98334e012af7>.
+    
+<http://data.lblod.info/id/remote-data-objects/73742950-7191-4d39-9a61-e19464a0d08f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73742950-7191-4d39-9a61-e19464a0d08f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15079.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73742950-7191-4d39-9a61-e19464a0d08f>.
+    
+<http://data.lblod.info/id/remote-data-objects/18ae291b-9d62-41a3-b59c-a06b5dcbc64e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18ae291b-9d62-41a3-b59c-a06b5dcbc64e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15896.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18ae291b-9d62-41a3-b59c-a06b5dcbc64e>.
+    
+<http://data.lblod.info/id/remote-data-objects/770021c8-217e-40d5-80bf-892a1ce1b929> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "770021c8-217e-40d5-80bf-892a1ce1b929";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15897.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/770021c8-217e-40d5-80bf-892a1ce1b929>.
+    
+<http://data.lblod.info/id/remote-data-objects/885ce3fd-2951-4c29-852d-a363de62038a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "885ce3fd-2951-4c29-852d-a363de62038a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15898.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/885ce3fd-2951-4c29-852d-a363de62038a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca7b2c0d-e0a4-4365-8847-fbe8a0061e4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca7b2c0d-e0a4-4365-8847-fbe8a0061e4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15899.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca7b2c0d-e0a4-4365-8847-fbe8a0061e4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d233f67-f233-4a29-a3cf-6c131ca59575> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d233f67-f233-4a29-a3cf-6c131ca59575";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15900.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d233f67-f233-4a29-a3cf-6c131ca59575>.
+    
+<http://data.lblod.info/id/remote-data-objects/e064b26f-4fc9-41af-ace1-612cae9d0343> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e064b26f-4fc9-41af-ace1-612cae9d0343";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15901.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e064b26f-4fc9-41af-ace1-612cae9d0343>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8fc1d7c-acf1-4a7a-9e3b-28c9d82c5cc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8fc1d7c-acf1-4a7a-9e3b-28c9d82c5cc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15902.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8fc1d7c-acf1-4a7a-9e3b-28c9d82c5cc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/bccfdff6-5391-4c2a-8425-8f5eab090927> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bccfdff6-5391-4c2a-8425-8f5eab090927";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15903.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bccfdff6-5391-4c2a-8425-8f5eab090927>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1dec737-4990-46d1-a08b-c991c20dbc1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1dec737-4990-46d1-a08b-c991c20dbc1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15904.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1dec737-4990-46d1-a08b-c991c20dbc1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/862edbd7-75c5-4a5a-a1be-16aa56168c14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "862edbd7-75c5-4a5a-a1be-16aa56168c14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15905.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/862edbd7-75c5-4a5a-a1be-16aa56168c14>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac4d4e71-d3a8-4d6d-bc40-03a19e2d123d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac4d4e71-d3a8-4d6d-bc40-03a19e2d123d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15906.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac4d4e71-d3a8-4d6d-bc40-03a19e2d123d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e490f719-a21f-47b8-8a41-3a6edbb99ac7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e490f719-a21f-47b8-8a41-3a6edbb99ac7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15907.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e490f719-a21f-47b8-8a41-3a6edbb99ac7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea459ca3-6c40-4a4f-aefc-df852dba515a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea459ca3-6c40-4a4f-aefc-df852dba515a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15908.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea459ca3-6c40-4a4f-aefc-df852dba515a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d943d0d-78ab-43b4-9acc-a97f9a520ee7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d943d0d-78ab-43b4-9acc-a97f9a520ee7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15909.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d943d0d-78ab-43b4-9acc-a97f9a520ee7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2d0eabd-0d2e-437b-bde4-6b44f4702e4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2d0eabd-0d2e-437b-bde4-6b44f4702e4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15910.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2d0eabd-0d2e-437b-bde4-6b44f4702e4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6945334e-6d04-4fa2-b17c-74c086333559> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6945334e-6d04-4fa2-b17c-74c086333559";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15911.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6945334e-6d04-4fa2-b17c-74c086333559>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4928f88-4cb7-4afb-9429-53e85a291ad7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4928f88-4cb7-4afb-9429-53e85a291ad7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15912.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4928f88-4cb7-4afb-9429-53e85a291ad7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e76cb19a-c865-4b79-bde0-01f4536887a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e76cb19a-c865-4b79-bde0-01f4536887a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15913.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e76cb19a-c865-4b79-bde0-01f4536887a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3775209-4b15-41c6-97ff-1cc8c36ba356> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3775209-4b15-41c6-97ff-1cc8c36ba356";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15914.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3775209-4b15-41c6-97ff-1cc8c36ba356>.
+    
+<http://data.lblod.info/id/remote-data-objects/06f5e4a8-9de0-4a2e-871d-c6511137a5d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06f5e4a8-9de0-4a2e-871d-c6511137a5d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15920.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06f5e4a8-9de0-4a2e-871d-c6511137a5d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e964c931-ca4f-4972-a154-f183a18365cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e964c931-ca4f-4972-a154-f183a18365cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15921.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e964c931-ca4f-4972-a154-f183a18365cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4a551f0-e224-4e9e-ad48-c8c4de66d0af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4a551f0-e224-4e9e-ad48-c8c4de66d0af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15944.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4a551f0-e224-4e9e-ad48-c8c4de66d0af>.
+    
+<http://data.lblod.info/id/remote-data-objects/36794dc9-da8a-4a8d-8a08-b849b209bc2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36794dc9-da8a-4a8d-8a08-b849b209bc2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_22-12-2021_15957.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36794dc9-da8a-4a8d-8a08-b849b209bc2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b65f543e-b90e-4a5d-88f0-9d7436c5b514> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b65f543e-b90e-4a5d-88f0-9d7436c5b514";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_23-02-2022_16447.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b65f543e-b90e-4a5d-88f0-9d7436c5b514>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf193c90-6dff-4505-87e4-f0aa341754ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf193c90-6dff-4505-87e4-f0aa341754ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_23-02-2022_16460.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf193c90-6dff-4505-87e4-f0aa341754ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5f62ab3-3943-4461-b117-97bef6eecf2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5f62ab3-3943-4461-b117-97bef6eecf2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_23-02-2022_16642.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5f62ab3-3943-4461-b117-97bef6eecf2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba127cc3-7f52-4467-807e-836ee02bcde9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba127cc3-7f52-4467-807e-836ee02bcde9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_23-02-2022_16648.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba127cc3-7f52-4467-807e-836ee02bcde9>.
+    
+<http://data.lblod.info/id/remote-data-objects/31120abe-ba32-4a1c-bc94-577e5d9c052c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31120abe-ba32-4a1c-bc94-577e5d9c052c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_23-02-2022_16649.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31120abe-ba32-4a1c-bc94-577e5d9c052c>.
+    
+<http://data.lblod.info/id/remote-data-objects/31a03857-05bf-41fa-ac58-49cfd53ae888> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31a03857-05bf-41fa-ac58-49cfd53ae888";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_23-03-2022_16850.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31a03857-05bf-41fa-ac58-49cfd53ae888>.
+    
+<http://data.lblod.info/id/remote-data-objects/c769cd65-9d38-4709-8b5e-68f3a54144d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c769cd65-9d38-4709-8b5e-68f3a54144d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_23-03-2022_16903.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c769cd65-9d38-4709-8b5e-68f3a54144d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9598fcb3-8e63-4858-aa99-1b21bb0e4c1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9598fcb3-8e63-4858-aa99-1b21bb0e4c1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_23-03-2022_16916.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9598fcb3-8e63-4858-aa99-1b21bb0e4c1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/69a9de34-4ab7-4c8c-829f-9acdab23b12d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69a9de34-4ab7-4c8c-829f-9acdab23b12d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_23-03-2022_16924.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69a9de34-4ab7-4c8c-829f-9acdab23b12d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d86dd823-8ed7-4ba3-bf68-db0b8421596c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d86dd823-8ed7-4ba3-bf68-db0b8421596c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_23-03-2022_16925.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d86dd823-8ed7-4ba3-bf68-db0b8421596c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f533483-c8d3-44e0-96d1-ba370193ae40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f533483-c8d3-44e0-96d1-ba370193ae40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_23-03-2022_16926.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f533483-c8d3-44e0-96d1-ba370193ae40>.
+    
+<http://data.lblod.info/id/remote-data-objects/03423bfd-5d8e-4456-b707-d70bdc892b4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03423bfd-5d8e-4456-b707-d70bdc892b4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_23-03-2022_16927.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03423bfd-5d8e-4456-b707-d70bdc892b4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b583d859-07ab-4668-b6e5-341df440b070> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b583d859-07ab-4668-b6e5-341df440b070";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_23-03-2022_16928.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b583d859-07ab-4668-b6e5-341df440b070>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae1421b0-3817-4d2e-b5f3-29f4ac8f4e4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae1421b0-3817-4d2e-b5f3-29f4ac8f4e4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_23-03-2022_16929.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae1421b0-3817-4d2e-b5f3-29f4ac8f4e4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/eea75801-9ba3-46ff-95ff-7bed1c576fa5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eea75801-9ba3-46ff-95ff-7bed1c576fa5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_23-03-2022_16930.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eea75801-9ba3-46ff-95ff-7bed1c576fa5>.
+    
+<http://data.lblod.info/id/remote-data-objects/140fb995-895a-4e21-ba18-5bb8ba02f888> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "140fb995-895a-4e21-ba18-5bb8ba02f888";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_23-03-2022_16931.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/140fb995-895a-4e21-ba18-5bb8ba02f888>.
+    
+<http://data.lblod.info/id/remote-data-objects/31fa44c9-a29d-4b43-bfa5-1e920f78cdb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31fa44c9-a29d-4b43-bfa5-1e920f78cdb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_24-11-2021_15632.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d2a9b711-8441-4189-96b9-dd35f609388e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31fa44c9-a29d-4b43-bfa5-1e920f78cdb7>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201358-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201358-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201358-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201358-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f8a57d7a-e8f6-4e2b-ac5a-366e73f59778> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f8a57d7a-e8f6-4e2b-ac5a-366e73f59778";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dda5380c-b08a-4d42-9c84-5a1841c60ac7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/94d595c4-95e4-4ab9-952d-927f0a4c59ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "94d595c4-95e4-4ab9-952d-927f0a4c59ab";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7>.
+
+  <http://redpencil.data.gift/id/task/03788b11-c328-4a6f-9ed9-7ab7d6167310> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "03788b11-c328-4a6f-9ed9-7ab7d6167310";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f8a57d7a-e8f6-4e2b-ac5a-366e73f59778>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/94d595c4-95e4-4ab9-952d-927f0a4c59ab>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/123aca77-0b56-4855-96ba-6ab342ef167f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "123aca77-0b56-4855-96ba-6ab342ef167f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_24-11-2021_15633.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/123aca77-0b56-4855-96ba-6ab342ef167f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1b95f58-1de1-42b3-afa8-ea873104f2e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1b95f58-1de1-42b3-afa8-ea873104f2e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_24-11-2021_15634.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1b95f58-1de1-42b3-afa8-ea873104f2e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c022a39-0c94-4fe6-b6f9-22d4e480cc64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c022a39-0c94-4fe6-b6f9-22d4e480cc64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_24-11-2021_15635.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c022a39-0c94-4fe6-b6f9-22d4e480cc64>.
+    
+<http://data.lblod.info/id/remote-data-objects/e137c9b6-88a9-4d09-841d-c5b755a56197> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e137c9b6-88a9-4d09-841d-c5b755a56197";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_24-11-2021_15636.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e137c9b6-88a9-4d09-841d-c5b755a56197>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c0686c8-1d74-4ded-a287-43ca4feebcd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c0686c8-1d74-4ded-a287-43ca4feebcd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_24-11-2021_15637.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c0686c8-1d74-4ded-a287-43ca4feebcd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a8ff8f6-a890-49c4-8387-6370e3032bcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a8ff8f6-a890-49c4-8387-6370e3032bcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_24-11-2021_15638.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a8ff8f6-a890-49c4-8387-6370e3032bcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/77490701-6ed8-4e83-a997-dd27b2fd24ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77490701-6ed8-4e83-a997-dd27b2fd24ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/2d2d5f23e64db9e744e3277fbc20b26c0116c419200a4071795bbfea5989208c/GetPublication?filename=Uittreksels_24-11-2021_15639.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77490701-6ed8-4e83-a997-dd27b2fd24ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/90f2f53d-ce59-4eaa-abc3-cacefd1be4f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90f2f53d-ce59-4eaa-abc3-cacefd1be4f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90f2f53d-ce59-4eaa-abc3-cacefd1be4f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/83b732d3-1cff-423c-9881-8d271e2dac19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83b732d3-1cff-423c-9881-8d271e2dac19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_01-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83b732d3-1cff-423c-9881-8d271e2dac19>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2f97284-7de1-43cd-a204-8677906791c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2f97284-7de1-43cd-a204-8677906791c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_02-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2f97284-7de1-43cd-a204-8677906791c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d8f37c3-f001-4ff9-a14c-1b9c8d2cd36c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d8f37c3-f001-4ff9-a14c-1b9c8d2cd36c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_02-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d8f37c3-f001-4ff9-a14c-1b9c8d2cd36c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d598c3ef-418b-4331-aeb8-21f01edbade4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d598c3ef-418b-4331-aeb8-21f01edbade4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d598c3ef-418b-4331-aeb8-21f01edbade4>.
+    
+<http://data.lblod.info/id/remote-data-objects/baee3a78-24a7-4ec3-a532-856d0203f497> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "baee3a78-24a7-4ec3-a532-856d0203f497";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/baee3a78-24a7-4ec3-a532-856d0203f497>.
+    
+<http://data.lblod.info/id/remote-data-objects/f03da8cb-4040-44cd-8282-46dd7f90ca2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f03da8cb-4040-44cd-8282-46dd7f90ca2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f03da8cb-4040-44cd-8282-46dd7f90ca2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/598cacb4-0be2-4091-91e2-a1b9018cef67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "598cacb4-0be2-4091-91e2-a1b9018cef67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/598cacb4-0be2-4091-91e2-a1b9018cef67>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7242a10-3448-48d0-ae28-ad7c24a7f7b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7242a10-3448-48d0-ae28-ad7c24a7f7b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_06-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7242a10-3448-48d0-ae28-ad7c24a7f7b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fd8e167-ae3a-40be-b385-3f117b14a7fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fd8e167-ae3a-40be-b385-3f117b14a7fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fd8e167-ae3a-40be-b385-3f117b14a7fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbc20998-9c6e-4241-91a9-10c8415555d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbc20998-9c6e-4241-91a9-10c8415555d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbc20998-9c6e-4241-91a9-10c8415555d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ecf6214-23d8-43d9-bcc4-aee33706c24e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ecf6214-23d8-43d9-bcc4-aee33706c24e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ecf6214-23d8-43d9-bcc4-aee33706c24e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b60de57a-5a3a-4d75-abc1-8d2490eda4b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b60de57a-5a3a-4d75-abc1-8d2490eda4b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b60de57a-5a3a-4d75-abc1-8d2490eda4b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/25baf168-2a9d-45fa-a701-f0b0c94e7ef8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25baf168-2a9d-45fa-a701-f0b0c94e7ef8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25baf168-2a9d-45fa-a701-f0b0c94e7ef8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2a26278-ebcc-4bb8-a2da-baafe34f8acf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2a26278-ebcc-4bb8-a2da-baafe34f8acf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2a26278-ebcc-4bb8-a2da-baafe34f8acf>.
+    
+<http://data.lblod.info/id/remote-data-objects/92871f7e-a82d-45a3-aeec-ea2b8e3cba58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92871f7e-a82d-45a3-aeec-ea2b8e3cba58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_12-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92871f7e-a82d-45a3-aeec-ea2b8e3cba58>.
+    
+<http://data.lblod.info/id/remote-data-objects/f92f77a4-51fb-48b4-875c-ced6e1b223cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f92f77a4-51fb-48b4-875c-ced6e1b223cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_13-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f92f77a4-51fb-48b4-875c-ced6e1b223cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/210b0bea-6209-4969-b9ae-c6760cccc9e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "210b0bea-6209-4969-b9ae-c6760cccc9e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/210b0bea-6209-4969-b9ae-c6760cccc9e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b846be9-43aa-4216-89b4-286eb9208071> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b846be9-43aa-4216-89b4-286eb9208071";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b846be9-43aa-4216-89b4-286eb9208071>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1de578b-9197-4460-8980-cc19c3edcde3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1de578b-9197-4460-8980-cc19c3edcde3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1de578b-9197-4460-8980-cc19c3edcde3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c98cf847-262a-4330-b6c3-dceae9d2b9cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c98cf847-262a-4330-b6c3-dceae9d2b9cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c98cf847-262a-4330-b6c3-dceae9d2b9cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fb5ca3d-323f-4aad-9a1e-54fd3845401d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fb5ca3d-323f-4aad-9a1e-54fd3845401d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fb5ca3d-323f-4aad-9a1e-54fd3845401d>.
+    
+<http://data.lblod.info/id/remote-data-objects/48c7bd0c-31a5-48cf-93cf-e2766e0f218b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48c7bd0c-31a5-48cf-93cf-e2766e0f218b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_16-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48c7bd0c-31a5-48cf-93cf-e2766e0f218b>.
+    
+<http://data.lblod.info/id/remote-data-objects/78728673-5ca4-4b56-9d42-bfb3b2fa2cc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78728673-5ca4-4b56-9d42-bfb3b2fa2cc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_16-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78728673-5ca4-4b56-9d42-bfb3b2fa2cc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7d0956c-8cbe-4ede-b772-32797e04dc28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7d0956c-8cbe-4ede-b772-32797e04dc28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7d0956c-8cbe-4ede-b772-32797e04dc28>.
+    
+<http://data.lblod.info/id/remote-data-objects/620a53db-52d1-47ed-bd94-bf8228d56916> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "620a53db-52d1-47ed-bd94-bf8228d56916";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/620a53db-52d1-47ed-bd94-bf8228d56916>.
+    
+<http://data.lblod.info/id/remote-data-objects/68360013-0f98-4165-a1e3-629d7eaf93ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68360013-0f98-4165-a1e3-629d7eaf93ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_19-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68360013-0f98-4165-a1e3-629d7eaf93ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc642df4-c668-447b-9eef-6bc706ebf4f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc642df4-c668-447b-9eef-6bc706ebf4f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc642df4-c668-447b-9eef-6bc706ebf4f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab6ed7df-e7d1-4ac2-a7ea-873d0a4febba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab6ed7df-e7d1-4ac2-a7ea-873d0a4febba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_20-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab6ed7df-e7d1-4ac2-a7ea-873d0a4febba>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b4085b9-9897-4f5b-ae08-15468d1679a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b4085b9-9897-4f5b-ae08-15468d1679a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_20-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b4085b9-9897-4f5b-ae08-15468d1679a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e295616d-a3be-4086-95b9-258e2b5a4c0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e295616d-a3be-4086-95b9-258e2b5a4c0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e295616d-a3be-4086-95b9-258e2b5a4c0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/348ec871-520a-4f91-b37b-7e3b210a80b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "348ec871-520a-4f91-b37b-7e3b210a80b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/348ec871-520a-4f91-b37b-7e3b210a80b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3acf6292-aa38-4869-87ba-fc2f8081aa13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3acf6292-aa38-4869-87ba-fc2f8081aa13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3acf6292-aa38-4869-87ba-fc2f8081aa13>.
+    
+<http://data.lblod.info/id/remote-data-objects/f586920b-629f-4a43-b54f-f4ff118edc6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f586920b-629f-4a43-b54f-f4ff118edc6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f586920b-629f-4a43-b54f-f4ff118edc6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6ff3080-0981-4a6b-a90f-7923329d6ac9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6ff3080-0981-4a6b-a90f-7923329d6ac9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6ff3080-0981-4a6b-a90f-7923329d6ac9>.
+    
+<http://data.lblod.info/id/remote-data-objects/cac84894-f803-4adf-86ee-ba7ea4c700d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cac84894-f803-4adf-86ee-ba7ea4c700d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cac84894-f803-4adf-86ee-ba7ea4c700d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3a9ffaa-4c98-4273-934f-19bb4694e78d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3a9ffaa-4c98-4273-934f-19bb4694e78d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3a9ffaa-4c98-4273-934f-19bb4694e78d>.
+    
+<http://data.lblod.info/id/remote-data-objects/85a8faa6-e5e6-484b-ac57-8789e5777e92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85a8faa6-e5e6-484b-ac57-8789e5777e92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85a8faa6-e5e6-484b-ac57-8789e5777e92>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9c43b43-b0be-450e-b6ce-bc25279d1b2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9c43b43-b0be-450e-b6ce-bc25279d1b2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9c43b43-b0be-450e-b6ce-bc25279d1b2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/99018380-5562-44e1-bbd9-c53ac9cbc7e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99018380-5562-44e1-bbd9-c53ac9cbc7e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99018380-5562-44e1-bbd9-c53ac9cbc7e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/82a3f12a-1158-49ee-bbb5-e86636e043b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82a3f12a-1158-49ee-bbb5-e86636e043b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82a3f12a-1158-49ee-bbb5-e86636e043b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2e52d43-89a1-4ab4-8d60-ce824f999d85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2e52d43-89a1-4ab4-8d60-ce824f999d85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_29-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2e52d43-89a1-4ab4-8d60-ce824f999d85>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ffaedaf-925c-4b64-a602-136ab039e92f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ffaedaf-925c-4b64-a602-136ab039e92f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=BesluitenLijst_College_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dda5380c-b08a-4d42-9c84-5a1841c60ac7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ffaedaf-925c-4b64-a602-136ab039e92f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201359-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201359-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201359-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201359-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c7c84afe-aaa2-4a99-91dc-cb7b83c8bcdc> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c7c84afe-aaa2-4a99-91dc-cb7b83c8bcdc";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d7334645-7861-4a73-982e-e10fe547c744";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9003e624-1354-4983-8caf-803b05b7b858> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9003e624-1354-4983-8caf-803b05b7b858";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744>.
+
+  <http://redpencil.data.gift/id/task/841a536a-1546-4079-a19f-17c92917d074> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "841a536a-1546-4079-a19f-17c92917d074";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c7c84afe-aaa2-4a99-91dc-cb7b83c8bcdc>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9003e624-1354-4983-8caf-803b05b7b858>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e1b1fdc3-a150-41f0-b5a3-c2a680534af2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1b1fdc3-a150-41f0-b5a3-c2a680534af2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_01-06-2022_17670.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1b1fdc3-a150-41f0-b5a3-c2a680534af2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3baff348-fcad-490c-b40c-e2ddd640d343> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3baff348-fcad-490c-b40c-e2ddd640d343";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_01-12-2021_15814.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3baff348-fcad-490c-b40c-e2ddd640d343>.
+    
+<http://data.lblod.info/id/remote-data-objects/e390ce2c-ff5e-4429-ae1f-74823ed9a679> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e390ce2c-ff5e-4429-ae1f-74823ed9a679";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_02-03-2022_16755.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e390ce2c-ff5e-4429-ae1f-74823ed9a679>.
+    
+<http://data.lblod.info/id/remote-data-objects/d45840a2-5ad6-4508-809a-4e1b86c02a2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d45840a2-5ad6-4508-809a-4e1b86c02a2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_04-05-2022_17398.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d45840a2-5ad6-4508-809a-4e1b86c02a2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a43c9cdb-dc89-4a9e-896f-c3570033a31d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a43c9cdb-dc89-4a9e-896f-c3570033a31d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_06-04-2022_17091.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a43c9cdb-dc89-4a9e-896f-c3570033a31d>.
+    
+<http://data.lblod.info/id/remote-data-objects/132af3cd-8dc2-47d3-8321-0d0135b1952c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "132af3cd-8dc2-47d3-8321-0d0135b1952c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_06-04-2022_17093.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/132af3cd-8dc2-47d3-8321-0d0135b1952c>.
+    
+<http://data.lblod.info/id/remote-data-objects/12abffac-df54-4b1b-ad19-b466c093bcad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12abffac-df54-4b1b-ad19-b466c093bcad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_06-04-2022_17118.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12abffac-df54-4b1b-ad19-b466c093bcad>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae475b08-7aaa-4887-b3be-774794be9497> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae475b08-7aaa-4887-b3be-774794be9497";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_06-07-2022_18069.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae475b08-7aaa-4887-b3be-774794be9497>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7902f63-45ea-4864-80a2-c069683e074c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7902f63-45ea-4864-80a2-c069683e074c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_06-07-2022_18080.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7902f63-45ea-4864-80a2-c069683e074c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d081372a-31ca-4803-87cc-96ebb93c4afc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d081372a-31ca-4803-87cc-96ebb93c4afc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_06-07-2022_18087.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d081372a-31ca-4803-87cc-96ebb93c4afc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f79e88fa-91fb-4243-9c7b-8acb1b974d8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f79e88fa-91fb-4243-9c7b-8acb1b974d8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_06-10-2021_15246.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f79e88fa-91fb-4243-9c7b-8acb1b974d8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e73dcce-096f-459f-a663-343295bc7211> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e73dcce-096f-459f-a663-343295bc7211";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_06-10-2021_15315.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e73dcce-096f-459f-a663-343295bc7211>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c23101e-f9c3-4e74-a61d-275f8d486a01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c23101e-f9c3-4e74-a61d-275f8d486a01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_08-06-2022_17713.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c23101e-f9c3-4e74-a61d-275f8d486a01>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fa434e4-0a36-4126-93e3-4babc044eaa5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fa434e4-0a36-4126-93e3-4babc044eaa5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_08-06-2022_17719.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fa434e4-0a36-4126-93e3-4babc044eaa5>.
+    
+<http://data.lblod.info/id/remote-data-objects/85bc1d35-0218-42e6-9c78-bf08ea5d5ce8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85bc1d35-0218-42e6-9c78-bf08ea5d5ce8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_08-06-2022_17725.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85bc1d35-0218-42e6-9c78-bf08ea5d5ce8>.
+    
+<http://data.lblod.info/id/remote-data-objects/34c38bdd-3feb-40dc-9c0f-638675b8c8a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34c38bdd-3feb-40dc-9c0f-638675b8c8a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_09-02-2022_16567.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34c38bdd-3feb-40dc-9c0f-638675b8c8a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/006ecdec-e4cc-4755-8e19-6a9696bb146a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "006ecdec-e4cc-4755-8e19-6a9696bb146a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_09-03-2022_16877.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/006ecdec-e4cc-4755-8e19-6a9696bb146a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e22a5bb8-765d-4c1d-a859-70a0b76cbc84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e22a5bb8-765d-4c1d-a859-70a0b76cbc84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_11-05-2022_17431.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e22a5bb8-765d-4c1d-a859-70a0b76cbc84>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e231b14-5ba2-491e-a95f-9bd3feaf3aea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e231b14-5ba2-491e-a95f-9bd3feaf3aea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_11-05-2022_17433.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e231b14-5ba2-491e-a95f-9bd3feaf3aea>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb93964f-b9cb-43e8-aabd-674376345e6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb93964f-b9cb-43e8-aabd-674376345e6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_12-01-2022_16189.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb93964f-b9cb-43e8-aabd-674376345e6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/18d969d6-a59d-4c27-af11-ef55c0dcb6aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18d969d6-a59d-4c27-af11-ef55c0dcb6aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_15-06-2022_17779.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18d969d6-a59d-4c27-af11-ef55c0dcb6aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf1ad08c-26ed-413b-963f-3d482fae4a9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf1ad08c-26ed-413b-963f-3d482fae4a9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_15-06-2022_17787.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf1ad08c-26ed-413b-963f-3d482fae4a9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce4de7ad-1780-4be4-b86f-1156749d9767> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce4de7ad-1780-4be4-b86f-1156749d9767";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_15-06-2022_17803.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce4de7ad-1780-4be4-b86f-1156749d9767>.
+    
+<http://data.lblod.info/id/remote-data-objects/01016102-3b72-4e2b-a9cd-2796b1bc4892> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01016102-3b72-4e2b-a9cd-2796b1bc4892";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_16-03-2022_16863.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01016102-3b72-4e2b-a9cd-2796b1bc4892>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe2ca12b-5b69-4ea6-9b0d-a0a5a5ecf956> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe2ca12b-5b69-4ea6-9b0d-a0a5a5ecf956";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_16-03-2022_16864.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe2ca12b-5b69-4ea6-9b0d-a0a5a5ecf956>.
+    
+<http://data.lblod.info/id/remote-data-objects/a35232fd-79f5-406c-b00f-8a00183e1046> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a35232fd-79f5-406c-b00f-8a00183e1046";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_16-03-2022_16866.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a35232fd-79f5-406c-b00f-8a00183e1046>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5c3d0fd-4233-4d2d-a90a-417fad920dce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5c3d0fd-4233-4d2d-a90a-417fad920dce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_16-03-2022_16868.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5c3d0fd-4233-4d2d-a90a-417fad920dce>.
+    
+<http://data.lblod.info/id/remote-data-objects/27ae423d-2660-49a9-a8e8-2a72ca0e3122> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27ae423d-2660-49a9-a8e8-2a72ca0e3122";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_16-03-2022_16869.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27ae423d-2660-49a9-a8e8-2a72ca0e3122>.
+    
+<http://data.lblod.info/id/remote-data-objects/f298d38f-0f95-45db-b12c-218390ec4821> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f298d38f-0f95-45db-b12c-218390ec4821";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_16-03-2022_16875.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f298d38f-0f95-45db-b12c-218390ec4821>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbf3753d-3050-494d-be70-a90a4e5ebe48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbf3753d-3050-494d-be70-a90a4e5ebe48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_16-03-2022_16876.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbf3753d-3050-494d-be70-a90a4e5ebe48>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce4f9a17-1f53-46ab-9f89-97258f57c5fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce4f9a17-1f53-46ab-9f89-97258f57c5fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_17-11-2021_15670.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce4f9a17-1f53-46ab-9f89-97258f57c5fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfa64c5a-1e01-4df9-84eb-cbc4ac660e7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfa64c5a-1e01-4df9-84eb-cbc4ac660e7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_18-05-2022_17529.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfa64c5a-1e01-4df9-84eb-cbc4ac660e7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6606cb64-c25c-484b-9d64-836093042c8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6606cb64-c25c-484b-9d64-836093042c8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_18-05-2022_17531.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6606cb64-c25c-484b-9d64-836093042c8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/733ec536-1fe2-448e-9831-fbe9c4e0e487> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "733ec536-1fe2-448e-9831-fbe9c4e0e487";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_18-05-2022_17533.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/733ec536-1fe2-448e-9831-fbe9c4e0e487>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a25147c-357f-453a-bc04-70e35701af82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a25147c-357f-453a-bc04-70e35701af82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_20-10-2021_15422.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a25147c-357f-453a-bc04-70e35701af82>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecea991f-3404-4636-8f90-ebd949516476> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecea991f-3404-4636-8f90-ebd949516476";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_22-06-2022_17972.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecea991f-3404-4636-8f90-ebd949516476>.
+    
+<http://data.lblod.info/id/remote-data-objects/584f8919-e7aa-4df4-bc5d-7aaa54d2243b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "584f8919-e7aa-4df4-bc5d-7aaa54d2243b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_23-03-2022_16969.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/584f8919-e7aa-4df4-bc5d-7aaa54d2243b>.
+    
+<http://data.lblod.info/id/remote-data-objects/95b951d8-d23f-4edd-9852-d0a38bf06531> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95b951d8-d23f-4edd-9852-d0a38bf06531";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_26-01-2022_16345.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95b951d8-d23f-4edd-9852-d0a38bf06531>.
+    
+<http://data.lblod.info/id/remote-data-objects/843e0d63-a2a9-44f7-80d5-f67e5bba492f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "843e0d63-a2a9-44f7-80d5-f67e5bba492f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_27-04-2022_17273.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/843e0d63-a2a9-44f7-80d5-f67e5bba492f>.
+    
+<http://data.lblod.info/id/remote-data-objects/19b64fc0-86cd-462d-9fac-1e914818b2ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19b64fc0-86cd-462d-9fac-1e914818b2ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_27-04-2022_17285.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19b64fc0-86cd-462d-9fac-1e914818b2ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/66e637e8-ab9e-4a57-a3f1-440eb4ca89d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66e637e8-ab9e-4a57-a3f1-440eb4ca89d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_29-06-2022_18009.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66e637e8-ab9e-4a57-a3f1-440eb4ca89d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/348f1c3a-758c-428e-8d2a-f8480d37b749> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "348f1c3a-758c-428e-8d2a-f8480d37b749";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_29-06-2022_18010.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/348f1c3a-758c-428e-8d2a-f8480d37b749>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae1122c3-98ad-45bb-b76a-032ac35ea668> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae1122c3-98ad-45bb-b76a-032ac35ea668";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_29-06-2022_18023.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae1122c3-98ad-45bb-b76a-032ac35ea668>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a8114fd-4724-4fa9-979d-c882a1c5c4d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a8114fd-4724-4fa9-979d-c882a1c5c4d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_29-06-2022_18030.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a8114fd-4724-4fa9-979d-c882a1c5c4d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e80ddf11-583f-485d-834c-9d5ac82db43b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e80ddf11-583f-485d-834c-9d5ac82db43b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_30-03-2022_17010.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e80ddf11-583f-485d-834c-9d5ac82db43b>.
+    
+<http://data.lblod.info/id/remote-data-objects/aedf4d16-6100-413a-a424-595e62b5123b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aedf4d16-6100-413a-a424-595e62b5123b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_30-03-2022_17014.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aedf4d16-6100-413a-a424-595e62b5123b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e1cdc89-b935-44bd-84ae-4defd66a2b56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e1cdc89-b935-44bd-84ae-4defd66a2b56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/430e00db4e5403269daf312d57606e0e6f8cd3f30f27cac2143f0c0ba78e2f02/GetPublication?filename=Uittreksels_30-03-2022_17027.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e1cdc89-b935-44bd-84ae-4defd66a2b56>.
+    
+<http://data.lblod.info/id/remote-data-objects/18ae40d6-12b7-4c20-8a5c-0123f48269e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18ae40d6-12b7-4c20-8a5c-0123f48269e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18ae40d6-12b7-4c20-8a5c-0123f48269e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/13d87ec5-01d0-4559-ad39-3601f730f132> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13d87ec5-01d0-4559-ad39-3601f730f132";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_01-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13d87ec5-01d0-4559-ad39-3601f730f132>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f943d5f-bfc4-4270-8378-a7d557186a8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f943d5f-bfc4-4270-8378-a7d557186a8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_02-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:13:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7334645-7861-4a73-982e-e10fe547c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f943d5f-bfc4-4270-8378-a7d557186a8c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201400-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201400-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201400-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201400-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b6e54f38-f0ea-4621-a400-10970ba9d477> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b6e54f38-f0ea-4621-a400-10970ba9d477";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "74923bb2-1160-466e-a7d2-cc2ab98d043d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/36af6598-4dfc-47a8-abf8-0fe012766e10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "36af6598-4dfc-47a8-abf8-0fe012766e10";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d>.
+
+  <http://redpencil.data.gift/id/task/5c4a94fb-b427-4715-be0f-d797fd1b95db> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5c4a94fb-b427-4715-be0f-d797fd1b95db";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b6e54f38-f0ea-4621-a400-10970ba9d477>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/36af6598-4dfc-47a8-abf8-0fe012766e10>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d0574fb6-8051-4bdc-a39a-082a61748c13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0574fb6-8051-4bdc-a39a-082a61748c13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_02-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0574fb6-8051-4bdc-a39a-082a61748c13>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea78360f-fcc9-4fa2-a470-e0a6a6df3d0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea78360f-fcc9-4fa2-a470-e0a6a6df3d0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea78360f-fcc9-4fa2-a470-e0a6a6df3d0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6df889ec-954c-4ece-bc92-bad259ee2421> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6df889ec-954c-4ece-bc92-bad259ee2421";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6df889ec-954c-4ece-bc92-bad259ee2421>.
+    
+<http://data.lblod.info/id/remote-data-objects/f67a05c6-9718-4bce-a99c-6ff1c1caf0ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f67a05c6-9718-4bce-a99c-6ff1c1caf0ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f67a05c6-9718-4bce-a99c-6ff1c1caf0ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/08c048a9-e9f6-4495-86c3-50c792df5082> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08c048a9-e9f6-4495-86c3-50c792df5082";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08c048a9-e9f6-4495-86c3-50c792df5082>.
+    
+<http://data.lblod.info/id/remote-data-objects/57956c80-0ad2-4ceb-8503-99d58790e5e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57956c80-0ad2-4ceb-8503-99d58790e5e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_06-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57956c80-0ad2-4ceb-8503-99d58790e5e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f4c5a9d-0ebb-4ed1-98a7-44484747eb89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f4c5a9d-0ebb-4ed1-98a7-44484747eb89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f4c5a9d-0ebb-4ed1-98a7-44484747eb89>.
+    
+<http://data.lblod.info/id/remote-data-objects/2092784f-e078-4d12-aaed-b151ee6f45f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2092784f-e078-4d12-aaed-b151ee6f45f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2092784f-e078-4d12-aaed-b151ee6f45f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/69519ee3-a60e-478c-865c-a985d2473004> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69519ee3-a60e-478c-865c-a985d2473004";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69519ee3-a60e-478c-865c-a985d2473004>.
+    
+<http://data.lblod.info/id/remote-data-objects/268e00cd-04b5-4fbb-8f97-93bb142ef330> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "268e00cd-04b5-4fbb-8f97-93bb142ef330";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/268e00cd-04b5-4fbb-8f97-93bb142ef330>.
+    
+<http://data.lblod.info/id/remote-data-objects/312354d7-ea7d-4802-ac57-5d6e4c1735fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "312354d7-ea7d-4802-ac57-5d6e4c1735fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/312354d7-ea7d-4802-ac57-5d6e4c1735fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/494db31c-329f-4c67-971c-c47250dcac1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "494db31c-329f-4c67-971c-c47250dcac1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/494db31c-329f-4c67-971c-c47250dcac1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c34bc997-10b2-4321-b7af-b60f92c33320> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c34bc997-10b2-4321-b7af-b60f92c33320";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_12-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c34bc997-10b2-4321-b7af-b60f92c33320>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b50ba9c-3c3e-459e-afa2-c0da606bf41b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b50ba9c-3c3e-459e-afa2-c0da606bf41b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b50ba9c-3c3e-459e-afa2-c0da606bf41b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ac7fe89-b761-4d47-9375-4ba17354c367> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ac7fe89-b761-4d47-9375-4ba17354c367";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ac7fe89-b761-4d47-9375-4ba17354c367>.
+    
+<http://data.lblod.info/id/remote-data-objects/83f91cb3-80c8-4e9d-a9fd-e5079c5a23c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83f91cb3-80c8-4e9d-a9fd-e5079c5a23c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83f91cb3-80c8-4e9d-a9fd-e5079c5a23c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/53989f56-be4a-4ab2-bb99-a4df8f343182> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53989f56-be4a-4ab2-bb99-a4df8f343182";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53989f56-be4a-4ab2-bb99-a4df8f343182>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4cf6402-2969-437d-93bf-475f0ed1353c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4cf6402-2969-437d-93bf-475f0ed1353c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4cf6402-2969-437d-93bf-475f0ed1353c>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbcc9a28-e1b7-46c0-8d7f-d44532c41282> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbcc9a28-e1b7-46c0-8d7f-d44532c41282";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbcc9a28-e1b7-46c0-8d7f-d44532c41282>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ddd08bb-4589-4765-82bf-ac0f54d9d53f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ddd08bb-4589-4765-82bf-ac0f54d9d53f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ddd08bb-4589-4765-82bf-ac0f54d9d53f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b56f16d4-5f13-4519-ba5f-aa9b7e2b275a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b56f16d4-5f13-4519-ba5f-aa9b7e2b275a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b56f16d4-5f13-4519-ba5f-aa9b7e2b275a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab1abb75-4e70-41b9-8130-19c3f2bc72a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab1abb75-4e70-41b9-8130-19c3f2bc72a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab1abb75-4e70-41b9-8130-19c3f2bc72a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/32803fb1-1ab1-4b00-bc19-5841170a8ee1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32803fb1-1ab1-4b00-bc19-5841170a8ee1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_19-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32803fb1-1ab1-4b00-bc19-5841170a8ee1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a157e89a-8bfb-4dd3-8934-6d417c12c725> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a157e89a-8bfb-4dd3-8934-6d417c12c725";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a157e89a-8bfb-4dd3-8934-6d417c12c725>.
+    
+<http://data.lblod.info/id/remote-data-objects/375cc2d0-e0a6-4031-80c0-3e0bd8bc2ee7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "375cc2d0-e0a6-4031-80c0-3e0bd8bc2ee7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/375cc2d0-e0a6-4031-80c0-3e0bd8bc2ee7>.
+    
+<http://data.lblod.info/id/remote-data-objects/5292a649-8bae-4a58-951b-f4af225c6bb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5292a649-8bae-4a58-951b-f4af225c6bb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5292a649-8bae-4a58-951b-f4af225c6bb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/da199e17-203f-4cb8-81c5-fdc279ff5ac3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da199e17-203f-4cb8-81c5-fdc279ff5ac3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da199e17-203f-4cb8-81c5-fdc279ff5ac3>.
+    
+<http://data.lblod.info/id/remote-data-objects/953a8c4f-02cc-4c1b-90fc-b7a1e9aa528a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "953a8c4f-02cc-4c1b-90fc-b7a1e9aa528a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/953a8c4f-02cc-4c1b-90fc-b7a1e9aa528a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5852c0a3-921b-4a25-ba65-ea00a205b22a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5852c0a3-921b-4a25-ba65-ea00a205b22a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5852c0a3-921b-4a25-ba65-ea00a205b22a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b89b3424-0345-47b9-9b84-3289fdd8e3ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b89b3424-0345-47b9-9b84-3289fdd8e3ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b89b3424-0345-47b9-9b84-3289fdd8e3ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/abb539a4-0b3c-4fbb-8b06-2e5a68c4c244> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abb539a4-0b3c-4fbb-8b06-2e5a68c4c244";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abb539a4-0b3c-4fbb-8b06-2e5a68c4c244>.
+    
+<http://data.lblod.info/id/remote-data-objects/98b75300-4cbd-4389-9921-185318ac903c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98b75300-4cbd-4389-9921-185318ac903c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98b75300-4cbd-4389-9921-185318ac903c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e58ed783-ead5-4162-a9c8-2aabda0b1b0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e58ed783-ead5-4162-a9c8-2aabda0b1b0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e58ed783-ead5-4162-a9c8-2aabda0b1b0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/95c4162a-7f50-4423-8945-04f028c06960> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95c4162a-7f50-4423-8945-04f028c06960";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95c4162a-7f50-4423-8945-04f028c06960>.
+    
+<http://data.lblod.info/id/remote-data-objects/19905fc7-a668-4823-94ff-a5faab23da30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19905fc7-a668-4823-94ff-a5faab23da30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19905fc7-a668-4823-94ff-a5faab23da30>.
+    
+<http://data.lblod.info/id/remote-data-objects/38286270-0a51-423d-bc3e-8f0e9744e693> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38286270-0a51-423d-bc3e-8f0e9744e693";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38286270-0a51-423d-bc3e-8f0e9744e693>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e86d57b-6dbb-4dc0-aec7-78abdaae83a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e86d57b-6dbb-4dc0-aec7-78abdaae83a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e86d57b-6dbb-4dc0-aec7-78abdaae83a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/6aa5487b-dda4-4640-98b9-ea73fe2edd88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6aa5487b-dda4-4640-98b9-ea73fe2edd88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=BesluitenLijst_Vast%20Bureau_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6aa5487b-dda4-4640-98b9-ea73fe2edd88>.
+    
+<http://data.lblod.info/id/remote-data-objects/56d1aedf-202a-460b-84eb-b621250186a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56d1aedf-202a-460b-84eb-b621250186a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/b0fe4274af7fcd306800b1aca6d345b64be95916c687ccf09a6ce0c842c5da6a/GetPublication?filename=Uittreksels_09-03-2022_16880.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56d1aedf-202a-460b-84eb-b621250186a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/66266d2b-ec5f-4fe4-a5a3-3eba9ee95012> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66266d2b-ec5f-4fe4-a5a3-3eba9ee95012";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66266d2b-ec5f-4fe4-a5a3-3eba9ee95012>.
+    
+<http://data.lblod.info/id/remote-data-objects/e42e9f29-a698-4ab4-a513-32d38521e753> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e42e9f29-a698-4ab4-a513-32d38521e753";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e42e9f29-a698-4ab4-a513-32d38521e753>.
+    
+<http://data.lblod.info/id/remote-data-objects/898b8ba3-7cbc-4d9f-8a8a-66b59ca05ae9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "898b8ba3-7cbc-4d9f-8a8a-66b59ca05ae9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/898b8ba3-7cbc-4d9f-8a8a-66b59ca05ae9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d8cca57-e60c-4caa-bbf8-883ac3a40e49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d8cca57-e60c-4caa-bbf8-883ac3a40e49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d8cca57-e60c-4caa-bbf8-883ac3a40e49>.
+    
+<http://data.lblod.info/id/remote-data-objects/e994a8d1-4f11-49d6-85f1-befd05b80d6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e994a8d1-4f11-49d6-85f1-befd05b80d6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e994a8d1-4f11-49d6-85f1-befd05b80d6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/90a0153f-95e3-4cf2-86f3-8f76134b3fbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90a0153f-95e3-4cf2-86f3-8f76134b3fbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90a0153f-95e3-4cf2-86f3-8f76134b3fbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd231a88-8efe-42bb-9591-336dfbf26827> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd231a88-8efe-42bb-9591-336dfbf26827";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd231a88-8efe-42bb-9591-336dfbf26827>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f5fe0c5-bac5-470b-9860-5a600f9b6307> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f5fe0c5-bac5-470b-9860-5a600f9b6307";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f5fe0c5-bac5-470b-9860-5a600f9b6307>.
+    
+<http://data.lblod.info/id/remote-data-objects/022c9085-bba5-4345-9ef0-dda154d9ed73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "022c9085-bba5-4345-9ef0-dda154d9ed73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/022c9085-bba5-4345-9ef0-dda154d9ed73>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cff95cf-2e07-425e-88b1-2287e6260350> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cff95cf-2e07-425e-88b1-2287e6260350";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cff95cf-2e07-425e-88b1-2287e6260350>.
+    
+<http://data.lblod.info/id/remote-data-objects/35fd377f-3704-47b6-aa57-fbb2cf2597d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35fd377f-3704-47b6-aa57-fbb2cf2597d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74923bb2-1160-466e-a7d2-cc2ab98d043d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35fd377f-3704-47b6-aa57-fbb2cf2597d4>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201401-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201401-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201401-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201401-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/0ae1a14d-86d0-41ed-83b4-e4c52635b39a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0ae1a14d-86d0-41ed-83b4-e4c52635b39a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e08978a7-cf15-45b0-b8a1-826e73e4854c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e08978a7-cf15-45b0-b8a1-826e73e4854c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16>.
+
+  <http://redpencil.data.gift/id/task/1809c5b7-e179-46c2-9da3-e2ffd0911151> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1809c5b7-e179-46c2-9da3-e2ffd0911151";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/0ae1a14d-86d0-41ed-83b4-e4c52635b39a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e08978a7-cf15-45b0-b8a1-826e73e4854c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/53cc1114-0629-45ab-a926-3a04a364b42c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53cc1114-0629-45ab-a926-3a04a364b42c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53cc1114-0629-45ab-a926-3a04a364b42c>.
+    
+<http://data.lblod.info/id/remote-data-objects/01bb0af6-dd04-4cb8-ba8a-a7ff5c5f12a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01bb0af6-dd04-4cb8-ba8a-a7ff5c5f12a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01bb0af6-dd04-4cb8-ba8a-a7ff5c5f12a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/0052c5db-480d-4cda-89e5-1ec0c37e955f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0052c5db-480d-4cda-89e5-1ec0c37e955f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0052c5db-480d-4cda-89e5-1ec0c37e955f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a02d61f-7841-4c0f-bcf4-2e30034baa95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a02d61f-7841-4c0f-bcf4-2e30034baa95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a02d61f-7841-4c0f-bcf4-2e30034baa95>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e5e7374-91cb-4965-87e0-b18148e46d02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e5e7374-91cb-4965-87e0-b18148e46d02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e5e7374-91cb-4965-87e0-b18148e46d02>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e62c59d-fa09-4a19-90f9-e91cf1cc81df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e62c59d-fa09-4a19-90f9-e91cf1cc81df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e62c59d-fa09-4a19-90f9-e91cf1cc81df>.
+    
+<http://data.lblod.info/id/remote-data-objects/768a512f-4bf5-47f4-860a-5760582719bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "768a512f-4bf5-47f4-860a-5760582719bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/768a512f-4bf5-47f4-860a-5760582719bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3b57e57-881b-41bd-892d-e615962ed529> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3b57e57-881b-41bd-892d-e615962ed529";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3b57e57-881b-41bd-892d-e615962ed529>.
+    
+<http://data.lblod.info/id/remote-data-objects/636dedf5-75cb-4854-a056-6eea4eeb0c61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "636dedf5-75cb-4854-a056-6eea4eeb0c61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=Uittreksels_22-12-2021_15919.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/636dedf5-75cb-4854-a056-6eea4eeb0c61>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffcb930d-a7b7-4b84-b3f3-b7da5465ee0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffcb930d-a7b7-4b84-b3f3-b7da5465ee0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.herzele.be/LBLODWeb/Home/Overzicht/ed1883f7f3f8ccd6adf2bdc1a1a255dae01aef391ddd80cc5faa500228b5bd30/GetPublication?filename=Uittreksels_22-12-2021_15960.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffcb930d-a7b7-4b84-b3f3-b7da5465ee0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/60d520b9-1be3-439e-ae4c-8b31bcaa63f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60d520b9-1be3-439e-ae4c-8b31bcaa63f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60d520b9-1be3-439e-ae4c-8b31bcaa63f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1948c37a-b09c-4ddb-bf28-489665395ef7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1948c37a-b09c-4ddb-bf28-489665395ef7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1948c37a-b09c-4ddb-bf28-489665395ef7>.
+    
+<http://data.lblod.info/id/remote-data-objects/91d906de-d3dc-427f-9e94-d7f733142d96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91d906de-d3dc-427f-9e94-d7f733142d96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_02-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91d906de-d3dc-427f-9e94-d7f733142d96>.
+    
+<http://data.lblod.info/id/remote-data-objects/85ca3d25-90ce-427f-b25f-b978be592596> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85ca3d25-90ce-427f-b25f-b978be592596";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85ca3d25-90ce-427f-b25f-b978be592596>.
+    
+<http://data.lblod.info/id/remote-data-objects/174500bb-365c-4e51-9120-9f288757c973> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "174500bb-365c-4e51-9120-9f288757c973";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/174500bb-365c-4e51-9120-9f288757c973>.
+    
+<http://data.lblod.info/id/remote-data-objects/569b6701-e958-4c3f-929f-de76707c0f93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "569b6701-e958-4c3f-929f-de76707c0f93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/569b6701-e958-4c3f-929f-de76707c0f93>.
+    
+<http://data.lblod.info/id/remote-data-objects/486dd91c-5dd4-4911-81a7-7343e46a83cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "486dd91c-5dd4-4911-81a7-7343e46a83cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/486dd91c-5dd4-4911-81a7-7343e46a83cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dea4e79-f898-4df8-8a91-25b08a8b4e0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dea4e79-f898-4df8-8a91-25b08a8b4e0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dea4e79-f898-4df8-8a91-25b08a8b4e0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cf9617b-b4a4-4f0a-8efb-5216a4f63036> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cf9617b-b4a4-4f0a-8efb-5216a4f63036";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_06-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cf9617b-b4a4-4f0a-8efb-5216a4f63036>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9af9da1-1584-4adc-a06b-b39041219cad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9af9da1-1584-4adc-a06b-b39041219cad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9af9da1-1584-4adc-a06b-b39041219cad>.
+    
+<http://data.lblod.info/id/remote-data-objects/35400474-b72f-4b22-98cd-9da66f16d673> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35400474-b72f-4b22-98cd-9da66f16d673";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35400474-b72f-4b22-98cd-9da66f16d673>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dc30dc9-840d-42e4-96b1-ce3764b0ae64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dc30dc9-840d-42e4-96b1-ce3764b0ae64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dc30dc9-840d-42e4-96b1-ce3764b0ae64>.
+    
+<http://data.lblod.info/id/remote-data-objects/463a6334-a17d-4a87-9a51-294b5fa08165> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "463a6334-a17d-4a87-9a51-294b5fa08165";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/463a6334-a17d-4a87-9a51-294b5fa08165>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd1eeff4-711b-407e-8be6-e0944e9f6338> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd1eeff4-711b-407e-8be6-e0944e9f6338";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd1eeff4-711b-407e-8be6-e0944e9f6338>.
+    
+<http://data.lblod.info/id/remote-data-objects/2dfc12ae-e02f-4df9-bb9c-65e6a524ea18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2dfc12ae-e02f-4df9-bb9c-65e6a524ea18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2dfc12ae-e02f-4df9-bb9c-65e6a524ea18>.
+    
+<http://data.lblod.info/id/remote-data-objects/41962fa6-9fbf-4d6c-a83d-0751d02eeacd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41962fa6-9fbf-4d6c-a83d-0751d02eeacd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_12-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41962fa6-9fbf-4d6c-a83d-0751d02eeacd>.
+    
+<http://data.lblod.info/id/remote-data-objects/04a24495-e7e5-4579-a27a-448be4994e07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04a24495-e7e5-4579-a27a-448be4994e07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_13-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04a24495-e7e5-4579-a27a-448be4994e07>.
+    
+<http://data.lblod.info/id/remote-data-objects/17d5665b-7bc0-49ec-92d3-d1316de9e697> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17d5665b-7bc0-49ec-92d3-d1316de9e697";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17d5665b-7bc0-49ec-92d3-d1316de9e697>.
+    
+<http://data.lblod.info/id/remote-data-objects/36586d19-b48b-46d7-8eb7-4ab002b6fc81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36586d19-b48b-46d7-8eb7-4ab002b6fc81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36586d19-b48b-46d7-8eb7-4ab002b6fc81>.
+    
+<http://data.lblod.info/id/remote-data-objects/e20f6fc6-21c4-4b8b-b2ba-fcff6d78e1b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e20f6fc6-21c4-4b8b-b2ba-fcff6d78e1b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e20f6fc6-21c4-4b8b-b2ba-fcff6d78e1b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3be357f8-33e1-44fa-9ee5-1b627a92dbda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3be357f8-33e1-44fa-9ee5-1b627a92dbda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3be357f8-33e1-44fa-9ee5-1b627a92dbda>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6ab26fc-bc33-4421-8dcc-a4819cf4bc09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6ab26fc-bc33-4421-8dcc-a4819cf4bc09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6ab26fc-bc33-4421-8dcc-a4819cf4bc09>.
+    
+<http://data.lblod.info/id/remote-data-objects/2916faae-ccc7-4738-bc0f-93152b561675> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2916faae-ccc7-4738-bc0f-93152b561675";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_16-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2916faae-ccc7-4738-bc0f-93152b561675>.
+    
+<http://data.lblod.info/id/remote-data-objects/97d85854-908c-4c59-9d78-2e2ad06ebe1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97d85854-908c-4c59-9d78-2e2ad06ebe1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_16-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97d85854-908c-4c59-9d78-2e2ad06ebe1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce839c3f-dfa9-4f85-83c2-5c88be22cdee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce839c3f-dfa9-4f85-83c2-5c88be22cdee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce839c3f-dfa9-4f85-83c2-5c88be22cdee>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1e2b915-a0f2-4c4b-8fdf-ccb673f44bd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1e2b915-a0f2-4c4b-8fdf-ccb673f44bd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1e2b915-a0f2-4c4b-8fdf-ccb673f44bd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d77abfc-0f45-49d0-a374-a8affebf811c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d77abfc-0f45-49d0-a374-a8affebf811c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d77abfc-0f45-49d0-a374-a8affebf811c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6de076fc-bae9-43c0-b51c-3316ac85b1fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6de076fc-bae9-43c0-b51c-3316ac85b1fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6de076fc-bae9-43c0-b51c-3316ac85b1fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ecd907d-c931-4f26-b885-e85d6f196d8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ecd907d-c931-4f26-b885-e85d6f196d8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_20-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ecd907d-c931-4f26-b885-e85d6f196d8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d049d52-e969-4371-b31f-cdccd6bf0357> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d049d52-e969-4371-b31f-cdccd6bf0357";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d049d52-e969-4371-b31f-cdccd6bf0357>.
+    
+<http://data.lblod.info/id/remote-data-objects/de332992-3460-49a3-9c91-52aa9733bcd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de332992-3460-49a3-9c91-52aa9733bcd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de332992-3460-49a3-9c91-52aa9733bcd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/d32772f2-cc80-42d6-b95b-07564d0d84ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d32772f2-cc80-42d6-b95b-07564d0d84ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d32772f2-cc80-42d6-b95b-07564d0d84ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/21e39afb-e00a-4a85-afe8-17013cdf410e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21e39afb-e00a-4a85-afe8-17013cdf410e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21e39afb-e00a-4a85-afe8-17013cdf410e>.
+    
+<http://data.lblod.info/id/remote-data-objects/802f2702-f448-4e91-9049-18d575da5e6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "802f2702-f448-4e91-9049-18d575da5e6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/802f2702-f448-4e91-9049-18d575da5e6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d0e9174-9864-4667-b210-34fdc931b46b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d0e9174-9864-4667-b210-34fdc931b46b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d0e9174-9864-4667-b210-34fdc931b46b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8ba4100-9aad-4666-9ff2-68adeb7d28fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8ba4100-9aad-4666-9ff2-68adeb7d28fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8ba4100-9aad-4666-9ff2-68adeb7d28fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2f23d48-c2a3-4c1c-85e3-52f83d25e04d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2f23d48-c2a3-4c1c-85e3-52f83d25e04d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2f23d48-c2a3-4c1c-85e3-52f83d25e04d>.
+    
+<http://data.lblod.info/id/remote-data-objects/04410a42-a11f-4fd2-96b5-297c0f9e3d2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04410a42-a11f-4fd2-96b5-297c0f9e3d2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04410a42-a11f-4fd2-96b5-297c0f9e3d2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa9c8b77-e18f-4327-b959-c17d9fc3e528> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa9c8b77-e18f-4327-b959-c17d9fc3e528";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa9c8b77-e18f-4327-b959-c17d9fc3e528>.
+    
+<http://data.lblod.info/id/remote-data-objects/d754f5da-eb94-4f9b-95bb-5ecb763766e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d754f5da-eb94-4f9b-95bb-5ecb763766e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0935d6c8-a2fb-4d31-ad99-59778903d256/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ba82a1c1-b4e3-4b78-babe-bf81fbd9ee16> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d754f5da-eb94-4f9b-95bb-5ecb763766e8>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201403-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201403-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201403-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201403-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/28a241ed-5155-4c0c-a0c6-3397ddf5ffec> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "28a241ed-5155-4c0c-a0c6-3397ddf5ffec";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "04793994-7517-4596-8fd5-f643c176a470";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/82efd6e6-f819-4b71-a9aa-5038533e5202> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "82efd6e6-f819-4b71-a9aa-5038533e5202";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470>.
+
+  <http://redpencil.data.gift/id/task/2e1dec41-5770-4a37-8543-33f0fd693ac4> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2e1dec41-5770-4a37-8543-33f0fd693ac4";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/28a241ed-5155-4c0c-a0c6-3397ddf5ffec>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/82efd6e6-f819-4b71-a9aa-5038533e5202>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e1d830c6-66bb-4f02-854a-85750dc84236> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1d830c6-66bb-4f02-854a-85750dc84236";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1d830c6-66bb-4f02-854a-85750dc84236>.
+    
+<http://data.lblod.info/id/remote-data-objects/618b588f-9330-4df9-a632-7fb6af424050> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "618b588f-9330-4df9-a632-7fb6af424050";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/618b588f-9330-4df9-a632-7fb6af424050>.
+    
+<http://data.lblod.info/id/remote-data-objects/2950aa3d-7ec2-4807-8ccf-0e410e944f24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2950aa3d-7ec2-4807-8ccf-0e410e944f24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_02-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2950aa3d-7ec2-4807-8ccf-0e410e944f24>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae510fa0-5f2e-40ed-bf68-ff20d291753c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae510fa0-5f2e-40ed-bf68-ff20d291753c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae510fa0-5f2e-40ed-bf68-ff20d291753c>.
+    
+<http://data.lblod.info/id/remote-data-objects/19ef6956-ad13-4856-a871-e178e5a6bf3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19ef6956-ad13-4856-a871-e178e5a6bf3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19ef6956-ad13-4856-a871-e178e5a6bf3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c54ace90-1240-4d1d-97f3-a2c1b67eefdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c54ace90-1240-4d1d-97f3-a2c1b67eefdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c54ace90-1240-4d1d-97f3-a2c1b67eefdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/fff51c4f-e9be-411b-9ca4-bae7b2ba4695> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fff51c4f-e9be-411b-9ca4-bae7b2ba4695";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fff51c4f-e9be-411b-9ca4-bae7b2ba4695>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e7a4c42-4da9-493b-9f01-6f443aa97551> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e7a4c42-4da9-493b-9f01-6f443aa97551";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e7a4c42-4da9-493b-9f01-6f443aa97551>.
+    
+<http://data.lblod.info/id/remote-data-objects/9399fb49-cf11-46e8-95ec-228c50856325> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9399fb49-cf11-46e8-95ec-228c50856325";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9399fb49-cf11-46e8-95ec-228c50856325>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d413a7f-022f-457f-9c51-701cd0bb960b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d413a7f-022f-457f-9c51-701cd0bb960b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d413a7f-022f-457f-9c51-701cd0bb960b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ac3f257-b776-4ef5-a77b-41f438cc1b9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ac3f257-b776-4ef5-a77b-41f438cc1b9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ac3f257-b776-4ef5-a77b-41f438cc1b9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc1ed44f-7e32-45da-8621-84e808c748b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc1ed44f-7e32-45da-8621-84e808c748b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc1ed44f-7e32-45da-8621-84e808c748b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/632021f3-240a-419a-88a2-5bb27a2ba796> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "632021f3-240a-419a-88a2-5bb27a2ba796";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/632021f3-240a-419a-88a2-5bb27a2ba796>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e86338f-c583-429b-a2d2-df298525c3bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e86338f-c583-429b-a2d2-df298525c3bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e86338f-c583-429b-a2d2-df298525c3bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/a525daa5-4db3-4aa1-b0c1-96a89c7af55c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a525daa5-4db3-4aa1-b0c1-96a89c7af55c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a525daa5-4db3-4aa1-b0c1-96a89c7af55c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cbf5b26-bf04-4392-b3a6-c87131faf7cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cbf5b26-bf04-4392-b3a6-c87131faf7cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cbf5b26-bf04-4392-b3a6-c87131faf7cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dd50f8e-97b5-474d-b661-a8cb5ce14340> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dd50f8e-97b5-474d-b661-a8cb5ce14340";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dd50f8e-97b5-474d-b661-a8cb5ce14340>.
+    
+<http://data.lblod.info/id/remote-data-objects/de101b59-9a8b-4964-bde5-cd575e4ca5de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de101b59-9a8b-4964-bde5-cd575e4ca5de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de101b59-9a8b-4964-bde5-cd575e4ca5de>.
+    
+<http://data.lblod.info/id/remote-data-objects/4407e399-6076-4a8b-8120-f3845f7ac5af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4407e399-6076-4a8b-8120-f3845f7ac5af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4407e399-6076-4a8b-8120-f3845f7ac5af>.
+    
+<http://data.lblod.info/id/remote-data-objects/39eaa814-1b8b-47d2-8aa5-efb557c008e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39eaa814-1b8b-47d2-8aa5-efb557c008e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39eaa814-1b8b-47d2-8aa5-efb557c008e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e8ab0be-cd75-4eeb-928a-d0f279a5ebf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e8ab0be-cd75-4eeb-928a-d0f279a5ebf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e8ab0be-cd75-4eeb-928a-d0f279a5ebf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/290fb020-d9f3-46f4-9adb-5f8ce3a0a71f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "290fb020-d9f3-46f4-9adb-5f8ce3a0a71f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/290fb020-d9f3-46f4-9adb-5f8ce3a0a71f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c602a46-be55-4427-a69a-315dfd459402> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c602a46-be55-4427-a69a-315dfd459402";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c602a46-be55-4427-a69a-315dfd459402>.
+    
+<http://data.lblod.info/id/remote-data-objects/02e4ca83-1848-49d5-a952-2a56d625f55f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02e4ca83-1848-49d5-a952-2a56d625f55f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02e4ca83-1848-49d5-a952-2a56d625f55f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b4171b8-770d-496c-b46d-10c983c1e87f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b4171b8-770d-496c-b46d-10c983c1e87f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b4171b8-770d-496c-b46d-10c983c1e87f>.
+    
+<http://data.lblod.info/id/remote-data-objects/345aee77-781b-49e2-a443-825a2c57a5e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "345aee77-781b-49e2-a443-825a2c57a5e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_19-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/345aee77-781b-49e2-a443-825a2c57a5e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/560932e7-3633-45d4-8a2d-a5b5aac35215> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "560932e7-3633-45d4-8a2d-a5b5aac35215";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/560932e7-3633-45d4-8a2d-a5b5aac35215>.
+    
+<http://data.lblod.info/id/remote-data-objects/5326e745-11cc-4250-a50d-0a3781b6df3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5326e745-11cc-4250-a50d-0a3781b6df3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5326e745-11cc-4250-a50d-0a3781b6df3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/43f30e49-03e0-4ab2-9f96-25b529c4fd9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43f30e49-03e0-4ab2-9f96-25b529c4fd9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43f30e49-03e0-4ab2-9f96-25b529c4fd9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7d4abd4-09dc-4569-bb60-bf701ccb2d28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7d4abd4-09dc-4569-bb60-bf701ccb2d28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7d4abd4-09dc-4569-bb60-bf701ccb2d28>.
+    
+<http://data.lblod.info/id/remote-data-objects/22b2ba59-e4af-40f0-b0ec-a7102d1d6842> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22b2ba59-e4af-40f0-b0ec-a7102d1d6842";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22b2ba59-e4af-40f0-b0ec-a7102d1d6842>.
+    
+<http://data.lblod.info/id/remote-data-objects/11e02ee2-d4ee-4685-9c33-fe9eab222e84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11e02ee2-d4ee-4685-9c33-fe9eab222e84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11e02ee2-d4ee-4685-9c33-fe9eab222e84>.
+    
+<http://data.lblod.info/id/remote-data-objects/6923354a-0460-4fc6-8d70-92b4d57f716a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6923354a-0460-4fc6-8d70-92b4d57f716a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6923354a-0460-4fc6-8d70-92b4d57f716a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f12551e-e22e-442a-abec-344f15d6f2da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f12551e-e22e-442a-abec-344f15d6f2da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f12551e-e22e-442a-abec-344f15d6f2da>.
+    
+<http://data.lblod.info/id/remote-data-objects/494f1deb-628d-4e8f-a0bd-754b65e7048e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "494f1deb-628d-4e8f-a0bd-754b65e7048e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/494f1deb-628d-4e8f-a0bd-754b65e7048e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6920c8f-a695-474f-a589-a897d44a8fc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6920c8f-a695-474f-a589-a897d44a8fc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6920c8f-a695-474f-a589-a897d44a8fc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/74f1d127-3f6f-4e92-9437-b4fd46fff6e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74f1d127-3f6f-4e92-9437-b4fd46fff6e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74f1d127-3f6f-4e92-9437-b4fd46fff6e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/38480602-5b32-4197-a874-dfbcfb72604c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38480602-5b32-4197-a874-dfbcfb72604c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38480602-5b32-4197-a874-dfbcfb72604c>.
+    
+<http://data.lblod.info/id/remote-data-objects/43fe68db-88a8-46d9-9595-9909ab1d6394> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43fe68db-88a8-46d9-9595-9909ab1d6394";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43fe68db-88a8-46d9-9595-9909ab1d6394>.
+    
+<http://data.lblod.info/id/remote-data-objects/291acf48-0a66-4118-87f5-31c86fd3afbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "291acf48-0a66-4118-87f5-31c86fd3afbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/291acf48-0a66-4118-87f5-31c86fd3afbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8a6c229-5c07-4ba2-bf56-ccdb1b4514b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8a6c229-5c07-4ba2-bf56-ccdb1b4514b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8a6c229-5c07-4ba2-bf56-ccdb1b4514b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce785346-9bad-4dc0-8dde-293cbf3c25f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce785346-9bad-4dc0-8dde-293cbf3c25f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_01-06-2022_4317.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce785346-9bad-4dc0-8dde-293cbf3c25f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/10f2f67c-766a-49ec-b9f7-a823068e086a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10f2f67c-766a-49ec-b9f7-a823068e086a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_01-06-2022_4318.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10f2f67c-766a-49ec-b9f7-a823068e086a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bf5e451-ffa9-4175-9900-99ef05a3c430> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bf5e451-ffa9-4175-9900-99ef05a3c430";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_05-01-2022_3056.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bf5e451-ffa9-4175-9900-99ef05a3c430>.
+    
+<http://data.lblod.info/id/remote-data-objects/40aaee0d-934d-4329-b4d8-aed63ae64670> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40aaee0d-934d-4329-b4d8-aed63ae64670";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_06-07-2022_4640.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40aaee0d-934d-4329-b4d8-aed63ae64670>.
+    
+<http://data.lblod.info/id/remote-data-objects/b290e2cd-ce9b-44a9-a6e0-e2352b2c7e7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b290e2cd-ce9b-44a9-a6e0-e2352b2c7e7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_06-07-2022_4643.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b290e2cd-ce9b-44a9-a6e0-e2352b2c7e7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/37dc36df-5f6f-4731-9f5c-604b80758fc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37dc36df-5f6f-4731-9f5c-604b80758fc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_06-07-2022_4644.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37dc36df-5f6f-4731-9f5c-604b80758fc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c8f8b48-5aa1-4a60-a291-5bcee798e560> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c8f8b48-5aa1-4a60-a291-5bcee798e560";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_06-10-2021_2451.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c8f8b48-5aa1-4a60-a291-5bcee798e560>.
+    
+<http://data.lblod.info/id/remote-data-objects/859422a0-f2ac-4674-b1ab-5e4c227c4a7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "859422a0-f2ac-4674-b1ab-5e4c227c4a7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_08-06-2022_4363.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/859422a0-f2ac-4674-b1ab-5e4c227c4a7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1f87a31-0f92-4900-be59-83e07d1c2093> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1f87a31-0f92-4900-be59-83e07d1c2093";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_08-06-2022_4401.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/04793994-7517-4596-8fd5-f643c176a470> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1f87a31-0f92-4900-be59-83e07d1c2093>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201404-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201404-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201404-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201404-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/580a6943-9f02-4771-9e1b-824a71abbcb0> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "580a6943-9f02-4771-9e1b-824a71abbcb0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1d373d47-26b0-48bd-9dd3-f83a10bbb3d1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e2c3a51a-2880-425c-8f47-7e6c6b7cfdbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e2c3a51a-2880-425c-8f47-7e6c6b7cfdbe";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1>.
+
+  <http://redpencil.data.gift/id/task/bb863322-588e-41f4-b615-29d64eb45596> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bb863322-588e-41f4-b615-29d64eb45596";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/580a6943-9f02-4771-9e1b-824a71abbcb0>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e2c3a51a-2880-425c-8f47-7e6c6b7cfdbe>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c49d483e-3437-407e-85db-a665a3408d0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c49d483e-3437-407e-85db-a665a3408d0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_09-02-2022_3338.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c49d483e-3437-407e-85db-a665a3408d0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d142e023-b9bb-44da-8564-527aa81cc174> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d142e023-b9bb-44da-8564-527aa81cc174";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_09-02-2022_3339.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d142e023-b9bb-44da-8564-527aa81cc174>.
+    
+<http://data.lblod.info/id/remote-data-objects/16ed356a-9b49-430e-86ac-6eee2375ca42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16ed356a-9b49-430e-86ac-6eee2375ca42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_09-02-2022_3349.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16ed356a-9b49-430e-86ac-6eee2375ca42>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dfec0eb-81c4-43a3-b916-a016436306de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dfec0eb-81c4-43a3-b916-a016436306de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_09-02-2022_3353.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dfec0eb-81c4-43a3-b916-a016436306de>.
+    
+<http://data.lblod.info/id/remote-data-objects/653b6f98-4003-453b-b298-ab4f6ddf8e38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "653b6f98-4003-453b-b298-ab4f6ddf8e38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_09-02-2022_3358.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/653b6f98-4003-453b-b298-ab4f6ddf8e38>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1d23c02-2dbd-4a95-9d89-e07eb343b976> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1d23c02-2dbd-4a95-9d89-e07eb343b976";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_09-02-2022_3366.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1d23c02-2dbd-4a95-9d89-e07eb343b976>.
+    
+<http://data.lblod.info/id/remote-data-objects/d31a070a-da09-428d-b245-38a2e4958dae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d31a070a-da09-428d-b245-38a2e4958dae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_09-03-2022_3607.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d31a070a-da09-428d-b245-38a2e4958dae>.
+    
+<http://data.lblod.info/id/remote-data-objects/93d76824-d436-487a-ba49-1dd81ebbd8fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93d76824-d436-487a-ba49-1dd81ebbd8fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_11-05-2022_4165.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93d76824-d436-487a-ba49-1dd81ebbd8fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0ac5de9-cb8b-489c-8336-f9b879fdb7ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0ac5de9-cb8b-489c-8336-f9b879fdb7ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_11-05-2022_4169.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0ac5de9-cb8b-489c-8336-f9b879fdb7ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/e97fe318-69fc-44de-8f2c-cc83d11267d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e97fe318-69fc-44de-8f2c-cc83d11267d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_13-07-2022_4788.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e97fe318-69fc-44de-8f2c-cc83d11267d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f2fbbb3-41e5-4b2f-955b-2276ff8490eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f2fbbb3-41e5-4b2f-955b-2276ff8490eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_13-07-2022_4814.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f2fbbb3-41e5-4b2f-955b-2276ff8490eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfc8bca6-eeeb-4ed4-9d4c-78755838f2bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfc8bca6-eeeb-4ed4-9d4c-78755838f2bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_13-07-2022_4834.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfc8bca6-eeeb-4ed4-9d4c-78755838f2bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe631713-bc90-4a06-bf94-ea32014ec35a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe631713-bc90-4a06-bf94-ea32014ec35a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_13-07-2022_4835.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe631713-bc90-4a06-bf94-ea32014ec35a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c467b7a-41dc-4c2f-8a21-98961efdc80e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c467b7a-41dc-4c2f-8a21-98961efdc80e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_13-07-2022_4837.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c467b7a-41dc-4c2f-8a21-98961efdc80e>.
+    
+<http://data.lblod.info/id/remote-data-objects/80c1fcfb-9eb7-4df5-bb83-f9199c93e289> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80c1fcfb-9eb7-4df5-bb83-f9199c93e289";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_13-07-2022_4838.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80c1fcfb-9eb7-4df5-bb83-f9199c93e289>.
+    
+<http://data.lblod.info/id/remote-data-objects/481fa138-e9a3-4adf-ab39-74dc73bcdb5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "481fa138-e9a3-4adf-ab39-74dc73bcdb5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_15-06-2022_4411.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/481fa138-e9a3-4adf-ab39-74dc73bcdb5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3514bc72-aa98-47cb-9e00-33ce1747a4c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3514bc72-aa98-47cb-9e00-33ce1747a4c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_20-04-2022_4003.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3514bc72-aa98-47cb-9e00-33ce1747a4c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8444e9bf-96b7-41f2-945a-3c065e4a4e09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8444e9bf-96b7-41f2-945a-3c065e4a4e09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_20-04-2022_4004.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8444e9bf-96b7-41f2-945a-3c065e4a4e09>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c78e202-2358-43da-81f5-725b204961be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c78e202-2358-43da-81f5-725b204961be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_20-04-2022_4005.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c78e202-2358-43da-81f5-725b204961be>.
+    
+<http://data.lblod.info/id/remote-data-objects/aaf269a5-c5e9-4958-81a7-da80a89dd68e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aaf269a5-c5e9-4958-81a7-da80a89dd68e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_20-04-2022_4010.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aaf269a5-c5e9-4958-81a7-da80a89dd68e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a810bbb3-b6c0-4768-8bf0-e2469dfdaab7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a810bbb3-b6c0-4768-8bf0-e2469dfdaab7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_20-04-2022_4014.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a810bbb3-b6c0-4768-8bf0-e2469dfdaab7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3d28fb9-5ca1-42bd-9070-ecedeff71b4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3d28fb9-5ca1-42bd-9070-ecedeff71b4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_25-05-2022_4307.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3d28fb9-5ca1-42bd-9070-ecedeff71b4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/19013ee7-b072-44fa-a57b-a4a7ee6a2ffe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19013ee7-b072-44fa-a57b-a4a7ee6a2ffe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_27-04-2022_4031.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19013ee7-b072-44fa-a57b-a4a7ee6a2ffe>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd75643f-f91b-4c46-97dc-adfa015aa09c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd75643f-f91b-4c46-97dc-adfa015aa09c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_29-06-2022_4564.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd75643f-f91b-4c46-97dc-adfa015aa09c>.
+    
+<http://data.lblod.info/id/remote-data-objects/53f14890-7d1c-4c3e-a7ab-464349797623> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53f14890-7d1c-4c3e-a7ab-464349797623";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/0d496d0c2ac92e60882cd8cd457b1ce4a9420151e70627e494cdea63b871fe8f/GetPublication?filename=Uittreksels_30-03-2022_3805.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53f14890-7d1c-4c3e-a7ab-464349797623>.
+    
+<http://data.lblod.info/id/remote-data-objects/20d7f1a3-38b5-41d3-a791-5aff4fe4aed3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20d7f1a3-38b5-41d3-a791-5aff4fe4aed3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Agenda_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20d7f1a3-38b5-41d3-a791-5aff4fe4aed3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7120b1df-76ff-44eb-9c6e-77fbbcfb796a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7120b1df-76ff-44eb-9c6e-77fbbcfb796a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Agenda_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7120b1df-76ff-44eb-9c6e-77fbbcfb796a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b974c6c2-ac42-4261-a475-88ff7fdd108c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b974c6c2-ac42-4261-a475-88ff7fdd108c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Agenda_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b974c6c2-ac42-4261-a475-88ff7fdd108c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2caf28c8-d41e-4913-b050-ea6409f428de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2caf28c8-d41e-4913-b050-ea6409f428de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Agenda_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2caf28c8-d41e-4913-b050-ea6409f428de>.
+    
+<http://data.lblod.info/id/remote-data-objects/5624c1a4-897b-44fa-87f2-ed055ef48552> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5624c1a4-897b-44fa-87f2-ed055ef48552";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Agenda_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5624c1a4-897b-44fa-87f2-ed055ef48552>.
+    
+<http://data.lblod.info/id/remote-data-objects/91845e8b-cb1c-4488-9460-b8eec91e8ef5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91845e8b-cb1c-4488-9460-b8eec91e8ef5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Agenda_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91845e8b-cb1c-4488-9460-b8eec91e8ef5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0ddd466-339a-4094-9b9b-bda90d43cd42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0ddd466-339a-4094-9b9b-bda90d43cd42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Agenda_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0ddd466-339a-4094-9b9b-bda90d43cd42>.
+    
+<http://data.lblod.info/id/remote-data-objects/62fc2410-6a6b-4e79-8845-4a48f5795a69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62fc2410-6a6b-4e79-8845-4a48f5795a69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62fc2410-6a6b-4e79-8845-4a48f5795a69>.
+    
+<http://data.lblod.info/id/remote-data-objects/47bc95f1-658d-4ad0-ae3d-97161a7732b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47bc95f1-658d-4ad0-ae3d-97161a7732b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47bc95f1-658d-4ad0-ae3d-97161a7732b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a60f463-b844-4676-92f1-31890125389e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a60f463-b844-4676-92f1-31890125389e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a60f463-b844-4676-92f1-31890125389e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dea4543-f22d-4e70-a8a4-3b548421f363> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dea4543-f22d-4e70-a8a4-3b548421f363";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dea4543-f22d-4e70-a8a4-3b548421f363>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f7cdff0-fd50-41cd-a637-56d816f1af1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f7cdff0-fd50-41cd-a637-56d816f1af1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f7cdff0-fd50-41cd-a637-56d816f1af1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b736d420-fdce-4fdc-acf9-bdea7144c76c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b736d420-fdce-4fdc-acf9-bdea7144c76c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b736d420-fdce-4fdc-acf9-bdea7144c76c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f462e57-593f-45aa-a54a-12bc681e5358> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f462e57-593f-45aa-a54a-12bc681e5358";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f462e57-593f-45aa-a54a-12bc681e5358>.
+    
+<http://data.lblod.info/id/remote-data-objects/947248d4-44b8-48a6-b881-57a0530b4a46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "947248d4-44b8-48a6-b881-57a0530b4a46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/947248d4-44b8-48a6-b881-57a0530b4a46>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6bd6f5d-0bdd-4c6d-a5e1-716288f083c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6bd6f5d-0bdd-4c6d-a5e1-716288f083c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Notulen_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6bd6f5d-0bdd-4c6d-a5e1-716288f083c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7c1ac87-34d9-4b1b-a93a-1731bb7f8aae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7c1ac87-34d9-4b1b-a93a-1731bb7f8aae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Notulen_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7c1ac87-34d9-4b1b-a93a-1731bb7f8aae>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8e03b69-46f9-4666-9e67-e2aec6ba2856> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8e03b69-46f9-4666-9e67-e2aec6ba2856";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Notulen_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8e03b69-46f9-4666-9e67-e2aec6ba2856>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d386b2f-d52d-4561-98ac-4deb460cb215> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d386b2f-d52d-4561-98ac-4deb460cb215";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Notulen_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d386b2f-d52d-4561-98ac-4deb460cb215>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc5e43fa-a344-4cfb-8c76-51d08814802a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc5e43fa-a344-4cfb-8c76-51d08814802a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Notulen_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc5e43fa-a344-4cfb-8c76-51d08814802a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ce089e8-db3e-4e5c-a8e9-ed3d3978e7cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ce089e8-db3e-4e5c-a8e9-ed3d3978e7cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Notulen_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ce089e8-db3e-4e5c-a8e9-ed3d3978e7cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/81961d02-af6b-44a1-8296-9f61f2e8935a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81961d02-af6b-44a1-8296-9f61f2e8935a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Notulen_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81961d02-af6b-44a1-8296-9f61f2e8935a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c88753e4-b929-4ebb-a9c6-8e8b72d9747c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c88753e4-b929-4ebb-a9c6-8e8b72d9747c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_20-12-2021_2732.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c88753e4-b929-4ebb-a9c6-8e8b72d9747c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f59aa79-56cd-4612-9bf5-6dff9964150a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f59aa79-56cd-4612-9bf5-6dff9964150a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_20-12-2021_2733.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f59aa79-56cd-4612-9bf5-6dff9964150a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b4eb903-a183-43da-9fa4-fe98e5f0afb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b4eb903-a183-43da-9fa4-fe98e5f0afb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_20-12-2021_2837.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d373d47-26b0-48bd-9dd3-f83a10bbb3d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b4eb903-a183-43da-9fa4-fe98e5f0afb3>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201405-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201405-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201405-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201405-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/55810a09-3e27-4aaa-9698-4b831392ece6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "55810a09-3e27-4aaa-9698-4b831392ece6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "084196e0-9550-43e7-ab34-fc24ef92559d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/8bc04460-3c9f-493d-b6d1-23d46677924a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8bc04460-3c9f-493d-b6d1-23d46677924a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d>.
+
+  <http://redpencil.data.gift/id/task/c6067289-f47b-4e5e-b396-5d9c23045dcb> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c6067289-f47b-4e5e-b396-5d9c23045dcb";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/55810a09-3e27-4aaa-9698-4b831392ece6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/8bc04460-3c9f-493d-b6d1-23d46677924a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/78fb554f-9eae-443d-a9a2-03e18ea7234e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78fb554f-9eae-443d-a9a2-03e18ea7234e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_20-12-2021_2862.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78fb554f-9eae-443d-a9a2-03e18ea7234e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe6ab7a4-31e1-414b-bed8-2e18d5c55ebd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe6ab7a4-31e1-414b-bed8-2e18d5c55ebd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_20-12-2021_2917.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe6ab7a4-31e1-414b-bed8-2e18d5c55ebd>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dcd45f6-0c90-4e11-a167-b6d41fdc14e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dcd45f6-0c90-4e11-a167-b6d41fdc14e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_20-12-2021_2918.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dcd45f6-0c90-4e11-a167-b6d41fdc14e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c70526f-946f-4e9f-ba35-c7fe6c930f21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c70526f-946f-4e9f-ba35-c7fe6c930f21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_25-04-2022_3972.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c70526f-946f-4e9f-ba35-c7fe6c930f21>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c1b0035-bb66-4d17-92f6-93704da628d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c1b0035-bb66-4d17-92f6-93704da628d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_25-04-2022_3973.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c1b0035-bb66-4d17-92f6-93704da628d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/40935d9a-7a4d-49ab-8e3b-01ddf8f13aeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40935d9a-7a4d-49ab-8e3b-01ddf8f13aeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_25-04-2022_3974.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40935d9a-7a4d-49ab-8e3b-01ddf8f13aeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/6df6ef04-54b2-4171-a0ea-70620562edb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6df6ef04-54b2-4171-a0ea-70620562edb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_25-04-2022_3989.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6df6ef04-54b2-4171-a0ea-70620562edb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/96a0e339-1c07-4b9a-baa0-80948f373d4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96a0e339-1c07-4b9a-baa0-80948f373d4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_25-04-2022_3990.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96a0e339-1c07-4b9a-baa0-80948f373d4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cfd2cb5-6a22-4041-b140-8a4d38bc7824> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cfd2cb5-6a22-4041-b140-8a4d38bc7824";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_25-10-2021_2355.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cfd2cb5-6a22-4041-b140-8a4d38bc7824>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a44e0b5-2831-46b8-b239-c52fe07d8d6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a44e0b5-2831-46b8-b239-c52fe07d8d6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_25-10-2021_2478.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a44e0b5-2831-46b8-b239-c52fe07d8d6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ca60672-c6db-4349-b091-601f3858cb34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ca60672-c6db-4349-b091-601f3858cb34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_27-06-2022_4436.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ca60672-c6db-4349-b091-601f3858cb34>.
+    
+<http://data.lblod.info/id/remote-data-objects/e47ae68a-b90d-4f94-ac06-744965c9aa68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e47ae68a-b90d-4f94-ac06-744965c9aa68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_27-06-2022_4437.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e47ae68a-b90d-4f94-ac06-744965c9aa68>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e118a3e-140e-4be2-a94f-274467e392b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e118a3e-140e-4be2-a94f-274467e392b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_27-06-2022_4439.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e118a3e-140e-4be2-a94f-274467e392b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9e5015d-439c-4324-801c-fdd956864ec7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9e5015d-439c-4324-801c-fdd956864ec7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_27-06-2022_4440.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9e5015d-439c-4324-801c-fdd956864ec7>.
+    
+<http://data.lblod.info/id/remote-data-objects/860739a3-e3a3-41c6-9939-044549fa11ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "860739a3-e3a3-41c6-9939-044549fa11ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_27-06-2022_4465.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/860739a3-e3a3-41c6-9939-044549fa11ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/e605c9f0-7719-4106-86fc-6827d6d1e0b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e605c9f0-7719-4106-86fc-6827d6d1e0b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_27-06-2022_4466.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e605c9f0-7719-4106-86fc-6827d6d1e0b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cc912bd-1727-4773-b41a-294e5f6c9daf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cc912bd-1727-4773-b41a-294e5f6c9daf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_27-06-2022_4467.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cc912bd-1727-4773-b41a-294e5f6c9daf>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f29b38c-7d3a-4667-8b42-76d3fbf7c88c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f29b38c-7d3a-4667-8b42-76d3fbf7c88c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_29-11-2021_2644.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f29b38c-7d3a-4667-8b42-76d3fbf7c88c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1749097-74a3-4af8-8fb4-17d1764c7466> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1749097-74a3-4af8-8fb4-17d1764c7466";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_29-11-2021_2702.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1749097-74a3-4af8-8fb4-17d1764c7466>.
+    
+<http://data.lblod.info/id/remote-data-objects/73b3efa7-dff2-40c2-93bc-be7b70bb6e67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73b3efa7-dff2-40c2-93bc-be7b70bb6e67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_29-11-2021_2766.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73b3efa7-dff2-40c2-93bc-be7b70bb6e67>.
+    
+<http://data.lblod.info/id/remote-data-objects/33e5694f-d924-4a49-955c-81e41575e753> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33e5694f-d924-4a49-955c-81e41575e753";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_30-05-2022_4155.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33e5694f-d924-4a49-955c-81e41575e753>.
+    
+<http://data.lblod.info/id/remote-data-objects/f44f7cf9-7770-4d6a-bb4b-c25b0d34e9be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f44f7cf9-7770-4d6a-bb4b-c25b0d34e9be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_31-01-2022_3096.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f44f7cf9-7770-4d6a-bb4b-c25b0d34e9be>.
+    
+<http://data.lblod.info/id/remote-data-objects/5836f352-cab5-4124-8d2d-a98b264372e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5836f352-cab5-4124-8d2d-a98b264372e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_31-01-2022_3163.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5836f352-cab5-4124-8d2d-a98b264372e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/10632528-9eed-4bce-a673-a3e515b1d8b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10632528-9eed-4bce-a673-a3e515b1d8b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_31-01-2022_3304.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10632528-9eed-4bce-a673-a3e515b1d8b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4ebb947-0f79-4265-8f46-c36255322632> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4ebb947-0f79-4265-8f46-c36255322632";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/379d50591d747de727cadf0d8a738492528d6ef778c75cb93a0c183a0fe0bf4a/GetPublication?filename=Uittreksels_31-01-2022_3305.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4ebb947-0f79-4265-8f46-c36255322632>.
+    
+<http://data.lblod.info/id/remote-data-objects/16ddf733-670b-4a30-b604-c8801c3b794b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16ddf733-670b-4a30-b604-c8801c3b794b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16ddf733-670b-4a30-b604-c8801c3b794b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb182142-5227-441b-9785-06f376fae3b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb182142-5227-441b-9785-06f376fae3b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb182142-5227-441b-9785-06f376fae3b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/eea7a296-db96-494d-a377-1b65ad7eafd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eea7a296-db96-494d-a377-1b65ad7eafd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eea7a296-db96-494d-a377-1b65ad7eafd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0245724-d5a9-48ef-b589-1949afcd5a32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0245724-d5a9-48ef-b589-1949afcd5a32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0245724-d5a9-48ef-b589-1949afcd5a32>.
+    
+<http://data.lblod.info/id/remote-data-objects/242446e0-2c4b-4cbc-8ea4-bb04d5abf3d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "242446e0-2c4b-4cbc-8ea4-bb04d5abf3d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/242446e0-2c4b-4cbc-8ea4-bb04d5abf3d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7373bbb6-a109-46eb-abde-7306a375b360> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7373bbb6-a109-46eb-abde-7306a375b360";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7373bbb6-a109-46eb-abde-7306a375b360>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b258934-578f-456c-815a-57591dcfd9b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b258934-578f-456c-815a-57591dcfd9b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b258934-578f-456c-815a-57591dcfd9b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/48210533-d013-4415-8cad-39a87098a463> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48210533-d013-4415-8cad-39a87098a463";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48210533-d013-4415-8cad-39a87098a463>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6e62283-c4f8-48a9-b18c-ba0e81d739ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6e62283-c4f8-48a9-b18c-ba0e81d739ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6e62283-c4f8-48a9-b18c-ba0e81d739ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/1aa69c8d-a2f0-4e1d-b10f-f307d1e0b34d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1aa69c8d-a2f0-4e1d-b10f-f307d1e0b34d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1aa69c8d-a2f0-4e1d-b10f-f307d1e0b34d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f15e1976-a8c4-4b9e-a22f-446b8f20d69e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f15e1976-a8c4-4b9e-a22f-446b8f20d69e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f15e1976-a8c4-4b9e-a22f-446b8f20d69e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d57948e3-9bbb-4f56-99e6-41f62a341d16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d57948e3-9bbb-4f56-99e6-41f62a341d16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d57948e3-9bbb-4f56-99e6-41f62a341d16>.
+    
+<http://data.lblod.info/id/remote-data-objects/c98d5d3d-2507-409b-83f0-227c9d03fc16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c98d5d3d-2507-409b-83f0-227c9d03fc16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c98d5d3d-2507-409b-83f0-227c9d03fc16>.
+    
+<http://data.lblod.info/id/remote-data-objects/13dbdd0d-2108-4217-9e36-6dbf3028b244> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13dbdd0d-2108-4217-9e36-6dbf3028b244";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13dbdd0d-2108-4217-9e36-6dbf3028b244>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad9a6992-f567-46c9-9061-3a2c6e2ea779> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad9a6992-f567-46c9-9061-3a2c6e2ea779";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad9a6992-f567-46c9-9061-3a2c6e2ea779>.
+    
+<http://data.lblod.info/id/remote-data-objects/67581540-faaa-4ff1-a20b-c9ff39737fc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67581540-faaa-4ff1-a20b-c9ff39737fc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67581540-faaa-4ff1-a20b-c9ff39737fc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ac075b0-e9cd-49a4-9bbd-019d0391316f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ac075b0-e9cd-49a4-9bbd-019d0391316f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ac075b0-e9cd-49a4-9bbd-019d0391316f>.
+    
+<http://data.lblod.info/id/remote-data-objects/27426ca8-81c0-471c-9c9f-516e48e07a05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27426ca8-81c0-471c-9c9f-516e48e07a05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27426ca8-81c0-471c-9c9f-516e48e07a05>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7ec2c4d-cb63-4d65-bdeb-de568f1b5629> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7ec2c4d-cb63-4d65-bdeb-de568f1b5629";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7ec2c4d-cb63-4d65-bdeb-de568f1b5629>.
+    
+<http://data.lblod.info/id/remote-data-objects/26793b07-d18c-4803-99fd-b567498269b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26793b07-d18c-4803-99fd-b567498269b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26793b07-d18c-4803-99fd-b567498269b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/95139dab-79ef-4897-98b0-e285d73ce037> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95139dab-79ef-4897-98b0-e285d73ce037";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95139dab-79ef-4897-98b0-e285d73ce037>.
+    
+<http://data.lblod.info/id/remote-data-objects/685fb12d-299f-4ea4-ab71-7891828be40a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "685fb12d-299f-4ea4-ab71-7891828be40a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Uittreksels_20-12-2021_2835.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/685fb12d-299f-4ea4-ab71-7891828be40a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ab18e0c-7669-4cab-915a-cebfd13e918b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ab18e0c-7669-4cab-915a-cebfd13e918b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Uittreksels_20-12-2021_2863.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ab18e0c-7669-4cab-915a-cebfd13e918b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb6f01d0-73d0-445e-a528-59de72de81a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb6f01d0-73d0-445e-a528-59de72de81a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Uittreksels_29-11-2021_2738.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb6f01d0-73d0-445e-a528-59de72de81a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/877bf1b9-0c80-48a4-8b02-ec9a2593f094> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "877bf1b9-0c80-48a4-8b02-ec9a2593f094";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Uittreksels_30-05-2022_4156.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/084196e0-9550-43e7-ab34-fc24ef92559d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/877bf1b9-0c80-48a4-8b02-ec9a2593f094>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201406-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201406-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201406-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201406-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/6099e3f0-e683-4f66-ad56-4d44a96113e6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6099e3f0-e683-4f66-ad56-4d44a96113e6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5241f79e-999a-44d2-8f8f-7b3595809b96";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/95b0bd6d-ec50-455a-b76d-8ca18b3383e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "95b0bd6d-ec50-455a-b76d-8ca18b3383e8";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96>.
+
+  <http://redpencil.data.gift/id/task/a94af48f-025c-4ba9-b6f9-68b165807636> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a94af48f-025c-4ba9-b6f9-68b165807636";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/6099e3f0-e683-4f66-ad56-4d44a96113e6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/95b0bd6d-ec50-455a-b76d-8ca18b3383e8>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/fa3f30a6-6d89-457f-aa7a-209bd3f18b70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa3f30a6-6d89-457f-aa7a-209bd3f18b70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Uittreksels_31-01-2022_3157.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa3f30a6-6d89-457f-aa7a-209bd3f18b70>.
+    
+<http://data.lblod.info/id/remote-data-objects/a068ee3f-f0e2-4f79-8469-cef736f6e980> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a068ee3f-f0e2-4f79-8469-cef736f6e980";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/9327afbb59e2a5afc416960a2cb566cee47600786d233924d152be3f30697377/GetPublication?filename=Uittreksels_31-01-2022_3168.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a068ee3f-f0e2-4f79-8469-cef736f6e980>.
+    
+<http://data.lblod.info/id/remote-data-objects/5418f6d2-1dfb-4f68-a959-3ebc93fb821c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5418f6d2-1dfb-4f68-a959-3ebc93fb821c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/e4775e3294d6d5ca1ae2f53195f2636af6f18b96f2a931812f432a88d4a9a6e4/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20van%20de%20burgemeester_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5418f6d2-1dfb-4f68-a959-3ebc93fb821c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e25343c6-0bc3-44d0-9658-ea101c305056> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e25343c6-0bc3-44d0-9658-ea101c305056";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/e4775e3294d6d5ca1ae2f53195f2636af6f18b96f2a931812f432a88d4a9a6e4/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20van%20de%20burgemeester_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e25343c6-0bc3-44d0-9658-ea101c305056>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5a2f9d5-c458-453e-aed5-988fe848eb2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5a2f9d5-c458-453e-aed5-988fe848eb2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/e4775e3294d6d5ca1ae2f53195f2636af6f18b96f2a931812f432a88d4a9a6e4/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20van%20de%20burgemeester_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5a2f9d5-c458-453e-aed5-988fe848eb2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9afcdb34-3fc9-4828-b27b-992753e55dbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9afcdb34-3fc9-4828-b27b-992753e55dbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/e4775e3294d6d5ca1ae2f53195f2636af6f18b96f2a931812f432a88d4a9a6e4/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20van%20de%20burgemeester_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9afcdb34-3fc9-4828-b27b-992753e55dbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/092c6860-e47b-4540-8b11-ab4ee835ae09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "092c6860-e47b-4540-8b11-ab4ee835ae09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/e4775e3294d6d5ca1ae2f53195f2636af6f18b96f2a931812f432a88d4a9a6e4/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20van%20de%20burgemeester_25-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/092c6860-e47b-4540-8b11-ab4ee835ae09>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b6cb933-b313-4382-bd68-58d4e0ed8001> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b6cb933-b313-4382-bd68-58d4e0ed8001";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/e4775e3294d6d5ca1ae2f53195f2636af6f18b96f2a931812f432a88d4a9a6e4/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20van%20de%20burgemeester_25-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b6cb933-b313-4382-bd68-58d4e0ed8001>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd6092c2-210f-4e81-84e7-8da68992dc16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd6092c2-210f-4e81-84e7-8da68992dc16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/e4775e3294d6d5ca1ae2f53195f2636af6f18b96f2a931812f432a88d4a9a6e4/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20van%20de%20burgemeester_26-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd6092c2-210f-4e81-84e7-8da68992dc16>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4138c0c-b8f6-4940-9ebc-902afb2ed41d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4138c0c-b8f6-4940-9ebc-902afb2ed41d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/e4775e3294d6d5ca1ae2f53195f2636af6f18b96f2a931812f432a88d4a9a6e4/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20van%20de%20burgemeester_27-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4138c0c-b8f6-4940-9ebc-902afb2ed41d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b339006-09e7-4b30-af03-4a9a0b87fbed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b339006-09e7-4b30-af03-4a9a0b87fbed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/e4775e3294d6d5ca1ae2f53195f2636af6f18b96f2a931812f432a88d4a9a6e4/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20van%20de%20burgemeester_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b339006-09e7-4b30-af03-4a9a0b87fbed>.
+    
+<http://data.lblod.info/id/remote-data-objects/81adf179-38ae-4537-82a7-ae03022611b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81adf179-38ae-4537-82a7-ae03022611b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/e4775e3294d6d5ca1ae2f53195f2636af6f18b96f2a931812f432a88d4a9a6e4/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20van%20de%20burgemeester_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81adf179-38ae-4537-82a7-ae03022611b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a300c451-b24b-4700-bd8a-2c3dd77ae6f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a300c451-b24b-4700-bd8a-2c3dd77ae6f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.heuvelland.be/LBLODWeb/Home/Overzicht/e4775e3294d6d5ca1ae2f53195f2636af6f18b96f2a931812f432a88d4a9a6e4/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20van%20de%20burgemeester_29-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a300c451-b24b-4700-bd8a-2c3dd77ae6f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/93a88052-9975-43c6-963d-8c7a9d680041> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93a88052-9975-43c6-963d-8c7a9d680041";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/04a219dd-af49-4b97-86e1-a690812e7c35/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93a88052-9975-43c6-963d-8c7a9d680041>.
+    
+<http://data.lblod.info/id/remote-data-objects/0223fc7e-febf-4a91-a210-340775cd1c19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0223fc7e-febf-4a91-a210-340775cd1c19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/04a219dd-af49-4b97-86e1-a690812e7c35/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0223fc7e-febf-4a91-a210-340775cd1c19>.
+    
+<http://data.lblod.info/id/remote-data-objects/82bc7e4d-c345-40cd-a9de-aafe0c892df5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82bc7e4d-c345-40cd-a9de-aafe0c892df5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/04a219dd-af49-4b97-86e1-a690812e7c35/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82bc7e4d-c345-40cd-a9de-aafe0c892df5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a76f4693-5e92-4495-a185-8166428c2e94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a76f4693-5e92-4495-a185-8166428c2e94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/04a219dd-af49-4b97-86e1-a690812e7c35/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a76f4693-5e92-4495-a185-8166428c2e94>.
+    
+<http://data.lblod.info/id/remote-data-objects/008e2905-07c9-4f2e-9433-17424114f03c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "008e2905-07c9-4f2e-9433-17424114f03c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/04a219dd-af49-4b97-86e1-a690812e7c35/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/008e2905-07c9-4f2e-9433-17424114f03c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9bf23758-b6cd-4525-b2a3-18795a98c1ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9bf23758-b6cd-4525-b2a3-18795a98c1ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/04a219dd-af49-4b97-86e1-a690812e7c35/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9bf23758-b6cd-4525-b2a3-18795a98c1ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a029633-9dbf-4825-b347-d3f7f755c0a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a029633-9dbf-4825-b347-d3f7f755c0a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/04a219dd-af49-4b97-86e1-a690812e7c35/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a029633-9dbf-4825-b347-d3f7f755c0a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d7d7da3-f917-40de-9f12-5f841febe74c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d7d7da3-f917-40de-9f12-5f841febe74c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/04a219dd-af49-4b97-86e1-a690812e7c35/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d7d7da3-f917-40de-9f12-5f841febe74c>.
+    
+<http://data.lblod.info/id/remote-data-objects/21269196-9a19-4ff4-b439-ef84b7731ef3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21269196-9a19-4ff4-b439-ef84b7731ef3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/04a219dd-af49-4b97-86e1-a690812e7c35/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21269196-9a19-4ff4-b439-ef84b7731ef3>.
+    
+<http://data.lblod.info/id/remote-data-objects/21c38ec7-2b10-4a86-b5a8-a6b437623b13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21c38ec7-2b10-4a86-b5a8-a6b437623b13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/ce7e5da1d9e0daeca1ab9e6112fb2e00850f77ad73de61c356006be82f108889/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21c38ec7-2b10-4a86-b5a8-a6b437623b13>.
+    
+<http://data.lblod.info/id/remote-data-objects/789955f0-4b63-404a-a23e-80e840066271> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "789955f0-4b63-404a-a23e-80e840066271";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/ce7e5da1d9e0daeca1ab9e6112fb2e00850f77ad73de61c356006be82f108889/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/789955f0-4b63-404a-a23e-80e840066271>.
+    
+<http://data.lblod.info/id/remote-data-objects/80361aa9-0d39-4091-80f3-fbe62db274aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80361aa9-0d39-4091-80f3-fbe62db274aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/ce7e5da1d9e0daeca1ab9e6112fb2e00850f77ad73de61c356006be82f108889/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80361aa9-0d39-4091-80f3-fbe62db274aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a576272-0ec4-481e-b8b8-12fea9a6b818> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a576272-0ec4-481e-b8b8-12fea9a6b818";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/ce7e5da1d9e0daeca1ab9e6112fb2e00850f77ad73de61c356006be82f108889/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a576272-0ec4-481e-b8b8-12fea9a6b818>.
+    
+<http://data.lblod.info/id/remote-data-objects/9edec8be-ead0-494f-ada1-76edba6dd73e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9edec8be-ead0-494f-ada1-76edba6dd73e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/ce7e5da1d9e0daeca1ab9e6112fb2e00850f77ad73de61c356006be82f108889/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9edec8be-ead0-494f-ada1-76edba6dd73e>.
+    
+<http://data.lblod.info/id/remote-data-objects/42e8365c-c5e6-4387-b8bd-ad1709dcb0fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42e8365c-c5e6-4387-b8bd-ad1709dcb0fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/ce7e5da1d9e0daeca1ab9e6112fb2e00850f77ad73de61c356006be82f108889/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42e8365c-c5e6-4387-b8bd-ad1709dcb0fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d9b1818-6271-4350-b71c-edbf995d1cb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d9b1818-6271-4350-b71c-edbf995d1cb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/ce7e5da1d9e0daeca1ab9e6112fb2e00850f77ad73de61c356006be82f108889/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d9b1818-6271-4350-b71c-edbf995d1cb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/12cf1da9-5e90-4247-bbca-e1063861cf0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12cf1da9-5e90-4247-bbca-e1063861cf0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/ce7e5da1d9e0daeca1ab9e6112fb2e00850f77ad73de61c356006be82f108889/GetPublication?filename=Uittreksels_27-06-2022_495.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12cf1da9-5e90-4247-bbca-e1063861cf0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/879fd6cf-6518-477d-b734-d8ed52072d07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "879fd6cf-6518-477d-b734-d8ed52072d07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/cfb697822916c7daf782bd0f35690b48afb020bd5bd2f53ade7bb5694991f904/GetPublication?filename=Agenda_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/879fd6cf-6518-477d-b734-d8ed52072d07>.
+    
+<http://data.lblod.info/id/remote-data-objects/6646e80f-cca3-448c-be35-e94bc9d6381d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6646e80f-cca3-448c-be35-e94bc9d6381d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/cfb697822916c7daf782bd0f35690b48afb020bd5bd2f53ade7bb5694991f904/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6646e80f-cca3-448c-be35-e94bc9d6381d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f4a6972-62b1-4c3b-96d5-30707224350d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f4a6972-62b1-4c3b-96d5-30707224350d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/cfb697822916c7daf782bd0f35690b48afb020bd5bd2f53ade7bb5694991f904/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f4a6972-62b1-4c3b-96d5-30707224350d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7c17a02-4c03-4493-908a-cfb76dc19a6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7c17a02-4c03-4493-908a-cfb76dc19a6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/cfb697822916c7daf782bd0f35690b48afb020bd5bd2f53ade7bb5694991f904/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7c17a02-4c03-4493-908a-cfb76dc19a6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6770c93d-c11a-43a4-89c4-2c3f4349a31d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6770c93d-c11a-43a4-89c4-2c3f4349a31d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/cfb697822916c7daf782bd0f35690b48afb020bd5bd2f53ade7bb5694991f904/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6770c93d-c11a-43a4-89c4-2c3f4349a31d>.
+    
+<http://data.lblod.info/id/remote-data-objects/278037bf-2c01-4c23-955e-bac9f2e22342> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "278037bf-2c01-4c23-955e-bac9f2e22342";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/cfb697822916c7daf782bd0f35690b48afb020bd5bd2f53ade7bb5694991f904/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/278037bf-2c01-4c23-955e-bac9f2e22342>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffc5342e-8fe9-4b2d-853c-c23e89ee17e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffc5342e-8fe9-4b2d-853c-c23e89ee17e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/cfb697822916c7daf782bd0f35690b48afb020bd5bd2f53ade7bb5694991f904/GetPublication?filename=Notulen_Gemeenteraad_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffc5342e-8fe9-4b2d-853c-c23e89ee17e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a7490bd-70d3-4679-a3e2-1d656ca8a892> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a7490bd-70d3-4679-a3e2-1d656ca8a892";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/cfb697822916c7daf782bd0f35690b48afb020bd5bd2f53ade7bb5694991f904/GetPublication?filename=Notulen_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a7490bd-70d3-4679-a3e2-1d656ca8a892>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a72a2f6-59f8-4800-929b-26dfc9fd3ecf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a72a2f6-59f8-4800-929b-26dfc9fd3ecf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/cfb697822916c7daf782bd0f35690b48afb020bd5bd2f53ade7bb5694991f904/GetPublication?filename=Notulen_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a72a2f6-59f8-4800-929b-26dfc9fd3ecf>.
+    
+<http://data.lblod.info/id/remote-data-objects/89c474e4-1edd-4141-b135-8219cfb01c7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89c474e4-1edd-4141-b135-8219cfb01c7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/cfb697822916c7daf782bd0f35690b48afb020bd5bd2f53ade7bb5694991f904/GetPublication?filename=Notulen_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89c474e4-1edd-4141-b135-8219cfb01c7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b17a3e9b-299a-4640-9059-73f7dabdf79a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b17a3e9b-299a-4640-9059-73f7dabdf79a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/cfb697822916c7daf782bd0f35690b48afb020bd5bd2f53ade7bb5694991f904/GetPublication?filename=Notulen_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b17a3e9b-299a-4640-9059-73f7dabdf79a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5eec3391-ad7f-4d44-8020-5436e9deac08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5eec3391-ad7f-4d44-8020-5436e9deac08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/cfb697822916c7daf782bd0f35690b48afb020bd5bd2f53ade7bb5694991f904/GetPublication?filename=Uittreksels_07-03-2022_304.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5eec3391-ad7f-4d44-8020-5436e9deac08>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dd3877b-6795-4cc6-87f3-37f04e2c1dce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dd3877b-6795-4cc6-87f3-37f04e2c1dce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/cfb697822916c7daf782bd0f35690b48afb020bd5bd2f53ade7bb5694991f904/GetPublication?filename=Uittreksels_07-03-2022_305.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dd3877b-6795-4cc6-87f3-37f04e2c1dce>.
+    
+<http://data.lblod.info/id/remote-data-objects/981017bb-e110-4390-a256-1b71a6d8aac2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "981017bb-e110-4390-a256-1b71a6d8aac2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/cfb697822916c7daf782bd0f35690b48afb020bd5bd2f53ade7bb5694991f904/GetPublication?filename=Uittreksels_27-06-2022_490.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/981017bb-e110-4390-a256-1b71a6d8aac2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9e2f62e-9961-4c39-a97d-5199d5d82056> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9e2f62e-9961-4c39-a97d-5199d5d82056";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/cfb697822916c7daf782bd0f35690b48afb020bd5bd2f53ade7bb5694991f904/GetPublication?filename=Uittreksels_27-06-2022_492.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9e2f62e-9961-4c39-a97d-5199d5d82056>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb5f0278-e6c6-42d6-b136-424fe9087ee5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb5f0278-e6c6-42d6-b136-424fe9087ee5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb5f0278-e6c6-42d6-b136-424fe9087ee5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ee3c796-afb3-4229-940f-a0a285483e5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ee3c796-afb3-4229-940f-a0a285483e5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ee3c796-afb3-4229-940f-a0a285483e5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a191b4f-ce89-447f-ba44-be8390a648ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a191b4f-ce89-447f-ba44-be8390a648ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a191b4f-ce89-447f-ba44-be8390a648ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b79f876-1b8f-4a6f-9f46-2f2a636695f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b79f876-1b8f-4a6f-9f46-2f2a636695f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b79f876-1b8f-4a6f-9f46-2f2a636695f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea807a86-89c1-487d-865a-9e37b467347b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea807a86-89c1-487d-865a-9e37b467347b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5241f79e-999a-44d2-8f8f-7b3595809b96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea807a86-89c1-487d-865a-9e37b467347b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201407-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201407-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201407-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201407-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/bf8e8aa3-30a1-40f0-b797-efbb0841590b> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bf8e8aa3-30a1-40f0-b797-efbb0841590b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "62bb0d74-cefb-4dda-90da-9726f2139a4d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/84518281-2adb-4ecc-8aa2-d46b93e27883> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "84518281-2adb-4ecc-8aa2-d46b93e27883";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d>.
+
+  <http://redpencil.data.gift/id/task/5ab1305e-f402-49e2-aea9-5cc9862eadad> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5ab1305e-f402-49e2-aea9-5cc9862eadad";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/bf8e8aa3-30a1-40f0-b797-efbb0841590b>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/84518281-2adb-4ecc-8aa2-d46b93e27883>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/0ce55122-9b0c-466c-8748-36801fb5f932> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ce55122-9b0c-466c-8748-36801fb5f932";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ce55122-9b0c-466c-8748-36801fb5f932>.
+    
+<http://data.lblod.info/id/remote-data-objects/995ed14a-a268-4d94-ae82-6ffe960a3017> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "995ed14a-a268-4d94-ae82-6ffe960a3017";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/995ed14a-a268-4d94-ae82-6ffe960a3017>.
+    
+<http://data.lblod.info/id/remote-data-objects/97411a37-bca2-4344-9b86-7bd58a0601c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97411a37-bca2-4344-9b86-7bd58a0601c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97411a37-bca2-4344-9b86-7bd58a0601c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e032111-51e6-4d5e-acec-6aa93a9fc644> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e032111-51e6-4d5e-acec-6aa93a9fc644";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e032111-51e6-4d5e-acec-6aa93a9fc644>.
+    
+<http://data.lblod.info/id/remote-data-objects/c13d9d22-bd29-42f3-bafb-5937fbd8077d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c13d9d22-bd29-42f3-bafb-5937fbd8077d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c13d9d22-bd29-42f3-bafb-5937fbd8077d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b85fffb6-1907-403f-94c0-08a33f91fca4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b85fffb6-1907-403f-94c0-08a33f91fca4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b85fffb6-1907-403f-94c0-08a33f91fca4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7841a793-2463-4c21-8b3b-994a4b658b56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7841a793-2463-4c21-8b3b-994a4b658b56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7841a793-2463-4c21-8b3b-994a4b658b56>.
+    
+<http://data.lblod.info/id/remote-data-objects/b982328e-8599-473e-b4da-8e2ae3abb65c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b982328e-8599-473e-b4da-8e2ae3abb65c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b982328e-8599-473e-b4da-8e2ae3abb65c>.
+    
+<http://data.lblod.info/id/remote-data-objects/23f9f49b-0ab1-476a-aa3d-89fd72c9c4aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23f9f49b-0ab1-476a-aa3d-89fd72c9c4aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23f9f49b-0ab1-476a-aa3d-89fd72c9c4aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5667395-39f2-4621-b507-2b7ff17bdd09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5667395-39f2-4621-b507-2b7ff17bdd09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5667395-39f2-4621-b507-2b7ff17bdd09>.
+    
+<http://data.lblod.info/id/remote-data-objects/273cff93-e08f-4e61-b0bc-03deb2ba8da6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "273cff93-e08f-4e61-b0bc-03deb2ba8da6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/273cff93-e08f-4e61-b0bc-03deb2ba8da6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f2002e9-3034-497c-b622-3a992d6808d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f2002e9-3034-497c-b622-3a992d6808d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f2002e9-3034-497c-b622-3a992d6808d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a70d8684-35d9-4a4d-aa33-73e37c11fe54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a70d8684-35d9-4a4d-aa33-73e37c11fe54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a70d8684-35d9-4a4d-aa33-73e37c11fe54>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e84d673-73fb-4745-8621-e0f54116e08a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e84d673-73fb-4745-8621-e0f54116e08a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e84d673-73fb-4745-8621-e0f54116e08a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f19ae1f4-41f5-4855-a54e-070fdbde16f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f19ae1f4-41f5-4855-a54e-070fdbde16f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f19ae1f4-41f5-4855-a54e-070fdbde16f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/954e9297-8619-4886-8346-ae7b40b9fc0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "954e9297-8619-4886-8346-ae7b40b9fc0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/954e9297-8619-4886-8346-ae7b40b9fc0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6951c1f-a2ab-47ca-85e0-afe78eff48c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6951c1f-a2ab-47ca-85e0-afe78eff48c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6951c1f-a2ab-47ca-85e0-afe78eff48c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1aa9670f-24d9-431e-a273-8bf009d61c21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1aa9670f-24d9-431e-a273-8bf009d61c21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.horebeke.be/LBLODWeb/Home/Overzicht/f8693ede6d9c9554b1dead6fe2c6ddc56c8aae697358ac45b0d04df27f73309c/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1aa9670f-24d9-431e-a273-8bf009d61c21>.
+    
+<http://data.lblod.info/id/remote-data-objects/70c291c2-7878-41e9-ba45-7bf147e9a3fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70c291c2-7878-41e9-ba45-7bf147e9a3fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70c291c2-7878-41e9-ba45-7bf147e9a3fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1f24f7b-4db3-4cb0-8e34-1ec02901d61c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1f24f7b-4db3-4cb0-8e34-1ec02901d61c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1f24f7b-4db3-4cb0-8e34-1ec02901d61c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6204ef98-e67a-44da-ab2c-25dc598ced15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6204ef98-e67a-44da-ab2c-25dc598ced15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6204ef98-e67a-44da-ab2c-25dc598ced15>.
+    
+<http://data.lblod.info/id/remote-data-objects/f42f300d-2d5f-465f-b005-3fd671d23cc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f42f300d-2d5f-465f-b005-3fd671d23cc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f42f300d-2d5f-465f-b005-3fd671d23cc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/51a229cd-d882-4acd-8698-d99bb4108b6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51a229cd-d882-4acd-8698-d99bb4108b6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51a229cd-d882-4acd-8698-d99bb4108b6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/865595a0-7965-40fa-90c1-6c29a58add31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "865595a0-7965-40fa-90c1-6c29a58add31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/865595a0-7965-40fa-90c1-6c29a58add31>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2b5baa6-838d-4cad-b4ac-ee3a58b5958c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2b5baa6-838d-4cad-b4ac-ee3a58b5958c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2b5baa6-838d-4cad-b4ac-ee3a58b5958c>.
+    
+<http://data.lblod.info/id/remote-data-objects/575e157c-f8e4-4a89-83a3-a49d62a45882> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "575e157c-f8e4-4a89-83a3-a49d62a45882";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/575e157c-f8e4-4a89-83a3-a49d62a45882>.
+    
+<http://data.lblod.info/id/remote-data-objects/3069950f-e652-4df3-b11f-ffc21bcd5fab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3069950f-e652-4df3-b11f-ffc21bcd5fab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_10-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3069950f-e652-4df3-b11f-ffc21bcd5fab>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e69e89e-3ada-4669-875c-8f1c534fa52a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e69e89e-3ada-4669-875c-8f1c534fa52a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e69e89e-3ada-4669-875c-8f1c534fa52a>.
+    
+<http://data.lblod.info/id/remote-data-objects/366fd8e3-d593-4448-8025-aafdee2f608f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "366fd8e3-d593-4448-8025-aafdee2f608f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/366fd8e3-d593-4448-8025-aafdee2f608f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a5f6b10-ed53-4b30-bfe6-1b099b7e660a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a5f6b10-ed53-4b30-bfe6-1b099b7e660a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_15-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a5f6b10-ed53-4b30-bfe6-1b099b7e660a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c091381-e17b-43c5-847b-f760678d3598> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c091381-e17b-43c5-847b-f760678d3598";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c091381-e17b-43c5-847b-f760678d3598>.
+    
+<http://data.lblod.info/id/remote-data-objects/11c145c2-5e35-4e25-8357-3f6044e8579f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11c145c2-5e35-4e25-8357-3f6044e8579f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11c145c2-5e35-4e25-8357-3f6044e8579f>.
+    
+<http://data.lblod.info/id/remote-data-objects/797af0f7-573c-4472-bfb3-d47d3021b847> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "797af0f7-573c-4472-bfb3-d47d3021b847";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/797af0f7-573c-4472-bfb3-d47d3021b847>.
+    
+<http://data.lblod.info/id/remote-data-objects/abb01ba5-1d75-4a47-bb2f-6da9b1651c8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abb01ba5-1d75-4a47-bb2f-6da9b1651c8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_17-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abb01ba5-1d75-4a47-bb2f-6da9b1651c8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/51bba055-4708-4c5f-b90c-98d586cf8af6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51bba055-4708-4c5f-b90c-98d586cf8af6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51bba055-4708-4c5f-b90c-98d586cf8af6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d79b758-c611-4901-9ab2-3b87367170d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d79b758-c611-4901-9ab2-3b87367170d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_20-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d79b758-c611-4901-9ab2-3b87367170d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/200475c6-8e6a-4bcc-97b0-a6d84ba8a119> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "200475c6-8e6a-4bcc-97b0-a6d84ba8a119";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/200475c6-8e6a-4bcc-97b0-a6d84ba8a119>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ea1291f-8b9f-4fbc-a97b-fed8c00f25fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ea1291f-8b9f-4fbc-a97b-fed8c00f25fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ea1291f-8b9f-4fbc-a97b-fed8c00f25fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/a603499b-5423-4adf-bdcb-b6ec8e13c2ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a603499b-5423-4adf-bdcb-b6ec8e13c2ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a603499b-5423-4adf-bdcb-b6ec8e13c2ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0d33233-be0a-40e9-99ea-b549f4e00506> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0d33233-be0a-40e9-99ea-b549f4e00506";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0d33233-be0a-40e9-99ea-b549f4e00506>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd806bc9-697e-43a2-a5aa-9e0c2f92dd4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd806bc9-697e-43a2-a5aa-9e0c2f92dd4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd806bc9-697e-43a2-a5aa-9e0c2f92dd4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/abcccfad-4d9b-4094-baab-4c1af9170cf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abcccfad-4d9b-4094-baab-4c1af9170cf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abcccfad-4d9b-4094-baab-4c1af9170cf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/25d57c55-47b9-4a67-b1e5-b0279444fa86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25d57c55-47b9-4a67-b1e5-b0279444fa86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25d57c55-47b9-4a67-b1e5-b0279444fa86>.
+    
+<http://data.lblod.info/id/remote-data-objects/18250ef7-7cc7-4ca6-a55b-b156297f50e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18250ef7-7cc7-4ca6-a55b-b156297f50e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18250ef7-7cc7-4ca6-a55b-b156297f50e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/656e674a-0324-4390-ac4f-2ed84d13ac7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "656e674a-0324-4390-ac4f-2ed84d13ac7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_27-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/656e674a-0324-4390-ac4f-2ed84d13ac7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fbefc6b-daf6-4fbf-9326-8d614f81bb77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fbefc6b-daf6-4fbf-9326-8d614f81bb77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fbefc6b-daf6-4fbf-9326-8d614f81bb77>.
+    
+<http://data.lblod.info/id/remote-data-objects/da747ac7-39f0-4ea9-84b1-932b2e02ce16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da747ac7-39f0-4ea9-84b1-932b2e02ce16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da747ac7-39f0-4ea9-84b1-932b2e02ce16>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e9894bc-69ae-401a-9431-d413871f7477> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e9894bc-69ae-401a-9431-d413871f7477";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_29-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e9894bc-69ae-401a-9431-d413871f7477>.
+    
+<http://data.lblod.info/id/remote-data-objects/a482731a-5ac7-4c1c-a2a8-a7f39fdc84f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a482731a-5ac7-4c1c-a2a8-a7f39fdc84f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/12c96eaaa4b12c8c08cef7c669da09ff328c61babd89c36fce9961b11b544068/GetPublication?filename=BesluitenLijst_burgemeester_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a482731a-5ac7-4c1c-a2a8-a7f39fdc84f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/76fe9c7b-eda9-4967-8d98-459044d9a33c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76fe9c7b-eda9-4967-8d98-459044d9a33c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/62bb0d74-cefb-4dda-90da-9726f2139a4d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76fe9c7b-eda9-4967-8d98-459044d9a33c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201409-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201409-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201409-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201409-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a3ed18ae-bd5c-4936-a913-5322831daa82> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a3ed18ae-bd5c-4936-a913-5322831daa82";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9a9a271a-93eb-4d6e-b27d-ddb305ef08d6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/32558b7d-1123-4e7c-b1a9-9c1169fc381e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "32558b7d-1123-4e7c-b1a9-9c1169fc381e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6>.
+
+  <http://redpencil.data.gift/id/task/5a93e35f-6a27-4783-b1b9-5ec8f551d72d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5a93e35f-6a27-4783-b1b9-5ec8f551d72d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a3ed18ae-bd5c-4936-a913-5322831daa82>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/32558b7d-1123-4e7c-b1a9-9c1169fc381e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/1b138c8b-e49d-4eb1-b4f7-fa9e88f580f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b138c8b-e49d-4eb1-b4f7-fa9e88f580f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b138c8b-e49d-4eb1-b4f7-fa9e88f580f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa7881c0-a283-41f9-b326-bd834d954ccb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa7881c0-a283-41f9-b326-bd834d954ccb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa7881c0-a283-41f9-b326-bd834d954ccb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d41625d1-8e47-4c6b-a0cb-219ed4e21d52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d41625d1-8e47-4c6b-a0cb-219ed4e21d52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d41625d1-8e47-4c6b-a0cb-219ed4e21d52>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e0b8b43-ab8e-4f38-b69d-e4dd9ab637a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e0b8b43-ab8e-4f38-b69d-e4dd9ab637a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e0b8b43-ab8e-4f38-b69d-e4dd9ab637a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/94047af2-ab05-4421-8f46-c6b8a1bc1677> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94047af2-ab05-4421-8f46-c6b8a1bc1677";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94047af2-ab05-4421-8f46-c6b8a1bc1677>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a0b9545-eeda-4e1a-99d8-851f18e894de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a0b9545-eeda-4e1a-99d8-851f18e894de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a0b9545-eeda-4e1a-99d8-851f18e894de>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9f0a745-b198-471c-9ee4-1427fba8ff90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9f0a745-b198-471c-9ee4-1427fba8ff90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9f0a745-b198-471c-9ee4-1427fba8ff90>.
+    
+<http://data.lblod.info/id/remote-data-objects/20b4a044-8c99-49bf-8635-600c72ca0482> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20b4a044-8c99-49bf-8635-600c72ca0482";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20b4a044-8c99-49bf-8635-600c72ca0482>.
+    
+<http://data.lblod.info/id/remote-data-objects/43d37024-43fd-4e92-b9a6-93f937c5d4b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43d37024-43fd-4e92-b9a6-93f937c5d4b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43d37024-43fd-4e92-b9a6-93f937c5d4b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/db7841cd-0315-44a0-a145-121fd4e7b163> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db7841cd-0315-44a0-a145-121fd4e7b163";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db7841cd-0315-44a0-a145-121fd4e7b163>.
+    
+<http://data.lblod.info/id/remote-data-objects/db7185d6-e749-4f40-bb03-654ade1be59a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db7185d6-e749-4f40-bb03-654ade1be59a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db7185d6-e749-4f40-bb03-654ade1be59a>.
+    
+<http://data.lblod.info/id/remote-data-objects/634c94ab-bd12-428e-a529-0506170f5a2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "634c94ab-bd12-428e-a529-0506170f5a2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/634c94ab-bd12-428e-a529-0506170f5a2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/143c632e-2e03-4218-9204-c7e9fd2b8676> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "143c632e-2e03-4218-9204-c7e9fd2b8676";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/143c632e-2e03-4218-9204-c7e9fd2b8676>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba7d1369-6540-4771-b247-f95d0096ad45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba7d1369-6540-4771-b247-f95d0096ad45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba7d1369-6540-4771-b247-f95d0096ad45>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cd42d0a-4d95-42de-9c99-9421fcefcc50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cd42d0a-4d95-42de-9c99-9421fcefcc50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cd42d0a-4d95-42de-9c99-9421fcefcc50>.
+    
+<http://data.lblod.info/id/remote-data-objects/4456904e-4327-4abb-a14a-9c018dac6dfc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4456904e-4327-4abb-a14a-9c018dac6dfc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4456904e-4327-4abb-a14a-9c018dac6dfc>.
+    
+<http://data.lblod.info/id/remote-data-objects/43b51958-cb6d-4e36-a44c-982e000d4b6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43b51958-cb6d-4e36-a44c-982e000d4b6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43b51958-cb6d-4e36-a44c-982e000d4b6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/76bf542c-2130-4f2c-a6c9-2d4bee8da147> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76bf542c-2130-4f2c-a6c9-2d4bee8da147";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76bf542c-2130-4f2c-a6c9-2d4bee8da147>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0b37f12-e0b8-4928-9aa6-2ca612ded128> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0b37f12-e0b8-4928-9aa6-2ca612ded128";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0b37f12-e0b8-4928-9aa6-2ca612ded128>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1729deb-0948-4757-811a-99f73f83b0ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1729deb-0948-4757-811a-99f73f83b0ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1729deb-0948-4757-811a-99f73f83b0ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2168a0a-b280-46ae-ad79-ebec2717bb2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2168a0a-b280-46ae-ad79-ebec2717bb2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2168a0a-b280-46ae-ad79-ebec2717bb2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebac2d54-32d3-4fdb-9801-68f09dcde70a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebac2d54-32d3-4fdb-9801-68f09dcde70a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebac2d54-32d3-4fdb-9801-68f09dcde70a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4ca3325-7abc-4627-8789-001f270432a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4ca3325-7abc-4627-8789-001f270432a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4ca3325-7abc-4627-8789-001f270432a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e1b2278-fb62-4d0a-966e-0db4e4c24efd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e1b2278-fb62-4d0a-966e-0db4e4c24efd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e1b2278-fb62-4d0a-966e-0db4e4c24efd>.
+    
+<http://data.lblod.info/id/remote-data-objects/84722991-5c3c-4594-9d86-5215a94b6022> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84722991-5c3c-4594-9d86-5215a94b6022";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84722991-5c3c-4594-9d86-5215a94b6022>.
+    
+<http://data.lblod.info/id/remote-data-objects/252a5159-b97e-45c7-942f-0df5e43784ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "252a5159-b97e-45c7-942f-0df5e43784ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/252a5159-b97e-45c7-942f-0df5e43784ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/e707bd18-3be1-4864-8f60-98bc06072d29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e707bd18-3be1-4864-8f60-98bc06072d29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e707bd18-3be1-4864-8f60-98bc06072d29>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e1fd721-2026-41ba-8687-451cf9e21c8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e1fd721-2026-41ba-8687-451cf9e21c8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e1fd721-2026-41ba-8687-451cf9e21c8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/29e8519c-d4a3-4bbf-b15a-47ecac901355> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29e8519c-d4a3-4bbf-b15a-47ecac901355";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29e8519c-d4a3-4bbf-b15a-47ecac901355>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9aef91e-7df2-4a23-b07d-a488258b1d5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9aef91e-7df2-4a23-b07d-a488258b1d5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9aef91e-7df2-4a23-b07d-a488258b1d5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8350e80-4619-48d3-854e-31aeb88a4fd6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8350e80-4619-48d3-854e-31aeb88a4fd6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8350e80-4619-48d3-854e-31aeb88a4fd6>.
+    
+<http://data.lblod.info/id/remote-data-objects/498920fa-aad4-4b46-8b8c-d25e36692109> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "498920fa-aad4-4b46-8b8c-d25e36692109";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/498920fa-aad4-4b46-8b8c-d25e36692109>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a9b934c-fa70-441e-b405-1a4e47304f1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a9b934c-fa70-441e-b405-1a4e47304f1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a9b934c-fa70-441e-b405-1a4e47304f1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f707978f-77ac-4f6a-8b02-850347d5629f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f707978f-77ac-4f6a-8b02-850347d5629f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_26-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f707978f-77ac-4f6a-8b02-850347d5629f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea2d2269-e5ef-4b38-99fd-506b00854fa9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea2d2269-e5ef-4b38-99fd-506b00854fa9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea2d2269-e5ef-4b38-99fd-506b00854fa9>.
+    
+<http://data.lblod.info/id/remote-data-objects/070c5ac8-667d-42d4-a95f-561ea88918fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "070c5ac8-667d-42d4-a95f-561ea88918fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/070c5ac8-667d-42d4-a95f-561ea88918fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/1493b784-1563-4cfa-9632-9b236110ffdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1493b784-1563-4cfa-9632-9b236110ffdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1493b784-1563-4cfa-9632-9b236110ffdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b3ed94a-703f-4bbc-8787-cacbeeca44a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b3ed94a-703f-4bbc-8787-cacbeeca44a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_29-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b3ed94a-703f-4bbc-8787-cacbeeca44a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1cbbfc1-5abd-44d2-b44d-bf02788b8b77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1cbbfc1-5abd-44d2-b44d-bf02788b8b77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1cbbfc1-5abd-44d2-b44d-bf02788b8b77>.
+    
+<http://data.lblod.info/id/remote-data-objects/0023159c-9df1-4a36-9817-39f8f6cadbc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0023159c-9df1-4a36-9817-39f8f6cadbc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/4a5b62e2c27fe656774f2cba118dbd20bb12621344c96ce733dc28e6ee7471fd/GetPublication?filename=BesluitenLijst_Vast%20bureau_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0023159c-9df1-4a36-9817-39f8f6cadbc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/55983b16-18f3-4e22-9a3f-749756682229> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55983b16-18f3-4e22-9a3f-749756682229";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55983b16-18f3-4e22-9a3f-749756682229>.
+    
+<http://data.lblod.info/id/remote-data-objects/77308f06-6d5f-4771-8ba3-88112d3270cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77308f06-6d5f-4771-8ba3-88112d3270cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77308f06-6d5f-4771-8ba3-88112d3270cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7792cef-4e8f-49c2-b82d-d7dc63a6ccb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7792cef-4e8f-49c2-b82d-d7dc63a6ccb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7792cef-4e8f-49c2-b82d-d7dc63a6ccb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e89cce6-660f-4db5-a1e4-618bbd10fa97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e89cce6-660f-4db5-a1e4-618bbd10fa97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e89cce6-660f-4db5-a1e4-618bbd10fa97>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf58a909-2023-4249-bb93-2b1bbbc484f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf58a909-2023-4249-bb93-2b1bbbc484f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf58a909-2023-4249-bb93-2b1bbbc484f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa74762a-f226-441d-a4e6-23403494b2c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa74762a-f226-441d-a4e6-23403494b2c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa74762a-f226-441d-a4e6-23403494b2c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/807107e3-7081-49c6-912a-af8476dbff03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "807107e3-7081-49c6-912a-af8476dbff03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/807107e3-7081-49c6-912a-af8476dbff03>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a079c1e-8836-4221-8ae3-9296525c8bcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a079c1e-8836-4221-8ae3-9296525c8bcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a079c1e-8836-4221-8ae3-9296525c8bcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/32b63ee0-e911-4f3f-a12a-74204986cc61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32b63ee0-e911-4f3f-a12a-74204986cc61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32b63ee0-e911-4f3f-a12a-74204986cc61>.
+    
+<http://data.lblod.info/id/remote-data-objects/074a5f22-401c-4d8b-b0e0-ce5815b78d73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "074a5f22-401c-4d8b-b0e0-ce5815b78d73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a9a271a-93eb-4d6e-b27d-ddb305ef08d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/074a5f22-401c-4d8b-b0e0-ce5815b78d73>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201410-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201410-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201410-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201410-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/50199085-c3b8-487d-9f84-c0c20906bcde> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "50199085-c3b8-487d-9f84-c0c20906bcde";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/3b3bb795-00e6-44e3-9e3f-172344647ab2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3b3bb795-00e6-44e3-9e3f-172344647ab2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2>.
+
+  <http://redpencil.data.gift/id/task/9295d286-091f-4bcb-b562-7ca22792ff66> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9295d286-091f-4bcb-b562-7ca22792ff66";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/50199085-c3b8-487d-9f84-c0c20906bcde>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/3b3bb795-00e6-44e3-9e3f-172344647ab2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7c61c3c9-dc21-460d-a833-1c41cf3974d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c61c3c9-dc21-460d-a833-1c41cf3974d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c61c3c9-dc21-460d-a833-1c41cf3974d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a1f9cf2-c03f-44b8-a6ff-9e615c90b2ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a1f9cf2-c03f-44b8-a6ff-9e615c90b2ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a1f9cf2-c03f-44b8-a6ff-9e615c90b2ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/eebf743d-cc98-4b9a-9de4-df45fc6321af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eebf743d-cc98-4b9a-9de4-df45fc6321af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eebf743d-cc98-4b9a-9de4-df45fc6321af>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdd14dc0-e4bf-4224-99b2-3f2a523b49a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdd14dc0-e4bf-4224-99b2-3f2a523b49a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdd14dc0-e4bf-4224-99b2-3f2a523b49a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/01a015f3-4684-4798-94ec-7c16bb02b41c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01a015f3-4684-4798-94ec-7c16bb02b41c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01a015f3-4684-4798-94ec-7c16bb02b41c>.
+    
+<http://data.lblod.info/id/remote-data-objects/518bb691-9043-45cb-83f0-bd6715063d85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "518bb691-9043-45cb-83f0-bd6715063d85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/518bb691-9043-45cb-83f0-bd6715063d85>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb5af229-7ec1-479c-8032-d4a9a6d441bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb5af229-7ec1-479c-8032-d4a9a6d441bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb5af229-7ec1-479c-8032-d4a9a6d441bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/e641f2a3-8c55-4c2a-b99d-533834f2bd95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e641f2a3-8c55-4c2a-b99d-533834f2bd95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e641f2a3-8c55-4c2a-b99d-533834f2bd95>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bfd024e-1e56-4466-b84a-12f4321dfa60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bfd024e-1e56-4466-b84a-12f4321dfa60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bfd024e-1e56-4466-b84a-12f4321dfa60>.
+    
+<http://data.lblod.info/id/remote-data-objects/50793040-877f-4ba9-914d-c366ba27ecf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50793040-877f-4ba9-914d-c366ba27ecf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50793040-877f-4ba9-914d-c366ba27ecf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2512ca36-03a5-460e-bc6e-13b014f31e54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2512ca36-03a5-460e-bc6e-13b014f31e54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2512ca36-03a5-460e-bc6e-13b014f31e54>.
+    
+<http://data.lblod.info/id/remote-data-objects/42626f68-053d-46a9-897e-fdaa901762f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42626f68-053d-46a9-897e-fdaa901762f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42626f68-053d-46a9-897e-fdaa901762f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddec2ce0-d03c-49b6-8425-91671d9b8a1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddec2ce0-d03c-49b6-8425-91671d9b8a1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddec2ce0-d03c-49b6-8425-91671d9b8a1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9698e80-a177-4725-afc3-ebb994d96367> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9698e80-a177-4725-afc3-ebb994d96367";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9698e80-a177-4725-afc3-ebb994d96367>.
+    
+<http://data.lblod.info/id/remote-data-objects/68a35fc9-31ec-4079-bf8d-20d1a20bc5c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68a35fc9-31ec-4079-bf8d-20d1a20bc5c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68a35fc9-31ec-4079-bf8d-20d1a20bc5c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd200c5c-1b54-461a-8e41-c0a696c0c2e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd200c5c-1b54-461a-8e41-c0a696c0c2e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd200c5c-1b54-461a-8e41-c0a696c0c2e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d6486e6-f7ca-4ba4-8da4-6fc68133923d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d6486e6-f7ca-4ba4-8da4-6fc68133923d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d6486e6-f7ca-4ba4-8da4-6fc68133923d>.
+    
+<http://data.lblod.info/id/remote-data-objects/16711201-8927-4062-aaa0-265c075c7146> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16711201-8927-4062-aaa0-265c075c7146";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16711201-8927-4062-aaa0-265c075c7146>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcf03118-5414-4cb6-938b-46ad23644c0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcf03118-5414-4cb6-938b-46ad23644c0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcf03118-5414-4cb6-938b-46ad23644c0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7758ac8-39d4-4e81-82df-9715347d3e45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7758ac8-39d4-4e81-82df-9715347d3e45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7758ac8-39d4-4e81-82df-9715347d3e45>.
+    
+<http://data.lblod.info/id/remote-data-objects/59bb71b5-17c1-4d32-a39c-15fc36297c52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59bb71b5-17c1-4d32-a39c-15fc36297c52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59bb71b5-17c1-4d32-a39c-15fc36297c52>.
+    
+<http://data.lblod.info/id/remote-data-objects/c864c51b-2bb9-479d-b03f-ae922c40377b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c864c51b-2bb9-479d-b03f-ae922c40377b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c864c51b-2bb9-479d-b03f-ae922c40377b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4f928c8-84ac-47d2-aaff-8388d4c74b61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4f928c8-84ac-47d2-aaff-8388d4c74b61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4f928c8-84ac-47d2-aaff-8388d4c74b61>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4fe65a8-9e56-4295-90e9-67071f1f4d1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4fe65a8-9e56-4295-90e9-67071f1f4d1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4fe65a8-9e56-4295-90e9-67071f1f4d1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d29f3c56-b2a1-4196-8574-efeba2aae74f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d29f3c56-b2a1-4196-8574-efeba2aae74f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_26-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d29f3c56-b2a1-4196-8574-efeba2aae74f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c42cb9a-9fe7-4f44-9fed-059a07ec1481> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c42cb9a-9fe7-4f44-9fed-059a07ec1481";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c42cb9a-9fe7-4f44-9fed-059a07ec1481>.
+    
+<http://data.lblod.info/id/remote-data-objects/59dfb586-bd62-4bcc-9ec5-4fa0ebb2ea98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59dfb586-bd62-4bcc-9ec5-4fa0ebb2ea98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59dfb586-bd62-4bcc-9ec5-4fa0ebb2ea98>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e6489a1-dc82-4b0e-b26a-22dc63fcad26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e6489a1-dc82-4b0e-b26a-22dc63fcad26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e6489a1-dc82-4b0e-b26a-22dc63fcad26>.
+    
+<http://data.lblod.info/id/remote-data-objects/fca4e8b7-8adb-428d-a728-5603ab5b7d1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fca4e8b7-8adb-428d-a728-5603ab5b7d1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fca4e8b7-8adb-428d-a728-5603ab5b7d1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9d4271b-7ced-44d0-bf7f-89988ec8ddca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9d4271b-7ced-44d0-bf7f-89988ec8ddca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/55629de826f955825204c2424a7b3749370f5e32abced5b9768c036532b7c107/GetPublication?filename=BesluitenLijst_college_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9d4271b-7ced-44d0-bf7f-89988ec8ddca>.
+    
+<http://data.lblod.info/id/remote-data-objects/b83e17b0-2af6-4f6b-b0ba-48fa4e84551e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b83e17b0-2af6-4f6b-b0ba-48fa4e84551e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Agenda_OCMW-raad_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b83e17b0-2af6-4f6b-b0ba-48fa4e84551e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6cd8fb9-ada4-47fc-8a7f-d37a21415dc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6cd8fb9-ada4-47fc-8a7f-d37a21415dc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Agenda_OCMW-raad_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6cd8fb9-ada4-47fc-8a7f-d37a21415dc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1ccf02a-fe43-42fd-bf34-129d851c8f40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1ccf02a-fe43-42fd-bf34-129d851c8f40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Agenda_OCMW-raad_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1ccf02a-fe43-42fd-bf34-129d851c8f40>.
+    
+<http://data.lblod.info/id/remote-data-objects/430f5117-ae08-4803-814c-c1cd6c6625d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "430f5117-ae08-4803-814c-c1cd6c6625d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Agenda_OCMW-raad_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/430f5117-ae08-4803-814c-c1cd6c6625d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/03062700-5df4-4177-a290-41a0ac2e446c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03062700-5df4-4177-a290-41a0ac2e446c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Agenda_OCMW-raad_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03062700-5df4-4177-a290-41a0ac2e446c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6c43da3-d205-4a24-bae4-5fa2f0ed43de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6c43da3-d205-4a24-bae4-5fa2f0ed43de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Agenda_OCMW-raad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6c43da3-d205-4a24-bae4-5fa2f0ed43de>.
+    
+<http://data.lblod.info/id/remote-data-objects/f78ea621-0101-414d-968e-faf5472818f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f78ea621-0101-414d-968e-faf5472818f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Agenda_OCMW-raad_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f78ea621-0101-414d-968e-faf5472818f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f6dd0ee-b163-4c29-9ec0-b2067d7b1f3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f6dd0ee-b163-4c29-9ec0-b2067d7b1f3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Agenda_OCMW-raad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f6dd0ee-b163-4c29-9ec0-b2067d7b1f3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7445bdc1-c428-47fa-a5db-324e216dd7b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7445bdc1-c428-47fa-a5db-324e216dd7b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Agenda_OCMW-raad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7445bdc1-c428-47fa-a5db-324e216dd7b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/efb925a1-8e5b-4e2e-b22a-27d04dcff7fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efb925a1-8e5b-4e2e-b22a-27d04dcff7fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=BesluitenLijst_OCMW-raad_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efb925a1-8e5b-4e2e-b22a-27d04dcff7fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/26be8a75-576b-4ad3-8a02-33c2dcde0200> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26be8a75-576b-4ad3-8a02-33c2dcde0200";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=BesluitenLijst_OCMW-raad_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26be8a75-576b-4ad3-8a02-33c2dcde0200>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fa50914-9aa5-463e-af15-2d88c1994c72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fa50914-9aa5-463e-af15-2d88c1994c72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=BesluitenLijst_OCMW-raad_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fa50914-9aa5-463e-af15-2d88c1994c72>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fa52be7-0c05-4a76-b551-e9450ce4afc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fa52be7-0c05-4a76-b551-e9450ce4afc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=BesluitenLijst_OCMW-raad_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fa52be7-0c05-4a76-b551-e9450ce4afc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/133bdc41-0f10-4ef0-a831-dd4ef706351c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "133bdc41-0f10-4ef0-a831-dd4ef706351c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=BesluitenLijst_OCMW-raad_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/133bdc41-0f10-4ef0-a831-dd4ef706351c>.
+    
+<http://data.lblod.info/id/remote-data-objects/92aa54d5-4edf-47b7-9452-edf99ed599cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92aa54d5-4edf-47b7-9452-edf99ed599cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=BesluitenLijst_OCMW-raad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92aa54d5-4edf-47b7-9452-edf99ed599cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3fd4b5b-34e2-4561-8d61-1b8ade37028d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3fd4b5b-34e2-4561-8d61-1b8ade37028d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=BesluitenLijst_OCMW-raad_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3fd4b5b-34e2-4561-8d61-1b8ade37028d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c4263d0-30de-4f18-abbc-4552fa20aed7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c4263d0-30de-4f18-abbc-4552fa20aed7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=BesluitenLijst_OCMW-raad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c4263d0-30de-4f18-abbc-4552fa20aed7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bee46fc-6eef-4ea2-8d70-97f2f2c9b9b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bee46fc-6eef-4ea2-8d70-97f2f2c9b9b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=BesluitenLijst_OCMW-raad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bee46fc-6eef-4ea2-8d70-97f2f2c9b9b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4e63a0f-617d-4d07-8982-39de9ec49dbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4e63a0f-617d-4d07-8982-39de9ec49dbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Notulen_OCMW-raad_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4e63a0f-617d-4d07-8982-39de9ec49dbb>.
+    
+<http://data.lblod.info/id/remote-data-objects/76b3ab0f-4a47-4f55-9594-4d3572041e94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76b3ab0f-4a47-4f55-9594-4d3572041e94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Notulen_OCMW-raad_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4b4f9838-dd4a-4cef-9c2f-37463bb9a2c2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76b3ab0f-4a47-4f55-9594-4d3572041e94>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201411-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201411-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201411-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201411-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/85a00edc-9ac2-4f30-8d43-d5a13b84c9d8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "85a00edc-9ac2-4f30-8d43-d5a13b84c9d8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "93ca2b02-9b30-47be-9922-05fdcfec1ee7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4f41151c-5c77-4b95-a73b-666cd6feb932> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4f41151c-5c77-4b95-a73b-666cd6feb932";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7>.
+
+  <http://redpencil.data.gift/id/task/cd9f7c44-a89c-4b3c-929b-7df285a251b7> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cd9f7c44-a89c-4b3c-929b-7df285a251b7";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/85a00edc-9ac2-4f30-8d43-d5a13b84c9d8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4f41151c-5c77-4b95-a73b-666cd6feb932>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/882714c4-a561-4f62-be25-1a41acc02fe5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "882714c4-a561-4f62-be25-1a41acc02fe5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Notulen_OCMW-raad_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/882714c4-a561-4f62-be25-1a41acc02fe5>.
+    
+<http://data.lblod.info/id/remote-data-objects/435b0bbe-a9ab-4cc1-bf0f-a83e78214063> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "435b0bbe-a9ab-4cc1-bf0f-a83e78214063";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Notulen_OCMW-raad_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/435b0bbe-a9ab-4cc1-bf0f-a83e78214063>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b208433-aa41-43a3-9d9f-dcd90cc0fa1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b208433-aa41-43a3-9d9f-dcd90cc0fa1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Notulen_OCMW-raad_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b208433-aa41-43a3-9d9f-dcd90cc0fa1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/36eb83fe-2063-4589-a5cb-5700c67c5d94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36eb83fe-2063-4589-a5cb-5700c67c5d94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Notulen_OCMW-raad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36eb83fe-2063-4589-a5cb-5700c67c5d94>.
+    
+<http://data.lblod.info/id/remote-data-objects/47c703ea-67d8-4b54-af6e-d49d4fdbc545> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47c703ea-67d8-4b54-af6e-d49d4fdbc545";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Notulen_OCMW-raad_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47c703ea-67d8-4b54-af6e-d49d4fdbc545>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef9e5b61-f34c-484e-8d48-a503b1154aed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef9e5b61-f34c-484e-8d48-a503b1154aed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Notulen_OCMW-raad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef9e5b61-f34c-484e-8d48-a503b1154aed>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d89cd59-5222-4799-bd65-dbe934d11571> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d89cd59-5222-4799-bd65-dbe934d11571";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Uittreksels_07-10-2021_34871.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d89cd59-5222-4799-bd65-dbe934d11571>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ab07328-d271-47af-ba55-aca32c705db3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ab07328-d271-47af-ba55-aca32c705db3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Uittreksels_07-10-2021_34907.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ab07328-d271-47af-ba55-aca32c705db3>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b437390-25d2-41b5-9d65-4aa2bfc8aef8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b437390-25d2-41b5-9d65-4aa2bfc8aef8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Uittreksels_16-12-2021_36025.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b437390-25d2-41b5-9d65-4aa2bfc8aef8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c37f762a-b5f4-4337-9ac2-11ac75453648> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c37f762a-b5f4-4337-9ac2-11ac75453648";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Uittreksels_16-12-2021_36367.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c37f762a-b5f4-4337-9ac2-11ac75453648>.
+    
+<http://data.lblod.info/id/remote-data-objects/905bedc4-e093-4741-b589-c06f52d91eb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "905bedc4-e093-4741-b589-c06f52d91eb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Uittreksels_16-12-2021_36369.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/905bedc4-e093-4741-b589-c06f52d91eb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd088fdc-7343-4195-b4ff-78406ae82469> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd088fdc-7343-4195-b4ff-78406ae82469";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Uittreksels_16-12-2021_36477.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd088fdc-7343-4195-b4ff-78406ae82469>.
+    
+<http://data.lblod.info/id/remote-data-objects/affb2e16-b651-4a02-8ccf-f8702ce8c525> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "affb2e16-b651-4a02-8ccf-f8702ce8c525";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Uittreksels_18-11-2021_35950.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/affb2e16-b651-4a02-8ccf-f8702ce8c525>.
+    
+<http://data.lblod.info/id/remote-data-objects/57c9f910-64ed-4859-9a37-b692ead9fc93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57c9f910-64ed-4859-9a37-b692ead9fc93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Uittreksels_18-11-2021_36155.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57c9f910-64ed-4859-9a37-b692ead9fc93>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a74fc73-954d-46bf-b38e-3b8177b06584> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a74fc73-954d-46bf-b38e-3b8177b06584";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Uittreksels_30-06-2022_38386.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a74fc73-954d-46bf-b38e-3b8177b06584>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a9acde1-31bf-4aed-b1ef-ccf989aea400> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a9acde1-31bf-4aed-b1ef-ccf989aea400";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Uittreksels_30-06-2022_38983.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a9acde1-31bf-4aed-b1ef-ccf989aea400>.
+    
+<http://data.lblod.info/id/remote-data-objects/90a1eced-16bb-473c-89e4-7b5d0b21bd1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90a1eced-16bb-473c-89e4-7b5d0b21bd1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/6d81a1e745b6fe8ea0cef9f5451601ea8a07401c4bf08bd61837fc61d8f8bb35/GetPublication?filename=Uittreksels_30-06-2022_39176.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90a1eced-16bb-473c-89e4-7b5d0b21bd1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e58ec82a-2cd2-4d80-955e-14fe95f5242f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e58ec82a-2cd2-4d80-955e-14fe95f5242f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Agenda_gemeenteraad_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e58ec82a-2cd2-4d80-955e-14fe95f5242f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b079937-ec6a-49a8-8056-61aa891725d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b079937-ec6a-49a8-8056-61aa891725d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Agenda_gemeenteraad_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b079937-ec6a-49a8-8056-61aa891725d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c65734dd-a945-4a24-8b52-f037041aba4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c65734dd-a945-4a24-8b52-f037041aba4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Agenda_gemeenteraad_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c65734dd-a945-4a24-8b52-f037041aba4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d735dea-712f-4c9b-b2a3-fdf36028e091> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d735dea-712f-4c9b-b2a3-fdf36028e091";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Agenda_gemeenteraad_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d735dea-712f-4c9b-b2a3-fdf36028e091>.
+    
+<http://data.lblod.info/id/remote-data-objects/0120dd06-7add-4d31-9d2f-e44953bc4e3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0120dd06-7add-4d31-9d2f-e44953bc4e3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Agenda_gemeenteraad_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0120dd06-7add-4d31-9d2f-e44953bc4e3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a989f021-4dca-423f-aaac-7a27b98929ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a989f021-4dca-423f-aaac-7a27b98929ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Agenda_gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a989f021-4dca-423f-aaac-7a27b98929ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d9a8073-7f81-4f4d-b5ce-8f1cf239670e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d9a8073-7f81-4f4d-b5ce-8f1cf239670e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Agenda_gemeenteraad_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d9a8073-7f81-4f4d-b5ce-8f1cf239670e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b31f1ec-d1d4-4551-9ff8-73bae6fe59ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b31f1ec-d1d4-4551-9ff8-73bae6fe59ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Agenda_gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b31f1ec-d1d4-4551-9ff8-73bae6fe59ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddcd2b6d-40c9-4042-aa00-0a85a2acc134> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddcd2b6d-40c9-4042-aa00-0a85a2acc134";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Agenda_gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddcd2b6d-40c9-4042-aa00-0a85a2acc134>.
+    
+<http://data.lblod.info/id/remote-data-objects/5912c2d4-9698-40a2-9978-bf992575d22c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5912c2d4-9698-40a2-9978-bf992575d22c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=BesluitenLijst_gemeenteraad_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5912c2d4-9698-40a2-9978-bf992575d22c>.
+    
+<http://data.lblod.info/id/remote-data-objects/77578fab-9bf3-486f-917d-a48632c2b23d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77578fab-9bf3-486f-917d-a48632c2b23d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=BesluitenLijst_gemeenteraad_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77578fab-9bf3-486f-917d-a48632c2b23d>.
+    
+<http://data.lblod.info/id/remote-data-objects/00b09561-0f1c-4c59-b091-4f0dc3f2f142> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00b09561-0f1c-4c59-b091-4f0dc3f2f142";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=BesluitenLijst_gemeenteraad_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00b09561-0f1c-4c59-b091-4f0dc3f2f142>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f4a7cd4-7c64-44a4-9181-fe8e45556779> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f4a7cd4-7c64-44a4-9181-fe8e45556779";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=BesluitenLijst_gemeenteraad_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f4a7cd4-7c64-44a4-9181-fe8e45556779>.
+    
+<http://data.lblod.info/id/remote-data-objects/85e3653b-6fca-4bd7-a5d9-943feb8248b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85e3653b-6fca-4bd7-a5d9-943feb8248b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=BesluitenLijst_gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85e3653b-6fca-4bd7-a5d9-943feb8248b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f085a0c-d2bd-4558-9dab-a2a97a82ad92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f085a0c-d2bd-4558-9dab-a2a97a82ad92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=BesluitenLijst_gemeenteraad_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f085a0c-d2bd-4558-9dab-a2a97a82ad92>.
+    
+<http://data.lblod.info/id/remote-data-objects/42aa7522-5d53-4b22-a8bf-91f4e24f29fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42aa7522-5d53-4b22-a8bf-91f4e24f29fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=BesluitenLijst_gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42aa7522-5d53-4b22-a8bf-91f4e24f29fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a0dc8e5-6d11-43bf-b156-bb1e7bb10bfe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a0dc8e5-6d11-43bf-b156-bb1e7bb10bfe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=BesluitenLijst_gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a0dc8e5-6d11-43bf-b156-bb1e7bb10bfe>.
+    
+<http://data.lblod.info/id/remote-data-objects/4910b0a3-161e-44bb-88d1-587b4de648d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4910b0a3-161e-44bb-88d1-587b4de648d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Notulen_gemeenteraad_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4910b0a3-161e-44bb-88d1-587b4de648d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ce2a93a-d454-463e-a22c-05689070f8a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ce2a93a-d454-463e-a22c-05689070f8a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Notulen_gemeenteraad_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ce2a93a-d454-463e-a22c-05689070f8a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d6a7987-4c4d-4509-b8fb-84056a62c62e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d6a7987-4c4d-4509-b8fb-84056a62c62e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Notulen_gemeenteraad_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d6a7987-4c4d-4509-b8fb-84056a62c62e>.
+    
+<http://data.lblod.info/id/remote-data-objects/06dc1191-6e5b-4bfd-a4dd-ec668693977c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06dc1191-6e5b-4bfd-a4dd-ec668693977c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Notulen_gemeenteraad_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06dc1191-6e5b-4bfd-a4dd-ec668693977c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e0d52c6-23db-480a-8dc3-e614b279131f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e0d52c6-23db-480a-8dc3-e614b279131f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Notulen_gemeenteraad_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e0d52c6-23db-480a-8dc3-e614b279131f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f4331cb-c2ff-46ae-adce-667a7b0314bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f4331cb-c2ff-46ae-adce-667a7b0314bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Notulen_gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f4331cb-c2ff-46ae-adce-667a7b0314bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1f81a25-b902-4cc7-8db4-1fca54b4e00c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1f81a25-b902-4cc7-8db4-1fca54b4e00c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Notulen_gemeenteraad_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1f81a25-b902-4cc7-8db4-1fca54b4e00c>.
+    
+<http://data.lblod.info/id/remote-data-objects/59e60a66-1cb3-490a-97c1-ea36e50d2be2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59e60a66-1cb3-490a-97c1-ea36e50d2be2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Notulen_gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59e60a66-1cb3-490a-97c1-ea36e50d2be2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f7442d7-ee42-4f51-905b-76dde5999049> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f7442d7-ee42-4f51-905b-76dde5999049";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_03-02-2022_37210.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f7442d7-ee42-4f51-905b-76dde5999049>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc79bc0f-9e80-4ce0-a77d-947ae38fb8c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc79bc0f-9e80-4ce0-a77d-947ae38fb8c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_05-05-2022_37799.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc79bc0f-9e80-4ce0-a77d-947ae38fb8c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0d403ce-8aa6-4466-918d-a8e371cda56e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0d403ce-8aa6-4466-918d-a8e371cda56e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_05-05-2022_37802.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0d403ce-8aa6-4466-918d-a8e371cda56e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7884a8bf-5a5e-4269-804a-979663702941> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7884a8bf-5a5e-4269-804a-979663702941";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_05-05-2022_38398.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7884a8bf-5a5e-4269-804a-979663702941>.
+    
+<http://data.lblod.info/id/remote-data-objects/c015c2c4-32f0-43ae-9721-d0bd1304cde3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c015c2c4-32f0-43ae-9721-d0bd1304cde3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_07-10-2021_34904.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c015c2c4-32f0-43ae-9721-d0bd1304cde3>.
+    
+<http://data.lblod.info/id/remote-data-objects/afce0848-724b-4b4e-8917-c06e231a2391> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afce0848-724b-4b4e-8917-c06e231a2391";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_07-10-2021_35276.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afce0848-724b-4b4e-8917-c06e231a2391>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ccb33a0-e4fa-4572-8473-6335eaa82c2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ccb33a0-e4fa-4572-8473-6335eaa82c2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_16-12-2021_35023.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ccb33a0-e4fa-4572-8473-6335eaa82c2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/63e4ed7b-ac36-48a6-b780-51d7abce296b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63e4ed7b-ac36-48a6-b780-51d7abce296b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_16-12-2021_35024.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/93ca2b02-9b30-47be-9922-05fdcfec1ee7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63e4ed7b-ac36-48a6-b780-51d7abce296b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201412-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201412-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201412-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201412-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/18b808fb-6306-4ad0-985a-836531ac577a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "18b808fb-6306-4ad0-985a-836531ac577a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0c91062e-a486-40f7-8f0a-6ecf7e9a4a07";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/867b83e1-207c-4733-9014-a727c1cc6a82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "867b83e1-207c-4733-9014-a727c1cc6a82";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07>.
+
+  <http://redpencil.data.gift/id/task/d7b7b429-665c-49ca-97af-14e49d9a702c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d7b7b429-665c-49ca-97af-14e49d9a702c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/18b808fb-6306-4ad0-985a-836531ac577a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/867b83e1-207c-4733-9014-a727c1cc6a82>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d18e00b3-de30-4218-bb78-c92190beb50b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d18e00b3-de30-4218-bb78-c92190beb50b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_16-12-2021_35025.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d18e00b3-de30-4218-bb78-c92190beb50b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c325b1a7-6fb7-4026-a3e1-bd4d3e7b09a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c325b1a7-6fb7-4026-a3e1-bd4d3e7b09a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_16-12-2021_36357.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c325b1a7-6fb7-4026-a3e1-bd4d3e7b09a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8a6c88a-d490-4ea2-b717-c08a8cf3451f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8a6c88a-d490-4ea2-b717-c08a8cf3451f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_16-12-2021_36358.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8a6c88a-d490-4ea2-b717-c08a8cf3451f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2e28c63-b619-46f6-8379-7bded22f9fb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2e28c63-b619-46f6-8379-7bded22f9fb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_16-12-2021_36359.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2e28c63-b619-46f6-8379-7bded22f9fb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3a91220-418f-43b2-a243-3ebe85da397d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3a91220-418f-43b2-a243-3ebe85da397d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_16-12-2021_36361.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3a91220-418f-43b2-a243-3ebe85da397d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6d64f4e-ca1f-4e8e-909c-4bf2e76e064e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6d64f4e-ca1f-4e8e-909c-4bf2e76e064e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_16-12-2021_36362.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6d64f4e-ca1f-4e8e-909c-4bf2e76e064e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cc6c6cc-d039-4b75-a25b-d0ad52f6c48a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cc6c6cc-d039-4b75-a25b-d0ad52f6c48a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_16-12-2021_36363.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cc6c6cc-d039-4b75-a25b-d0ad52f6c48a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e18a0bb3-cf6a-46a7-836c-09b5d144016c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e18a0bb3-cf6a-46a7-836c-09b5d144016c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_16-12-2021_36366.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e18a0bb3-cf6a-46a7-836c-09b5d144016c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9a50d8a-9566-496a-8883-b20f26e19432> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9a50d8a-9566-496a-8883-b20f26e19432";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_16-12-2021_36660.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9a50d8a-9566-496a-8883-b20f26e19432>.
+    
+<http://data.lblod.info/id/remote-data-objects/1645b703-ac6a-44cc-80f9-76fb3c21a5aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1645b703-ac6a-44cc-80f9-76fb3c21a5aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_18-11-2021_33613.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1645b703-ac6a-44cc-80f9-76fb3c21a5aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbb384e7-d335-483b-afec-c062fe64b2ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbb384e7-d335-483b-afec-c062fe64b2ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_18-11-2021_36103.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbb384e7-d335-483b-afec-c062fe64b2ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1d61535-97b9-4245-87da-beff875eb555> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1d61535-97b9-4245-87da-beff875eb555";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_18-11-2021_36205.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1d61535-97b9-4245-87da-beff875eb555>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b3a15c2-0187-4ddb-be77-c6fc248abaf0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b3a15c2-0187-4ddb-be77-c6fc248abaf0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_30-06-2022_38385.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b3a15c2-0187-4ddb-be77-c6fc248abaf0>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a47b68c-ca29-46a6-a3fb-dbe5012ddcb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a47b68c-ca29-46a6-a3fb-dbe5012ddcb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_30-06-2022_38982.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a47b68c-ca29-46a6-a3fb-dbe5012ddcb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cd76bf6-efc4-48d5-a603-3e02f47b08cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cd76bf6-efc4-48d5-a603-3e02f47b08cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_30-06-2022_39178.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cd76bf6-efc4-48d5-a603-3e02f47b08cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/56c5b53e-e28f-4705-b760-042b9affaa0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56c5b53e-e28f-4705-b760-042b9affaa0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_30-06-2022_39211.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56c5b53e-e28f-4705-b760-042b9affaa0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ec106ca-999c-417a-ac31-d1f3fe4e11de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ec106ca-999c-417a-ac31-d1f3fe4e11de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ichtegem.be/LBLODWeb/Home/Overzicht/b6830ca8bc0a841724882f769d616ca55700da2d2a8d0e73f27f93b9e46586dd/GetPublication?filename=Uittreksels_30-06-2022_39246.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ec106ca-999c-417a-ac31-d1f3fe4e11de>.
+    
+<http://data.lblod.info/id/remote-data-objects/68623f5a-228f-43cd-933a-503c3f6a93cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68623f5a-228f-43cd-933a-503c3f6a93cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68623f5a-228f-43cd-933a-503c3f6a93cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/24f590f4-cdc7-40d2-8379-7070a4a3bcf0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24f590f4-cdc7-40d2-8379-7070a4a3bcf0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_01-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24f590f4-cdc7-40d2-8379-7070a4a3bcf0>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cba710e-9647-4657-ac85-82c7e351d7a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cba710e-9647-4657-ac85-82c7e351d7a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cba710e-9647-4657-ac85-82c7e351d7a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4867563-fc97-4721-8666-54b40ffa345a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4867563-fc97-4721-8666-54b40ffa345a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4867563-fc97-4721-8666-54b40ffa345a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f1c86f2-dd63-46a3-8889-98aa8c2baa26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f1c86f2-dd63-46a3-8889-98aa8c2baa26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f1c86f2-dd63-46a3-8889-98aa8c2baa26>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef32878e-e6cb-494e-83ba-675736c5b333> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef32878e-e6cb-494e-83ba-675736c5b333";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_07-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef32878e-e6cb-494e-83ba-675736c5b333>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc9e8e05-f398-4cfe-acf0-448779b2ea37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc9e8e05-f398-4cfe-acf0-448779b2ea37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc9e8e05-f398-4cfe-acf0-448779b2ea37>.
+    
+<http://data.lblod.info/id/remote-data-objects/79998b3f-d272-4a07-8703-a558b64b2757> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79998b3f-d272-4a07-8703-a558b64b2757";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_09-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79998b3f-d272-4a07-8703-a558b64b2757>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd3af3db-6a83-4626-accb-8a862c88efb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd3af3db-6a83-4626-accb-8a862c88efb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_11-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd3af3db-6a83-4626-accb-8a862c88efb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a75411f0-4748-4168-8020-54e67ab6fa81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a75411f0-4748-4168-8020-54e67ab6fa81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a75411f0-4748-4168-8020-54e67ab6fa81>.
+    
+<http://data.lblod.info/id/remote-data-objects/862e7162-cb72-4ddd-a829-692a6257afeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "862e7162-cb72-4ddd-a829-692a6257afeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/862e7162-cb72-4ddd-a829-692a6257afeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a71598d-e97a-4676-988a-e4989af036cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a71598d-e97a-4676-988a-e4989af036cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a71598d-e97a-4676-988a-e4989af036cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/34218292-94f2-4beb-ad0f-8d096885a241> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34218292-94f2-4beb-ad0f-8d096885a241";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34218292-94f2-4beb-ad0f-8d096885a241>.
+    
+<http://data.lblod.info/id/remote-data-objects/546974ff-ea7f-4385-9e1e-d53d37288a20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "546974ff-ea7f-4385-9e1e-d53d37288a20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/546974ff-ea7f-4385-9e1e-d53d37288a20>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7f21b6b-a641-4b30-872e-e92b38043044> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7f21b6b-a641-4b30-872e-e92b38043044";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7f21b6b-a641-4b30-872e-e92b38043044>.
+    
+<http://data.lblod.info/id/remote-data-objects/7603d770-bb5b-47d2-925b-be0c0c6634c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7603d770-bb5b-47d2-925b-be0c0c6634c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7603d770-bb5b-47d2-925b-be0c0c6634c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/faad37a6-0af0-472d-a3de-099de3d31a7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "faad37a6-0af0-472d-a3de-099de3d31a7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/faad37a6-0af0-472d-a3de-099de3d31a7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc1e8dfc-3028-446e-95b0-0ebb0dde1d10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc1e8dfc-3028-446e-95b0-0ebb0dde1d10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc1e8dfc-3028-446e-95b0-0ebb0dde1d10>.
+    
+<http://data.lblod.info/id/remote-data-objects/d225437f-f90e-4af1-b36d-2b6b84d99cb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d225437f-f90e-4af1-b36d-2b6b84d99cb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d225437f-f90e-4af1-b36d-2b6b84d99cb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ebf047b-cf84-402e-8fbe-5f3db8006e46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ebf047b-cf84-402e-8fbe-5f3db8006e46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_27-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ebf047b-cf84-402e-8fbe-5f3db8006e46>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e6cb3bd-9b72-4f1d-9572-a817a8619b6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e6cb3bd-9b72-4f1d-9572-a817a8619b6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e6cb3bd-9b72-4f1d-9572-a817a8619b6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0adad61-936b-4472-9f30-10fac5b6c852> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0adad61-936b-4472-9f30-10fac5b6c852";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0adad61-936b-4472-9f30-10fac5b6c852>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2b569d5-122f-4f07-9f3c-2cf69e07ed01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2b569d5-122f-4f07-9f3c-2cf69e07ed01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2b569d5-122f-4f07-9f3c-2cf69e07ed01>.
+    
+<http://data.lblod.info/id/remote-data-objects/91a52f96-d123-4753-ba0f-860635b62b9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91a52f96-d123-4753-ba0f-860635b62b9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=BesluitenLijst_Burgemeester_29-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91a52f96-d123-4753-ba0f-860635b62b9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca0c58c7-b203-4913-a22b-ba2afa2bae96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca0c58c7-b203-4913-a22b-ba2afa2bae96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_01-03-2022_23496.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca0c58c7-b203-4913-a22b-ba2afa2bae96>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ec5c00a-9e41-43da-abfc-77db203e5460> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ec5c00a-9e41-43da-abfc-77db203e5460";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_01-07-2022_24425.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ec5c00a-9e41-43da-abfc-77db203e5460>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed820d4f-a5f7-46f7-a420-2f42759c0af2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed820d4f-a5f7-46f7-a420-2f42759c0af2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_01-07-2022_24426.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed820d4f-a5f7-46f7-a420-2f42759c0af2>.
+    
+<http://data.lblod.info/id/remote-data-objects/91166782-2747-41a9-ab63-b012a8d4c436> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91166782-2747-41a9-ab63-b012a8d4c436";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_04-05-2022_23941.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91166782-2747-41a9-ab63-b012a8d4c436>.
+    
+<http://data.lblod.info/id/remote-data-objects/9694f884-f383-4feb-85dd-2f81dcc84e80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9694f884-f383-4feb-85dd-2f81dcc84e80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_04-05-2022_23946.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9694f884-f383-4feb-85dd-2f81dcc84e80>.
+    
+<http://data.lblod.info/id/remote-data-objects/34fb80c6-9e97-47e5-907a-7431c30e38a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34fb80c6-9e97-47e5-907a-7431c30e38a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_07-04-2022_23789.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34fb80c6-9e97-47e5-907a-7431c30e38a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/41cd7a3d-e965-4546-87a8-8aacf820fdbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41cd7a3d-e965-4546-87a8-8aacf820fdbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_08-03-2022_23533.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41cd7a3d-e965-4546-87a8-8aacf820fdbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b37ac69-a9fb-4f4f-bb94-8e571ba39ce5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b37ac69-a9fb-4f4f-bb94-8e571ba39ce5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_08-03-2022_23536.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b37ac69-a9fb-4f4f-bb94-8e571ba39ce5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5fc1be0-6e6a-4228-8e33-403de7641c85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5fc1be0-6e6a-4228-8e33-403de7641c85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_09-06-2022_24257.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0c91062e-a486-40f7-8f0a-6ecf7e9a4a07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5fc1be0-6e6a-4228-8e33-403de7641c85>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201414-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201414-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201414-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201414-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/69bf7167-153c-4b4b-b0af-5cc2e468d8a3> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "69bf7167-153c-4b4b-b0af-5cc2e468d8a3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e5f37429-24b2-41a5-8cea-01a945b05479";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/2810b7ba-7d37-4572-b4e5-f5cdcd58076a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2810b7ba-7d37-4572-b4e5-f5cdcd58076a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479>.
+
+  <http://redpencil.data.gift/id/task/80e273d7-ff11-49b5-a78b-22ff7c10c668> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "80e273d7-ff11-49b5-a78b-22ff7c10c668";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/69bf7167-153c-4b4b-b0af-5cc2e468d8a3>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/2810b7ba-7d37-4572-b4e5-f5cdcd58076a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/682b727d-98b5-4ebc-bf47-5f6900fc731c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "682b727d-98b5-4ebc-bf47-5f6900fc731c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_11-03-2022_23572.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/682b727d-98b5-4ebc-bf47-5f6900fc731c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d52b0ae1-e1a6-457d-ba2d-0e0149f81bc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d52b0ae1-e1a6-457d-ba2d-0e0149f81bc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_11-05-2022_23990.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d52b0ae1-e1a6-457d-ba2d-0e0149f81bc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e583aaf-e3b9-4323-b1f1-c73b161e5368> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e583aaf-e3b9-4323-b1f1-c73b161e5368";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_11-05-2022_24023.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e583aaf-e3b9-4323-b1f1-c73b161e5368>.
+    
+<http://data.lblod.info/id/remote-data-objects/f142d6a4-a517-446d-9be8-23cf9ddc2001> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f142d6a4-a517-446d-9be8-23cf9ddc2001";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_15-02-2022_23393.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f142d6a4-a517-446d-9be8-23cf9ddc2001>.
+    
+<http://data.lblod.info/id/remote-data-objects/e14972b9-027b-4cd2-bd65-745b41b7a080> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e14972b9-027b-4cd2-bd65-745b41b7a080";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_17-05-2022_24058.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e14972b9-027b-4cd2-bd65-745b41b7a080>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b51f62c-7742-4e50-96cc-a370ef07db07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b51f62c-7742-4e50-96cc-a370ef07db07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_19-04-2022_23823.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b51f62c-7742-4e50-96cc-a370ef07db07>.
+    
+<http://data.lblod.info/id/remote-data-objects/90c5942d-e6dd-44f8-92bd-2b34cbec83e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90c5942d-e6dd-44f8-92bd-2b34cbec83e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_19-04-2022_23824.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90c5942d-e6dd-44f8-92bd-2b34cbec83e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/73e5e576-17dd-49b9-b9d4-822eea640a9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73e5e576-17dd-49b9-b9d4-822eea640a9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_20-05-2022_24109.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73e5e576-17dd-49b9-b9d4-822eea640a9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b89269e4-06ce-4374-9236-3c1f81b2d499> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b89269e4-06ce-4374-9236-3c1f81b2d499";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_22-06-2022_24349.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b89269e4-06ce-4374-9236-3c1f81b2d499>.
+    
+<http://data.lblod.info/id/remote-data-objects/be162813-2587-4939-bc78-2ba3e9c5ad57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be162813-2587-4939-bc78-2ba3e9c5ad57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_24-02-2022_23475.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be162813-2587-4939-bc78-2ba3e9c5ad57>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec949d85-332e-40fc-9cd9-47bad38678b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec949d85-332e-40fc-9cd9-47bad38678b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_24-02-2022_23476.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec949d85-332e-40fc-9cd9-47bad38678b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/37a05efc-417a-48ac-b3d2-d0881387f427> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37a05efc-417a-48ac-b3d2-d0881387f427";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_25-01-2022_23341.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37a05efc-417a-48ac-b3d2-d0881387f427>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3eb68cc-6efa-43e7-811c-07224528114f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3eb68cc-6efa-43e7-811c-07224528114f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/22c78a0e5fded39bcf1f053a94c2110b42681141ab819c638e71cc61da01745f/GetPublication?filename=Uittreksels_28-06-2022_24385.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3eb68cc-6efa-43e7-811c-07224528114f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4b18533-2353-4ca7-b6ab-f82854b0a88e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4b18533-2353-4ca7-b6ab-f82854b0a88e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_01-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4b18533-2353-4ca7-b6ab-f82854b0a88e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9292e150-9fcd-4273-8d8f-3d438532f94c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9292e150-9fcd-4273-8d8f-3d438532f94c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9292e150-9fcd-4273-8d8f-3d438532f94c>.
+    
+<http://data.lblod.info/id/remote-data-objects/41c179f9-92c3-4807-8a28-2b70fb61855a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41c179f9-92c3-4807-8a28-2b70fb61855a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41c179f9-92c3-4807-8a28-2b70fb61855a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ea74499-07c2-4b39-9244-0150f8ccdbbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ea74499-07c2-4b39-9244-0150f8ccdbbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ea74499-07c2-4b39-9244-0150f8ccdbbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dc2d706-8f3a-43c9-b4e4-84b5eeee7636> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dc2d706-8f3a-43c9-b4e4-84b5eeee7636";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dc2d706-8f3a-43c9-b4e4-84b5eeee7636>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1b6f9fc-f165-49c7-abb1-536e15876abb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1b6f9fc-f165-49c7-abb1-536e15876abb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1b6f9fc-f165-49c7-abb1-536e15876abb>.
+    
+<http://data.lblod.info/id/remote-data-objects/01ef47b9-500b-4a7c-9731-b44d1c074d07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01ef47b9-500b-4a7c-9731-b44d1c074d07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_06-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01ef47b9-500b-4a7c-9731-b44d1c074d07>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4d5f522-56d1-4ec7-8d2e-67ecd84e4db2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4d5f522-56d1-4ec7-8d2e-67ecd84e4db2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4d5f522-56d1-4ec7-8d2e-67ecd84e4db2>.
+    
+<http://data.lblod.info/id/remote-data-objects/57f68233-4373-4481-bded-b7df694b6f42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57f68233-4373-4481-bded-b7df694b6f42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57f68233-4373-4481-bded-b7df694b6f42>.
+    
+<http://data.lblod.info/id/remote-data-objects/99530597-a3cf-442a-84bc-3b3994f7f37e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99530597-a3cf-442a-84bc-3b3994f7f37e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99530597-a3cf-442a-84bc-3b3994f7f37e>.
+    
+<http://data.lblod.info/id/remote-data-objects/23a253f3-ffd7-457e-9856-75ec4b54d5e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23a253f3-ffd7-457e-9856-75ec4b54d5e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23a253f3-ffd7-457e-9856-75ec4b54d5e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6aad508-64f7-4190-a862-4b5751edda8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6aad508-64f7-4190-a862-4b5751edda8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6aad508-64f7-4190-a862-4b5751edda8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a42e489-36a8-4a1f-a169-c8d86c25cda2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a42e489-36a8-4a1f-a169-c8d86c25cda2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a42e489-36a8-4a1f-a169-c8d86c25cda2>.
+    
+<http://data.lblod.info/id/remote-data-objects/38ed4f57-123e-4db2-9e97-fd826915085b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38ed4f57-123e-4db2-9e97-fd826915085b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38ed4f57-123e-4db2-9e97-fd826915085b>.
+    
+<http://data.lblod.info/id/remote-data-objects/aeae5677-7fb9-4e0b-8e39-ae858ee86416> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aeae5677-7fb9-4e0b-8e39-ae858ee86416";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aeae5677-7fb9-4e0b-8e39-ae858ee86416>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a080d36-16bb-4f05-8c57-cf34bf1cc63e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a080d36-16bb-4f05-8c57-cf34bf1cc63e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a080d36-16bb-4f05-8c57-cf34bf1cc63e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a628796f-4f39-4ea1-a6e4-022504875bb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a628796f-4f39-4ea1-a6e4-022504875bb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a628796f-4f39-4ea1-a6e4-022504875bb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/193fcc09-54b8-4755-8de2-ea4b625f58d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "193fcc09-54b8-4755-8de2-ea4b625f58d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_13-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/193fcc09-54b8-4755-8de2-ea4b625f58d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/883d0dc5-2bd4-4e03-85e9-a2d675d42957> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "883d0dc5-2bd4-4e03-85e9-a2d675d42957";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/883d0dc5-2bd4-4e03-85e9-a2d675d42957>.
+    
+<http://data.lblod.info/id/remote-data-objects/bce554aa-39d4-4a1b-99fb-934b946b53ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bce554aa-39d4-4a1b-99fb-934b946b53ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bce554aa-39d4-4a1b-99fb-934b946b53ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8b99960-5a4c-4aad-82c8-d5cfacdf4a51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8b99960-5a4c-4aad-82c8-d5cfacdf4a51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8b99960-5a4c-4aad-82c8-d5cfacdf4a51>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcdff7fa-8cc7-4883-9da0-713d98fce65b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcdff7fa-8cc7-4883-9da0-713d98fce65b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcdff7fa-8cc7-4883-9da0-713d98fce65b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab7bc523-e940-4397-b4d0-615b3a6c2563> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab7bc523-e940-4397-b4d0-615b3a6c2563";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab7bc523-e940-4397-b4d0-615b3a6c2563>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d20fdd9-cd4e-4482-8d43-69b1339eea42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d20fdd9-cd4e-4482-8d43-69b1339eea42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d20fdd9-cd4e-4482-8d43-69b1339eea42>.
+    
+<http://data.lblod.info/id/remote-data-objects/f106d7cf-05bc-4f48-8138-2bce09e1da5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f106d7cf-05bc-4f48-8138-2bce09e1da5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f106d7cf-05bc-4f48-8138-2bce09e1da5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5bc5ea7-2b3c-45f4-9df4-c06847c4efd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5bc5ea7-2b3c-45f4-9df4-c06847c4efd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5bc5ea7-2b3c-45f4-9df4-c06847c4efd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/af36571f-5262-4f48-9a92-0e74a038c5c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af36571f-5262-4f48-9a92-0e74a038c5c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af36571f-5262-4f48-9a92-0e74a038c5c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d98ff4a7-0f49-499d-9a21-20ca5b319019> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d98ff4a7-0f49-499d-9a21-20ca5b319019";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d98ff4a7-0f49-499d-9a21-20ca5b319019>.
+    
+<http://data.lblod.info/id/remote-data-objects/acf4869d-2a39-49c7-8867-b03c47b512d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acf4869d-2a39-49c7-8867-b03c47b512d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acf4869d-2a39-49c7-8867-b03c47b512d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4e1605c-7336-4ffd-b2fa-285f403ae086> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4e1605c-7336-4ffd-b2fa-285f403ae086";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4e1605c-7336-4ffd-b2fa-285f403ae086>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fbc25db-0e56-4f01-9810-7ac64b02295d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fbc25db-0e56-4f01-9810-7ac64b02295d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fbc25db-0e56-4f01-9810-7ac64b02295d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c48c571b-9a9f-4953-a615-2561db83eb6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c48c571b-9a9f-4953-a615-2561db83eb6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c48c571b-9a9f-4953-a615-2561db83eb6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b149cbd3-ad75-4657-bc79-5284d781abfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b149cbd3-ad75-4657-bc79-5284d781abfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b149cbd3-ad75-4657-bc79-5284d781abfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2892ba7-67a4-46e3-98bc-c59e54ad860e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2892ba7-67a4-46e3-98bc-c59e54ad860e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2892ba7-67a4-46e3-98bc-c59e54ad860e>.
+    
+<http://data.lblod.info/id/remote-data-objects/02f0f78e-4044-41c0-bf86-a078accf4ef1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02f0f78e-4044-41c0-bf86-a078accf4ef1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02f0f78e-4044-41c0-bf86-a078accf4ef1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7e7af88-21f2-43d5-9623-5c5a2159acc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7e7af88-21f2-43d5-9623-5c5a2159acc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7e7af88-21f2-43d5-9623-5c5a2159acc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/844fce76-6a1d-4174-b6ba-598d3d137052> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "844fce76-6a1d-4174-b6ba-598d3d137052";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5f37429-24b2-41a5-8cea-01a945b05479> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/844fce76-6a1d-4174-b6ba-598d3d137052>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201415-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201415-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201415-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201415-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e3ddb5e3-b219-4259-823e-b796a572f5c1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e3ddb5e3-b219-4259-823e-b796a572f5c1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4540ff1b-41d3-4408-b4d5-adc04db4b85e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/8616983d-97f4-4c4d-a633-bf5dc0e51816> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8616983d-97f4-4c4d-a633-bf5dc0e51816";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e>.
+
+  <http://redpencil.data.gift/id/task/cadce630-2ca1-4a52-95b2-2f89edeed0d9> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cadce630-2ca1-4a52-95b2-2f89edeed0d9";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e3ddb5e3-b219-4259-823e-b796a572f5c1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/8616983d-97f4-4c4d-a633-bf5dc0e51816>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/34951278-70dc-46f8-93e4-f5670d664b58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34951278-70dc-46f8-93e4-f5670d664b58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34951278-70dc-46f8-93e4-f5670d664b58>.
+    
+<http://data.lblod.info/id/remote-data-objects/f35f0271-015f-4f0e-a59c-c17308c4dc79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f35f0271-015f-4f0e-a59c-c17308c4dc79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f35f0271-015f-4f0e-a59c-c17308c4dc79>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f9eda29-7fb2-47a7-9a9a-61c14a55f03c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f9eda29-7fb2-47a7-9a9a-61c14a55f03c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f9eda29-7fb2-47a7-9a9a-61c14a55f03c>.
+    
+<http://data.lblod.info/id/remote-data-objects/97805ffe-9603-459a-ba75-dbc5cf56bc8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97805ffe-9603-459a-ba75-dbc5cf56bc8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97805ffe-9603-459a-ba75-dbc5cf56bc8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/366ac3d7-23b2-45e3-9952-287ade67df08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "366ac3d7-23b2-45e3-9952-287ade67df08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/366ac3d7-23b2-45e3-9952-287ade67df08>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9502979-e42a-4ed4-a6ff-4eb470a3600a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9502979-e42a-4ed4-a6ff-4eb470a3600a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9502979-e42a-4ed4-a6ff-4eb470a3600a>.
+    
+<http://data.lblod.info/id/remote-data-objects/38b5681f-49e7-468e-886e-209e90e8f94c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38b5681f-49e7-468e-886e-209e90e8f94c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38b5681f-49e7-468e-886e-209e90e8f94c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d273368c-64fd-43f1-a2ec-38d2a05a50c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d273368c-64fd-43f1-a2ec-38d2a05a50c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d273368c-64fd-43f1-a2ec-38d2a05a50c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/69f3070f-a5bd-4d5f-aa84-c75fe66ce4f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69f3070f-a5bd-4d5f-aa84-c75fe66ce4f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_02-05-2022_23885.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69f3070f-a5bd-4d5f-aa84-c75fe66ce4f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/0601c860-8042-4d7d-89d3-c2b565c68132> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0601c860-8042-4d7d-89d3-c2b565c68132";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_04-04-2022_23717.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0601c860-8042-4d7d-89d3-c2b565c68132>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c01337d-fbfa-42fd-ae43-40742565fcda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c01337d-fbfa-42fd-ae43-40742565fcda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_04-07-2022_24286.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c01337d-fbfa-42fd-ae43-40742565fcda>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5126806-bb00-4ff6-996d-e08fc0f95edb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5126806-bb00-4ff6-996d-e08fc0f95edb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_04-07-2022_24376.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5126806-bb00-4ff6-996d-e08fc0f95edb>.
+    
+<http://data.lblod.info/id/remote-data-objects/23e1e6cc-11b2-422f-9e05-658a23b9fac3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23e1e6cc-11b2-422f-9e05-658a23b9fac3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_04-07-2022_24415.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23e1e6cc-11b2-422f-9e05-658a23b9fac3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bc844a8-9519-47b8-b1d2-30234385b043> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bc844a8-9519-47b8-b1d2-30234385b043";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_04-07-2022_24416.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bc844a8-9519-47b8-b1d2-30234385b043>.
+    
+<http://data.lblod.info/id/remote-data-objects/df183ab4-024d-4c45-bd5e-8db256ff95f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df183ab4-024d-4c45-bd5e-8db256ff95f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_04-07-2022_24418.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df183ab4-024d-4c45-bd5e-8db256ff95f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/5efb0aff-c26e-4fdf-8ee8-00d96ec7910a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5efb0aff-c26e-4fdf-8ee8-00d96ec7910a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_04-10-2021_22336.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5efb0aff-c26e-4fdf-8ee8-00d96ec7910a>.
+    
+<http://data.lblod.info/id/remote-data-objects/18b2b050-3355-4fcf-952a-480a5c9b7e4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18b2b050-3355-4fcf-952a-480a5c9b7e4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_07-03-2022_23502.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18b2b050-3355-4fcf-952a-480a5c9b7e4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c881923-2479-488c-aeef-1b63812da40c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c881923-2479-488c-aeef-1b63812da40c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_09-05-2022_23924.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c881923-2479-488c-aeef-1b63812da40c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c6252db-f4b8-4dc5-81cd-cd0803696172> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c6252db-f4b8-4dc5-81cd-cd0803696172";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_09-05-2022_23928.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c6252db-f4b8-4dc5-81cd-cd0803696172>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c60d0ac-0bb2-4d35-8444-477945510eff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c60d0ac-0bb2-4d35-8444-477945510eff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_10-01-2022_23031.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c60d0ac-0bb2-4d35-8444-477945510eff>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdbb6462-5d55-4b1b-9fda-e9140f763d98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdbb6462-5d55-4b1b-9fda-e9140f763d98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_11-07-2022_24446.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdbb6462-5d55-4b1b-9fda-e9140f763d98>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f835fa1-6d70-40c1-883d-167d1298cd69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f835fa1-6d70-40c1-883d-167d1298cd69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_13-04-2022_23735.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f835fa1-6d70-40c1-883d-167d1298cd69>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9ede871-493e-4997-b330-5c268e64e7df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9ede871-493e-4997-b330-5c268e64e7df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_13-04-2022_23747.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9ede871-493e-4997-b330-5c268e64e7df>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4007467-aa82-43e3-8bf0-cf9c910ee001> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4007467-aa82-43e3-8bf0-cf9c910ee001";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_13-04-2022_23771.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4007467-aa82-43e3-8bf0-cf9c910ee001>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb56a9ad-1648-4744-b5bd-965cf2160dec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb56a9ad-1648-4744-b5bd-965cf2160dec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_13-04-2022_23772.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb56a9ad-1648-4744-b5bd-965cf2160dec>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd8102de-9d29-433d-8dd4-411225c7e103> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd8102de-9d29-433d-8dd4-411225c7e103";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_13-06-2022_24254.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd8102de-9d29-433d-8dd4-411225c7e103>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd0b5309-e23d-488b-aa9c-152bce7c41a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd0b5309-e23d-488b-aa9c-152bce7c41a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_13-12-2021_22815.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd0b5309-e23d-488b-aa9c-152bce7c41a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a8e1c0b-b66a-41b1-99e9-0ad9aa68b5a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a8e1c0b-b66a-41b1-99e9-0ad9aa68b5a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_14-02-2022_23370.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a8e1c0b-b66a-41b1-99e9-0ad9aa68b5a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/af332c9e-f37a-4a53-a739-09c9244dc08f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af332c9e-f37a-4a53-a739-09c9244dc08f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_14-03-2022_23543.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af332c9e-f37a-4a53-a739-09c9244dc08f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a2101e8-c525-4bcf-b5b8-c7abb5bc5857> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a2101e8-c525-4bcf-b5b8-c7abb5bc5857";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_15-11-2021_22617.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a2101e8-c525-4bcf-b5b8-c7abb5bc5857>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d890d40-7174-4cdf-b9b2-68a4bded81d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d890d40-7174-4cdf-b9b2-68a4bded81d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_18-07-2022_24469.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d890d40-7174-4cdf-b9b2-68a4bded81d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f3dbf6a-c9ad-484e-b9b4-726328efc0cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f3dbf6a-c9ad-484e-b9b4-726328efc0cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_18-07-2022_24472.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f3dbf6a-c9ad-484e-b9b4-726328efc0cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/73c482d0-cd18-4b99-9235-b311c1deb55c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73c482d0-cd18-4b99-9235-b311c1deb55c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_18-07-2022_24479.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73c482d0-cd18-4b99-9235-b311c1deb55c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a743bf8-62dc-4b50-a4c0-aa4d59901da9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a743bf8-62dc-4b50-a4c0-aa4d59901da9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_18-07-2022_24491.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a743bf8-62dc-4b50-a4c0-aa4d59901da9>.
+    
+<http://data.lblod.info/id/remote-data-objects/78049521-4ee6-4375-84cf-b62274f0ccfb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78049521-4ee6-4375-84cf-b62274f0ccfb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_20-06-2022_24245.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78049521-4ee6-4375-84cf-b62274f0ccfb>.
+    
+<http://data.lblod.info/id/remote-data-objects/07c75f8a-b547-4c5b-9f82-836e6f33e6fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07c75f8a-b547-4c5b-9f82-836e6f33e6fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_20-06-2022_24256.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07c75f8a-b547-4c5b-9f82-836e6f33e6fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ff030b0-2a50-41ae-a274-6f4e897c740f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ff030b0-2a50-41ae-a274-6f4e897c740f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_20-06-2022_24259.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ff030b0-2a50-41ae-a274-6f4e897c740f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae964d09-1dbc-451e-8221-11ebe6b6c438> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae964d09-1dbc-451e-8221-11ebe6b6c438";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_20-12-2021_22814.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae964d09-1dbc-451e-8221-11ebe6b6c438>.
+    
+<http://data.lblod.info/id/remote-data-objects/bec0747e-4a42-4a39-a849-68e43ac86781> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bec0747e-4a42-4a39-a849-68e43ac86781";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_21-02-2022_23376.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bec0747e-4a42-4a39-a849-68e43ac86781>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6dce609-4348-4497-b3df-d4f81d6ce2df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6dce609-4348-4497-b3df-d4f81d6ce2df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_21-02-2022_23399.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6dce609-4348-4497-b3df-d4f81d6ce2df>.
+    
+<http://data.lblod.info/id/remote-data-objects/0802c98e-7f85-4e55-9e0b-db326a1e881f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0802c98e-7f85-4e55-9e0b-db326a1e881f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_22-11-2021_22689.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0802c98e-7f85-4e55-9e0b-db326a1e881f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e3fe718-f1f5-4106-a709-2635f1676df2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e3fe718-f1f5-4106-a709-2635f1676df2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_23-05-2022_24098.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e3fe718-f1f5-4106-a709-2635f1676df2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e767d8a1-65e1-4ca5-b671-2a2b6eaf1780> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e767d8a1-65e1-4ca5-b671-2a2b6eaf1780";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_25-04-2022_23837.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e767d8a1-65e1-4ca5-b671-2a2b6eaf1780>.
+    
+<http://data.lblod.info/id/remote-data-objects/da17779f-c0c8-475b-b780-1ba7d9a62d58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da17779f-c0c8-475b-b780-1ba7d9a62d58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_25-07-2022_24497.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da17779f-c0c8-475b-b780-1ba7d9a62d58>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f28fe0c-9fdf-4e99-bb93-5823b154212b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f28fe0c-9fdf-4e99-bb93-5823b154212b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_25-07-2022_24509.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f28fe0c-9fdf-4e99-bb93-5823b154212b>.
+    
+<http://data.lblod.info/id/remote-data-objects/09053aab-ed56-4766-ac9f-ca324ab8dd26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09053aab-ed56-4766-ac9f-ca324ab8dd26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_27-06-2022_24332.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09053aab-ed56-4766-ac9f-ca324ab8dd26>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac9b218c-e94a-4734-9982-5b3f2104f79d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac9b218c-e94a-4734-9982-5b3f2104f79d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_27-06-2022_24364.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac9b218c-e94a-4734-9982-5b3f2104f79d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b89b7623-be13-4261-8222-185c81a3b841> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b89b7623-be13-4261-8222-185c81a3b841";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_27-12-2021_22812.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b89b7623-be13-4261-8222-185c81a3b841>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2a4dbe7-69f3-4699-bf9a-8dfc59b9eb41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2a4dbe7-69f3-4699-bf9a-8dfc59b9eb41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_27-12-2021_23010.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2a4dbe7-69f3-4699-bf9a-8dfc59b9eb41>.
+    
+<http://data.lblod.info/id/remote-data-objects/aebaf06c-bd67-4d0c-93c1-de73d83bf8f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aebaf06c-bd67-4d0c-93c1-de73d83bf8f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_28-03-2022_23652.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4540ff1b-41d3-4408-b4d5-adc04db4b85e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aebaf06c-bd67-4d0c-93c1-de73d83bf8f4>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201416-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201416-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201416-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201416-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3a7370bf-f76b-4789-836e-94e312cea058> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3a7370bf-f76b-4789-836e-94e312cea058";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "276dff73-f3f9-4f44-b29f-88465d1d9ed6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/99263d22-ca72-4547-8214-515203338597> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "99263d22-ca72-4547-8214-515203338597";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6>.
+
+  <http://redpencil.data.gift/id/task/b6717e32-7303-4e0d-ba10-27577339395c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b6717e32-7303-4e0d-ba10-27577339395c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3a7370bf-f76b-4789-836e-94e312cea058>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/99263d22-ca72-4547-8214-515203338597>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/6f6b34fd-8a31-4968-849d-0754ea4f9b8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f6b34fd-8a31-4968-849d-0754ea4f9b8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_28-03-2022_23667.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f6b34fd-8a31-4968-849d-0754ea4f9b8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f2e4b48-60e7-48fa-8493-c6be56bbf84b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f2e4b48-60e7-48fa-8493-c6be56bbf84b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_30-05-2022_24137.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f2e4b48-60e7-48fa-8493-c6be56bbf84b>.
+    
+<http://data.lblod.info/id/remote-data-objects/de2890a7-1789-41b0-8638-5cd54c7c3638> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de2890a7-1789-41b0-8638-5cd54c7c3638";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/6996650cfeabe917a3b87e7a9148a1a7f236161f376c8db41f72cbb3e4c900cd/GetPublication?filename=Uittreksels_31-01-2022_23170.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de2890a7-1789-41b0-8638-5cd54c7c3638>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec2e1fe0-5d2c-4a12-a461-88f5af7e5864> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec2e1fe0-5d2c-4a12-a461-88f5af7e5864";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Agenda_Gemeenteraad_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec2e1fe0-5d2c-4a12-a461-88f5af7e5864>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb5cfc4d-5b78-441c-8013-629cb24b3310> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb5cfc4d-5b78-441c-8013-629cb24b3310";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Agenda_Gemeenteraad_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb5cfc4d-5b78-441c-8013-629cb24b3310>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2f9093b-4281-4370-92e2-b58f35e68b16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2f9093b-4281-4370-92e2-b58f35e68b16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Agenda_Gemeenteraad_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2f9093b-4281-4370-92e2-b58f35e68b16>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c44f3fd-032a-4b87-83fd-b5bc6c765abd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c44f3fd-032a-4b87-83fd-b5bc6c765abd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Agenda_Gemeenteraad_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c44f3fd-032a-4b87-83fd-b5bc6c765abd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee5932fb-dc28-46bf-bbc6-b26d575efd86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee5932fb-dc28-46bf-bbc6-b26d575efd86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Agenda_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee5932fb-dc28-46bf-bbc6-b26d575efd86>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd13f89d-ba19-44df-a660-882fc1dbb93b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd13f89d-ba19-44df-a660-882fc1dbb93b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Agenda_Gemeenteraad_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd13f89d-ba19-44df-a660-882fc1dbb93b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6237b44-3e6b-4d68-a101-0ab9ada58ce0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6237b44-3e6b-4d68-a101-0ab9ada58ce0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Agenda_Gemeenteraad_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6237b44-3e6b-4d68-a101-0ab9ada58ce0>.
+    
+<http://data.lblod.info/id/remote-data-objects/60279cc1-ca28-4a7d-9b4a-82581589d892> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60279cc1-ca28-4a7d-9b4a-82581589d892";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Agenda_Gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60279cc1-ca28-4a7d-9b4a-82581589d892>.
+    
+<http://data.lblod.info/id/remote-data-objects/f23f9b68-55fc-444f-bbf2-41327e274d96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f23f9b68-55fc-444f-bbf2-41327e274d96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Agenda_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f23f9b68-55fc-444f-bbf2-41327e274d96>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6dec3e8-121b-43dc-b992-b3938f73d5b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6dec3e8-121b-43dc-b992-b3938f73d5b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=BesluitenLijst_Gemeenteraad_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6dec3e8-121b-43dc-b992-b3938f73d5b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/17799b87-8838-4f8f-a60e-a7df91a00475> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17799b87-8838-4f8f-a60e-a7df91a00475";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=BesluitenLijst_Gemeenteraad_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17799b87-8838-4f8f-a60e-a7df91a00475>.
+    
+<http://data.lblod.info/id/remote-data-objects/e47d974b-bb5a-4cd6-a456-811a5ed0c2eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e47d974b-bb5a-4cd6-a456-811a5ed0c2eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=BesluitenLijst_Gemeenteraad_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e47d974b-bb5a-4cd6-a456-811a5ed0c2eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/72ad9ba4-f592-495e-824a-d2b0f0c54630> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72ad9ba4-f592-495e-824a-d2b0f0c54630";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72ad9ba4-f592-495e-824a-d2b0f0c54630>.
+    
+<http://data.lblod.info/id/remote-data-objects/be3c636a-8bf0-44dc-8435-812c15d13c25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be3c636a-8bf0-44dc-8435-812c15d13c25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=BesluitenLijst_Gemeenteraad_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be3c636a-8bf0-44dc-8435-812c15d13c25>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5166fed-98a3-4644-9e44-d0e69cb81050> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5166fed-98a3-4644-9e44-d0e69cb81050";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5166fed-98a3-4644-9e44-d0e69cb81050>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed834f6c-e65d-4869-83ab-52ca7e079f8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed834f6c-e65d-4869-83ab-52ca7e079f8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed834f6c-e65d-4869-83ab-52ca7e079f8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/47c05afe-5823-49b1-be7f-7774ae6e9e62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47c05afe-5823-49b1-be7f-7774ae6e9e62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Notulen_Gemeenteraad_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47c05afe-5823-49b1-be7f-7774ae6e9e62>.
+    
+<http://data.lblod.info/id/remote-data-objects/74d51c09-6067-4bb5-a837-e41b872b81b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74d51c09-6067-4bb5-a837-e41b872b81b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Notulen_Gemeenteraad_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74d51c09-6067-4bb5-a837-e41b872b81b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/255b64e1-0664-4519-bf38-7cb26169aee8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "255b64e1-0664-4519-bf38-7cb26169aee8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Notulen_Gemeenteraad_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/255b64e1-0664-4519-bf38-7cb26169aee8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d46f2e7-83e2-4395-b766-eacbed6eb78b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d46f2e7-83e2-4395-b766-eacbed6eb78b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Notulen_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d46f2e7-83e2-4395-b766-eacbed6eb78b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa0154dc-e211-46b4-bf67-6ad156466798> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa0154dc-e211-46b4-bf67-6ad156466798";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Notulen_Gemeenteraad_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa0154dc-e211-46b4-bf67-6ad156466798>.
+    
+<http://data.lblod.info/id/remote-data-objects/29417219-3380-40b2-a504-50d570de422f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29417219-3380-40b2-a504-50d570de422f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Notulen_Gemeenteraad_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29417219-3380-40b2-a504-50d570de422f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb3fec3a-97cd-4780-9a13-311c2aa159fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb3fec3a-97cd-4780-9a13-311c2aa159fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Notulen_Gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb3fec3a-97cd-4780-9a13-311c2aa159fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/532a158c-f444-43d7-9569-da8d491b61d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "532a158c-f444-43d7-9569-da8d491b61d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/532a158c-f444-43d7-9569-da8d491b61d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3aa3329-8cab-4772-88c3-9850a3d5be4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3aa3329-8cab-4772-88c3-9850a3d5be4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3aa3329-8cab-4772-88c3-9850a3d5be4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b6198c8-31bc-4362-8df3-6291e45ca704> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b6198c8-31bc-4362-8df3-6291e45ca704";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b6198c8-31bc-4362-8df3-6291e45ca704>.
+    
+<http://data.lblod.info/id/remote-data-objects/69c6082f-385b-49f8-93d5-e02fac77adaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69c6082f-385b-49f8-93d5-e02fac77adaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_19-04-2022_23591.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69c6082f-385b-49f8-93d5-e02fac77adaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/73cf969b-f553-41c3-a0a4-de17f6575c4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73cf969b-f553-41c3-a0a4-de17f6575c4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_19-04-2022_23592.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73cf969b-f553-41c3-a0a4-de17f6575c4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd915bfb-4805-4cad-b913-80fd286c81cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd915bfb-4805-4cad-b913-80fd286c81cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_19-10-2021_22354.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd915bfb-4805-4cad-b913-80fd286c81cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ee47385-ddd0-4def-846a-b422598d159c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ee47385-ddd0-4def-846a-b422598d159c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_21-06-2022_23951.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ee47385-ddd0-4def-846a-b422598d159c>.
+    
+<http://data.lblod.info/id/remote-data-objects/afa4ce72-0fc6-4cc1-bb32-65524ea15c7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afa4ce72-0fc6-4cc1-bb32-65524ea15c7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_21-06-2022_24073.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afa4ce72-0fc6-4cc1-bb32-65524ea15c7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdc94eec-b1df-4aee-99af-362de4b0301e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdc94eec-b1df-4aee-99af-362de4b0301e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_21-06-2022_24233.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdc94eec-b1df-4aee-99af-362de4b0301e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c32b4a3-fa2a-4fe6-b95e-464b96065807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c32b4a3-fa2a-4fe6-b95e-464b96065807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_21-12-2021_22606.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c32b4a3-fa2a-4fe6-b95e-464b96065807>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c6db179-f530-4857-b412-686ad06951ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c6db179-f530-4857-b412-686ad06951ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_21-12-2021_22721.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c6db179-f530-4857-b412-686ad06951ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/775e447d-5109-4c09-8f3e-1165de6cb1d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "775e447d-5109-4c09-8f3e-1165de6cb1d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_22-03-2022_23426.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/775e447d-5109-4c09-8f3e-1165de6cb1d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/007abad3-48ee-490a-b2d7-ca7be34b3fef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "007abad3-48ee-490a-b2d7-ca7be34b3fef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_22-03-2022_23491.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/007abad3-48ee-490a-b2d7-ca7be34b3fef>.
+    
+<http://data.lblod.info/id/remote-data-objects/e75cf840-2f80-437a-8cf8-640cc9b0d7b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e75cf840-2f80-437a-8cf8-640cc9b0d7b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_22-03-2022_23514.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e75cf840-2f80-437a-8cf8-640cc9b0d7b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/50f61477-77c5-4f1a-b1f8-b47a2279c56b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50f61477-77c5-4f1a-b1f8-b47a2279c56b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_22-03-2022_23522.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50f61477-77c5-4f1a-b1f8-b47a2279c56b>.
+    
+<http://data.lblod.info/id/remote-data-objects/67a21dae-1319-4e75-89a3-86ea1e69a14c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67a21dae-1319-4e75-89a3-86ea1e69a14c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_22-03-2022_23524.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67a21dae-1319-4e75-89a3-86ea1e69a14c>.
+    
+<http://data.lblod.info/id/remote-data-objects/203da5ff-ae69-4629-932b-3e2d5c1b3244> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "203da5ff-ae69-4629-932b-3e2d5c1b3244";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_23-11-2021_22588.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/203da5ff-ae69-4629-932b-3e2d5c1b3244>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7b4ef1f-d203-4efd-92f7-04a25028cb88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7b4ef1f-d203-4efd-92f7-04a25028cb88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_23-11-2021_22601.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7b4ef1f-d203-4efd-92f7-04a25028cb88>.
+    
+<http://data.lblod.info/id/remote-data-objects/61245229-692e-45ce-86ec-d3ed1db75a06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61245229-692e-45ce-86ec-d3ed1db75a06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_23-11-2021_22610.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61245229-692e-45ce-86ec-d3ed1db75a06>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3ea73d2-b4e8-465e-ae90-aa1f48478511> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3ea73d2-b4e8-465e-ae90-aa1f48478511";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/780220006b1fa1aaf69e8afa325e56c6ef29d781d138057a722c3879e7321cf1/GetPublication?filename=Uittreksels_23-11-2021_22625.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3ea73d2-b4e8-465e-ae90-aa1f48478511>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb491135-b9cd-4056-a5ce-5f6771179d44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb491135-b9cd-4056-a5ce-5f6771179d44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb491135-b9cd-4056-a5ce-5f6771179d44>.
+    
+<http://data.lblod.info/id/remote-data-objects/096ea775-d669-43cd-9b03-5c4143f71c91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "096ea775-d669-43cd-9b03-5c4143f71c91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/096ea775-d669-43cd-9b03-5c4143f71c91>.
+    
+<http://data.lblod.info/id/remote-data-objects/edd2869f-dee3-4463-8790-82a0ecfd3e06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edd2869f-dee3-4463-8790-82a0ecfd3e06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edd2869f-dee3-4463-8790-82a0ecfd3e06>.
+    
+<http://data.lblod.info/id/remote-data-objects/88703241-e7c1-461f-b475-d2203fd720a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88703241-e7c1-461f-b475-d2203fd720a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/276dff73-f3f9-4f44-b29f-88465d1d9ed6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88703241-e7c1-461f-b475-d2203fd720a7>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201417-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201417-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201417-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201417-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c3982d5d-b149-42bd-aac1-199694384bbe> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c3982d5d-b149-42bd-aac1-199694384bbe";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/21a3845f-0ac7-4635-840b-15a38e7b8555> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "21a3845f-0ac7-4635-840b-15a38e7b8555";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003>.
+
+  <http://redpencil.data.gift/id/task/e5e8110d-efca-4ad2-a548-247005bdb7f4> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e5e8110d-efca-4ad2-a548-247005bdb7f4";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c3982d5d-b149-42bd-aac1-199694384bbe>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/21a3845f-0ac7-4635-840b-15a38e7b8555>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5b9db16f-ec43-4fe3-b453-e4dba153d96f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b9db16f-ec43-4fe3-b453-e4dba153d96f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b9db16f-ec43-4fe3-b453-e4dba153d96f>.
+    
+<http://data.lblod.info/id/remote-data-objects/73674364-a699-48ac-b1b2-45c78dbe6c63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73674364-a699-48ac-b1b2-45c78dbe6c63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73674364-a699-48ac-b1b2-45c78dbe6c63>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb1d2422-3112-4ba2-b4fe-e41407556e18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb1d2422-3112-4ba2-b4fe-e41407556e18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb1d2422-3112-4ba2-b4fe-e41407556e18>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5e06e14-6749-4fa3-8663-546708140bc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5e06e14-6749-4fa3-8663-546708140bc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5e06e14-6749-4fa3-8663-546708140bc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/89c8b075-a15b-4985-97c0-994e45397256> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89c8b075-a15b-4985-97c0-994e45397256";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89c8b075-a15b-4985-97c0-994e45397256>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff151502-b407-4598-88ec-576044ee5cd4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff151502-b407-4598-88ec-576044ee5cd4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff151502-b407-4598-88ec-576044ee5cd4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a2a7161-59ea-4066-98c0-966c557567c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a2a7161-59ea-4066-98c0-966c557567c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a2a7161-59ea-4066-98c0-966c557567c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/13f12ee7-e381-4803-a8a9-beefecadec8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13f12ee7-e381-4803-a8a9-beefecadec8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13f12ee7-e381-4803-a8a9-beefecadec8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a822b80e-bc42-4efd-89d1-a4b73a0ecc87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a822b80e-bc42-4efd-89d1-a4b73a0ecc87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a822b80e-bc42-4efd-89d1-a4b73a0ecc87>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3ee4302-fa0a-43e8-99c3-5880401eb8af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3ee4302-fa0a-43e8-99c3-5880401eb8af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3ee4302-fa0a-43e8-99c3-5880401eb8af>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ddf8115-c86d-41aa-8d42-642ea265d731> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ddf8115-c86d-41aa-8d42-642ea265d731";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ddf8115-c86d-41aa-8d42-642ea265d731>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb58864e-a122-48bd-8cc0-360b5dd41b81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb58864e-a122-48bd-8cc0-360b5dd41b81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb58864e-a122-48bd-8cc0-360b5dd41b81>.
+    
+<http://data.lblod.info/id/remote-data-objects/be70ac45-1032-4d56-a4a9-5442eff14c4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be70ac45-1032-4d56-a4a9-5442eff14c4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be70ac45-1032-4d56-a4a9-5442eff14c4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1a9bbeb-6d51-46f1-9955-15395019c73c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1a9bbeb-6d51-46f1-9955-15395019c73c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Uittreksels_19-04-2022_23593.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1a9bbeb-6d51-46f1-9955-15395019c73c>.
+    
+<http://data.lblod.info/id/remote-data-objects/283f56fe-c7ed-428d-b53f-dd2e4be00ef7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "283f56fe-c7ed-428d-b53f-dd2e4be00ef7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Uittreksels_21-06-2022_24176.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/283f56fe-c7ed-428d-b53f-dd2e4be00ef7>.
+    
+<http://data.lblod.info/id/remote-data-objects/095ec2c5-707e-4e1c-b51a-b0fd5fdae0ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "095ec2c5-707e-4e1c-b51a-b0fd5fdae0ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Uittreksels_21-12-2021_22725.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/095ec2c5-707e-4e1c-b51a-b0fd5fdae0ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca6c4193-4ee1-443a-a6e7-1dc7247c854c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca6c4193-4ee1-443a-a6e7-1dc7247c854c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Uittreksels_21-12-2021_22792.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca6c4193-4ee1-443a-a6e7-1dc7247c854c>.
+    
+<http://data.lblod.info/id/remote-data-objects/474600f1-a9a7-40b5-a5a4-b92ff57cb6ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "474600f1-a9a7-40b5-a5a4-b92ff57cb6ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Uittreksels_23-11-2021_22501.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/474600f1-a9a7-40b5-a5a4-b92ff57cb6ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/e861bd11-f7a2-4aa5-ac0a-232c71b0871b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e861bd11-f7a2-4aa5-ac0a-232c71b0871b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Uittreksels_23-11-2021_22602.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e861bd11-f7a2-4aa5-ac0a-232c71b0871b>.
+    
+<http://data.lblod.info/id/remote-data-objects/65306ea5-9450-45bd-aacb-c9ca14618e4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65306ea5-9450-45bd-aacb-c9ca14618e4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/e96d54a99ba5db27ee77744fce97d629c0ae72aba598ffd2b4c3db013d3cbb02/GetPublication?filename=Uittreksels_23-11-2021_22626.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65306ea5-9450-45bd-aacb-c9ca14618e4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0702d59-2a2d-48bb-83ac-4a7f10c233f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0702d59-2a2d-48bb-83ac-4a7f10c233f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_01-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0702d59-2a2d-48bb-83ac-4a7f10c233f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc2b30ee-ea7b-4a03-aae9-529b3ad267c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc2b30ee-ea7b-4a03-aae9-529b3ad267c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc2b30ee-ea7b-4a03-aae9-529b3ad267c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcb45db2-8d67-4682-a838-864028736221> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcb45db2-8d67-4682-a838-864028736221";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcb45db2-8d67-4682-a838-864028736221>.
+    
+<http://data.lblod.info/id/remote-data-objects/651c61c2-1e84-46e0-a91b-65da8bc43d42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "651c61c2-1e84-46e0-a91b-65da8bc43d42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/651c61c2-1e84-46e0-a91b-65da8bc43d42>.
+    
+<http://data.lblod.info/id/remote-data-objects/23258429-694c-42c8-a3df-6f9e85d0a497> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23258429-694c-42c8-a3df-6f9e85d0a497";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23258429-694c-42c8-a3df-6f9e85d0a497>.
+    
+<http://data.lblod.info/id/remote-data-objects/78280fcb-ebc0-48c3-9085-660bae32b294> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78280fcb-ebc0-48c3-9085-660bae32b294";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78280fcb-ebc0-48c3-9085-660bae32b294>.
+    
+<http://data.lblod.info/id/remote-data-objects/660277d8-4258-4d50-8d1f-d3cf3eca21a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "660277d8-4258-4d50-8d1f-d3cf3eca21a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/660277d8-4258-4d50-8d1f-d3cf3eca21a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b19cccb-cee8-41a7-afb9-535fc407c454> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b19cccb-cee8-41a7-afb9-535fc407c454";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b19cccb-cee8-41a7-afb9-535fc407c454>.
+    
+<http://data.lblod.info/id/remote-data-objects/584d41ad-1f63-4aaa-958b-2a17903ffeb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "584d41ad-1f63-4aaa-958b-2a17903ffeb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/584d41ad-1f63-4aaa-958b-2a17903ffeb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba6a23bc-77f3-4b58-a187-3085de809a48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba6a23bc-77f3-4b58-a187-3085de809a48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba6a23bc-77f3-4b58-a187-3085de809a48>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ab04841-5645-4658-b4db-561a33c77f3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ab04841-5645-4658-b4db-561a33c77f3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ab04841-5645-4658-b4db-561a33c77f3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c311f78-881f-4e95-9617-b3ead4b77bbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c311f78-881f-4e95-9617-b3ead4b77bbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c311f78-881f-4e95-9617-b3ead4b77bbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/48e83ba0-770f-4b98-ab3b-e26ddbf48588> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48e83ba0-770f-4b98-ab3b-e26ddbf48588";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48e83ba0-770f-4b98-ab3b-e26ddbf48588>.
+    
+<http://data.lblod.info/id/remote-data-objects/eac8069e-5360-4867-8dfd-d3e6069f2af9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eac8069e-5360-4867-8dfd-d3e6069f2af9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_13-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eac8069e-5360-4867-8dfd-d3e6069f2af9>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d649275-14c6-4809-9945-1ecd36c96dee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d649275-14c6-4809-9945-1ecd36c96dee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d649275-14c6-4809-9945-1ecd36c96dee>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5eaf45b-1f67-4f51-83ea-970b3b5553a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5eaf45b-1f67-4f51-83ea-970b3b5553a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5eaf45b-1f67-4f51-83ea-970b3b5553a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/acdfc840-7c0e-4024-b101-f11961fbc52b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acdfc840-7c0e-4024-b101-f11961fbc52b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acdfc840-7c0e-4024-b101-f11961fbc52b>.
+    
+<http://data.lblod.info/id/remote-data-objects/408c4346-f176-45f2-8f48-6bbfae28ac81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "408c4346-f176-45f2-8f48-6bbfae28ac81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/408c4346-f176-45f2-8f48-6bbfae28ac81>.
+    
+<http://data.lblod.info/id/remote-data-objects/997d32df-3c84-4f23-b48f-af000081f6ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "997d32df-3c84-4f23-b48f-af000081f6ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/997d32df-3c84-4f23-b48f-af000081f6ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4a119e1-0dee-4ceb-8b73-806eff176051> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4a119e1-0dee-4ceb-8b73-806eff176051";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4a119e1-0dee-4ceb-8b73-806eff176051>.
+    
+<http://data.lblod.info/id/remote-data-objects/91ef7bf8-4fcf-43f2-9ed6-9e70a3e0dda9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91ef7bf8-4fcf-43f2-9ed6-9e70a3e0dda9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91ef7bf8-4fcf-43f2-9ed6-9e70a3e0dda9>.
+    
+<http://data.lblod.info/id/remote-data-objects/666f6fe0-6b11-415a-8096-b9d47e5d35a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "666f6fe0-6b11-415a-8096-b9d47e5d35a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/666f6fe0-6b11-415a-8096-b9d47e5d35a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a567248c-1c8b-4a9f-a89b-5a7439562f89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a567248c-1c8b-4a9f-a89b-5a7439562f89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a567248c-1c8b-4a9f-a89b-5a7439562f89>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f905ec2-6967-4e96-a584-aad8501abc21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f905ec2-6967-4e96-a584-aad8501abc21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f905ec2-6967-4e96-a584-aad8501abc21>.
+    
+<http://data.lblod.info/id/remote-data-objects/26431d2f-8fbc-46eb-b27a-dfb1e444a359> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26431d2f-8fbc-46eb-b27a-dfb1e444a359";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26431d2f-8fbc-46eb-b27a-dfb1e444a359>.
+    
+<http://data.lblod.info/id/remote-data-objects/20d15c10-b6ce-4c16-b1cc-e80235d98285> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20d15c10-b6ce-4c16-b1cc-e80235d98285";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20d15c10-b6ce-4c16-b1cc-e80235d98285>.
+    
+<http://data.lblod.info/id/remote-data-objects/32ca9c04-bab0-4643-b47a-2c3c3d1cc2cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32ca9c04-bab0-4643-b47a-2c3c3d1cc2cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32ca9c04-bab0-4643-b47a-2c3c3d1cc2cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/16437494-c748-4020-9288-4ee2c9233e60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16437494-c748-4020-9288-4ee2c9233e60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16437494-c748-4020-9288-4ee2c9233e60>.
+    
+<http://data.lblod.info/id/remote-data-objects/04f46c31-1f63-4733-bfc1-3514c1d54f1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04f46c31-1f63-4733-bfc1-3514c1d54f1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04f46c31-1f63-4733-bfc1-3514c1d54f1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c617cc44-0e2f-4639-b79f-8fef057af36a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c617cc44-0e2f-4639-b79f-8fef057af36a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d1ac0e5-af18-4d9c-a42b-c20b2f0d1003> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c617cc44-0e2f-4639-b79f-8fef057af36a>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201419-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201419-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201419-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201419-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2febcbc5-f7ac-4ba9-ada8-4c565886e35a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2febcbc5-f7ac-4ba9-ada8-4c565886e35a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c0faaa16-f37e-4f1e-84db-12e27d392c5f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ced41805-ca78-4880-b2d1-0849380077d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ced41805-ca78-4880-b2d1-0849380077d1";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f>.
+
+  <http://redpencil.data.gift/id/task/355932e7-8164-416d-b940-a112715e3a1d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "355932e7-8164-416d-b940-a112715e3a1d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2febcbc5-f7ac-4ba9-ada8-4c565886e35a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ced41805-ca78-4880-b2d1-0849380077d1>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/8777ecc6-43c8-4669-9a4d-20f9196a70df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8777ecc6-43c8-4669-9a4d-20f9196a70df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8777ecc6-43c8-4669-9a4d-20f9196a70df>.
+    
+<http://data.lblod.info/id/remote-data-objects/61c5509a-5df3-491c-b782-57b46f510d7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61c5509a-5df3-491c-b782-57b46f510d7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61c5509a-5df3-491c-b782-57b46f510d7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a17f2e4-f7a3-421a-bfeb-aa5bb5bb60c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a17f2e4-f7a3-421a-bfeb-aa5bb5bb60c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a17f2e4-f7a3-421a-bfeb-aa5bb5bb60c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fb83543-ee12-4c4c-8a41-a9f63c3714ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fb83543-ee12-4c4c-8a41-a9f63c3714ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fb83543-ee12-4c4c-8a41-a9f63c3714ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/465eafe5-9954-4fa7-bdcc-095b7bf53e3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "465eafe5-9954-4fa7-bdcc-095b7bf53e3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/465eafe5-9954-4fa7-bdcc-095b7bf53e3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/85174ea7-f751-4745-8f90-d7043cd3c177> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85174ea7-f751-4745-8f90-d7043cd3c177";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85174ea7-f751-4745-8f90-d7043cd3c177>.
+    
+<http://data.lblod.info/id/remote-data-objects/51cd4c2f-f549-42b3-b8d3-59b88a63f4e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51cd4c2f-f549-42b3-b8d3-59b88a63f4e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51cd4c2f-f549-42b3-b8d3-59b88a63f4e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/724f7bf3-8a7d-43b2-9e11-7e79416a9435> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "724f7bf3-8a7d-43b2-9e11-7e79416a9435";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/724f7bf3-8a7d-43b2-9e11-7e79416a9435>.
+    
+<http://data.lblod.info/id/remote-data-objects/8489750c-a1b0-4c9c-8715-28d1005b2135> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8489750c-a1b0-4c9c-8715-28d1005b2135";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8489750c-a1b0-4c9c-8715-28d1005b2135>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa9737b5-34a9-4294-9561-efe731957210> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa9737b5-34a9-4294-9561-efe731957210";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=BesluitenLijst_Vast%20bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa9737b5-34a9-4294-9561-efe731957210>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ef9575c-5b97-4153-98c9-d59034c7b404> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ef9575c-5b97-4153-98c9-d59034c7b404";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=Uittreksels_10-01-2022_23032.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ef9575c-5b97-4153-98c9-d59034c7b404>.
+    
+<http://data.lblod.info/id/remote-data-objects/9af9cc40-0626-4720-b37e-53e8636fad10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9af9cc40-0626-4720-b37e-53e8636fad10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=Uittreksels_14-03-2022_23544.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9af9cc40-0626-4720-b37e-53e8636fad10>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3a0c5be-e7d8-4624-8efa-540e68f4a72c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3a0c5be-e7d8-4624-8efa-540e68f4a72c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=Uittreksels_17-01-2022_23071.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3a0c5be-e7d8-4624-8efa-540e68f4a72c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4004b07c-b0b5-4b78-bcfe-32cc3c84990b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4004b07c-b0b5-4b78-bcfe-32cc3c84990b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ingelmunster.be/LBLODWeb/Home/Overzicht/ebb8e26d1e4eae847daf937562b1c98cb30ed2a77e77ffb82ea0fd3c6560070e/GetPublication?filename=Uittreksels_27-06-2022_24345.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4004b07c-b0b5-4b78-bcfe-32cc3c84990b>.
+    
+<http://data.lblod.info/id/remote-data-objects/dafe3132-ea0f-4f43-aa74-ac1311778b4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dafe3132-ea0f-4f43-aa74-ac1311778b4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dafe3132-ea0f-4f43-aa74-ac1311778b4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/534a846c-9346-4aef-b502-80a3a762a7f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "534a846c-9346-4aef-b502-80a3a762a7f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/534a846c-9346-4aef-b502-80a3a762a7f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/deaba0e3-f6bb-435c-84f5-e9004c31a45a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "deaba0e3-f6bb-435c-84f5-e9004c31a45a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/deaba0e3-f6bb-435c-84f5-e9004c31a45a>.
+    
+<http://data.lblod.info/id/remote-data-objects/848ec11c-eef6-45e8-908d-cfde2a7206ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "848ec11c-eef6-45e8-908d-cfde2a7206ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/848ec11c-eef6-45e8-908d-cfde2a7206ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e34d806-7d57-4fa3-adc4-40bfafe9e7b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e34d806-7d57-4fa3-adc4-40bfafe9e7b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e34d806-7d57-4fa3-adc4-40bfafe9e7b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad675ce8-90c3-485a-a9cb-0b42727bc311> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad675ce8-90c3-485a-a9cb-0b42727bc311";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad675ce8-90c3-485a-a9cb-0b42727bc311>.
+    
+<http://data.lblod.info/id/remote-data-objects/8366496c-e6a2-4a2f-9783-7ea921ad5cab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8366496c-e6a2-4a2f-9783-7ea921ad5cab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8366496c-e6a2-4a2f-9783-7ea921ad5cab>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d2becd5-3741-4516-b555-f64d56d28869> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d2becd5-3741-4516-b555-f64d56d28869";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d2becd5-3741-4516-b555-f64d56d28869>.
+    
+<http://data.lblod.info/id/remote-data-objects/be753046-dfc1-4d71-8231-d0f2bc59a46c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be753046-dfc1-4d71-8231-d0f2bc59a46c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be753046-dfc1-4d71-8231-d0f2bc59a46c>.
+    
+<http://data.lblod.info/id/remote-data-objects/18f4ca7a-8b08-4a1d-b01c-90f4b2bb9260> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18f4ca7a-8b08-4a1d-b01c-90f4b2bb9260";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18f4ca7a-8b08-4a1d-b01c-90f4b2bb9260>.
+    
+<http://data.lblod.info/id/remote-data-objects/6299413f-eafc-41a5-825d-c8361cb91613> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6299413f-eafc-41a5-825d-c8361cb91613";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6299413f-eafc-41a5-825d-c8361cb91613>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e998127-9b61-434b-8bdd-553469d4f436> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e998127-9b61-434b-8bdd-553469d4f436";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e998127-9b61-434b-8bdd-553469d4f436>.
+    
+<http://data.lblod.info/id/remote-data-objects/3996dcf7-8f48-4d04-9a20-9206f5e6c33c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3996dcf7-8f48-4d04-9a20-9206f5e6c33c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3996dcf7-8f48-4d04-9a20-9206f5e6c33c>.
+    
+<http://data.lblod.info/id/remote-data-objects/342ae9c6-765d-4ebd-a563-84f90a43b00d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "342ae9c6-765d-4ebd-a563-84f90a43b00d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/342ae9c6-765d-4ebd-a563-84f90a43b00d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d2293a3-2611-4a9b-ba12-c5d47d56f6c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d2293a3-2611-4a9b-ba12-c5d47d56f6c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d2293a3-2611-4a9b-ba12-c5d47d56f6c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/901a0971-0a89-4b9f-a0a3-6e2807411a7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "901a0971-0a89-4b9f-a0a3-6e2807411a7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/901a0971-0a89-4b9f-a0a3-6e2807411a7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/478f9190-be16-4485-be88-86f35bf28638> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "478f9190-be16-4485-be88-86f35bf28638";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/478f9190-be16-4485-be88-86f35bf28638>.
+    
+<http://data.lblod.info/id/remote-data-objects/0087bd61-49e7-4454-b2d0-f13b3522377b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0087bd61-49e7-4454-b2d0-f13b3522377b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0087bd61-49e7-4454-b2d0-f13b3522377b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0612431e-ec25-48ce-a529-d4c239fd8001> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0612431e-ec25-48ce-a529-d4c239fd8001";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0612431e-ec25-48ce-a529-d4c239fd8001>.
+    
+<http://data.lblod.info/id/remote-data-objects/38af0c42-eb3d-4450-b03c-0f34dfb209c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38af0c42-eb3d-4450-b03c-0f34dfb209c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38af0c42-eb3d-4450-b03c-0f34dfb209c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e737b6d-cc9e-4aa8-b7d5-6bf23409b100> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e737b6d-cc9e-4aa8-b7d5-6bf23409b100";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e737b6d-cc9e-4aa8-b7d5-6bf23409b100>.
+    
+<http://data.lblod.info/id/remote-data-objects/88772cf2-df06-4a76-9e05-f88d989457bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88772cf2-df06-4a76-9e05-f88d989457bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88772cf2-df06-4a76-9e05-f88d989457bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/4438d51f-9926-4c8b-a9cb-1f6c3312a1b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4438d51f-9926-4c8b-a9cb-1f6c3312a1b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4438d51f-9926-4c8b-a9cb-1f6c3312a1b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2b8679a-7653-40f6-b126-737ce05d4c3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2b8679a-7653-40f6-b126-737ce05d4c3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2b8679a-7653-40f6-b126-737ce05d4c3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/92f207b1-6e0f-42d0-88aa-06920d1369a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92f207b1-6e0f-42d0-88aa-06920d1369a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92f207b1-6e0f-42d0-88aa-06920d1369a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/64b0e7f8-64aa-443b-96ff-1a014a40cef8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64b0e7f8-64aa-443b-96ff-1a014a40cef8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64b0e7f8-64aa-443b-96ff-1a014a40cef8>.
+    
+<http://data.lblod.info/id/remote-data-objects/6da2dea1-8bbd-4399-8445-d5044aafd70b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6da2dea1-8bbd-4399-8445-d5044aafd70b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6da2dea1-8bbd-4399-8445-d5044aafd70b>.
+    
+<http://data.lblod.info/id/remote-data-objects/da09b7f7-b5a4-4e22-a146-603ed4b14b96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da09b7f7-b5a4-4e22-a146-603ed4b14b96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da09b7f7-b5a4-4e22-a146-603ed4b14b96>.
+    
+<http://data.lblod.info/id/remote-data-objects/72b75198-25de-4596-b50f-ac0857ab492a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72b75198-25de-4596-b50f-ac0857ab492a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72b75198-25de-4596-b50f-ac0857ab492a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f99b20eb-1122-464c-a069-4a81b4b3277b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f99b20eb-1122-464c-a069-4a81b4b3277b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f99b20eb-1122-464c-a069-4a81b4b3277b>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa88b16e-6cc0-4465-99bd-e3ca8393efcf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa88b16e-6cc0-4465-99bd-e3ca8393efcf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa88b16e-6cc0-4465-99bd-e3ca8393efcf>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b9e0678-717c-4011-8218-31f34b2ca42f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b9e0678-717c-4011-8218-31f34b2ca42f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b9e0678-717c-4011-8218-31f34b2ca42f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5537101d-a3f6-474e-86df-dbbfc63dea67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5537101d-a3f6-474e-86df-dbbfc63dea67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5537101d-a3f6-474e-86df-dbbfc63dea67>.
+    
+<http://data.lblod.info/id/remote-data-objects/14648607-3841-4b4c-818c-bf223f99e380> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14648607-3841-4b4c-818c-bf223f99e380";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14648607-3841-4b4c-818c-bf223f99e380>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d2e693b-e3f1-4542-b8a3-40db81bd4277> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d2e693b-e3f1-4542-b8a3-40db81bd4277";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d2e693b-e3f1-4542-b8a3-40db81bd4277>.
+    
+<http://data.lblod.info/id/remote-data-objects/97bc1766-6a08-457e-afab-03f19be6badc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97bc1766-6a08-457e-afab-03f19be6badc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c0faaa16-f37e-4f1e-84db-12e27d392c5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97bc1766-6a08-457e-afab-03f19be6badc>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201420-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201420-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201420-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201420-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d15c17e8-546f-4070-a712-904e7fe461de> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d15c17e8-546f-4070-a712-904e7fe461de";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "14f1ab7a-96e8-4091-92a6-a8f2980c4c4a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c4e728c3-b418-4b5d-98d6-d9431e1d9221> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c4e728c3-b418-4b5d-98d6-d9431e1d9221";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a>.
+
+  <http://redpencil.data.gift/id/task/136dd0c7-00e6-4c61-b053-ce33a923e324> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "136dd0c7-00e6-4c61-b053-ce33a923e324";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d15c17e8-546f-4070-a712-904e7fe461de>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c4e728c3-b418-4b5d-98d6-d9431e1d9221>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d45d447b-4547-447a-939b-b95e01d1ed60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d45d447b-4547-447a-939b-b95e01d1ed60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_04-07-2022_36911.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d45d447b-4547-447a-939b-b95e01d1ed60>.
+    
+<http://data.lblod.info/id/remote-data-objects/2641b065-47a2-4178-a17b-86a42427b901> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2641b065-47a2-4178-a17b-86a42427b901";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_04-07-2022_37150.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2641b065-47a2-4178-a17b-86a42427b901>.
+    
+<http://data.lblod.info/id/remote-data-objects/6085ffeb-4540-4957-8e1e-8c3a12bc6a54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6085ffeb-4540-4957-8e1e-8c3a12bc6a54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_04-07-2022_37151.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6085ffeb-4540-4957-8e1e-8c3a12bc6a54>.
+    
+<http://data.lblod.info/id/remote-data-objects/3810fab6-1fbb-479b-ae7a-ca09d17a2e7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3810fab6-1fbb-479b-ae7a-ca09d17a2e7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_13-06-2022_36424.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3810fab6-1fbb-479b-ae7a-ca09d17a2e7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c714c89-a249-4950-8118-6273a6928356> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c714c89-a249-4950-8118-6273a6928356";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_15-11-2021_31333.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c714c89-a249-4950-8118-6273a6928356>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a44bb57-8eaa-4810-9207-b54bea4de694> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a44bb57-8eaa-4810-9207-b54bea4de694";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_17-01-2022_32851.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a44bb57-8eaa-4810-9207-b54bea4de694>.
+    
+<http://data.lblod.info/id/remote-data-objects/9afd86a0-5b7a-4c67-8c3a-275afedca54a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9afd86a0-5b7a-4c67-8c3a-275afedca54a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_21-02-2022_33415.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9afd86a0-5b7a-4c67-8c3a-275afedca54a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1688edf6-1cc7-4b99-b1ec-8fe45e54038f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1688edf6-1cc7-4b99-b1ec-8fe45e54038f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_23-05-2022_36238.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1688edf6-1cc7-4b99-b1ec-8fe45e54038f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b601a71-2109-412b-93f5-f886692fac2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b601a71-2109-412b-93f5-f886692fac2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_23-05-2022_36416.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b601a71-2109-412b-93f5-f886692fac2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/08f34dac-81df-456c-a670-09a7e75d42fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08f34dac-81df-456c-a670-09a7e75d42fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_23-05-2022_36418.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08f34dac-81df-456c-a670-09a7e75d42fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7b4d66c-6231-4896-ab24-afa928ccf93f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7b4d66c-6231-4896-ab24-afa928ccf93f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_24-01-2022_32832.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7b4d66c-6231-4896-ab24-afa928ccf93f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a22eefb-a81f-4e69-b3d6-66e93231ef19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a22eefb-a81f-4e69-b3d6-66e93231ef19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_25-04-2022_35710.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a22eefb-a81f-4e69-b3d6-66e93231ef19>.
+    
+<http://data.lblod.info/id/remote-data-objects/5139c33b-e6d6-49e8-b8e0-87ddd307ceb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5139c33b-e6d6-49e8-b8e0-87ddd307ceb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_25-04-2022_35724.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5139c33b-e6d6-49e8-b8e0-87ddd307ceb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4276dea6-057e-4ad5-a8b4-cb34437c0c2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4276dea6-057e-4ad5-a8b4-cb34437c0c2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_25-04-2022_35727.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4276dea6-057e-4ad5-a8b4-cb34437c0c2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/869bbe32-bfb6-4a0a-90a2-1f0706a4ef3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "869bbe32-bfb6-4a0a-90a2-1f0706a4ef3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_25-04-2022_35728.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/869bbe32-bfb6-4a0a-90a2-1f0706a4ef3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/53adac22-9691-4508-bf1a-943c85c61a86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53adac22-9691-4508-bf1a-943c85c61a86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_29-11-2021_31807.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53adac22-9691-4508-bf1a-943c85c61a86>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d733d18-7005-4961-96e8-c077cdf8a7da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d733d18-7005-4961-96e8-c077cdf8a7da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/2824d8d378f3f745b12b9a8d2d4558923a2fa37625f7fed4cabc967f427804f5/GetPublication?filename=Uittreksels_29-11-2021_31829.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d733d18-7005-4961-96e8-c077cdf8a7da>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc11dac6-d098-44aa-beb1-a8a61648b97c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc11dac6-d098-44aa-beb1-a8a61648b97c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Agenda_Gemeenteraad_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc11dac6-d098-44aa-beb1-a8a61648b97c>.
+    
+<http://data.lblod.info/id/remote-data-objects/98efdd62-4e09-469d-91eb-4c6935a31f66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98efdd62-4e09-469d-91eb-4c6935a31f66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Agenda_Gemeenteraad_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98efdd62-4e09-469d-91eb-4c6935a31f66>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fc80408-032e-4d82-93fe-bd3ea552b3bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fc80408-032e-4d82-93fe-bd3ea552b3bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Agenda_Gemeenteraad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fc80408-032e-4d82-93fe-bd3ea552b3bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/fde46e8a-f2dd-4e8e-9c39-7ebf3f828a58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fde46e8a-f2dd-4e8e-9c39-7ebf3f828a58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Agenda_Gemeenteraad_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fde46e8a-f2dd-4e8e-9c39-7ebf3f828a58>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e687df4-a17a-4a8d-a95e-0015f97fec31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e687df4-a17a-4a8d-a95e-0015f97fec31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Agenda_Gemeenteraad_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e687df4-a17a-4a8d-a95e-0015f97fec31>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e8af9c1-bfd0-465e-acfa-a7be7a0a8f33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e8af9c1-bfd0-465e-acfa-a7be7a0a8f33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Agenda_Gemeenteraad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e8af9c1-bfd0-465e-acfa-a7be7a0a8f33>.
+    
+<http://data.lblod.info/id/remote-data-objects/704fb1d5-2666-429d-9a51-03e3683b02b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "704fb1d5-2666-429d-9a51-03e3683b02b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Agenda_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/704fb1d5-2666-429d-9a51-03e3683b02b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff48cdd6-fb6d-4ab0-a5f3-994b4251d2af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff48cdd6-fb6d-4ab0-a5f3-994b4251d2af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Agenda_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff48cdd6-fb6d-4ab0-a5f3-994b4251d2af>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb030e0c-f72c-403e-bdfa-06fdcac31872> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb030e0c-f72c-403e-bdfa-06fdcac31872";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Agenda_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb030e0c-f72c-403e-bdfa-06fdcac31872>.
+    
+<http://data.lblod.info/id/remote-data-objects/529dd4e9-7540-4901-9ea2-a2256428cbd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "529dd4e9-7540-4901-9ea2-a2256428cbd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/529dd4e9-7540-4901-9ea2-a2256428cbd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/82036609-7afd-40d1-a03f-a9bdb46ed96d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82036609-7afd-40d1-a03f-a9bdb46ed96d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82036609-7afd-40d1-a03f-a9bdb46ed96d>.
+    
+<http://data.lblod.info/id/remote-data-objects/981b3ce3-2f7e-43ea-8159-8fbcc9a98b44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "981b3ce3-2f7e-43ea-8159-8fbcc9a98b44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/981b3ce3-2f7e-43ea-8159-8fbcc9a98b44>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e99b277-3629-48e3-a331-5fe6edf2af49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e99b277-3629-48e3-a331-5fe6edf2af49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e99b277-3629-48e3-a331-5fe6edf2af49>.
+    
+<http://data.lblod.info/id/remote-data-objects/8888d53d-4911-4970-99f5-dfce7752735a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8888d53d-4911-4970-99f5-dfce7752735a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8888d53d-4911-4970-99f5-dfce7752735a>.
+    
+<http://data.lblod.info/id/remote-data-objects/10152fe1-9bd4-4103-82bd-ef6bbdb18c94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10152fe1-9bd4-4103-82bd-ef6bbdb18c94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10152fe1-9bd4-4103-82bd-ef6bbdb18c94>.
+    
+<http://data.lblod.info/id/remote-data-objects/e39e26f4-7b61-4717-90fe-21092b725154> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e39e26f4-7b61-4717-90fe-21092b725154";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e39e26f4-7b61-4717-90fe-21092b725154>.
+    
+<http://data.lblod.info/id/remote-data-objects/d23ff10e-1c13-42a5-a0d8-ecc875ab4fdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d23ff10e-1c13-42a5-a0d8-ecc875ab4fdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d23ff10e-1c13-42a5-a0d8-ecc875ab4fdf>.
+    
+<http://data.lblod.info/id/remote-data-objects/509e3090-dc19-4654-b70f-d572624a263a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "509e3090-dc19-4654-b70f-d572624a263a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/509e3090-dc19-4654-b70f-d572624a263a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c8913a7-3d61-462f-b174-51202a4a7821> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c8913a7-3d61-462f-b174-51202a4a7821";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Notulen_Gemeenteraad_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c8913a7-3d61-462f-b174-51202a4a7821>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5f7c2bb-0ff6-4f4f-9800-6bba63314fa4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5f7c2bb-0ff6-4f4f-9800-6bba63314fa4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Notulen_Gemeenteraad_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5f7c2bb-0ff6-4f4f-9800-6bba63314fa4>.
+    
+<http://data.lblod.info/id/remote-data-objects/77998a62-fd65-470b-a9bf-d16acad91473> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77998a62-fd65-470b-a9bf-d16acad91473";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Notulen_Gemeenteraad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77998a62-fd65-470b-a9bf-d16acad91473>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1ba3a9e-6d19-4e70-b5bb-134b25a02dae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1ba3a9e-6d19-4e70-b5bb-134b25a02dae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Notulen_Gemeenteraad_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1ba3a9e-6d19-4e70-b5bb-134b25a02dae>.
+    
+<http://data.lblod.info/id/remote-data-objects/457860e3-fcf0-4b32-ba3f-ef268da6b8b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "457860e3-fcf0-4b32-ba3f-ef268da6b8b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Notulen_Gemeenteraad_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/457860e3-fcf0-4b32-ba3f-ef268da6b8b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/b01e18f5-9e8f-4a6a-ba18-bedc4cdb681b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b01e18f5-9e8f-4a6a-ba18-bedc4cdb681b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Notulen_Gemeenteraad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b01e18f5-9e8f-4a6a-ba18-bedc4cdb681b>.
+    
+<http://data.lblod.info/id/remote-data-objects/befd4076-0165-49a8-badf-5565212c521e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "befd4076-0165-49a8-badf-5565212c521e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Notulen_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/befd4076-0165-49a8-badf-5565212c521e>.
+    
+<http://data.lblod.info/id/remote-data-objects/28d9600b-0780-4237-b9e0-5672a1f249fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28d9600b-0780-4237-b9e0-5672a1f249fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Notulen_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28d9600b-0780-4237-b9e0-5672a1f249fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae7e9e74-03bb-4d6c-b338-efccf82bef45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae7e9e74-03bb-4d6c-b338-efccf82bef45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Notulen_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae7e9e74-03bb-4d6c-b338-efccf82bef45>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef597820-58f9-43ce-a12d-052958fdaab9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef597820-58f9-43ce-a12d-052958fdaab9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef597820-58f9-43ce-a12d-052958fdaab9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4e6610d-8c14-456d-ad09-9d30b14bcad6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4e6610d-8c14-456d-ad09-9d30b14bcad6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4e6610d-8c14-456d-ad09-9d30b14bcad6>.
+    
+<http://data.lblod.info/id/remote-data-objects/32aa4dc4-38bd-4771-8395-75b487fdbda6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32aa4dc4-38bd-4771-8395-75b487fdbda6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32aa4dc4-38bd-4771-8395-75b487fdbda6>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe258b20-3996-42da-bc95-20ee737b0e82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe258b20-3996-42da-bc95-20ee737b0e82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe258b20-3996-42da-bc95-20ee737b0e82>.
+    
+<http://data.lblod.info/id/remote-data-objects/005ab21c-f7c2-4476-9c89-f8377a65a1b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "005ab21c-f7c2-4476-9c89-f8377a65a1b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/005ab21c-f7c2-4476-9c89-f8377a65a1b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/4597dbbe-88d0-46f4-b41a-42dc347ad5a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4597dbbe-88d0-46f4-b41a-42dc347ad5a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/14f1ab7a-96e8-4091-92a6-a8f2980c4c4a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4597dbbe-88d0-46f4-b41a-42dc347ad5a7>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201421-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201421-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201421-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201421-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/5cf7e248-9a54-4105-b311-96a6d90e2ead> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5cf7e248-9a54-4105-b311-96a6d90e2ead";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "16bceffe-5906-4857-996f-64c9bf28101c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/2b68b3ef-acb4-4de5-b9ca-4011b8276a9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2b68b3ef-acb4-4de5-b9ca-4011b8276a9d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c>.
+
+  <http://redpencil.data.gift/id/task/74b6153f-d47b-46b3-91be-fac7ac247cd1> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "74b6153f-d47b-46b3-91be-fac7ac247cd1";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/5cf7e248-9a54-4105-b311-96a6d90e2ead>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/2b68b3ef-acb4-4de5-b9ca-4011b8276a9d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5c83f9e9-0376-459c-b0c2-5a918ac3e250> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c83f9e9-0376-459c-b0c2-5a918ac3e250";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c83f9e9-0376-459c-b0c2-5a918ac3e250>.
+    
+<http://data.lblod.info/id/remote-data-objects/df6ef2a4-be35-441e-8791-871f76805748> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df6ef2a4-be35-441e-8791-871f76805748";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df6ef2a4-be35-441e-8791-871f76805748>.
+    
+<http://data.lblod.info/id/remote-data-objects/9061d8cb-4e22-4bc9-a577-594300be59a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9061d8cb-4e22-4bc9-a577-594300be59a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9061d8cb-4e22-4bc9-a577-594300be59a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e3ec21a-c906-446a-9c01-1706272d56b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e3ec21a-c906-446a-9c01-1706272d56b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Uittreksels_13-12-2021_31721.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e3ec21a-c906-446a-9c01-1706272d56b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/df31344b-bf06-4b0a-9788-e8904a5d8861> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df31344b-bf06-4b0a-9788-e8904a5d8861";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Uittreksels_13-12-2021_31781.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df31344b-bf06-4b0a-9788-e8904a5d8861>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d236b28-001a-41d7-9032-cf786a8ce626> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d236b28-001a-41d7-9032-cf786a8ce626";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Uittreksels_13-12-2021_31782.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d236b28-001a-41d7-9032-cf786a8ce626>.
+    
+<http://data.lblod.info/id/remote-data-objects/37bad4e0-170b-4761-8b8d-6f0692ae6ee0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37bad4e0-170b-4761-8b8d-6f0692ae6ee0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Uittreksels_17-01-2022_32608.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37bad4e0-170b-4761-8b8d-6f0692ae6ee0>.
+    
+<http://data.lblod.info/id/remote-data-objects/31f54e2f-5ed4-4908-a871-a67083efa3f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31f54e2f-5ed4-4908-a871-a67083efa3f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Uittreksels_27-06-2022_36396.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31f54e2f-5ed4-4908-a871-a67083efa3f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e6536c4-1faa-450c-8df1-7f752b290db7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e6536c4-1faa-450c-8df1-7f752b290db7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Uittreksels_27-06-2022_36407.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e6536c4-1faa-450c-8df1-7f752b290db7>.
+    
+<http://data.lblod.info/id/remote-data-objects/34b4b530-71d3-485c-aada-e656f78019ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34b4b530-71d3-485c-aada-e656f78019ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Uittreksels_27-06-2022_36801.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34b4b530-71d3-485c-aada-e656f78019ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f8c3146-e5ed-4e78-b933-6158dbfc3abd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f8c3146-e5ed-4e78-b933-6158dbfc3abd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Uittreksels_27-06-2022_36871.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f8c3146-e5ed-4e78-b933-6158dbfc3abd>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d43ab13-703e-487d-8402-5ce9da174d8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d43ab13-703e-487d-8402-5ce9da174d8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Uittreksels_27-06-2022_36875.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d43ab13-703e-487d-8402-5ce9da174d8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/69791962-16d0-4502-bca1-8c8c1eec01d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69791962-16d0-4502-bca1-8c8c1eec01d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Uittreksels_30-05-2022_36029.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69791962-16d0-4502-bca1-8c8c1eec01d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/2aa96f73-5aa8-49ca-9e5a-3055e14aa1a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2aa96f73-5aa8-49ca-9e5a-3055e14aa1a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/4daec95bfe0ad44a09ff60222ada11725d5145d3a5c76dc645feed7b26eee7ad/GetPublication?filename=Uittreksels_30-05-2022_36032.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2aa96f73-5aa8-49ca-9e5a-3055e14aa1a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9097d12d-2a33-4b11-b1b9-677d10454cae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9097d12d-2a33-4b11-b1b9-677d10454cae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/71996707a44b98f80a5b06b6e5c43175cef2e73ec02052d7202bd40ce97b506b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9097d12d-2a33-4b11-b1b9-677d10454cae>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b0933b1-2c09-462d-ac45-d0e385737482> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b0933b1-2c09-462d-ac45-d0e385737482";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/71996707a44b98f80a5b06b6e5c43175cef2e73ec02052d7202bd40ce97b506b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_01-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b0933b1-2c09-462d-ac45-d0e385737482>.
+    
+<http://data.lblod.info/id/remote-data-objects/351b58a5-4706-42a5-8f94-fd507ddb7f5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "351b58a5-4706-42a5-8f94-fd507ddb7f5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/71996707a44b98f80a5b06b6e5c43175cef2e73ec02052d7202bd40ce97b506b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_02-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/351b58a5-4706-42a5-8f94-fd507ddb7f5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9bf78e5-c270-4b97-9eb9-dbf47bbbc540> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9bf78e5-c270-4b97-9eb9-dbf47bbbc540";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/71996707a44b98f80a5b06b6e5c43175cef2e73ec02052d7202bd40ce97b506b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9bf78e5-c270-4b97-9eb9-dbf47bbbc540>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3abce2b-4c9d-489c-934d-63d5af13aa32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3abce2b-4c9d-489c-934d-63d5af13aa32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/71996707a44b98f80a5b06b6e5c43175cef2e73ec02052d7202bd40ce97b506b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3abce2b-4c9d-489c-934d-63d5af13aa32>.
+    
+<http://data.lblod.info/id/remote-data-objects/aeb0e7d1-e7b3-43ce-a334-00655d105a96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aeb0e7d1-e7b3-43ce-a334-00655d105a96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/71996707a44b98f80a5b06b6e5c43175cef2e73ec02052d7202bd40ce97b506b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aeb0e7d1-e7b3-43ce-a334-00655d105a96>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5b10286-2c95-42c1-8052-b5105a6ffdfd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5b10286-2c95-42c1-8052-b5105a6ffdfd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/71996707a44b98f80a5b06b6e5c43175cef2e73ec02052d7202bd40ce97b506b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5b10286-2c95-42c1-8052-b5105a6ffdfd>.
+    
+<http://data.lblod.info/id/remote-data-objects/832b38cf-c450-47a7-b118-4db5afba57a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "832b38cf-c450-47a7-b118-4db5afba57a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/71996707a44b98f80a5b06b6e5c43175cef2e73ec02052d7202bd40ce97b506b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/832b38cf-c450-47a7-b118-4db5afba57a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea9bef4a-d8c5-48ed-b2fa-8dc735166818> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea9bef4a-d8c5-48ed-b2fa-8dc735166818";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/71996707a44b98f80a5b06b6e5c43175cef2e73ec02052d7202bd40ce97b506b/GetPublication?filename=Uittreksels_01-02-2022_33245.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea9bef4a-d8c5-48ed-b2fa-8dc735166818>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f6dc5bd-f465-4181-88bd-b318d70843c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f6dc5bd-f465-4181-88bd-b318d70843c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/71996707a44b98f80a5b06b6e5c43175cef2e73ec02052d7202bd40ce97b506b/GetPublication?filename=Uittreksels_02-02-2022_33296.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f6dc5bd-f465-4181-88bd-b318d70843c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4909c853-416b-4ab6-af50-3d94396b4b04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4909c853-416b-4ab6-af50-3d94396b4b04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/71996707a44b98f80a5b06b6e5c43175cef2e73ec02052d7202bd40ce97b506b/GetPublication?filename=Uittreksels_08-02-2022_33327.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4909c853-416b-4ab6-af50-3d94396b4b04>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ed9b346-5658-4959-9c4c-a9bf3edc2510> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ed9b346-5658-4959-9c4c-a9bf3edc2510";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=Agenda_OCMW-raad_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ed9b346-5658-4959-9c4c-a9bf3edc2510>.
+    
+<http://data.lblod.info/id/remote-data-objects/39620c3b-0342-43f8-b25a-adb13b00d4de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39620c3b-0342-43f8-b25a-adb13b00d4de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=Agenda_OCMW-raad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39620c3b-0342-43f8-b25a-adb13b00d4de>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e9c840d-f54e-4380-86b5-19010f68c3fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e9c840d-f54e-4380-86b5-19010f68c3fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=Agenda_OCMW-raad_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e9c840d-f54e-4380-86b5-19010f68c3fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/854aefa4-33c8-4bf7-bf6d-9cc9a01a1b79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "854aefa4-33c8-4bf7-bf6d-9cc9a01a1b79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=Agenda_OCMW-raad_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/854aefa4-33c8-4bf7-bf6d-9cc9a01a1b79>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bcd0915-253d-4b63-bd66-045eee6b34a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bcd0915-253d-4b63-bd66-045eee6b34a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=Agenda_OCMW-raad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bcd0915-253d-4b63-bd66-045eee6b34a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/55df909b-e56a-48a0-b590-ea97e8e8f6b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55df909b-e56a-48a0-b590-ea97e8e8f6b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=Agenda_OCMW-raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55df909b-e56a-48a0-b590-ea97e8e8f6b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8f39af9-9975-424f-a401-da06e7804f41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8f39af9-9975-424f-a401-da06e7804f41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=Agenda_OCMW-raad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8f39af9-9975-424f-a401-da06e7804f41>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e621a7e-bade-4c31-8c2a-abf8fa3c426d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e621a7e-bade-4c31-8c2a-abf8fa3c426d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e621a7e-bade-4c31-8c2a-abf8fa3c426d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb292f42-ffb3-445d-bf44-a0a8e5404932> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb292f42-ffb3-445d-bf44-a0a8e5404932";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb292f42-ffb3-445d-bf44-a0a8e5404932>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e220efc-e11d-4652-8285-d0c71ae7051d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e220efc-e11d-4652-8285-d0c71ae7051d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e220efc-e11d-4652-8285-d0c71ae7051d>.
+    
+<http://data.lblod.info/id/remote-data-objects/31e31822-ecad-4fb2-91c4-c34a2c187d93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31e31822-ecad-4fb2-91c4-c34a2c187d93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31e31822-ecad-4fb2-91c4-c34a2c187d93>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbfba8c1-660b-4392-80f6-94ee34e6087c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbfba8c1-660b-4392-80f6-94ee34e6087c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbfba8c1-660b-4392-80f6-94ee34e6087c>.
+    
+<http://data.lblod.info/id/remote-data-objects/42e9d7c1-3ef0-4a15-9164-f29a10cb1ba5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42e9d7c1-3ef0-4a15-9164-f29a10cb1ba5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42e9d7c1-3ef0-4a15-9164-f29a10cb1ba5>.
+    
+<http://data.lblod.info/id/remote-data-objects/874d4fa8-16f5-4f98-a6c4-e60aa2088354> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "874d4fa8-16f5-4f98-a6c4-e60aa2088354";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/874d4fa8-16f5-4f98-a6c4-e60aa2088354>.
+    
+<http://data.lblod.info/id/remote-data-objects/47e1db58-fd5b-48da-b4c7-8b06471ccea2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47e1db58-fd5b-48da-b4c7-8b06471ccea2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=Notulen_OCMW-raad_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47e1db58-fd5b-48da-b4c7-8b06471ccea2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3e57738-d3e7-490d-9ddc-d3e756ece4df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3e57738-d3e7-490d-9ddc-d3e756ece4df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=Notulen_OCMW-raad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3e57738-d3e7-490d-9ddc-d3e756ece4df>.
+    
+<http://data.lblod.info/id/remote-data-objects/e00117e9-36b2-4753-a91c-801d878d42bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e00117e9-36b2-4753-a91c-801d878d42bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=Notulen_OCMW-raad_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e00117e9-36b2-4753-a91c-801d878d42bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/56b2f1bf-6944-497c-8d19-ee03d7c0fa0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56b2f1bf-6944-497c-8d19-ee03d7c0fa0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=Notulen_OCMW-raad_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56b2f1bf-6944-497c-8d19-ee03d7c0fa0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/311e40d0-a0be-4e87-a7c6-c907d5656407> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "311e40d0-a0be-4e87-a7c6-c907d5656407";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=Notulen_OCMW-raad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/311e40d0-a0be-4e87-a7c6-c907d5656407>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d7545cb-368f-4a89-9b11-62474dc2546f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d7545cb-368f-4a89-9b11-62474dc2546f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=Notulen_OCMW-raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d7545cb-368f-4a89-9b11-62474dc2546f>.
+    
+<http://data.lblod.info/id/remote-data-objects/90a65916-5aff-4080-8794-f80342a3078f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90a65916-5aff-4080-8794-f80342a3078f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=Notulen_OCMW-raad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90a65916-5aff-4080-8794-f80342a3078f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1c5f8d0-797e-4847-9f92-fcbc66f49c19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1c5f8d0-797e-4847-9f92-fcbc66f49c19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=ToegevoegdeAgenda_OCMW-raad_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1c5f8d0-797e-4847-9f92-fcbc66f49c19>.
+    
+<http://data.lblod.info/id/remote-data-objects/60f6a40a-ac42-4b5e-bab3-eb295abd026f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60f6a40a-ac42-4b5e-bab3-eb295abd026f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/9334f7a6ba1670edce5bd994199265a996e763c4b92c00f84541bd036533dba3/GetPublication?filename=Uittreksels_30-05-2022_36033.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60f6a40a-ac42-4b5e-bab3-eb295abd026f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bad77ea-e934-45ce-9a0a-dea6c69395d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bad77ea-e934-45ce-9a0a-dea6c69395d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bad77ea-e934-45ce-9a0a-dea6c69395d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f4e2c54-ca2a-474d-87c6-55925772b683> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f4e2c54-ca2a-474d-87c6-55925772b683";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/16bceffe-5906-4857-996f-64c9bf28101c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f4e2c54-ca2a-474d-87c6-55925772b683>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201422-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201422-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201422-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201422-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3de35dcc-20d1-4fa5-9564-98bd963822bf> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3de35dcc-20d1-4fa5-9564-98bd963822bf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cd2e6f01-5ba3-4a27-99e2-40000ab399d5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/df53f444-d1ab-4f0d-b1cf-7e88c5f604bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "df53f444-d1ab-4f0d-b1cf-7e88c5f604bd";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5>.
+
+  <http://redpencil.data.gift/id/task/1ee9292d-37ab-4375-b3c3-68397013b362> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1ee9292d-37ab-4375-b3c3-68397013b362";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3de35dcc-20d1-4fa5-9564-98bd963822bf>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/df53f444-d1ab-4f0d-b1cf-7e88c5f604bd>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d6029731-a4d5-48c4-81e8-f02fcb0e3a94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6029731-a4d5-48c4-81e8-f02fcb0e3a94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6029731-a4d5-48c4-81e8-f02fcb0e3a94>.
+    
+<http://data.lblod.info/id/remote-data-objects/3143e2a7-b795-4442-b1e5-93d36df42ea4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3143e2a7-b795-4442-b1e5-93d36df42ea4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3143e2a7-b795-4442-b1e5-93d36df42ea4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e133055-4c76-42a6-bbd7-2679c89b1089> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e133055-4c76-42a6-bbd7-2679c89b1089";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e133055-4c76-42a6-bbd7-2679c89b1089>.
+    
+<http://data.lblod.info/id/remote-data-objects/02da4bcc-eb92-4d73-80e0-1418e5afb9d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02da4bcc-eb92-4d73-80e0-1418e5afb9d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02da4bcc-eb92-4d73-80e0-1418e5afb9d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/33f209a1-0751-44ea-b803-138e84e3a7a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33f209a1-0751-44ea-b803-138e84e3a7a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33f209a1-0751-44ea-b803-138e84e3a7a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/8160d0df-a10f-4970-b231-cfc41903c0fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8160d0df-a10f-4970-b231-cfc41903c0fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8160d0df-a10f-4970-b231-cfc41903c0fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/9df0a20e-79a4-47d5-a9dc-ee70d9db9d44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9df0a20e-79a4-47d5-a9dc-ee70d9db9d44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9df0a20e-79a4-47d5-a9dc-ee70d9db9d44>.
+    
+<http://data.lblod.info/id/remote-data-objects/c26220bd-8020-458c-89f0-3280ec5118c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c26220bd-8020-458c-89f0-3280ec5118c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c26220bd-8020-458c-89f0-3280ec5118c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a72780d3-0cf9-483e-9334-b05afd9a1218> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a72780d3-0cf9-483e-9334-b05afd9a1218";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a72780d3-0cf9-483e-9334-b05afd9a1218>.
+    
+<http://data.lblod.info/id/remote-data-objects/668b997b-efd4-4f36-a318-7634685ecdef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "668b997b-efd4-4f36-a318-7634685ecdef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/668b997b-efd4-4f36-a318-7634685ecdef>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bff385c-bbd4-47eb-adab-96ff683c108d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bff385c-bbd4-47eb-adab-96ff683c108d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bff385c-bbd4-47eb-adab-96ff683c108d>.
+    
+<http://data.lblod.info/id/remote-data-objects/379bcfdb-fe6b-4488-a7c0-68a5d8726722> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "379bcfdb-fe6b-4488-a7c0-68a5d8726722";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/379bcfdb-fe6b-4488-a7c0-68a5d8726722>.
+    
+<http://data.lblod.info/id/remote-data-objects/209c6a10-7ef3-4de3-8f7c-99712a2237fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "209c6a10-7ef3-4de3-8f7c-99712a2237fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/209c6a10-7ef3-4de3-8f7c-99712a2237fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/66d15e08-fcf8-43c4-b4cc-03da0d035c77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66d15e08-fcf8-43c4-b4cc-03da0d035c77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66d15e08-fcf8-43c4-b4cc-03da0d035c77>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f92815a-80a0-4148-8a9b-dea6a795ea44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f92815a-80a0-4148-8a9b-dea6a795ea44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f92815a-80a0-4148-8a9b-dea6a795ea44>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b6599a8-413f-465e-a7c0-960088358962> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b6599a8-413f-465e-a7c0-960088358962";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b6599a8-413f-465e-a7c0-960088358962>.
+    
+<http://data.lblod.info/id/remote-data-objects/02b0a356-1703-4992-8888-8666d83144b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02b0a356-1703-4992-8888-8666d83144b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02b0a356-1703-4992-8888-8666d83144b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e9f7215-f020-4252-acc5-7cc201a14663> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e9f7215-f020-4252-acc5-7cc201a14663";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e9f7215-f020-4252-acc5-7cc201a14663>.
+    
+<http://data.lblod.info/id/remote-data-objects/86a3b24f-beb7-4d23-abee-e2a0f6bf531b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86a3b24f-beb7-4d23-abee-e2a0f6bf531b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86a3b24f-beb7-4d23-abee-e2a0f6bf531b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5e9aa0e-8d1b-4fad-8898-b875bb8cfbb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5e9aa0e-8d1b-4fad-8898-b875bb8cfbb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5e9aa0e-8d1b-4fad-8898-b875bb8cfbb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/860b83bc-10b7-4b66-8edc-83052eabb538> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "860b83bc-10b7-4b66-8edc-83052eabb538";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/860b83bc-10b7-4b66-8edc-83052eabb538>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcdfa913-915b-4ef1-9a66-834a881fc37e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcdfa913-915b-4ef1-9a66-834a881fc37e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcdfa913-915b-4ef1-9a66-834a881fc37e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b5e9b47-8e02-40eb-b39b-07a1b9489545> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b5e9b47-8e02-40eb-b39b-07a1b9489545";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.izegem.be/LBLODWeb/Home/Overzicht/cdc1e4ed99029a7e5ac9f37fbe5be5f955917d0d50f4ff9ace169746927465ea/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20OCMW_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b5e9b47-8e02-40eb-b39b-07a1b9489545>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2083890-94fa-4880-8bd1-2e008a87470a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2083890-94fa-4880-8bd1-2e008a87470a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2083890-94fa-4880-8bd1-2e008a87470a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbc25a1e-53be-429e-80b9-b056eaade6a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbc25a1e-53be-429e-80b9-b056eaade6a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbc25a1e-53be-429e-80b9-b056eaade6a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/25e19b61-664e-44fa-89f1-04fb454416e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25e19b61-664e-44fa-89f1-04fb454416e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25e19b61-664e-44fa-89f1-04fb454416e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/62091b1d-d097-4e11-88c2-6df218818b08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62091b1d-d097-4e11-88c2-6df218818b08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62091b1d-d097-4e11-88c2-6df218818b08>.
+    
+<http://data.lblod.info/id/remote-data-objects/71703031-c7c5-4252-aa76-075ac69fee33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71703031-c7c5-4252-aa76-075ac69fee33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71703031-c7c5-4252-aa76-075ac69fee33>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e03e260-8582-4c0f-b7f7-f2a254c0d792> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e03e260-8582-4c0f-b7f7-f2a254c0d792";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e03e260-8582-4c0f-b7f7-f2a254c0d792>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfea0ecd-4dd3-4b6f-bb15-d6fae78fa048> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfea0ecd-4dd3-4b6f-bb15-d6fae78fa048";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfea0ecd-4dd3-4b6f-bb15-d6fae78fa048>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9267440-1036-41d4-939b-96fa604ec117> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9267440-1036-41d4-939b-96fa604ec117";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9267440-1036-41d4-939b-96fa604ec117>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c142324-a3d5-443a-b53e-6f7ed8a483b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c142324-a3d5-443a-b53e-6f7ed8a483b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c142324-a3d5-443a-b53e-6f7ed8a483b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e056620-f95f-46d1-a26b-b9e675d2d066> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e056620-f95f-46d1-a26b-b9e675d2d066";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e056620-f95f-46d1-a26b-b9e675d2d066>.
+    
+<http://data.lblod.info/id/remote-data-objects/93e3f325-a754-499c-ae95-d622077a7c8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93e3f325-a754-499c-ae95-d622077a7c8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93e3f325-a754-499c-ae95-d622077a7c8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/96f7b315-6c89-4a58-a032-3d519ead781e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96f7b315-6c89-4a58-a032-3d519ead781e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=Uittreksels_07-03-2022_191.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96f7b315-6c89-4a58-a032-3d519ead781e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d37b666b-0f15-418d-aa9c-8cf1abfaa925> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d37b666b-0f15-418d-aa9c-8cf1abfaa925";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=Uittreksels_07-03-2022_192.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d37b666b-0f15-418d-aa9c-8cf1abfaa925>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7bbfd5e-6f8d-4425-971a-a1470870bb30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7bbfd5e-6f8d-4425-971a-a1470870bb30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=Uittreksels_13-06-2022_262.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7bbfd5e-6f8d-4425-971a-a1470870bb30>.
+    
+<http://data.lblod.info/id/remote-data-objects/993bc404-9cf0-4500-b877-b9d0e791066d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "993bc404-9cf0-4500-b877-b9d0e791066d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=Uittreksels_16-05-2022_243.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/993bc404-9cf0-4500-b877-b9d0e791066d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef530280-b808-459c-9117-b42bd254674b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef530280-b808-459c-9117-b42bd254674b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=Uittreksels_20-12-2021_143.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef530280-b808-459c-9117-b42bd254674b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c02456e3-efe3-4830-9369-765c51b55b93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c02456e3-efe3-4830-9369-765c51b55b93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/27fc96f774aecfdfec21b54c21ffac5dd67cb45f901923391f31955f18844c08/GetPublication?filename=Uittreksels_20-12-2021_144.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c02456e3-efe3-4830-9369-765c51b55b93>.
+    
+<http://data.lblod.info/id/remote-data-objects/61d6df73-e5c6-4e18-8060-75a5fd7c8d19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61d6df73-e5c6-4e18-8060-75a5fd7c8d19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=Agenda_gemeenteraad_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61d6df73-e5c6-4e18-8060-75a5fd7c8d19>.
+    
+<http://data.lblod.info/id/remote-data-objects/b00eb311-c7ee-4afe-9098-453c38bde279> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b00eb311-c7ee-4afe-9098-453c38bde279";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b00eb311-c7ee-4afe-9098-453c38bde279>.
+    
+<http://data.lblod.info/id/remote-data-objects/55469a82-7058-4e76-8171-1f2f0d92da7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55469a82-7058-4e76-8171-1f2f0d92da7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55469a82-7058-4e76-8171-1f2f0d92da7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/464c4461-1011-4bef-a16d-99628dd4e021> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "464c4461-1011-4bef-a16d-99628dd4e021";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/464c4461-1011-4bef-a16d-99628dd4e021>.
+    
+<http://data.lblod.info/id/remote-data-objects/9134449b-0267-48f0-ae87-5997cfc73da4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9134449b-0267-48f0-ae87-5997cfc73da4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9134449b-0267-48f0-ae87-5997cfc73da4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c93c08f-abae-4c5d-bde5-2d752645956b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c93c08f-abae-4c5d-bde5-2d752645956b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c93c08f-abae-4c5d-bde5-2d752645956b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5be90cab-37ee-499e-bb27-cc15711d14b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5be90cab-37ee-499e-bb27-cc15711d14b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5be90cab-37ee-499e-bb27-cc15711d14b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e1ddebd-dbde-4f80-bb6a-ac99befb23c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e1ddebd-dbde-4f80-bb6a-ac99befb23c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e1ddebd-dbde-4f80-bb6a-ac99befb23c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/15a284d0-449e-4d53-a8ad-9ecda2f2c7b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15a284d0-449e-4d53-a8ad-9ecda2f2c7b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15a284d0-449e-4d53-a8ad-9ecda2f2c7b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/220a126d-5198-4879-bcec-9995e022a6db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "220a126d-5198-4879-bcec-9995e022a6db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd2e6f01-5ba3-4a27-99e2-40000ab399d5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/220a126d-5198-4879-bcec-9995e022a6db>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201423-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201423-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201423-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201423-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/701d36a7-4e57-454d-970b-4c56398ec3a2> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "701d36a7-4e57-454d-970b-4c56398ec3a2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e8b40f95-40aa-4f71-b778-17a797feda9b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/5a390e8e-88c0-4bbc-b80c-21b76ed6d97e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5a390e8e-88c0-4bbc-b80c-21b76ed6d97e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b>.
+
+  <http://redpencil.data.gift/id/task/79c56c08-ed7b-46e3-876d-129e07ad697e> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "79c56c08-ed7b-46e3-876d-129e07ad697e";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/701d36a7-4e57-454d-970b-4c56398ec3a2>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/5a390e8e-88c0-4bbc-b80c-21b76ed6d97e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b7898a19-bb98-4ae2-b30d-97fff851a4c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7898a19-bb98-4ae2-b30d-97fff851a4c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7898a19-bb98-4ae2-b30d-97fff851a4c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff30da88-4ebd-419e-bbe5-028f336e4a8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff30da88-4ebd-419e-bbe5-028f336e4a8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=Uittreksels_04-04-2022_205.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff30da88-4ebd-419e-bbe5-028f336e4a8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/79bfc6ab-4185-4770-a03e-67c3939071fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79bfc6ab-4185-4770-a03e-67c3939071fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=Uittreksels_04-10-2021_81.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79bfc6ab-4185-4770-a03e-67c3939071fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c9c2743-fbd1-45e6-8a43-2fd26e7f2355> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c9c2743-fbd1-45e6-8a43-2fd26e7f2355";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=Uittreksels_04-10-2021_85.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c9c2743-fbd1-45e6-8a43-2fd26e7f2355>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d7a6d10-28bd-4234-b765-aa73f2c150d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d7a6d10-28bd-4234-b765-aa73f2c150d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=Uittreksels_06-12-2021_116.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d7a6d10-28bd-4234-b765-aa73f2c150d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/cedc2565-b900-4eae-8b7e-1df831437f94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cedc2565-b900-4eae-8b7e-1df831437f94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=Uittreksels_07-03-2022_176.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cedc2565-b900-4eae-8b7e-1df831437f94>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b347829-006d-4259-abf0-7e646045e238> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b347829-006d-4259-abf0-7e646045e238";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=Uittreksels_08-11-2021_103.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b347829-006d-4259-abf0-7e646045e238>.
+    
+<http://data.lblod.info/id/remote-data-objects/89aa9cd9-85b6-4f25-b11a-ffc941a1eb0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89aa9cd9-85b6-4f25-b11a-ffc941a1eb0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=Uittreksels_13-06-2022_246.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89aa9cd9-85b6-4f25-b11a-ffc941a1eb0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fad4f3b-c503-4c92-b5c6-eacaea14cede> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fad4f3b-c503-4c92-b5c6-eacaea14cede";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=Uittreksels_13-06-2022_251.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fad4f3b-c503-4c92-b5c6-eacaea14cede>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b149a3a-5933-44ef-81e3-d4e561654749> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b149a3a-5933-44ef-81e3-d4e561654749";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=Uittreksels_20-12-2021_135.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b149a3a-5933-44ef-81e3-d4e561654749>.
+    
+<http://data.lblod.info/id/remote-data-objects/981b9404-66e7-444e-8a54-5679d70503a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "981b9404-66e7-444e-8a54-5679d70503a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=Uittreksels_20-12-2021_139.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/981b9404-66e7-444e-8a54-5679d70503a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8109ac98-7e58-4bfd-bb1f-531ee5008784> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8109ac98-7e58-4bfd-bb1f-531ee5008784";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=Uittreksels_20-12-2021_140.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8109ac98-7e58-4bfd-bb1f-531ee5008784>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ff2af29-597a-43db-bc52-81de253ce725> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ff2af29-597a-43db-bc52-81de253ce725";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=Uittreksels_20-12-2021_141.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ff2af29-597a-43db-bc52-81de253ce725>.
+    
+<http://data.lblod.info/id/remote-data-objects/131a05ea-d7d6-4a56-9e46-185ebd8b2999> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "131a05ea-d7d6-4a56-9e46-185ebd8b2999";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=Uittreksels_20-12-2021_142.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/131a05ea-d7d6-4a56-9e46-185ebd8b2999>.
+    
+<http://data.lblod.info/id/remote-data-objects/89767e99-9394-4544-97ce-eb944c5bdf49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89767e99-9394-4544-97ce-eb944c5bdf49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.jabbeke.be/LBLODWeb/Home/Overzicht/28d76ad1933ee3b1b3a6646a92ac6ebe2e5847e2c3db021fe6b63309689f241e/GetPublication?filename=Uittreksels_31-01-2022_154.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89767e99-9394-4544-97ce-eb944c5bdf49>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1b0cc55-d508-4316-9f3b-888c5b725bc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1b0cc55-d508-4316-9f3b-888c5b725bc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_01-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1b0cc55-d508-4316-9f3b-888c5b725bc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/10b1c050-d488-4b71-a412-42eb9d9231b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10b1c050-d488-4b71-a412-42eb9d9231b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10b1c050-d488-4b71-a412-42eb9d9231b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/36b3f418-e3c7-4e04-aab8-6959bdc0ee5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36b3f418-e3c7-4e04-aab8-6959bdc0ee5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36b3f418-e3c7-4e04-aab8-6959bdc0ee5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/23848fa6-88d4-4476-9610-d5da682cdc6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23848fa6-88d4-4476-9610-d5da682cdc6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23848fa6-88d4-4476-9610-d5da682cdc6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/db83d315-0dec-4566-b3d9-1333417593d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db83d315-0dec-4566-b3d9-1333417593d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db83d315-0dec-4566-b3d9-1333417593d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/20f00705-cdc2-4639-bd89-b4df3b2749c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20f00705-cdc2-4639-bd89-b4df3b2749c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20f00705-cdc2-4639-bd89-b4df3b2749c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/0eddcec9-dfba-4890-9733-29366175b22f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0eddcec9-dfba-4890-9733-29366175b22f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0eddcec9-dfba-4890-9733-29366175b22f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c53ee808-3254-48c5-859a-290791d537db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c53ee808-3254-48c5-859a-290791d537db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c53ee808-3254-48c5-859a-290791d537db>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a30f89b-d1f0-44a9-9391-d166a9d157b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a30f89b-d1f0-44a9-9391-d166a9d157b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a30f89b-d1f0-44a9-9391-d166a9d157b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9ebf01c-81d9-4b3e-ac1b-bc17d693466b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9ebf01c-81d9-4b3e-ac1b-bc17d693466b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9ebf01c-81d9-4b3e-ac1b-bc17d693466b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9ba8010-2068-415e-a419-80db4aed231e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9ba8010-2068-415e-a419-80db4aed231e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9ba8010-2068-415e-a419-80db4aed231e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b49f0bc6-2ac3-497c-b2ee-e455fdd7dc6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b49f0bc6-2ac3-497c-b2ee-e455fdd7dc6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b49f0bc6-2ac3-497c-b2ee-e455fdd7dc6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e1ad48d-f5c9-49e8-ab9e-d6b5e45676c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e1ad48d-f5c9-49e8-ab9e-d6b5e45676c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e1ad48d-f5c9-49e8-ab9e-d6b5e45676c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f052e61e-8d87-4b29-a0e5-8fb78c92bef5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f052e61e-8d87-4b29-a0e5-8fb78c92bef5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f052e61e-8d87-4b29-a0e5-8fb78c92bef5>.
+    
+<http://data.lblod.info/id/remote-data-objects/433a509d-6f44-423e-bca1-a6fd1356cd48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "433a509d-6f44-423e-bca1-a6fd1356cd48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/433a509d-6f44-423e-bca1-a6fd1356cd48>.
+    
+<http://data.lblod.info/id/remote-data-objects/f902b5f5-266e-4806-b770-7fd6121697ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f902b5f5-266e-4806-b770-7fd6121697ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f902b5f5-266e-4806-b770-7fd6121697ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/241bd1f7-e671-4c1d-bde0-2893e7deb63f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "241bd1f7-e671-4c1d-bde0-2893e7deb63f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/241bd1f7-e671-4c1d-bde0-2893e7deb63f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9dbd71c-2b22-4859-8c7a-2df0b7685a04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9dbd71c-2b22-4859-8c7a-2df0b7685a04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9dbd71c-2b22-4859-8c7a-2df0b7685a04>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd2d9f17-99e2-4d8b-9349-575343fd868c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd2d9f17-99e2-4d8b-9349-575343fd868c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd2d9f17-99e2-4d8b-9349-575343fd868c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a4dbca4-08d1-407b-a8e2-3d1c42b5c309> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a4dbca4-08d1-407b-a8e2-3d1c42b5c309";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a4dbca4-08d1-407b-a8e2-3d1c42b5c309>.
+    
+<http://data.lblod.info/id/remote-data-objects/a62949a9-e53a-407d-a96b-88a77c7ea16e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a62949a9-e53a-407d-a96b-88a77c7ea16e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a62949a9-e53a-407d-a96b-88a77c7ea16e>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc97e84c-9241-4697-b940-e0e69a2e1cad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc97e84c-9241-4697-b940-e0e69a2e1cad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc97e84c-9241-4697-b940-e0e69a2e1cad>.
+    
+<http://data.lblod.info/id/remote-data-objects/a750b1c0-4eea-4819-bdd7-d1ee4480e8ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a750b1c0-4eea-4819-bdd7-d1ee4480e8ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a750b1c0-4eea-4819-bdd7-d1ee4480e8ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ca6ec6c-b850-47f1-a7f8-73d7eb6c0a06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ca6ec6c-b850-47f1-a7f8-73d7eb6c0a06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ca6ec6c-b850-47f1-a7f8-73d7eb6c0a06>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e81a296-9619-44d8-8b6f-8c11d300284d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e81a296-9619-44d8-8b6f-8c11d300284d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e81a296-9619-44d8-8b6f-8c11d300284d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5d6a5a1-dbb4-41b4-907c-dee860e92fa7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5d6a5a1-dbb4-41b4-907c-dee860e92fa7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5d6a5a1-dbb4-41b4-907c-dee860e92fa7>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d505169-1ab0-4ff7-a017-c29d2bc92abf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d505169-1ab0-4ff7-a017-c29d2bc92abf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d505169-1ab0-4ff7-a017-c29d2bc92abf>.
+    
+<http://data.lblod.info/id/remote-data-objects/530cbd4b-e5a6-4d22-a98a-c5c2156265da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "530cbd4b-e5a6-4d22-a98a-c5c2156265da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/530cbd4b-e5a6-4d22-a98a-c5c2156265da>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5f3cc7b-b023-4427-bdc9-081bbc3c35c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5f3cc7b-b023-4427-bdc9-081bbc3c35c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5f3cc7b-b023-4427-bdc9-081bbc3c35c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b0c6295-a580-4e4f-a163-85a89afb8d56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b0c6295-a580-4e4f-a163-85a89afb8d56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b0c6295-a580-4e4f-a163-85a89afb8d56>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cde1dc8-f91c-429a-9619-9135967c5b36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cde1dc8-f91c-429a-9619-9135967c5b36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cde1dc8-f91c-429a-9619-9135967c5b36>.
+    
+<http://data.lblod.info/id/remote-data-objects/80802381-c056-4910-9cab-e256a3490f51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80802381-c056-4910-9cab-e256a3490f51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80802381-c056-4910-9cab-e256a3490f51>.
+    
+<http://data.lblod.info/id/remote-data-objects/811552fe-386a-4bb6-a201-d0c67563c2d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "811552fe-386a-4bb6-a201-d0c67563c2d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/811552fe-386a-4bb6-a201-d0c67563c2d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b3dc56f-3c11-4cf3-88d8-1eea8a5daaae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b3dc56f-3c11-4cf3-88d8-1eea8a5daaae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b3dc56f-3c11-4cf3-88d8-1eea8a5daaae>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd833ce2-4fdf-406c-9b05-1328d7a98b84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd833ce2-4fdf-406c-9b05-1328d7a98b84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e8b40f95-40aa-4f71-b778-17a797feda9b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd833ce2-4fdf-406c-9b05-1328d7a98b84>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201425-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201425-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201425-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201425-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/885c412a-7ed0-441a-b2da-d6e31b440fb1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "885c412a-7ed0-441a-b2da-d6e31b440fb1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fbc5000f-d7eb-4d5f-aeca-8317ed880919";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/638b2b3b-f300-4f5c-ad96-a88c340bd7c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "638b2b3b-f300-4f5c-ad96-a88c340bd7c5";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919>.
+
+  <http://redpencil.data.gift/id/task/f8257a9e-7611-4c42-9f24-f084276306e7> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f8257a9e-7611-4c42-9f24-f084276306e7";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/885c412a-7ed0-441a-b2da-d6e31b440fb1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/638b2b3b-f300-4f5c-ad96-a88c340bd7c5>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4e461412-55c4-475a-afa4-4c0197a3818e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e461412-55c4-475a-afa4-4c0197a3818e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e461412-55c4-475a-afa4-4c0197a3818e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc951c54-6abc-4fa9-ba14-f54f3573455e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc951c54-6abc-4fa9-ba14-f54f3573455e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc951c54-6abc-4fa9-ba14-f54f3573455e>.
+    
+<http://data.lblod.info/id/remote-data-objects/eba3bd7c-38fb-49c9-8ea5-344076f43085> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eba3bd7c-38fb-49c9-8ea5-344076f43085";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eba3bd7c-38fb-49c9-8ea5-344076f43085>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d1636ad-8d08-45ef-8eb8-13dc1e72fba5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d1636ad-8d08-45ef-8eb8-13dc1e72fba5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d1636ad-8d08-45ef-8eb8-13dc1e72fba5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a82bf46c-c727-4c6d-b5c0-333019557aef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a82bf46c-c727-4c6d-b5c0-333019557aef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=BesluitenLijst_OCMW%20-%20Vast%20Bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a82bf46c-c727-4c6d-b5c0-333019557aef>.
+    
+<http://data.lblod.info/id/remote-data-objects/4669c020-0b6f-4d60-92e3-1aa3ec35c183> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4669c020-0b6f-4d60-92e3-1aa3ec35c183";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=Uittreksels_17-01-2022_39358.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4669c020-0b6f-4d60-92e3-1aa3ec35c183>.
+    
+<http://data.lblod.info/id/remote-data-objects/763b702d-0049-4402-9da4-11673d8e2191> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "763b702d-0049-4402-9da4-11673d8e2191";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/04a08934ef787d2dd5fc4fba87c2c25d62b43ce6570816ee2b1d3b447cc32afa/GetPublication?filename=Uittreksels_28-03-2022_40328.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/763b702d-0049-4402-9da4-11673d8e2191>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a1e8401-4116-451b-93ba-d45b73e3accf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a1e8401-4116-451b-93ba-d45b73e3accf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a1e8401-4116-451b-93ba-d45b73e3accf>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cf6b12c-a3b0-40ca-94b1-923857c57e25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cf6b12c-a3b0-40ca-94b1-923857c57e25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cf6b12c-a3b0-40ca-94b1-923857c57e25>.
+    
+<http://data.lblod.info/id/remote-data-objects/c68888dc-392e-4edc-8a63-6fada3ab046a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c68888dc-392e-4edc-8a63-6fada3ab046a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c68888dc-392e-4edc-8a63-6fada3ab046a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fe432b8-0c21-44d4-a71d-0818a76ba75e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fe432b8-0c21-44d4-a71d-0818a76ba75e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fe432b8-0c21-44d4-a71d-0818a76ba75e>.
+    
+<http://data.lblod.info/id/remote-data-objects/485df741-1f8d-41d1-b5b8-e6ed42505bfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "485df741-1f8d-41d1-b5b8-e6ed42505bfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/485df741-1f8d-41d1-b5b8-e6ed42505bfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5f046b1-2495-48e3-9203-b79081d88f0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5f046b1-2495-48e3-9203-b79081d88f0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5f046b1-2495-48e3-9203-b79081d88f0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/78345474-5dec-4843-a191-91aa9ffc2f42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78345474-5dec-4843-a191-91aa9ffc2f42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78345474-5dec-4843-a191-91aa9ffc2f42>.
+    
+<http://data.lblod.info/id/remote-data-objects/00054c43-753a-4b9d-a24d-ff632a95b23f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00054c43-753a-4b9d-a24d-ff632a95b23f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00054c43-753a-4b9d-a24d-ff632a95b23f>.
+    
+<http://data.lblod.info/id/remote-data-objects/716d541f-d6e3-49c6-972a-4461036d5d52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "716d541f-d6e3-49c6-972a-4461036d5d52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/716d541f-d6e3-49c6-972a-4461036d5d52>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f37b14f-4c7c-47dd-a112-6f4022d4ec5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f37b14f-4c7c-47dd-a112-6f4022d4ec5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_04-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f37b14f-4c7c-47dd-a112-6f4022d4ec5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/059022f2-de86-41d6-8673-5121f56bcd6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "059022f2-de86-41d6-8673-5121f56bcd6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/059022f2-de86-41d6-8673-5121f56bcd6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8fe30de-c451-44e0-a63b-45224f3247a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8fe30de-c451-44e0-a63b-45224f3247a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8fe30de-c451-44e0-a63b-45224f3247a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ffb709c-4797-4e61-993b-d152fed7b190> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ffb709c-4797-4e61-993b-d152fed7b190";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ffb709c-4797-4e61-993b-d152fed7b190>.
+    
+<http://data.lblod.info/id/remote-data-objects/eee39bc4-da98-46f1-8d29-e9b9825cb05f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eee39bc4-da98-46f1-8d29-e9b9825cb05f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eee39bc4-da98-46f1-8d29-e9b9825cb05f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b14201c4-0814-4dfe-97b4-ff6fc2c66c9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b14201c4-0814-4dfe-97b4-ff6fc2c66c9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b14201c4-0814-4dfe-97b4-ff6fc2c66c9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cfa641a-5134-47e6-8572-1c156f2ca33a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cfa641a-5134-47e6-8572-1c156f2ca33a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cfa641a-5134-47e6-8572-1c156f2ca33a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ac4e509-4b82-4094-885d-97b1e9f55ef0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ac4e509-4b82-4094-885d-97b1e9f55ef0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ac4e509-4b82-4094-885d-97b1e9f55ef0>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbb371b8-300c-4c68-a5b1-c33bc461470b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbb371b8-300c-4c68-a5b1-c33bc461470b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbb371b8-300c-4c68-a5b1-c33bc461470b>.
+    
+<http://data.lblod.info/id/remote-data-objects/26a939ba-b4e2-4df8-810b-c7b96a01c48e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26a939ba-b4e2-4df8-810b-c7b96a01c48e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26a939ba-b4e2-4df8-810b-c7b96a01c48e>.
+    
+<http://data.lblod.info/id/remote-data-objects/61066a36-af95-4aae-95a3-583e1d026a3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61066a36-af95-4aae-95a3-583e1d026a3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61066a36-af95-4aae-95a3-583e1d026a3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dc91470-06b1-4691-a103-83e033111883> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dc91470-06b1-4691-a103-83e033111883";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dc91470-06b1-4691-a103-83e033111883>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf4a6c56-21e9-4ddd-8f46-c286a08dbdeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf4a6c56-21e9-4ddd-8f46-c286a08dbdeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf4a6c56-21e9-4ddd-8f46-c286a08dbdeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/719d43bc-48e0-4322-a4cc-41b10a54d327> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "719d43bc-48e0-4322-a4cc-41b10a54d327";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/719d43bc-48e0-4322-a4cc-41b10a54d327>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5e8f9ac-4b4d-442a-80f9-1924192ddd6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5e8f9ac-4b4d-442a-80f9-1924192ddd6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5e8f9ac-4b4d-442a-80f9-1924192ddd6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0c386d4-dbe7-48b1-ab80-22923e705c27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0c386d4-dbe7-48b1-ab80-22923e705c27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_12-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0c386d4-dbe7-48b1-ab80-22923e705c27>.
+    
+<http://data.lblod.info/id/remote-data-objects/1800aed7-899d-403c-bda1-1abd13126f35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1800aed7-899d-403c-bda1-1abd13126f35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1800aed7-899d-403c-bda1-1abd13126f35>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef616e90-46c2-4a5e-9611-a2b1143fd43a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef616e90-46c2-4a5e-9611-a2b1143fd43a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef616e90-46c2-4a5e-9611-a2b1143fd43a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0f1214a-3e7a-43d7-9b68-809da23e4b83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0f1214a-3e7a-43d7-9b68-809da23e4b83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0f1214a-3e7a-43d7-9b68-809da23e4b83>.
+    
+<http://data.lblod.info/id/remote-data-objects/05c3bea6-3146-4e35-8041-6494e7347cf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05c3bea6-3146-4e35-8041-6494e7347cf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05c3bea6-3146-4e35-8041-6494e7347cf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ac509c4-1904-4b64-843f-7bdc6fadd088> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ac509c4-1904-4b64-843f-7bdc6fadd088";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_16-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ac509c4-1904-4b64-843f-7bdc6fadd088>.
+    
+<http://data.lblod.info/id/remote-data-objects/678391f1-f5db-4f1a-9105-54e7c90cbd91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "678391f1-f5db-4f1a-9105-54e7c90cbd91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_16-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/678391f1-f5db-4f1a-9105-54e7c90cbd91>.
+    
+<http://data.lblod.info/id/remote-data-objects/d049c42e-7797-457e-9de4-a12cb5c36bae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d049c42e-7797-457e-9de4-a12cb5c36bae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d049c42e-7797-457e-9de4-a12cb5c36bae>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8b85ea4-f30a-4d84-b3d4-4dd53a8edab4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8b85ea4-f30a-4d84-b3d4-4dd53a8edab4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8b85ea4-f30a-4d84-b3d4-4dd53a8edab4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7a85046-5045-4eea-b418-ba4878f21b10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7a85046-5045-4eea-b418-ba4878f21b10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7a85046-5045-4eea-b418-ba4878f21b10>.
+    
+<http://data.lblod.info/id/remote-data-objects/19a344ec-151f-4660-82cc-1525e62ca0ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19a344ec-151f-4660-82cc-1525e62ca0ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19a344ec-151f-4660-82cc-1525e62ca0ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/837e7be2-f75b-4829-baea-1c01adfd6b3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "837e7be2-f75b-4829-baea-1c01adfd6b3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/837e7be2-f75b-4829-baea-1c01adfd6b3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2106a098-d676-4dff-920d-1491e9c851ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2106a098-d676-4dff-920d-1491e9c851ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2106a098-d676-4dff-920d-1491e9c851ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/afa236c5-7292-4021-aef6-722d917de768> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afa236c5-7292-4021-aef6-722d917de768";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afa236c5-7292-4021-aef6-722d917de768>.
+    
+<http://data.lblod.info/id/remote-data-objects/097108ca-ffe1-486a-9ce0-71c331ac7bbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "097108ca-ffe1-486a-9ce0-71c331ac7bbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/097108ca-ffe1-486a-9ce0-71c331ac7bbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7be507a-02d8-4428-9281-157f0c174a04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7be507a-02d8-4428-9281-157f0c174a04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7be507a-02d8-4428-9281-157f0c174a04>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8e7e602-6261-4a06-a07a-c4796b23dae3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8e7e602-6261-4a06-a07a-c4796b23dae3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8e7e602-6261-4a06-a07a-c4796b23dae3>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0f7a5e2-dab8-4192-8e34-699adc395b49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0f7a5e2-dab8-4192-8e34-699adc395b49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0f7a5e2-dab8-4192-8e34-699adc395b49>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc162f6b-66d1-477a-9b8b-b8643a93af68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc162f6b-66d1-477a-9b8b-b8643a93af68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_20-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbc5000f-d7eb-4d5f-aeca-8317ed880919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc162f6b-66d1-477a-9b8b-b8643a93af68>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201426-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201426-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201426-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201426-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/0e454861-476c-4345-9c74-06ad8240e9c1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0e454861-476c-4345-9c74-06ad8240e9c1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e5bf4b38-59bb-40be-80de-d4411d73d5eb";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/47fc0ce0-cffd-4f0e-9b86-25b0cda666a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "47fc0ce0-cffd-4f0e-9b86-25b0cda666a2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb>.
+
+  <http://redpencil.data.gift/id/task/07b9dfb2-bcd5-48fb-aa5f-ccd83f2ae169> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "07b9dfb2-bcd5-48fb-aa5f-ccd83f2ae169";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/0e454861-476c-4345-9c74-06ad8240e9c1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/47fc0ce0-cffd-4f0e-9b86-25b0cda666a2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/8d9e06e3-4021-4432-9373-b9a4ec49b556> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d9e06e3-4021-4432-9373-b9a4ec49b556";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_20-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d9e06e3-4021-4432-9373-b9a4ec49b556>.
+    
+<http://data.lblod.info/id/remote-data-objects/25926d74-1528-43af-83ba-65892c04481b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25926d74-1528-43af-83ba-65892c04481b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25926d74-1528-43af-83ba-65892c04481b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b53df80b-545a-4e45-877d-4f21b645867f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b53df80b-545a-4e45-877d-4f21b645867f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b53df80b-545a-4e45-877d-4f21b645867f>.
+    
+<http://data.lblod.info/id/remote-data-objects/15225de8-fdda-43a7-85bb-1ffcd2faefc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15225de8-fdda-43a7-85bb-1ffcd2faefc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15225de8-fdda-43a7-85bb-1ffcd2faefc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cf5dc8c-2764-436c-a04e-168909bbbebb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cf5dc8c-2764-436c-a04e-168909bbbebb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cf5dc8c-2764-436c-a04e-168909bbbebb>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb81e492-cb10-4d0a-9a05-af7eee19342c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb81e492-cb10-4d0a-9a05-af7eee19342c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb81e492-cb10-4d0a-9a05-af7eee19342c>.
+    
+<http://data.lblod.info/id/remote-data-objects/be1a6cf8-cdae-4245-acf0-3e67b4bbbd77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be1a6cf8-cdae-4245-acf0-3e67b4bbbd77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be1a6cf8-cdae-4245-acf0-3e67b4bbbd77>.
+    
+<http://data.lblod.info/id/remote-data-objects/a89b394c-21c7-472d-936e-bb8d081982e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a89b394c-21c7-472d-936e-bb8d081982e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a89b394c-21c7-472d-936e-bb8d081982e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd0d88a4-421d-43ae-b0d7-7d384a99b306> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd0d88a4-421d-43ae-b0d7-7d384a99b306";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd0d88a4-421d-43ae-b0d7-7d384a99b306>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b5b9557-f67b-44ba-8453-ed43fab309ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b5b9557-f67b-44ba-8453-ed43fab309ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b5b9557-f67b-44ba-8453-ed43fab309ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ee5bde1-e60a-4935-97df-03319e3826f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ee5bde1-e60a-4935-97df-03319e3826f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ee5bde1-e60a-4935-97df-03319e3826f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/590a0d9e-4e9a-40bd-b7da-5774daf179cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "590a0d9e-4e9a-40bd-b7da-5774daf179cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/590a0d9e-4e9a-40bd-b7da-5774daf179cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a8a3c71-bbad-4271-b405-d92ae2de62df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a8a3c71-bbad-4271-b405-d92ae2de62df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a8a3c71-bbad-4271-b405-d92ae2de62df>.
+    
+<http://data.lblod.info/id/remote-data-objects/93af0e27-1d51-44dc-ab55-e754c578c4d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93af0e27-1d51-44dc-ab55-e754c578c4d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93af0e27-1d51-44dc-ab55-e754c578c4d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/15579f78-a062-4848-99b4-a0523e0df6f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15579f78-a062-4848-99b4-a0523e0df6f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15579f78-a062-4848-99b4-a0523e0df6f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d844ac2a-9a0d-4fb5-ae48-738acdfaf2c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d844ac2a-9a0d-4fb5-ae48-738acdfaf2c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d844ac2a-9a0d-4fb5-ae48-738acdfaf2c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4992cc1-0ba7-459b-8f86-0e1c8ce98839> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4992cc1-0ba7-459b-8f86-0e1c8ce98839";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4992cc1-0ba7-459b-8f86-0e1c8ce98839>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a3a58d8-c346-4606-a093-6e426f8b373e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a3a58d8-c346-4606-a093-6e426f8b373e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_26-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a3a58d8-c346-4606-a093-6e426f8b373e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f82b1b52-869f-437e-808f-209572789f94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f82b1b52-869f-437e-808f-209572789f94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f82b1b52-869f-437e-808f-209572789f94>.
+    
+<http://data.lblod.info/id/remote-data-objects/39f15a61-31d8-40bd-b4b2-7a8420a66469> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39f15a61-31d8-40bd-b4b2-7a8420a66469";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39f15a61-31d8-40bd-b4b2-7a8420a66469>.
+    
+<http://data.lblod.info/id/remote-data-objects/b66cbf32-3fbc-495a-aaa9-9a8abaaf7150> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b66cbf32-3fbc-495a-aaa9-9a8abaaf7150";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b66cbf32-3fbc-495a-aaa9-9a8abaaf7150>.
+    
+<http://data.lblod.info/id/remote-data-objects/c86c81da-cdd4-434f-93ca-cc55aa66fc7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c86c81da-cdd4-434f-93ca-cc55aa66fc7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c86c81da-cdd4-434f-93ca-cc55aa66fc7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e42323a3-e5d1-4c89-b6b7-f5e7857627ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e42323a3-e5d1-4c89-b6b7-f5e7857627ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e42323a3-e5d1-4c89-b6b7-f5e7857627ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2ec78de-b718-4ae2-b043-07b6e7c9bac6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2ec78de-b718-4ae2-b043-07b6e7c9bac6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2ec78de-b718-4ae2-b043-07b6e7c9bac6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c605a5d3-7057-4106-a6a5-9424588fe701> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c605a5d3-7057-4106-a6a5-9424588fe701";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c605a5d3-7057-4106-a6a5-9424588fe701>.
+    
+<http://data.lblod.info/id/remote-data-objects/06af288b-e52e-4371-8fc5-79c0a871a857> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06af288b-e52e-4371-8fc5-79c0a871a857";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06af288b-e52e-4371-8fc5-79c0a871a857>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0ee392e-6dd6-4199-a71d-241f4a68ff63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0ee392e-6dd6-4199-a71d-241f4a68ff63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0ee392e-6dd6-4199-a71d-241f4a68ff63>.
+    
+<http://data.lblod.info/id/remote-data-objects/7311d2b8-d675-450f-b361-435ef5829c12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7311d2b8-d675-450f-b361-435ef5829c12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Burgemeester_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7311d2b8-d675-450f-b361-435ef5829c12>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e9344f5-cdae-4d95-8832-511a287572a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e9344f5-cdae-4d95-8832-511a287572a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_01-02-2022_39706.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e9344f5-cdae-4d95-8832-511a287572a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/61cab638-d4d6-4bc3-9b1a-c939ffd66251> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61cab638-d4d6-4bc3-9b1a-c939ffd66251";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_01-06-2022_40958.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61cab638-d4d6-4bc3-9b1a-c939ffd66251>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4688e9b-032a-44f0-858a-cfd7ccc16cf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4688e9b-032a-44f0-858a-cfd7ccc16cf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_01-06-2022_40972.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4688e9b-032a-44f0-858a-cfd7ccc16cf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc52adfe-e833-41fd-ae5a-f7681a7d795b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc52adfe-e833-41fd-ae5a-f7681a7d795b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_02-05-2022_40696.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc52adfe-e833-41fd-ae5a-f7681a7d795b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b79d110-72dd-420d-a71b-74ccf2eb8888> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b79d110-72dd-420d-a71b-74ccf2eb8888";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_02-05-2022_40702.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b79d110-72dd-420d-a71b-74ccf2eb8888>.
+    
+<http://data.lblod.info/id/remote-data-objects/107eafdb-aa04-4765-a6ab-4f8f66ae4a2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "107eafdb-aa04-4765-a6ab-4f8f66ae4a2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_02-12-2021_39063.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/107eafdb-aa04-4765-a6ab-4f8f66ae4a2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1395e12b-5b97-4f92-a667-6d7acd6dd428> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1395e12b-5b97-4f92-a667-6d7acd6dd428";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_03-02-2022_39729.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1395e12b-5b97-4f92-a667-6d7acd6dd428>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6d51a8e-0f8e-4a4b-b583-4f6d19de43bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6d51a8e-0f8e-4a4b-b583-4f6d19de43bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_04-01-2022_39352.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6d51a8e-0f8e-4a4b-b583-4f6d19de43bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/691e795e-886f-448d-8faf-a2fb49fa69b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "691e795e-886f-448d-8faf-a2fb49fa69b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_04-01-2022_39364.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/691e795e-886f-448d-8faf-a2fb49fa69b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d953e968-45a9-49e7-a0aa-c3ef5404b6a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d953e968-45a9-49e7-a0aa-c3ef5404b6a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_04-04-2022_40419.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d953e968-45a9-49e7-a0aa-c3ef5404b6a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/da10d33e-2397-4887-8834-5bef7634aacb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da10d33e-2397-4887-8834-5bef7634aacb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_04-04-2022_40426.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da10d33e-2397-4887-8834-5bef7634aacb>.
+    
+<http://data.lblod.info/id/remote-data-objects/a661b504-6230-4d8b-8439-3616084f2259> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a661b504-6230-4d8b-8439-3616084f2259";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_04-04-2022_40429.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a661b504-6230-4d8b-8439-3616084f2259>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8be3113-1880-4a00-a1cf-8b8554659e8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8be3113-1880-4a00-a1cf-8b8554659e8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_04-04-2022_40437.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8be3113-1880-4a00-a1cf-8b8554659e8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5502179-9eba-4b36-971c-072668ad64a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5502179-9eba-4b36-971c-072668ad64a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_04-07-2022_41244.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5502179-9eba-4b36-971c-072668ad64a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/dba9b8c3-a2f4-44b7-bca9-6d6dc025a964> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dba9b8c3-a2f4-44b7-bca9-6d6dc025a964";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_04-07-2022_41249.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dba9b8c3-a2f4-44b7-bca9-6d6dc025a964>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bb98e30-79e9-4cd3-9619-7187b47c555d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bb98e30-79e9-4cd3-9619-7187b47c555d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_04-07-2022_41255.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bb98e30-79e9-4cd3-9619-7187b47c555d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbe487d5-f957-4210-bb79-63da872e81a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbe487d5-f957-4210-bb79-63da872e81a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_05-07-2022_41257.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbe487d5-f957-4210-bb79-63da872e81a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/36b3605a-4e41-46ec-aa23-2f5540c7149b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36b3605a-4e41-46ec-aa23-2f5540c7149b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_05-07-2022_41264.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36b3605a-4e41-46ec-aa23-2f5540c7149b>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcd24220-6f9d-4105-9568-87b5657e93f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcd24220-6f9d-4105-9568-87b5657e93f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_05-07-2022_41272.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcd24220-6f9d-4105-9568-87b5657e93f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/76c4c2db-5638-4164-92a4-3b82d15604ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76c4c2db-5638-4164-92a4-3b82d15604ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_05-07-2022_41276.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76c4c2db-5638-4164-92a4-3b82d15604ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/3129b2e6-0919-48b0-8dec-01964ed22207> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3129b2e6-0919-48b0-8dec-01964ed22207";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_05-07-2022_41282.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3129b2e6-0919-48b0-8dec-01964ed22207>.
+    
+<http://data.lblod.info/id/remote-data-objects/23a60ded-1a72-4c48-9bf6-f515bb9cb5a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23a60ded-1a72-4c48-9bf6-f515bb9cb5a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_06-01-2022_39374.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e5bf4b38-59bb-40be-80de-d4411d73d5eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23a60ded-1a72-4c48-9bf6-f515bb9cb5a1>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201427-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201427-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201427-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201427-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c0a0872c-dfc6-483f-949a-4e12e9fa0622> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c0a0872c-dfc6-483f-949a-4e12e9fa0622";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e6480c86-163b-4b75-9fa2-0d5b1050d936";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b39c7d87-e699-422e-819a-84557df20642> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b39c7d87-e699-422e-819a-84557df20642";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936>.
+
+  <http://redpencil.data.gift/id/task/d67cf894-a534-4179-9c4e-284599939aaf> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d67cf894-a534-4179-9c4e-284599939aaf";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c0a0872c-dfc6-483f-949a-4e12e9fa0622>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b39c7d87-e699-422e-819a-84557df20642>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b8229642-d6a5-4c2d-9e41-a6acfc1229df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8229642-d6a5-4c2d-9e41-a6acfc1229df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_06-01-2022_39383.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8229642-d6a5-4c2d-9e41-a6acfc1229df>.
+    
+<http://data.lblod.info/id/remote-data-objects/297ad2a3-68eb-402f-8f53-469363c859fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "297ad2a3-68eb-402f-8f53-469363c859fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_06-01-2022_39384.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/297ad2a3-68eb-402f-8f53-469363c859fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a8604fb-faa1-4540-beb7-e763cb9615f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a8604fb-faa1-4540-beb7-e763cb9615f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_07-02-2022_39754.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a8604fb-faa1-4540-beb7-e763cb9615f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bee1930-bd10-4560-8180-637bd47ec96a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bee1930-bd10-4560-8180-637bd47ec96a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_07-02-2022_39765.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bee1930-bd10-4560-8180-637bd47ec96a>.
+    
+<http://data.lblod.info/id/remote-data-objects/152f92f7-0b5c-4db1-a412-fbaaa5c50d95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "152f92f7-0b5c-4db1-a412-fbaaa5c50d95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_07-03-2022_40078.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/152f92f7-0b5c-4db1-a412-fbaaa5c50d95>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4ae6cfc-9625-4982-88dd-4df0c22952bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4ae6cfc-9625-4982-88dd-4df0c22952bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_07-03-2022_40096.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4ae6cfc-9625-4982-88dd-4df0c22952bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cc402bd-5dc2-44e5-98a0-5191a629f6dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cc402bd-5dc2-44e5-98a0-5191a629f6dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_07-12-2021_39083.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cc402bd-5dc2-44e5-98a0-5191a629f6dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/2716a611-f196-4aa1-bde6-e8fe6ddbef97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2716a611-f196-4aa1-bde6-e8fe6ddbef97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_07-12-2021_39085.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2716a611-f196-4aa1-bde6-e8fe6ddbef97>.
+    
+<http://data.lblod.info/id/remote-data-objects/93530836-808b-433d-9c54-3b7dbaafc864> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93530836-808b-433d-9c54-3b7dbaafc864";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_07-12-2021_39091.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93530836-808b-433d-9c54-3b7dbaafc864>.
+    
+<http://data.lblod.info/id/remote-data-objects/5920b90f-ae76-4f52-ab32-de9abf997092> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5920b90f-ae76-4f52-ab32-de9abf997092";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_09-03-2022_40106.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5920b90f-ae76-4f52-ab32-de9abf997092>.
+    
+<http://data.lblod.info/id/remote-data-objects/1803098e-0fea-45f2-8bbc-449c04e055b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1803098e-0fea-45f2-8bbc-449c04e055b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_09-03-2022_40128.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1803098e-0fea-45f2-8bbc-449c04e055b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0434376-7b59-4d9a-9b5c-3ce1e3f65497> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0434376-7b59-4d9a-9b5c-3ce1e3f65497";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_09-03-2022_40139.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0434376-7b59-4d9a-9b5c-3ce1e3f65497>.
+    
+<http://data.lblod.info/id/remote-data-objects/b070f6a2-a5eb-4578-b57c-3f12cca06b4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b070f6a2-a5eb-4578-b57c-3f12cca06b4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_10-01-2022_39270.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b070f6a2-a5eb-4578-b57c-3f12cca06b4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c19f6e5d-ec9e-4624-92e3-58dbfaaf5b59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c19f6e5d-ec9e-4624-92e3-58dbfaaf5b59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_10-01-2022_39403.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c19f6e5d-ec9e-4624-92e3-58dbfaaf5b59>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdf5eebf-8fbb-4aea-8d23-319ee900d05e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdf5eebf-8fbb-4aea-8d23-319ee900d05e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_10-01-2022_39405.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdf5eebf-8fbb-4aea-8d23-319ee900d05e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1352b15a-6d1d-402a-bf9f-a8cd0b9e54ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1352b15a-6d1d-402a-bf9f-a8cd0b9e54ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_10-05-2022_40775.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1352b15a-6d1d-402a-bf9f-a8cd0b9e54ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/42fea9e1-a9a5-466b-b97e-ce18f0991f51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42fea9e1-a9a5-466b-b97e-ce18f0991f51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_10-05-2022_40776.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42fea9e1-a9a5-466b-b97e-ce18f0991f51>.
+    
+<http://data.lblod.info/id/remote-data-objects/1caa1d95-503c-4c80-9cff-f376e6d28038> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1caa1d95-503c-4c80-9cff-f376e6d28038";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_12-01-2022_39410.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1caa1d95-503c-4c80-9cff-f376e6d28038>.
+    
+<http://data.lblod.info/id/remote-data-objects/9489eee2-449a-4d83-8633-30897fc72911> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9489eee2-449a-4d83-8633-30897fc72911";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_12-01-2022_39440.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9489eee2-449a-4d83-8633-30897fc72911>.
+    
+<http://data.lblod.info/id/remote-data-objects/2211b52d-91da-46ca-9635-83ee34c9efcf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2211b52d-91da-46ca-9635-83ee34c9efcf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_13-07-2022_41324.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2211b52d-91da-46ca-9635-83ee34c9efcf>.
+    
+<http://data.lblod.info/id/remote-data-objects/0608bbca-4477-4b3c-bf62-850d4a02b3fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0608bbca-4477-4b3c-bf62-850d4a02b3fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_13-07-2022_41325.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0608bbca-4477-4b3c-bf62-850d4a02b3fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ee7e47c-31e9-4f97-aa3c-7db1013f8eb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ee7e47c-31e9-4f97-aa3c-7db1013f8eb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_14-03-2022_40158.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ee7e47c-31e9-4f97-aa3c-7db1013f8eb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/07f385dd-793d-41f1-87ce-2f55e43abfcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07f385dd-793d-41f1-87ce-2f55e43abfcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_16-03-2022_40179.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07f385dd-793d-41f1-87ce-2f55e43abfcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9243680-09cd-47b9-ba3f-6a9f2046988f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9243680-09cd-47b9-ba3f-6a9f2046988f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_16-05-2022_40846.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9243680-09cd-47b9-ba3f-6a9f2046988f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab5d1d63-abd1-4329-8b07-18d65dfc4c77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab5d1d63-abd1-4329-8b07-18d65dfc4c77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_16-06-2022_41079.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab5d1d63-abd1-4329-8b07-18d65dfc4c77>.
+    
+<http://data.lblod.info/id/remote-data-objects/17415d04-93bd-4f8d-9ea7-66bed18d09ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17415d04-93bd-4f8d-9ea7-66bed18d09ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_16-11-2021_38796.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17415d04-93bd-4f8d-9ea7-66bed18d09ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0bdf381-9124-4ea0-a245-79c04ffe1fe2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0bdf381-9124-4ea0-a245-79c04ffe1fe2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_16-11-2021_38803.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0bdf381-9124-4ea0-a245-79c04ffe1fe2>.
+    
+<http://data.lblod.info/id/remote-data-objects/09c4b6a5-7d2f-43ac-b452-ef0f5dcb3d9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09c4b6a5-7d2f-43ac-b452-ef0f5dcb3d9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_17-01-2022_39477.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09c4b6a5-7d2f-43ac-b452-ef0f5dcb3d9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6fd9b8e-c1c4-4c0b-a5cd-7ec77f43c9c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6fd9b8e-c1c4-4c0b-a5cd-7ec77f43c9c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_17-01-2022_39500.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6fd9b8e-c1c4-4c0b-a5cd-7ec77f43c9c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a97b9739-e602-4b14-8b30-d631c3acd94e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a97b9739-e602-4b14-8b30-d631c3acd94e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_17-01-2022_39502.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a97b9739-e602-4b14-8b30-d631c3acd94e>.
+    
+<http://data.lblod.info/id/remote-data-objects/69aaa9f8-f898-494e-8e6b-3b6920d27574> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69aaa9f8-f898-494e-8e6b-3b6920d27574";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_17-02-2022_39901.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69aaa9f8-f898-494e-8e6b-3b6920d27574>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdd71c70-fb8b-42d5-850d-f49ec0e0a1dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdd71c70-fb8b-42d5-850d-f49ec0e0a1dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_17-03-2022_40224.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdd71c70-fb8b-42d5-850d-f49ec0e0a1dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5db9444-9f08-42ef-aee9-43abcf693f9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5db9444-9f08-42ef-aee9-43abcf693f9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_19-04-2022_40545.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5db9444-9f08-42ef-aee9-43abcf693f9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/44202c20-f370-4461-928e-e151eca089c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44202c20-f370-4461-928e-e151eca089c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_19-04-2022_40550.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44202c20-f370-4461-928e-e151eca089c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e056ed6-c7e9-4b55-9a8c-061ca60c673e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e056ed6-c7e9-4b55-9a8c-061ca60c673e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_19-05-2022_40843.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e056ed6-c7e9-4b55-9a8c-061ca60c673e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9d67422-a43d-42dc-b2a4-c6fd82e65d08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9d67422-a43d-42dc-b2a4-c6fd82e65d08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_19-05-2022_40870.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9d67422-a43d-42dc-b2a4-c6fd82e65d08>.
+    
+<http://data.lblod.info/id/remote-data-objects/54422130-cad6-4a58-a0cb-8732a34c55fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54422130-cad6-4a58-a0cb-8732a34c55fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_21-02-2022_39891.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54422130-cad6-4a58-a0cb-8732a34c55fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/449b5f4f-0b42-4daa-9216-23cbd86d0ee4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "449b5f4f-0b42-4daa-9216-23cbd86d0ee4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_21-02-2022_39938.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/449b5f4f-0b42-4daa-9216-23cbd86d0ee4>.
+    
+<http://data.lblod.info/id/remote-data-objects/052585ca-1635-4c89-aa8e-9d00c82bbb9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "052585ca-1635-4c89-aa8e-9d00c82bbb9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_21-02-2022_39943.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/052585ca-1635-4c89-aa8e-9d00c82bbb9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ee21a86-2585-4952-8854-de8c204eb777> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ee21a86-2585-4952-8854-de8c204eb777";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_21-03-2022_40225.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ee21a86-2585-4952-8854-de8c204eb777>.
+    
+<http://data.lblod.info/id/remote-data-objects/502c05a9-3bde-43be-98e3-4fde0ee400d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "502c05a9-3bde-43be-98e3-4fde0ee400d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_21-04-2022_40602.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/502c05a9-3bde-43be-98e3-4fde0ee400d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bc588d6-61ca-4e8e-b3d3-1c88b15f788c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bc588d6-61ca-4e8e-b3d3-1c88b15f788c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_21-10-2021_38557.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bc588d6-61ca-4e8e-b3d3-1c88b15f788c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5493ebb6-b309-40c5-aa06-a5cda778b306> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5493ebb6-b309-40c5-aa06-a5cda778b306";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_22-06-2022_41113.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5493ebb6-b309-40c5-aa06-a5cda778b306>.
+    
+<http://data.lblod.info/id/remote-data-objects/d92c706c-30a2-4d42-b706-3c67754f23eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d92c706c-30a2-4d42-b706-3c67754f23eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_23-11-2021_38861.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d92c706c-30a2-4d42-b706-3c67754f23eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fbb9d9a-9de6-44d3-aeb2-c02a8f0e7c49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fbb9d9a-9de6-44d3-aeb2-c02a8f0e7c49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_24-01-2022_39614.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fbb9d9a-9de6-44d3-aeb2-c02a8f0e7c49>.
+    
+<http://data.lblod.info/id/remote-data-objects/563b0262-73fd-4119-af32-c75a1d3b6e6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "563b0262-73fd-4119-af32-c75a1d3b6e6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_24-01-2022_39636.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/563b0262-73fd-4119-af32-c75a1d3b6e6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f457cb83-bedd-44fb-8852-d86513cc9198> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f457cb83-bedd-44fb-8852-d86513cc9198";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_24-03-2022_40311.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f457cb83-bedd-44fb-8852-d86513cc9198>.
+    
+<http://data.lblod.info/id/remote-data-objects/939381f1-67b3-441a-ac1f-c9d2752771bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "939381f1-67b3-441a-ac1f-c9d2752771bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_24-03-2022_40316.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/939381f1-67b3-441a-ac1f-c9d2752771bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/a600d4e5-766e-4cdb-a78c-0af0f65fd4c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a600d4e5-766e-4cdb-a78c-0af0f65fd4c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_25-05-2022_40913.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a600d4e5-766e-4cdb-a78c-0af0f65fd4c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c947503d-7052-4e0a-bd9b-fd85d612610c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c947503d-7052-4e0a-bd9b-fd85d612610c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_25-11-2021_38968.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6480c86-163b-4b75-9fa2-0d5b1050d936> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c947503d-7052-4e0a-bd9b-fd85d612610c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201428-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201428-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201428-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201428-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d8254446-013a-4725-8436-d33b8a0ebff7> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d8254446-013a-4725-8436-d33b8a0ebff7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5e466058-28e3-43ee-9688-b6310aa519d3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/0ff6e669-a177-40f2-84bc-da85fc1e51ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0ff6e669-a177-40f2-84bc-da85fc1e51ff";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3>.
+
+  <http://redpencil.data.gift/id/task/6d759ab7-84cc-4532-9594-c787f4ca2de1> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6d759ab7-84cc-4532-9594-c787f4ca2de1";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d8254446-013a-4725-8436-d33b8a0ebff7>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/0ff6e669-a177-40f2-84bc-da85fc1e51ff>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/680da2b9-2d89-4703-88e5-84c5921a5f79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "680da2b9-2d89-4703-88e5-84c5921a5f79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_25-11-2021_38971.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/680da2b9-2d89-4703-88e5-84c5921a5f79>.
+    
+<http://data.lblod.info/id/remote-data-objects/927641c9-a7fe-4ae6-93e0-0ebf92900404> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "927641c9-a7fe-4ae6-93e0-0ebf92900404";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_26-10-2021_38625.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/927641c9-a7fe-4ae6-93e0-0ebf92900404>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7f2c157-3060-4f04-a2d7-c864167987b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7f2c157-3060-4f04-a2d7-c864167987b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_26-10-2021_38632.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7f2c157-3060-4f04-a2d7-c864167987b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0690fde-8c46-4f94-9eb2-7aa53e640e4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0690fde-8c46-4f94-9eb2-7aa53e640e4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_26-10-2021_38635.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0690fde-8c46-4f94-9eb2-7aa53e640e4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/89df247f-74fb-475f-a8b7-b38012a432f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89df247f-74fb-475f-a8b7-b38012a432f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_26-10-2021_38636.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89df247f-74fb-475f-a8b7-b38012a432f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/aef7d0d4-a155-4e13-90cb-ade3b92ee1ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aef7d0d4-a155-4e13-90cb-ade3b92ee1ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_27-01-2022_39643.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aef7d0d4-a155-4e13-90cb-ade3b92ee1ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/a245b4ec-4341-4c7b-a485-f8ca1353c480> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a245b4ec-4341-4c7b-a485-f8ca1353c480";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_27-01-2022_39651.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a245b4ec-4341-4c7b-a485-f8ca1353c480>.
+    
+<http://data.lblod.info/id/remote-data-objects/e18a5cf2-487e-44b9-9c40-7bbc6f50b445> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e18a5cf2-487e-44b9-9c40-7bbc6f50b445";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_27-01-2022_39663.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e18a5cf2-487e-44b9-9c40-7bbc6f50b445>.
+    
+<http://data.lblod.info/id/remote-data-objects/113ffe68-84d9-4451-8151-02e7d6fff1cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "113ffe68-84d9-4451-8151-02e7d6fff1cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_27-06-2022_41200.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/113ffe68-84d9-4451-8151-02e7d6fff1cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4eb4c5a-bac5-4a37-bc0e-ce52413af7dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4eb4c5a-bac5-4a37-bc0e-ce52413af7dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_28-03-2022_40345.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4eb4c5a-bac5-4a37-bc0e-ce52413af7dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d66bc0e6-21b3-40b3-9944-780757c281ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d66bc0e6-21b3-40b3-9944-780757c281ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_28-04-2022_40667.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d66bc0e6-21b3-40b3-9944-780757c281ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/b789a99d-c51d-4d21-820e-23d4c70543a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b789a99d-c51d-4d21-820e-23d4c70543a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_28-07-2022_41438.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b789a99d-c51d-4d21-820e-23d4c70543a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d217d09c-be96-4fb6-ab23-62300b302fc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d217d09c-be96-4fb6-ab23-62300b302fc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_29-06-2022_41217.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d217d09c-be96-4fb6-ab23-62300b302fc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5aadd583-79d1-4710-8305-fcb695c73567> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5aadd583-79d1-4710-8305-fcb695c73567";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_30-03-2022_40355.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5aadd583-79d1-4710-8305-fcb695c73567>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce8bd865-8ee5-4f29-83ed-c8fb8077ad0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce8bd865-8ee5-4f29-83ed-c8fb8077ad0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_30-03-2022_40356.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce8bd865-8ee5-4f29-83ed-c8fb8077ad0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/329343a2-0b54-4fd1-8a4d-c77aa634fc39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "329343a2-0b54-4fd1-8a4d-c77aa634fc39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_30-05-2022_40936.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/329343a2-0b54-4fd1-8a4d-c77aa634fc39>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fbfb5af-a493-430c-9b8b-fdfc7989f30e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fbfb5af-a493-430c-9b8b-fdfc7989f30e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_30-05-2022_40940.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fbfb5af-a493-430c-9b8b-fdfc7989f30e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbecbde7-645a-4399-bd1e-864ef0d1d67c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbecbde7-645a-4399-bd1e-864ef0d1d67c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_30-05-2022_40947.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbecbde7-645a-4399-bd1e-864ef0d1d67c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7afa2f8e-8d5d-4720-bdab-81a1581a15a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7afa2f8e-8d5d-4720-bdab-81a1581a15a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/0a0682f720d903dd99ba6f9573fbe2a08ebc866eaa2a70943be879a55852b1ce/GetPublication?filename=Uittreksels_30-11-2021_39014.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7afa2f8e-8d5d-4720-bdab-81a1581a15a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/38273dfd-cd89-44ad-8a8c-78d07e500bb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38273dfd-cd89-44ad-8a8c-78d07e500bb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Agenda_GEMEENTE%20-%20Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38273dfd-cd89-44ad-8a8c-78d07e500bb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c356bee-f1b1-47e1-a37f-39ac4e8cd6de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c356bee-f1b1-47e1-a37f-39ac4e8cd6de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Agenda_GEMEENTE%20-%20Gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c356bee-f1b1-47e1-a37f-39ac4e8cd6de>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e8afd62-9e6f-4335-ab36-f89ec0a64b73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e8afd62-9e6f-4335-ab36-f89ec0a64b73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Agenda_GEMEENTE%20-%20Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e8afd62-9e6f-4335-ab36-f89ec0a64b73>.
+    
+<http://data.lblod.info/id/remote-data-objects/5dc10da1-dceb-4863-a8fe-95b5f3d7575e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5dc10da1-dceb-4863-a8fe-95b5f3d7575e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Agenda_GEMEENTE%20-%20Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5dc10da1-dceb-4863-a8fe-95b5f3d7575e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e40ad01b-f22f-4f12-ad74-e305018db232> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e40ad01b-f22f-4f12-ad74-e305018db232";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Agenda_GEMEENTE%20-%20Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e40ad01b-f22f-4f12-ad74-e305018db232>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e05c6d5-e83c-442c-b0fc-863bd3e394ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e05c6d5-e83c-442c-b0fc-863bd3e394ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Agenda_GEMEENTE%20-%20Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e05c6d5-e83c-442c-b0fc-863bd3e394ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7c1ebde-c041-49b0-8a99-8e0fb85425d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7c1ebde-c041-49b0-8a99-8e0fb85425d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Agenda_GEMEENTE%20-%20Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7c1ebde-c041-49b0-8a99-8e0fb85425d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/9598a3c5-ac56-49fe-a273-746e0c698bb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9598a3c5-ac56-49fe-a273-746e0c698bb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9598a3c5-ac56-49fe-a273-746e0c698bb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/b084ed01-224b-4ebe-b015-094dbe656691> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b084ed01-224b-4ebe-b015-094dbe656691";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b084ed01-224b-4ebe-b015-094dbe656691>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7ab366b-ece0-4683-bf3c-acffb4518a56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7ab366b-ece0-4683-bf3c-acffb4518a56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7ab366b-ece0-4683-bf3c-acffb4518a56>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bbb71f9-bbf2-48ac-b7e7-3f493e15d73b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bbb71f9-bbf2-48ac-b7e7-3f493e15d73b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bbb71f9-bbf2-48ac-b7e7-3f493e15d73b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d5bf79f-ec35-403e-bf77-36ea020cd6aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d5bf79f-ec35-403e-bf77-36ea020cd6aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d5bf79f-ec35-403e-bf77-36ea020cd6aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfa4f12b-935f-4cf2-a5c3-d43956306b86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfa4f12b-935f-4cf2-a5c3-d43956306b86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfa4f12b-935f-4cf2-a5c3-d43956306b86>.
+    
+<http://data.lblod.info/id/remote-data-objects/39f48948-019e-4d6d-abe3-fac8a2646bc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39f48948-019e-4d6d-abe3-fac8a2646bc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39f48948-019e-4d6d-abe3-fac8a2646bc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b223ddd3-40bd-4e9c-a58a-761441c3a9d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b223ddd3-40bd-4e9c-a58a-761441c3a9d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b223ddd3-40bd-4e9c-a58a-761441c3a9d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/377aafc0-9a49-48ae-b71b-6f8c414d9647> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "377aafc0-9a49-48ae-b71b-6f8c414d9647";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/377aafc0-9a49-48ae-b71b-6f8c414d9647>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5bc2264-9edb-4731-b0ef-fbcb55a84153> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5bc2264-9edb-4731-b0ef-fbcb55a84153";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Notulen_GEMEENTE%20-%20Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5bc2264-9edb-4731-b0ef-fbcb55a84153>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e57f1f3-b308-446b-b3d3-598908bb76c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e57f1f3-b308-446b-b3d3-598908bb76c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Notulen_GEMEENTE%20-%20Gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e57f1f3-b308-446b-b3d3-598908bb76c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/afc4bae3-b034-4386-84b7-6e0441113273> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afc4bae3-b034-4386-84b7-6e0441113273";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Notulen_GEMEENTE%20-%20Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afc4bae3-b034-4386-84b7-6e0441113273>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3c409a1-9a53-4256-9f8a-039419850eac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3c409a1-9a53-4256-9f8a-039419850eac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Notulen_GEMEENTE%20-%20Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3c409a1-9a53-4256-9f8a-039419850eac>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a5102d6-65c8-4584-a77f-b8f591742431> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a5102d6-65c8-4584-a77f-b8f591742431";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Notulen_GEMEENTE%20-%20Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a5102d6-65c8-4584-a77f-b8f591742431>.
+    
+<http://data.lblod.info/id/remote-data-objects/eeffbbf8-f9ef-4083-95a2-097177b6a7fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eeffbbf8-f9ef-4083-95a2-097177b6a7fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Notulen_GEMEENTE%20-%20Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eeffbbf8-f9ef-4083-95a2-097177b6a7fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1a25743-f7fd-4577-a062-a72b251cd739> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1a25743-f7fd-4577-a062-a72b251cd739";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Notulen_GEMEENTE%20-%20Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1a25743-f7fd-4577-a062-a72b251cd739>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cdfdf57-885c-4b18-be6c-2731ff06ecad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cdfdf57-885c-4b18-be6c-2731ff06ecad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_16-12-2021_39024.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cdfdf57-885c-4b18-be6c-2731ff06ecad>.
+    
+<http://data.lblod.info/id/remote-data-objects/be4785b6-cc15-44a7-9c01-85fe085be862> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be4785b6-cc15-44a7-9c01-85fe085be862";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_16-12-2021_39116.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be4785b6-cc15-44a7-9c01-85fe085be862>.
+    
+<http://data.lblod.info/id/remote-data-objects/f06f3300-e817-4c61-9505-e12d0c463030> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f06f3300-e817-4c61-9505-e12d0c463030";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_16-12-2021_39120.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f06f3300-e817-4c61-9505-e12d0c463030>.
+    
+<http://data.lblod.info/id/remote-data-objects/a13869d7-d408-4ebf-940a-7aa586c47abe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a13869d7-d408-4ebf-940a-7aa586c47abe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_16-12-2021_39122.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a13869d7-d408-4ebf-940a-7aa586c47abe>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdace6a1-004d-4dfe-b462-2ea261635659> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdace6a1-004d-4dfe-b462-2ea261635659";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_16-12-2021_39124.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdace6a1-004d-4dfe-b462-2ea261635659>.
+    
+<http://data.lblod.info/id/remote-data-objects/15d5d1d0-e940-4435-8b90-f8815d0dfe8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15d5d1d0-e940-4435-8b90-f8815d0dfe8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_16-12-2021_39125.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15d5d1d0-e940-4435-8b90-f8815d0dfe8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7d5bc69-024f-44e1-862d-9cbb0f9c368c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7d5bc69-024f-44e1-862d-9cbb0f9c368c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_16-12-2021_39127.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7d5bc69-024f-44e1-862d-9cbb0f9c368c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e373cfb8-d4a7-46e1-9474-b65e70d30aee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e373cfb8-d4a7-46e1-9474-b65e70d30aee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_16-12-2021_39131.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5e466058-28e3-43ee-9688-b6310aa519d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e373cfb8-d4a7-46e1-9474-b65e70d30aee>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201430-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201430-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201430-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201430-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/13da9706-2f44-4a4a-b409-4cc6a44edd3a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "13da9706-2f44-4a4a-b409-4cc6a44edd3a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "095a295f-2ecc-495d-9d71-a6aa322b0cce";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a0db2f46-8ed9-4cfd-8d7e-a055dff948f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a0db2f46-8ed9-4cfd-8d7e-a055dff948f6";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce>.
+
+  <http://redpencil.data.gift/id/task/b5af8304-2ffa-4acb-a623-31f835f4e612> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b5af8304-2ffa-4acb-a623-31f835f4e612";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/13da9706-2f44-4a4a-b409-4cc6a44edd3a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a0db2f46-8ed9-4cfd-8d7e-a055dff948f6>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/2cff350d-e810-49c0-9c4d-4ff80b388c1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cff350d-e810-49c0-9c4d-4ff80b388c1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_24-02-2022_39878.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cff350d-e810-49c0-9c4d-4ff80b388c1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9ac2933-a32a-46f8-aebf-39288f4a7bda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9ac2933-a32a-46f8-aebf-39288f4a7bda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_24-02-2022_39879.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9ac2933-a32a-46f8-aebf-39288f4a7bda>.
+    
+<http://data.lblod.info/id/remote-data-objects/5986c831-d30d-4583-8efd-3edd13ae7ab4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5986c831-d30d-4583-8efd-3edd13ae7ab4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_25-11-2021_38833.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5986c831-d30d-4583-8efd-3edd13ae7ab4>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b173118-b0df-4f52-b3b8-16036e13efd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b173118-b0df-4f52-b3b8-16036e13efd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_25-11-2021_38834.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b173118-b0df-4f52-b3b8-16036e13efd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfed220d-d2d7-417c-8924-fda103836755> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfed220d-d2d7-417c-8924-fda103836755";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_25-11-2021_38839.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfed220d-d2d7-417c-8924-fda103836755>.
+    
+<http://data.lblod.info/id/remote-data-objects/4605fee9-78cf-41d5-b546-b64471de2895> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4605fee9-78cf-41d5-b546-b64471de2895";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_25-11-2021_38897.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4605fee9-78cf-41d5-b546-b64471de2895>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c3339fa-1914-42f7-b8ab-5c8b98ba190c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c3339fa-1914-42f7-b8ab-5c8b98ba190c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_27-01-2022_39544.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c3339fa-1914-42f7-b8ab-5c8b98ba190c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e8325bb-8b0c-40ca-afa3-0ddec65c5528> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e8325bb-8b0c-40ca-afa3-0ddec65c5528";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_27-01-2022_39553.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e8325bb-8b0c-40ca-afa3-0ddec65c5528>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bc7dd5f-1c21-4383-a86f-d36109c9f679> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bc7dd5f-1c21-4383-a86f-d36109c9f679";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_27-01-2022_39556.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bc7dd5f-1c21-4383-a86f-d36109c9f679>.
+    
+<http://data.lblod.info/id/remote-data-objects/04badd5a-70ff-4350-8d40-6e2d8185f745> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04badd5a-70ff-4350-8d40-6e2d8185f745";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_27-01-2022_39621.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04badd5a-70ff-4350-8d40-6e2d8185f745>.
+    
+<http://data.lblod.info/id/remote-data-objects/e911d0f7-d140-470e-a6c9-47a5371dc354> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e911d0f7-d140-470e-a6c9-47a5371dc354";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_28-04-2022_40567.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e911d0f7-d140-470e-a6c9-47a5371dc354>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce8559aa-c161-4aef-b24b-ae9735a66c42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce8559aa-c161-4aef-b24b-ae9735a66c42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_28-04-2022_40568.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce8559aa-c161-4aef-b24b-ae9735a66c42>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1239464-b023-41c6-98be-61f33911bf32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1239464-b023-41c6-98be-61f33911bf32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_28-04-2022_40569.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1239464-b023-41c6-98be-61f33911bf32>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e5f5ce7-b0bc-4de5-bf84-b69585677fc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e5f5ce7-b0bc-4de5-bf84-b69585677fc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_28-10-2021_38536.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e5f5ce7-b0bc-4de5-bf84-b69585677fc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c25aecf7-24d5-41ed-9bdb-c4095c9c18b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c25aecf7-24d5-41ed-9bdb-c4095c9c18b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_28-10-2021_38539.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c25aecf7-24d5-41ed-9bdb-c4095c9c18b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bc6ffa8-cc0a-4c6e-9d0c-965807d667d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bc6ffa8-cc0a-4c6e-9d0c-965807d667d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_30-06-2022_41054.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bc6ffa8-cc0a-4c6e-9d0c-965807d667d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f187a18-80df-42f9-b735-98cb56109a1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f187a18-80df-42f9-b735-98cb56109a1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_30-06-2022_41125.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f187a18-80df-42f9-b735-98cb56109a1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ad29bb9-65cc-4e44-a494-10491f4fd74d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ad29bb9-65cc-4e44-a494-10491f4fd74d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_30-06-2022_41126.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ad29bb9-65cc-4e44-a494-10491f4fd74d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c057579-1733-40aa-b184-4b4f6d7d4c0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c057579-1733-40aa-b184-4b4f6d7d4c0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_30-06-2022_41129.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c057579-1733-40aa-b184-4b4f6d7d4c0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcdd8178-b6e6-4cd6-b41b-32f80038c14c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcdd8178-b6e6-4cd6-b41b-32f80038c14c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_30-06-2022_41130.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcdd8178-b6e6-4cd6-b41b-32f80038c14c>.
+    
+<http://data.lblod.info/id/remote-data-objects/245bf774-ed0d-4ec8-9299-d5552a811667> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "245bf774-ed0d-4ec8-9299-d5552a811667";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_30-06-2022_41131.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/245bf774-ed0d-4ec8-9299-d5552a811667>.
+    
+<http://data.lblod.info/id/remote-data-objects/f42bf84e-db7c-4b5d-a296-b38ff4fcb844> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f42bf84e-db7c-4b5d-a296-b38ff4fcb844";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_30-06-2022_41134.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f42bf84e-db7c-4b5d-a296-b38ff4fcb844>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5f665bf-0bba-4719-9ea6-a773f3ea596d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5f665bf-0bba-4719-9ea6-a773f3ea596d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_31-03-2022_40284.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5f665bf-0bba-4719-9ea6-a773f3ea596d>.
+    
+<http://data.lblod.info/id/remote-data-objects/865dbed0-ccb4-4943-881e-f9152eee39ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "865dbed0-ccb4-4943-881e-f9152eee39ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_31-03-2022_40285.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/865dbed0-ccb4-4943-881e-f9152eee39ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f897480-befc-4c3a-a076-bb2c7158415f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f897480-befc-4c3a-a076-bb2c7158415f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_31-03-2022_40286.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f897480-befc-4c3a-a076-bb2c7158415f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb830d95-8630-40e3-b65b-e52e96a8fdf0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb830d95-8630-40e3-b65b-e52e96a8fdf0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_31-03-2022_40292.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb830d95-8630-40e3-b65b-e52e96a8fdf0>.
+    
+<http://data.lblod.info/id/remote-data-objects/802e1e04-19e3-4528-90c3-9997bf52ce90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "802e1e04-19e3-4528-90c3-9997bf52ce90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_31-03-2022_40293.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/802e1e04-19e3-4528-90c3-9997bf52ce90>.
+    
+<http://data.lblod.info/id/remote-data-objects/a19a2ef1-2f49-48f8-b909-8ea37f83a244> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a19a2ef1-2f49-48f8-b909-8ea37f83a244";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/21290af58149e0458d9f5a05806ea4d4df63089b7ef6f7667d20c458c113591e/GetPublication?filename=Uittreksels_31-03-2022_40294.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a19a2ef1-2f49-48f8-b909-8ea37f83a244>.
+    
+<http://data.lblod.info/id/remote-data-objects/1645ca1b-c5b8-4b9c-a661-dcfccbc49412> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1645ca1b-c5b8-4b9c-a661-dcfccbc49412";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_01-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1645ca1b-c5b8-4b9c-a661-dcfccbc49412>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4c10822-6642-4a5b-9706-20eb1f80767e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4c10822-6642-4a5b-9706-20eb1f80767e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4c10822-6642-4a5b-9706-20eb1f80767e>.
+    
+<http://data.lblod.info/id/remote-data-objects/83758aa2-f32c-49af-98e0-a9672eba0466> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83758aa2-f32c-49af-98e0-a9672eba0466";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83758aa2-f32c-49af-98e0-a9672eba0466>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fb27c31-084d-4cc0-bd2d-2627dfe0c1de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fb27c31-084d-4cc0-bd2d-2627dfe0c1de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fb27c31-084d-4cc0-bd2d-2627dfe0c1de>.
+    
+<http://data.lblod.info/id/remote-data-objects/57762708-4ba2-4a5e-934c-a1c5494845c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57762708-4ba2-4a5e-934c-a1c5494845c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57762708-4ba2-4a5e-934c-a1c5494845c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b7febdc-e306-41fd-a400-c4f2a32c4a1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b7febdc-e306-41fd-a400-c4f2a32c4a1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b7febdc-e306-41fd-a400-c4f2a32c4a1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad80ae0b-967e-4081-ad26-fefb523dfdab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad80ae0b-967e-4081-ad26-fefb523dfdab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad80ae0b-967e-4081-ad26-fefb523dfdab>.
+    
+<http://data.lblod.info/id/remote-data-objects/a06bccb0-0327-4639-8c7a-64f8014bfbc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a06bccb0-0327-4639-8c7a-64f8014bfbc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a06bccb0-0327-4639-8c7a-64f8014bfbc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/cac0a558-79b6-4937-b43f-87fdac3e3bd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cac0a558-79b6-4937-b43f-87fdac3e3bd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cac0a558-79b6-4937-b43f-87fdac3e3bd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/38a299f5-c9b0-494d-a46f-83d3afc192bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38a299f5-c9b0-494d-a46f-83d3afc192bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38a299f5-c9b0-494d-a46f-83d3afc192bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fb06382-b262-4554-9911-261932d31630> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fb06382-b262-4554-9911-261932d31630";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fb06382-b262-4554-9911-261932d31630>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b606a60-5fc0-4905-b5a2-c0b6ee95b76a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b606a60-5fc0-4905-b5a2-c0b6ee95b76a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b606a60-5fc0-4905-b5a2-c0b6ee95b76a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef20f28d-3825-4f11-8bad-eff3a4fabc78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef20f28d-3825-4f11-8bad-eff3a4fabc78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef20f28d-3825-4f11-8bad-eff3a4fabc78>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b16ecf2-856f-426c-9bfb-ffc144d6d4e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b16ecf2-856f-426c-9bfb-ffc144d6d4e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b16ecf2-856f-426c-9bfb-ffc144d6d4e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b520c690-5979-434b-afe2-1ba82e179b53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b520c690-5979-434b-afe2-1ba82e179b53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b520c690-5979-434b-afe2-1ba82e179b53>.
+    
+<http://data.lblod.info/id/remote-data-objects/11fa27df-1906-4e1f-ac1e-391c53659a9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11fa27df-1906-4e1f-ac1e-391c53659a9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11fa27df-1906-4e1f-ac1e-391c53659a9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfe2651a-3843-466a-a634-7e42000c52ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfe2651a-3843-466a-a634-7e42000c52ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfe2651a-3843-466a-a634-7e42000c52ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/35036029-7fe7-4976-8bb8-b8e4121f4966> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35036029-7fe7-4976-8bb8-b8e4121f4966";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35036029-7fe7-4976-8bb8-b8e4121f4966>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2228ea5-549b-4bb2-94a6-b15f5535d5e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2228ea5-549b-4bb2-94a6-b15f5535d5e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2228ea5-549b-4bb2-94a6-b15f5535d5e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/47fa04cd-7308-41c9-a2b3-e278cb37ce90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47fa04cd-7308-41c9-a2b3-e278cb37ce90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47fa04cd-7308-41c9-a2b3-e278cb37ce90>.
+    
+<http://data.lblod.info/id/remote-data-objects/a00c3a25-ef41-4dd5-8323-c52e7749f9dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a00c3a25-ef41-4dd5-8323-c52e7749f9dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a00c3a25-ef41-4dd5-8323-c52e7749f9dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/95373020-6479-4bc2-9231-a11fff6f59f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95373020-6479-4bc2-9231-a11fff6f59f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/095a295f-2ecc-495d-9d71-a6aa322b0cce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95373020-6479-4bc2-9231-a11fff6f59f7>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201431-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201431-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201431-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201431-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/bca91e61-6264-4d2c-86fa-50e0adf1da41> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bca91e61-6264-4d2c-86fa-50e0adf1da41";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "389d48bc-10b5-4283-92f9-0a2191397959";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/3f9f4a1a-aa5c-4652-9233-6da5d25c594d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3f9f4a1a-aa5c-4652-9233-6da5d25c594d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959>.
+
+  <http://redpencil.data.gift/id/task/837ff4aa-0644-43a5-873e-9a3bfe44c6c2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "837ff4aa-0644-43a5-873e-9a3bfe44c6c2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/bca91e61-6264-4d2c-86fa-50e0adf1da41>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/3f9f4a1a-aa5c-4652-9233-6da5d25c594d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c827b5ca-89a3-4798-be95-0b203416f324> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c827b5ca-89a3-4798-be95-0b203416f324";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c827b5ca-89a3-4798-be95-0b203416f324>.
+    
+<http://data.lblod.info/id/remote-data-objects/77ea4308-a949-4cce-a43d-fb8a6c0b2775> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77ea4308-a949-4cce-a43d-fb8a6c0b2775";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77ea4308-a949-4cce-a43d-fb8a6c0b2775>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d5ad342-104f-4f9a-b3fd-bf69701fef88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d5ad342-104f-4f9a-b3fd-bf69701fef88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d5ad342-104f-4f9a-b3fd-bf69701fef88>.
+    
+<http://data.lblod.info/id/remote-data-objects/603c05a9-9e61-414c-9dc7-e3910a4a8c88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "603c05a9-9e61-414c-9dc7-e3910a4a8c88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/603c05a9-9e61-414c-9dc7-e3910a4a8c88>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2a089ed-5b04-4143-bf47-024368305a97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2a089ed-5b04-4143-bf47-024368305a97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2a089ed-5b04-4143-bf47-024368305a97>.
+    
+<http://data.lblod.info/id/remote-data-objects/18cd1ac1-ffcb-432d-baa2-98cbf599369f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18cd1ac1-ffcb-432d-baa2-98cbf599369f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18cd1ac1-ffcb-432d-baa2-98cbf599369f>.
+    
+<http://data.lblod.info/id/remote-data-objects/79930fdb-c696-459c-8363-88419501d266> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79930fdb-c696-459c-8363-88419501d266";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79930fdb-c696-459c-8363-88419501d266>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3e21350-a73b-4aba-86c6-5699288fa071> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3e21350-a73b-4aba-86c6-5699288fa071";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3e21350-a73b-4aba-86c6-5699288fa071>.
+    
+<http://data.lblod.info/id/remote-data-objects/46215153-65bc-4a81-838d-16d8662085fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46215153-65bc-4a81-838d-16d8662085fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46215153-65bc-4a81-838d-16d8662085fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ece1a13-d42f-40f9-b9fd-6618b90a08e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ece1a13-d42f-40f9-b9fd-6618b90a08e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ece1a13-d42f-40f9-b9fd-6618b90a08e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ffbef1b-c066-4d3a-a343-b586a737aafc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ffbef1b-c066-4d3a-a343-b586a737aafc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ffbef1b-c066-4d3a-a343-b586a737aafc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c354f5af-5004-4e8f-b4da-6f536a10345f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c354f5af-5004-4e8f-b4da-6f536a10345f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c354f5af-5004-4e8f-b4da-6f536a10345f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1cd026a-e968-4f2c-a8cb-1f06e32efb22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1cd026a-e968-4f2c-a8cb-1f06e32efb22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1cd026a-e968-4f2c-a8cb-1f06e32efb22>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0406c9b-3550-4fa6-928c-6fb29fe9cfbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0406c9b-3550-4fa6-928c-6fb29fe9cfbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0406c9b-3550-4fa6-928c-6fb29fe9cfbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/da60b6fc-4f0f-466f-9e95-57986a73f264> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da60b6fc-4f0f-466f-9e95-57986a73f264";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da60b6fc-4f0f-466f-9e95-57986a73f264>.
+    
+<http://data.lblod.info/id/remote-data-objects/09a120c5-893b-40c5-96ff-b1d59b7628d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09a120c5-893b-40c5-96ff-b1d59b7628d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09a120c5-893b-40c5-96ff-b1d59b7628d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e39fbcdf-159e-420b-b0e2-ecc71fa4ec7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e39fbcdf-159e-420b-b0e2-ecc71fa4ec7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e39fbcdf-159e-420b-b0e2-ecc71fa4ec7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b498976-f1f5-4052-b4ae-7db66e0e0640> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b498976-f1f5-4052-b4ae-7db66e0e0640";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b498976-f1f5-4052-b4ae-7db66e0e0640>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfb48599-368e-4bfb-af1a-f8e00d08058e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfb48599-368e-4bfb-af1a-f8e00d08058e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfb48599-368e-4bfb-af1a-f8e00d08058e>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb8306cd-4f39-4bca-94d9-59c82cec219c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb8306cd-4f39-4bca-94d9-59c82cec219c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb8306cd-4f39-4bca-94d9-59c82cec219c>.
+    
+<http://data.lblod.info/id/remote-data-objects/913f0663-00f8-4e1f-bccd-72bbf983fdcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "913f0663-00f8-4e1f-bccd-72bbf983fdcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=BesluitenLijst_GEMEENTE%20-%20Schepencollege_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/913f0663-00f8-4e1f-bccd-72bbf983fdcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/75e5bdb5-9705-4abb-afed-3342f6aebe5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75e5bdb5-9705-4abb-afed-3342f6aebe5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_01-11-2021_38433.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75e5bdb5-9705-4abb-afed-3342f6aebe5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/10de42e7-9393-4257-b85c-4f5cb59f7c88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10de42e7-9393-4257-b85c-4f5cb59f7c88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_04-04-2022_39817.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10de42e7-9393-4257-b85c-4f5cb59f7c88>.
+    
+<http://data.lblod.info/id/remote-data-objects/7808eae2-b6e7-427f-9b85-fd43f2a79161> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7808eae2-b6e7-427f-9b85-fd43f2a79161";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_04-07-2022_41229.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7808eae2-b6e7-427f-9b85-fd43f2a79161>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d784367-639d-4bbd-b5a2-14e0d58d3653> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d784367-639d-4bbd-b5a2-14e0d58d3653";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_07-02-2022_39738.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d784367-639d-4bbd-b5a2-14e0d58d3653>.
+    
+<http://data.lblod.info/id/remote-data-objects/fccd25c3-b4c8-4d80-a2e5-fbf1d12ec4c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fccd25c3-b4c8-4d80-a2e5-fbf1d12ec4c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_07-02-2022_39739.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fccd25c3-b4c8-4d80-a2e5-fbf1d12ec4c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9b8b9a9-1fa0-4fd6-babb-5cb369efdcc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9b8b9a9-1fa0-4fd6-babb-5cb369efdcc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_07-02-2022_39740.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9b8b9a9-1fa0-4fd6-babb-5cb369efdcc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f8ce091-8521-4767-8990-cfe9fb0f1243> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f8ce091-8521-4767-8990-cfe9fb0f1243";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_07-06-2022_40943.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f8ce091-8521-4767-8990-cfe9fb0f1243>.
+    
+<http://data.lblod.info/id/remote-data-objects/a53d79bd-e440-458b-86c4-e35c2ef17283> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a53d79bd-e440-458b-86c4-e35c2ef17283";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_09-05-2022_40686.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a53d79bd-e440-458b-86c4-e35c2ef17283>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b757701-f6ee-4c23-a04b-a0c28d22c061> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b757701-f6ee-4c23-a04b-a0c28d22c061";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_11-04-2022_39944.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b757701-f6ee-4c23-a04b-a0c28d22c061>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e2a5c3b-4a8e-47c9-ba3d-e5157b9e3223> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e2a5c3b-4a8e-47c9-ba3d-e5157b9e3223";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_11-04-2022_40079.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e2a5c3b-4a8e-47c9-ba3d-e5157b9e3223>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2d395ba-60b7-4534-914b-af938fd8a9a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2d395ba-60b7-4534-914b-af938fd8a9a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_11-04-2022_40443.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2d395ba-60b7-4534-914b-af938fd8a9a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e64d770-2ecd-4a44-af20-3eb1267c8f38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e64d770-2ecd-4a44-af20-3eb1267c8f38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_11-10-2021_38323.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e64d770-2ecd-4a44-af20-3eb1267c8f38>.
+    
+<http://data.lblod.info/id/remote-data-objects/facc0110-edac-42d5-bbb3-5afa7d973935> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "facc0110-edac-42d5-bbb3-5afa7d973935";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_11-10-2021_38324.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/facc0110-edac-42d5-bbb3-5afa7d973935>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdcc9c78-9ea1-4ef2-b5ca-ebf159bcc386> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdcc9c78-9ea1-4ef2-b5ca-ebf159bcc386";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_14-02-2022_39672.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdcc9c78-9ea1-4ef2-b5ca-ebf159bcc386>.
+    
+<http://data.lblod.info/id/remote-data-objects/e74d3b67-393e-4d3f-950b-a2ce421c5074> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e74d3b67-393e-4d3f-950b-a2ce421c5074";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_14-02-2022_39796.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e74d3b67-393e-4d3f-950b-a2ce421c5074>.
+    
+<http://data.lblod.info/id/remote-data-objects/d78756de-dda5-42bc-870b-612374c90af8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d78756de-dda5-42bc-870b-612374c90af8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_14-02-2022_39806.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d78756de-dda5-42bc-870b-612374c90af8>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ec84be7-6974-4a25-b34b-8a78f9d3cf7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ec84be7-6974-4a25-b34b-8a78f9d3cf7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_14-02-2022_39810.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ec84be7-6974-4a25-b34b-8a78f9d3cf7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a73f39d3-9d6b-4eac-8a8a-c587438127ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a73f39d3-9d6b-4eac-8a8a-c587438127ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_15-11-2021_38326.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a73f39d3-9d6b-4eac-8a8a-c587438127ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/176d548f-84ae-41f0-9313-5518ddc5224d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "176d548f-84ae-41f0-9313-5518ddc5224d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_17-01-2022_39357.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/176d548f-84ae-41f0-9313-5518ddc5224d>.
+    
+<http://data.lblod.info/id/remote-data-objects/40514eed-722e-4c9d-9a61-3e5c519941bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40514eed-722e-4c9d-9a61-3e5c519941bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_19-04-2022_40493.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40514eed-722e-4c9d-9a61-3e5c519941bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a22745e-f215-4f02-8c39-5bdd95ee7121> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a22745e-f215-4f02-8c39-5bdd95ee7121";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_20-12-2021_39219.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a22745e-f215-4f02-8c39-5bdd95ee7121>.
+    
+<http://data.lblod.info/id/remote-data-objects/f294be30-23d6-453b-b64a-6d6aeb60b589> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f294be30-23d6-453b-b64a-6d6aeb60b589";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_21-02-2022_39866.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f294be30-23d6-453b-b64a-6d6aeb60b589>.
+    
+<http://data.lblod.info/id/remote-data-objects/4647bfb6-fbba-484d-a93e-9b3852bf38e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4647bfb6-fbba-484d-a93e-9b3852bf38e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_21-02-2022_39931.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4647bfb6-fbba-484d-a93e-9b3852bf38e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3ac3671-0e88-4f57-a77f-04e75b6f3405> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3ac3671-0e88-4f57-a77f-04e75b6f3405";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_25-04-2022_40376.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3ac3671-0e88-4f57-a77f-04e75b6f3405>.
+    
+<http://data.lblod.info/id/remote-data-objects/80c8d6d0-23c0-448e-b471-bd6cf03049a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80c8d6d0-23c0-448e-b471-bd6cf03049a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_27-06-2022_40704.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80c8d6d0-23c0-448e-b471-bd6cf03049a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/b65ae682-133f-4bcc-b073-dbab8bd94236> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b65ae682-133f-4bcc-b073-dbab8bd94236";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_27-06-2022_40937.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b65ae682-133f-4bcc-b073-dbab8bd94236>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c1f208d-5116-4b35-88b1-d0bd72e10bde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c1f208d-5116-4b35-88b1-d0bd72e10bde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_28-03-2022_40319.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c1f208d-5116-4b35-88b1-d0bd72e10bde>.
+    
+<http://data.lblod.info/id/remote-data-objects/d39ba772-d649-4959-bc6f-7e12a4d178b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d39ba772-d649-4959-bc6f-7e12a4d178b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_29-11-2021_38976.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d39ba772-d649-4959-bc6f-7e12a4d178b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/25e9a855-ae6e-4522-8162-c535ae9251db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25e9a855-ae6e-4522-8162-c535ae9251db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_30-05-2022_40490.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/389d48bc-10b5-4283-92f9-0a2191397959> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25e9a855-ae6e-4522-8162-c535ae9251db>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201432-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201432-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201432-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201432-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/75f8d46f-3d65-4da7-9f91-013b9701d199> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "75f8d46f-3d65-4da7-9f91-013b9701d199";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3f52a4a2-f2f0-47b8-a496-25b5bbd559bc";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f2e7e974-b631-4ff7-8abf-7750e566d631> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f2e7e974-b631-4ff7-8abf-7750e566d631";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc>.
+
+  <http://redpencil.data.gift/id/task/a691f6a9-9a9d-44bd-bf82-e87bf902cd1a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a691f6a9-9a9d-44bd-bf82-e87bf902cd1a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/75f8d46f-3d65-4da7-9f91-013b9701d199>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f2e7e974-b631-4ff7-8abf-7750e566d631>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/1d85c0d1-6475-4d98-865c-09bd71972058> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d85c0d1-6475-4d98-865c-09bd71972058";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_30-05-2022_40844.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d85c0d1-6475-4d98-865c-09bd71972058>.
+    
+<http://data.lblod.info/id/remote-data-objects/22c54f82-946d-4778-b7b3-9b4e3c552511> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22c54f82-946d-4778-b7b3-9b4e3c552511";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/9b403a3bd0b5775a39caa658cef032009c03a789776f804717027ff727971405/GetPublication?filename=Uittreksels_30-05-2022_40911.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22c54f82-946d-4778-b7b3-9b4e3c552511>.
+    
+<http://data.lblod.info/id/remote-data-objects/69f9c1b1-3c13-4e9e-9707-4731d7a0f259> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69f9c1b1-3c13-4e9e-9707-4731d7a0f259";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Agenda_OCMW%20-%20Raad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69f9c1b1-3c13-4e9e-9707-4731d7a0f259>.
+    
+<http://data.lblod.info/id/remote-data-objects/8204b20a-0dbd-4a53-ad89-fc67e46c8bd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8204b20a-0dbd-4a53-ad89-fc67e46c8bd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Agenda_OCMW%20-%20Raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8204b20a-0dbd-4a53-ad89-fc67e46c8bd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f39827ac-e94c-4327-a366-8b8be6d262d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f39827ac-e94c-4327-a366-8b8be6d262d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Agenda_OCMW%20-%20Raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f39827ac-e94c-4327-a366-8b8be6d262d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0e0b732-f1de-40a0-b329-7e800f8e9879> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0e0b732-f1de-40a0-b329-7e800f8e9879";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Agenda_OCMW%20-%20Raad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0e0b732-f1de-40a0-b329-7e800f8e9879>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8eff062-70d6-4eee-ac0f-e20f6f51e662> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8eff062-70d6-4eee-ac0f-e20f6f51e662";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Agenda_OCMW%20-%20Raad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8eff062-70d6-4eee-ac0f-e20f6f51e662>.
+    
+<http://data.lblod.info/id/remote-data-objects/9849fd53-4e1f-4858-a671-595646461294> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9849fd53-4e1f-4858-a671-595646461294";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=BesluitenLijst_OCMW%20-%20Raad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9849fd53-4e1f-4858-a671-595646461294>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbdbd0ba-a3cf-4c20-91f4-1e969a42ed5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbdbd0ba-a3cf-4c20-91f4-1e969a42ed5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=BesluitenLijst_OCMW%20-%20Raad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbdbd0ba-a3cf-4c20-91f4-1e969a42ed5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c6cc838-ebc4-4df1-9544-76e67d5cf9cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c6cc838-ebc4-4df1-9544-76e67d5cf9cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=BesluitenLijst_OCMW%20-%20Raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c6cc838-ebc4-4df1-9544-76e67d5cf9cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac50a02a-3405-44aa-9e0f-f43af7fe0e83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac50a02a-3405-44aa-9e0f-f43af7fe0e83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=BesluitenLijst_OCMW%20-%20Raad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac50a02a-3405-44aa-9e0f-f43af7fe0e83>.
+    
+<http://data.lblod.info/id/remote-data-objects/c75c0421-b008-4952-8645-e84766b4ebbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c75c0421-b008-4952-8645-e84766b4ebbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=BesluitenLijst_OCMW%20-%20Raad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c75c0421-b008-4952-8645-e84766b4ebbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/efdf0f46-e3fe-488d-b547-4778b4067d00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efdf0f46-e3fe-488d-b547-4778b4067d00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=BesluitenLijst_OCMW%20-%20Raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efdf0f46-e3fe-488d-b547-4778b4067d00>.
+    
+<http://data.lblod.info/id/remote-data-objects/18f1a3d3-656d-4eaf-9b4f-163602e8df24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18f1a3d3-656d-4eaf-9b4f-163602e8df24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=BesluitenLijst_OCMW%20-%20Raad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18f1a3d3-656d-4eaf-9b4f-163602e8df24>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3a04c00-7105-43dd-9516-c9802ccc2026> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3a04c00-7105-43dd-9516-c9802ccc2026";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=BesluitenLijst_OCMW%20-%20Raad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3a04c00-7105-43dd-9516-c9802ccc2026>.
+    
+<http://data.lblod.info/id/remote-data-objects/67c52789-a47f-489c-ba6d-1164a4f8c2c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67c52789-a47f-489c-ba6d-1164a4f8c2c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=BesluitenLijst_OCMW%20-%20Raad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67c52789-a47f-489c-ba6d-1164a4f8c2c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/63f84e10-a8b7-4cce-8f98-11881e59c8ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63f84e10-a8b7-4cce-8f98-11881e59c8ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Notulen_OCMW%20-%20Raad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63f84e10-a8b7-4cce-8f98-11881e59c8ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/df76fe5e-7490-4bce-a0a4-6ae257e898c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df76fe5e-7490-4bce-a0a4-6ae257e898c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Notulen_OCMW%20-%20Raad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df76fe5e-7490-4bce-a0a4-6ae257e898c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd4b206d-ccac-4fd0-88f3-65107cb43096> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd4b206d-ccac-4fd0-88f3-65107cb43096";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Notulen_OCMW%20-%20Raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd4b206d-ccac-4fd0-88f3-65107cb43096>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c3a8a87-f489-40a8-b8ff-8502cd899050> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c3a8a87-f489-40a8-b8ff-8502cd899050";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Notulen_OCMW%20-%20Raad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c3a8a87-f489-40a8-b8ff-8502cd899050>.
+    
+<http://data.lblod.info/id/remote-data-objects/917616dd-8995-4d93-be2a-28e128035c58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "917616dd-8995-4d93-be2a-28e128035c58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Notulen_OCMW%20-%20Raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/917616dd-8995-4d93-be2a-28e128035c58>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2ed2e54-0bef-4097-a45d-d009aabc7037> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2ed2e54-0bef-4097-a45d-d009aabc7037";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Notulen_OCMW%20-%20Raad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2ed2e54-0bef-4097-a45d-d009aabc7037>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fb11bb7-29f5-4031-99c4-ee961d0aa2a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fb11bb7-29f5-4031-99c4-ee961d0aa2a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Notulen_OCMW%20-%20Raad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fb11bb7-29f5-4031-99c4-ee961d0aa2a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c944ed88-bc91-40fe-a91d-a2f8ff82e775> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c944ed88-bc91-40fe-a91d-a2f8ff82e775";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Uittreksels_16-12-2021_39022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c944ed88-bc91-40fe-a91d-a2f8ff82e775>.
+    
+<http://data.lblod.info/id/remote-data-objects/afc42c81-74f7-4b1d-b1b3-1306ee72969a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afc42c81-74f7-4b1d-b1b3-1306ee72969a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Uittreksels_16-12-2021_39112.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afc42c81-74f7-4b1d-b1b3-1306ee72969a>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa0e4c0d-5fd3-4a2d-a73a-d3aa6dfab655> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa0e4c0d-5fd3-4a2d-a73a-d3aa6dfab655";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Uittreksels_24-02-2022_39871.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa0e4c0d-5fd3-4a2d-a73a-d3aa6dfab655>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9fc963c-9e71-42ac-8a2b-5611f68bc894> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9fc963c-9e71-42ac-8a2b-5611f68bc894";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Uittreksels_27-01-2022_39531.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9fc963c-9e71-42ac-8a2b-5611f68bc894>.
+    
+<http://data.lblod.info/id/remote-data-objects/244d3cc0-9688-493c-a947-1ab19e9287cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "244d3cc0-9688-493c-a947-1ab19e9287cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Uittreksels_27-01-2022_39532.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/244d3cc0-9688-493c-a947-1ab19e9287cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf5dc31a-e97f-472f-98ad-733f81bee6c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf5dc31a-e97f-472f-98ad-733f81bee6c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Uittreksels_27-01-2022_39535.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf5dc31a-e97f-472f-98ad-733f81bee6c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/430ece9f-98ec-4b86-812f-0d52a7c5f5fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "430ece9f-98ec-4b86-812f-0d52a7c5f5fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Uittreksels_28-10-2021_38519.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/430ece9f-98ec-4b86-812f-0d52a7c5f5fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/0677adfc-ce7f-412d-8f1a-ca9a027c44e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0677adfc-ce7f-412d-8f1a-ca9a027c44e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Uittreksels_30-06-2022_41051.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0677adfc-ce7f-412d-8f1a-ca9a027c44e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/98fb22a5-34f5-496a-b451-ef565d0e7e46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98fb22a5-34f5-496a-b451-ef565d0e7e46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Uittreksels_30-06-2022_41118.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98fb22a5-34f5-496a-b451-ef565d0e7e46>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ce52b4d-53d1-4dc7-b082-812de715a635> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ce52b4d-53d1-4dc7-b082-812de715a635";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Uittreksels_30-06-2022_41124.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ce52b4d-53d1-4dc7-b082-812de715a635>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2e114ee-a16f-4dc0-b057-6818091e0d2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2e114ee-a16f-4dc0-b057-6818091e0d2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Uittreksels_31-03-2022_40266.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2e114ee-a16f-4dc0-b057-6818091e0d2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b34fe39-e082-4ea7-a1f6-d7bf8bb1a0f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b34fe39-e082-4ea7-a1f6-d7bf8bb1a0f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kaprijke.be/LBLODWeb/Home/Overzicht/a149b9992f4d81366c9af4e7f904507d3d885537f563b81adeecbd261f3896e1/GetPublication?filename=Uittreksels_31-03-2022_40270.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b34fe39-e082-4ea7-a1f6-d7bf8bb1a0f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7d9aef9-03df-470c-a093-f3389950c46a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7d9aef9-03df-470c-a093-f3389950c46a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=Agenda_OCMW-Raad%20(diensten%20en%20schepenen)_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7d9aef9-03df-470c-a093-f3389950c46a>.
+    
+<http://data.lblod.info/id/remote-data-objects/415e50c5-3122-44a5-b2b1-2ee9f9f359eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "415e50c5-3122-44a5-b2b1-2ee9f9f359eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=Agenda_OCMW-Raad%20(diensten%20en%20schepenen)_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/415e50c5-3122-44a5-b2b1-2ee9f9f359eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fb47740-8107-4d9b-91ee-f870904d3f9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fb47740-8107-4d9b-91ee-f870904d3f9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=Agenda_OCMW-Raad%20(diensten%20en%20schepenen)_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fb47740-8107-4d9b-91ee-f870904d3f9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/96dfbe54-bc5d-46f6-96c4-de5bc460c0d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96dfbe54-bc5d-46f6-96c4-de5bc460c0d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=Agenda_OCMW-Raad%20(diensten%20en%20schepenen)_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96dfbe54-bc5d-46f6-96c4-de5bc460c0d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4bb3eb6-5bc0-4113-850b-85b8613c021c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4bb3eb6-5bc0-4113-850b-85b8613c021c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=Agenda_OCMW-Raad%20(diensten%20en%20schepenen)_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4bb3eb6-5bc0-4113-850b-85b8613c021c>.
+    
+<http://data.lblod.info/id/remote-data-objects/94ba4961-de94-4e80-8ac5-dcb9b8a1a4be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94ba4961-de94-4e80-8ac5-dcb9b8a1a4be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=Agenda_OCMW-Raad%20(diensten%20en%20schepenen)_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94ba4961-de94-4e80-8ac5-dcb9b8a1a4be>.
+    
+<http://data.lblod.info/id/remote-data-objects/07dd87e6-2e12-40da-aa17-059edf75a6c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07dd87e6-2e12-40da-aa17-059edf75a6c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=Agenda_OCMW-Raad%20(diensten%20en%20schepenen)_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07dd87e6-2e12-40da-aa17-059edf75a6c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6aee0881-8606-44d7-b97a-149778359cc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6aee0881-8606-44d7-b97a-149778359cc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=BesluitenLijst_OCMW-Raad%20(diensten%20en%20schepenen)_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6aee0881-8606-44d7-b97a-149778359cc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6d4cb8b-2644-4444-9368-6f4ef17a758c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6d4cb8b-2644-4444-9368-6f4ef17a758c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=BesluitenLijst_OCMW-Raad%20(diensten%20en%20schepenen)_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6d4cb8b-2644-4444-9368-6f4ef17a758c>.
+    
+<http://data.lblod.info/id/remote-data-objects/dce05206-9067-428a-8f88-d1053e3f3066> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dce05206-9067-428a-8f88-d1053e3f3066";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=BesluitenLijst_OCMW-Raad%20(diensten%20en%20schepenen)_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dce05206-9067-428a-8f88-d1053e3f3066>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba56e9c7-4094-434d-bc60-bdea87c2406a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba56e9c7-4094-434d-bc60-bdea87c2406a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=BesluitenLijst_OCMW-Raad%20(diensten%20en%20schepenen)_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba56e9c7-4094-434d-bc60-bdea87c2406a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f86a1fb3-0495-4248-86cf-4dae9408f69c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f86a1fb3-0495-4248-86cf-4dae9408f69c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=BesluitenLijst_OCMW-Raad%20(diensten%20en%20schepenen)_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f86a1fb3-0495-4248-86cf-4dae9408f69c>.
+    
+<http://data.lblod.info/id/remote-data-objects/afb64c0a-b919-4dea-978f-5c6e0ef61ec4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afb64c0a-b919-4dea-978f-5c6e0ef61ec4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=BesluitenLijst_OCMW-Raad%20(diensten%20en%20schepenen)_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afb64c0a-b919-4dea-978f-5c6e0ef61ec4>.
+    
+<http://data.lblod.info/id/remote-data-objects/94f6e428-07fe-4443-9a38-f387763ff0e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94f6e428-07fe-4443-9a38-f387763ff0e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=BesluitenLijst_OCMW-Raad%20(diensten%20en%20schepenen)_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94f6e428-07fe-4443-9a38-f387763ff0e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/7164a8ed-1048-4bb5-89e9-8413f357f02f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7164a8ed-1048-4bb5-89e9-8413f357f02f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=Notulen_OCMW-Raad%20(diensten%20en%20schepenen)_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f52a4a2-f2f0-47b8-a496-25b5bbd559bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7164a8ed-1048-4bb5-89e9-8413f357f02f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201433-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201433-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201433-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201433-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a631d72c-18d2-4c92-8948-366c4fe47068> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a631d72c-18d2-4c92-8948-366c4fe47068";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f7a6e044-0cca-4305-b595-2e305d9528f5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/8e3c5376-2ab6-452b-9089-3e58be163a44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8e3c5376-2ab6-452b-9089-3e58be163a44";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5>.
+
+  <http://redpencil.data.gift/id/task/176ecbb8-ae9a-44a1-99fd-9d4bd8021416> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "176ecbb8-ae9a-44a1-99fd-9d4bd8021416";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a631d72c-18d2-4c92-8948-366c4fe47068>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/8e3c5376-2ab6-452b-9089-3e58be163a44>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c7adffcb-56c0-43e6-b505-46583b8476b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7adffcb-56c0-43e6-b505-46583b8476b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=Uittreksels_25-05-2022_77700.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7adffcb-56c0-43e6-b505-46583b8476b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a411a897-258e-4ccc-b4ae-3d4c711a8124> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a411a897-258e-4ccc-b4ae-3d4c711a8124";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=Uittreksels_25-05-2022_77705.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a411a897-258e-4ccc-b4ae-3d4c711a8124>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf2692d1-1c43-40fe-aca9-9a061970571c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf2692d1-1c43-40fe-aca9-9a061970571c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=Uittreksels_30-06-2022_77933.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf2692d1-1c43-40fe-aca9-9a061970571c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1d20446-3d16-4fae-8672-f8f9a8d8eeb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1d20446-3d16-4fae-8672-f8f9a8d8eeb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=Uittreksels_30-06-2022_77934.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1d20446-3d16-4fae-8672-f8f9a8d8eeb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/5adcea45-410b-4cab-8b28-539703e40f88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5adcea45-410b-4cab-8b28-539703e40f88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=Uittreksels_30-06-2022_78246.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5adcea45-410b-4cab-8b28-539703e40f88>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bbf8f69-cc2e-46b6-9ac8-53e7350a44ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bbf8f69-cc2e-46b6-9ac8-53e7350a44ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/07bdb3e28ee4b047f2a0a7514669221a4a6c395bb67afb9eafaab50fb24374c3/GetPublication?filename=Uittreksels_30-06-2022_78402.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bbf8f69-cc2e-46b6-9ac8-53e7350a44ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/c407c8ee-dc17-4d85-9060-63a59437f160> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c407c8ee-dc17-4d85-9060-63a59437f160";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/131aaf1533d212103b7848956a4fa99961fcd7fa03efce4b030b665a1c73ccf8/GetPublication?filename=BesluitenLijst_Burgemeester_31-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c407c8ee-dc17-4d85-9060-63a59437f160>.
+    
+<http://data.lblod.info/id/remote-data-objects/479b7205-3565-45ca-b7ad-622dcc4605dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "479b7205-3565-45ca-b7ad-622dcc4605dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/479b7205-3565-45ca-b7ad-622dcc4605dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff409343-918f-406d-9f45-b6de4a3dc00c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff409343-918f-406d-9f45-b6de4a3dc00c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff409343-918f-406d-9f45-b6de4a3dc00c>.
+    
+<http://data.lblod.info/id/remote-data-objects/993e5aad-debd-49bb-9499-4ddfd0396c9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "993e5aad-debd-49bb-9499-4ddfd0396c9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_03-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/993e5aad-debd-49bb-9499-4ddfd0396c9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bbdcab8-465e-4b5a-a92c-78c20c10ba96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bbdcab8-465e-4b5a-a92c-78c20c10ba96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bbdcab8-465e-4b5a-a92c-78c20c10ba96>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4062b4d-0138-41c1-a5e4-e486f8e0d642> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4062b4d-0138-41c1-a5e4-e486f8e0d642";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_05-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4062b4d-0138-41c1-a5e4-e486f8e0d642>.
+    
+<http://data.lblod.info/id/remote-data-objects/cebd2778-7d45-46d9-8c6b-94949711c7a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cebd2778-7d45-46d9-8c6b-94949711c7a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cebd2778-7d45-46d9-8c6b-94949711c7a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3773405a-719a-43bc-9ef4-83bed8d72b2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3773405a-719a-43bc-9ef4-83bed8d72b2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_07-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3773405a-719a-43bc-9ef4-83bed8d72b2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7553e974-1739-46eb-9830-8bb3c323a5e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7553e974-1739-46eb-9830-8bb3c323a5e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7553e974-1739-46eb-9830-8bb3c323a5e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e8a42a8-760c-4c6d-8e94-aab2aad99e9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e8a42a8-760c-4c6d-8e94-aab2aad99e9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_08-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e8a42a8-760c-4c6d-8e94-aab2aad99e9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1069bb10-c7d2-4778-9b5f-8b6f63e3995f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1069bb10-c7d2-4778-9b5f-8b6f63e3995f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_10-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1069bb10-c7d2-4778-9b5f-8b6f63e3995f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e11fc917-f117-4a06-aa36-5afd8c78a31e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e11fc917-f117-4a06-aa36-5afd8c78a31e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_11-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e11fc917-f117-4a06-aa36-5afd8c78a31e>.
+    
+<http://data.lblod.info/id/remote-data-objects/909f0560-8fdc-4792-a68b-b64ac8183d62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "909f0560-8fdc-4792-a68b-b64ac8183d62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_12-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/909f0560-8fdc-4792-a68b-b64ac8183d62>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4872127-61c4-4142-a1b8-a1e38cb2542f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4872127-61c4-4142-a1b8-a1e38cb2542f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4872127-61c4-4142-a1b8-a1e38cb2542f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c19b306-1160-42aa-ae05-a2ec23677c3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c19b306-1160-42aa-ae05-a2ec23677c3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_14-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c19b306-1160-42aa-ae05-a2ec23677c3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8554801-918b-47f3-b5c1-49efc77f44a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8554801-918b-47f3-b5c1-49efc77f44a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_15-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8554801-918b-47f3-b5c1-49efc77f44a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/16e66f17-e6cd-48b3-808c-41cc0de28242> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16e66f17-e6cd-48b3-808c-41cc0de28242";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16e66f17-e6cd-48b3-808c-41cc0de28242>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd62bc94-5cfa-40f4-aa5f-c1543ef94ad0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd62bc94-5cfa-40f4-aa5f-c1543ef94ad0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_17-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd62bc94-5cfa-40f4-aa5f-c1543ef94ad0>.
+    
+<http://data.lblod.info/id/remote-data-objects/17524b7e-9b42-4ca5-8589-e0391b4dcef8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17524b7e-9b42-4ca5-8589-e0391b4dcef8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17524b7e-9b42-4ca5-8589-e0391b4dcef8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3fc75d7-7054-438b-80f0-a975f1e6b0e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3fc75d7-7054-438b-80f0-a975f1e6b0e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_18-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3fc75d7-7054-438b-80f0-a975f1e6b0e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/800a2dbf-288d-4d52-8a05-a1945d47527d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "800a2dbf-288d-4d52-8a05-a1945d47527d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/800a2dbf-288d-4d52-8a05-a1945d47527d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9968e0ae-83d5-4e8e-b982-c8f681f4eaa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9968e0ae-83d5-4e8e-b982-c8f681f4eaa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_21-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9968e0ae-83d5-4e8e-b982-c8f681f4eaa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e17f9482-249b-421e-b0ea-092bfe98ed43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e17f9482-249b-421e-b0ea-092bfe98ed43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_22-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e17f9482-249b-421e-b0ea-092bfe98ed43>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0c30c4f-f062-4c52-b2d4-ce003f64ab60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0c30c4f-f062-4c52-b2d4-ce003f64ab60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_22-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0c30c4f-f062-4c52-b2d4-ce003f64ab60>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e43e364-3fff-432f-8558-7ced7504162a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e43e364-3fff-432f-8558-7ced7504162a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_22-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e43e364-3fff-432f-8558-7ced7504162a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecf4d1ea-1dda-4fa4-975c-431ef48cecc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecf4d1ea-1dda-4fa4-975c-431ef48cecc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecf4d1ea-1dda-4fa4-975c-431ef48cecc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b81a088-d7d1-44bd-b451-27c4abc1cf20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b81a088-d7d1-44bd-b451-27c4abc1cf20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_24-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b81a088-d7d1-44bd-b451-27c4abc1cf20>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b12505c-0ce0-45da-b080-c7f332acba00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b12505c-0ce0-45da-b080-c7f332acba00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_25-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b12505c-0ce0-45da-b080-c7f332acba00>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5965c34-0e9f-499e-9d69-d80f1f6b39ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5965c34-0e9f-499e-9d69-d80f1f6b39ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_26-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5965c34-0e9f-499e-9d69-d80f1f6b39ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea0debed-e43f-4ccb-abb1-a5de65fbf8e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea0debed-e43f-4ccb-abb1-a5de65fbf8e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea0debed-e43f-4ccb-abb1-a5de65fbf8e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/278926ad-126a-477c-88be-132d6bd16787> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "278926ad-126a-477c-88be-132d6bd16787";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/278926ad-126a-477c-88be-132d6bd16787>.
+    
+<http://data.lblod.info/id/remote-data-objects/80f7a638-3739-4410-9b6e-ffd78101d7f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80f7a638-3739-4410-9b6e-ffd78101d7f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_29-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80f7a638-3739-4410-9b6e-ffd78101d7f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b30a9ed-07e7-4a97-9827-3d05a6a1ea73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b30a9ed-07e7-4a97-9827-3d05a6a1ea73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/20283ce3-2183-4122-bdec-f5f7cb9cef4a/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20(diensten%20en%20schepenen)_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b30a9ed-07e7-4a97-9827-3d05a6a1ea73>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9450ee2-f181-4dfc-a39d-27deadac7ebe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9450ee2-f181-4dfc-a39d-27deadac7ebe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Agenda_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9450ee2-f181-4dfc-a39d-27deadac7ebe>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a2278cb-f90c-416a-a8e8-3f4a54bf779e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a2278cb-f90c-416a-a8e8-3f4a54bf779e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Agenda_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a2278cb-f90c-416a-a8e8-3f4a54bf779e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad9d8b83-1df1-4b4c-ae5a-45a884b7ba49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad9d8b83-1df1-4b4c-ae5a-45a884b7ba49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Agenda_Gemeenteraad_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad9d8b83-1df1-4b4c-ae5a-45a884b7ba49>.
+    
+<http://data.lblod.info/id/remote-data-objects/caf35138-fbdf-435a-976b-0510714963a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "caf35138-fbdf-435a-976b-0510714963a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Agenda_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/caf35138-fbdf-435a-976b-0510714963a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4167b46c-9155-429d-a085-3f4c249e2acd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4167b46c-9155-429d-a085-3f4c249e2acd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Agenda_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4167b46c-9155-429d-a085-3f4c249e2acd>.
+    
+<http://data.lblod.info/id/remote-data-objects/61095134-7234-4caf-86f7-8b47a31cd441> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61095134-7234-4caf-86f7-8b47a31cd441";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Agenda_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61095134-7234-4caf-86f7-8b47a31cd441>.
+    
+<http://data.lblod.info/id/remote-data-objects/b02ce689-9fcf-4600-8397-339e17752fa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b02ce689-9fcf-4600-8397-339e17752fa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Agenda_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b02ce689-9fcf-4600-8397-339e17752fa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae7f5c26-a79e-4512-8b91-97b8fda755ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae7f5c26-a79e-4512-8b91-97b8fda755ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Agenda_Gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae7f5c26-a79e-4512-8b91-97b8fda755ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbbbaf4f-8cef-4d6b-bba6-63cadfc9ba64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbbbaf4f-8cef-4d6b-bba6-63cadfc9ba64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Agenda_Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbbbaf4f-8cef-4d6b-bba6-63cadfc9ba64>.
+    
+<http://data.lblod.info/id/remote-data-objects/8689b5c6-bb55-431b-a8c7-682ca60b2681> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8689b5c6-bb55-431b-a8c7-682ca60b2681";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=BesluitenLijst_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8689b5c6-bb55-431b-a8c7-682ca60b2681>.
+    
+<http://data.lblod.info/id/remote-data-objects/16c0cbe6-6d01-42ea-af41-6f1bb1454194> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16c0cbe6-6d01-42ea-af41-6f1bb1454194";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f7a6e044-0cca-4305-b595-2e305d9528f5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16c0cbe6-6d01-42ea-af41-6f1bb1454194>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201435-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201435-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201435-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201435-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/38d87657-88e7-4c16-bd3c-ad9e04ffc8a8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "38d87657-88e7-4c16-bd3c-ad9e04ffc8a8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ea2aecbc-f420-4f02-a6d7-133abce1f560";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d589fc8c-6d01-46e0-b4c0-abd78ca4776d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d589fc8c-6d01-46e0-b4c0-abd78ca4776d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560>.
+
+  <http://redpencil.data.gift/id/task/6f9792fe-fd52-4390-b3a4-9f3f82599d55> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6f9792fe-fd52-4390-b3a4-9f3f82599d55";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/38d87657-88e7-4c16-bd3c-ad9e04ffc8a8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d589fc8c-6d01-46e0-b4c0-abd78ca4776d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/9fe631e5-9827-4c8f-aa5b-f96d2d102944> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fe631e5-9827-4c8f-aa5b-f96d2d102944";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fe631e5-9827-4c8f-aa5b-f96d2d102944>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e85b51b-dc84-404a-995c-bfbc8a950ef8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e85b51b-dc84-404a-995c-bfbc8a950ef8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e85b51b-dc84-404a-995c-bfbc8a950ef8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a814f1b8-0232-4633-83d9-2ed55dd1b0fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a814f1b8-0232-4633-83d9-2ed55dd1b0fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a814f1b8-0232-4633-83d9-2ed55dd1b0fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/016fc0ac-4e4f-4b37-98fc-f8290a9aa010> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "016fc0ac-4e4f-4b37-98fc-f8290a9aa010";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/016fc0ac-4e4f-4b37-98fc-f8290a9aa010>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0cbf864-f42b-4796-92b8-45f9a28ea8d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0cbf864-f42b-4796-92b8-45f9a28ea8d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0cbf864-f42b-4796-92b8-45f9a28ea8d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a93d4e75-e978-458b-ad02-866bdc47133c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a93d4e75-e978-458b-ad02-866bdc47133c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=BesluitenLijst_Gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a93d4e75-e978-458b-ad02-866bdc47133c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8897766e-3425-4583-a642-7066e5a0ebd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8897766e-3425-4583-a642-7066e5a0ebd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=BesluitenLijst_Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8897766e-3425-4583-a642-7066e5a0ebd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/16d3c6d9-3bbb-46e7-804a-0ab5bba628a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16d3c6d9-3bbb-46e7-804a-0ab5bba628a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_16-12-2021_74599.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16d3c6d9-3bbb-46e7-804a-0ab5bba628a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/498e734d-a731-4422-915b-c12ee9634f44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "498e734d-a731-4422-915b-c12ee9634f44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_16-12-2021_74701.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/498e734d-a731-4422-915b-c12ee9634f44>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e9f930d-ed56-4e63-abee-1a0005e52287> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e9f930d-ed56-4e63-abee-1a0005e52287";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_16-12-2021_74705.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e9f930d-ed56-4e63-abee-1a0005e52287>.
+    
+<http://data.lblod.info/id/remote-data-objects/646c636c-5d32-41fd-b921-98bf7dc128a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "646c636c-5d32-41fd-b921-98bf7dc128a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_16-12-2021_74706.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/646c636c-5d32-41fd-b921-98bf7dc128a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/01a177c1-9286-4db9-ba6b-0b0764790450> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01a177c1-9286-4db9-ba6b-0b0764790450";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_16-12-2021_74708.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01a177c1-9286-4db9-ba6b-0b0764790450>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbdaacc4-1fea-4737-86da-f1bff6584095> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbdaacc4-1fea-4737-86da-f1bff6584095";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_24-02-2022_75908.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbdaacc4-1fea-4737-86da-f1bff6584095>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cb9ce00-d17b-4aa0-8acb-5097a7d35dcf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cb9ce00-d17b-4aa0-8acb-5097a7d35dcf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_25-05-2022_77336.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cb9ce00-d17b-4aa0-8acb-5097a7d35dcf>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ad709a5-3e3f-456b-82e1-124feb2d23bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ad709a5-3e3f-456b-82e1-124feb2d23bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_25-05-2022_77397.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ad709a5-3e3f-456b-82e1-124feb2d23bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/b283185f-bef6-4a7a-8a55-06faf8b73dda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b283185f-bef6-4a7a-8a55-06faf8b73dda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_25-05-2022_77697.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b283185f-bef6-4a7a-8a55-06faf8b73dda>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecc1c3d7-754d-41a0-9464-4cbb32493842> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecc1c3d7-754d-41a0-9464-4cbb32493842";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_25-05-2022_77703.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecc1c3d7-754d-41a0-9464-4cbb32493842>.
+    
+<http://data.lblod.info/id/remote-data-objects/befcdb62-7aec-4585-ba02-41de8853528c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "befcdb62-7aec-4585-ba02-41de8853528c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_25-05-2022_77729.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/befcdb62-7aec-4585-ba02-41de8853528c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6944c03-956d-4f9a-852d-2b7153da89e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6944c03-956d-4f9a-852d-2b7153da89e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_25-11-2021_72738.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6944c03-956d-4f9a-852d-2b7153da89e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cca3b2f-fe5b-4e8f-abcc-8255377769c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cca3b2f-fe5b-4e8f-abcc-8255377769c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_25-11-2021_73867.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cca3b2f-fe5b-4e8f-abcc-8255377769c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b405a1c-1e3e-470a-9e16-2f888ea491a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b405a1c-1e3e-470a-9e16-2f888ea491a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_25-11-2021_73903.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b405a1c-1e3e-470a-9e16-2f888ea491a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/953c6b84-7962-4ec9-b998-c6a0606584af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "953c6b84-7962-4ec9-b998-c6a0606584af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_25-11-2021_74346.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/953c6b84-7962-4ec9-b998-c6a0606584af>.
+    
+<http://data.lblod.info/id/remote-data-objects/f03fe814-741f-4400-9b39-1f370657aad6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f03fe814-741f-4400-9b39-1f370657aad6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_25-11-2021_74360.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f03fe814-741f-4400-9b39-1f370657aad6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae95598d-c520-412e-a3a3-bca629455942> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae95598d-c520-412e-a3a3-bca629455942";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_27-01-2022_75308.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae95598d-c520-412e-a3a3-bca629455942>.
+    
+<http://data.lblod.info/id/remote-data-objects/340dc42e-e49d-476a-9c7f-22b8804019c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "340dc42e-e49d-476a-9c7f-22b8804019c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_27-01-2022_75378.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/340dc42e-e49d-476a-9c7f-22b8804019c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/476ed0ec-6cc9-490a-b388-2f8d4675e0c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "476ed0ec-6cc9-490a-b388-2f8d4675e0c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_27-01-2022_75410.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/476ed0ec-6cc9-490a-b388-2f8d4675e0c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5344c1c-9be6-4e1e-a354-96ec29e6182f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5344c1c-9be6-4e1e-a354-96ec29e6182f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_27-01-2022_75425.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5344c1c-9be6-4e1e-a354-96ec29e6182f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f78ff77d-ba16-4861-a78e-67da32d11cdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f78ff77d-ba16-4861-a78e-67da32d11cdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_28-04-2022_76860.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f78ff77d-ba16-4861-a78e-67da32d11cdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6791d88-da68-41d8-b97c-02fc54721920> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6791d88-da68-41d8-b97c-02fc54721920";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_28-04-2022_76861.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6791d88-da68-41d8-b97c-02fc54721920>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcd12d83-7d8b-418d-ac93-5ea35dc43566> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcd12d83-7d8b-418d-ac93-5ea35dc43566";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_28-04-2022_77043.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcd12d83-7d8b-418d-ac93-5ea35dc43566>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cfc9c0f-4a86-4b0b-a3c8-431f005cdd2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cfc9c0f-4a86-4b0b-a3c8-431f005cdd2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_28-10-2021_73596.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cfc9c0f-4a86-4b0b-a3c8-431f005cdd2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/caca1952-c7f4-4288-bac2-82387752e636> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "caca1952-c7f4-4288-bac2-82387752e636";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_28-10-2021_73598.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/caca1952-c7f4-4288-bac2-82387752e636>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ef6552a-7ee3-4de9-b989-93c830d14d36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ef6552a-7ee3-4de9-b989-93c830d14d36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_28-10-2021_73600.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ef6552a-7ee3-4de9-b989-93c830d14d36>.
+    
+<http://data.lblod.info/id/remote-data-objects/f002e5ae-d4cc-48e4-bea9-f1f341d8424b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f002e5ae-d4cc-48e4-bea9-f1f341d8424b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_28-10-2021_73649.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f002e5ae-d4cc-48e4-bea9-f1f341d8424b>.
+    
+<http://data.lblod.info/id/remote-data-objects/279a1596-304c-4c89-86fc-245249dd5ebb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "279a1596-304c-4c89-86fc-245249dd5ebb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_28-10-2021_73680.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/279a1596-304c-4c89-86fc-245249dd5ebb>.
+    
+<http://data.lblod.info/id/remote-data-objects/08c8b1ca-cacb-4833-b4d2-0c30e3ef9b43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08c8b1ca-cacb-4833-b4d2-0c30e3ef9b43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_28-10-2021_73683.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08c8b1ca-cacb-4833-b4d2-0c30e3ef9b43>.
+    
+<http://data.lblod.info/id/remote-data-objects/10d83ecf-8742-4179-8660-1d5fe67adb49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10d83ecf-8742-4179-8660-1d5fe67adb49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_30-06-2022_77706.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10d83ecf-8742-4179-8660-1d5fe67adb49>.
+    
+<http://data.lblod.info/id/remote-data-objects/44263f35-ba27-48af-bdc3-268713d39f83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44263f35-ba27-48af-bdc3-268713d39f83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_30-06-2022_77869.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44263f35-ba27-48af-bdc3-268713d39f83>.
+    
+<http://data.lblod.info/id/remote-data-objects/0814157d-e004-4120-97b7-2e6a60b30c63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0814157d-e004-4120-97b7-2e6a60b30c63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_30-06-2022_78158.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0814157d-e004-4120-97b7-2e6a60b30c63>.
+    
+<http://data.lblod.info/id/remote-data-objects/8aaf80f8-6c74-492e-bc9a-ee6d72c99de7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8aaf80f8-6c74-492e-bc9a-ee6d72c99de7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_30-06-2022_78229.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8aaf80f8-6c74-492e-bc9a-ee6d72c99de7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d70c9c7a-e4ee-4a38-ad22-47558b2f8529> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d70c9c7a-e4ee-4a38-ad22-47558b2f8529";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_30-06-2022_78254.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d70c9c7a-e4ee-4a38-ad22-47558b2f8529>.
+    
+<http://data.lblod.info/id/remote-data-objects/aefa2a3b-b7db-431f-ba6e-cda4a9fc8561> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aefa2a3b-b7db-431f-ba6e-cda4a9fc8561";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_30-06-2022_78289.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aefa2a3b-b7db-431f-ba6e-cda4a9fc8561>.
+    
+<http://data.lblod.info/id/remote-data-objects/77faf0b2-351d-4094-825c-c70df6d5658d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77faf0b2-351d-4094-825c-c70df6d5658d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_30-06-2022_78348.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77faf0b2-351d-4094-825c-c70df6d5658d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c5b0726-566d-49bc-918e-58ca79c16d73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c5b0726-566d-49bc-918e-58ca79c16d73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_31-03-2022_76421.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c5b0726-566d-49bc-918e-58ca79c16d73>.
+    
+<http://data.lblod.info/id/remote-data-objects/e45c823d-1aaa-4b0e-9ea1-209adbc10cfd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e45c823d-1aaa-4b0e-9ea1-209adbc10cfd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_31-03-2022_76499.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e45c823d-1aaa-4b0e-9ea1-209adbc10cfd>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4d7ca6d-485b-4947-b3d5-887e98304272> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4d7ca6d-485b-4947-b3d5-887e98304272";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_31-03-2022_76534.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4d7ca6d-485b-4947-b3d5-887e98304272>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2dce5cd-00af-4944-8f9e-d666a3784c37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2dce5cd-00af-4944-8f9e-d666a3784c37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/d178a281bd113bf519b2bccd90c01b1eb53468c7e625767edd9f8e37e1600702/GetPublication?filename=Uittreksels_31-03-2022_76654.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2dce5cd-00af-4944-8f9e-d666a3784c37>.
+    
+<http://data.lblod.info/id/remote-data-objects/b178c6f4-3b2a-4d80-8c88-c8dc34fa6b07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b178c6f4-3b2a-4d80-8c88-c8dc34fa6b07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b178c6f4-3b2a-4d80-8c88-c8dc34fa6b07>.
+    
+<http://data.lblod.info/id/remote-data-objects/f483be6c-5e5f-436b-8d0f-cd36f7c1ea4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f483be6c-5e5f-436b-8d0f-cd36f7c1ea4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_01-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f483be6c-5e5f-436b-8d0f-cd36f7c1ea4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c10bfda0-5602-4445-9dc9-4fac67851a57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c10bfda0-5602-4445-9dc9-4fac67851a57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea2aecbc-f420-4f02-a6d7-133abce1f560> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c10bfda0-5602-4445-9dc9-4fac67851a57>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201436-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201436-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201436-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201436-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2548b83f-f797-4048-bee9-eea2ad989057> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2548b83f-f797-4048-bee9-eea2ad989057";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1fe2c1f5-85d5-4038-ac61-733b4ad7e879";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c14ce074-b9d4-45ee-b1d5-2dbff79c5e5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c14ce074-b9d4-45ee-b1d5-2dbff79c5e5e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879>.
+
+  <http://redpencil.data.gift/id/task/a3f2ce49-fc8b-4f13-b343-d0d1e5da4596> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a3f2ce49-fc8b-4f13-b343-d0d1e5da4596";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2548b83f-f797-4048-bee9-eea2ad989057>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c14ce074-b9d4-45ee-b1d5-2dbff79c5e5e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4469b37b-d244-4590-a4d1-f2adf814a30b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4469b37b-d244-4590-a4d1-f2adf814a30b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4469b37b-d244-4590-a4d1-f2adf814a30b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b17d2e24-92fb-436e-92db-e21037baf0a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b17d2e24-92fb-436e-92db-e21037baf0a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_03-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b17d2e24-92fb-436e-92db-e21037baf0a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/416be79c-5b85-4f1b-b17a-b4bd5dcdf33e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "416be79c-5b85-4f1b-b17a-b4bd5dcdf33e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/416be79c-5b85-4f1b-b17a-b4bd5dcdf33e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f081ab63-8aaf-4ce5-910d-ea9f01970b1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f081ab63-8aaf-4ce5-910d-ea9f01970b1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_04-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f081ab63-8aaf-4ce5-910d-ea9f01970b1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f805c443-5f85-4eca-a8c4-7646c55b605a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f805c443-5f85-4eca-a8c4-7646c55b605a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_05-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f805c443-5f85-4eca-a8c4-7646c55b605a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8425b9f6-eb89-4c79-bf15-a882da887f85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8425b9f6-eb89-4c79-bf15-a882da887f85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8425b9f6-eb89-4c79-bf15-a882da887f85>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ab23757-aec9-4433-af33-a3cda2ec8256> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ab23757-aec9-4433-af33-a3cda2ec8256";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_07-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ab23757-aec9-4433-af33-a3cda2ec8256>.
+    
+<http://data.lblod.info/id/remote-data-objects/65dac372-ef67-4202-b990-bb0e85a1b4a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65dac372-ef67-4202-b990-bb0e85a1b4a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_08-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65dac372-ef67-4202-b990-bb0e85a1b4a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/b717aa9f-f6d0-41c9-bf89-84bc1563490e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b717aa9f-f6d0-41c9-bf89-84bc1563490e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b717aa9f-f6d0-41c9-bf89-84bc1563490e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e2d8379-579f-45cd-b969-3f9f8d93ef38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e2d8379-579f-45cd-b969-3f9f8d93ef38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_08-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e2d8379-579f-45cd-b969-3f9f8d93ef38>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a7575de-5fc5-4aa6-8263-407bd89e064f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a7575de-5fc5-4aa6-8263-407bd89e064f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_10-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a7575de-5fc5-4aa6-8263-407bd89e064f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4859e333-248a-4b4f-b6b5-7802bea13330> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4859e333-248a-4b4f-b6b5-7802bea13330";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_10-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4859e333-248a-4b4f-b6b5-7802bea13330>.
+    
+<http://data.lblod.info/id/remote-data-objects/f12f1df9-9bc1-4af6-b90f-ed4210b97808> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f12f1df9-9bc1-4af6-b90f-ed4210b97808";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_11-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f12f1df9-9bc1-4af6-b90f-ed4210b97808>.
+    
+<http://data.lblod.info/id/remote-data-objects/a228453c-fdc2-492f-ad8e-d3e300b5a781> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a228453c-fdc2-492f-ad8e-d3e300b5a781";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_11-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a228453c-fdc2-492f-ad8e-d3e300b5a781>.
+    
+<http://data.lblod.info/id/remote-data-objects/7796efb2-612a-45b0-857e-e4b478be35ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7796efb2-612a-45b0-857e-e4b478be35ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_12-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7796efb2-612a-45b0-857e-e4b478be35ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfef13cc-4a72-4682-93ef-6027c6d8ed3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfef13cc-4a72-4682-93ef-6027c6d8ed3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfef13cc-4a72-4682-93ef-6027c6d8ed3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a48e2334-a792-4a9a-8260-1d2038d76b85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a48e2334-a792-4a9a-8260-1d2038d76b85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_14-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a48e2334-a792-4a9a-8260-1d2038d76b85>.
+    
+<http://data.lblod.info/id/remote-data-objects/cde747bc-9bef-4dac-be25-7db9674f4ce0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cde747bc-9bef-4dac-be25-7db9674f4ce0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_15-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cde747bc-9bef-4dac-be25-7db9674f4ce0>.
+    
+<http://data.lblod.info/id/remote-data-objects/6af2923e-e738-4c53-8cfa-a55d44557c49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6af2923e-e738-4c53-8cfa-a55d44557c49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6af2923e-e738-4c53-8cfa-a55d44557c49>.
+    
+<http://data.lblod.info/id/remote-data-objects/220616c9-20aa-459f-92bd-e9b38d470885> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "220616c9-20aa-459f-92bd-e9b38d470885";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/220616c9-20aa-459f-92bd-e9b38d470885>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8829ea2-8d38-4ad7-94f8-25695a64571e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8829ea2-8d38-4ad7-94f8-25695a64571e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8829ea2-8d38-4ad7-94f8-25695a64571e>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdb8859a-e3a4-4cdc-a382-bc438cdd8c6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdb8859a-e3a4-4cdc-a382-bc438cdd8c6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_17-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdb8859a-e3a4-4cdc-a382-bc438cdd8c6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/65256032-fdfc-4261-9322-55e9c1d974fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65256032-fdfc-4261-9322-55e9c1d974fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65256032-fdfc-4261-9322-55e9c1d974fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dfa65bb-ee0b-4691-bccf-b8849b2f79dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dfa65bb-ee0b-4691-bccf-b8849b2f79dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_18-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dfa65bb-ee0b-4691-bccf-b8849b2f79dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/641ee8e2-890c-49b2-b28a-6c59d5bc1b5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "641ee8e2-890c-49b2-b28a-6c59d5bc1b5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/641ee8e2-890c-49b2-b28a-6c59d5bc1b5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/66ae6883-bb9e-40b4-a95e-8fe61f1702b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66ae6883-bb9e-40b4-a95e-8fe61f1702b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_21-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66ae6883-bb9e-40b4-a95e-8fe61f1702b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0256ec23-a4b9-4903-976a-8026936a5db8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0256ec23-a4b9-4903-976a-8026936a5db8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_22-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0256ec23-a4b9-4903-976a-8026936a5db8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b19121d6-1221-4098-be59-cd04dbf2899d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b19121d6-1221-4098-be59-cd04dbf2899d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_22-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b19121d6-1221-4098-be59-cd04dbf2899d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1a5d3a3-a074-4719-9824-6cdc655bfeae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1a5d3a3-a074-4719-9824-6cdc655bfeae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_22-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1a5d3a3-a074-4719-9824-6cdc655bfeae>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cc78bcd-9d90-4abc-a330-a06969f87487> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cc78bcd-9d90-4abc-a330-a06969f87487";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cc78bcd-9d90-4abc-a330-a06969f87487>.
+    
+<http://data.lblod.info/id/remote-data-objects/a178d972-fd9a-4539-96d6-5cc9af491c21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a178d972-fd9a-4539-96d6-5cc9af491c21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_24-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a178d972-fd9a-4539-96d6-5cc9af491c21>.
+    
+<http://data.lblod.info/id/remote-data-objects/05ae9cd1-44d2-4950-9f53-f9ed50c57f81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05ae9cd1-44d2-4950-9f53-f9ed50c57f81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_25-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05ae9cd1-44d2-4950-9f53-f9ed50c57f81>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa16fff9-bbb7-4457-8104-89a59242ce3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa16fff9-bbb7-4457-8104-89a59242ce3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_25-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa16fff9-bbb7-4457-8104-89a59242ce3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3ae501c-ab5c-49e4-a101-54295ebc37c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3ae501c-ab5c-49e4-a101-54295ebc37c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3ae501c-ab5c-49e4-a101-54295ebc37c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ef3345f-12f3-4e2b-aeba-41a5020b5088> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ef3345f-12f3-4e2b-aeba-41a5020b5088";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_26-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ef3345f-12f3-4e2b-aeba-41a5020b5088>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d2ab2a2-35dd-4bfb-bf54-051f2d00e334> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d2ab2a2-35dd-4bfb-bf54-051f2d00e334";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d2ab2a2-35dd-4bfb-bf54-051f2d00e334>.
+    
+<http://data.lblod.info/id/remote-data-objects/79887554-cbe9-4f4a-abb5-fe769af53cc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79887554-cbe9-4f4a-abb5-fe769af53cc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79887554-cbe9-4f4a-abb5-fe769af53cc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/6884511f-29a1-4d51-9102-9543aefd0186> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6884511f-29a1-4d51-9102-9543aefd0186";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_29-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6884511f-29a1-4d51-9102-9543aefd0186>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d6fbf76-432b-4a04-b5f3-ee2f98d66915> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d6fbf76-432b-4a04-b5f3-ee2f98d66915";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d6fbf76-432b-4a04-b5f3-ee2f98d66915>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ef19896-1ca7-4b97-87d0-e83191ec6755> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ef19896-1ca7-4b97-87d0-e83191ec6755";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=BesluitenLijst_College%20(diensten%20en%20schepenen)_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ef19896-1ca7-4b97-87d0-e83191ec6755>.
+    
+<http://data.lblod.info/id/remote-data-objects/56524b0f-8586-4350-9ea7-25cb3ecf684e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56524b0f-8586-4350-9ea7-25cb3ecf684e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=Uittreksels_01-04-2022_76995.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56524b0f-8586-4350-9ea7-25cb3ecf684e>.
+    
+<http://data.lblod.info/id/remote-data-objects/61e1d84f-b5e2-4fce-b100-52816cdc3739> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61e1d84f-b5e2-4fce-b100-52816cdc3739";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=Uittreksels_01-10-2021_73346.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61e1d84f-b5e2-4fce-b100-52816cdc3739>.
+    
+<http://data.lblod.info/id/remote-data-objects/73f08c06-d83b-4933-96d1-9ca30ec73980> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73f08c06-d83b-4933-96d1-9ca30ec73980";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=Uittreksels_08-07-2022_78763.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73f08c06-d83b-4933-96d1-9ca30ec73980>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cdacc57-f157-48db-ad70-d7079b7595a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cdacc57-f157-48db-ad70-d7079b7595a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=Uittreksels_08-07-2022_78766.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cdacc57-f157-48db-ad70-d7079b7595a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7eec696-298c-40a1-bff4-e936b13fc306> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7eec696-298c-40a1-bff4-e936b13fc306";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=Uittreksels_10-06-2022_78221.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7eec696-298c-40a1-bff4-e936b13fc306>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c75cde3-9550-4efe-b000-45d09cb36f97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c75cde3-9550-4efe-b000-45d09cb36f97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=Uittreksels_18-02-2022_75983.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c75cde3-9550-4efe-b000-45d09cb36f97>.
+    
+<http://data.lblod.info/id/remote-data-objects/a79d91ad-b301-4a2c-ae62-8e03077361f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a79d91ad-b301-4a2c-ae62-8e03077361f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=Uittreksels_24-06-2022_78394.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a79d91ad-b301-4a2c-ae62-8e03077361f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/00171dba-6cfd-49a3-ba3f-43402cf41d2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00171dba-6cfd-49a3-ba3f-43402cf41d2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=Uittreksels_29-04-2022_77382.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00171dba-6cfd-49a3-ba3f-43402cf41d2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5848a27a-94a2-4013-86a0-9f927508dc96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5848a27a-94a2-4013-86a0-9f927508dc96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.knokke-heist.be/LBLODWeb/Home/Overzicht/e713c9c881ab4545aadab052a15a0a2a5cb63cc15f9e309d741ad45bf71fe76b/GetPublication?filename=Uittreksels_29-07-2022_79242.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5848a27a-94a2-4013-86a0-9f927508dc96>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fdd9a2e-b20e-4088-972e-695316701167> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fdd9a2e-b20e-4088-972e-695316701167";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Agenda_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1fe2c1f5-85d5-4038-ac61-733b4ad7e879> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fdd9a2e-b20e-4088-972e-695316701167>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201437-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201437-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201437-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201437-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7301c521-67d6-4662-9ece-7d1dc97077f1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7301c521-67d6-4662-9ece-7d1dc97077f1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "05f762eb-e00e-48a9-8f09-9bf7ac8b70a4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/37e51efa-00c3-4c8f-9d89-7f8218cfdec4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "37e51efa-00c3-4c8f-9d89-7f8218cfdec4";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4>.
+
+  <http://redpencil.data.gift/id/task/6a91d7c8-5a67-4c65-85b4-bbf37e3060f4> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6a91d7c8-5a67-4c65-85b4-bbf37e3060f4";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7301c521-67d6-4662-9ece-7d1dc97077f1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/37e51efa-00c3-4c8f-9d89-7f8218cfdec4>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/645629ae-b611-487a-8a2f-bb566354d447> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "645629ae-b611-487a-8a2f-bb566354d447";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Agenda_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/645629ae-b611-487a-8a2f-bb566354d447>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c5bec9b-26b1-4070-9644-ad69b42e65e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c5bec9b-26b1-4070-9644-ad69b42e65e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Agenda_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c5bec9b-26b1-4070-9644-ad69b42e65e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3840dcb4-9efe-4b03-8d8b-3494a1e3d1a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3840dcb4-9efe-4b03-8d8b-3494a1e3d1a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Agenda_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3840dcb4-9efe-4b03-8d8b-3494a1e3d1a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a31bf741-9ee8-42f1-a73a-c9caa443f150> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a31bf741-9ee8-42f1-a73a-c9caa443f150";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Agenda_Gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a31bf741-9ee8-42f1-a73a-c9caa443f150>.
+    
+<http://data.lblod.info/id/remote-data-objects/13c4a627-d6cc-46f9-bdc2-87d7f6d73d6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13c4a627-d6cc-46f9-bdc2-87d7f6d73d6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Agenda_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13c4a627-d6cc-46f9-bdc2-87d7f6d73d6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/79c227c0-535d-4569-959c-39042ec60299> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79c227c0-535d-4569-959c-39042ec60299";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Agenda_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79c227c0-535d-4569-959c-39042ec60299>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6606d73-2af0-45c0-bed9-645fe43971ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6606d73-2af0-45c0-bed9-645fe43971ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Agenda_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6606d73-2af0-45c0-bed9-645fe43971ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd6605c9-3da2-415d-97a3-bb27afb45b56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd6605c9-3da2-415d-97a3-bb27afb45b56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=BesluitenLijst_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd6605c9-3da2-415d-97a3-bb27afb45b56>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f39a907-c16a-4d1d-b2c5-69fbd0f810f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f39a907-c16a-4d1d-b2c5-69fbd0f810f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f39a907-c16a-4d1d-b2c5-69fbd0f810f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/01ae5e5f-adf1-414e-a256-984fd3e4f18d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01ae5e5f-adf1-414e-a256-984fd3e4f18d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01ae5e5f-adf1-414e-a256-984fd3e4f18d>.
+    
+<http://data.lblod.info/id/remote-data-objects/00734932-2335-4c04-825c-0658a5dc5059> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00734932-2335-4c04-825c-0658a5dc5059";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00734932-2335-4c04-825c-0658a5dc5059>.
+    
+<http://data.lblod.info/id/remote-data-objects/50d05188-7b9e-426c-a8e5-53d10795467a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50d05188-7b9e-426c-a8e5-53d10795467a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50d05188-7b9e-426c-a8e5-53d10795467a>.
+    
+<http://data.lblod.info/id/remote-data-objects/14d0d073-3880-4cee-b41a-a8a05504cc23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14d0d073-3880-4cee-b41a-a8a05504cc23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14d0d073-3880-4cee-b41a-a8a05504cc23>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a791987-c946-4447-a86d-28e2969758be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a791987-c946-4447-a86d-28e2969758be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a791987-c946-4447-a86d-28e2969758be>.
+    
+<http://data.lblod.info/id/remote-data-objects/84fe8d20-8900-4622-a098-99c89e258d0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84fe8d20-8900-4622-a098-99c89e258d0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84fe8d20-8900-4622-a098-99c89e258d0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4772b05-7478-40e3-b7ce-3e9b833e447b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4772b05-7478-40e3-b7ce-3e9b833e447b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Notulen_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4772b05-7478-40e3-b7ce-3e9b833e447b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c8b4aac-e117-44ba-a3a5-224dc38c626c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c8b4aac-e117-44ba-a3a5-224dc38c626c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Notulen_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c8b4aac-e117-44ba-a3a5-224dc38c626c>.
+    
+<http://data.lblod.info/id/remote-data-objects/46e52968-d81e-4aaf-b1c9-5ead2e179098> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46e52968-d81e-4aaf-b1c9-5ead2e179098";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Notulen_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46e52968-d81e-4aaf-b1c9-5ead2e179098>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9fdea7e-c21c-4909-a9d2-d2c708218cb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9fdea7e-c21c-4909-a9d2-d2c708218cb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Notulen_Gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9fdea7e-c21c-4909-a9d2-d2c708218cb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/0214043d-fe89-4ba1-a5d8-f8ada0fd2cce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0214043d-fe89-4ba1-a5d8-f8ada0fd2cce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Notulen_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0214043d-fe89-4ba1-a5d8-f8ada0fd2cce>.
+    
+<http://data.lblod.info/id/remote-data-objects/f76fdf5b-5174-4886-a715-758cc24686f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f76fdf5b-5174-4886-a715-758cc24686f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Notulen_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f76fdf5b-5174-4886-a715-758cc24686f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e022c9ce-8e60-4481-b212-9f2128ac57f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e022c9ce-8e60-4481-b212-9f2128ac57f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Notulen_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e022c9ce-8e60-4481-b212-9f2128ac57f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c62d29e-1d77-4a99-99a3-3ef913175795> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c62d29e-1d77-4a99-99a3-3ef913175795";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_11700.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c62d29e-1d77-4a99-99a3-3ef913175795>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e018621-3cf8-4c0a-9976-a3c639e11ea9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e018621-3cf8-4c0a-9976-a3c639e11ea9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14216.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e018621-3cf8-4c0a-9976-a3c639e11ea9>.
+    
+<http://data.lblod.info/id/remote-data-objects/aca76641-0d85-48de-9dc7-8af53cada9f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aca76641-0d85-48de-9dc7-8af53cada9f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14238.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aca76641-0d85-48de-9dc7-8af53cada9f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc8eca97-7d2e-4bb3-8108-663c28a6a2df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc8eca97-7d2e-4bb3-8108-663c28a6a2df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14244.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc8eca97-7d2e-4bb3-8108-663c28a6a2df>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9e80f11-7c8b-49c7-a143-e5b7336f45ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9e80f11-7c8b-49c7-a143-e5b7336f45ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14272.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9e80f11-7c8b-49c7-a143-e5b7336f45ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/c84b7e43-df89-4bef-80cb-e4b3f1972eef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c84b7e43-df89-4bef-80cb-e4b3f1972eef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14275.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c84b7e43-df89-4bef-80cb-e4b3f1972eef>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3ec4911-9ad1-4d6a-aa76-506038574c19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3ec4911-9ad1-4d6a-aa76-506038574c19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14338.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3ec4911-9ad1-4d6a-aa76-506038574c19>.
+    
+<http://data.lblod.info/id/remote-data-objects/78a8f0ea-8c20-4380-b419-18bcaa9355c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78a8f0ea-8c20-4380-b419-18bcaa9355c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14393.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78a8f0ea-8c20-4380-b419-18bcaa9355c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/04a6d03e-89f7-46ec-81a5-d47bf8bbc32f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04a6d03e-89f7-46ec-81a5-d47bf8bbc32f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14435.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04a6d03e-89f7-46ec-81a5-d47bf8bbc32f>.
+    
+<http://data.lblod.info/id/remote-data-objects/750bf42d-8c74-4516-b319-798770d91aa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "750bf42d-8c74-4516-b319-798770d91aa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14492.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/750bf42d-8c74-4516-b319-798770d91aa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c51de586-9710-4773-8f6b-e9ecee99e8dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c51de586-9710-4773-8f6b-e9ecee99e8dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14497.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c51de586-9710-4773-8f6b-e9ecee99e8dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/e652fd20-f940-46db-8a0e-cb340764cd5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e652fd20-f940-46db-8a0e-cb340764cd5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14500.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e652fd20-f940-46db-8a0e-cb340764cd5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6af6c78e-0657-4b88-b645-d73e853ef79a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6af6c78e-0657-4b88-b645-d73e853ef79a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14503.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6af6c78e-0657-4b88-b645-d73e853ef79a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d95cc3b-90e4-458f-9b67-5a202e10de7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d95cc3b-90e4-458f-9b67-5a202e10de7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14542.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d95cc3b-90e4-458f-9b67-5a202e10de7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/927bfd74-fcf0-4430-8f58-55117f56b2f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "927bfd74-fcf0-4430-8f58-55117f56b2f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14544.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/927bfd74-fcf0-4430-8f58-55117f56b2f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/41bcc3ed-508a-4b78-b913-f7ed53693daa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41bcc3ed-508a-4b78-b913-f7ed53693daa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14547.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41bcc3ed-508a-4b78-b913-f7ed53693daa>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cf23918-3068-488c-8ae5-5932c5f8aee6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cf23918-3068-488c-8ae5-5932c5f8aee6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14563.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cf23918-3068-488c-8ae5-5932c5f8aee6>.
+    
+<http://data.lblod.info/id/remote-data-objects/4113eadb-0cd7-4796-a1e4-41ffc9db4012> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4113eadb-0cd7-4796-a1e4-41ffc9db4012";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14564.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4113eadb-0cd7-4796-a1e4-41ffc9db4012>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e4bdaf2-6351-4887-9970-a79e1a3d9a8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e4bdaf2-6351-4887-9970-a79e1a3d9a8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14565.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e4bdaf2-6351-4887-9970-a79e1a3d9a8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/56344dc8-6ae6-49ff-93d0-aa9bd8f94742> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56344dc8-6ae6-49ff-93d0-aa9bd8f94742";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14569.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56344dc8-6ae6-49ff-93d0-aa9bd8f94742>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8dbe948-e088-44ea-a72a-24c72e2e0d71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8dbe948-e088-44ea-a72a-24c72e2e0d71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14571.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8dbe948-e088-44ea-a72a-24c72e2e0d71>.
+    
+<http://data.lblod.info/id/remote-data-objects/17e51018-dc8e-4050-9a7f-16f3b76860d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17e51018-dc8e-4050-9a7f-16f3b76860d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14573.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17e51018-dc8e-4050-9a7f-16f3b76860d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0802ee1d-c4f3-445e-90ea-79a8421df9b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0802ee1d-c4f3-445e-90ea-79a8421df9b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14574.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0802ee1d-c4f3-445e-90ea-79a8421df9b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/585094eb-4a9c-4962-8f8f-4de6c60ac089> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "585094eb-4a9c-4962-8f8f-4de6c60ac089";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14584.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/585094eb-4a9c-4962-8f8f-4de6c60ac089>.
+    
+<http://data.lblod.info/id/remote-data-objects/b95a5f8e-178b-491e-9eca-ba5af2dbcf40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b95a5f8e-178b-491e-9eca-ba5af2dbcf40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14586.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b95a5f8e-178b-491e-9eca-ba5af2dbcf40>.
+    
+<http://data.lblod.info/id/remote-data-objects/4090b23e-8f28-460c-a511-7d07b2de64b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4090b23e-8f28-460c-a511-7d07b2de64b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14588.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4090b23e-8f28-460c-a511-7d07b2de64b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/01fc2e3b-4552-4fb7-8ea2-8f0c8d4d0a93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01fc2e3b-4552-4fb7-8ea2-8f0c8d4d0a93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_16-12-2021_14591.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01fc2e3b-4552-4fb7-8ea2-8f0c8d4d0a93>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d2a796a-66c9-4b3d-8cd3-4a8d6d61a0d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d2a796a-66c9-4b3d-8cd3-4a8d6d61a0d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_23-06-2022_15852.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/05f762eb-e00e-48a9-8f09-9bf7ac8b70a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d2a796a-66c9-4b3d-8cd3-4a8d6d61a0d0>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201438-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201438-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201438-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201438-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/ecb9e3e2-4178-4e35-85e2-11b031b25330> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ecb9e3e2-4178-4e35-85e2-11b031b25330";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "df958041-93fa-41f5-ace6-2f8049aba540";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c77d525c-149f-4847-88ff-68825495546f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c77d525c-149f-4847-88ff-68825495546f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540>.
+
+  <http://redpencil.data.gift/id/task/e9fdad4f-8b89-42df-90a0-b3b624bcf12b> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e9fdad4f-8b89-42df-90a0-b3b624bcf12b";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/ecb9e3e2-4178-4e35-85e2-11b031b25330>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c77d525c-149f-4847-88ff-68825495546f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/ca06f37c-016b-4e5e-9ac1-29a4ff76cf0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca06f37c-016b-4e5e-9ac1-29a4ff76cf0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_23-06-2022_15993.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca06f37c-016b-4e5e-9ac1-29a4ff76cf0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e5fbb3a-f735-48a5-b939-4fd3fddc4835> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e5fbb3a-f735-48a5-b939-4fd3fddc4835";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_23-06-2022_15996.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e5fbb3a-f735-48a5-b939-4fd3fddc4835>.
+    
+<http://data.lblod.info/id/remote-data-objects/f18fbdb7-6249-4150-996c-d8c04b46f78c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f18fbdb7-6249-4150-996c-d8c04b46f78c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_24-02-2022_15029.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f18fbdb7-6249-4150-996c-d8c04b46f78c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9db13ad0-8eee-4d77-ad41-b3c65594a11b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9db13ad0-8eee-4d77-ad41-b3c65594a11b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_24-02-2022_15036.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9db13ad0-8eee-4d77-ad41-b3c65594a11b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1dbcfba-f1a4-4c07-8631-5963f7548077> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1dbcfba-f1a4-4c07-8631-5963f7548077";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_24-02-2022_15090.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1dbcfba-f1a4-4c07-8631-5963f7548077>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a2c24e4-8a98-4265-ab6a-e10baf2073f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a2c24e4-8a98-4265-ab6a-e10baf2073f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_24-02-2022_15109.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a2c24e4-8a98-4265-ab6a-e10baf2073f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/838e4b7a-5dda-4beb-b8a3-1725e34a0e8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "838e4b7a-5dda-4beb-b8a3-1725e34a0e8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_24-03-2022_15240.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/838e4b7a-5dda-4beb-b8a3-1725e34a0e8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffb8e1d9-90d4-4a4b-8762-4140a6c43ef1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffb8e1d9-90d4-4a4b-8762-4140a6c43ef1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_24-03-2022_15307.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffb8e1d9-90d4-4a4b-8762-4140a6c43ef1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3df86ac-32d9-4249-9ac0-a51e0fef4fdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3df86ac-32d9-4249-9ac0-a51e0fef4fdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_24-03-2022_15325.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3df86ac-32d9-4249-9ac0-a51e0fef4fdf>.
+    
+<http://data.lblod.info/id/remote-data-objects/c639825d-81a3-4ba9-86fe-82c80ab83e83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c639825d-81a3-4ba9-86fe-82c80ab83e83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_24-03-2022_15335.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c639825d-81a3-4ba9-86fe-82c80ab83e83>.
+    
+<http://data.lblod.info/id/remote-data-objects/eab3aa4e-5ac2-463f-9504-96b76a898b5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eab3aa4e-5ac2-463f-9504-96b76a898b5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_24-03-2022_15350.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eab3aa4e-5ac2-463f-9504-96b76a898b5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/63851cbe-fd67-428e-8c09-2cc70c70e727> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63851cbe-fd67-428e-8c09-2cc70c70e727";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_24-05-2022_15725.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63851cbe-fd67-428e-8c09-2cc70c70e727>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4304c35-83f3-4536-8e5b-d66d728ab2fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4304c35-83f3-4536-8e5b-d66d728ab2fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_24-05-2022_15848.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4304c35-83f3-4536-8e5b-d66d728ab2fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/b11087fe-0524-406e-824f-67a0550ab273> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b11087fe-0524-406e-824f-67a0550ab273";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_24-05-2022_15849.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b11087fe-0524-406e-824f-67a0550ab273>.
+    
+<http://data.lblod.info/id/remote-data-objects/e19c3b26-2334-4897-bf4d-83a0f3c76f67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e19c3b26-2334-4897-bf4d-83a0f3c76f67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_27-01-2022_14767.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e19c3b26-2334-4897-bf4d-83a0f3c76f67>.
+    
+<http://data.lblod.info/id/remote-data-objects/115ce9c3-9a14-475e-aa66-25036c509bce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "115ce9c3-9a14-475e-aa66-25036c509bce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_28-04-2022_15457.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/115ce9c3-9a14-475e-aa66-25036c509bce>.
+    
+<http://data.lblod.info/id/remote-data-objects/486f5cbc-92fa-40ee-9c80-46b7b5074a9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "486f5cbc-92fa-40ee-9c80-46b7b5074a9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_28-10-2021_14156.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/486f5cbc-92fa-40ee-9c80-46b7b5074a9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/aee11b08-e64d-40c7-b63f-79079a6ff44b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aee11b08-e64d-40c7-b63f-79079a6ff44b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/1a8063f37f467f9ff318fa60ba9c4e780a24872e5113ca12ec2d2489841b4d10/GetPublication?filename=Uittreksels_28-10-2021_14257.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aee11b08-e64d-40c7-b63f-79079a6ff44b>.
+    
+<http://data.lblod.info/id/remote-data-objects/59ab8ef7-f155-4e56-8437-008ec82e5299> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59ab8ef7-f155-4e56-8437-008ec82e5299";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Agenda_OCMW-raad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59ab8ef7-f155-4e56-8437-008ec82e5299>.
+    
+<http://data.lblod.info/id/remote-data-objects/13c08a2b-2878-4aa9-ad8a-82e62ad7703a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13c08a2b-2878-4aa9-ad8a-82e62ad7703a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Agenda_OCMW-raad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13c08a2b-2878-4aa9-ad8a-82e62ad7703a>.
+    
+<http://data.lblod.info/id/remote-data-objects/749a0f5f-a416-482d-8e07-9e7e4d891ff2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "749a0f5f-a416-482d-8e07-9e7e4d891ff2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Agenda_OCMW-raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/749a0f5f-a416-482d-8e07-9e7e4d891ff2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b787520-aac7-433d-9981-2616678afec0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b787520-aac7-433d-9981-2616678afec0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Agenda_OCMW-raad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b787520-aac7-433d-9981-2616678afec0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c41134db-f6b9-4159-908a-9508196f4fcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c41134db-f6b9-4159-908a-9508196f4fcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Agenda_OCMW-raad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c41134db-f6b9-4159-908a-9508196f4fcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/30badd81-7492-455a-b34a-7a4d6541d5f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30badd81-7492-455a-b34a-7a4d6541d5f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Agenda_OCMW-raad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30badd81-7492-455a-b34a-7a4d6541d5f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/80521746-4e1f-480d-9841-c143db3dc47c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80521746-4e1f-480d-9841-c143db3dc47c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Agenda_OCMW-raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80521746-4e1f-480d-9841-c143db3dc47c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a741a80-bef8-4a7e-91a4-f6e7c98b918e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a741a80-bef8-4a7e-91a4-f6e7c98b918e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Agenda_OCMW-raad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a741a80-bef8-4a7e-91a4-f6e7c98b918e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d0d61fc-8be5-4491-8de8-cda50723df41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d0d61fc-8be5-4491-8de8-cda50723df41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=BesluitenLijst_OCMW-raad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d0d61fc-8be5-4491-8de8-cda50723df41>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfe3f14e-816f-4ce1-8ab4-fdceca8ea82f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfe3f14e-816f-4ce1-8ab4-fdceca8ea82f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=BesluitenLijst_OCMW-raad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfe3f14e-816f-4ce1-8ab4-fdceca8ea82f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f85f5695-02ed-49db-804c-10e70c37963b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f85f5695-02ed-49db-804c-10e70c37963b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=BesluitenLijst_OCMW-raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f85f5695-02ed-49db-804c-10e70c37963b>.
+    
+<http://data.lblod.info/id/remote-data-objects/39dd617d-9f81-4414-a27e-41d0572750c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39dd617d-9f81-4414-a27e-41d0572750c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=BesluitenLijst_OCMW-raad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39dd617d-9f81-4414-a27e-41d0572750c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0e9772c-1dfa-48bd-b0b5-083560428d48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0e9772c-1dfa-48bd-b0b5-083560428d48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=BesluitenLijst_OCMW-raad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0e9772c-1dfa-48bd-b0b5-083560428d48>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a73a792-92a1-4924-84aa-e4790f95c98e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a73a792-92a1-4924-84aa-e4790f95c98e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=BesluitenLijst_OCMW-raad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a73a792-92a1-4924-84aa-e4790f95c98e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c0297a4-7d3b-4bd6-a0ae-2e202262451e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c0297a4-7d3b-4bd6-a0ae-2e202262451e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=BesluitenLijst_OCMW-raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c0297a4-7d3b-4bd6-a0ae-2e202262451e>.
+    
+<http://data.lblod.info/id/remote-data-objects/15391468-03a4-4649-92b6-a50bd7d40345> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15391468-03a4-4649-92b6-a50bd7d40345";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=BesluitenLijst_OCMW-raad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15391468-03a4-4649-92b6-a50bd7d40345>.
+    
+<http://data.lblod.info/id/remote-data-objects/acaf2b9d-849f-486a-aecb-7f2dc40102bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acaf2b9d-849f-486a-aecb-7f2dc40102bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Notulen_OCMW-raad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acaf2b9d-849f-486a-aecb-7f2dc40102bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1d368a8-9b11-44bc-866b-5b795b72f851> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1d368a8-9b11-44bc-866b-5b795b72f851";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Notulen_OCMW-raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1d368a8-9b11-44bc-866b-5b795b72f851>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ea28447-4a6b-4057-a5f6-a5c9cfeda6c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ea28447-4a6b-4057-a5f6-a5c9cfeda6c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Notulen_OCMW-raad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ea28447-4a6b-4057-a5f6-a5c9cfeda6c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf5614bd-7934-48cd-a54a-44fa0b921213> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf5614bd-7934-48cd-a54a-44fa0b921213";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Notulen_OCMW-raad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf5614bd-7934-48cd-a54a-44fa0b921213>.
+    
+<http://data.lblod.info/id/remote-data-objects/6150af12-b300-45b5-8778-8f155e881221> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6150af12-b300-45b5-8778-8f155e881221";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Notulen_OCMW-raad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6150af12-b300-45b5-8778-8f155e881221>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d93c1e3-05c0-464f-a7d7-e751ab214951> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d93c1e3-05c0-464f-a7d7-e751ab214951";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Notulen_OCMW-raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d93c1e3-05c0-464f-a7d7-e751ab214951>.
+    
+<http://data.lblod.info/id/remote-data-objects/057e65ef-4b09-4155-9006-a126e74bde39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "057e65ef-4b09-4155-9006-a126e74bde39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Notulen_OCMW-raad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/057e65ef-4b09-4155-9006-a126e74bde39>.
+    
+<http://data.lblod.info/id/remote-data-objects/4343f0c3-ce08-4ba9-a330-efdc118c4d85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4343f0c3-ce08-4ba9-a330-efdc118c4d85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Uittreksels_16-12-2021_14551.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4343f0c3-ce08-4ba9-a330-efdc118c4d85>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8fe2dfb-4941-4ce3-b5ee-fe29d20615d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8fe2dfb-4941-4ce3-b5ee-fe29d20615d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Uittreksels_16-12-2021_14552.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8fe2dfb-4941-4ce3-b5ee-fe29d20615d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/42209d44-b7eb-4cf4-a966-c2aa839602d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42209d44-b7eb-4cf4-a966-c2aa839602d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Uittreksels_16-12-2021_14562.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42209d44-b7eb-4cf4-a966-c2aa839602d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/36326186-5469-471a-8d22-0eb3c07e5d8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36326186-5469-471a-8d22-0eb3c07e5d8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Uittreksels_23-06-2022_15998.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36326186-5469-471a-8d22-0eb3c07e5d8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7e42cc5-6bd4-4d7b-b1ea-a52c19c5525c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7e42cc5-6bd4-4d7b-b1ea-a52c19c5525c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/240098e5071df8100b72a3a226d18c9a6d71d365ddaa9a18440eb77e40296c84/GetPublication?filename=Uittreksels_24-02-2022_15099.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7e42cc5-6bd4-4d7b-b1ea-a52c19c5525c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8174426-6d48-4c79-9b12-e36e8fce273d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8174426-6d48-4c79-9b12-e36e8fce273d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/9aac7ca0316f2d51ddcd7b5f5cff8fb248a10e462c4ea6fbcb3ca50960aa7260/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8174426-6d48-4c79-9b12-e36e8fce273d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a97e5fe-54bb-4d9c-8d9f-1589613f2ad5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a97e5fe-54bb-4d9c-8d9f-1589613f2ad5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/9aac7ca0316f2d51ddcd7b5f5cff8fb248a10e462c4ea6fbcb3ca50960aa7260/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a97e5fe-54bb-4d9c-8d9f-1589613f2ad5>.
+    
+<http://data.lblod.info/id/remote-data-objects/886ff299-5796-49bf-b672-28d5e8a08b5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "886ff299-5796-49bf-b672-28d5e8a08b5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/886ff299-5796-49bf-b672-28d5e8a08b5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a1b9424-4cfe-40c5-a979-a44d4a0df9ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a1b9424-4cfe-40c5-a979-a44d4a0df9ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/df958041-93fa-41f5-ace6-2f8049aba540> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a1b9424-4cfe-40c5-a979-a44d4a0df9ad>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201440-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201440-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201440-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201440-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/afb94cfd-6504-4a53-9255-a79d296fa298> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "afb94cfd-6504-4a53-9255-a79d296fa298";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b40e27e7-d3da-4afb-86db-3307efe6422c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/18ac54b3-5dd8-426d-9560-0f5154eae51c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "18ac54b3-5dd8-426d-9560-0f5154eae51c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c>.
+
+  <http://redpencil.data.gift/id/task/fb5a2e39-2f2e-4226-bd12-1c542330b5c4> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fb5a2e39-2f2e-4226-bd12-1c542330b5c4";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/afb94cfd-6504-4a53-9255-a79d296fa298>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/18ac54b3-5dd8-426d-9560-0f5154eae51c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/6e821839-7431-43f4-bae5-b8257fcdded5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e821839-7431-43f4-bae5-b8257fcdded5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e821839-7431-43f4-bae5-b8257fcdded5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f61c8f6-fe1a-401f-acb1-5cf9b42efa9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f61c8f6-fe1a-401f-acb1-5cf9b42efa9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f61c8f6-fe1a-401f-acb1-5cf9b42efa9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8896824-11cc-446f-a381-4368b1ae287b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8896824-11cc-446f-a381-4368b1ae287b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8896824-11cc-446f-a381-4368b1ae287b>.
+    
+<http://data.lblod.info/id/remote-data-objects/47b505c2-ec04-4bae-8597-f4b40cfd7d94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47b505c2-ec04-4bae-8597-f4b40cfd7d94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47b505c2-ec04-4bae-8597-f4b40cfd7d94>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9edf0f0-973b-4ec3-b586-365ca07fabb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9edf0f0-973b-4ec3-b586-365ca07fabb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9edf0f0-973b-4ec3-b586-365ca07fabb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/11e451f1-0afc-4487-8268-faa84843935d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11e451f1-0afc-4487-8268-faa84843935d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11e451f1-0afc-4487-8268-faa84843935d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b807666b-8c71-404e-8bec-ff86fca92435> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b807666b-8c71-404e-8bec-ff86fca92435";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b807666b-8c71-404e-8bec-ff86fca92435>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f664bdd-83a1-4d7b-a224-6c5b1fac7194> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f664bdd-83a1-4d7b-a224-6c5b1fac7194";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f664bdd-83a1-4d7b-a224-6c5b1fac7194>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fefaed1-93c7-4b02-9726-f42653eb594e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fefaed1-93c7-4b02-9726-f42653eb594e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fefaed1-93c7-4b02-9726-f42653eb594e>.
+    
+<http://data.lblod.info/id/remote-data-objects/639440dc-259b-43af-bd3d-68601402a3d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "639440dc-259b-43af-bd3d-68601402a3d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_08-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/639440dc-259b-43af-bd3d-68601402a3d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/6226d24d-caf1-4a4c-b2a0-624fdd0e6a23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6226d24d-caf1-4a4c-b2a0-624fdd0e6a23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6226d24d-caf1-4a4c-b2a0-624fdd0e6a23>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f1515b8-0f37-49b5-8712-bc9a24130995> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f1515b8-0f37-49b5-8712-bc9a24130995";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f1515b8-0f37-49b5-8712-bc9a24130995>.
+    
+<http://data.lblod.info/id/remote-data-objects/8820aa3c-4367-4092-955d-dd2291c61f05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8820aa3c-4367-4092-955d-dd2291c61f05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8820aa3c-4367-4092-955d-dd2291c61f05>.
+    
+<http://data.lblod.info/id/remote-data-objects/771410ec-d1ff-497a-b661-4ccb29dc17e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "771410ec-d1ff-497a-b661-4ccb29dc17e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/771410ec-d1ff-497a-b661-4ccb29dc17e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbcf8ac2-2252-4279-a17a-f518adf0390e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbcf8ac2-2252-4279-a17a-f518adf0390e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbcf8ac2-2252-4279-a17a-f518adf0390e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e193ca7-e026-4deb-bf38-7eaf31f32391> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e193ca7-e026-4deb-bf38-7eaf31f32391";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e193ca7-e026-4deb-bf38-7eaf31f32391>.
+    
+<http://data.lblod.info/id/remote-data-objects/deacd3a6-5c2b-4eb6-b820-4bf1653bc973> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "deacd3a6-5c2b-4eb6-b820-4bf1653bc973";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_12-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/deacd3a6-5c2b-4eb6-b820-4bf1653bc973>.
+    
+<http://data.lblod.info/id/remote-data-objects/364992ee-b996-4591-a390-28b7eb547270> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "364992ee-b996-4591-a390-28b7eb547270";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/364992ee-b996-4591-a390-28b7eb547270>.
+    
+<http://data.lblod.info/id/remote-data-objects/d222c8ec-79fb-4c2e-afd7-5dc38dbffb07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d222c8ec-79fb-4c2e-afd7-5dc38dbffb07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d222c8ec-79fb-4c2e-afd7-5dc38dbffb07>.
+    
+<http://data.lblod.info/id/remote-data-objects/563dfed4-bdd8-427d-9c3f-8a08317deef7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "563dfed4-bdd8-427d-9c3f-8a08317deef7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/563dfed4-bdd8-427d-9c3f-8a08317deef7>.
+    
+<http://data.lblod.info/id/remote-data-objects/73b9fcec-d737-4dd9-acd5-6316251de821> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73b9fcec-d737-4dd9-acd5-6316251de821";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73b9fcec-d737-4dd9-acd5-6316251de821>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bd55000-b736-4b27-9dca-90913f465938> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bd55000-b736-4b27-9dca-90913f465938";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bd55000-b736-4b27-9dca-90913f465938>.
+    
+<http://data.lblod.info/id/remote-data-objects/568dd325-8582-4603-aaa3-04e9e6ef46ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "568dd325-8582-4603-aaa3-04e9e6ef46ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/568dd325-8582-4603-aaa3-04e9e6ef46ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa9bee85-019e-4c52-9db1-9f20f7378a3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa9bee85-019e-4c52-9db1-9f20f7378a3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa9bee85-019e-4c52-9db1-9f20f7378a3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ee11119-c9ad-4c85-95dc-481dae3a82bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ee11119-c9ad-4c85-95dc-481dae3a82bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ee11119-c9ad-4c85-95dc-481dae3a82bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/721ad9b8-baa1-4750-93fc-36ee733d3172> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "721ad9b8-baa1-4750-93fc-36ee733d3172";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/721ad9b8-baa1-4750-93fc-36ee733d3172>.
+    
+<http://data.lblod.info/id/remote-data-objects/e36e960c-1939-488c-aaef-c4d47c667187> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e36e960c-1939-488c-aaef-c4d47c667187";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e36e960c-1939-488c-aaef-c4d47c667187>.
+    
+<http://data.lblod.info/id/remote-data-objects/59eee6e4-33a9-46c6-b661-f8843b143d13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59eee6e4-33a9-46c6-b661-f8843b143d13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59eee6e4-33a9-46c6-b661-f8843b143d13>.
+    
+<http://data.lblod.info/id/remote-data-objects/85d8da7a-3a4a-4e3c-b573-bb02d7ea6afd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85d8da7a-3a4a-4e3c-b573-bb02d7ea6afd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85d8da7a-3a4a-4e3c-b573-bb02d7ea6afd>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7ac14cc-b2f9-4ed5-a920-41238373e51b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7ac14cc-b2f9-4ed5-a920-41238373e51b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7ac14cc-b2f9-4ed5-a920-41238373e51b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8515fef8-1f46-4195-beac-e082a8ea893e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8515fef8-1f46-4195-beac-e082a8ea893e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8515fef8-1f46-4195-beac-e082a8ea893e>.
+    
+<http://data.lblod.info/id/remote-data-objects/30866f51-7c20-4fbf-b343-76c1e7aa8358> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30866f51-7c20-4fbf-b343-76c1e7aa8358";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30866f51-7c20-4fbf-b343-76c1e7aa8358>.
+    
+<http://data.lblod.info/id/remote-data-objects/69d1e1d7-e468-44c3-838f-40fee3b28932> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69d1e1d7-e468-44c3-838f-40fee3b28932";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69d1e1d7-e468-44c3-838f-40fee3b28932>.
+    
+<http://data.lblod.info/id/remote-data-objects/287bc3db-10db-44da-b662-05a23ec847c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "287bc3db-10db-44da-b662-05a23ec847c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/287bc3db-10db-44da-b662-05a23ec847c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcf3c0b8-005e-40b0-9ac1-2ca9a41969ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcf3c0b8-005e-40b0-9ac1-2ca9a41969ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcf3c0b8-005e-40b0-9ac1-2ca9a41969ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/5993c9f1-ac69-4018-89f5-c5d54610cd3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5993c9f1-ac69-4018-89f5-c5d54610cd3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5993c9f1-ac69-4018-89f5-c5d54610cd3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a0d1395-0d2a-4214-b777-b230c653fc07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a0d1395-0d2a-4214-b777-b230c653fc07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a0d1395-0d2a-4214-b777-b230c653fc07>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec24671e-f660-4317-bc30-ffe456627432> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec24671e-f660-4317-bc30-ffe456627432";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec24671e-f660-4317-bc30-ffe456627432>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d989354-9da9-41a5-b651-27637c036f5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d989354-9da9-41a5-b651-27637c036f5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d989354-9da9-41a5-b651-27637c036f5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f80381ce-0f46-4469-a7ab-fb074fb06571> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f80381ce-0f46-4469-a7ab-fb074fb06571";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f80381ce-0f46-4469-a7ab-fb074fb06571>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ad8dc58-34a1-4787-a7de-d57ece288668> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ad8dc58-34a1-4787-a7de-d57ece288668";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ad8dc58-34a1-4787-a7de-d57ece288668>.
+    
+<http://data.lblod.info/id/remote-data-objects/77f2662b-d80b-4870-bffa-23c8cff622e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77f2662b-d80b-4870-bffa-23c8cff622e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77f2662b-d80b-4870-bffa-23c8cff622e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a90c9332-ad18-4a62-91c6-3488e55c5f80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a90c9332-ad18-4a62-91c6-3488e55c5f80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a90c9332-ad18-4a62-91c6-3488e55c5f80>.
+    
+<http://data.lblod.info/id/remote-data-objects/c29a97a1-8850-47cc-8353-671589166538> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c29a97a1-8850-47cc-8353-671589166538";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c29a97a1-8850-47cc-8353-671589166538>.
+    
+<http://data.lblod.info/id/remote-data-objects/96d8b8bf-a3da-47fb-9679-2eca83385a0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96d8b8bf-a3da-47fb-9679-2eca83385a0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_04-04-2022_15534.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96d8b8bf-a3da-47fb-9679-2eca83385a0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/df28e38d-f42c-41af-bdec-6d4080fd3b1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df28e38d-f42c-41af-bdec-6d4080fd3b1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_07-02-2022_15095.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df28e38d-f42c-41af-bdec-6d4080fd3b1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/284639d1-0ba1-41ba-9b3f-03b1fd5fcfa6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "284639d1-0ba1-41ba-9b3f-03b1fd5fcfa6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_07-02-2022_15096.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/284639d1-0ba1-41ba-9b3f-03b1fd5fcfa6>.
+    
+<http://data.lblod.info/id/remote-data-objects/27b6a387-4f37-498d-8b91-92d333a14aa1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27b6a387-4f37-498d-8b91-92d333a14aa1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_08-11-2021_14405.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27b6a387-4f37-498d-8b91-92d333a14aa1>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f247698-6ae8-4828-b8e5-6e92a0f5af27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f247698-6ae8-4828-b8e5-6e92a0f5af27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_09-05-2022_15815.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f247698-6ae8-4828-b8e5-6e92a0f5af27>.
+    
+<http://data.lblod.info/id/remote-data-objects/176c8dd3-f301-473c-b4da-93448a8680fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "176c8dd3-f301-473c-b4da-93448a8680fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_10-01-2022_14788.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b40e27e7-d3da-4afb-86db-3307efe6422c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/176c8dd3-f301-473c-b4da-93448a8680fa>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201441-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201441-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201441-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201441-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/bcdb968d-9878-4120-83d1-c6b00ffb4bf3> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bcdb968d-9878-4120-83d1-c6b00ffb4bf3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e92e2f0e-76ce-4d3f-b04f-02610439fd48";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6ced0647-dc45-4419-9880-67a649bff99b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6ced0647-dc45-4419-9880-67a649bff99b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48>.
+
+  <http://redpencil.data.gift/id/task/2f78558f-364a-4668-8f0a-2679aea7e141> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2f78558f-364a-4668-8f0a-2679aea7e141";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/bcdb968d-9878-4120-83d1-c6b00ffb4bf3>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6ced0647-dc45-4419-9880-67a649bff99b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/fc525aa8-6b7d-4f00-823d-78bf33f98894> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc525aa8-6b7d-4f00-823d-78bf33f98894";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_11-04-2022_15599.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc525aa8-6b7d-4f00-823d-78bf33f98894>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ad1b7ad-c921-4d42-a40c-68f93897b425> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ad1b7ad-c921-4d42-a40c-68f93897b425";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_11-04-2022_15601.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ad1b7ad-c921-4d42-a40c-68f93897b425>.
+    
+<http://data.lblod.info/id/remote-data-objects/33e3ab0e-72a4-4feb-b4e8-6a1a81e82053> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33e3ab0e-72a4-4feb-b4e8-6a1a81e82053";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_11-04-2022_15603.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33e3ab0e-72a4-4feb-b4e8-6a1a81e82053>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ab64e51-231a-42a4-b258-c37dfffa8b13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ab64e51-231a-42a4-b258-c37dfffa8b13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_11-04-2022_15605.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ab64e51-231a-42a4-b258-c37dfffa8b13>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7759c86-62e4-492b-b83b-8263518e8074> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7759c86-62e4-492b-b83b-8263518e8074";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_11-04-2022_15615.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7759c86-62e4-492b-b83b-8263518e8074>.
+    
+<http://data.lblod.info/id/remote-data-objects/46a77a1e-a479-49b7-a3c5-7ddbfebe2287> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46a77a1e-a479-49b7-a3c5-7ddbfebe2287";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_11-04-2022_15627.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46a77a1e-a479-49b7-a3c5-7ddbfebe2287>.
+    
+<http://data.lblod.info/id/remote-data-objects/96b83f5d-8f46-4113-8955-003fcca18001> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96b83f5d-8f46-4113-8955-003fcca18001";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_11-04-2022_15634.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96b83f5d-8f46-4113-8955-003fcca18001>.
+    
+<http://data.lblod.info/id/remote-data-objects/65fe4e54-888e-48f8-b8fd-b76c97db318c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65fe4e54-888e-48f8-b8fd-b76c97db318c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_13-06-2022_16106.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65fe4e54-888e-48f8-b8fd-b76c97db318c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2823663-a81e-4a61-ae7e-7bb92256516e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2823663-a81e-4a61-ae7e-7bb92256516e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_16-05-2022_15885.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2823663-a81e-4a61-ae7e-7bb92256516e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c39d43a2-1311-4059-85a8-895f142de9b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c39d43a2-1311-4059-85a8-895f142de9b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_16-05-2022_15887.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c39d43a2-1311-4059-85a8-895f142de9b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c078b8d-674a-4750-b9c8-9a02f4d7651c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c078b8d-674a-4750-b9c8-9a02f4d7651c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_16-05-2022_15889.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c078b8d-674a-4750-b9c8-9a02f4d7651c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c240b88d-e60d-44ac-9399-c749d3a59455> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c240b88d-e60d-44ac-9399-c749d3a59455";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_18-07-2022_16353.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c240b88d-e60d-44ac-9399-c749d3a59455>.
+    
+<http://data.lblod.info/id/remote-data-objects/180f0fb6-aba4-439e-89c8-64194295f558> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "180f0fb6-aba4-439e-89c8-64194295f558";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_18-07-2022_16354.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/180f0fb6-aba4-439e-89c8-64194295f558>.
+    
+<http://data.lblod.info/id/remote-data-objects/058a59b9-4707-45ee-98e5-ca65e8bb4163> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "058a59b9-4707-45ee-98e5-ca65e8bb4163";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_18-07-2022_16358.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/058a59b9-4707-45ee-98e5-ca65e8bb4163>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f26ec66-04c3-4503-9851-5a9951dd3147> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f26ec66-04c3-4503-9851-5a9951dd3147";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_18-07-2022_16359.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f26ec66-04c3-4503-9851-5a9951dd3147>.
+    
+<http://data.lblod.info/id/remote-data-objects/04e7206b-884f-4d65-b10b-807c55f4a302> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04e7206b-884f-4d65-b10b-807c55f4a302";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_18-07-2022_16363.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04e7206b-884f-4d65-b10b-807c55f4a302>.
+    
+<http://data.lblod.info/id/remote-data-objects/a18d9ca7-640c-4925-aebb-ac9607e3ddb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a18d9ca7-640c-4925-aebb-ac9607e3ddb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_21-02-2022_15203.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a18d9ca7-640c-4925-aebb-ac9607e3ddb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf99fdc4-fbf1-45d3-bb36-e0931df3f8f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf99fdc4-fbf1-45d3-bb36-e0931df3f8f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_21-02-2022_15205.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf99fdc4-fbf1-45d3-bb36-e0931df3f8f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd71d8b2-0c79-4333-bcf4-fd87e0eca623> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd71d8b2-0c79-4333-bcf4-fd87e0eca623";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_21-03-2022_15449.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd71d8b2-0c79-4333-bcf4-fd87e0eca623>.
+    
+<http://data.lblod.info/id/remote-data-objects/1af09eb0-6ea4-4ae1-aa5f-7abb8d82a408> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1af09eb0-6ea4-4ae1-aa5f-7abb8d82a408";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_23-05-2022_15945.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1af09eb0-6ea4-4ae1-aa5f-7abb8d82a408>.
+    
+<http://data.lblod.info/id/remote-data-objects/60c7471a-beaf-47fd-8ba3-40f4f8a922e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60c7471a-beaf-47fd-8ba3-40f4f8a922e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_23-05-2022_15947.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60c7471a-beaf-47fd-8ba3-40f4f8a922e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c02ec038-352d-4a56-af74-410e22f3745c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c02ec038-352d-4a56-af74-410e22f3745c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_25-10-2021_14296.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c02ec038-352d-4a56-af74-410e22f3745c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fffecd89-352b-424c-94f8-b7c396e2e289> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fffecd89-352b-424c-94f8-b7c396e2e289";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_25-10-2021_14300.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fffecd89-352b-424c-94f8-b7c396e2e289>.
+    
+<http://data.lblod.info/id/remote-data-objects/77ebfe94-43c0-47e3-86f2-929833994b17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77ebfe94-43c0-47e3-86f2-929833994b17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_27-06-2022_16197.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77ebfe94-43c0-47e3-86f2-929833994b17>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bad95a1-9a3e-44ed-9d09-cea7aabe8ce1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bad95a1-9a3e-44ed-9d09-cea7aabe8ce1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_27-06-2022_16199.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bad95a1-9a3e-44ed-9d09-cea7aabe8ce1>.
+    
+<http://data.lblod.info/id/remote-data-objects/85b0f050-ef50-4dcf-8b62-0b469e075a0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85b0f050-ef50-4dcf-8b62-0b469e075a0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_27-06-2022_16219.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85b0f050-ef50-4dcf-8b62-0b469e075a0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d447754-465d-4439-9334-db49394fe4e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d447754-465d-4439-9334-db49394fe4e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_27-06-2022_16226.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d447754-465d-4439-9334-db49394fe4e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/3744822f-8e03-4469-87ed-e6062d7e9b32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3744822f-8e03-4469-87ed-e6062d7e9b32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_27-06-2022_16243.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3744822f-8e03-4469-87ed-e6062d7e9b32>.
+    
+<http://data.lblod.info/id/remote-data-objects/97b74775-7d85-48a1-8284-26011cbbdb10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97b74775-7d85-48a1-8284-26011cbbdb10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_27-06-2022_16244.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97b74775-7d85-48a1-8284-26011cbbdb10>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9bb26b5-f6a6-418b-9bf0-2ce593263fdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9bb26b5-f6a6-418b-9bf0-2ce593263fdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/b028f31e15210ac2974a5bfb85c4448cdc78ed792aa018cb3c14be7782456871/GetPublication?filename=Uittreksels_30-05-2022_15997.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9bb26b5-f6a6-418b-9bf0-2ce593263fdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a7f751a-73f9-42ab-b222-7590b8621f86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a7f751a-73f9-42ab-b222-7590b8621f86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a7f751a-73f9-42ab-b222-7590b8621f86>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b38b654-659a-4a0e-ab45-50597ac944b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b38b654-659a-4a0e-ab45-50597ac944b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b38b654-659a-4a0e-ab45-50597ac944b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ef4f5ba-48ff-49d5-b934-af0e2799e9cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ef4f5ba-48ff-49d5-b934-af0e2799e9cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ef4f5ba-48ff-49d5-b934-af0e2799e9cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/da95f78b-afb9-4aae-82bd-bcc4595407f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da95f78b-afb9-4aae-82bd-bcc4595407f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da95f78b-afb9-4aae-82bd-bcc4595407f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/11712775-22c6-42c7-b40b-d1b00b4a24e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11712775-22c6-42c7-b40b-d1b00b4a24e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11712775-22c6-42c7-b40b-d1b00b4a24e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a57c8f7-51c4-4247-9653-3e7523db9bd4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a57c8f7-51c4-4247-9653-3e7523db9bd4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a57c8f7-51c4-4247-9653-3e7523db9bd4>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb5e9975-01e0-4d67-8487-bd3e8ffc48c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb5e9975-01e0-4d67-8487-bd3e8ffc48c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb5e9975-01e0-4d67-8487-bd3e8ffc48c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5dbc2039-2043-4a66-baed-352db7dd0698> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5dbc2039-2043-4a66-baed-352db7dd0698";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5dbc2039-2043-4a66-baed-352db7dd0698>.
+    
+<http://data.lblod.info/id/remote-data-objects/83bf50bf-8819-42f3-b8c5-3e555371fdaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83bf50bf-8819-42f3-b8c5-3e555371fdaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83bf50bf-8819-42f3-b8c5-3e555371fdaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e2a7efe-d709-407d-ace2-236d5e1ea453> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e2a7efe-d709-407d-ace2-236d5e1ea453";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e2a7efe-d709-407d-ace2-236d5e1ea453>.
+    
+<http://data.lblod.info/id/remote-data-objects/35b1b1f4-fa2b-4aba-9ab2-5e062c8c7963> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35b1b1f4-fa2b-4aba-9ab2-5e062c8c7963";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35b1b1f4-fa2b-4aba-9ab2-5e062c8c7963>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffb48135-ba8b-440a-ae0a-4bb48789d6eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffb48135-ba8b-440a-ae0a-4bb48789d6eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffb48135-ba8b-440a-ae0a-4bb48789d6eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3f9b547-7654-404c-96f1-8dc05f1fbbce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3f9b547-7654-404c-96f1-8dc05f1fbbce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3f9b547-7654-404c-96f1-8dc05f1fbbce>.
+    
+<http://data.lblod.info/id/remote-data-objects/936811c5-9255-4230-9725-2ed75baaa8ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "936811c5-9255-4230-9725-2ed75baaa8ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/936811c5-9255-4230-9725-2ed75baaa8ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/63c35e03-cef9-40a6-a2c5-137266bf19a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63c35e03-cef9-40a6-a2c5-137266bf19a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63c35e03-cef9-40a6-a2c5-137266bf19a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/85465a1b-21c8-46f6-9976-1b72e828c6e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85465a1b-21c8-46f6-9976-1b72e828c6e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85465a1b-21c8-46f6-9976-1b72e828c6e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/62c2245f-a1a5-470c-a36e-f239091bc3a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62c2245f-a1a5-470c-a36e-f239091bc3a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62c2245f-a1a5-470c-a36e-f239091bc3a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/19304660-b5d9-4afb-9ba0-e6b835dc2db2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19304660-b5d9-4afb-9ba0-e6b835dc2db2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19304660-b5d9-4afb-9ba0-e6b835dc2db2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f430bbd8-f9d4-4085-ae38-59c33fc0c9ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f430bbd8-f9d4-4085-ae38-59c33fc0c9ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f430bbd8-f9d4-4085-ae38-59c33fc0c9ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a825672-c5aa-4acf-a429-91bdfacafa9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a825672-c5aa-4acf-a429-91bdfacafa9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e92e2f0e-76ce-4d3f-b04f-02610439fd48> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a825672-c5aa-4acf-a429-91bdfacafa9b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201442-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201442-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201442-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201442-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/66970c30-9b39-4799-933e-a34a9731311f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "66970c30-9b39-4799-933e-a34a9731311f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "288d2984-b828-4490-9891-86b39bc2f0a5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/1865d020-8be9-4d53-91fa-ae88be5ab2e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1865d020-8be9-4d53-91fa-ae88be5ab2e3";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5>.
+
+  <http://redpencil.data.gift/id/task/0d1eb3af-b9cc-4c3d-b9a8-902df6e25995> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0d1eb3af-b9cc-4c3d-b9a8-902df6e25995";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/66970c30-9b39-4799-933e-a34a9731311f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/1865d020-8be9-4d53-91fa-ae88be5ab2e3>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/70888893-091f-40aa-a7e2-2e142929d2a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70888893-091f-40aa-a7e2-2e142929d2a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70888893-091f-40aa-a7e2-2e142929d2a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9efba9a-f112-4d64-a738-ed723b06fa94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9efba9a-f112-4d64-a738-ed723b06fa94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9efba9a-f112-4d64-a738-ed723b06fa94>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e5dfaa5-6d41-481e-9a48-9386de662844> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e5dfaa5-6d41-481e-9a48-9386de662844";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e5dfaa5-6d41-481e-9a48-9386de662844>.
+    
+<http://data.lblod.info/id/remote-data-objects/72849110-24c3-4984-9d71-b4a63ec23ec4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72849110-24c3-4984-9d71-b4a63ec23ec4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72849110-24c3-4984-9d71-b4a63ec23ec4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5e27bbd-00d7-4413-b67e-ce06baa6d464> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5e27bbd-00d7-4413-b67e-ce06baa6d464";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5e27bbd-00d7-4413-b67e-ce06baa6d464>.
+    
+<http://data.lblod.info/id/remote-data-objects/c39b974a-aab5-4b64-a7e8-8a137ae73ede> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c39b974a-aab5-4b64-a7e8-8a137ae73ede";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c39b974a-aab5-4b64-a7e8-8a137ae73ede>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e893dde-bc89-46fc-b92a-5a21af8806e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e893dde-bc89-46fc-b92a-5a21af8806e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e893dde-bc89-46fc-b92a-5a21af8806e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2435b180-7f3f-4e3a-b097-40dadc996867> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2435b180-7f3f-4e3a-b097-40dadc996867";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2435b180-7f3f-4e3a-b097-40dadc996867>.
+    
+<http://data.lblod.info/id/remote-data-objects/33aae71d-2315-4ffe-b684-72c188e177b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33aae71d-2315-4ffe-b684-72c188e177b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33aae71d-2315-4ffe-b684-72c188e177b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e8a601d-81c6-424f-849d-11f9f7e4012c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e8a601d-81c6-424f-849d-11f9f7e4012c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e8a601d-81c6-424f-849d-11f9f7e4012c>.
+    
+<http://data.lblod.info/id/remote-data-objects/05b14304-310b-4504-b17f-e27a0156f606> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05b14304-310b-4504-b17f-e27a0156f606";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kortenaken.be/LBLODWeb/Home/Overzicht/c890c0a5d66a228b79ba5309c8adbedd0063d43e40f07e86b2a6c8c05e5d5e05/GetPublication?filename=BesluitenLijst_Vast%20Bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05b14304-310b-4504-b17f-e27a0156f606>.
+    
+<http://data.lblod.info/id/remote-data-objects/a086f02c-78d1-483e-9d3d-5471996c42ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a086f02c-78d1-483e-9d3d-5471996c42ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Agenda_Gemeenteraad_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a086f02c-78d1-483e-9d3d-5471996c42ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1f4c8e8-d64c-4f65-9d40-f0514a6ef199> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1f4c8e8-d64c-4f65-9d40-f0514a6ef199";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Agenda_Gemeenteraad_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1f4c8e8-d64c-4f65-9d40-f0514a6ef199>.
+    
+<http://data.lblod.info/id/remote-data-objects/77313109-d250-4f91-8df2-2bc752aa8739> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77313109-d250-4f91-8df2-2bc752aa8739";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Agenda_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77313109-d250-4f91-8df2-2bc752aa8739>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2b8fbe7-af1e-4d05-9807-6169d9c22881> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2b8fbe7-af1e-4d05-9807-6169d9c22881";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Agenda_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2b8fbe7-af1e-4d05-9807-6169d9c22881>.
+    
+<http://data.lblod.info/id/remote-data-objects/aada3ac5-ede8-47f0-bf0e-09cdaa58c423> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aada3ac5-ede8-47f0-bf0e-09cdaa58c423";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Agenda_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aada3ac5-ede8-47f0-bf0e-09cdaa58c423>.
+    
+<http://data.lblod.info/id/remote-data-objects/6213c196-7917-4fb8-b7ef-ce4a9a5d9169> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6213c196-7917-4fb8-b7ef-ce4a9a5d9169";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Agenda_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6213c196-7917-4fb8-b7ef-ce4a9a5d9169>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd3aba47-6b75-41e3-9606-1955a2d2d7f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd3aba47-6b75-41e3-9606-1955a2d2d7f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Agenda_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd3aba47-6b75-41e3-9606-1955a2d2d7f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/737dd959-495b-433d-b7fa-4a213de1783b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "737dd959-495b-433d-b7fa-4a213de1783b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Agenda_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/737dd959-495b-433d-b7fa-4a213de1783b>.
+    
+<http://data.lblod.info/id/remote-data-objects/980994c1-3c17-4177-a4a0-4a8a66ae51d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "980994c1-3c17-4177-a4a0-4a8a66ae51d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/980994c1-3c17-4177-a4a0-4a8a66ae51d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/64a8d043-5517-4e4c-a3aa-2a53ae82a36f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64a8d043-5517-4e4c-a3aa-2a53ae82a36f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64a8d043-5517-4e4c-a3aa-2a53ae82a36f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e9f124c-6daf-4fc5-b8f9-4e4dfb136312> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e9f124c-6daf-4fc5-b8f9-4e4dfb136312";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e9f124c-6daf-4fc5-b8f9-4e4dfb136312>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8c3e174-91bf-4856-888a-4793ca5d57bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8c3e174-91bf-4856-888a-4793ca5d57bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8c3e174-91bf-4856-888a-4793ca5d57bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a1bbdd6-c725-4d86-8d66-9d9f03235c5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a1bbdd6-c725-4d86-8d66-9d9f03235c5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a1bbdd6-c725-4d86-8d66-9d9f03235c5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfefa09a-a50f-4f45-9e74-ae4a36115105> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfefa09a-a50f-4f45-9e74-ae4a36115105";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfefa09a-a50f-4f45-9e74-ae4a36115105>.
+    
+<http://data.lblod.info/id/remote-data-objects/92c317f3-90bd-4761-ae35-7cc0cfd6ef79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92c317f3-90bd-4761-ae35-7cc0cfd6ef79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92c317f3-90bd-4761-ae35-7cc0cfd6ef79>.
+    
+<http://data.lblod.info/id/remote-data-objects/a42a367b-d517-4a19-9bcd-00a78ac4d6f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a42a367b-d517-4a19-9bcd-00a78ac4d6f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a42a367b-d517-4a19-9bcd-00a78ac4d6f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/52131513-cff8-4332-967b-5e6d8cc1aaf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52131513-cff8-4332-967b-5e6d8cc1aaf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52131513-cff8-4332-967b-5e6d8cc1aaf9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9112490a-9b58-4d5f-8af6-fa146bb09038> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9112490a-9b58-4d5f-8af6-fa146bb09038";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9112490a-9b58-4d5f-8af6-fa146bb09038>.
+    
+<http://data.lblod.info/id/remote-data-objects/fea3598b-6726-4251-9086-9288a6ca1ce0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fea3598b-6726-4251-9086-9288a6ca1ce0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Notulen_Gemeenteraad_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fea3598b-6726-4251-9086-9288a6ca1ce0>.
+    
+<http://data.lblod.info/id/remote-data-objects/109331a9-e179-42a5-93bc-98d05ee5fc35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "109331a9-e179-42a5-93bc-98d05ee5fc35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Notulen_Gemeenteraad_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/109331a9-e179-42a5-93bc-98d05ee5fc35>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bafccda-67a0-42de-81a0-2f61e269d6bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bafccda-67a0-42de-81a0-2f61e269d6bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Notulen_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bafccda-67a0-42de-81a0-2f61e269d6bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb850083-fb59-4f15-92a0-785979b2c957> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb850083-fb59-4f15-92a0-785979b2c957";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Notulen_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb850083-fb59-4f15-92a0-785979b2c957>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1f45970-5761-47c2-bebd-641ea3623214> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1f45970-5761-47c2-bebd-641ea3623214";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Notulen_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1f45970-5761-47c2-bebd-641ea3623214>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecc19984-079e-4da7-a5d9-bda10ab86ccb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecc19984-079e-4da7-a5d9-bda10ab86ccb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_04-10-2021_36183.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecc19984-079e-4da7-a5d9-bda10ab86ccb>.
+    
+<http://data.lblod.info/id/remote-data-objects/632235cd-fe22-4f2b-a32f-125191e4a2d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "632235cd-fe22-4f2b-a32f-125191e4a2d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_04-10-2021_36228.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/632235cd-fe22-4f2b-a32f-125191e4a2d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a718722f-b95e-4f41-a89a-9d8e645e416a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a718722f-b95e-4f41-a89a-9d8e645e416a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_08-11-2021_36242.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a718722f-b95e-4f41-a89a-9d8e645e416a>.
+    
+<http://data.lblod.info/id/remote-data-objects/59da8b62-24d4-4b45-b44f-5c958238610b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59da8b62-24d4-4b45-b44f-5c958238610b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_08-11-2021_36555.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59da8b62-24d4-4b45-b44f-5c958238610b>.
+    
+<http://data.lblod.info/id/remote-data-objects/23f08c53-8224-4fab-8fa9-6d884c6fae32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23f08c53-8224-4fab-8fa9-6d884c6fae32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_08-11-2021_36707.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23f08c53-8224-4fab-8fa9-6d884c6fae32>.
+    
+<http://data.lblod.info/id/remote-data-objects/454bec33-3db6-4079-8def-e399ecfc5f1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "454bec33-3db6-4079-8def-e399ecfc5f1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_08-11-2021_36800.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/454bec33-3db6-4079-8def-e399ecfc5f1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e87610ae-3d80-4774-a513-68c67d93813d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e87610ae-3d80-4774-a513-68c67d93813d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_08-11-2021_36878.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e87610ae-3d80-4774-a513-68c67d93813d>.
+    
+<http://data.lblod.info/id/remote-data-objects/00dbf2b5-5db9-44f5-aa79-77ca0f35f234> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00dbf2b5-5db9-44f5-aa79-77ca0f35f234";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_08-11-2021_36950.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00dbf2b5-5db9-44f5-aa79-77ca0f35f234>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e170d65-8a70-495d-993e-19e8f7879554> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e170d65-8a70-495d-993e-19e8f7879554";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_20-12-2021_36235.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e170d65-8a70-495d-993e-19e8f7879554>.
+    
+<http://data.lblod.info/id/remote-data-objects/1929c2c3-272e-4937-a6ee-6b5efbbc8ad8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1929c2c3-272e-4937-a6ee-6b5efbbc8ad8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_20-12-2021_36236.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1929c2c3-272e-4937-a6ee-6b5efbbc8ad8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b2ff22a-d4cc-45dc-b055-d7f413927f8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b2ff22a-d4cc-45dc-b055-d7f413927f8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_20-12-2021_36237.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b2ff22a-d4cc-45dc-b055-d7f413927f8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f31df06a-0fa7-4e82-b548-a7205d30ea18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f31df06a-0fa7-4e82-b548-a7205d30ea18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_20-12-2021_36916.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f31df06a-0fa7-4e82-b548-a7205d30ea18>.
+    
+<http://data.lblod.info/id/remote-data-objects/867d33a1-2f07-4fc4-9d2a-cee227870eab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "867d33a1-2f07-4fc4-9d2a-cee227870eab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_20-12-2021_36917.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/867d33a1-2f07-4fc4-9d2a-cee227870eab>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b629a37-3073-4aac-9769-988f4260eb95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b629a37-3073-4aac-9769-988f4260eb95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_20-12-2021_36918.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b629a37-3073-4aac-9769-988f4260eb95>.
+    
+<http://data.lblod.info/id/remote-data-objects/49cc44b5-e81c-44b1-9d91-2cccb058520b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49cc44b5-e81c-44b1-9d91-2cccb058520b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_20-12-2021_37051.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49cc44b5-e81c-44b1-9d91-2cccb058520b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5541dd8-0943-480f-9fde-11b51fa316de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5541dd8-0943-480f-9fde-11b51fa316de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_20-12-2021_37243.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/288d2984-b828-4490-9891-86b39bc2f0a5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5541dd8-0943-480f-9fde-11b51fa316de>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201443-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201443-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201443-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201443-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/609f59fb-5b35-46a0-a95a-dae6925d97ea> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "609f59fb-5b35-46a0-a95a-dae6925d97ea";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5d1c5381-e57a-4052-b780-1994571cb851";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/5c64d6c1-a3d3-4a55-92ee-1ac6806421a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5c64d6c1-a3d3-4a55-92ee-1ac6806421a5";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851>.
+
+  <http://redpencil.data.gift/id/task/d65bd170-b0cc-4f5b-a7f7-38abef73229c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d65bd170-b0cc-4f5b-a7f7-38abef73229c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/609f59fb-5b35-46a0-a95a-dae6925d97ea>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/5c64d6c1-a3d3-4a55-92ee-1ac6806421a5>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/3d418532-9c62-4179-8bff-1c12e3b55b19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d418532-9c62-4179-8bff-1c12e3b55b19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_20-12-2021_37244.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d418532-9c62-4179-8bff-1c12e3b55b19>.
+    
+<http://data.lblod.info/id/remote-data-objects/e603e020-1a27-4723-a0e3-12be829615fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e603e020-1a27-4723-a0e3-12be829615fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_20-12-2021_37245.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e603e020-1a27-4723-a0e3-12be829615fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/1590ffd1-1b4b-4367-ad72-6311f186c4b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1590ffd1-1b4b-4367-ad72-6311f186c4b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_20-12-2021_37246.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1590ffd1-1b4b-4367-ad72-6311f186c4b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cb95822-6bc7-4219-bec8-587abb75da15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cb95822-6bc7-4219-bec8-587abb75da15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_20-12-2021_37247.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cb95822-6bc7-4219-bec8-587abb75da15>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bba4b65-da2c-40d2-8620-0c40c6efa8bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bba4b65-da2c-40d2-8620-0c40c6efa8bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_20-12-2021_37371.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bba4b65-da2c-40d2-8620-0c40c6efa8bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ffef3f0-c8c5-4cbf-b63d-4fca54653772> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ffef3f0-c8c5-4cbf-b63d-4fca54653772";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_20-12-2021_37447.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ffef3f0-c8c5-4cbf-b63d-4fca54653772>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae02385e-a8a9-4150-bd7b-39e6f1d30f1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae02385e-a8a9-4150-bd7b-39e6f1d30f1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_21-02-2022_40246.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae02385e-a8a9-4150-bd7b-39e6f1d30f1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae87f73e-23ea-4ccd-9dcf-4dd18cddff63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae87f73e-23ea-4ccd-9dcf-4dd18cddff63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_21-02-2022_40247.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae87f73e-23ea-4ccd-9dcf-4dd18cddff63>.
+    
+<http://data.lblod.info/id/remote-data-objects/51d0c155-aff5-47e1-ae6c-23dadbbc28cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51d0c155-aff5-47e1-ae6c-23dadbbc28cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_21-02-2022_40248.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51d0c155-aff5-47e1-ae6c-23dadbbc28cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/362124c7-5930-434f-abba-be014927f0d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "362124c7-5930-434f-abba-be014927f0d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_21-02-2022_40292.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/362124c7-5930-434f-abba-be014927f0d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/62a6cd7d-3d8b-4c84-afb7-1d8d9e234a02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62a6cd7d-3d8b-4c84-afb7-1d8d9e234a02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_21-02-2022_40297.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62a6cd7d-3d8b-4c84-afb7-1d8d9e234a02>.
+    
+<http://data.lblod.info/id/remote-data-objects/4046a3e9-f565-4f35-9886-b26f9cad9c25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4046a3e9-f565-4f35-9886-b26f9cad9c25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_21-02-2022_40335.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4046a3e9-f565-4f35-9886-b26f9cad9c25>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2b67efa-dcc9-4891-ba32-09515f919a22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2b67efa-dcc9-4891-ba32-09515f919a22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_21-02-2022_40353.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2b67efa-dcc9-4891-ba32-09515f919a22>.
+    
+<http://data.lblod.info/id/remote-data-objects/5dca12a9-fa45-42df-96e2-cbbd324cb975> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5dca12a9-fa45-42df-96e2-cbbd324cb975";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_21-02-2022_40354.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5dca12a9-fa45-42df-96e2-cbbd324cb975>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d7fe8e3-7bad-4919-ab20-c6ded7b85a7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d7fe8e3-7bad-4919-ab20-c6ded7b85a7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_21-02-2022_40355.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d7fe8e3-7bad-4919-ab20-c6ded7b85a7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8f6071e-5d1e-4136-b41f-56af3d2275d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8f6071e-5d1e-4136-b41f-56af3d2275d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_21-02-2022_40356.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8f6071e-5d1e-4136-b41f-56af3d2275d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f68bed77-bd59-462d-8854-72b51ae45696> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f68bed77-bd59-462d-8854-72b51ae45696";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_24-01-2022_37827.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f68bed77-bd59-462d-8854-72b51ae45696>.
+    
+<http://data.lblod.info/id/remote-data-objects/50166c7c-6c09-4a31-969d-e05b48016699> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50166c7c-6c09-4a31-969d-e05b48016699";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_24-01-2022_38873.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50166c7c-6c09-4a31-969d-e05b48016699>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea4a7662-151e-44cb-bf2c-9ea3b72ee97a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea4a7662-151e-44cb-bf2c-9ea3b72ee97a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_24-01-2022_38935.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea4a7662-151e-44cb-bf2c-9ea3b72ee97a>.
+    
+<http://data.lblod.info/id/remote-data-objects/40630614-4088-468d-90e5-d5474784327c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40630614-4088-468d-90e5-d5474784327c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_24-01-2022_38972.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40630614-4088-468d-90e5-d5474784327c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f554fef-d372-44bf-ae6d-eeed083934c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f554fef-d372-44bf-ae6d-eeed083934c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_25-04-2022_40865.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f554fef-d372-44bf-ae6d-eeed083934c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/613e61b4-d2c4-4662-aaeb-bb0581dd6b46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "613e61b4-d2c4-4662-aaeb-bb0581dd6b46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_25-04-2022_40866.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/613e61b4-d2c4-4662-aaeb-bb0581dd6b46>.
+    
+<http://data.lblod.info/id/remote-data-objects/2013113a-a741-4cab-a0fd-db7dabce68db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2013113a-a741-4cab-a0fd-db7dabce68db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_25-04-2022_40867.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2013113a-a741-4cab-a0fd-db7dabce68db>.
+    
+<http://data.lblod.info/id/remote-data-objects/2259bff1-1e2e-43b9-b83f-0c4d7569001f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2259bff1-1e2e-43b9-b83f-0c4d7569001f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_25-04-2022_41012.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2259bff1-1e2e-43b9-b83f-0c4d7569001f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d0709da-7470-478e-a7f6-81a361dfd0d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d0709da-7470-478e-a7f6-81a361dfd0d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_25-04-2022_41087.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d0709da-7470-478e-a7f6-81a361dfd0d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e591dac7-5a44-45b9-980f-57ddf5fed784> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e591dac7-5a44-45b9-980f-57ddf5fed784";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_27-06-2022_42057.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e591dac7-5a44-45b9-980f-57ddf5fed784>.
+    
+<http://data.lblod.info/id/remote-data-objects/25c9c2e9-821a-44dd-b0c8-2c2e64319ea2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25c9c2e9-821a-44dd-b0c8-2c2e64319ea2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_27-06-2022_42058.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25c9c2e9-821a-44dd-b0c8-2c2e64319ea2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a763c37a-796e-49bc-a0b6-7396013bc4aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a763c37a-796e-49bc-a0b6-7396013bc4aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_27-06-2022_42059.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a763c37a-796e-49bc-a0b6-7396013bc4aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/50743d4e-824d-45a9-a979-572affe41edd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50743d4e-824d-45a9-a979-572affe41edd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_27-06-2022_42060.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50743d4e-824d-45a9-a979-572affe41edd>.
+    
+<http://data.lblod.info/id/remote-data-objects/daf9c654-03bd-46bd-9a41-7b9e585191de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "daf9c654-03bd-46bd-9a41-7b9e585191de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_27-06-2022_42066.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/daf9c654-03bd-46bd-9a41-7b9e585191de>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c24114c-4e1d-41cc-a882-bbccd5e3f092> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c24114c-4e1d-41cc-a882-bbccd5e3f092";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_27-06-2022_42068.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c24114c-4e1d-41cc-a882-bbccd5e3f092>.
+    
+<http://data.lblod.info/id/remote-data-objects/75befd0d-ca5e-4050-8226-2f903f6ccec0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75befd0d-ca5e-4050-8226-2f903f6ccec0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_27-06-2022_42072.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75befd0d-ca5e-4050-8226-2f903f6ccec0>.
+    
+<http://data.lblod.info/id/remote-data-objects/3213e847-61bf-4794-9538-2b39f1c20e21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3213e847-61bf-4794-9538-2b39f1c20e21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_27-06-2022_42080.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3213e847-61bf-4794-9538-2b39f1c20e21>.
+    
+<http://data.lblod.info/id/remote-data-objects/e250a264-acda-44aa-a71f-42e32036bac8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e250a264-acda-44aa-a71f-42e32036bac8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_28-03-2022_40336.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e250a264-acda-44aa-a71f-42e32036bac8>.
+    
+<http://data.lblod.info/id/remote-data-objects/af101def-7759-4fc1-9df7-f772b2f3c7f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af101def-7759-4fc1-9df7-f772b2f3c7f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_28-03-2022_40358.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af101def-7759-4fc1-9df7-f772b2f3c7f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f41aa46-538b-4860-be5c-6d501b651364> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f41aa46-538b-4860-be5c-6d501b651364";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_28-03-2022_40365.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f41aa46-538b-4860-be5c-6d501b651364>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a6072bd-185c-4a06-bcd4-12cc76657e17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a6072bd-185c-4a06-bcd4-12cc76657e17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_28-03-2022_40366.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a6072bd-185c-4a06-bcd4-12cc76657e17>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a994b17-a6b8-4fd7-bfe8-71ce3b6eec39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a994b17-a6b8-4fd7-bfe8-71ce3b6eec39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_28-03-2022_40367.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a994b17-a6b8-4fd7-bfe8-71ce3b6eec39>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d72bbb5-5a65-4e2d-9a1b-65793c1eefbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d72bbb5-5a65-4e2d-9a1b-65793c1eefbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_28-03-2022_40608.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d72bbb5-5a65-4e2d-9a1b-65793c1eefbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7b260b9-94c8-4007-b71c-74d541053d5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7b260b9-94c8-4007-b71c-74d541053d5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_28-03-2022_40615.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7b260b9-94c8-4007-b71c-74d541053d5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb607c31-8335-4383-9650-c58c59055c33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb607c31-8335-4383-9650-c58c59055c33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_28-03-2022_40816.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb607c31-8335-4383-9650-c58c59055c33>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f27fd72-e186-4c9c-9027-01e62290344d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f27fd72-e186-4c9c-9027-01e62290344d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_28-03-2022_40817.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f27fd72-e186-4c9c-9027-01e62290344d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f496b97-284f-4bf8-a0ae-00fec200a0af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f496b97-284f-4bf8-a0ae-00fec200a0af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_28-03-2022_40819.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f496b97-284f-4bf8-a0ae-00fec200a0af>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1a2be77-9d4b-4e04-933a-fc7134b5bb53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1a2be77-9d4b-4e04-933a-fc7134b5bb53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_28-03-2022_40848.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1a2be77-9d4b-4e04-933a-fc7134b5bb53>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc6e3982-1210-48ce-98e2-640e9a8f651e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc6e3982-1210-48ce-98e2-640e9a8f651e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_30-05-2022_41102.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc6e3982-1210-48ce-98e2-640e9a8f651e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4963dd8-2e69-411a-9fc3-9d08287bbca0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4963dd8-2e69-411a-9fc3-9d08287bbca0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_30-05-2022_41105.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4963dd8-2e69-411a-9fc3-9d08287bbca0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f010740-478a-40e2-b8e4-5ba8660ee4a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f010740-478a-40e2-b8e4-5ba8660ee4a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/0f5288768dc2570fe856cab05dd65f0dce9e58b1db37df5496d29f63ad3d7f7e/GetPublication?filename=Uittreksels_30-05-2022_41482.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f010740-478a-40e2-b8e4-5ba8660ee4a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/010efc17-28e8-49bc-824d-440d64b70d42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "010efc17-28e8-49bc-824d-440d64b70d42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/467df76fbe70edf64109154fb1827847cf902f0f58cf156fe6a26c035c4dbdce/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/010efc17-28e8-49bc-824d-440d64b70d42>.
+    
+<http://data.lblod.info/id/remote-data-objects/9132ae44-a289-4924-a12d-24f43536974e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9132ae44-a289-4924-a12d-24f43536974e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/467df76fbe70edf64109154fb1827847cf902f0f58cf156fe6a26c035c4dbdce/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9132ae44-a289-4924-a12d-24f43536974e>.
+    
+<http://data.lblod.info/id/remote-data-objects/858e6c25-c03e-4646-a16a-d426910b80c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "858e6c25-c03e-4646-a16a-d426910b80c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/467df76fbe70edf64109154fb1827847cf902f0f58cf156fe6a26c035c4dbdce/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5d1c5381-e57a-4052-b780-1994571cb851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/858e6c25-c03e-4646-a16a-d426910b80c8>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201444-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201444-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201444-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201444-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/672e47c5-20ad-4083-beef-211adb8000cb> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "672e47c5-20ad-4083-beef-211adb8000cb";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cca78054-d642-4223-a30f-e7dc33b612d7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ec671201-cd00-46a3-9dc9-6d3ca705e0c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ec671201-cd00-46a3-9dc9-6d3ca705e0c7";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7>.
+
+  <http://redpencil.data.gift/id/task/3ece17ba-98b7-4ad3-9b72-702d6978952f> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3ece17ba-98b7-4ad3-9b72-702d6978952f";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/672e47c5-20ad-4083-beef-211adb8000cb>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ec671201-cd00-46a3-9dc9-6d3ca705e0c7>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/2d40dce8-85ef-4945-bfcd-0943e18393d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d40dce8-85ef-4945-bfcd-0943e18393d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/467df76fbe70edf64109154fb1827847cf902f0f58cf156fe6a26c035c4dbdce/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d40dce8-85ef-4945-bfcd-0943e18393d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c1bf396-1de9-4912-bd23-4809dc008bf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c1bf396-1de9-4912-bd23-4809dc008bf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/467df76fbe70edf64109154fb1827847cf902f0f58cf156fe6a26c035c4dbdce/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c1bf396-1de9-4912-bd23-4809dc008bf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/84caee4f-37de-4d66-bb5f-6b0f6432905c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84caee4f-37de-4d66-bb5f-6b0f6432905c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/467df76fbe70edf64109154fb1827847cf902f0f58cf156fe6a26c035c4dbdce/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84caee4f-37de-4d66-bb5f-6b0f6432905c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cb8a948-a21a-4096-9d2f-d8253489ed6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cb8a948-a21a-4096-9d2f-d8253489ed6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/467df76fbe70edf64109154fb1827847cf902f0f58cf156fe6a26c035c4dbdce/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_28-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cb8a948-a21a-4096-9d2f-d8253489ed6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/526d6b41-930a-4b45-b9b4-37454bbb0a10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "526d6b41-930a-4b45-b9b4-37454bbb0a10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/467df76fbe70edf64109154fb1827847cf902f0f58cf156fe6a26c035c4dbdce/GetPublication?filename=Uittreksels_17-02-2022_40460.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/526d6b41-930a-4b45-b9b4-37454bbb0a10>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9b44391-0480-400b-ad82-dde80d22de01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9b44391-0480-400b-ad82-dde80d22de01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/467df76fbe70edf64109154fb1827847cf902f0f58cf156fe6a26c035c4dbdce/GetPublication?filename=Uittreksels_19-11-2021_37367.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9b44391-0480-400b-ad82-dde80d22de01>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b05b652-af06-4386-a0bf-56149c0a31d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b05b652-af06-4386-a0bf-56149c0a31d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/467df76fbe70edf64109154fb1827847cf902f0f58cf156fe6a26c035c4dbdce/GetPublication?filename=Uittreksels_24-11-2021_37412.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b05b652-af06-4386-a0bf-56149c0a31d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcf6043b-07a6-4b25-852e-d4c97007be32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcf6043b-07a6-4b25-852e-d4c97007be32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/467df76fbe70edf64109154fb1827847cf902f0f58cf156fe6a26c035c4dbdce/GetPublication?filename=Uittreksels_26-01-2022_40207.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcf6043b-07a6-4b25-852e-d4c97007be32>.
+    
+<http://data.lblod.info/id/remote-data-objects/e238e0f3-33b0-40a7-9adc-c60e1708d734> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e238e0f3-33b0-40a7-9adc-c60e1708d734";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/467df76fbe70edf64109154fb1827847cf902f0f58cf156fe6a26c035c4dbdce/GetPublication?filename=Uittreksels_28-12-2021_38921.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e238e0f3-33b0-40a7-9adc-c60e1708d734>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea707747-4629-4d59-b4d6-0a91d1034c2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea707747-4629-4d59-b4d6-0a91d1034c2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Agenda_Raad%20v%20Maatschappelijk%20Welzijn_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea707747-4629-4d59-b4d6-0a91d1034c2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1316f5d-2eee-4bb4-b66b-99a1021cb1dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1316f5d-2eee-4bb4-b66b-99a1021cb1dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Agenda_Raad%20v%20Maatschappelijk%20Welzijn_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1316f5d-2eee-4bb4-b66b-99a1021cb1dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/b965537e-f42a-455a-9304-604022026ac2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b965537e-f42a-455a-9304-604022026ac2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Agenda_Raad%20v%20Maatschappelijk%20Welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b965537e-f42a-455a-9304-604022026ac2>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac2e8302-e97b-4006-95a7-aef4af1b5c92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac2e8302-e97b-4006-95a7-aef4af1b5c92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Agenda_Raad%20v%20Maatschappelijk%20Welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac2e8302-e97b-4006-95a7-aef4af1b5c92>.
+    
+<http://data.lblod.info/id/remote-data-objects/70fb0ec1-f50a-4d80-8fc1-763ab117f80d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70fb0ec1-f50a-4d80-8fc1-763ab117f80d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Agenda_Raad%20v%20Maatschappelijk%20Welzijn_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70fb0ec1-f50a-4d80-8fc1-763ab117f80d>.
+    
+<http://data.lblod.info/id/remote-data-objects/177812fc-464b-4824-8415-16b192534761> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "177812fc-464b-4824-8415-16b192534761";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Agenda_Raad%20v%20Maatschappelijk%20Welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/177812fc-464b-4824-8415-16b192534761>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc68282d-cbd5-4f69-9f34-125ca7325c0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc68282d-cbd5-4f69-9f34-125ca7325c0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Agenda_Raad%20v%20Maatschappelijk%20Welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc68282d-cbd5-4f69-9f34-125ca7325c0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/17fc06c4-13dd-45ec-9f5a-aee77acb3150> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17fc06c4-13dd-45ec-9f5a-aee77acb3150";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Agenda_Raad%20v%20Maatschappelijk%20Welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17fc06c4-13dd-45ec-9f5a-aee77acb3150>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d7d01a9-e11a-4537-b6f8-e9a54ee6afad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d7d01a9-e11a-4537-b6f8-e9a54ee6afad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=BesluitenLijstUitspraak_Raad%20v%20Maatschappelijk%20Welzijn_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d7d01a9-e11a-4537-b6f8-e9a54ee6afad>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac20a04b-a11b-4082-91bb-ddef3ee1500a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac20a04b-a11b-4082-91bb-ddef3ee1500a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=BesluitenLijstUitspraak_Raad%20v%20Maatschappelijk%20Welzijn_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac20a04b-a11b-4082-91bb-ddef3ee1500a>.
+    
+<http://data.lblod.info/id/remote-data-objects/74b4ac9b-dd65-4695-93fa-5d6211dc0c46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74b4ac9b-dd65-4695-93fa-5d6211dc0c46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=BesluitenLijstUitspraak_Raad%20v%20Maatschappelijk%20Welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74b4ac9b-dd65-4695-93fa-5d6211dc0c46>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d5e8419-5930-46cd-ae4f-acbf22bd1a94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d5e8419-5930-46cd-ae4f-acbf22bd1a94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=BesluitenLijstUitspraak_Raad%20v%20Maatschappelijk%20Welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d5e8419-5930-46cd-ae4f-acbf22bd1a94>.
+    
+<http://data.lblod.info/id/remote-data-objects/c089165a-c75f-45a9-957a-5a3005688f47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c089165a-c75f-45a9-957a-5a3005688f47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=BesluitenLijstUitspraak_Raad%20v%20Maatschappelijk%20Welzijn_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c089165a-c75f-45a9-957a-5a3005688f47>.
+    
+<http://data.lblod.info/id/remote-data-objects/92ace3bb-7405-4895-be52-6a77095f489b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92ace3bb-7405-4895-be52-6a77095f489b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=BesluitenLijstUitspraak_Raad%20v%20Maatschappelijk%20Welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92ace3bb-7405-4895-be52-6a77095f489b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2aa2be28-52da-4071-ae07-28f842b41056> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2aa2be28-52da-4071-ae07-28f842b41056";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=BesluitenLijstUitspraak_Raad%20v%20Maatschappelijk%20Welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2aa2be28-52da-4071-ae07-28f842b41056>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ce44b6a-ab92-4d2c-981c-b4f4e1cb3159> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ce44b6a-ab92-4d2c-981c-b4f4e1cb3159";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=BesluitenLijstUitspraak_Raad%20v%20Maatschappelijk%20Welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ce44b6a-ab92-4d2c-981c-b4f4e1cb3159>.
+    
+<http://data.lblod.info/id/remote-data-objects/ece36aa9-f547-4c3e-8558-83be5b092f02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ece36aa9-f547-4c3e-8558-83be5b092f02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=BesluitenLijstUitspraak_Raad%20v%20Maatschappelijk%20Welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ece36aa9-f547-4c3e-8558-83be5b092f02>.
+    
+<http://data.lblod.info/id/remote-data-objects/f75ee0fb-26ca-4ed0-8902-aefc418a4f17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f75ee0fb-26ca-4ed0-8902-aefc418a4f17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Notulen_Raad%20v%20Maatschappelijk%20Welzijn_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f75ee0fb-26ca-4ed0-8902-aefc418a4f17>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4e8ec95-68ac-4400-9692-fdb99f180ee1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4e8ec95-68ac-4400-9692-fdb99f180ee1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Notulen_Raad%20v%20Maatschappelijk%20Welzijn_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4e8ec95-68ac-4400-9692-fdb99f180ee1>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfac0e7f-30d3-4083-80c0-0890a97a2a43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfac0e7f-30d3-4083-80c0-0890a97a2a43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Notulen_Raad%20v%20Maatschappelijk%20Welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfac0e7f-30d3-4083-80c0-0890a97a2a43>.
+    
+<http://data.lblod.info/id/remote-data-objects/76eb6614-155b-4857-955e-0ac63b4be84a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76eb6614-155b-4857-955e-0ac63b4be84a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Notulen_Raad%20v%20Maatschappelijk%20Welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76eb6614-155b-4857-955e-0ac63b4be84a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ded8671b-3806-4b97-9e2f-3f3d6da3983f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ded8671b-3806-4b97-9e2f-3f3d6da3983f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Notulen_Raad%20v%20Maatschappelijk%20Welzijn_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ded8671b-3806-4b97-9e2f-3f3d6da3983f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f452fe6-4d38-4f19-b1bf-92a19df3584b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f452fe6-4d38-4f19-b1bf-92a19df3584b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Notulen_Raad%20v%20Maatschappelijk%20Welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f452fe6-4d38-4f19-b1bf-92a19df3584b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e447399-ea40-4c8e-b841-5dfe5d105a71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e447399-ea40-4c8e-b841-5dfe5d105a71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Uittreksels_08-11-2021_36914.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e447399-ea40-4c8e-b841-5dfe5d105a71>.
+    
+<http://data.lblod.info/id/remote-data-objects/17e5c45d-c927-40aa-91e3-f5cbf63325b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17e5c45d-c927-40aa-91e3-f5cbf63325b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Uittreksels_08-11-2021_36970.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17e5c45d-c927-40aa-91e3-f5cbf63325b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a667160-d2e9-4367-99c7-ff785127692f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a667160-d2e9-4367-99c7-ff785127692f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Uittreksels_20-12-2021_37328.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a667160-d2e9-4367-99c7-ff785127692f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4771fce1-a09d-4d21-9ace-075f2c6782a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4771fce1-a09d-4d21-9ace-075f2c6782a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Uittreksels_20-12-2021_37509.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4771fce1-a09d-4d21-9ace-075f2c6782a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d916eeaa-21a1-4860-b089-2f2bfe36721b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d916eeaa-21a1-4860-b089-2f2bfe36721b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Uittreksels_20-12-2021_37512.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d916eeaa-21a1-4860-b089-2f2bfe36721b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7abcbde-754d-4480-b481-8a13ef0dc79e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7abcbde-754d-4480-b481-8a13ef0dc79e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Uittreksels_24-01-2022_38902.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7abcbde-754d-4480-b481-8a13ef0dc79e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7ad9703-63e2-42f8-b143-017246b5e15d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7ad9703-63e2-42f8-b143-017246b5e15d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Uittreksels_25-04-2022_41007.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7ad9703-63e2-42f8-b143-017246b5e15d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9815bd6f-800d-46e3-a987-4b3efc968ad2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9815bd6f-800d-46e3-a987-4b3efc968ad2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Uittreksels_27-06-2022_41801.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9815bd6f-800d-46e3-a987-4b3efc968ad2>.
+    
+<http://data.lblod.info/id/remote-data-objects/03fd004c-e12d-48a2-84e2-b1aac2d083f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03fd004c-e12d-48a2-84e2-b1aac2d083f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Uittreksels_27-06-2022_41854.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03fd004c-e12d-48a2-84e2-b1aac2d083f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/64030c7f-2e05-4e8c-a7ea-345cf18f95ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64030c7f-2e05-4e8c-a7ea-345cf18f95ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Uittreksels_27-06-2022_41911.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64030c7f-2e05-4e8c-a7ea-345cf18f95ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/31895475-bd44-46a0-a0c0-f4aee49563ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31895475-bd44-46a0-a0c0-f4aee49563ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/47205483ae75a54cda01f10aa4362621ef980e5c272702de0181e935a21b0243/GetPublication?filename=Uittreksels_28-03-2022_40694.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31895475-bd44-46a0-a0c0-f4aee49563ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/64c4764c-740a-4077-a0e4-717d1ed77349> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64c4764c-740a-4077-a0e4-717d1ed77349";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64c4764c-740a-4077-a0e4-717d1ed77349>.
+    
+<http://data.lblod.info/id/remote-data-objects/740e8cb7-d89a-4d44-8325-76b4b2268fd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "740e8cb7-d89a-4d44-8325-76b4b2268fd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/740e8cb7-d89a-4d44-8325-76b4b2268fd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bd6ef8b-7ab6-4bd7-b0b7-dcf332e7c815> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bd6ef8b-7ab6-4bd7-b0b7-dcf332e7c815";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bd6ef8b-7ab6-4bd7-b0b7-dcf332e7c815>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c494c1e-3a33-4d0f-8ff0-afe5e4d68e36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c494c1e-3a33-4d0f-8ff0-afe5e4d68e36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c494c1e-3a33-4d0f-8ff0-afe5e4d68e36>.
+    
+<http://data.lblod.info/id/remote-data-objects/523f6711-9b89-47cf-b345-9681ae9f066e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "523f6711-9b89-47cf-b345-9681ae9f066e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/523f6711-9b89-47cf-b345-9681ae9f066e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7deb82a6-683c-42ac-b054-a5e3b7d210b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7deb82a6-683c-42ac-b054-a5e3b7d210b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7deb82a6-683c-42ac-b054-a5e3b7d210b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9385a65-b6e2-4606-a40b-58408c350687> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9385a65-b6e2-4606-a40b-58408c350687";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cca78054-d642-4223-a30f-e7dc33b612d7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9385a65-b6e2-4606-a40b-58408c350687>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201446-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201446-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201446-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201446-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3fff1d3d-f27b-4c0d-bbc9-950b5eeb7b79> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3fff1d3d-f27b-4c0d-bbc9-950b5eeb7b79";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a0c343fb-4890-448a-8fe5-176b328687f9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/aab9850e-8a94-4bf5-b48b-161ccb263fff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "aab9850e-8a94-4bf5-b48b-161ccb263fff";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9>.
+
+  <http://redpencil.data.gift/id/task/5cb38ff6-8686-45e8-92dc-2da8307fb697> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5cb38ff6-8686-45e8-92dc-2da8307fb697";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3fff1d3d-f27b-4c0d-bbc9-950b5eeb7b79>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/aab9850e-8a94-4bf5-b48b-161ccb263fff>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/ff6cf40b-7442-4c79-ac0f-a459cba19169> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff6cf40b-7442-4c79-ac0f-a459cba19169";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff6cf40b-7442-4c79-ac0f-a459cba19169>.
+    
+<http://data.lblod.info/id/remote-data-objects/f194cd40-6176-43ec-8365-33db6699c2d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f194cd40-6176-43ec-8365-33db6699c2d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f194cd40-6176-43ec-8365-33db6699c2d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/64508683-2835-43c1-aaeb-3ebe01a1ee62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64508683-2835-43c1-aaeb-3ebe01a1ee62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64508683-2835-43c1-aaeb-3ebe01a1ee62>.
+    
+<http://data.lblod.info/id/remote-data-objects/bea4d8b0-7a56-4ea8-bdee-4d312df57530> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bea4d8b0-7a56-4ea8-bdee-4d312df57530";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bea4d8b0-7a56-4ea8-bdee-4d312df57530>.
+    
+<http://data.lblod.info/id/remote-data-objects/abc71ee8-955c-40e9-9f63-1fcb4201da17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abc71ee8-955c-40e9-9f63-1fcb4201da17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abc71ee8-955c-40e9-9f63-1fcb4201da17>.
+    
+<http://data.lblod.info/id/remote-data-objects/86c73384-ac9f-4651-9ac4-fabcf34b8cbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86c73384-ac9f-4651-9ac4-fabcf34b8cbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86c73384-ac9f-4651-9ac4-fabcf34b8cbb>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f7a432d-7393-4e03-9526-9a5c5567b49d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f7a432d-7393-4e03-9526-9a5c5567b49d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f7a432d-7393-4e03-9526-9a5c5567b49d>.
+    
+<http://data.lblod.info/id/remote-data-objects/31cdbd16-ae9d-43d2-87fa-c9ca7e0985ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31cdbd16-ae9d-43d2-87fa-c9ca7e0985ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31cdbd16-ae9d-43d2-87fa-c9ca7e0985ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/b37c6829-71a2-46c4-a8b0-bcca44684cb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b37c6829-71a2-46c4-a8b0-bcca44684cb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b37c6829-71a2-46c4-a8b0-bcca44684cb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cd0c9be-abf8-4dd2-8fc5-160f3cac5201> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cd0c9be-abf8-4dd2-8fc5-160f3cac5201";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cd0c9be-abf8-4dd2-8fc5-160f3cac5201>.
+    
+<http://data.lblod.info/id/remote-data-objects/f116088c-2969-4b06-afd9-83c2f5a3e254> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f116088c-2969-4b06-afd9-83c2f5a3e254";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f116088c-2969-4b06-afd9-83c2f5a3e254>.
+    
+<http://data.lblod.info/id/remote-data-objects/0af55212-b124-4ea5-b846-441058660469> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0af55212-b124-4ea5-b846-441058660469";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0af55212-b124-4ea5-b846-441058660469>.
+    
+<http://data.lblod.info/id/remote-data-objects/439f0f6d-d144-46fe-8119-5194f4695a38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "439f0f6d-d144-46fe-8119-5194f4695a38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/439f0f6d-d144-46fe-8119-5194f4695a38>.
+    
+<http://data.lblod.info/id/remote-data-objects/f52259e2-ae84-44c4-87b6-ce75a00a1c9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f52259e2-ae84-44c4-87b6-ce75a00a1c9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f52259e2-ae84-44c4-87b6-ce75a00a1c9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c49353b-c13c-418b-a579-01df5510be1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c49353b-c13c-418b-a579-01df5510be1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c49353b-c13c-418b-a579-01df5510be1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9a2d839-d0f6-4f5a-ba37-e22d8090d162> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9a2d839-d0f6-4f5a-ba37-e22d8090d162";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9a2d839-d0f6-4f5a-ba37-e22d8090d162>.
+    
+<http://data.lblod.info/id/remote-data-objects/45e94a8a-bd42-4f3f-94fc-d5743534a1bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45e94a8a-bd42-4f3f-94fc-d5743534a1bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45e94a8a-bd42-4f3f-94fc-d5743534a1bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac6b4037-671b-40f1-8d8e-347a8093e27c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac6b4037-671b-40f1-8d8e-347a8093e27c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac6b4037-671b-40f1-8d8e-347a8093e27c>.
+    
+<http://data.lblod.info/id/remote-data-objects/37f5dc2d-0a63-4c1e-87e4-0f0b86601beb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37f5dc2d-0a63-4c1e-87e4-0f0b86601beb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37f5dc2d-0a63-4c1e-87e4-0f0b86601beb>.
+    
+<http://data.lblod.info/id/remote-data-objects/33493598-ddfc-4018-b302-0fdf5dddef22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33493598-ddfc-4018-b302-0fdf5dddef22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33493598-ddfc-4018-b302-0fdf5dddef22>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ebd3fa1-67b3-496e-9aca-7b890b440692> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ebd3fa1-67b3-496e-9aca-7b890b440692";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ebd3fa1-67b3-496e-9aca-7b890b440692>.
+    
+<http://data.lblod.info/id/remote-data-objects/864932c7-8c14-4e19-9fbf-e1a126bb8628> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "864932c7-8c14-4e19-9fbf-e1a126bb8628";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_26-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/864932c7-8c14-4e19-9fbf-e1a126bb8628>.
+    
+<http://data.lblod.info/id/remote-data-objects/349dece1-f963-44d5-a22a-4f9214cc0398> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "349dece1-f963-44d5-a22a-4f9214cc0398";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/349dece1-f963-44d5-a22a-4f9214cc0398>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a82922f-91ae-49df-8ddd-25a485af51a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a82922f-91ae-49df-8ddd-25a485af51a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a82922f-91ae-49df-8ddd-25a485af51a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/48d69af9-604c-44a6-8f90-1ef1ab3e5822> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48d69af9-604c-44a6-8f90-1ef1ab3e5822";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_28-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48d69af9-604c-44a6-8f90-1ef1ab3e5822>.
+    
+<http://data.lblod.info/id/remote-data-objects/18e2725c-0141-4475-a3a7-1262265cfb3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18e2725c-0141-4475-a3a7-1262265cfb3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_28-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18e2725c-0141-4475-a3a7-1262265cfb3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b78ccb9-3a90-41c3-a038-9d4972796c4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b78ccb9-3a90-41c3-a038-9d4972796c4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b78ccb9-3a90-41c3-a038-9d4972796c4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3d51b00-14d9-4197-bc7e-b5ed58f33259> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3d51b00-14d9-4197-bc7e-b5ed58f33259";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3d51b00-14d9-4197-bc7e-b5ed58f33259>.
+    
+<http://data.lblod.info/id/remote-data-objects/93f3a7f0-3964-4e14-9a3a-6e850ad88809> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93f3a7f0-3964-4e14-9a3a-6e850ad88809";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=Uittreksels_01-03-2022_40601.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93f3a7f0-3964-4e14-9a3a-6e850ad88809>.
+    
+<http://data.lblod.info/id/remote-data-objects/700b2c01-1d2d-46a1-9387-c997c40f94bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "700b2c01-1d2d-46a1-9387-c997c40f94bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=Uittreksels_01-03-2022_40602.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/700b2c01-1d2d-46a1-9387-c997c40f94bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ce3649a-d2d6-4ce4-b5ce-c84a33156a7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ce3649a-d2d6-4ce4-b5ce-c84a33156a7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=Uittreksels_07-06-2022_41842.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ce3649a-d2d6-4ce4-b5ce-c84a33156a7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd176f4f-97e1-46e9-ad18-7a29b998b101> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd176f4f-97e1-46e9-ad18-7a29b998b101";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=Uittreksels_07-06-2022_41860.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd176f4f-97e1-46e9-ad18-7a29b998b101>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a357a6c-ada1-459d-8658-2a23c3cc0b46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a357a6c-ada1-459d-8658-2a23c3cc0b46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=Uittreksels_10-05-2022_41438.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a357a6c-ada1-459d-8658-2a23c3cc0b46>.
+    
+<http://data.lblod.info/id/remote-data-objects/a515cdd3-d8f9-4671-b587-051f8ea69e9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a515cdd3-d8f9-4671-b587-051f8ea69e9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=Uittreksels_10-05-2022_41443.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a515cdd3-d8f9-4671-b587-051f8ea69e9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae1a7982-ee08-4576-bf41-897cb794286d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae1a7982-ee08-4576-bf41-897cb794286d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=Uittreksels_10-05-2022_41460.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae1a7982-ee08-4576-bf41-897cb794286d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5507f2c-de61-4a86-be58-6db2ff1ffe73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5507f2c-de61-4a86-be58-6db2ff1ffe73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=Uittreksels_10-05-2022_41466.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5507f2c-de61-4a86-be58-6db2ff1ffe73>.
+    
+<http://data.lblod.info/id/remote-data-objects/44199b55-7183-4699-80da-30dd210ee4a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44199b55-7183-4699-80da-30dd210ee4a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=Uittreksels_10-05-2022_41473.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44199b55-7183-4699-80da-30dd210ee4a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f35d26c7-d251-482c-81dd-b9deb5751c11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f35d26c7-d251-482c-81dd-b9deb5751c11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=Uittreksels_15-03-2022_40675.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f35d26c7-d251-482c-81dd-b9deb5751c11>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa44c8d8-8638-489b-b7a3-dc8c42f9177f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa44c8d8-8638-489b-b7a3-dc8c42f9177f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=Uittreksels_15-03-2022_40766.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa44c8d8-8638-489b-b7a3-dc8c42f9177f>.
+    
+<http://data.lblod.info/id/remote-data-objects/081b8a87-61a6-45c2-93b7-3b188bc76e90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "081b8a87-61a6-45c2-93b7-3b188bc76e90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=Uittreksels_17-05-2022_41622.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/081b8a87-61a6-45c2-93b7-3b188bc76e90>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c18a7b9-b59e-4be5-9876-4f8228d1daa5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c18a7b9-b59e-4be5-9876-4f8228d1daa5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=Uittreksels_18-01-2022_39064.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c18a7b9-b59e-4be5-9876-4f8228d1daa5>.
+    
+<http://data.lblod.info/id/remote-data-objects/71f5cfef-07a1-4c7b-8a7a-c88a80193f1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71f5cfef-07a1-4c7b-8a7a-c88a80193f1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=Uittreksels_26-04-2022_41217.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71f5cfef-07a1-4c7b-8a7a-c88a80193f1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d89fac6d-2ea3-42a1-add5-5fc6e44f3789> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d89fac6d-2ea3-42a1-add5-5fc6e44f3789";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/54fc4c523d810cc76b385dad30f25fd640ce616939b1be7f17f175e45cf0414a/GetPublication?filename=Uittreksels_28-06-2022_42037.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d89fac6d-2ea3-42a1-add5-5fc6e44f3789>.
+    
+<http://data.lblod.info/id/remote-data-objects/785a85df-cece-4cc9-8e6d-5c12f8d2c116> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "785a85df-cece-4cc9-8e6d-5c12f8d2c116";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/785a85df-cece-4cc9-8e6d-5c12f8d2c116>.
+    
+<http://data.lblod.info/id/remote-data-objects/962de9db-3089-4f46-99ed-30812fccf22a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "962de9db-3089-4f46-99ed-30812fccf22a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/962de9db-3089-4f46-99ed-30812fccf22a>.
+    
+<http://data.lblod.info/id/remote-data-objects/71611d9b-99b6-4642-8369-b8dc880583a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71611d9b-99b6-4642-8369-b8dc880583a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71611d9b-99b6-4642-8369-b8dc880583a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecd1ca43-cbb8-44b0-b445-f7b63bdbf6c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecd1ca43-cbb8-44b0-b445-f7b63bdbf6c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecd1ca43-cbb8-44b0-b445-f7b63bdbf6c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/669507d6-5929-420e-83c8-fb616317f061> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "669507d6-5929-420e-83c8-fb616317f061";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/669507d6-5929-420e-83c8-fb616317f061>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed560aef-a4d8-4185-9029-9b74e03fa5a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed560aef-a4d8-4185-9029-9b74e03fa5a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed560aef-a4d8-4185-9029-9b74e03fa5a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/00e8aec9-5314-4ae9-817b-6ee021430170> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00e8aec9-5314-4ae9-817b-6ee021430170";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a0c343fb-4890-448a-8fe5-176b328687f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00e8aec9-5314-4ae9-817b-6ee021430170>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201447-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201447-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201447-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201447-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e7a14905-4f50-4067-8369-3785acc65ac3> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e7a14905-4f50-4067-8369-3785acc65ac3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "38bac4dc-7aeb-4e17-bbba-d4bc1facdb58";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4403f7d5-20ba-495a-882c-7d769a2c56a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4403f7d5-20ba-495a-882c-7d769a2c56a1";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58>.
+
+  <http://redpencil.data.gift/id/task/29f63c1c-8b39-4b07-ab63-3f83b9029234> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "29f63c1c-8b39-4b07-ab63-3f83b9029234";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e7a14905-4f50-4067-8369-3785acc65ac3>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4403f7d5-20ba-495a-882c-7d769a2c56a1>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/3ef5c612-43e6-4887-8d4b-bc7b72d7636b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ef5c612-43e6-4887-8d4b-bc7b72d7636b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ef5c612-43e6-4887-8d4b-bc7b72d7636b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c06587e5-8aa8-465e-9a08-13ef7199bf06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c06587e5-8aa8-465e-9a08-13ef7199bf06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c06587e5-8aa8-465e-9a08-13ef7199bf06>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cf15063-44ce-494d-a164-74928dcc1482> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cf15063-44ce-494d-a164-74928dcc1482";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cf15063-44ce-494d-a164-74928dcc1482>.
+    
+<http://data.lblod.info/id/remote-data-objects/4141813a-1e34-47f6-bfba-65d44794e95f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4141813a-1e34-47f6-bfba-65d44794e95f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4141813a-1e34-47f6-bfba-65d44794e95f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b66f3c67-43de-4e1b-823b-25838b88c034> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b66f3c67-43de-4e1b-823b-25838b88c034";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b66f3c67-43de-4e1b-823b-25838b88c034>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fd57bfe-6a8d-49e9-9b96-d95e14406e7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fd57bfe-6a8d-49e9-9b96-d95e14406e7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fd57bfe-6a8d-49e9-9b96-d95e14406e7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6ce2886-361d-4898-9514-80b132d4715a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6ce2886-361d-4898-9514-80b132d4715a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6ce2886-361d-4898-9514-80b132d4715a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c666edc-c6b6-4774-a4af-c685f233d073> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c666edc-c6b6-4774-a4af-c685f233d073";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c666edc-c6b6-4774-a4af-c685f233d073>.
+    
+<http://data.lblod.info/id/remote-data-objects/2253b09d-b5b8-483e-9819-3555686e7967> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2253b09d-b5b8-483e-9819-3555686e7967";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2253b09d-b5b8-483e-9819-3555686e7967>.
+    
+<http://data.lblod.info/id/remote-data-objects/8132d4be-f6b5-49ae-a3cc-2f135e162bbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8132d4be-f6b5-49ae-a3cc-2f135e162bbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8132d4be-f6b5-49ae-a3cc-2f135e162bbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/da23da3c-388e-4638-a15c-2770f33ccbbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da23da3c-388e-4638-a15c-2770f33ccbbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da23da3c-388e-4638-a15c-2770f33ccbbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/7938e9ee-2c03-42ec-bb84-4883045af274> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7938e9ee-2c03-42ec-bb84-4883045af274";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7938e9ee-2c03-42ec-bb84-4883045af274>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2ede940-cc5a-4363-8f22-50241aff3cde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2ede940-cc5a-4363-8f22-50241aff3cde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2ede940-cc5a-4363-8f22-50241aff3cde>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f21c981-431a-4bc2-b307-3f53daaee7e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f21c981-431a-4bc2-b307-3f53daaee7e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f21c981-431a-4bc2-b307-3f53daaee7e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/91554010-f607-47ba-b0e6-ab63281dff20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91554010-f607-47ba-b0e6-ab63281dff20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91554010-f607-47ba-b0e6-ab63281dff20>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3a2ea07-e7d4-4e65-8de9-f330cdece32b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3a2ea07-e7d4-4e65-8de9-f330cdece32b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3a2ea07-e7d4-4e65-8de9-f330cdece32b>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb47341d-5015-42df-93c0-5703a179ddfb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb47341d-5015-42df-93c0-5703a179ddfb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb47341d-5015-42df-93c0-5703a179ddfb>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fb6e4bc-a0ea-4aa9-abe9-750efc8b4b70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fb6e4bc-a0ea-4aa9-abe9-750efc8b4b70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fb6e4bc-a0ea-4aa9-abe9-750efc8b4b70>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf9a0a89-85ff-4f46-9e73-3307cbd25e90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf9a0a89-85ff-4f46-9e73-3307cbd25e90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf9a0a89-85ff-4f46-9e73-3307cbd25e90>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4d449b2-9753-4ee9-8f6c-5bb662168a36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4d449b2-9753-4ee9-8f6c-5bb662168a36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4d449b2-9753-4ee9-8f6c-5bb662168a36>.
+    
+<http://data.lblod.info/id/remote-data-objects/7044ddf6-27e2-446e-a0ae-04398b3ab3e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7044ddf6-27e2-446e-a0ae-04398b3ab3e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7044ddf6-27e2-446e-a0ae-04398b3ab3e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/01192d89-a55b-4497-a2cf-88c9005d95b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01192d89-a55b-4497-a2cf-88c9005d95b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01192d89-a55b-4497-a2cf-88c9005d95b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7a19115-3c74-4052-b7fb-a649994eafd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7a19115-3c74-4052-b7fb-a649994eafd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7a19115-3c74-4052-b7fb-a649994eafd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a39c196-151c-4832-a567-d68087735f4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a39c196-151c-4832-a567-d68087735f4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a39c196-151c-4832-a567-d68087735f4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5381be1-8082-4b69-95dc-4a068cfe23ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5381be1-8082-4b69-95dc-4a068cfe23ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5381be1-8082-4b69-95dc-4a068cfe23ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9d101c5-57e5-4897-a1c7-9c86993dc990> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9d101c5-57e5-4897-a1c7-9c86993dc990";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9d101c5-57e5-4897-a1c7-9c86993dc990>.
+    
+<http://data.lblod.info/id/remote-data-objects/17d69800-fd36-4385-9428-33938306dd06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17d69800-fd36-4385-9428-33938306dd06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17d69800-fd36-4385-9428-33938306dd06>.
+    
+<http://data.lblod.info/id/remote-data-objects/e50ca92e-b09d-4c19-9e7d-2e68310fc5c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e50ca92e-b09d-4c19-9e7d-2e68310fc5c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e50ca92e-b09d-4c19-9e7d-2e68310fc5c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4299cb2a-0bf0-4d12-a2dd-d3150193ced4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4299cb2a-0bf0-4d12-a2dd-d3150193ced4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.kruibeke.be/LBLODWeb/Home/Overzicht/63b74ef7fadc678b616f4ff9d20e5d0f4dd24737645ae4a41c38d085be165ab5/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4299cb2a-0bf0-4d12-a2dd-d3150193ced4>.
+    
+<http://data.lblod.info/id/remote-data-objects/66f6b49c-8477-4a35-a014-edc39e7918d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66f6b49c-8477-4a35-a014-edc39e7918d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66f6b49c-8477-4a35-a014-edc39e7918d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/7722ae74-3882-4217-89f8-8843fc3be8bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7722ae74-3882-4217-89f8-8843fc3be8bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7722ae74-3882-4217-89f8-8843fc3be8bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/e48e05a2-b310-48cd-96df-aa53757a3202> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e48e05a2-b310-48cd-96df-aa53757a3202";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e48e05a2-b310-48cd-96df-aa53757a3202>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c042a8e-5878-4848-badc-b7da03ac7e8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c042a8e-5878-4848-badc-b7da03ac7e8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c042a8e-5878-4848-badc-b7da03ac7e8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bc4be96-ff99-4f42-8de6-2d9d6916dc33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bc4be96-ff99-4f42-8de6-2d9d6916dc33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_04-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bc4be96-ff99-4f42-8de6-2d9d6916dc33>.
+    
+<http://data.lblod.info/id/remote-data-objects/dccb5264-d502-4e78-aeb2-30f78088e226> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dccb5264-d502-4e78-aeb2-30f78088e226";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dccb5264-d502-4e78-aeb2-30f78088e226>.
+    
+<http://data.lblod.info/id/remote-data-objects/afde0344-75ae-45ef-b002-9637da2681cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afde0344-75ae-45ef-b002-9637da2681cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afde0344-75ae-45ef-b002-9637da2681cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b26b016-0a48-4beb-b0f9-72179fd115d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b26b016-0a48-4beb-b0f9-72179fd115d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_07-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b26b016-0a48-4beb-b0f9-72179fd115d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bbfbded-2603-443f-9099-68af87003708> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bbfbded-2603-443f-9099-68af87003708";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bbfbded-2603-443f-9099-68af87003708>.
+    
+<http://data.lblod.info/id/remote-data-objects/efa9bc7b-26c1-4c92-8e13-efd195d55786> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efa9bc7b-26c1-4c92-8e13-efd195d55786";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_09-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efa9bc7b-26c1-4c92-8e13-efd195d55786>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd4df6cd-e91d-42a7-acd1-3f4d357b3524> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd4df6cd-e91d-42a7-acd1-3f4d357b3524";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd4df6cd-e91d-42a7-acd1-3f4d357b3524>.
+    
+<http://data.lblod.info/id/remote-data-objects/47c0abc7-492d-4c7c-91ec-63402e0970bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47c0abc7-492d-4c7c-91ec-63402e0970bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47c0abc7-492d-4c7c-91ec-63402e0970bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/4756056e-e7df-4fc4-b03c-9ef6b6354099> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4756056e-e7df-4fc4-b03c-9ef6b6354099";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4756056e-e7df-4fc4-b03c-9ef6b6354099>.
+    
+<http://data.lblod.info/id/remote-data-objects/e14bad0b-ab16-41c2-9bfc-7d1de5855742> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e14bad0b-ab16-41c2-9bfc-7d1de5855742";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e14bad0b-ab16-41c2-9bfc-7d1de5855742>.
+    
+<http://data.lblod.info/id/remote-data-objects/19ea9be4-1459-43d3-ae93-198aac2f6e6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19ea9be4-1459-43d3-ae93-198aac2f6e6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_12-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19ea9be4-1459-43d3-ae93-198aac2f6e6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e279554d-c1d1-40d7-8972-dc4e4959410c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e279554d-c1d1-40d7-8972-dc4e4959410c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e279554d-c1d1-40d7-8972-dc4e4959410c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8426e0b-3b2d-4a04-9534-ea52af461ef2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8426e0b-3b2d-4a04-9534-ea52af461ef2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8426e0b-3b2d-4a04-9534-ea52af461ef2>.
+    
+<http://data.lblod.info/id/remote-data-objects/380df91b-546e-40f8-892f-29a21b2fa719> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "380df91b-546e-40f8-892f-29a21b2fa719";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/380df91b-546e-40f8-892f-29a21b2fa719>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcb93f13-2eac-4c45-b44a-830c5c5c421c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcb93f13-2eac-4c45-b44a-830c5c5c421c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcb93f13-2eac-4c45-b44a-830c5c5c421c>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcecb091-5a88-4ca1-913b-9b05e560c2b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcecb091-5a88-4ca1-913b-9b05e560c2b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcecb091-5a88-4ca1-913b-9b05e560c2b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0db40a14-b761-4440-809d-7ed462fdd57a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0db40a14-b761-4440-809d-7ed462fdd57a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/38bac4dc-7aeb-4e17-bbba-d4bc1facdb58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0db40a14-b761-4440-809d-7ed462fdd57a>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201448-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201448-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201448-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201448-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e0cbfed1-a718-4be2-9481-1982e08cdc35> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e0cbfed1-a718-4be2-9481-1982e08cdc35";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ab5088d8-d222-419a-8fe8-6cff9b550483";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9b4936bf-2a02-441d-83ab-e26c53097720> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9b4936bf-2a02-441d-83ab-e26c53097720";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483>.
+
+  <http://redpencil.data.gift/id/task/6f2160e5-c67d-4437-b11f-1210ddba2ea3> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6f2160e5-c67d-4437-b11f-1210ddba2ea3";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e0cbfed1-a718-4be2-9481-1982e08cdc35>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9b4936bf-2a02-441d-83ab-e26c53097720>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/9247b9d0-da67-4c9f-9d2c-766e4fcb84ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9247b9d0-da67-4c9f-9d2c-766e4fcb84ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9247b9d0-da67-4c9f-9d2c-766e4fcb84ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/450144de-c399-4831-964d-1c803089610c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "450144de-c399-4831-964d-1c803089610c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/450144de-c399-4831-964d-1c803089610c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cf3c6fe-6f60-4e45-abd7-a49d09b51dbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cf3c6fe-6f60-4e45-abd7-a49d09b51dbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cf3c6fe-6f60-4e45-abd7-a49d09b51dbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0ef1cb8-b8d1-46ac-8550-65698bb65bc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0ef1cb8-b8d1-46ac-8550-65698bb65bc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0ef1cb8-b8d1-46ac-8550-65698bb65bc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfbca482-d138-4579-88a6-f355a110c20a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfbca482-d138-4579-88a6-f355a110c20a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfbca482-d138-4579-88a6-f355a110c20a>.
+    
+<http://data.lblod.info/id/remote-data-objects/deb87c76-caad-4aa4-814b-03f64d01d896> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "deb87c76-caad-4aa4-814b-03f64d01d896";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/deb87c76-caad-4aa4-814b-03f64d01d896>.
+    
+<http://data.lblod.info/id/remote-data-objects/6061b53e-f96c-48df-bfe2-5d61a6a475cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6061b53e-f96c-48df-bfe2-5d61a6a475cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6061b53e-f96c-48df-bfe2-5d61a6a475cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a071ea9-ab49-4185-ab4f-391d160bf7e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a071ea9-ab49-4185-ab4f-391d160bf7e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a071ea9-ab49-4185-ab4f-391d160bf7e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6651eb58-2c9b-4e99-a4ea-b2e28d244507> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6651eb58-2c9b-4e99-a4ea-b2e28d244507";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6651eb58-2c9b-4e99-a4ea-b2e28d244507>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4418a26-cdff-457e-a172-08f7bfdac9d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4418a26-cdff-457e-a172-08f7bfdac9d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4418a26-cdff-457e-a172-08f7bfdac9d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7869f0b-f786-433c-a70a-45aecd3604fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7869f0b-f786-433c-a70a-45aecd3604fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7869f0b-f786-433c-a70a-45aecd3604fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a6a4a4c-d629-4615-9dca-435b3cd5f40c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a6a4a4c-d629-4615-9dca-435b3cd5f40c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a6a4a4c-d629-4615-9dca-435b3cd5f40c>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb096e01-3c32-4767-bd00-16b207ae12b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb096e01-3c32-4767-bd00-16b207ae12b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb096e01-3c32-4767-bd00-16b207ae12b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9ebf4eb-545b-4dcd-95b5-8606c5819f46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9ebf4eb-545b-4dcd-95b5-8606c5819f46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9ebf4eb-545b-4dcd-95b5-8606c5819f46>.
+    
+<http://data.lblod.info/id/remote-data-objects/241211fe-2111-4572-a720-f6a00e189f55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "241211fe-2111-4572-a720-f6a00e189f55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/241211fe-2111-4572-a720-f6a00e189f55>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5acfb78-8db6-46f4-9881-21a905a3d6d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5acfb78-8db6-46f4-9881-21a905a3d6d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5acfb78-8db6-46f4-9881-21a905a3d6d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/11635c8d-4773-4a16-874a-5b596c21a841> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11635c8d-4773-4a16-874a-5b596c21a841";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11635c8d-4773-4a16-874a-5b596c21a841>.
+    
+<http://data.lblod.info/id/remote-data-objects/1eb63ed9-81a1-4fb2-8ea8-f78d383734f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1eb63ed9-81a1-4fb2-8ea8-f78d383734f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=BesluitenLijst_Schepencollege_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1eb63ed9-81a1-4fb2-8ea8-f78d383734f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/25a481a4-ff6a-4778-8cd6-1621cdd2f4b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25a481a4-ff6a-4778-8cd6-1621cdd2f4b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=Uittreksels_09-06-2022_38305.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25a481a4-ff6a-4778-8cd6-1621cdd2f4b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd31ec0e-aa2d-42a1-b222-91ef691a77d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd31ec0e-aa2d-42a1-b222-91ef691a77d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=Uittreksels_12-05-2022_37426.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd31ec0e-aa2d-42a1-b222-91ef691a77d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/594eaa21-8a6c-4abd-8cf6-ae62ce6498eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "594eaa21-8a6c-4abd-8cf6-ae62ce6498eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=Uittreksels_14-04-2022_36942.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/594eaa21-8a6c-4abd-8cf6-ae62ce6498eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a1d555b-2f59-4f55-a6a9-aa4ece2e1877> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a1d555b-2f59-4f55-a6a9-aa4ece2e1877";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=Uittreksels_14-07-2022_36944.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a1d555b-2f59-4f55-a6a9-aa4ece2e1877>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c35c13c-d800-4adb-ab63-a7aaa10cabb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c35c13c-d800-4adb-ab63-a7aaa10cabb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=Uittreksels_14-07-2022_38635.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c35c13c-d800-4adb-ab63-a7aaa10cabb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/283326b2-ecd0-4184-b44a-ba2d11582c26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "283326b2-ecd0-4184-b44a-ba2d11582c26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=Uittreksels_14-07-2022_38721.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/283326b2-ecd0-4184-b44a-ba2d11582c26>.
+    
+<http://data.lblod.info/id/remote-data-objects/79d0eff7-43ad-4766-ae24-4f4bda47de24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79d0eff7-43ad-4766-ae24-4f4bda47de24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=Uittreksels_19-05-2022_38106.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79d0eff7-43ad-4766-ae24-4f4bda47de24>.
+    
+<http://data.lblod.info/id/remote-data-objects/8497c7d1-1fbd-4ee7-9890-ff4654678df2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8497c7d1-1fbd-4ee7-9890-ff4654678df2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=Uittreksels_19-05-2022_38109.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8497c7d1-1fbd-4ee7-9890-ff4654678df2>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfa7e4b5-643a-462b-82a1-3d26744dfb9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfa7e4b5-643a-462b-82a1-3d26744dfb9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=Uittreksels_24-03-2022_37368.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfa7e4b5-643a-462b-82a1-3d26744dfb9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb05d58a-1bf3-4453-a68e-229f571fc49c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb05d58a-1bf3-4453-a68e-229f571fc49c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/062cb4dc08fca3c1116133ac66cdfeeb11c783784117f2f9759f638ed44849d0/GetPublication?filename=Uittreksels_31-03-2022_37409.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb05d58a-1bf3-4453-a68e-229f571fc49c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6db1018-7a25-4e19-a89b-b213c7e04cdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6db1018-7a25-4e19-a89b-b213c7e04cdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6db1018-7a25-4e19-a89b-b213c7e04cdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1c646d3-6dae-47ae-ab95-97f8ceb020ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1c646d3-6dae-47ae-ab95-97f8ceb020ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1c646d3-6dae-47ae-ab95-97f8ceb020ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/6039c3a1-f1ec-4314-9dca-da1884f00739> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6039c3a1-f1ec-4314-9dca-da1884f00739";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6039c3a1-f1ec-4314-9dca-da1884f00739>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7365712-bf22-4997-8620-d0c9264a105b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7365712-bf22-4997-8620-d0c9264a105b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7365712-bf22-4997-8620-d0c9264a105b>.
+    
+<http://data.lblod.info/id/remote-data-objects/64621cd7-938a-4a94-b44c-3f8e11338dd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64621cd7-938a-4a94-b44c-3f8e11338dd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64621cd7-938a-4a94-b44c-3f8e11338dd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0ee619d-8b27-428f-9f88-140599ec4bb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0ee619d-8b27-428f-9f88-140599ec4bb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_02-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0ee619d-8b27-428f-9f88-140599ec4bb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/68f95a16-9762-4058-a921-e3afd93ccf00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68f95a16-9762-4058-a921-e3afd93ccf00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68f95a16-9762-4058-a921-e3afd93ccf00>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fc70c1b-eac1-4b7e-97f0-021b84959f11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fc70c1b-eac1-4b7e-97f0-021b84959f11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fc70c1b-eac1-4b7e-97f0-021b84959f11>.
+    
+<http://data.lblod.info/id/remote-data-objects/707d76c8-2dd2-49d3-8ad8-bd1a1916bb1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "707d76c8-2dd2-49d3-8ad8-bd1a1916bb1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/707d76c8-2dd2-49d3-8ad8-bd1a1916bb1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/badbef99-577c-4b5b-a654-7994e210fadf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "badbef99-577c-4b5b-a654-7994e210fadf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/badbef99-577c-4b5b-a654-7994e210fadf>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a9bb771-f52d-4660-9e52-68035d97df0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a9bb771-f52d-4660-9e52-68035d97df0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_04-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a9bb771-f52d-4660-9e52-68035d97df0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4930c9d2-7940-4b77-80fc-8e04057a301a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4930c9d2-7940-4b77-80fc-8e04057a301a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4930c9d2-7940-4b77-80fc-8e04057a301a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7960acd7-470f-4f8c-82ea-2f33b98d1ab8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7960acd7-470f-4f8c-82ea-2f33b98d1ab8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7960acd7-470f-4f8c-82ea-2f33b98d1ab8>.
+    
+<http://data.lblod.info/id/remote-data-objects/35d5d9ae-bb0f-457d-a240-dab3c837a0bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35d5d9ae-bb0f-457d-a240-dab3c837a0bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35d5d9ae-bb0f-457d-a240-dab3c837a0bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/e17b6f0d-11dc-40a4-bcdb-ef881c292cac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e17b6f0d-11dc-40a4-bcdb-ef881c292cac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_04-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e17b6f0d-11dc-40a4-bcdb-ef881c292cac>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed57ee86-0283-401b-ab40-8c4f8e891473> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed57ee86-0283-401b-ab40-8c4f8e891473";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed57ee86-0283-401b-ab40-8c4f8e891473>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fd71eb0-8cfd-4d48-91b9-4c9138df1ffb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fd71eb0-8cfd-4d48-91b9-4c9138df1ffb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fd71eb0-8cfd-4d48-91b9-4c9138df1ffb>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f60ec3e-657d-4667-bfeb-bc0480a84182> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f60ec3e-657d-4667-bfeb-bc0480a84182";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f60ec3e-657d-4667-bfeb-bc0480a84182>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f46605c-203e-4a28-b19a-70548fdedbd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f46605c-203e-4a28-b19a-70548fdedbd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_05-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f46605c-203e-4a28-b19a-70548fdedbd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/31dcb1fb-3850-408b-8aa9-a6f415c02d5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31dcb1fb-3850-408b-8aa9-a6f415c02d5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31dcb1fb-3850-408b-8aa9-a6f415c02d5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e173094-8462-4a10-8367-7db7be8b1907> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e173094-8462-4a10-8367-7db7be8b1907";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e173094-8462-4a10-8367-7db7be8b1907>.
+    
+<http://data.lblod.info/id/remote-data-objects/15e55d22-9b9f-44a2-a6c1-821ef3eb571b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15e55d22-9b9f-44a2-a6c1-821ef3eb571b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab5088d8-d222-419a-8fe8-6cff9b550483> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15e55d22-9b9f-44a2-a6c1-821ef3eb571b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201449-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201449-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201449-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201449-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b707e072-fdc3-46f7-b351-fa1ad04a50ae> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b707e072-fdc3-46f7-b351-fa1ad04a50ae";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0a22b8c7-239c-4341-b8e9-11dc85fefeae";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/713b24c1-e01e-4e5e-9bd0-184c0153f7c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "713b24c1-e01e-4e5e-9bd0-184c0153f7c9";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae>.
+
+  <http://redpencil.data.gift/id/task/32aadc79-dd25-408b-b185-a59992287436> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "32aadc79-dd25-408b-b185-a59992287436";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b707e072-fdc3-46f7-b351-fa1ad04a50ae>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/713b24c1-e01e-4e5e-9bd0-184c0153f7c9>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/591d86f0-02c0-4db5-87fb-5f259476b3eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "591d86f0-02c0-4db5-87fb-5f259476b3eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_06-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/591d86f0-02c0-4db5-87fb-5f259476b3eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/203b2a89-efdf-4a5c-9a96-dba691960ac6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "203b2a89-efdf-4a5c-9a96-dba691960ac6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/203b2a89-efdf-4a5c-9a96-dba691960ac6>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc65d140-8990-4276-8dc0-3d90d928883a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc65d140-8990-4276-8dc0-3d90d928883a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc65d140-8990-4276-8dc0-3d90d928883a>.
+    
+<http://data.lblod.info/id/remote-data-objects/644e86f8-bb2e-4f2a-8fbd-1fb0f71370fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "644e86f8-bb2e-4f2a-8fbd-1fb0f71370fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/644e86f8-bb2e-4f2a-8fbd-1fb0f71370fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c25748b0-698b-4d34-9759-db117c07c037> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c25748b0-698b-4d34-9759-db117c07c037";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c25748b0-698b-4d34-9759-db117c07c037>.
+    
+<http://data.lblod.info/id/remote-data-objects/aef9e33c-20ec-4b06-9d47-c3ad0b32a3a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aef9e33c-20ec-4b06-9d47-c3ad0b32a3a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aef9e33c-20ec-4b06-9d47-c3ad0b32a3a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfd04f34-44eb-4be2-9db4-a923c480b3a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfd04f34-44eb-4be2-9db4-a923c480b3a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfd04f34-44eb-4be2-9db4-a923c480b3a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/86731333-5544-48a0-95c3-d6e1f3da9c65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86731333-5544-48a0-95c3-d6e1f3da9c65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86731333-5544-48a0-95c3-d6e1f3da9c65>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef4a07e5-093d-4b80-9cf5-61761cc6eab4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef4a07e5-093d-4b80-9cf5-61761cc6eab4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef4a07e5-093d-4b80-9cf5-61761cc6eab4>.
+    
+<http://data.lblod.info/id/remote-data-objects/56348a7f-b77a-47ed-b5c7-5fc01d105678> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56348a7f-b77a-47ed-b5c7-5fc01d105678";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56348a7f-b77a-47ed-b5c7-5fc01d105678>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d35278f-3455-459f-b879-6b278b8434e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d35278f-3455-459f-b879-6b278b8434e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d35278f-3455-459f-b879-6b278b8434e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bb17596-374b-4543-b71e-992513b99a7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bb17596-374b-4543-b71e-992513b99a7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_09-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bb17596-374b-4543-b71e-992513b99a7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c962cf07-47b5-43b0-8979-15078fd9544a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c962cf07-47b5-43b0-8979-15078fd9544a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c962cf07-47b5-43b0-8979-15078fd9544a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc59bb2c-6ee6-4737-82ad-7c277a885f6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc59bb2c-6ee6-4737-82ad-7c277a885f6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc59bb2c-6ee6-4737-82ad-7c277a885f6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbef9b52-16b6-4b02-8a1f-5ff8a8a81a7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbef9b52-16b6-4b02-8a1f-5ff8a8a81a7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbef9b52-16b6-4b02-8a1f-5ff8a8a81a7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0379aea-a38c-4523-a7a0-0508fda2e4ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0379aea-a38c-4523-a7a0-0508fda2e4ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0379aea-a38c-4523-a7a0-0508fda2e4ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/092f418d-0ecf-4f54-8898-652e00e1c7a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "092f418d-0ecf-4f54-8898-652e00e1c7a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/092f418d-0ecf-4f54-8898-652e00e1c7a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/43ccbae8-1999-40b9-a446-64ce74a3abd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43ccbae8-1999-40b9-a446-64ce74a3abd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43ccbae8-1999-40b9-a446-64ce74a3abd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3c45f86-84b4-4869-b57b-50a017d03d3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3c45f86-84b4-4869-b57b-50a017d03d3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3c45f86-84b4-4869-b57b-50a017d03d3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/38a7b309-ba42-4592-9950-c3003c96dd76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38a7b309-ba42-4592-9950-c3003c96dd76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38a7b309-ba42-4592-9950-c3003c96dd76>.
+    
+<http://data.lblod.info/id/remote-data-objects/706613be-1171-4128-94b7-a42832bb401f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "706613be-1171-4128-94b7-a42832bb401f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/706613be-1171-4128-94b7-a42832bb401f>.
+    
+<http://data.lblod.info/id/remote-data-objects/cce11345-9748-4bd8-b8c1-3dfc513afb1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cce11345-9748-4bd8-b8c1-3dfc513afb1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cce11345-9748-4bd8-b8c1-3dfc513afb1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/21ccaa6b-1a87-43a7-a236-5b6ea6d229d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21ccaa6b-1a87-43a7-a236-5b6ea6d229d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21ccaa6b-1a87-43a7-a236-5b6ea6d229d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5297ad3b-f61c-4550-81bf-6ce95bea95e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5297ad3b-f61c-4550-81bf-6ce95bea95e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5297ad3b-f61c-4550-81bf-6ce95bea95e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0ae5f1b-99b0-46c3-a5c5-b97c66fd2843> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0ae5f1b-99b0-46c3-a5c5-b97c66fd2843";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0ae5f1b-99b0-46c3-a5c5-b97c66fd2843>.
+    
+<http://data.lblod.info/id/remote-data-objects/226e2a15-38bf-4743-81e6-fcf71b278bf4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "226e2a15-38bf-4743-81e6-fcf71b278bf4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/226e2a15-38bf-4743-81e6-fcf71b278bf4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ac7aede-939e-4afd-b1c7-d1f580a4502c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ac7aede-939e-4afd-b1c7-d1f580a4502c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ac7aede-939e-4afd-b1c7-d1f580a4502c>.
+    
+<http://data.lblod.info/id/remote-data-objects/74c0742a-6288-4913-a9b4-9f7d8e8d321a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74c0742a-6288-4913-a9b4-9f7d8e8d321a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74c0742a-6288-4913-a9b4-9f7d8e8d321a>.
+    
+<http://data.lblod.info/id/remote-data-objects/85275afe-1e87-4912-a3d8-86f61428e26a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85275afe-1e87-4912-a3d8-86f61428e26a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85275afe-1e87-4912-a3d8-86f61428e26a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d79eeb6e-6d4c-4c13-8b87-277539649860> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d79eeb6e-6d4c-4c13-8b87-277539649860";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d79eeb6e-6d4c-4c13-8b87-277539649860>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d75937f-fe2c-4612-9833-94ad3e2d4740> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d75937f-fe2c-4612-9833-94ad3e2d4740";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d75937f-fe2c-4612-9833-94ad3e2d4740>.
+    
+<http://data.lblod.info/id/remote-data-objects/96dde44f-dc8f-4aa9-8439-a7634e3e4169> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96dde44f-dc8f-4aa9-8439-a7634e3e4169";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96dde44f-dc8f-4aa9-8439-a7634e3e4169>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5dbc28f-7f07-4407-b016-d27eaf2e4159> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5dbc28f-7f07-4407-b016-d27eaf2e4159";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5dbc28f-7f07-4407-b016-d27eaf2e4159>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9064dfd-6caa-4b91-bf33-754ebb125f5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9064dfd-6caa-4b91-bf33-754ebb125f5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9064dfd-6caa-4b91-bf33-754ebb125f5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c403aadf-7854-4c1f-9648-4534b9e3e7a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c403aadf-7854-4c1f-9648-4534b9e3e7a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c403aadf-7854-4c1f-9648-4534b9e3e7a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b84b411-7abb-4cac-861e-0c14efb84287> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b84b411-7abb-4cac-861e-0c14efb84287";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b84b411-7abb-4cac-861e-0c14efb84287>.
+    
+<http://data.lblod.info/id/remote-data-objects/79a93cc3-6e33-4d9d-b13d-10511b24c418> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79a93cc3-6e33-4d9d-b13d-10511b24c418";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79a93cc3-6e33-4d9d-b13d-10511b24c418>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a194015-fdea-4cdc-aee1-aab41cb952d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a194015-fdea-4cdc-aee1-aab41cb952d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a194015-fdea-4cdc-aee1-aab41cb952d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/afa86127-5708-43f3-addc-fe985944614d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afa86127-5708-43f3-addc-fe985944614d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afa86127-5708-43f3-addc-fe985944614d>.
+    
+<http://data.lblod.info/id/remote-data-objects/70946806-b9d8-4070-a2fc-6e61d1095de8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70946806-b9d8-4070-a2fc-6e61d1095de8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70946806-b9d8-4070-a2fc-6e61d1095de8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2f91f64-5ba4-4abb-80e0-dbc988bfa1a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2f91f64-5ba4-4abb-80e0-dbc988bfa1a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2f91f64-5ba4-4abb-80e0-dbc988bfa1a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/896e0adb-1dba-4866-85e4-01e749be5f38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "896e0adb-1dba-4866-85e4-01e749be5f38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/896e0adb-1dba-4866-85e4-01e749be5f38>.
+    
+<http://data.lblod.info/id/remote-data-objects/f32b1ae1-36c6-41eb-a40f-5701ad5332e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f32b1ae1-36c6-41eb-a40f-5701ad5332e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f32b1ae1-36c6-41eb-a40f-5701ad5332e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/01a887f5-951f-4c4d-ba1c-5e787abb39d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01a887f5-951f-4c4d-ba1c-5e787abb39d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01a887f5-951f-4c4d-ba1c-5e787abb39d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/582d02c4-4d71-4884-bac8-c9c505c4f069> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "582d02c4-4d71-4884-bac8-c9c505c4f069";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/582d02c4-4d71-4884-bac8-c9c505c4f069>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed4e395b-4f10-49ca-9e24-e8131ec80124> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed4e395b-4f10-49ca-9e24-e8131ec80124";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed4e395b-4f10-49ca-9e24-e8131ec80124>.
+    
+<http://data.lblod.info/id/remote-data-objects/4081b388-b1dc-4a96-b6cb-b6bd78f042e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4081b388-b1dc-4a96-b6cb-b6bd78f042e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4081b388-b1dc-4a96-b6cb-b6bd78f042e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/594852e8-966e-45af-a1e3-4c9a28185040> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "594852e8-966e-45af-a1e3-4c9a28185040";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/594852e8-966e-45af-a1e3-4c9a28185040>.
+    
+<http://data.lblod.info/id/remote-data-objects/110942c5-d1a8-4381-b6b6-3c269e9837ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "110942c5-d1a8-4381-b6b6-3c269e9837ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/110942c5-d1a8-4381-b6b6-3c269e9837ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d662210-2965-4faa-aeb2-ec3da4aa3d9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d662210-2965-4faa-aeb2-ec3da4aa3d9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0a22b8c7-239c-4341-b8e9-11dc85fefeae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d662210-2965-4faa-aeb2-ec3da4aa3d9d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201451-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201451-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201451-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201451-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/188a2dbc-9123-4169-b2e3-24510573c2f6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "188a2dbc-9123-4169-b2e3-24510573c2f6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "15bf9ef2-6b41-4c02-9c76-98ed318e3941";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/8fc7a0bf-0607-483e-b6e5-5bb7fba21cec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8fc7a0bf-0607-483e-b6e5-5bb7fba21cec";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941>.
+
+  <http://redpencil.data.gift/id/task/89723d48-220e-4690-ab87-b3f10b3f9001> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "89723d48-220e-4690-ab87-b3f10b3f9001";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/188a2dbc-9123-4169-b2e3-24510573c2f6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/8fc7a0bf-0607-483e-b6e5-5bb7fba21cec>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/41c345af-7265-4452-a9e2-5a50af993038> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41c345af-7265-4452-a9e2-5a50af993038";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41c345af-7265-4452-a9e2-5a50af993038>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5243676-f302-45e3-8759-4edd33af7f4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5243676-f302-45e3-8759-4edd33af7f4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5243676-f302-45e3-8759-4edd33af7f4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9fa5081-16ae-418c-9e5e-4b8ebdcb5fa2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9fa5081-16ae-418c-9e5e-4b8ebdcb5fa2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9fa5081-16ae-418c-9e5e-4b8ebdcb5fa2>.
+    
+<http://data.lblod.info/id/remote-data-objects/35f63403-b067-415b-8e51-15f19315baed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35f63403-b067-415b-8e51-15f19315baed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35f63403-b067-415b-8e51-15f19315baed>.
+    
+<http://data.lblod.info/id/remote-data-objects/81d5533a-6408-43a7-aa1a-4c26671ffa49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81d5533a-6408-43a7-aa1a-4c26671ffa49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81d5533a-6408-43a7-aa1a-4c26671ffa49>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d64b5a8-ac0d-4e85-b933-90247c126896> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d64b5a8-ac0d-4e85-b933-90247c126896";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d64b5a8-ac0d-4e85-b933-90247c126896>.
+    
+<http://data.lblod.info/id/remote-data-objects/7aff4b4c-8e14-46e0-90f7-8f9cf7078ad1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7aff4b4c-8e14-46e0-90f7-8f9cf7078ad1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_25-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7aff4b4c-8e14-46e0-90f7-8f9cf7078ad1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d40aafb-4f68-4443-a171-4feccef0318b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d40aafb-4f68-4443-a171-4feccef0318b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d40aafb-4f68-4443-a171-4feccef0318b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f60ddd6-44bf-481d-9d1c-da1d0e5a93c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f60ddd6-44bf-481d-9d1c-da1d0e5a93c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f60ddd6-44bf-481d-9d1c-da1d0e5a93c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/f777a0e0-2421-4d52-9060-0cb591ed84fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f777a0e0-2421-4d52-9060-0cb591ed84fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f777a0e0-2421-4d52-9060-0cb591ed84fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c4a5a28-3ed7-4972-830d-ddd7ba5f6078> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c4a5a28-3ed7-4972-830d-ddd7ba5f6078";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c4a5a28-3ed7-4972-830d-ddd7ba5f6078>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cff3798-d68b-4f30-bf1f-cbf611472ed0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cff3798-d68b-4f30-bf1f-cbf611472ed0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cff3798-d68b-4f30-bf1f-cbf611472ed0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a34d9336-42c9-43c5-9f74-a07ecd40855a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a34d9336-42c9-43c5-9f74-a07ecd40855a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a34d9336-42c9-43c5-9f74-a07ecd40855a>.
+    
+<http://data.lblod.info/id/remote-data-objects/10b8a0bd-4bde-4c2b-b598-cf7b0e2f18a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10b8a0bd-4bde-4c2b-b598-cf7b0e2f18a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10b8a0bd-4bde-4c2b-b598-cf7b0e2f18a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a64486da-d49c-473a-ab5f-5a4d31749a7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a64486da-d49c-473a-ab5f-5a4d31749a7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a64486da-d49c-473a-ab5f-5a4d31749a7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e662a717-ff78-42a4-984c-c61367ecb7c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e662a717-ff78-42a4-984c-c61367ecb7c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e662a717-ff78-42a4-984c-c61367ecb7c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5592195-0824-453e-96ec-7c41cd6916af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5592195-0824-453e-96ec-7c41cd6916af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5592195-0824-453e-96ec-7c41cd6916af>.
+    
+<http://data.lblod.info/id/remote-data-objects/99d80be3-950a-4a96-bf4c-f3e7ccfa6d6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99d80be3-950a-4a96-bf4c-f3e7ccfa6d6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99d80be3-950a-4a96-bf4c-f3e7ccfa6d6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb291528-7ca4-4235-a673-7ffe58ded7f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb291528-7ca4-4235-a673-7ffe58ded7f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb291528-7ca4-4235-a673-7ffe58ded7f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/293cefd8-1e52-45ec-a870-fa46bea34fda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "293cefd8-1e52-45ec-a870-fa46bea34fda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/293cefd8-1e52-45ec-a870-fa46bea34fda>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb486f3e-717b-4b30-bb6f-954a607486a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb486f3e-717b-4b30-bb6f-954a607486a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb486f3e-717b-4b30-bb6f-954a607486a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/060239c4-fbb1-48b4-816f-19d7428c6aa6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "060239c4-fbb1-48b4-816f-19d7428c6aa6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/060239c4-fbb1-48b4-816f-19d7428c6aa6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0485036-4098-4dad-a920-dd8b4e362152> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0485036-4098-4dad-a920-dd8b4e362152";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/32134e23dd60ccaf2a164181424a1a6e8f8022ed66d937065406e145c9c4ada8/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20Burgemeester_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0485036-4098-4dad-a920-dd8b4e362152>.
+    
+<http://data.lblod.info/id/remote-data-objects/e291cf1f-2812-4f28-994e-8caae1b3f0d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e291cf1f-2812-4f28-994e-8caae1b3f0d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e291cf1f-2812-4f28-994e-8caae1b3f0d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c0c26d0-785b-4f51-b2ba-87baff0f05bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c0c26d0-785b-4f51-b2ba-87baff0f05bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c0c26d0-785b-4f51-b2ba-87baff0f05bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/2959da6c-b623-40f3-809e-a7f9f40f2607> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2959da6c-b623-40f3-809e-a7f9f40f2607";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2959da6c-b623-40f3-809e-a7f9f40f2607>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5e441ca-02a4-4d6b-8d80-c22b46617eb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5e441ca-02a4-4d6b-8d80-c22b46617eb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5e441ca-02a4-4d6b-8d80-c22b46617eb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/28a36f89-c7cd-4fdf-a2c5-c6d35b2c5184> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28a36f89-c7cd-4fdf-a2c5-c6d35b2c5184";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_04-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28a36f89-c7cd-4fdf-a2c5-c6d35b2c5184>.
+    
+<http://data.lblod.info/id/remote-data-objects/82df8f53-3beb-4541-90fc-08170fbe7782> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82df8f53-3beb-4541-90fc-08170fbe7782";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82df8f53-3beb-4541-90fc-08170fbe7782>.
+    
+<http://data.lblod.info/id/remote-data-objects/5082a5ab-c20b-447c-8e5e-89886958da71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5082a5ab-c20b-447c-8e5e-89886958da71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5082a5ab-c20b-447c-8e5e-89886958da71>.
+    
+<http://data.lblod.info/id/remote-data-objects/050ebe55-5a59-4453-95fa-227bf579381c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "050ebe55-5a59-4453-95fa-227bf579381c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/050ebe55-5a59-4453-95fa-227bf579381c>.
+    
+<http://data.lblod.info/id/remote-data-objects/71728f9e-a123-4a33-b17b-8ae02b626d3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71728f9e-a123-4a33-b17b-8ae02b626d3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71728f9e-a123-4a33-b17b-8ae02b626d3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/49cf8186-37b9-48d0-b30f-2cb1b78aa943> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49cf8186-37b9-48d0-b30f-2cb1b78aa943";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49cf8186-37b9-48d0-b30f-2cb1b78aa943>.
+    
+<http://data.lblod.info/id/remote-data-objects/be98753b-969e-466c-83b5-3cc145518739> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be98753b-969e-466c-83b5-3cc145518739";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_09-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be98753b-969e-466c-83b5-3cc145518739>.
+    
+<http://data.lblod.info/id/remote-data-objects/90063622-a852-42c7-9e66-fcd83f04343b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90063622-a852-42c7-9e66-fcd83f04343b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90063622-a852-42c7-9e66-fcd83f04343b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fe049b2-754b-4ba4-8743-2569a44795a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fe049b2-754b-4ba4-8743-2569a44795a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fe049b2-754b-4ba4-8743-2569a44795a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/214da27a-14c7-48d6-a90f-14466fb0c207> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "214da27a-14c7-48d6-a90f-14466fb0c207";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/214da27a-14c7-48d6-a90f-14466fb0c207>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3122e43-bc98-4639-901f-c82ee19b1e39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3122e43-bc98-4639-901f-c82ee19b1e39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3122e43-bc98-4639-901f-c82ee19b1e39>.
+    
+<http://data.lblod.info/id/remote-data-objects/f837ceac-81c3-4223-8f8c-2fd56e53b41e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f837ceac-81c3-4223-8f8c-2fd56e53b41e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f837ceac-81c3-4223-8f8c-2fd56e53b41e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d67a122-e858-4b01-9378-42b20e3bab24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d67a122-e858-4b01-9378-42b20e3bab24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d67a122-e858-4b01-9378-42b20e3bab24>.
+    
+<http://data.lblod.info/id/remote-data-objects/5776888c-6d13-4fe4-ae30-a5a717c7ea9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5776888c-6d13-4fe4-ae30-a5a717c7ea9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5776888c-6d13-4fe4-ae30-a5a717c7ea9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b55adc7-72ef-4bd6-8a9e-cc9395ffcde4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b55adc7-72ef-4bd6-8a9e-cc9395ffcde4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b55adc7-72ef-4bd6-8a9e-cc9395ffcde4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e58c6aa-beaa-4ba2-b77a-e8ec21a27641> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e58c6aa-beaa-4ba2-b77a-e8ec21a27641";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e58c6aa-beaa-4ba2-b77a-e8ec21a27641>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb2a1632-bd72-497a-a596-11c97f6bee4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb2a1632-bd72-497a-a596-11c97f6bee4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb2a1632-bd72-497a-a596-11c97f6bee4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/061c8dd5-64d4-462f-88c8-841464f6f836> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "061c8dd5-64d4-462f-88c8-841464f6f836";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/061c8dd5-64d4-462f-88c8-841464f6f836>.
+    
+<http://data.lblod.info/id/remote-data-objects/e40c66a6-84e4-4587-a2c5-27a0a6dce7cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e40c66a6-84e4-4587-a2c5-27a0a6dce7cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e40c66a6-84e4-4587-a2c5-27a0a6dce7cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/560c7116-21fb-4049-8a68-7226c9e6a2e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "560c7116-21fb-4049-8a68-7226c9e6a2e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/560c7116-21fb-4049-8a68-7226c9e6a2e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/28288190-8f4f-4380-89e3-907f89c6be94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28288190-8f4f-4380-89e3-907f89c6be94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28288190-8f4f-4380-89e3-907f89c6be94>.
+    
+<http://data.lblod.info/id/remote-data-objects/48854e32-2f93-42d9-a621-dbdc199165da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48854e32-2f93-42d9-a621-dbdc199165da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48854e32-2f93-42d9-a621-dbdc199165da>.
+    
+<http://data.lblod.info/id/remote-data-objects/77fb0110-b2a1-4707-9a22-727e6653c3c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77fb0110-b2a1-4707-9a22-727e6653c3c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15bf9ef2-6b41-4c02-9c76-98ed318e3941> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77fb0110-b2a1-4707-9a22-727e6653c3c1>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201452-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201452-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201452-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201452-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/0a64bc30-b505-450a-81fe-38ba13f1ebf9> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0a64bc30-b505-450a-81fe-38ba13f1ebf9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8bce86de-90f8-47d9-9ede-3142fc327147";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/35efbbfc-c9c6-4a00-b053-a57418d1f290> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "35efbbfc-c9c6-4a00-b053-a57418d1f290";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147>.
+
+  <http://redpencil.data.gift/id/task/54cd8993-2f63-4ab6-82d1-0d40d93c84d7> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "54cd8993-2f63-4ab6-82d1-0d40d93c84d7";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/0a64bc30-b505-450a-81fe-38ba13f1ebf9>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/35efbbfc-c9c6-4a00-b053-a57418d1f290>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/aa878c2f-ade0-4812-ba31-814def12732d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa878c2f-ade0-4812-ba31-814def12732d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa878c2f-ade0-4812-ba31-814def12732d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c99baf09-3de9-4f30-bef6-785215a95efd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c99baf09-3de9-4f30-bef6-785215a95efd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c99baf09-3de9-4f30-bef6-785215a95efd>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4776873-f247-4dbe-8998-8b10f35162ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4776873-f247-4dbe-8998-8b10f35162ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4776873-f247-4dbe-8998-8b10f35162ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc9cfe3b-afde-44c0-8f7d-a00281ba639f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc9cfe3b-afde-44c0-8f7d-a00281ba639f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc9cfe3b-afde-44c0-8f7d-a00281ba639f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b8232b2-6641-474f-a84d-ef0cd662d082> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b8232b2-6641-474f-a84d-ef0cd662d082";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b8232b2-6641-474f-a84d-ef0cd662d082>.
+    
+<http://data.lblod.info/id/remote-data-objects/58406459-c909-40de-ac4e-ffbe00b7886f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58406459-c909-40de-ac4e-ffbe00b7886f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58406459-c909-40de-ac4e-ffbe00b7886f>.
+    
+<http://data.lblod.info/id/remote-data-objects/af491502-f58b-4123-adb4-23b2e285079e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af491502-f58b-4123-adb4-23b2e285079e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af491502-f58b-4123-adb4-23b2e285079e>.
+    
+<http://data.lblod.info/id/remote-data-objects/77e48151-fc7a-43cd-8fba-115d14da8403> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77e48151-fc7a-43cd-8fba-115d14da8403";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77e48151-fc7a-43cd-8fba-115d14da8403>.
+    
+<http://data.lblod.info/id/remote-data-objects/57e401ef-274f-4636-a9cf-5f57ff4e0444> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57e401ef-274f-4636-a9cf-5f57ff4e0444";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57e401ef-274f-4636-a9cf-5f57ff4e0444>.
+    
+<http://data.lblod.info/id/remote-data-objects/093b6233-4c01-40eb-81f7-3aa6bab447ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "093b6233-4c01-40eb-81f7-3aa6bab447ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/093b6233-4c01-40eb-81f7-3aa6bab447ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/703bd0cc-185a-4bb4-83ab-f7ef7edcb7a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "703bd0cc-185a-4bb4-83ab-f7ef7edcb7a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/54a9e112e45170ffee95805d824b27d7b51c17d6b7d47da700fd2ae63189e42e/GetPublication?filename=BesluitenLijst_Vast%20bureau_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/703bd0cc-185a-4bb4-83ab-f7ef7edcb7a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/591a1144-447a-4d80-90f7-20b65263919a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "591a1144-447a-4d80-90f7-20b65263919a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Agenda_OCMW-Raad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/591a1144-447a-4d80-90f7-20b65263919a>.
+    
+<http://data.lblod.info/id/remote-data-objects/565ba6ba-40e6-46e9-923d-bce15fa80ece> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "565ba6ba-40e6-46e9-923d-bce15fa80ece";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Agenda_OCMW-Raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/565ba6ba-40e6-46e9-923d-bce15fa80ece>.
+    
+<http://data.lblod.info/id/remote-data-objects/bced5579-167b-4d56-bbfb-e0689c2d2951> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bced5579-167b-4d56-bbfb-e0689c2d2951";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Agenda_OCMW-Raad_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bced5579-167b-4d56-bbfb-e0689c2d2951>.
+    
+<http://data.lblod.info/id/remote-data-objects/833a6e73-8009-4dca-bdff-4e00a70fcd73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "833a6e73-8009-4dca-bdff-4e00a70fcd73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Agenda_OCMW-Raad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/833a6e73-8009-4dca-bdff-4e00a70fcd73>.
+    
+<http://data.lblod.info/id/remote-data-objects/115c0054-55e5-495a-b325-4f53c493a58e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "115c0054-55e5-495a-b325-4f53c493a58e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Agenda_OCMW-Raad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/115c0054-55e5-495a-b325-4f53c493a58e>.
+    
+<http://data.lblod.info/id/remote-data-objects/02623e35-e614-43c3-b91c-c32b89d322df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02623e35-e614-43c3-b91c-c32b89d322df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Agenda_OCMW-Raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02623e35-e614-43c3-b91c-c32b89d322df>.
+    
+<http://data.lblod.info/id/remote-data-objects/87f06bf1-9e05-4f1e-8ef2-f9b92116e1a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87f06bf1-9e05-4f1e-8ef2-f9b92116e1a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Agenda_OCMW-Raad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87f06bf1-9e05-4f1e-8ef2-f9b92116e1a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb565a9f-5f0c-432c-bfb5-d5170c296e4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb565a9f-5f0c-432c-bfb5-d5170c296e4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Agenda_OCMW-Raad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb565a9f-5f0c-432c-bfb5-d5170c296e4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7f8c6d9-a6e0-4b2a-97a7-7b62545748f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7f8c6d9-a6e0-4b2a-97a7-7b62545748f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Agenda_OCMW-Raad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7f8c6d9-a6e0-4b2a-97a7-7b62545748f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/41ba41bd-3f11-47e5-a248-4064b7d5735c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41ba41bd-3f11-47e5-a248-4064b7d5735c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=BesluitenLijst_OCMW-Raad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41ba41bd-3f11-47e5-a248-4064b7d5735c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5d047c3-276f-41b9-87e3-8a14d2a6932c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5d047c3-276f-41b9-87e3-8a14d2a6932c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=BesluitenLijst_OCMW-Raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5d047c3-276f-41b9-87e3-8a14d2a6932c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7107978-1f3c-407b-a938-4887f73f5c33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7107978-1f3c-407b-a938-4887f73f5c33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=BesluitenLijst_OCMW-Raad_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7107978-1f3c-407b-a938-4887f73f5c33>.
+    
+<http://data.lblod.info/id/remote-data-objects/f697374d-e276-4ec4-985e-a069c536b665> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f697374d-e276-4ec4-985e-a069c536b665";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=BesluitenLijst_OCMW-Raad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f697374d-e276-4ec4-985e-a069c536b665>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b0accb4-9a0d-41f2-97e6-ccb62b9ef360> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b0accb4-9a0d-41f2-97e6-ccb62b9ef360";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=BesluitenLijst_OCMW-Raad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b0accb4-9a0d-41f2-97e6-ccb62b9ef360>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebb8d752-a994-4dd5-889d-52a6e20e48e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebb8d752-a994-4dd5-889d-52a6e20e48e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=BesluitenLijst_OCMW-Raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebb8d752-a994-4dd5-889d-52a6e20e48e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcaf33d7-64aa-4861-a70c-da048d4e6527> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcaf33d7-64aa-4861-a70c-da048d4e6527";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=BesluitenLijst_OCMW-Raad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcaf33d7-64aa-4861-a70c-da048d4e6527>.
+    
+<http://data.lblod.info/id/remote-data-objects/35cc822a-adde-4a27-86d3-39d96c39ceb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35cc822a-adde-4a27-86d3-39d96c39ceb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=BesluitenLijst_OCMW-Raad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35cc822a-adde-4a27-86d3-39d96c39ceb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f24afd3-3e80-4457-b78b-d0638a604b90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f24afd3-3e80-4457-b78b-d0638a604b90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=BesluitenLijst_OCMW-Raad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f24afd3-3e80-4457-b78b-d0638a604b90>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2cebd2f-2584-457c-bbfe-1dac6bd069c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2cebd2f-2584-457c-bbfe-1dac6bd069c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Notulen_OCMW-Raad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2cebd2f-2584-457c-bbfe-1dac6bd069c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0178768-0991-404e-98c3-6d569d1609b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0178768-0991-404e-98c3-6d569d1609b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Notulen_OCMW-Raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0178768-0991-404e-98c3-6d569d1609b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/6217473e-10fb-45ce-ab92-9402b20ea302> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6217473e-10fb-45ce-ab92-9402b20ea302";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Notulen_OCMW-Raad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6217473e-10fb-45ce-ab92-9402b20ea302>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e1a630a-42b3-49eb-882c-a8f9c4fc4ed5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e1a630a-42b3-49eb-882c-a8f9c4fc4ed5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Notulen_OCMW-Raad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e1a630a-42b3-49eb-882c-a8f9c4fc4ed5>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e0f7d53-2c0c-4a84-949a-aab5a1f21457> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e0f7d53-2c0c-4a84-949a-aab5a1f21457";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Notulen_OCMW-Raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e0f7d53-2c0c-4a84-949a-aab5a1f21457>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c3912bf-4c30-4c05-a41a-93ee7cc451ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c3912bf-4c30-4c05-a41a-93ee7cc451ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Notulen_OCMW-Raad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c3912bf-4c30-4c05-a41a-93ee7cc451ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/e79e61fa-70c9-42dd-b27a-7390c4306d86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e79e61fa-70c9-42dd-b27a-7390c4306d86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Notulen_OCMW-Raad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e79e61fa-70c9-42dd-b27a-7390c4306d86>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c948575-9131-4c8b-acde-8820c9c47a5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c948575-9131-4c8b-acde-8820c9c47a5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=ToegevoegdeAgenda_OCMW-Raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c948575-9131-4c8b-acde-8820c9c47a5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/38670807-9fcd-4b9a-b296-00d987dd166a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38670807-9fcd-4b9a-b296-00d987dd166a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=ToegevoegdeAgenda_OCMW-Raad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38670807-9fcd-4b9a-b296-00d987dd166a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b32e83c-8475-4972-9514-b8b369820ae5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b32e83c-8475-4972-9514-b8b369820ae5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Uittreksels_23-12-2021_35889.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b32e83c-8475-4972-9514-b8b369820ae5>.
+    
+<http://data.lblod.info/id/remote-data-objects/670e49ef-6662-4a0c-8d97-c81c7baadad8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "670e49ef-6662-4a0c-8d97-c81c7baadad8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Uittreksels_24-02-2022_36629.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/670e49ef-6662-4a0c-8d97-c81c7baadad8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4ef90dc-9074-4bcc-ba48-bdbfbda9c9f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4ef90dc-9074-4bcc-ba48-bdbfbda9c9f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Uittreksels_24-02-2022_36639.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4ef90dc-9074-4bcc-ba48-bdbfbda9c9f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ea7f87f-d02b-43d7-937f-4cb47e194c4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ea7f87f-d02b-43d7-937f-4cb47e194c4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Uittreksels_25-05-2022_37932.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ea7f87f-d02b-43d7-937f-4cb47e194c4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6a5417d-940d-4a3a-9ad8-ed15484079b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6a5417d-940d-4a3a-9ad8-ed15484079b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Uittreksels_27-01-2022_35922.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6a5417d-940d-4a3a-9ad8-ed15484079b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8c85bdb-7e5d-4a84-9732-ba948d216862> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8c85bdb-7e5d-4a84-9732-ba948d216862";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Uittreksels_28-04-2022_37751.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8c85bdb-7e5d-4a84-9732-ba948d216862>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7754ec0-2443-4ab4-8ebf-6828c5f0624c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7754ec0-2443-4ab4-8ebf-6828c5f0624c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/cf968203402e3cc6da93f81e43c959f28ff868bb4e4d93142488df2a8cdbe412/GetPublication?filename=Uittreksels_28-10-2021_35251.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7754ec0-2443-4ab4-8ebf-6828c5f0624c>.
+    
+<http://data.lblod.info/id/remote-data-objects/806fb964-519f-4eeb-883b-0a74dc9f7fab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "806fb964-519f-4eeb-883b-0a74dc9f7fab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Agenda_Gemeenteraad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/806fb964-519f-4eeb-883b-0a74dc9f7fab>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ee1d4d5-3f54-421d-bd7b-5ce6b55eacdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ee1d4d5-3f54-421d-bd7b-5ce6b55eacdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Agenda_Gemeenteraad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ee1d4d5-3f54-421d-bd7b-5ce6b55eacdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/44f6f54f-0155-413f-bce0-3be051a49fbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44f6f54f-0155-413f-bce0-3be051a49fbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Agenda_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44f6f54f-0155-413f-bce0-3be051a49fbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/33f30d44-2f2a-4fc1-9620-0744a1c314dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33f30d44-2f2a-4fc1-9620-0744a1c314dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Agenda_Gemeenteraad_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33f30d44-2f2a-4fc1-9620-0744a1c314dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/0643d99f-4379-4f00-8c85-f2a6c1a14553> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0643d99f-4379-4f00-8c85-f2a6c1a14553";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Agenda_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8bce86de-90f8-47d9-9ede-3142fc327147> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0643d99f-4379-4f00-8c85-f2a6c1a14553>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201453-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201453-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201453-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201453-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/dfecaef1-2e1b-4e0f-819f-787c7e8bf024> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dfecaef1-2e1b-4e0f-819f-787c7e8bf024";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "42baba20-47ba-4b18-b13e-99377f509ce2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d3bd8d8d-f967-4e1b-91f7-6f1bc72e9257> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d3bd8d8d-f967-4e1b-91f7-6f1bc72e9257";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2>.
+
+  <http://redpencil.data.gift/id/task/0fc28b35-8556-49b0-bd1d-2f064bb79049> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0fc28b35-8556-49b0-bd1d-2f064bb79049";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/dfecaef1-2e1b-4e0f-819f-787c7e8bf024>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d3bd8d8d-f967-4e1b-91f7-6f1bc72e9257>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a2bf6c39-a005-42b6-9e62-132dc6546a4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2bf6c39-a005-42b6-9e62-132dc6546a4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Agenda_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2bf6c39-a005-42b6-9e62-132dc6546a4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8d83c80-6736-446a-8cdb-6da6e9a7bdaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8d83c80-6736-446a-8cdb-6da6e9a7bdaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Agenda_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8d83c80-6736-446a-8cdb-6da6e9a7bdaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/0265acf9-4a66-49a1-875c-d77603e62f18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0265acf9-4a66-49a1-875c-d77603e62f18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Agenda_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0265acf9-4a66-49a1-875c-d77603e62f18>.
+    
+<http://data.lblod.info/id/remote-data-objects/8395cccc-febb-4529-af34-fe87f2f44676> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8395cccc-febb-4529-af34-fe87f2f44676";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Agenda_Gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8395cccc-febb-4529-af34-fe87f2f44676>.
+    
+<http://data.lblod.info/id/remote-data-objects/7607c1f8-ed5a-48b8-bcb4-2de0303f2ef1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7607c1f8-ed5a-48b8-bcb4-2de0303f2ef1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Agenda_Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7607c1f8-ed5a-48b8-bcb4-2de0303f2ef1>.
+    
+<http://data.lblod.info/id/remote-data-objects/886c2e0a-b97c-479f-b1db-2a05a11f0123> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "886c2e0a-b97c-479f-b1db-2a05a11f0123";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/886c2e0a-b97c-479f-b1db-2a05a11f0123>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4ffd7e9-6d07-4b62-9b72-95974c20018b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4ffd7e9-6d07-4b62-9b72-95974c20018b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4ffd7e9-6d07-4b62-9b72-95974c20018b>.
+    
+<http://data.lblod.info/id/remote-data-objects/56d578aa-8e07-4b3f-a675-6a4fcd79cd9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56d578aa-8e07-4b3f-a675-6a4fcd79cd9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56d578aa-8e07-4b3f-a675-6a4fcd79cd9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/391275b8-d432-4eb1-ac50-6d8d0e9e649b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "391275b8-d432-4eb1-ac50-6d8d0e9e649b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/391275b8-d432-4eb1-ac50-6d8d0e9e649b>.
+    
+<http://data.lblod.info/id/remote-data-objects/186f6ab5-4c91-47ab-a7fb-ad8a73df38df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "186f6ab5-4c91-47ab-a7fb-ad8a73df38df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/186f6ab5-4c91-47ab-a7fb-ad8a73df38df>.
+    
+<http://data.lblod.info/id/remote-data-objects/089c8197-d27e-44eb-9748-1d30f42f4a24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "089c8197-d27e-44eb-9748-1d30f42f4a24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/089c8197-d27e-44eb-9748-1d30f42f4a24>.
+    
+<http://data.lblod.info/id/remote-data-objects/0aa9b735-92a9-4bff-8ef7-002f48eaa130> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0aa9b735-92a9-4bff-8ef7-002f48eaa130";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0aa9b735-92a9-4bff-8ef7-002f48eaa130>.
+    
+<http://data.lblod.info/id/remote-data-objects/afbb50d9-ffbf-44b9-9dd7-6482e397b819> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afbb50d9-ffbf-44b9-9dd7-6482e397b819";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=BesluitenLijst_Gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afbb50d9-ffbf-44b9-9dd7-6482e397b819>.
+    
+<http://data.lblod.info/id/remote-data-objects/44bcaa4f-a6df-4887-b908-ab7376a8ccec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44bcaa4f-a6df-4887-b908-ab7376a8ccec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=BesluitenLijst_Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44bcaa4f-a6df-4887-b908-ab7376a8ccec>.
+    
+<http://data.lblod.info/id/remote-data-objects/340628ed-7369-454a-9a01-75ae76dd2a75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "340628ed-7369-454a-9a01-75ae76dd2a75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Notulen_Gemeenteraad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/340628ed-7369-454a-9a01-75ae76dd2a75>.
+    
+<http://data.lblod.info/id/remote-data-objects/705b8665-202a-410d-8c26-4e39a73edf9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "705b8665-202a-410d-8c26-4e39a73edf9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Notulen_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/705b8665-202a-410d-8c26-4e39a73edf9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/66eca27a-1d07-4b08-97bd-fea64f48d253> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66eca27a-1d07-4b08-97bd-fea64f48d253";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Notulen_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66eca27a-1d07-4b08-97bd-fea64f48d253>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f8781ec-7088-4dd4-88ee-fe0d8e6c18f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f8781ec-7088-4dd4-88ee-fe0d8e6c18f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Notulen_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f8781ec-7088-4dd4-88ee-fe0d8e6c18f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5cc056a-31fd-418f-b663-e183f9cbb344> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5cc056a-31fd-418f-b663-e183f9cbb344";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Notulen_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5cc056a-31fd-418f-b663-e183f9cbb344>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ccfe91c-5ec7-4375-ab81-2f1edf5850ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ccfe91c-5ec7-4375-ab81-2f1edf5850ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Notulen_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ccfe91c-5ec7-4375-ab81-2f1edf5850ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d7c5079-adaf-4a4d-af8d-82a319c435fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d7c5079-adaf-4a4d-af8d-82a319c435fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Notulen_Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d7c5079-adaf-4a4d-af8d-82a319c435fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd0f8449-ead6-4630-96d8-b1e05b640844> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd0f8449-ead6-4630-96d8-b1e05b640844";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd0f8449-ead6-4630-96d8-b1e05b640844>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebbbdbcc-5689-4929-b3c8-cea0afa35e6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebbbdbcc-5689-4929-b3c8-cea0afa35e6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebbbdbcc-5689-4929-b3c8-cea0afa35e6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/051658cd-f45b-432b-8d9c-d770d2505347> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "051658cd-f45b-432b-8d9c-d770d2505347";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_23-12-2021_35857.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/051658cd-f45b-432b-8d9c-d770d2505347>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a63a6c0-8ad5-4e2c-b57b-937547a658d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a63a6c0-8ad5-4e2c-b57b-937547a658d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_23-12-2021_35888.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a63a6c0-8ad5-4e2c-b57b-937547a658d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/7696acf9-d9a2-4815-9e07-83c7328c199a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7696acf9-d9a2-4815-9e07-83c7328c199a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_23-12-2021_35901.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7696acf9-d9a2-4815-9e07-83c7328c199a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e0cc639-e268-48aa-b701-52cf3f520e97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e0cc639-e268-48aa-b701-52cf3f520e97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_24-02-2022_36460.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e0cc639-e268-48aa-b701-52cf3f520e97>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae3a90e8-612f-4fee-a043-0a0bef460c90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae3a90e8-612f-4fee-a043-0a0bef460c90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_25-05-2022_37933.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae3a90e8-612f-4fee-a043-0a0bef460c90>.
+    
+<http://data.lblod.info/id/remote-data-objects/bab7c7d2-a8e4-4bc9-a60f-6dfd68f61c12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bab7c7d2-a8e4-4bc9-a60f-6dfd68f61c12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_25-05-2022_37935.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bab7c7d2-a8e4-4bc9-a60f-6dfd68f61c12>.
+    
+<http://data.lblod.info/id/remote-data-objects/75c39540-fb60-433d-8207-e81ffdb3c11b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75c39540-fb60-433d-8207-e81ffdb3c11b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_25-11-2021_35598.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75c39540-fb60-433d-8207-e81ffdb3c11b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e0e77cf-25e8-491d-b643-8dbaca5d238e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e0e77cf-25e8-491d-b643-8dbaca5d238e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_27-01-2022_35921.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e0e77cf-25e8-491d-b643-8dbaca5d238e>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbb14787-d305-4fb2-a13b-46ee8e1a52dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbb14787-d305-4fb2-a13b-46ee8e1a52dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_27-01-2022_36086.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbb14787-d305-4fb2-a13b-46ee8e1a52dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/128078cb-1709-4c94-b0be-cef380291138> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "128078cb-1709-4c94-b0be-cef380291138";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_27-01-2022_36187.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/128078cb-1709-4c94-b0be-cef380291138>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab195e4a-f0db-4b73-99a1-c95536498a84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab195e4a-f0db-4b73-99a1-c95536498a84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_27-01-2022_36344.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab195e4a-f0db-4b73-99a1-c95536498a84>.
+    
+<http://data.lblod.info/id/remote-data-objects/86c405ed-227d-437c-8d9a-14914db13bf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86c405ed-227d-437c-8d9a-14914db13bf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_28-04-2022_37625.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86c405ed-227d-437c-8d9a-14914db13bf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb68e28e-e347-4cd2-9c1e-e57fc8469d2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb68e28e-e347-4cd2-9c1e-e57fc8469d2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_28-10-2021_34732.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb68e28e-e347-4cd2-9c1e-e57fc8469d2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/63c43eec-7b6e-45a6-a974-442ba23fee9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63c43eec-7b6e-45a6-a974-442ba23fee9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_28-10-2021_34983.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63c43eec-7b6e-45a6-a974-442ba23fee9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/808d275b-edf9-47a5-acef-c4d854bbddcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "808d275b-edf9-47a5-acef-c4d854bbddcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_28-10-2021_35161.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/808d275b-edf9-47a5-acef-c4d854bbddcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc6ac3bf-c14a-4d9b-8f18-d0c21ff11cb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc6ac3bf-c14a-4d9b-8f18-d0c21ff11cb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_28-10-2021_35250.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc6ac3bf-c14a-4d9b-8f18-d0c21ff11cb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/eaceae3f-c71d-4a03-8fb9-8a55e8b2d13c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eaceae3f-c71d-4a03-8fb9-8a55e8b2d13c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_30-06-2022_37927.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eaceae3f-c71d-4a03-8fb9-8a55e8b2d13c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e4ef2a5-9016-4106-98f1-9bd3a17b9bb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e4ef2a5-9016-4106-98f1-9bd3a17b9bb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_31-03-2022_36043.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e4ef2a5-9016-4106-98f1-9bd3a17b9bb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1044424-d6b0-486d-a8bb-59c924c779cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1044424-d6b0-486d-a8bb-59c924c779cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_31-03-2022_36150.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1044424-d6b0-486d-a8bb-59c924c779cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/1318861f-8d6f-4d58-b9e5-df3f98a10b8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1318861f-8d6f-4d58-b9e5-df3f98a10b8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_31-03-2022_36151.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1318861f-8d6f-4d58-b9e5-df3f98a10b8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/37cb3ea2-23e3-459f-ae1d-4c046b93094b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37cb3ea2-23e3-459f-ae1d-4c046b93094b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_31-03-2022_36182.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37cb3ea2-23e3-459f-ae1d-4c046b93094b>.
+    
+<http://data.lblod.info/id/remote-data-objects/349a618c-ec59-4bb2-8771-57088e4ff477> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "349a618c-ec59-4bb2-8771-57088e4ff477";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_31-03-2022_36185.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/349a618c-ec59-4bb2-8771-57088e4ff477>.
+    
+<http://data.lblod.info/id/remote-data-objects/491cfffe-b5a7-4fdf-b478-f5e65848b0f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "491cfffe-b5a7-4fdf-b478-f5e65848b0f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_31-03-2022_36190.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/491cfffe-b5a7-4fdf-b478-f5e65848b0f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e34314f5-cdff-40e3-a290-5800a286abc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e34314f5-cdff-40e3-a290-5800a286abc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_31-03-2022_36191.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e34314f5-cdff-40e3-a290-5800a286abc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c282f9eb-20cb-4293-b3cd-e139c068e230> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c282f9eb-20cb-4293-b3cd-e139c068e230";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_31-03-2022_36193.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c282f9eb-20cb-4293-b3cd-e139c068e230>.
+    
+<http://data.lblod.info/id/remote-data-objects/e71a2d6d-40bd-40fd-a618-7470e8c64e6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e71a2d6d-40bd-40fd-a618-7470e8c64e6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_31-03-2022_36194.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e71a2d6d-40bd-40fd-a618-7470e8c64e6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b954282d-f3c1-476f-b8f5-050981563d34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b954282d-f3c1-476f-b8f5-050981563d34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_31-03-2022_37308.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/42baba20-47ba-4b18-b13e-99377f509ce2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b954282d-f3c1-476f-b8f5-050981563d34>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201454-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201454-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201454-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201454-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2f100ebb-de9f-4977-8aea-a37c9c74ed2a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2f100ebb-de9f-4977-8aea-a37c9c74ed2a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "259603e9-b312-4276-ad35-6c07c045cdab";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d42d7222-556f-4e7f-82a3-70ad708d806f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d42d7222-556f-4e7f-82a3-70ad708d806f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab>.
+
+  <http://redpencil.data.gift/id/task/505f84ce-8d36-4a06-bf04-e935f974e91d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "505f84ce-8d36-4a06-bf04-e935f974e91d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2f100ebb-de9f-4977-8aea-a37c9c74ed2a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d42d7222-556f-4e7f-82a3-70ad708d806f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5f293b49-fb9f-42df-baeb-22f94e96ff0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f293b49-fb9f-42df-baeb-22f94e96ff0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.laarne.be/LBLODWeb/Home/Overzicht/e060fa97e8c1ea6031cea20b203a9c35e8c861f31b5fe89d702a55c2ebfbf19d/GetPublication?filename=Uittreksels_31-03-2022_37312.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f293b49-fb9f-42df-baeb-22f94e96ff0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1aeffdb2-f75a-43cb-921a-a2408f5449b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1aeffdb2-f75a-43cb-921a-a2408f5449b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1aeffdb2-f75a-43cb-921a-a2408f5449b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6a5f9ab-7d66-49f1-8174-3059f78c758b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6a5f9ab-7d66-49f1-8174-3059f78c758b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6a5f9ab-7d66-49f1-8174-3059f78c758b>.
+    
+<http://data.lblod.info/id/remote-data-objects/41c0f120-dd5c-4cba-b602-d8b88c6af5b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41c0f120-dd5c-4cba-b602-d8b88c6af5b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41c0f120-dd5c-4cba-b602-d8b88c6af5b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/33d95174-10de-4569-ae9a-d32f3619ffa2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33d95174-10de-4569-ae9a-d32f3619ffa2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33d95174-10de-4569-ae9a-d32f3619ffa2>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fa165c3-a7f6-4cb8-b665-cf475442e9a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fa165c3-a7f6-4cb8-b665-cf475442e9a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fa165c3-a7f6-4cb8-b665-cf475442e9a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3c47be3-bec2-4d70-9b93-c5bcc7168bc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3c47be3-bec2-4d70-9b93-c5bcc7168bc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3c47be3-bec2-4d70-9b93-c5bcc7168bc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/9180e6ee-5e17-43e0-a867-da42ce26a7a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9180e6ee-5e17-43e0-a867-da42ce26a7a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9180e6ee-5e17-43e0-a867-da42ce26a7a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a9de12e-1b74-4dd5-a705-57058b3a40b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a9de12e-1b74-4dd5-a705-57058b3a40b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a9de12e-1b74-4dd5-a705-57058b3a40b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/89b41c99-23e2-4437-b1ab-6d11a0cd53a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89b41c99-23e2-4437-b1ab-6d11a0cd53a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89b41c99-23e2-4437-b1ab-6d11a0cd53a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4eac31c1-05ae-4660-bc02-f454233f97eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4eac31c1-05ae-4660-bc02-f454233f97eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4eac31c1-05ae-4660-bc02-f454233f97eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf4f6a25-6296-49ed-a562-9c2a41cc03eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf4f6a25-6296-49ed-a562-9c2a41cc03eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf4f6a25-6296-49ed-a562-9c2a41cc03eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/59fcb058-b8b6-437c-9987-d17e2b84f972> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59fcb058-b8b6-437c-9987-d17e2b84f972";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59fcb058-b8b6-437c-9987-d17e2b84f972>.
+    
+<http://data.lblod.info/id/remote-data-objects/a595634d-8217-4446-876e-af5db623804b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a595634d-8217-4446-876e-af5db623804b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a595634d-8217-4446-876e-af5db623804b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a79fb066-f503-4df6-996f-fb4b8d111d2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a79fb066-f503-4df6-996f-fb4b8d111d2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a79fb066-f503-4df6-996f-fb4b8d111d2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/52fb367f-1dec-417c-9291-4867995204ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52fb367f-1dec-417c-9291-4867995204ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52fb367f-1dec-417c-9291-4867995204ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f234d3a-7eae-4ba0-8037-d2d8986b42e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f234d3a-7eae-4ba0-8037-d2d8986b42e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f234d3a-7eae-4ba0-8037-d2d8986b42e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/de7708ff-9b5b-4d5e-b900-4079fb259f1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de7708ff-9b5b-4d5e-b900-4079fb259f1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de7708ff-9b5b-4d5e-b900-4079fb259f1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/addd8c09-7efd-4316-a990-54be6d57294d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "addd8c09-7efd-4316-a990-54be6d57294d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/addd8c09-7efd-4316-a990-54be6d57294d>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb167f6d-694e-4497-ad75-e75077d034da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb167f6d-694e-4497-ad75-e75077d034da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb167f6d-694e-4497-ad75-e75077d034da>.
+    
+<http://data.lblod.info/id/remote-data-objects/80d68e4e-c9ab-43a2-818c-2db7853255e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80d68e4e-c9ab-43a2-818c-2db7853255e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80d68e4e-c9ab-43a2-818c-2db7853255e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/99ca07cb-33a6-4e08-b331-403ed9f01d52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99ca07cb-33a6-4e08-b331-403ed9f01d52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99ca07cb-33a6-4e08-b331-403ed9f01d52>.
+    
+<http://data.lblod.info/id/remote-data-objects/e93cb4f9-d94d-49d4-9f86-66b231c2e99e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e93cb4f9-d94d-49d4-9f86-66b231c2e99e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e93cb4f9-d94d-49d4-9f86-66b231c2e99e>.
+    
+<http://data.lblod.info/id/remote-data-objects/41d15f2b-754b-46c0-94e1-efb72a75b4fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41d15f2b-754b-46c0-94e1-efb72a75b4fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41d15f2b-754b-46c0-94e1-efb72a75b4fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f22ddafb-289e-4554-a434-a0c893c5edf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f22ddafb-289e-4554-a434-a0c893c5edf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f22ddafb-289e-4554-a434-a0c893c5edf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a01a3528-1374-4a5e-a8b1-58f314f5b0c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a01a3528-1374-4a5e-a8b1-58f314f5b0c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a01a3528-1374-4a5e-a8b1-58f314f5b0c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d252b7b-21bd-4fd4-a8a0-542f79e48617> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d252b7b-21bd-4fd4-a8a0-542f79e48617";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d252b7b-21bd-4fd4-a8a0-542f79e48617>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4c108bd-54d7-496f-9ca4-83f7ed75733c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4c108bd-54d7-496f-9ca4-83f7ed75733c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4c108bd-54d7-496f-9ca4-83f7ed75733c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3a8b3de-88d9-4d7d-8c9e-1aaef71edd9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3a8b3de-88d9-4d7d-8c9e-1aaef71edd9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3a8b3de-88d9-4d7d-8c9e-1aaef71edd9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa47676d-b788-4d26-a956-208914a59e78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa47676d-b788-4d26-a956-208914a59e78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa47676d-b788-4d26-a956-208914a59e78>.
+    
+<http://data.lblod.info/id/remote-data-objects/897d5e2a-271b-4a71-b99e-e3ebe053e94e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "897d5e2a-271b-4a71-b99e-e3ebe053e94e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/897d5e2a-271b-4a71-b99e-e3ebe053e94e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a95f40f3-2955-4fd2-8c57-a99de615d611> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a95f40f3-2955-4fd2-8c57-a99de615d611";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a95f40f3-2955-4fd2-8c57-a99de615d611>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1723b52-06d2-49c3-a5e8-edb16c4071ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1723b52-06d2-49c3-a5e8-edb16c4071ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_26-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1723b52-06d2-49c3-a5e8-edb16c4071ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/06ef6243-ddb8-470c-a5e5-741fee28ea9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06ef6243-ddb8-470c-a5e5-741fee28ea9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06ef6243-ddb8-470c-a5e5-741fee28ea9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1343b209-508d-43a8-a6a6-f1127ebde511> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1343b209-508d-43a8-a6a6-f1127ebde511";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1343b209-508d-43a8-a6a6-f1127ebde511>.
+    
+<http://data.lblod.info/id/remote-data-objects/23adb999-add9-43a9-99fe-0ec2e2214ae1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23adb999-add9-43a9-99fe-0ec2e2214ae1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23adb999-add9-43a9-99fe-0ec2e2214ae1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f36019f8-8b5b-4942-b9f2-5e06e3ebb6e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f36019f8-8b5b-4942-b9f2-5e06e3ebb6e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f36019f8-8b5b-4942-b9f2-5e06e3ebb6e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b4330bd-8ff5-4201-9bef-53219a5bbb1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b4330bd-8ff5-4201-9bef-53219a5bbb1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b4330bd-8ff5-4201-9bef-53219a5bbb1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8a7102b-df12-4658-9d69-3496c03ef15d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8a7102b-df12-4658-9d69-3496c03ef15d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_07-06-2022_18004.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8a7102b-df12-4658-9d69-3496c03ef15d>.
+    
+<http://data.lblod.info/id/remote-data-objects/df1ac455-5d1b-4a13-bc90-dd213a30cd62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df1ac455-5d1b-4a13-bc90-dd213a30cd62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_07-06-2022_18016.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df1ac455-5d1b-4a13-bc90-dd213a30cd62>.
+    
+<http://data.lblod.info/id/remote-data-objects/149d317b-eb51-4e36-8249-e9dbda5ce481> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "149d317b-eb51-4e36-8249-e9dbda5ce481";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_07-06-2022_18037.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/149d317b-eb51-4e36-8249-e9dbda5ce481>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d80b102-b032-448d-a911-bd75fe6c1778> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d80b102-b032-448d-a911-bd75fe6c1778";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_07-06-2022_18038.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d80b102-b032-448d-a911-bd75fe6c1778>.
+    
+<http://data.lblod.info/id/remote-data-objects/371ab976-00ae-4b74-a29a-4000bb188039> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "371ab976-00ae-4b74-a29a-4000bb188039";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_07-06-2022_18039.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/371ab976-00ae-4b74-a29a-4000bb188039>.
+    
+<http://data.lblod.info/id/remote-data-objects/a149efd3-274a-43b0-a210-15e4183eb643> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a149efd3-274a-43b0-a210-15e4183eb643";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_07-06-2022_18040.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a149efd3-274a-43b0-a210-15e4183eb643>.
+    
+<http://data.lblod.info/id/remote-data-objects/950317a6-6137-47d5-ba74-5c8990ac9c73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "950317a6-6137-47d5-ba74-5c8990ac9c73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_08-02-2022_16001.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/950317a6-6137-47d5-ba74-5c8990ac9c73>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2c67d42-5933-41c1-9477-7a091c4af6b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2c67d42-5933-41c1-9477-7a091c4af6b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_08-02-2022_16006.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2c67d42-5933-41c1-9477-7a091c4af6b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/50951b74-1074-4bca-82c2-4cdc8e1e462d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50951b74-1074-4bca-82c2-4cdc8e1e462d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_08-02-2022_16013.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50951b74-1074-4bca-82c2-4cdc8e1e462d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f076ec72-aa4c-4558-becf-b9f960a270f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f076ec72-aa4c-4558-becf-b9f960a270f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_08-03-2022_16106.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f076ec72-aa4c-4558-becf-b9f960a270f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddc4d264-a4b8-457c-8f7e-5489748d155e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddc4d264-a4b8-457c-8f7e-5489748d155e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_09-11-2021_15131.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddc4d264-a4b8-457c-8f7e-5489748d155e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ef53d34-2f97-4b64-8867-b5ef296c4398> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ef53d34-2f97-4b64-8867-b5ef296c4398";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_09-11-2021_15132.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/259603e9-b312-4276-ad35-6c07c045cdab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ef53d34-2f97-4b64-8867-b5ef296c4398>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201455-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201455-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201455-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201455-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c82f9464-1c62-46cf-bbe9-744db818a7da> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c82f9464-1c62-46cf-bbe9-744db818a7da";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b6f1d696-9996-4819-82c3-26dadf0c57bd";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/783d9496-682c-4903-bf5d-6429dddc62dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "783d9496-682c-4903-bf5d-6429dddc62dd";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd>.
+
+  <http://redpencil.data.gift/id/task/56af3c5e-e0c3-458b-9e71-655f4e6344f1> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "56af3c5e-e0c3-458b-9e71-655f4e6344f1";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c82f9464-1c62-46cf-bbe9-744db818a7da>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/783d9496-682c-4903-bf5d-6429dddc62dd>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5f688178-3e34-4136-bee1-b390db77f7e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f688178-3e34-4136-bee1-b390db77f7e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_10-05-2022_17778.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f688178-3e34-4136-bee1-b390db77f7e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/1505746b-1711-4982-95f8-ef9c87a20c5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1505746b-1711-4982-95f8-ef9c87a20c5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_11-01-2022_15844.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1505746b-1711-4982-95f8-ef9c87a20c5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/00315017-d99e-4e41-b759-05a6ce7f7cbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00315017-d99e-4e41-b759-05a6ce7f7cbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_11-01-2022_15845.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00315017-d99e-4e41-b759-05a6ce7f7cbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/cceba7a9-0bfe-43af-b9f1-cf69c773fc53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cceba7a9-0bfe-43af-b9f1-cf69c773fc53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_12-04-2022_16474.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cceba7a9-0bfe-43af-b9f1-cf69c773fc53>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfcd3b67-d88a-47cc-8f17-a7fd5c70b597> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfcd3b67-d88a-47cc-8f17-a7fd5c70b597";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_12-04-2022_16500.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfcd3b67-d88a-47cc-8f17-a7fd5c70b597>.
+    
+<http://data.lblod.info/id/remote-data-objects/8dce6a4e-b9ae-44dc-b58a-5160cb8b21bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8dce6a4e-b9ae-44dc-b58a-5160cb8b21bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_12-04-2022_16504.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8dce6a4e-b9ae-44dc-b58a-5160cb8b21bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/938b0160-5016-4170-96bf-1769111b1990> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "938b0160-5016-4170-96bf-1769111b1990";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_12-04-2022_16517.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/938b0160-5016-4170-96bf-1769111b1990>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffebeb0e-b7ab-4ef2-a502-823831167744> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffebeb0e-b7ab-4ef2-a502-823831167744";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_12-07-2022_18390.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffebeb0e-b7ab-4ef2-a502-823831167744>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f1a8d30-b78f-49d6-9b19-586a04ff078c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f1a8d30-b78f-49d6-9b19-586a04ff078c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_12-07-2022_18391.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f1a8d30-b78f-49d6-9b19-586a04ff078c>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfbeb6af-4b2f-4ae8-809c-1ac3af1f9f5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfbeb6af-4b2f-4ae8-809c-1ac3af1f9f5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_12-07-2022_18461.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfbeb6af-4b2f-4ae8-809c-1ac3af1f9f5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e94d95c-814e-42a5-868b-e80d7bd0f66e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e94d95c-814e-42a5-868b-e80d7bd0f66e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_12-07-2022_18475.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e94d95c-814e-42a5-868b-e80d7bd0f66e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d270e3ba-bcb1-4009-b9a2-386f6580fc26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d270e3ba-bcb1-4009-b9a2-386f6580fc26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_12-07-2022_18515.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d270e3ba-bcb1-4009-b9a2-386f6580fc26>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3c296de-aa73-477e-8083-46374cba5f2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3c296de-aa73-477e-8083-46374cba5f2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_12-10-2021_13949.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3c296de-aa73-477e-8083-46374cba5f2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f2aed2c-45eb-45d3-bf7c-e05f2045d7e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f2aed2c-45eb-45d3-bf7c-e05f2045d7e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_14-06-2022_18232.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f2aed2c-45eb-45d3-bf7c-e05f2045d7e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3eaf36ad-02be-467c-88c9-750dab4013ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3eaf36ad-02be-467c-88c9-750dab4013ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_14-06-2022_18233.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3eaf36ad-02be-467c-88c9-750dab4013ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/39349aa5-1d53-45a4-8ef9-7e2f68910954> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39349aa5-1d53-45a4-8ef9-7e2f68910954";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_14-06-2022_18236.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39349aa5-1d53-45a4-8ef9-7e2f68910954>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffb187b9-fe71-461c-852b-719699367911> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffb187b9-fe71-461c-852b-719699367911";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_14-12-2021_15544.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffb187b9-fe71-461c-852b-719699367911>.
+    
+<http://data.lblod.info/id/remote-data-objects/94b4cb52-d055-46d3-9d86-31c4efc6aa1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94b4cb52-d055-46d3-9d86-31c4efc6aa1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_15-02-2022_16058.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94b4cb52-d055-46d3-9d86-31c4efc6aa1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce89a354-d5dd-4acc-949d-f066a4f8c6b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce89a354-d5dd-4acc-949d-f066a4f8c6b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_15-03-2022_16282.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce89a354-d5dd-4acc-949d-f066a4f8c6b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/f011fd99-b165-42da-afc5-690eb46fb46f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f011fd99-b165-42da-afc5-690eb46fb46f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_17-05-2022_17844.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f011fd99-b165-42da-afc5-690eb46fb46f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b03dbf1a-eae2-49a3-9bc9-1cd3995a6f82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b03dbf1a-eae2-49a3-9bc9-1cd3995a6f82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_17-05-2022_17845.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b03dbf1a-eae2-49a3-9bc9-1cd3995a6f82>.
+    
+<http://data.lblod.info/id/remote-data-objects/d70a89c3-f56c-498a-85de-f414996f68da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d70a89c3-f56c-498a-85de-f414996f68da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_17-05-2022_17846.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d70a89c3-f56c-498a-85de-f414996f68da>.
+    
+<http://data.lblod.info/id/remote-data-objects/87a510df-d068-4019-a201-c1a12feb1bdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87a510df-d068-4019-a201-c1a12feb1bdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_18-01-2022_15859.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87a510df-d068-4019-a201-c1a12feb1bdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b1184c2-e1fb-4c75-9f68-af36b1a2e37e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b1184c2-e1fb-4c75-9f68-af36b1a2e37e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_19-04-2022_16580.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b1184c2-e1fb-4c75-9f68-af36b1a2e37e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d10cf645-aa3f-40f7-aef8-a1b3bb917982> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d10cf645-aa3f-40f7-aef8-a1b3bb917982";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_19-04-2022_16611.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d10cf645-aa3f-40f7-aef8-a1b3bb917982>.
+    
+<http://data.lblod.info/id/remote-data-objects/6770e0a3-6393-4846-b773-40a678da9d16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6770e0a3-6393-4846-b773-40a678da9d16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_19-10-2021_14058.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6770e0a3-6393-4846-b773-40a678da9d16>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd85303f-2832-4f89-8ce9-2e7491a70a46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd85303f-2832-4f89-8ce9-2e7491a70a46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_21-06-2022_17934.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd85303f-2832-4f89-8ce9-2e7491a70a46>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dd6109d-6c1c-4c2a-8713-795f32b51d10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dd6109d-6c1c-4c2a-8713-795f32b51d10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_21-12-2021_15655.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dd6109d-6c1c-4c2a-8713-795f32b51d10>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b6e17b8-41f1-47c5-8a69-5bb25ed83a78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b6e17b8-41f1-47c5-8a69-5bb25ed83a78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_22-03-2022_16284.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b6e17b8-41f1-47c5-8a69-5bb25ed83a78>.
+    
+<http://data.lblod.info/id/remote-data-objects/d85fc3d5-d4f2-49da-9e45-eece81e415f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d85fc3d5-d4f2-49da-9e45-eece81e415f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_22-03-2022_16343.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d85fc3d5-d4f2-49da-9e45-eece81e415f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7f60802-3538-4a29-8b7b-bcfc74608b84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7f60802-3538-4a29-8b7b-bcfc74608b84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_22-03-2022_16351.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7f60802-3538-4a29-8b7b-bcfc74608b84>.
+    
+<http://data.lblod.info/id/remote-data-objects/50c8bd4d-b0bb-4283-881f-72890b3c6b70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50c8bd4d-b0bb-4283-881f-72890b3c6b70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_23-11-2021_15071.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50c8bd4d-b0bb-4283-881f-72890b3c6b70>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8b9c0c9-e0b5-45ec-bd08-bb3254017758> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8b9c0c9-e0b5-45ec-bd08-bb3254017758";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_24-05-2022_17931.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8b9c0c9-e0b5-45ec-bd08-bb3254017758>.
+    
+<http://data.lblod.info/id/remote-data-objects/85654803-8101-4071-b40a-a15b7398f331> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85654803-8101-4071-b40a-a15b7398f331";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_24-05-2022_17933.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85654803-8101-4071-b40a-a15b7398f331>.
+    
+<http://data.lblod.info/id/remote-data-objects/a55ecf54-ea7c-4a33-92f4-82b802584bcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a55ecf54-ea7c-4a33-92f4-82b802584bcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_24-05-2022_17935.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a55ecf54-ea7c-4a33-92f4-82b802584bcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/6feb8388-e75e-44e9-86ab-4eb2a5ad8707> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6feb8388-e75e-44e9-86ab-4eb2a5ad8707";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_24-05-2022_17936.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6feb8388-e75e-44e9-86ab-4eb2a5ad8707>.
+    
+<http://data.lblod.info/id/remote-data-objects/66e2de42-a320-4cb7-a28a-e90c3d295a27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66e2de42-a320-4cb7-a28a-e90c3d295a27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_25-01-2022_15903.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66e2de42-a320-4cb7-a28a-e90c3d295a27>.
+    
+<http://data.lblod.info/id/remote-data-objects/30f4d27c-bcf6-480b-8ac6-cc205f42b428> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30f4d27c-bcf6-480b-8ac6-cc205f42b428";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_25-01-2022_15906.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30f4d27c-bcf6-480b-8ac6-cc205f42b428>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7eb26d1-83cc-44e0-a224-c251acf9bdb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7eb26d1-83cc-44e0-a224-c251acf9bdb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_25-01-2022_15907.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7eb26d1-83cc-44e0-a224-c251acf9bdb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/cca96854-40d0-4631-b398-47e4dfcaa727> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cca96854-40d0-4631-b398-47e4dfcaa727";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_26-04-2022_16508.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cca96854-40d0-4631-b398-47e4dfcaa727>.
+    
+<http://data.lblod.info/id/remote-data-objects/749dd7d4-813d-49af-b038-c5479ea444f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "749dd7d4-813d-49af-b038-c5479ea444f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_26-04-2022_16509.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/749dd7d4-813d-49af-b038-c5479ea444f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/00dcc229-47f3-417a-ac79-c8bac9733768> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00dcc229-47f3-417a-ac79-c8bac9733768";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_28-06-2022_18385.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00dcc229-47f3-417a-ac79-c8bac9733768>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dd83402-b41e-477f-a9f1-45780a388698> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dd83402-b41e-477f-a9f1-45780a388698";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_29-03-2022_16408.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dd83402-b41e-477f-a9f1-45780a388698>.
+    
+<http://data.lblod.info/id/remote-data-objects/871ca3bd-344e-4b25-8977-73252727b7ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "871ca3bd-344e-4b25-8977-73252727b7ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_29-03-2022_16409.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/871ca3bd-344e-4b25-8977-73252727b7ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/e41428af-89af-43d9-8169-fdba49093376> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e41428af-89af-43d9-8169-fdba49093376";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_31-05-2022_17974.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e41428af-89af-43d9-8169-fdba49093376>.
+    
+<http://data.lblod.info/id/remote-data-objects/8894d426-7d10-4968-9202-1afc06003f3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8894d426-7d10-4968-9202-1afc06003f3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_31-05-2022_17975.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8894d426-7d10-4968-9202-1afc06003f3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/89c2ab9b-69bc-4d22-9e8f-6cc883536d1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89c2ab9b-69bc-4d22-9e8f-6cc883536d1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/0e79d187-5ce3-49db-8881-738ef07256ea/GetPublication?filename=Uittreksels_31-05-2022_17979.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89c2ab9b-69bc-4d22-9e8f-6cc883536d1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/974494b0-7218-4c28-b8d4-c5a4ec2d65b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "974494b0-7218-4c28-b8d4-c5a4ec2d65b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/2693842d-6b8e-4268-92b5-6ea5ff3dd3f8/GetPublication?filename=BesluitenLijstUitspraak_besluit%20burgemeester_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/974494b0-7218-4c28-b8d4-c5a4ec2d65b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0973714-78b9-4480-97bc-d89bfeb0c46b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0973714-78b9-4480-97bc-d89bfeb0c46b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/2693842d-6b8e-4268-92b5-6ea5ff3dd3f8/GetPublication?filename=BesluitenLijstUitspraak_besluit%20burgemeester_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0973714-78b9-4480-97bc-d89bfeb0c46b>.
+    
+<http://data.lblod.info/id/remote-data-objects/938f63c9-5e7b-486a-9a47-a3a450ce1a45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "938f63c9-5e7b-486a-9a47-a3a450ce1a45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/2693842d-6b8e-4268-92b5-6ea5ff3dd3f8/GetPublication?filename=BesluitenLijstUitspraak_besluit%20burgemeester_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b6f1d696-9996-4819-82c3-26dadf0c57bd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/938f63c9-5e7b-486a-9a47-a3a450ce1a45>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201457-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201457-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201457-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201457-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f955bdd6-9bcf-4978-a833-87e89add8232> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f955bdd6-9bcf-4978-a833-87e89add8232";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "21e1dff5-192e-4bf1-868b-bb6c34cfa441";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/69a36105-f12a-4113-89c3-77c4760f8d32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "69a36105-f12a-4113-89c3-77c4760f8d32";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441>.
+
+  <http://redpencil.data.gift/id/task/d0c8ef55-e61d-4399-aeba-4e36fbf04e71> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d0c8ef55-e61d-4399-aeba-4e36fbf04e71";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f955bdd6-9bcf-4978-a833-87e89add8232>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/69a36105-f12a-4113-89c3-77c4760f8d32>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/385aa27a-7087-4394-84d9-f7179ae35067> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "385aa27a-7087-4394-84d9-f7179ae35067";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/2693842d-6b8e-4268-92b5-6ea5ff3dd3f8/GetPublication?filename=BesluitenLijstUitspraak_besluit%20burgemeester_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/385aa27a-7087-4394-84d9-f7179ae35067>.
+    
+<http://data.lblod.info/id/remote-data-objects/3305fe9a-c3d1-4d86-ad38-84ecdba667de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3305fe9a-c3d1-4d86-ad38-84ecdba667de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/2693842d-6b8e-4268-92b5-6ea5ff3dd3f8/GetPublication?filename=BesluitenLijstUitspraak_besluit%20burgemeester_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3305fe9a-c3d1-4d86-ad38-84ecdba667de>.
+    
+<http://data.lblod.info/id/remote-data-objects/75c2efcb-8dbe-4ecf-8c1c-d465f6e62add> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75c2efcb-8dbe-4ecf-8c1c-d465f6e62add";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/2693842d-6b8e-4268-92b5-6ea5ff3dd3f8/GetPublication?filename=BesluitenLijstUitspraak_besluit%20burgemeester_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75c2efcb-8dbe-4ecf-8c1c-d465f6e62add>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a6f87c0-4454-456d-a54b-d03ee2db4ad5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a6f87c0-4454-456d-a54b-d03ee2db4ad5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/2693842d-6b8e-4268-92b5-6ea5ff3dd3f8/GetPublication?filename=Uittreksels_13-05-2022_17872.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a6f87c0-4454-456d-a54b-d03ee2db4ad5>.
+    
+<http://data.lblod.info/id/remote-data-objects/8df7f326-537c-42e3-ab70-ef4332e3ba09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8df7f326-537c-42e3-ab70-ef4332e3ba09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/2693842d-6b8e-4268-92b5-6ea5ff3dd3f8/GetPublication?filename=Uittreksels_17-05-2022_17873.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8df7f326-537c-42e3-ab70-ef4332e3ba09>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5cfe0cf-a094-4843-a1d7-be5a8fb729b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5cfe0cf-a094-4843-a1d7-be5a8fb729b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/2693842d-6b8e-4268-92b5-6ea5ff3dd3f8/GetPublication?filename=Uittreksels_28-02-2022_16205.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5cfe0cf-a094-4843-a1d7-be5a8fb729b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff9fbdf2-465d-4ea0-9c0d-4d8205fc8a9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff9fbdf2-465d-4ea0-9c0d-4d8205fc8a9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=Agenda_gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff9fbdf2-465d-4ea0-9c0d-4d8205fc8a9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/39bb5ed6-21db-4ee9-92af-4885e504814b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39bb5ed6-21db-4ee9-92af-4885e504814b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=Agenda_gemeenteraad_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39bb5ed6-21db-4ee9-92af-4885e504814b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d725804-d798-442e-8a36-d0f4530e9de9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d725804-d798-442e-8a36-d0f4530e9de9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d725804-d798-442e-8a36-d0f4530e9de9>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c1ac5bb-b962-4717-a397-a2932d555fd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c1ac5bb-b962-4717-a397-a2932d555fd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c1ac5bb-b962-4717-a397-a2932d555fd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/09c31916-fc51-4ce2-83c7-97c724e457d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09c31916-fc51-4ce2-83c7-97c724e457d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09c31916-fc51-4ce2-83c7-97c724e457d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/62896b34-9643-4b3f-b5c5-564a23453b3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62896b34-9643-4b3f-b5c5-564a23453b3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62896b34-9643-4b3f-b5c5-564a23453b3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/17e64e61-29ca-4cac-996f-e6b6460a92c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17e64e61-29ca-4cac-996f-e6b6460a92c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17e64e61-29ca-4cac-996f-e6b6460a92c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/60864985-d122-475a-b791-d71a11aaac35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60864985-d122-475a-b791-d71a11aaac35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60864985-d122-475a-b791-d71a11aaac35>.
+    
+<http://data.lblod.info/id/remote-data-objects/a54b7f62-902f-4111-9147-d955d43fe894> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a54b7f62-902f-4111-9147-d955d43fe894";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a54b7f62-902f-4111-9147-d955d43fe894>.
+    
+<http://data.lblod.info/id/remote-data-objects/73c9e871-e3c4-4614-b313-aad47904ce4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73c9e871-e3c4-4614-b313-aad47904ce4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73c9e871-e3c4-4614-b313-aad47904ce4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0886846a-421b-4026-8d29-65ea3b5a13c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0886846a-421b-4026-8d29-65ea3b5a13c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=ToegevoegdeAgenda_gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0886846a-421b-4026-8d29-65ea3b5a13c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcb9ea30-9f84-4b38-ae84-0d462917e455> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcb9ea30-9f84-4b38-ae84-0d462917e455";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=Uittreksels_14-12-2021_15428.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcb9ea30-9f84-4b38-ae84-0d462917e455>.
+    
+<http://data.lblod.info/id/remote-data-objects/27606196-dbde-4805-bcff-5e4d2cc47865> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27606196-dbde-4805-bcff-5e4d2cc47865";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=Uittreksels_14-12-2021_15429.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27606196-dbde-4805-bcff-5e4d2cc47865>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed646109-5b50-4129-86da-827b26d22a81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed646109-5b50-4129-86da-827b26d22a81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=Uittreksels_14-12-2021_15430.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed646109-5b50-4129-86da-827b26d22a81>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5963b7c-ff59-4c5f-9279-543ff77a4ad6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5963b7c-ff59-4c5f-9279-543ff77a4ad6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=Uittreksels_24-05-2022_17809.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5963b7c-ff59-4c5f-9279-543ff77a4ad6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ba6723e-3629-4c31-bcf9-428137087a36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ba6723e-3629-4c31-bcf9-428137087a36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=Uittreksels_24-05-2022_17810.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ba6723e-3629-4c31-bcf9-428137087a36>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd3d7ef9-ed5f-4749-8fba-ed2e60823781> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd3d7ef9-ed5f-4749-8fba-ed2e60823781";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=Uittreksels_26-04-2022_16595.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd3d7ef9-ed5f-4749-8fba-ed2e60823781>.
+    
+<http://data.lblod.info/id/remote-data-objects/acc7d43d-7c1f-4cf1-8474-37edab0b4045> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acc7d43d-7c1f-4cf1-8474-37edab0b4045";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=Uittreksels_26-04-2022_16597.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acc7d43d-7c1f-4cf1-8474-37edab0b4045>.
+    
+<http://data.lblod.info/id/remote-data-objects/aebb717c-b443-41bc-b091-76594617b0b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aebb717c-b443-41bc-b091-76594617b0b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/5025c971b3d89381f543c4ff90e264db84f9e64209844fdfebeff1f140616c04/GetPublication?filename=Uittreksels_26-04-2022_16598.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aebb717c-b443-41bc-b091-76594617b0b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/63598f9b-743f-4589-86b3-dcc1d7fe7bef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63598f9b-743f-4589-86b3-dcc1d7fe7bef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63598f9b-743f-4589-86b3-dcc1d7fe7bef>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c7a0f3d-b74b-4895-a69c-dc051bc8d070> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c7a0f3d-b74b-4895-a69c-dc051bc8d070";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c7a0f3d-b74b-4895-a69c-dc051bc8d070>.
+    
+<http://data.lblod.info/id/remote-data-objects/6baa15c4-5a8d-414a-b5f9-02124a98691a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6baa15c4-5a8d-414a-b5f9-02124a98691a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6baa15c4-5a8d-414a-b5f9-02124a98691a>.
+    
+<http://data.lblod.info/id/remote-data-objects/cec41a99-c8a7-48cc-ba7e-58d16d302e68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cec41a99-c8a7-48cc-ba7e-58d16d302e68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cec41a99-c8a7-48cc-ba7e-58d16d302e68>.
+    
+<http://data.lblod.info/id/remote-data-objects/609d1d34-ff2d-49f1-97d0-b1847cf00347> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "609d1d34-ff2d-49f1-97d0-b1847cf00347";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/609d1d34-ff2d-49f1-97d0-b1847cf00347>.
+    
+<http://data.lblod.info/id/remote-data-objects/6633a581-d8ab-44ea-8317-ec321286bffe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6633a581-d8ab-44ea-8317-ec321286bffe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6633a581-d8ab-44ea-8317-ec321286bffe>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1cf21a5-573f-4deb-b9eb-2ffc841bf98b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1cf21a5-573f-4deb-b9eb-2ffc841bf98b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1cf21a5-573f-4deb-b9eb-2ffc841bf98b>.
+    
+<http://data.lblod.info/id/remote-data-objects/07d5eab6-0536-4b44-9eee-c9a1022cda14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07d5eab6-0536-4b44-9eee-c9a1022cda14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07d5eab6-0536-4b44-9eee-c9a1022cda14>.
+    
+<http://data.lblod.info/id/remote-data-objects/01da095d-e771-4e19-baf5-3ccd28579c9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01da095d-e771-4e19-baf5-3ccd28579c9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01da095d-e771-4e19-baf5-3ccd28579c9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/02a404d4-c037-486e-92b0-7e6436e6a915> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02a404d4-c037-486e-92b0-7e6436e6a915";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02a404d4-c037-486e-92b0-7e6436e6a915>.
+    
+<http://data.lblod.info/id/remote-data-objects/22bf10e4-cb1f-4140-8b65-98b710ef8c8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22bf10e4-cb1f-4140-8b65-98b710ef8c8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22bf10e4-cb1f-4140-8b65-98b710ef8c8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1909e65-f6d3-4664-bc51-22392eb7697a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1909e65-f6d3-4664-bc51-22392eb7697a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1909e65-f6d3-4664-bc51-22392eb7697a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f6b8d96-3e23-492e-ba30-a1d0e148ec32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f6b8d96-3e23-492e-ba30-a1d0e148ec32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f6b8d96-3e23-492e-ba30-a1d0e148ec32>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a5d6fc9-2dde-43fe-b0e3-0801ba39ee6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a5d6fc9-2dde-43fe-b0e3-0801ba39ee6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a5d6fc9-2dde-43fe-b0e3-0801ba39ee6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca4b259e-5f62-49c9-93cd-09f44c0c6d4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca4b259e-5f62-49c9-93cd-09f44c0c6d4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca4b259e-5f62-49c9-93cd-09f44c0c6d4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2454e7c-daea-4891-82b9-432959bb9af9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2454e7c-daea-4891-82b9-432959bb9af9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2454e7c-daea-4891-82b9-432959bb9af9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6214990-1a5f-4676-ba11-f71794eb657f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6214990-1a5f-4676-ba11-f71794eb657f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6214990-1a5f-4676-ba11-f71794eb657f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c5945ec-724b-472c-8ebf-4ec46d7545d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c5945ec-724b-472c-8ebf-4ec46d7545d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c5945ec-724b-472c-8ebf-4ec46d7545d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8deec0b-e257-49f2-a5ea-259f153b1f6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8deec0b-e257-49f2-a5ea-259f153b1f6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8deec0b-e257-49f2-a5ea-259f153b1f6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a69413b-16a6-48d8-88cb-bcf142dfc955> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a69413b-16a6-48d8-88cb-bcf142dfc955";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_26-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a69413b-16a6-48d8-88cb-bcf142dfc955>.
+    
+<http://data.lblod.info/id/remote-data-objects/f723c094-3bad-44eb-89f4-42e5a787a6ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f723c094-3bad-44eb-89f4-42e5a787a6ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f723c094-3bad-44eb-89f4-42e5a787a6ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cea3a18-2ba7-48ed-902f-e170fb630089> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cea3a18-2ba7-48ed-902f-e170fb630089";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cea3a18-2ba7-48ed-902f-e170fb630089>.
+    
+<http://data.lblod.info/id/remote-data-objects/c176d569-0aa7-451e-871d-56beaa159c08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c176d569-0aa7-451e-871d-56beaa159c08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c176d569-0aa7-451e-871d-56beaa159c08>.
+    
+<http://data.lblod.info/id/remote-data-objects/dda43b7f-0e52-4e98-af8d-2038f9b97dbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dda43b7f-0e52-4e98-af8d-2038f9b97dbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=Uittreksels_26-04-2022_16507.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dda43b7f-0e52-4e98-af8d-2038f9b97dbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bbd035a-6aa3-4860-9728-bbf08934db22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bbd035a-6aa3-4860-9728-bbf08934db22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/87113aa50a5dff46cd8be2f201fe77920e628ad1e9f95e16d5b5b2b34d428801/GetPublication?filename=Uittreksels_26-04-2022_16641.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/21e1dff5-192e-4bf1-868b-bb6c34cfa441> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bbd035a-6aa3-4860-9728-bbf08934db22>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201458-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201458-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201458-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201458-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f8ac90df-e43f-4ae4-82b9-9acb477ebe8c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f8ac90df-e43f-4ae4-82b9-9acb477ebe8c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "43165e5a-dbbf-43e1-bbc9-76c755ccbff0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/2cf8110f-6177-4b51-b150-2e36a604d0cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2cf8110f-6177-4b51-b150-2e36a604d0cc";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0>.
+
+  <http://redpencil.data.gift/id/task/6f55a28f-6b13-4deb-86e2-563d8df92c26> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6f55a28f-6b13-4deb-86e2-563d8df92c26";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f8ac90df-e43f-4ae4-82b9-9acb477ebe8c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/2cf8110f-6177-4b51-b150-2e36a604d0cc>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/53dd1a66-016b-4554-8112-5da9806ced6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53dd1a66-016b-4554-8112-5da9806ced6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53dd1a66-016b-4554-8112-5da9806ced6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c774934-df48-46cf-a15c-9fb85cc3824d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c774934-df48-46cf-a15c-9fb85cc3824d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c774934-df48-46cf-a15c-9fb85cc3824d>.
+    
+<http://data.lblod.info/id/remote-data-objects/540fdaaf-ea2b-448f-b06a-032c876b9489> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "540fdaaf-ea2b-448f-b06a-032c876b9489";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/540fdaaf-ea2b-448f-b06a-032c876b9489>.
+    
+<http://data.lblod.info/id/remote-data-objects/a417e396-aacb-4c9d-a16f-b0816f834edd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a417e396-aacb-4c9d-a16f-b0816f834edd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a417e396-aacb-4c9d-a16f-b0816f834edd>.
+    
+<http://data.lblod.info/id/remote-data-objects/39a36e21-9dcc-4864-a76d-abbbc3e2c8b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39a36e21-9dcc-4864-a76d-abbbc3e2c8b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39a36e21-9dcc-4864-a76d-abbbc3e2c8b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ae816fe-465b-4dca-b841-2ea9df1a1a1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ae816fe-465b-4dca-b841-2ea9df1a1a1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ae816fe-465b-4dca-b841-2ea9df1a1a1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/69a69b8b-dbcd-477f-9c58-ebfc9392309f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69a69b8b-dbcd-477f-9c58-ebfc9392309f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69a69b8b-dbcd-477f-9c58-ebfc9392309f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6be43703-73a6-424e-a37e-cff6e034b13f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6be43703-73a6-424e-a37e-cff6e034b13f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6be43703-73a6-424e-a37e-cff6e034b13f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4c59407-7ec9-4771-b30e-c8b08d7de14f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4c59407-7ec9-4771-b30e-c8b08d7de14f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4c59407-7ec9-4771-b30e-c8b08d7de14f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6824850-3c28-4cb3-abd1-b9dd0d37368b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6824850-3c28-4cb3-abd1-b9dd0d37368b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6824850-3c28-4cb3-abd1-b9dd0d37368b>.
+    
+<http://data.lblod.info/id/remote-data-objects/516f91ec-58b3-4760-98c5-89f6bad05e03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "516f91ec-58b3-4760-98c5-89f6bad05e03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/516f91ec-58b3-4760-98c5-89f6bad05e03>.
+    
+<http://data.lblod.info/id/remote-data-objects/68257f20-b434-45f3-bda0-4332e9b64c81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68257f20-b434-45f3-bda0-4332e9b64c81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68257f20-b434-45f3-bda0-4332e9b64c81>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c38a499-4197-4463-88bd-1ec0b193948e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c38a499-4197-4463-88bd-1ec0b193948e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c38a499-4197-4463-88bd-1ec0b193948e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d48ff441-010d-4e8e-bdd5-b630a69fb478> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d48ff441-010d-4e8e-bdd5-b630a69fb478";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d48ff441-010d-4e8e-bdd5-b630a69fb478>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd54d1ad-c356-4e70-8472-bbabad36366e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd54d1ad-c356-4e70-8472-bbabad36366e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd54d1ad-c356-4e70-8472-bbabad36366e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2fc2823-b0e9-4eca-8033-7fcd39fc1c58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2fc2823-b0e9-4eca-8033-7fcd39fc1c58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2fc2823-b0e9-4eca-8033-7fcd39fc1c58>.
+    
+<http://data.lblod.info/id/remote-data-objects/51707c86-4ed5-4419-be07-418e36a45686> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51707c86-4ed5-4419-be07-418e36a45686";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51707c86-4ed5-4419-be07-418e36a45686>.
+    
+<http://data.lblod.info/id/remote-data-objects/3398d765-39e5-4ec2-9075-9fd888fdc111> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3398d765-39e5-4ec2-9075-9fd888fdc111";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3398d765-39e5-4ec2-9075-9fd888fdc111>.
+    
+<http://data.lblod.info/id/remote-data-objects/5194dcf7-054b-48bf-8847-84125ce3f169> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5194dcf7-054b-48bf-8847-84125ce3f169";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5194dcf7-054b-48bf-8847-84125ce3f169>.
+    
+<http://data.lblod.info/id/remote-data-objects/940e3b06-820d-498b-8496-a1fdb9ed9f89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "940e3b06-820d-498b-8496-a1fdb9ed9f89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/940e3b06-820d-498b-8496-a1fdb9ed9f89>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e00b83f-6c33-47d8-8971-706b5987c663> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e00b83f-6c33-47d8-8971-706b5987c663";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e00b83f-6c33-47d8-8971-706b5987c663>.
+    
+<http://data.lblod.info/id/remote-data-objects/319dddda-b796-4773-b1de-d93ca8395618> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "319dddda-b796-4773-b1de-d93ca8395618";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/319dddda-b796-4773-b1de-d93ca8395618>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1e99be5-d010-4f18-a211-30f46514d0ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1e99be5-d010-4f18-a211-30f46514d0ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1e99be5-d010-4f18-a211-30f46514d0ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/95264104-c5ea-45e4-ab91-230f319db85a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95264104-c5ea-45e4-ab91-230f319db85a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Uittreksels_14-12-2021_15369.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95264104-c5ea-45e4-ab91-230f319db85a>.
+    
+<http://data.lblod.info/id/remote-data-objects/111cc26e-09ca-43e5-8df5-173525f478f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "111cc26e-09ca-43e5-8df5-173525f478f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Uittreksels_14-12-2021_15431.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/111cc26e-09ca-43e5-8df5-173525f478f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5eb81d6-c46a-4a61-9943-eaf25035bf50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5eb81d6-c46a-4a61-9943-eaf25035bf50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Uittreksels_14-12-2021_15432.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5eb81d6-c46a-4a61-9943-eaf25035bf50>.
+    
+<http://data.lblod.info/id/remote-data-objects/62c273df-96ad-465d-9dab-66abcede72cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62c273df-96ad-465d-9dab-66abcede72cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.landen.be/LBLODWeb/Home/Overzicht/ad415d25bf9db02da1315703295af41f89ebba60f7c2acc94713dd865f6e1e3f/GetPublication?filename=Uittreksels_27-06-2022_18086.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62c273df-96ad-465d-9dab-66abcede72cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/63a5c977-625d-4fd7-aab9-3f4812d89a05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63a5c977-625d-4fd7-aab9-3f4812d89a05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Agenda_OCMW-Raad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63a5c977-625d-4fd7-aab9-3f4812d89a05>.
+    
+<http://data.lblod.info/id/remote-data-objects/5eb3e5db-2735-4aef-9efb-087df021fa99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5eb3e5db-2735-4aef-9efb-087df021fa99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Agenda_OCMW-Raad_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5eb3e5db-2735-4aef-9efb-087df021fa99>.
+    
+<http://data.lblod.info/id/remote-data-objects/b02818b9-165a-404e-9d27-6df993c77b7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b02818b9-165a-404e-9d27-6df993c77b7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Agenda_OCMW-Raad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b02818b9-165a-404e-9d27-6df993c77b7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/958d199a-0185-4abc-93d3-5f892f176bd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "958d199a-0185-4abc-93d3-5f892f176bd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Agenda_OCMW-Raad_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/958d199a-0185-4abc-93d3-5f892f176bd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ec2c746-155e-41e5-bb86-ff8474f1d6e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ec2c746-155e-41e5-bb86-ff8474f1d6e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Agenda_OCMW-Raad_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ec2c746-155e-41e5-bb86-ff8474f1d6e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e46c721e-258c-4956-93bd-e32b753a9649> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e46c721e-258c-4956-93bd-e32b753a9649";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Agenda_OCMW-Raad_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e46c721e-258c-4956-93bd-e32b753a9649>.
+    
+<http://data.lblod.info/id/remote-data-objects/53e0245a-c017-4bf3-a25a-c7177c56e164> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53e0245a-c017-4bf3-a25a-c7177c56e164";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Agenda_OCMW-Raad_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53e0245a-c017-4bf3-a25a-c7177c56e164>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a579ffd-eee2-40fc-b730-ccf72bb1e355> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a579ffd-eee2-40fc-b730-ccf72bb1e355";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Agenda_OCMW-Raad_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a579ffd-eee2-40fc-b730-ccf72bb1e355>.
+    
+<http://data.lblod.info/id/remote-data-objects/15a95886-f594-4fbe-a042-396b50e72663> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15a95886-f594-4fbe-a042-396b50e72663";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Agenda_OCMW-Raad_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15a95886-f594-4fbe-a042-396b50e72663>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a6e6669-ecfe-44d6-a944-4c215b8cc867> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a6e6669-ecfe-44d6-a944-4c215b8cc867";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=BesluitenLijst_OCMW-Raad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a6e6669-ecfe-44d6-a944-4c215b8cc867>.
+    
+<http://data.lblod.info/id/remote-data-objects/218c02f2-08c1-4a50-910a-610a13b0fd96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "218c02f2-08c1-4a50-910a-610a13b0fd96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=BesluitenLijst_OCMW-Raad_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/218c02f2-08c1-4a50-910a-610a13b0fd96>.
+    
+<http://data.lblod.info/id/remote-data-objects/a102f33e-1b10-4215-8d92-4ef90105506f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a102f33e-1b10-4215-8d92-4ef90105506f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=BesluitenLijst_OCMW-Raad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a102f33e-1b10-4215-8d92-4ef90105506f>.
+    
+<http://data.lblod.info/id/remote-data-objects/94e6588c-ae89-455a-8bad-60e759b189be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94e6588c-ae89-455a-8bad-60e759b189be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=BesluitenLijst_OCMW-Raad_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94e6588c-ae89-455a-8bad-60e759b189be>.
+    
+<http://data.lblod.info/id/remote-data-objects/512828dc-124a-4086-9165-3832a691636c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "512828dc-124a-4086-9165-3832a691636c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=BesluitenLijst_OCMW-Raad_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/512828dc-124a-4086-9165-3832a691636c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbc4a1a5-9435-4c3a-9520-c24437b85b04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbc4a1a5-9435-4c3a-9520-c24437b85b04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=BesluitenLijst_OCMW-Raad_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbc4a1a5-9435-4c3a-9520-c24437b85b04>.
+    
+<http://data.lblod.info/id/remote-data-objects/03353aa0-3867-402d-b252-937ad1fb2830> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03353aa0-3867-402d-b252-937ad1fb2830";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=BesluitenLijst_OCMW-Raad_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03353aa0-3867-402d-b252-937ad1fb2830>.
+    
+<http://data.lblod.info/id/remote-data-objects/be76b49d-bb0c-460a-9999-42a3b584304b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be76b49d-bb0c-460a-9999-42a3b584304b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=BesluitenLijst_OCMW-Raad_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be76b49d-bb0c-460a-9999-42a3b584304b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2be2bad-d900-4fb0-a24b-fee961d08e9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2be2bad-d900-4fb0-a24b-fee961d08e9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=BesluitenLijst_OCMW-Raad_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2be2bad-d900-4fb0-a24b-fee961d08e9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a09f2de6-7910-4d13-a526-426062d50ce9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a09f2de6-7910-4d13-a526-426062d50ce9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Notulen_OCMW-Raad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a09f2de6-7910-4d13-a526-426062d50ce9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fb2ddc6-22f7-4d15-aa26-a9eacd481e2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fb2ddc6-22f7-4d15-aa26-a9eacd481e2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Notulen_OCMW-Raad_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fb2ddc6-22f7-4d15-aa26-a9eacd481e2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/75c7394e-a2f4-4cae-af03-bef4c76873e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75c7394e-a2f4-4cae-af03-bef4c76873e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Notulen_OCMW-Raad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75c7394e-a2f4-4cae-af03-bef4c76873e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e00ed1a3-fc38-4efa-a061-6364286492ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e00ed1a3-fc38-4efa-a061-6364286492ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Notulen_OCMW-Raad_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e00ed1a3-fc38-4efa-a061-6364286492ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd088529-eab3-44b7-8ad3-c3d5346de183> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd088529-eab3-44b7-8ad3-c3d5346de183";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Notulen_OCMW-Raad_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/43165e5a-dbbf-43e1-bbc9-76c755ccbff0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd088529-eab3-44b7-8ad3-c3d5346de183>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201459-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201459-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201459-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201459-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/43e858b0-64a1-43f9-ba26-7d39d69bc5e3> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "43e858b0-64a1-43f9-ba26-7d39d69bc5e3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "af5690e5-a727-433b-ba3d-f83feafe90c1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/2a51c2c7-12f8-4438-9a42-03abbf40cf40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2a51c2c7-12f8-4438-9a42-03abbf40cf40";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1>.
+
+  <http://redpencil.data.gift/id/task/607cbfde-29d0-437c-aea6-30a9b0774bfe> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "607cbfde-29d0-437c-aea6-30a9b0774bfe";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/43e858b0-64a1-43f9-ba26-7d39d69bc5e3>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/2a51c2c7-12f8-4438-9a42-03abbf40cf40>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/1a0be7f9-1526-449e-a028-e9dc7cf990cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a0be7f9-1526-449e-a028-e9dc7cf990cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Notulen_OCMW-Raad_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a0be7f9-1526-449e-a028-e9dc7cf990cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/250fb681-e909-493b-afac-1b7a9ce2a1be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "250fb681-e909-493b-afac-1b7a9ce2a1be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Notulen_OCMW-Raad_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/250fb681-e909-493b-afac-1b7a9ce2a1be>.
+    
+<http://data.lblod.info/id/remote-data-objects/30492c1c-f01e-40e2-8459-c5c496d69d2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30492c1c-f01e-40e2-8459-c5c496d69d2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Notulen_OCMW-Raad_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30492c1c-f01e-40e2-8459-c5c496d69d2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/88f67e2a-6b10-4e28-9bd0-a43f5659dce6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88f67e2a-6b10-4e28-9bd0-a43f5659dce6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Uittreksels_22-12-2021_35414.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88f67e2a-6b10-4e28-9bd0-a43f5659dce6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4ce3d84-d25b-4758-8079-df916e42e631> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4ce3d84-d25b-4758-8079-df916e42e631";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Uittreksels_24-11-2021_35102.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4ce3d84-d25b-4758-8079-df916e42e631>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba72c6bd-0626-407d-9337-d36fca1b3f91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba72c6bd-0626-407d-9337-d36fca1b3f91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/36e2bd5c8dd3f1bfdf4bf7d5512542047ca22a6e17b02287a6e01a86e122d60d/GetPublication?filename=Uittreksels_30-03-2022_38296.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba72c6bd-0626-407d-9337-d36fca1b3f91>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c1a2d86-7814-4078-9c66-0caf77f3a57d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c1a2d86-7814-4078-9c66-0caf77f3a57d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c1a2d86-7814-4078-9c66-0caf77f3a57d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7e79b40-2bb8-4c64-80f7-1a40478a8f6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7e79b40-2bb8-4c64-80f7-1a40478a8f6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7e79b40-2bb8-4c64-80f7-1a40478a8f6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a043bdbe-a31d-4298-b87e-b7ff80085d72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a043bdbe-a31d-4298-b87e-b7ff80085d72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a043bdbe-a31d-4298-b87e-b7ff80085d72>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c1effc3-8054-40c2-9160-fd75a08b6647> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c1effc3-8054-40c2-9160-fd75a08b6647";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c1effc3-8054-40c2-9160-fd75a08b6647>.
+    
+<http://data.lblod.info/id/remote-data-objects/c792f827-ff8d-4937-93fd-98f839933476> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c792f827-ff8d-4937-93fd-98f839933476";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c792f827-ff8d-4937-93fd-98f839933476>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ad44356-1da3-4772-86af-4338c2da9eeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ad44356-1da3-4772-86af-4338c2da9eeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ad44356-1da3-4772-86af-4338c2da9eeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b57ef97-4404-4350-8ae6-863f26dd939a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b57ef97-4404-4350-8ae6-863f26dd939a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b57ef97-4404-4350-8ae6-863f26dd939a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cd84e0e-4c71-4012-b66c-f62e6fd230e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cd84e0e-4c71-4012-b66c-f62e6fd230e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cd84e0e-4c71-4012-b66c-f62e6fd230e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7a9f411-e56b-411a-8f65-56568431d43a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7a9f411-e56b-411a-8f65-56568431d43a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7a9f411-e56b-411a-8f65-56568431d43a>.
+    
+<http://data.lblod.info/id/remote-data-objects/504a7a9f-7935-47ee-8445-ddc18ab5b4c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "504a7a9f-7935-47ee-8445-ddc18ab5b4c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/504a7a9f-7935-47ee-8445-ddc18ab5b4c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ee6d0d1-0e39-4852-ab86-2366911b90cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ee6d0d1-0e39-4852-ab86-2366911b90cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ee6d0d1-0e39-4852-ab86-2366911b90cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/282bcd93-83da-4b42-884f-f05db694864c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "282bcd93-83da-4b42-884f-f05db694864c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/282bcd93-83da-4b42-884f-f05db694864c>.
+    
+<http://data.lblod.info/id/remote-data-objects/91216863-aaf8-4fc4-986d-7f6edfd38fc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91216863-aaf8-4fc4-986d-7f6edfd38fc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91216863-aaf8-4fc4-986d-7f6edfd38fc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ded819b-2b0c-475b-a497-10041c10bfe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ded819b-2b0c-475b-a497-10041c10bfe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ded819b-2b0c-475b-a497-10041c10bfe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/904ca792-3cee-4dbb-a71f-b7a5bac1fae8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "904ca792-3cee-4dbb-a71f-b7a5bac1fae8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/904ca792-3cee-4dbb-a71f-b7a5bac1fae8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2c25c27-7ee7-4d50-ba5c-623cb19ef4a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2c25c27-7ee7-4d50-ba5c-623cb19ef4a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2c25c27-7ee7-4d50-ba5c-623cb19ef4a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/327a8e1f-30c2-49b7-a344-062e0762b0db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "327a8e1f-30c2-49b7-a344-062e0762b0db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/327a8e1f-30c2-49b7-a344-062e0762b0db>.
+    
+<http://data.lblod.info/id/remote-data-objects/1791effb-0c2c-4692-87ed-a8a13e9a51fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1791effb-0c2c-4692-87ed-a8a13e9a51fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1791effb-0c2c-4692-87ed-a8a13e9a51fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce104989-29ca-4cc6-ac30-5a6a4b2e54b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce104989-29ca-4cc6-ac30-5a6a4b2e54b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce104989-29ca-4cc6-ac30-5a6a4b2e54b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d748804e-2731-4f99-bee6-3fcde52ea777> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d748804e-2731-4f99-bee6-3fcde52ea777";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d748804e-2731-4f99-bee6-3fcde52ea777>.
+    
+<http://data.lblod.info/id/remote-data-objects/03b747a5-e58a-4401-b422-63b0d44dcd1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03b747a5-e58a-4401-b422-63b0d44dcd1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03b747a5-e58a-4401-b422-63b0d44dcd1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9f9e6d8-6632-4e7c-adcb-e073652cd49d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9f9e6d8-6632-4e7c-adcb-e073652cd49d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9f9e6d8-6632-4e7c-adcb-e073652cd49d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f72815b5-aa12-48a2-a407-4ae5f5fed07c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f72815b5-aa12-48a2-a407-4ae5f5fed07c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f72815b5-aa12-48a2-a407-4ae5f5fed07c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4e4044d-4b42-436e-9e92-3099d6a96d1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4e4044d-4b42-436e-9e92-3099d6a96d1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4e4044d-4b42-436e-9e92-3099d6a96d1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b7f6e6a-ae04-45e1-b59e-08064fee4773> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b7f6e6a-ae04-45e1-b59e-08064fee4773";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b7f6e6a-ae04-45e1-b59e-08064fee4773>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6699339-0f8f-4f40-8f89-5f0d13cc52c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6699339-0f8f-4f40-8f89-5f0d13cc52c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6699339-0f8f-4f40-8f89-5f0d13cc52c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ed4b507-5f53-40f4-a9fb-380a6b94448d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ed4b507-5f53-40f4-a9fb-380a6b94448d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ed4b507-5f53-40f4-a9fb-380a6b94448d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e17d16ea-378b-445f-8c88-4fda2e993716> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e17d16ea-378b-445f-8c88-4fda2e993716";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e17d16ea-378b-445f-8c88-4fda2e993716>.
+    
+<http://data.lblod.info/id/remote-data-objects/b211e416-701a-4f8f-8237-dec77cefd393> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b211e416-701a-4f8f-8237-dec77cefd393";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b211e416-701a-4f8f-8237-dec77cefd393>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b98e47f-79ec-440f-8291-e16efe2f0896> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b98e47f-79ec-440f-8291-e16efe2f0896";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b98e47f-79ec-440f-8291-e16efe2f0896>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7a94e6b-b4f9-4a11-a09d-8a59b1d656b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7a94e6b-b4f9-4a11-a09d-8a59b1d656b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7a94e6b-b4f9-4a11-a09d-8a59b1d656b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/b66f2618-6554-42e5-b73a-bd24ad5abf73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b66f2618-6554-42e5-b73a-bd24ad5abf73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b66f2618-6554-42e5-b73a-bd24ad5abf73>.
+    
+<http://data.lblod.info/id/remote-data-objects/a23017ad-7059-4db5-82c2-628f9eadb8dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a23017ad-7059-4db5-82c2-628f9eadb8dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a23017ad-7059-4db5-82c2-628f9eadb8dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/c231e4a3-ed32-42f0-a58b-990190d76394> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c231e4a3-ed32-42f0-a58b-990190d76394";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c231e4a3-ed32-42f0-a58b-990190d76394>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3163010-2a55-4ef3-81fe-69e99c5d80f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3163010-2a55-4ef3-81fe-69e99c5d80f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/c2fbb7b6e32982461b1b586ff37ae8e41fb5012b8108354c174865998fe7445f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3163010-2a55-4ef3-81fe-69e99c5d80f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f94d2acd-d8dd-48cc-9074-441bd75a5cd6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f94d2acd-d8dd-48cc-9074-441bd75a5cd6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Agenda_Gemeenteraad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f94d2acd-d8dd-48cc-9074-441bd75a5cd6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bdf312a-6bb9-41c7-8845-ade4f6f36162> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bdf312a-6bb9-41c7-8845-ade4f6f36162";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Agenda_Gemeenteraad_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bdf312a-6bb9-41c7-8845-ade4f6f36162>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddc5a119-70cb-418b-9fce-68801be338b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddc5a119-70cb-418b-9fce-68801be338b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Agenda_Gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddc5a119-70cb-418b-9fce-68801be338b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a679128-4da3-4e60-98fb-21d86331b4b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a679128-4da3-4e60-98fb-21d86331b4b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Agenda_Gemeenteraad_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a679128-4da3-4e60-98fb-21d86331b4b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/37291ffe-5b97-4625-a74a-b5d65ece4e63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37291ffe-5b97-4625-a74a-b5d65ece4e63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Agenda_Gemeenteraad_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37291ffe-5b97-4625-a74a-b5d65ece4e63>.
+    
+<http://data.lblod.info/id/remote-data-objects/558eab18-2eae-481c-92d2-86b81f30e70c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "558eab18-2eae-481c-92d2-86b81f30e70c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Agenda_Gemeenteraad_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/558eab18-2eae-481c-92d2-86b81f30e70c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f524d23b-961c-48e2-a301-38f917b61832> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f524d23b-961c-48e2-a301-38f917b61832";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Agenda_Gemeenteraad_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f524d23b-961c-48e2-a301-38f917b61832>.
+    
+<http://data.lblod.info/id/remote-data-objects/53efd7cd-a426-46dd-9a07-079c403efde3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53efd7cd-a426-46dd-9a07-079c403efde3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Agenda_Gemeenteraad_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53efd7cd-a426-46dd-9a07-079c403efde3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8afd0012-c4e4-483f-9fdc-924be06e9ff4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8afd0012-c4e4-483f-9fdc-924be06e9ff4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Agenda_Gemeenteraad_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:14:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/af5690e5-a727-433b-ba3d-f83feafe90c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8afd0012-c4e4-483f-9fdc-924be06e9ff4>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201500-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201500-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201500-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201500-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7c96f791-1f7a-46d4-b64b-a3f906ca16bf> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7c96f791-1f7a-46d4-b64b-a3f906ca16bf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9efbc8e5-d7ca-423c-b583-d4ce07d194ef";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/568c40da-65f9-401d-859c-b78aad2ccb77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "568c40da-65f9-401d-859c-b78aad2ccb77";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef>.
+
+  <http://redpencil.data.gift/id/task/13d07a44-ae04-4287-895d-942b7f0c5845> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "13d07a44-ae04-4287-895d-942b7f0c5845";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7c96f791-1f7a-46d4-b64b-a3f906ca16bf>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/568c40da-65f9-401d-859c-b78aad2ccb77>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/fa9dc170-39de-4a9e-9305-3e759eaae813> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa9dc170-39de-4a9e-9305-3e759eaae813";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=BesluitenLijst_Gemeenteraad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa9dc170-39de-4a9e-9305-3e759eaae813>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d80f387-fa6f-46bf-94f1-c977e0b83a0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d80f387-fa6f-46bf-94f1-c977e0b83a0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d80f387-fa6f-46bf-94f1-c977e0b83a0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/587ddca7-ef99-4817-a243-97578b09d371> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "587ddca7-ef99-4817-a243-97578b09d371";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/587ddca7-ef99-4817-a243-97578b09d371>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e972430-2cbf-4352-89c7-3c0161551c99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e972430-2cbf-4352-89c7-3c0161551c99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e972430-2cbf-4352-89c7-3c0161551c99>.
+    
+<http://data.lblod.info/id/remote-data-objects/98d8f7a8-8f66-4b61-9a67-1e0a4b046f8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98d8f7a8-8f66-4b61-9a67-1e0a4b046f8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=BesluitenLijst_Gemeenteraad_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98d8f7a8-8f66-4b61-9a67-1e0a4b046f8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e36ecb8-bb53-402f-bbc7-391c3c7fd13b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e36ecb8-bb53-402f-bbc7-391c3c7fd13b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e36ecb8-bb53-402f-bbc7-391c3c7fd13b>.
+    
+<http://data.lblod.info/id/remote-data-objects/89da318d-3148-4efb-8a4f-f9c36a44a042> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89da318d-3148-4efb-8a4f-f9c36a44a042";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89da318d-3148-4efb-8a4f-f9c36a44a042>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee256386-361d-4158-8a72-61ca7eb20f34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee256386-361d-4158-8a72-61ca7eb20f34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=BesluitenLijst_Gemeenteraad_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee256386-361d-4158-8a72-61ca7eb20f34>.
+    
+<http://data.lblod.info/id/remote-data-objects/7468b5b7-1e8d-4901-9322-bc3eb324986b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7468b5b7-1e8d-4901-9322-bc3eb324986b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=BesluitenLijst_Gemeenteraad_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7468b5b7-1e8d-4901-9322-bc3eb324986b>.
+    
+<http://data.lblod.info/id/remote-data-objects/437c319d-8018-4723-8d5c-8bee7d608282> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "437c319d-8018-4723-8d5c-8bee7d608282";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Notulen_Gemeenteraad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/437c319d-8018-4723-8d5c-8bee7d608282>.
+    
+<http://data.lblod.info/id/remote-data-objects/605f1bc1-94d6-4970-99a6-81464b2b01fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "605f1bc1-94d6-4970-99a6-81464b2b01fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Notulen_Gemeenteraad_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/605f1bc1-94d6-4970-99a6-81464b2b01fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/112a5270-4d69-467c-bf65-009f34b5e10d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "112a5270-4d69-467c-bf65-009f34b5e10d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Notulen_Gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/112a5270-4d69-467c-bf65-009f34b5e10d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7e363f9-4f8e-4f1c-b15c-2fe815bc9c0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7e363f9-4f8e-4f1c-b15c-2fe815bc9c0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Notulen_Gemeenteraad_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7e363f9-4f8e-4f1c-b15c-2fe815bc9c0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/76380a2f-5922-44e6-8ad6-00a90956b7b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76380a2f-5922-44e6-8ad6-00a90956b7b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Notulen_Gemeenteraad_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76380a2f-5922-44e6-8ad6-00a90956b7b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8392b15c-1a35-4950-a28d-a3c39d73d612> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8392b15c-1a35-4950-a28d-a3c39d73d612";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Notulen_Gemeenteraad_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8392b15c-1a35-4950-a28d-a3c39d73d612>.
+    
+<http://data.lblod.info/id/remote-data-objects/d43ad733-18c1-468d-9859-fb6353bd22f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d43ad733-18c1-468d-9859-fb6353bd22f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Notulen_Gemeenteraad_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d43ad733-18c1-468d-9859-fb6353bd22f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/88552186-ce3e-403b-840e-d6e60cd0b995> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88552186-ce3e-403b-840e-d6e60cd0b995";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Notulen_Gemeenteraad_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88552186-ce3e-403b-840e-d6e60cd0b995>.
+    
+<http://data.lblod.info/id/remote-data-objects/2982b49c-621c-4eca-9c77-08abb61a0723> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2982b49c-621c-4eca-9c77-08abb61a0723";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_22-12-2021_35354.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2982b49c-621c-4eca-9c77-08abb61a0723>.
+    
+<http://data.lblod.info/id/remote-data-objects/05e62cc8-d365-4a82-9d10-a9bb2f4d2dbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05e62cc8-d365-4a82-9d10-a9bb2f4d2dbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_22-12-2021_35408.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05e62cc8-d365-4a82-9d10-a9bb2f4d2dbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e237341-b206-4c8d-8605-513e4e73784a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e237341-b206-4c8d-8605-513e4e73784a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_22-12-2021_35425.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e237341-b206-4c8d-8605-513e4e73784a>.
+    
+<http://data.lblod.info/id/remote-data-objects/621b043c-f5e9-4937-bedd-bac83f4d90ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "621b043c-f5e9-4937-bedd-bac83f4d90ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_22-12-2021_35426.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/621b043c-f5e9-4937-bedd-bac83f4d90ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/158fb01e-4cce-41db-80b1-00d66b1e7103> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "158fb01e-4cce-41db-80b1-00d66b1e7103";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_22-12-2021_35427.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/158fb01e-4cce-41db-80b1-00d66b1e7103>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b22187f-5954-47b0-8a34-3076a9fd7df6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b22187f-5954-47b0-8a34-3076a9fd7df6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_22-12-2021_35428.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b22187f-5954-47b0-8a34-3076a9fd7df6>.
+    
+<http://data.lblod.info/id/remote-data-objects/99908735-645a-436a-8452-9470d4227ed4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99908735-645a-436a-8452-9470d4227ed4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_22-12-2021_35431.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99908735-645a-436a-8452-9470d4227ed4>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb3b98f7-b2d4-4363-8f48-206ea590c53d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb3b98f7-b2d4-4363-8f48-206ea590c53d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_22-12-2021_35433.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb3b98f7-b2d4-4363-8f48-206ea590c53d>.
+    
+<http://data.lblod.info/id/remote-data-objects/691334f7-13b4-4290-a7ce-d889f73b82f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "691334f7-13b4-4290-a7ce-d889f73b82f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_23-02-2022_36941.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/691334f7-13b4-4290-a7ce-d889f73b82f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/30d41a82-b4a9-4f6e-917e-bb4d63732bc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30d41a82-b4a9-4f6e-917e-bb4d63732bc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_24-05-2022_38954.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30d41a82-b4a9-4f6e-917e-bb4d63732bc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/594b8acc-8357-4a0c-8d3e-6817aab384ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "594b8acc-8357-4a0c-8d3e-6817aab384ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_24-11-2021_35115.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/594b8acc-8357-4a0c-8d3e-6817aab384ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ee1f3a6-07dc-4e9c-a30a-61b52f0dd971> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ee1f3a6-07dc-4e9c-a30a-61b52f0dd971";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_24-11-2021_35117.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ee1f3a6-07dc-4e9c-a30a-61b52f0dd971>.
+    
+<http://data.lblod.info/id/remote-data-objects/56073734-577b-4c54-9dfb-2da838033e7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56073734-577b-4c54-9dfb-2da838033e7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_26-01-2022_35684.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56073734-577b-4c54-9dfb-2da838033e7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d248e1e-2c43-4e6e-b1db-e1f1febdf63e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d248e1e-2c43-4e6e-b1db-e1f1febdf63e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_26-01-2022_35731.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d248e1e-2c43-4e6e-b1db-e1f1febdf63e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b908da9-cfd9-498c-84e9-567ce8a4a5fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b908da9-cfd9-498c-84e9-567ce8a4a5fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_27-04-2022_38443.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b908da9-cfd9-498c-84e9-567ce8a4a5fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd52e598-af72-4d21-9e8a-3f6b8027961a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd52e598-af72-4d21-9e8a-3f6b8027961a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_27-10-2021_34827.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd52e598-af72-4d21-9e8a-3f6b8027961a>.
+    
+<http://data.lblod.info/id/remote-data-objects/afd124ee-b38c-46a5-8d73-03b2d9e931ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afd124ee-b38c-46a5-8d73-03b2d9e931ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_29-06-2022_39378.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afd124ee-b38c-46a5-8d73-03b2d9e931ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0ff8f24-fbc9-429c-b2b0-c9e29cc194a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0ff8f24-fbc9-429c-b2b0-c9e29cc194a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_29-06-2022_39379.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0ff8f24-fbc9-429c-b2b0-c9e29cc194a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea0d2914-04ae-4783-9ad2-8da739d2b183> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea0d2914-04ae-4783-9ad2-8da739d2b183";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_30-03-2022_35429.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea0d2914-04ae-4783-9ad2-8da739d2b183>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8e4cf91-2d22-4d25-b543-62aa1a1da81b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8e4cf91-2d22-4d25-b543-62aa1a1da81b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/cfe84a7f48fbe4a4176e047955bd3fd013f26a17753c9dc888e2f2e289188f00/GetPublication?filename=Uittreksels_30-03-2022_35430.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8e4cf91-2d22-4d25-b543-62aa1a1da81b>.
+    
+<http://data.lblod.info/id/remote-data-objects/48389600-a216-4f5e-8db3-e7715bfe6dc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48389600-a216-4f5e-8db3-e7715bfe6dc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48389600-a216-4f5e-8db3-e7715bfe6dc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/66292d4c-6882-44aa-8b55-d8a2675b7495> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66292d4c-6882-44aa-8b55-d8a2675b7495";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66292d4c-6882-44aa-8b55-d8a2675b7495>.
+    
+<http://data.lblod.info/id/remote-data-objects/753cd474-1ef1-4343-8d28-f2bf5fb73447> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "753cd474-1ef1-4343-8d28-f2bf5fb73447";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/753cd474-1ef1-4343-8d28-f2bf5fb73447>.
+    
+<http://data.lblod.info/id/remote-data-objects/02ae776c-edcf-40d4-9235-f785ab2cd3a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02ae776c-edcf-40d4-9235-f785ab2cd3a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02ae776c-edcf-40d4-9235-f785ab2cd3a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d13188f-1be3-424a-b320-7b8121973898> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d13188f-1be3-424a-b320-7b8121973898";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d13188f-1be3-424a-b320-7b8121973898>.
+    
+<http://data.lblod.info/id/remote-data-objects/c04f466d-5773-412c-b55b-cddef33ac01b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c04f466d-5773-412c-b55b-cddef33ac01b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c04f466d-5773-412c-b55b-cddef33ac01b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8da373bf-8eb7-4240-8c86-d148c1bf34a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8da373bf-8eb7-4240-8c86-d148c1bf34a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8da373bf-8eb7-4240-8c86-d148c1bf34a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/244e7ec3-1d58-4e99-8db3-1c2f937db531> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "244e7ec3-1d58-4e99-8db3-1c2f937db531";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/244e7ec3-1d58-4e99-8db3-1c2f937db531>.
+    
+<http://data.lblod.info/id/remote-data-objects/611ae6a6-a313-4bf8-ad6e-392b073601a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "611ae6a6-a313-4bf8-ad6e-392b073601a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/611ae6a6-a313-4bf8-ad6e-392b073601a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/759e4ab5-afcd-4765-8d55-223589c58ad9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "759e4ab5-afcd-4765-8d55-223589c58ad9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/759e4ab5-afcd-4765-8d55-223589c58ad9>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa320613-f381-4272-b408-fa7799f74696> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa320613-f381-4272-b408-fa7799f74696";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa320613-f381-4272-b408-fa7799f74696>.
+    
+<http://data.lblod.info/id/remote-data-objects/f325ee6d-2817-436c-838b-f06cfab1a93c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f325ee6d-2817-436c-838b-f06cfab1a93c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f325ee6d-2817-436c-838b-f06cfab1a93c>.
+    
+<http://data.lblod.info/id/remote-data-objects/805678f5-cdca-4cd2-99a3-5789ae8e03af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "805678f5-cdca-4cd2-99a3-5789ae8e03af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9efbc8e5-d7ca-423c-b583-d4ce07d194ef> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/805678f5-cdca-4cd2-99a3-5789ae8e03af>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201502-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201502-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201502-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201502-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/316a9a22-4a16-4ca7-8c1b-3e5518928c4c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "316a9a22-4a16-4ca7-8c1b-3e5518928c4c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "67f21300-9a6d-4662-89ce-bf97c9b0ea07";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d0ecc4c7-1403-4b0b-b0d4-1f21e03e509d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d0ecc4c7-1403-4b0b-b0d4-1f21e03e509d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07>.
+
+  <http://redpencil.data.gift/id/task/25223375-da4c-4384-b5ab-58d6c122272e> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "25223375-da4c-4384-b5ab-58d6c122272e";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/316a9a22-4a16-4ca7-8c1b-3e5518928c4c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d0ecc4c7-1403-4b0b-b0d4-1f21e03e509d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7f6719a1-da0b-48ff-aad0-ad38db606cd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f6719a1-da0b-48ff-aad0-ad38db606cd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f6719a1-da0b-48ff-aad0-ad38db606cd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4fac596-e484-4482-af3f-c98d1f98c970> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4fac596-e484-4482-af3f-c98d1f98c970";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4fac596-e484-4482-af3f-c98d1f98c970>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb695382-9e60-4224-9230-90e39ac61e5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb695382-9e60-4224-9230-90e39ac61e5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb695382-9e60-4224-9230-90e39ac61e5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bb39b81-a8ba-4e3a-b043-7cbf24e37883> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bb39b81-a8ba-4e3a-b043-7cbf24e37883";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bb39b81-a8ba-4e3a-b043-7cbf24e37883>.
+    
+<http://data.lblod.info/id/remote-data-objects/78231341-ca2f-4afd-8fa5-01ddc75be5e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78231341-ca2f-4afd-8fa5-01ddc75be5e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78231341-ca2f-4afd-8fa5-01ddc75be5e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/be5e7b80-4371-4a0d-a2ee-ec9ade3e8558> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be5e7b80-4371-4a0d-a2ee-ec9ade3e8558";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be5e7b80-4371-4a0d-a2ee-ec9ade3e8558>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb63c838-9a5c-49a1-b0c5-522a469fc022> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb63c838-9a5c-49a1-b0c5-522a469fc022";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb63c838-9a5c-49a1-b0c5-522a469fc022>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9a41ab4-159b-4e24-9fe7-f72acf3793d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9a41ab4-159b-4e24-9fe7-f72acf3793d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9a41ab4-159b-4e24-9fe7-f72acf3793d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7d72f06-a849-4264-858a-552635e8fd16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7d72f06-a849-4264-858a-552635e8fd16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7d72f06-a849-4264-858a-552635e8fd16>.
+    
+<http://data.lblod.info/id/remote-data-objects/10b08bb3-fb57-42a7-a645-2f2c128614c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10b08bb3-fb57-42a7-a645-2f2c128614c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10b08bb3-fb57-42a7-a645-2f2c128614c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef1c86d3-6a62-432d-9479-9e424540d0a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef1c86d3-6a62-432d-9479-9e424540d0a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef1c86d3-6a62-432d-9479-9e424540d0a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/60995c0e-c90b-4a3c-a218-72e167da54b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60995c0e-c90b-4a3c-a218-72e167da54b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60995c0e-c90b-4a3c-a218-72e167da54b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e04421de-fd9a-40f2-9ca0-15fb84ab0f4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e04421de-fd9a-40f2-9ca0-15fb84ab0f4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e04421de-fd9a-40f2-9ca0-15fb84ab0f4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/65ff4ed0-2375-4e0b-bcf7-0e56663d835a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65ff4ed0-2375-4e0b-bcf7-0e56663d835a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65ff4ed0-2375-4e0b-bcf7-0e56663d835a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d822556-de06-4d31-a375-4860fef4b60b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d822556-de06-4d31-a375-4860fef4b60b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d822556-de06-4d31-a375-4860fef4b60b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b55d0592-ea77-4ae8-b9b7-174418b3b97f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b55d0592-ea77-4ae8-b9b7-174418b3b97f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b55d0592-ea77-4ae8-b9b7-174418b3b97f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fd5cf8d-c299-4e9f-9093-fe6d4a8d805d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fd5cf8d-c299-4e9f-9093-fe6d4a8d805d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fd5cf8d-c299-4e9f-9093-fe6d4a8d805d>.
+    
+<http://data.lblod.info/id/remote-data-objects/47444204-75e1-421f-8cc4-e5c32fd7b398> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47444204-75e1-421f-8cc4-e5c32fd7b398";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47444204-75e1-421f-8cc4-e5c32fd7b398>.
+    
+<http://data.lblod.info/id/remote-data-objects/fae67900-16f1-49ef-b1f8-980bf9c31548> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fae67900-16f1-49ef-b1f8-980bf9c31548";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fae67900-16f1-49ef-b1f8-980bf9c31548>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7a9f9cf-f847-46fb-99c9-9dbc0aa31807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7a9f9cf-f847-46fb-99c9-9dbc0aa31807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7a9f9cf-f847-46fb-99c9-9dbc0aa31807>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ce815c2-5f77-4066-904c-0da698dbf2b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ce815c2-5f77-4066-904c-0da698dbf2b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ce815c2-5f77-4066-904c-0da698dbf2b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfb97593-80e3-4193-9601-16b101aff775> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfb97593-80e3-4193-9601-16b101aff775";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfb97593-80e3-4193-9601-16b101aff775>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee0e880d-6d2c-4571-bbb2-95cd2fc4d35c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee0e880d-6d2c-4571-bbb2-95cd2fc4d35c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_02-05-2022_38771.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee0e880d-6d2c-4571-bbb2-95cd2fc4d35c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9321b53-f327-4769-b2dd-eaae0298919b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9321b53-f327-4769-b2dd-eaae0298919b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_04-07-2022_39431.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9321b53-f327-4769-b2dd-eaae0298919b>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcdd44ea-74ba-44f3-a8b2-f6837868562d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcdd44ea-74ba-44f3-a8b2-f6837868562d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_04-07-2022_39532.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcdd44ea-74ba-44f3-a8b2-f6837868562d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b733043-f0c8-4b82-b50d-b62a0e5d12eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b733043-f0c8-4b82-b50d-b62a0e5d12eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_04-07-2022_39533.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b733043-f0c8-4b82-b50d-b62a0e5d12eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/e52e2fa3-d552-47d9-9184-2e1ac8734280> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e52e2fa3-d552-47d9-9184-2e1ac8734280";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_04-07-2022_39586.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e52e2fa3-d552-47d9-9184-2e1ac8734280>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea14e418-d4f2-4ee7-8d93-b7bd0ca4a045> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea14e418-d4f2-4ee7-8d93-b7bd0ca4a045";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_04-07-2022_39588.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea14e418-d4f2-4ee7-8d93-b7bd0ca4a045>.
+    
+<http://data.lblod.info/id/remote-data-objects/5938988a-1e2e-4a62-b4f3-378b976862ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5938988a-1e2e-4a62-b4f3-378b976862ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_04-07-2022_39589.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5938988a-1e2e-4a62-b4f3-378b976862ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/25c4a094-a094-48cf-a1c7-5ad322477ec8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25c4a094-a094-48cf-a1c7-5ad322477ec8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_04-07-2022_39597.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25c4a094-a094-48cf-a1c7-5ad322477ec8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ce79384-3132-4e96-830f-549021c04510> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ce79384-3132-4e96-830f-549021c04510";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_04-07-2022_39604.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ce79384-3132-4e96-830f-549021c04510>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a6fa5ba-31c4-4f98-84c0-15a383578d2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a6fa5ba-31c4-4f98-84c0-15a383578d2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_04-07-2022_39617.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a6fa5ba-31c4-4f98-84c0-15a383578d2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/268a321f-11ac-442d-851d-6f04b34c0069> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "268a321f-11ac-442d-851d-6f04b34c0069";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_04-10-2021_34706.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/268a321f-11ac-442d-851d-6f04b34c0069>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8d555e6-e557-466e-a68b-dfbe7734882b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8d555e6-e557-466e-a68b-dfbe7734882b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_08-11-2021_35012.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8d555e6-e557-466e-a68b-dfbe7734882b>.
+    
+<http://data.lblod.info/id/remote-data-objects/00084af7-803e-4dba-a7d6-423d124cfcec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00084af7-803e-4dba-a7d6-423d124cfcec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_08-11-2021_35031.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00084af7-803e-4dba-a7d6-423d124cfcec>.
+    
+<http://data.lblod.info/id/remote-data-objects/65817cfd-59aa-4135-8c00-dfedfcea8671> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65817cfd-59aa-4135-8c00-dfedfcea8671";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_09-05-2022_38808.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65817cfd-59aa-4135-8c00-dfedfcea8671>.
+    
+<http://data.lblod.info/id/remote-data-objects/b11cf5d8-44b3-478d-b292-4268cfb9b266> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b11cf5d8-44b3-478d-b292-4268cfb9b266";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_09-05-2022_38859.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b11cf5d8-44b3-478d-b292-4268cfb9b266>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ebcaa94-54dc-44ba-864c-6acddf14df08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ebcaa94-54dc-44ba-864c-6acddf14df08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_10-01-2022_35497.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ebcaa94-54dc-44ba-864c-6acddf14df08>.
+    
+<http://data.lblod.info/id/remote-data-objects/890410d2-21e6-4aa2-a493-078aabd92324> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "890410d2-21e6-4aa2-a493-078aabd92324";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_11-04-2022_38471.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/890410d2-21e6-4aa2-a493-078aabd92324>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac5f93f7-2472-4cba-b9a7-aefb92bf0af2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac5f93f7-2472-4cba-b9a7-aefb92bf0af2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_11-04-2022_38503.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac5f93f7-2472-4cba-b9a7-aefb92bf0af2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5892fee-4266-4f22-bfa9-da9ce64bb8c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5892fee-4266-4f22-bfa9-da9ce64bb8c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_11-04-2022_38528.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5892fee-4266-4f22-bfa9-da9ce64bb8c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f60c04a-0c77-4732-9c4a-5681eb57fc7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f60c04a-0c77-4732-9c4a-5681eb57fc7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_11-04-2022_38537.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f60c04a-0c77-4732-9c4a-5681eb57fc7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb640244-04c8-4097-8db1-c77dc4b3d815> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb640244-04c8-4097-8db1-c77dc4b3d815";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_11-04-2022_38578.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb640244-04c8-4097-8db1-c77dc4b3d815>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7cb9026-a1e7-47c7-bd74-d59c588206fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7cb9026-a1e7-47c7-bd74-d59c588206fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_11-04-2022_38616.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7cb9026-a1e7-47c7-bd74-d59c588206fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/86216ff5-1e78-456c-a799-d451b75ce309> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86216ff5-1e78-456c-a799-d451b75ce309";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_11-10-2021_34726.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86216ff5-1e78-456c-a799-d451b75ce309>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a5d5c13-571f-4c53-bc99-8a486536fa6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a5d5c13-571f-4c53-bc99-8a486536fa6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_13-06-2022_39230.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a5d5c13-571f-4c53-bc99-8a486536fa6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed662270-9c74-49d9-a428-661d2a673bb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed662270-9c74-49d9-a428-661d2a673bb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_13-06-2022_39248.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed662270-9c74-49d9-a428-661d2a673bb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff8cddf8-85aa-4827-96ab-b7f527f489dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff8cddf8-85aa-4827-96ab-b7f527f489dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_13-06-2022_39296.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff8cddf8-85aa-4827-96ab-b7f527f489dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f5cfa68-7437-4ad3-8eeb-6d2d9e6b7103> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f5cfa68-7437-4ad3-8eeb-6d2d9e6b7103";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_13-06-2022_39311.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f5cfa68-7437-4ad3-8eeb-6d2d9e6b7103>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf73430e-4ed3-45be-9165-258bf0c6e7ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf73430e-4ed3-45be-9165-258bf0c6e7ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_14-02-2022_36955.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/67f21300-9a6d-4662-89ce-bf97c9b0ea07> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf73430e-4ed3-45be-9165-258bf0c6e7ea>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201503-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201503-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201503-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201503-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/56cac9a0-31df-415b-8bed-e2559f5a48a7> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "56cac9a0-31df-415b-8bed-e2559f5a48a7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1ed038a4-8170-4ec8-a514-d149df235a97";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a16c1168-b5bd-4318-8832-3015a1d6ab73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a16c1168-b5bd-4318-8832-3015a1d6ab73";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97>.
+
+  <http://redpencil.data.gift/id/task/5fa8fd02-4876-4dc8-88c6-d98e0897b41d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5fa8fd02-4876-4dc8-88c6-d98e0897b41d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/56cac9a0-31df-415b-8bed-e2559f5a48a7>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a16c1168-b5bd-4318-8832-3015a1d6ab73>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a181f66a-333d-4df3-8ebd-b5919c10aa3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a181f66a-333d-4df3-8ebd-b5919c10aa3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_14-03-2022_38251.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a181f66a-333d-4df3-8ebd-b5919c10aa3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/97513f72-d084-4d28-9ce0-d79bb9ccd589> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97513f72-d084-4d28-9ce0-d79bb9ccd589";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_16-05-2022_39008.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97513f72-d084-4d28-9ce0-d79bb9ccd589>.
+    
+<http://data.lblod.info/id/remote-data-objects/707bead0-25dd-4e43-b869-f2ad56965465> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "707bead0-25dd-4e43-b869-f2ad56965465";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_17-01-2022_35539.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/707bead0-25dd-4e43-b869-f2ad56965465>.
+    
+<http://data.lblod.info/id/remote-data-objects/328f8353-5b3c-424e-b953-dbae9901043a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "328f8353-5b3c-424e-b953-dbae9901043a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_17-01-2022_35704.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/328f8353-5b3c-424e-b953-dbae9901043a>.
+    
+<http://data.lblod.info/id/remote-data-objects/880a576d-ca8d-4cea-a0c6-e80fa3699518> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "880a576d-ca8d-4cea-a0c6-e80fa3699518";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_20-06-2022_39142.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/880a576d-ca8d-4cea-a0c6-e80fa3699518>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b3ea312-2544-4db3-9ad8-60693f25325f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b3ea312-2544-4db3-9ad8-60693f25325f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_20-06-2022_39356.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b3ea312-2544-4db3-9ad8-60693f25325f>.
+    
+<http://data.lblod.info/id/remote-data-objects/907d02a2-ec8d-47b0-8514-068469f1ee9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "907d02a2-ec8d-47b0-8514-068469f1ee9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_20-06-2022_39401.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/907d02a2-ec8d-47b0-8514-068469f1ee9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/289fae84-0ef9-46cc-97b2-eedb13bd4b6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "289fae84-0ef9-46cc-97b2-eedb13bd4b6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_20-06-2022_39415.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/289fae84-0ef9-46cc-97b2-eedb13bd4b6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c46bd7a-daf6-4a81-a9d5-537428c6c5ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c46bd7a-daf6-4a81-a9d5-537428c6c5ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_20-06-2022_39416.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c46bd7a-daf6-4a81-a9d5-537428c6c5ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/50b39f9c-6f57-42ad-af7d-c2664136b516> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50b39f9c-6f57-42ad-af7d-c2664136b516";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_20-06-2022_39428.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50b39f9c-6f57-42ad-af7d-c2664136b516>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfbf7121-1081-4b69-b89c-9362baa2787a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfbf7121-1081-4b69-b89c-9362baa2787a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_20-12-2021_35445.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfbf7121-1081-4b69-b89c-9362baa2787a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6874223-7ff4-4406-ab94-0dc9a69155a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6874223-7ff4-4406-ab94-0dc9a69155a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_20-12-2021_35462.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6874223-7ff4-4406-ab94-0dc9a69155a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4de82958-0fc5-4f5d-ba3a-8dc7f255aa0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4de82958-0fc5-4f5d-ba3a-8dc7f255aa0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_20-12-2021_35488.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4de82958-0fc5-4f5d-ba3a-8dc7f255aa0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9ce913d-9387-4721-86ce-95e82c688151> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9ce913d-9387-4721-86ce-95e82c688151";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_21-02-2022_37060.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9ce913d-9387-4721-86ce-95e82c688151>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd788ce5-7410-4d77-99b2-7e70eefcad16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd788ce5-7410-4d77-99b2-7e70eefcad16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_21-03-2022_38217.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd788ce5-7410-4d77-99b2-7e70eefcad16>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6922d34-0295-40c6-859e-9f35a755964b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6922d34-0295-40c6-859e-9f35a755964b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_21-03-2022_38283.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6922d34-0295-40c6-859e-9f35a755964b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa1a34b6-3cd9-4eb3-b9d5-505e5d132c35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa1a34b6-3cd9-4eb3-b9d5-505e5d132c35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_21-03-2022_38295.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa1a34b6-3cd9-4eb3-b9d5-505e5d132c35>.
+    
+<http://data.lblod.info/id/remote-data-objects/d02ef52d-51ab-4e0f-a7be-6b4a8fc2d41e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d02ef52d-51ab-4e0f-a7be-6b4a8fc2d41e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_21-03-2022_38300.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d02ef52d-51ab-4e0f-a7be-6b4a8fc2d41e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e129ae61-d626-42ed-99e0-cdf416c32f68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e129ae61-d626-42ed-99e0-cdf416c32f68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_21-03-2022_38326.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e129ae61-d626-42ed-99e0-cdf416c32f68>.
+    
+<http://data.lblod.info/id/remote-data-objects/750a5d6e-12ad-4895-9876-3fa29f8ba76c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "750a5d6e-12ad-4895-9876-3fa29f8ba76c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_23-05-2022_39127.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/750a5d6e-12ad-4895-9876-3fa29f8ba76c>.
+    
+<http://data.lblod.info/id/remote-data-objects/40252ff4-dbaa-4aa6-87cb-ec994f16b772> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40252ff4-dbaa-4aa6-87cb-ec994f16b772";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_24-01-2022_35729.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40252ff4-dbaa-4aa6-87cb-ec994f16b772>.
+    
+<http://data.lblod.info/id/remote-data-objects/251e45d2-4639-44e6-adde-bb07a2ac00e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "251e45d2-4639-44e6-adde-bb07a2ac00e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_24-01-2022_35787.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/251e45d2-4639-44e6-adde-bb07a2ac00e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2fcc972-e43f-4953-bc81-5e19a035f366> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2fcc972-e43f-4953-bc81-5e19a035f366";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_27-06-2022_39443.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2fcc972-e43f-4953-bc81-5e19a035f366>.
+    
+<http://data.lblod.info/id/remote-data-objects/26a978d0-0630-45be-b69b-8d28fa4fa436> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26a978d0-0630-45be-b69b-8d28fa4fa436";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_27-06-2022_39448.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26a978d0-0630-45be-b69b-8d28fa4fa436>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3689ee0-27f8-4814-9ffa-fd62a7aeaad6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3689ee0-27f8-4814-9ffa-fd62a7aeaad6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_27-06-2022_39450.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3689ee0-27f8-4814-9ffa-fd62a7aeaad6>.
+    
+<http://data.lblod.info/id/remote-data-objects/28542734-eebd-4dad-be76-98c45d48e5d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28542734-eebd-4dad-be76-98c45d48e5d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_28-03-2022_38245.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28542734-eebd-4dad-be76-98c45d48e5d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/20102ce8-af07-4877-a017-651ad7981ff9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20102ce8-af07-4877-a017-651ad7981ff9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_28-03-2022_38446.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20102ce8-af07-4877-a017-651ad7981ff9>.
+    
+<http://data.lblod.info/id/remote-data-objects/365dea38-86e9-467d-b230-0090a7a9ad43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "365dea38-86e9-467d-b230-0090a7a9ad43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_29-11-2021_35211.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/365dea38-86e9-467d-b230-0090a7a9ad43>.
+    
+<http://data.lblod.info/id/remote-data-objects/da2624f3-bcc5-4b84-b2f7-c938fdd84d94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da2624f3-bcc5-4b84-b2f7-c938fdd84d94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_30-05-2022_39145.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da2624f3-bcc5-4b84-b2f7-c938fdd84d94>.
+    
+<http://data.lblod.info/id/remote-data-objects/7318c2fe-a41d-42e6-aa7e-8f04d05ec6e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7318c2fe-a41d-42e6-aa7e-8f04d05ec6e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lebbeke.be/LBLODWeb/Home/Overzicht/e5891af5b809144694692a26a05880c538ce0356c80ffc8556a8f2ce5597e639/GetPublication?filename=Uittreksels_30-05-2022_39223.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7318c2fe-a41d-42e6-aa7e-8f04d05ec6e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd5a2611-d534-4034-9f8c-3d6c1017d38b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd5a2611-d534-4034-9f8c-3d6c1017d38b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd5a2611-d534-4034-9f8c-3d6c1017d38b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f04eed91-7e0a-4a5b-85f7-36daa4ff0926> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f04eed91-7e0a-4a5b-85f7-36daa4ff0926";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f04eed91-7e0a-4a5b-85f7-36daa4ff0926>.
+    
+<http://data.lblod.info/id/remote-data-objects/178ca021-22f9-4e23-9a14-06575e012197> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "178ca021-22f9-4e23-9a14-06575e012197";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/178ca021-22f9-4e23-9a14-06575e012197>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7b22d45-dff7-4aba-add9-26646f0c0516> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7b22d45-dff7-4aba-add9-26646f0c0516";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7b22d45-dff7-4aba-add9-26646f0c0516>.
+    
+<http://data.lblod.info/id/remote-data-objects/478927b9-0b80-4168-8aa6-2dd8cb17a780> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "478927b9-0b80-4168-8aa6-2dd8cb17a780";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/478927b9-0b80-4168-8aa6-2dd8cb17a780>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed5b5907-8016-453a-b504-6b9c344a1fee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed5b5907-8016-453a-b504-6b9c344a1fee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed5b5907-8016-453a-b504-6b9c344a1fee>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ba836ef-e1ee-409d-8b90-8c55ffb93d65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ba836ef-e1ee-409d-8b90-8c55ffb93d65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ba836ef-e1ee-409d-8b90-8c55ffb93d65>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a9fa7ee-fe65-4550-9e2c-d8a1d9d07539> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a9fa7ee-fe65-4550-9e2c-d8a1d9d07539";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a9fa7ee-fe65-4550-9e2c-d8a1d9d07539>.
+    
+<http://data.lblod.info/id/remote-data-objects/95869775-a7b2-4e90-ad14-b3e5c8f1600a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95869775-a7b2-4e90-ad14-b3e5c8f1600a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95869775-a7b2-4e90-ad14-b3e5c8f1600a>.
+    
+<http://data.lblod.info/id/remote-data-objects/021c63ef-d313-4063-a061-d5064dae5906> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "021c63ef-d313-4063-a061-d5064dae5906";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/021c63ef-d313-4063-a061-d5064dae5906>.
+    
+<http://data.lblod.info/id/remote-data-objects/18b660d9-ef23-49a7-9ef7-c66cde0f04f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18b660d9-ef23-49a7-9ef7-c66cde0f04f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18b660d9-ef23-49a7-9ef7-c66cde0f04f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a637a595-e95b-48a8-8a5c-b615ad3c2e55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a637a595-e95b-48a8-8a5c-b615ad3c2e55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a637a595-e95b-48a8-8a5c-b615ad3c2e55>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a40e12d-b439-4a71-b078-50be0f85337f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a40e12d-b439-4a71-b078-50be0f85337f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a40e12d-b439-4a71-b078-50be0f85337f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f235a3a3-d282-4c19-bead-741ae42578a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f235a3a3-d282-4c19-bead-741ae42578a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f235a3a3-d282-4c19-bead-741ae42578a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a9c684d-4b66-4b47-a375-e343244da09c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a9c684d-4b66-4b47-a375-e343244da09c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a9c684d-4b66-4b47-a375-e343244da09c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4a8eb99-dca3-4b31-8d65-87f380ef585b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4a8eb99-dca3-4b31-8d65-87f380ef585b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4a8eb99-dca3-4b31-8d65-87f380ef585b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9cf7d77-0083-4665-b686-f16ffad80774> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9cf7d77-0083-4665-b686-f16ffad80774";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9cf7d77-0083-4665-b686-f16ffad80774>.
+    
+<http://data.lblod.info/id/remote-data-objects/575ec077-2945-44c6-8e9f-b6f74b0b378f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "575ec077-2945-44c6-8e9f-b6f74b0b378f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/575ec077-2945-44c6-8e9f-b6f74b0b378f>.
+    
+<http://data.lblod.info/id/remote-data-objects/30eba3b1-525c-4b9f-bd9b-18ecb419215e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30eba3b1-525c-4b9f-bd9b-18ecb419215e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30eba3b1-525c-4b9f-bd9b-18ecb419215e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b8d8a44-c7ca-4f8e-9e86-22a0be4d4fd6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b8d8a44-c7ca-4f8e-9e86-22a0be4d4fd6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ed038a4-8170-4ec8-a514-d149df235a97> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b8d8a44-c7ca-4f8e-9e86-22a0be4d4fd6>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201504-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201504-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201504-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201504-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/aedab441-545f-47de-bf13-be6c389acd5f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "aedab441-545f-47de-bf13-be6c389acd5f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "684af2af-1ad8-47b7-85a7-f1ad876b4fdf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9dd6ca4b-63ba-4f5a-a87a-6561fb3598d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9dd6ca4b-63ba-4f5a-a87a-6561fb3598d3";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf>.
+
+  <http://redpencil.data.gift/id/task/e792ccd0-b6fd-4ba9-95fb-061de9315ade> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e792ccd0-b6fd-4ba9-95fb-061de9315ade";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/aedab441-545f-47de-bf13-be6c389acd5f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9dd6ca4b-63ba-4f5a-a87a-6561fb3598d3>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a7f70b39-74bb-4ac5-9943-f1effa459480> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7f70b39-74bb-4ac5-9943-f1effa459480";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7f70b39-74bb-4ac5-9943-f1effa459480>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fa65968-d561-47a4-9650-78599102b538> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fa65968-d561-47a4-9650-78599102b538";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fa65968-d561-47a4-9650-78599102b538>.
+    
+<http://data.lblod.info/id/remote-data-objects/b11ed95e-d09c-4607-bfc6-e01da0bb6cc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b11ed95e-d09c-4607-bfc6-e01da0bb6cc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b11ed95e-d09c-4607-bfc6-e01da0bb6cc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed7e99af-4c23-4079-b160-903eee3ed55f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed7e99af-4c23-4079-b160-903eee3ed55f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed7e99af-4c23-4079-b160-903eee3ed55f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e15eb70-25d2-4982-b9a2-7e52afe7ce00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e15eb70-25d2-4982-b9a2-7e52afe7ce00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e15eb70-25d2-4982-b9a2-7e52afe7ce00>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a08e625-8972-45fe-b690-545b4314dce0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a08e625-8972-45fe-b690-545b4314dce0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a08e625-8972-45fe-b690-545b4314dce0>.
+    
+<http://data.lblod.info/id/remote-data-objects/cec822bd-ae99-47f8-9a29-62fc38feecab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cec822bd-ae99-47f8-9a29-62fc38feecab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cec822bd-ae99-47f8-9a29-62fc38feecab>.
+    
+<http://data.lblod.info/id/remote-data-objects/efaf858f-3cd3-402f-8651-abe2d706220f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efaf858f-3cd3-402f-8651-abe2d706220f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efaf858f-3cd3-402f-8651-abe2d706220f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b264db1e-7777-4d4e-8f47-e5b50c23642c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b264db1e-7777-4d4e-8f47-e5b50c23642c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b264db1e-7777-4d4e-8f47-e5b50c23642c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a2d06b4-a634-4750-a0dd-14f27c9b0ac1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a2d06b4-a634-4750-a0dd-14f27c9b0ac1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a2d06b4-a634-4750-a0dd-14f27c9b0ac1>.
+    
+<http://data.lblod.info/id/remote-data-objects/2af2d32a-c34e-4183-aea8-d7b942f74a62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2af2d32a-c34e-4183-aea8-d7b942f74a62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2af2d32a-c34e-4183-aea8-d7b942f74a62>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f0a8f4a-9fa9-441a-8702-7bf28d5ff5d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f0a8f4a-9fa9-441a-8702-7bf28d5ff5d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f0a8f4a-9fa9-441a-8702-7bf28d5ff5d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dd2ebca-d0aa-4c5f-a9b9-599e302b11e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dd2ebca-d0aa-4c5f-a9b9-599e302b11e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dd2ebca-d0aa-4c5f-a9b9-599e302b11e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ee71b5f-07de-42ab-a551-97c3998f19b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ee71b5f-07de-42ab-a551-97c3998f19b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ee71b5f-07de-42ab-a551-97c3998f19b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3e722e1-5408-425b-bd4a-b65095555983> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3e722e1-5408-425b-bd4a-b65095555983";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3e722e1-5408-425b-bd4a-b65095555983>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7733de5-8cff-4e19-bfc7-4e2bfbd648be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7733de5-8cff-4e19-bfc7-4e2bfbd648be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7733de5-8cff-4e19-bfc7-4e2bfbd648be>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9da3a05-36c8-4b5f-a8ae-7f572afdc0c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9da3a05-36c8-4b5f-a8ae-7f572afdc0c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9da3a05-36c8-4b5f-a8ae-7f572afdc0c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/83126678-e614-4717-805c-bea0d31d0608> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83126678-e614-4717-805c-bea0d31d0608";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83126678-e614-4717-805c-bea0d31d0608>.
+    
+<http://data.lblod.info/id/remote-data-objects/89ba5529-8a15-4d8c-9ae6-b8fade946e6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89ba5529-8a15-4d8c-9ae6-b8fade946e6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/038e25e5ac7eef3b5140db576f6a6cff764ea632a89566992ba8e60674c399b2/GetPublication?filename=BesluitenLijst_Vast%20bureau_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89ba5529-8a15-4d8c-9ae6-b8fade946e6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccba3f20-f941-4ba0-8793-145ee7fcac31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccba3f20-f941-4ba0-8793-145ee7fcac31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Agenda_Gemeenteraad_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccba3f20-f941-4ba0-8793-145ee7fcac31>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d8d7ebe-1ce4-4582-97ba-cec54ad1f76e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d8d7ebe-1ce4-4582-97ba-cec54ad1f76e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Agenda_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d8d7ebe-1ce4-4582-97ba-cec54ad1f76e>.
+    
+<http://data.lblod.info/id/remote-data-objects/32cf0a13-5012-47ea-8860-2a084f47dc4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32cf0a13-5012-47ea-8860-2a084f47dc4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Agenda_Gemeenteraad_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32cf0a13-5012-47ea-8860-2a084f47dc4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7aaaa74-212f-4ab8-a135-79ca470e2e8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7aaaa74-212f-4ab8-a135-79ca470e2e8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Agenda_Gemeenteraad_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7aaaa74-212f-4ab8-a135-79ca470e2e8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a918097-8264-4a0d-81ab-5cb8ec9e1019> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a918097-8264-4a0d-81ab-5cb8ec9e1019";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Agenda_Gemeenteraad_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a918097-8264-4a0d-81ab-5cb8ec9e1019>.
+    
+<http://data.lblod.info/id/remote-data-objects/89d35c2d-4bf3-48ca-b485-7a65ba02fded> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89d35c2d-4bf3-48ca-b485-7a65ba02fded";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Agenda_Gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89d35c2d-4bf3-48ca-b485-7a65ba02fded>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c82a601-769d-4a44-8bcf-d2d7612f3cc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c82a601-769d-4a44-8bcf-d2d7612f3cc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Agenda_Gemeenteraad_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c82a601-769d-4a44-8bcf-d2d7612f3cc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/731904bc-2e95-4591-9f3d-c954388e3b1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "731904bc-2e95-4591-9f3d-c954388e3b1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Agenda_Gemeenteraad_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/731904bc-2e95-4591-9f3d-c954388e3b1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f397bd6-fae7-4dd8-96d5-d3b4e3c45438> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f397bd6-fae7-4dd8-96d5-d3b4e3c45438";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Agenda_Gemeenteraad_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f397bd6-fae7-4dd8-96d5-d3b4e3c45438>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ce3e116-0fa1-46ce-952a-b8f23aa8ba97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ce3e116-0fa1-46ce-952a-b8f23aa8ba97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Agenda_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ce3e116-0fa1-46ce-952a-b8f23aa8ba97>.
+    
+<http://data.lblod.info/id/remote-data-objects/8884cd55-712e-434d-b310-c3e5d9f3dfa7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8884cd55-712e-434d-b310-c3e5d9f3dfa7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=BesluitenLijst_Gemeenteraad_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8884cd55-712e-434d-b310-c3e5d9f3dfa7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a567fd92-37fc-460c-8399-3b9e542d900e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a567fd92-37fc-460c-8399-3b9e542d900e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=BesluitenLijst_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a567fd92-37fc-460c-8399-3b9e542d900e>.
+    
+<http://data.lblod.info/id/remote-data-objects/74b8237f-347b-47bb-a6e1-c3c0e5e2604d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74b8237f-347b-47bb-a6e1-c3c0e5e2604d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=BesluitenLijst_Gemeenteraad_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74b8237f-347b-47bb-a6e1-c3c0e5e2604d>.
+    
+<http://data.lblod.info/id/remote-data-objects/18275bf4-1c6f-438a-8537-7fafa6167575> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18275bf4-1c6f-438a-8537-7fafa6167575";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=BesluitenLijst_Gemeenteraad_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18275bf4-1c6f-438a-8537-7fafa6167575>.
+    
+<http://data.lblod.info/id/remote-data-objects/31314c46-603a-4ec8-b261-b8998a65a7d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31314c46-603a-4ec8-b261-b8998a65a7d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=BesluitenLijst_Gemeenteraad_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31314c46-603a-4ec8-b261-b8998a65a7d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecdaeff3-42ab-49ca-b4db-61429c8f0887> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecdaeff3-42ab-49ca-b4db-61429c8f0887";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=BesluitenLijst_Gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecdaeff3-42ab-49ca-b4db-61429c8f0887>.
+    
+<http://data.lblod.info/id/remote-data-objects/e760144e-8cc3-4c49-96f6-777b1dd61398> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e760144e-8cc3-4c49-96f6-777b1dd61398";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=BesluitenLijst_Gemeenteraad_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e760144e-8cc3-4c49-96f6-777b1dd61398>.
+    
+<http://data.lblod.info/id/remote-data-objects/050cdc23-213b-4dea-8571-4c7a36edae53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "050cdc23-213b-4dea-8571-4c7a36edae53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/050cdc23-213b-4dea-8571-4c7a36edae53>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c4ee31e-22df-4a2d-8ab3-72a5f77718c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c4ee31e-22df-4a2d-8ab3-72a5f77718c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c4ee31e-22df-4a2d-8ab3-72a5f77718c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/735d94fc-2d22-4cf0-8c46-7bbf5afa44d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "735d94fc-2d22-4cf0-8c46-7bbf5afa44d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/735d94fc-2d22-4cf0-8c46-7bbf5afa44d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d91b7a3-02e6-4214-b4d9-a57ded057a63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d91b7a3-02e6-4214-b4d9-a57ded057a63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Notulen_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d91b7a3-02e6-4214-b4d9-a57ded057a63>.
+    
+<http://data.lblod.info/id/remote-data-objects/f24e0bc7-886b-4a03-833b-599a54ea5374> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f24e0bc7-886b-4a03-833b-599a54ea5374";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Notulen_Gemeenteraad_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f24e0bc7-886b-4a03-833b-599a54ea5374>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce3ee32e-8a50-4a7f-a986-3644e9cfe4f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce3ee32e-8a50-4a7f-a986-3644e9cfe4f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Notulen_Gemeenteraad_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce3ee32e-8a50-4a7f-a986-3644e9cfe4f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/3506c58c-2914-4dcb-a1c2-c5f656dcf1c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3506c58c-2914-4dcb-a1c2-c5f656dcf1c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Notulen_Gemeenteraad_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3506c58c-2914-4dcb-a1c2-c5f656dcf1c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c31cdda-a873-4486-b21a-cea93af41920> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c31cdda-a873-4486-b21a-cea93af41920";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Notulen_Gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c31cdda-a873-4486-b21a-cea93af41920>.
+    
+<http://data.lblod.info/id/remote-data-objects/a538e68d-da52-4fbd-bd24-d80f00df67ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a538e68d-da52-4fbd-bd24-d80f00df67ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Notulen_Gemeenteraad_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a538e68d-da52-4fbd-bd24-d80f00df67ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab8db673-3879-4e3e-90b6-fac14b83c9ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab8db673-3879-4e3e-90b6-fac14b83c9ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Notulen_Gemeenteraad_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab8db673-3879-4e3e-90b6-fac14b83c9ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/7039f454-dda4-4c50-9072-2a632a8fb86a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7039f454-dda4-4c50-9072-2a632a8fb86a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Notulen_Gemeenteraad_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7039f454-dda4-4c50-9072-2a632a8fb86a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f10bc9ce-51f8-4c31-9512-8787b73dde06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f10bc9ce-51f8-4c31-9512-8787b73dde06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Notulen_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f10bc9ce-51f8-4c31-9512-8787b73dde06>.
+    
+<http://data.lblod.info/id/remote-data-objects/146c4cfe-3016-4eea-b964-333b29a28b21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "146c4cfe-3016-4eea-b964-333b29a28b21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_16-12-2021_23484.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/146c4cfe-3016-4eea-b964-333b29a28b21>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e74d4a5-b663-4ceb-8a7e-7a8801ab0382> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e74d4a5-b663-4ceb-8a7e-7a8801ab0382";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_16-12-2021_23489.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/684af2af-1ad8-47b7-85a7-f1ad876b4fdf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e74d4a5-b663-4ceb-8a7e-7a8801ab0382>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201505-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201505-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201505-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201505-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/8d91aea7-7edc-429b-a57c-83dd5b36c6ca> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8d91aea7-7edc-429b-a57c-83dd5b36c6ca";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3f2b0773-d2bc-47bf-9422-b95406fab4df";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/af6b8a87-87c4-4e7f-b3fa-94fc32717488> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "af6b8a87-87c4-4e7f-b3fa-94fc32717488";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df>.
+
+  <http://redpencil.data.gift/id/task/410c3f5e-83d3-469a-a69d-d9900d6d8931> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "410c3f5e-83d3-469a-a69d-d9900d6d8931";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/8d91aea7-7edc-429b-a57c-83dd5b36c6ca>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/af6b8a87-87c4-4e7f-b3fa-94fc32717488>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4fe5468a-6776-43b9-9328-e2226dbe2310> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fe5468a-6776-43b9-9328-e2226dbe2310";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_16-12-2021_23580.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fe5468a-6776-43b9-9328-e2226dbe2310>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a68eebc-00ef-4b7d-998c-dd1624b8899f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a68eebc-00ef-4b7d-998c-dd1624b8899f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_16-12-2021_23581.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a68eebc-00ef-4b7d-998c-dd1624b8899f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7519522f-9d69-4576-a334-6e1f7f972d8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7519522f-9d69-4576-a334-6e1f7f972d8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_16-12-2021_23582.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7519522f-9d69-4576-a334-6e1f7f972d8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/15c511a7-1f4d-4781-8100-431cfdb5762e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15c511a7-1f4d-4781-8100-431cfdb5762e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_16-12-2021_23602.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15c511a7-1f4d-4781-8100-431cfdb5762e>.
+    
+<http://data.lblod.info/id/remote-data-objects/33ef4ac4-358f-4a31-afd3-9f6473426bf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33ef4ac4-358f-4a31-afd3-9f6473426bf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_16-12-2021_23607.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33ef4ac4-358f-4a31-afd3-9f6473426bf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f6aa979-7376-4ffc-a357-5d555bf8aa92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f6aa979-7376-4ffc-a357-5d555bf8aa92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_17-02-2022_24049.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f6aa979-7376-4ffc-a357-5d555bf8aa92>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff6f46b8-d880-4137-a2eb-647a3abac3fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff6f46b8-d880-4137-a2eb-647a3abac3fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_17-02-2022_24498.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff6f46b8-d880-4137-a2eb-647a3abac3fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d19f9a23-9f7b-4d3c-b32e-683aa7050146> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d19f9a23-9f7b-4d3c-b32e-683aa7050146";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_17-02-2022_24499.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d19f9a23-9f7b-4d3c-b32e-683aa7050146>.
+    
+<http://data.lblod.info/id/remote-data-objects/936cb504-42d5-44c3-96f4-00820f339a92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "936cb504-42d5-44c3-96f4-00820f339a92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_17-02-2022_24525.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/936cb504-42d5-44c3-96f4-00820f339a92>.
+    
+<http://data.lblod.info/id/remote-data-objects/06583b68-e88b-4eda-89b3-afd9efe01454> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06583b68-e88b-4eda-89b3-afd9efe01454";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_17-03-2022_24624.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06583b68-e88b-4eda-89b3-afd9efe01454>.
+    
+<http://data.lblod.info/id/remote-data-objects/02236d01-53db-40fa-a402-8944daa5fd14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02236d01-53db-40fa-a402-8944daa5fd14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_17-03-2022_24874.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02236d01-53db-40fa-a402-8944daa5fd14>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cd1e44e-b483-4a4d-9196-27b4e0d4b4fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cd1e44e-b483-4a4d-9196-27b4e0d4b4fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_17-03-2022_24875.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cd1e44e-b483-4a4d-9196-27b4e0d4b4fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/057cfb79-c652-4f96-9c07-997afd998126> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "057cfb79-c652-4f96-9c07-997afd998126";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_17-03-2022_25026.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/057cfb79-c652-4f96-9c07-997afd998126>.
+    
+<http://data.lblod.info/id/remote-data-objects/db37bf2f-4632-4fe1-9551-68b82bd446ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db37bf2f-4632-4fe1-9551-68b82bd446ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_18-11-2021_23246.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db37bf2f-4632-4fe1-9551-68b82bd446ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba43cce5-1c84-4b7d-81dd-70b34d74b967> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba43cce5-1c84-4b7d-81dd-70b34d74b967";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_18-11-2021_23247.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba43cce5-1c84-4b7d-81dd-70b34d74b967>.
+    
+<http://data.lblod.info/id/remote-data-objects/8dd8b8e8-b1de-4c84-859f-859326b18edf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8dd8b8e8-b1de-4c84-859f-859326b18edf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_18-11-2021_23345.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8dd8b8e8-b1de-4c84-859f-859326b18edf>.
+    
+<http://data.lblod.info/id/remote-data-objects/a361b126-550e-4f51-be83-efdb34866bca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a361b126-550e-4f51-be83-efdb34866bca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_19-05-2022_25649.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a361b126-550e-4f51-be83-efdb34866bca>.
+    
+<http://data.lblod.info/id/remote-data-objects/daa270ce-0aae-4808-9f32-8f6628693070> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "daa270ce-0aae-4808-9f32-8f6628693070";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_19-05-2022_25723.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/daa270ce-0aae-4808-9f32-8f6628693070>.
+    
+<http://data.lblod.info/id/remote-data-objects/c26fc0ee-7688-41dc-bcb5-3de928da80cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c26fc0ee-7688-41dc-bcb5-3de928da80cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_19-05-2022_25743.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c26fc0ee-7688-41dc-bcb5-3de928da80cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/32a1df28-83d3-4cb9-aa8c-37dce4d7f585> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32a1df28-83d3-4cb9-aa8c-37dce4d7f585";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_19-05-2022_25794.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32a1df28-83d3-4cb9-aa8c-37dce4d7f585>.
+    
+<http://data.lblod.info/id/remote-data-objects/e17abea7-7ed2-44c0-9966-cba98e686f73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e17abea7-7ed2-44c0-9966-cba98e686f73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_19-05-2022_25801.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e17abea7-7ed2-44c0-9966-cba98e686f73>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b431e06-e504-41df-ab44-e4a5e6300ace> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b431e06-e504-41df-ab44-e4a5e6300ace";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_20-01-2022_23810.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b431e06-e504-41df-ab44-e4a5e6300ace>.
+    
+<http://data.lblod.info/id/remote-data-objects/97744162-0b87-48c9-8e1e-36125b30320f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97744162-0b87-48c9-8e1e-36125b30320f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_20-01-2022_23813.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97744162-0b87-48c9-8e1e-36125b30320f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4d152e0-ea96-40b9-b99a-715f90b57042> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4d152e0-ea96-40b9-b99a-715f90b57042";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_20-01-2022_23927.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4d152e0-ea96-40b9-b99a-715f90b57042>.
+    
+<http://data.lblod.info/id/remote-data-objects/fed7333b-184e-4e25-b1cd-7303da4f6d70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fed7333b-184e-4e25-b1cd-7303da4f6d70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_20-01-2022_23928.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fed7333b-184e-4e25-b1cd-7303da4f6d70>.
+    
+<http://data.lblod.info/id/remote-data-objects/c97751b2-c991-4cb8-8ce1-4ce323c10be3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c97751b2-c991-4cb8-8ce1-4ce323c10be3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_20-01-2022_23929.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c97751b2-c991-4cb8-8ce1-4ce323c10be3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff2a483f-8035-4166-8815-82f5fe03d2d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff2a483f-8035-4166-8815-82f5fe03d2d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_20-01-2022_23931.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff2a483f-8035-4166-8815-82f5fe03d2d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b823c52a-a535-445c-a87f-e6bad553483c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b823c52a-a535-445c-a87f-e6bad553483c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_20-01-2022_23932.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b823c52a-a535-445c-a87f-e6bad553483c>.
+    
+<http://data.lblod.info/id/remote-data-objects/438e2f25-c7e5-4835-a0a7-0b53a7620902> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "438e2f25-c7e5-4835-a0a7-0b53a7620902";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_20-01-2022_23933.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/438e2f25-c7e5-4835-a0a7-0b53a7620902>.
+    
+<http://data.lblod.info/id/remote-data-objects/75d56c03-a5d9-4ca0-90fd-a308d5abcce0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75d56c03-a5d9-4ca0-90fd-a308d5abcce0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_20-01-2022_23936.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75d56c03-a5d9-4ca0-90fd-a308d5abcce0>.
+    
+<http://data.lblod.info/id/remote-data-objects/785991da-bfc4-4c01-a338-836db54a1c5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "785991da-bfc4-4c01-a338-836db54a1c5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_21-04-2022_24994.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/785991da-bfc4-4c01-a338-836db54a1c5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2c6dde3-5447-42d8-acbb-b6abef91ecb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2c6dde3-5447-42d8-acbb-b6abef91ecb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_21-04-2022_24997.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2c6dde3-5447-42d8-acbb-b6abef91ecb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbd60be2-1383-4c42-872a-ce12c986c826> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbd60be2-1383-4c42-872a-ce12c986c826";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_21-04-2022_25148.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbd60be2-1383-4c42-872a-ce12c986c826>.
+    
+<http://data.lblod.info/id/remote-data-objects/4df816dd-53fe-4776-aa8b-d0094f934986> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4df816dd-53fe-4776-aa8b-d0094f934986";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_21-04-2022_25354.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4df816dd-53fe-4776-aa8b-d0094f934986>.
+    
+<http://data.lblod.info/id/remote-data-objects/87c375b4-3092-4472-92d8-bde5284b541c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87c375b4-3092-4472-92d8-bde5284b541c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_21-04-2022_25434.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87c375b4-3092-4472-92d8-bde5284b541c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c4e24f8-0a08-442b-8a08-1514c27e4d42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c4e24f8-0a08-442b-8a08-1514c27e4d42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_21-10-2021_22823.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c4e24f8-0a08-442b-8a08-1514c27e4d42>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7c7bdd6-df7c-4f93-a129-8cecf48b1906> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7c7bdd6-df7c-4f93-a129-8cecf48b1906";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_27-01-2022_23808.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7c7bdd6-df7c-4f93-a129-8cecf48b1906>.
+    
+<http://data.lblod.info/id/remote-data-objects/15fcb7d5-a2dc-4b65-aa46-d510d6fb605a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15fcb7d5-a2dc-4b65-aa46-d510d6fb605a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_27-01-2022_23809.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15fcb7d5-a2dc-4b65-aa46-d510d6fb605a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c4bc04c-f100-468a-b110-7320762991fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c4bc04c-f100-468a-b110-7320762991fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_27-01-2022_24051.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c4bc04c-f100-468a-b110-7320762991fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/f201308c-c7f1-4887-8672-908e2ff17953> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f201308c-c7f1-4887-8672-908e2ff17953";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_27-01-2022_24066.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f201308c-c7f1-4887-8672-908e2ff17953>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b300ca2-8f31-442c-a6fe-de5f48429791> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b300ca2-8f31-442c-a6fe-de5f48429791";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_27-01-2022_24068.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b300ca2-8f31-442c-a6fe-de5f48429791>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ee8fcb0-a5b6-45b9-95b5-1cb379cd52f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ee8fcb0-a5b6-45b9-95b5-1cb379cd52f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_27-01-2022_24121.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ee8fcb0-a5b6-45b9-95b5-1cb379cd52f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c81cd346-4e25-4f79-9422-1ef7620b0e12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c81cd346-4e25-4f79-9422-1ef7620b0e12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/52eb51c354f6c705ea85af7502760cb5964d246e7ffdf1aca85d5988f0da62d9/GetPublication?filename=Uittreksels_27-01-2022_24123.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c81cd346-4e25-4f79-9422-1ef7620b0e12>.
+    
+<http://data.lblod.info/id/remote-data-objects/63dfdf46-ec92-4b06-b707-579d71fa6d07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63dfdf46-ec92-4b06-b707-579d71fa6d07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63dfdf46-ec92-4b06-b707-579d71fa6d07>.
+    
+<http://data.lblod.info/id/remote-data-objects/501eea79-3c57-4698-8c4c-57bcf9ae24c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "501eea79-3c57-4698-8c4c-57bcf9ae24c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/501eea79-3c57-4698-8c4c-57bcf9ae24c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d0891aa-92d7-469d-b3ce-5d5ff7460268> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d0891aa-92d7-469d-b3ce-5d5ff7460268";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d0891aa-92d7-469d-b3ce-5d5ff7460268>.
+    
+<http://data.lblod.info/id/remote-data-objects/c16b3345-90f3-4375-a04c-b7158c8ce7e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c16b3345-90f3-4375-a04c-b7158c8ce7e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c16b3345-90f3-4375-a04c-b7158c8ce7e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe921614-63de-4f0b-8104-0eecd0a262e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe921614-63de-4f0b-8104-0eecd0a262e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe921614-63de-4f0b-8104-0eecd0a262e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/82260ec8-206f-4d0c-95d6-042fa9429e3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82260ec8-206f-4d0c-95d6-042fa9429e3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82260ec8-206f-4d0c-95d6-042fa9429e3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cdbbb02-8433-42b7-af46-85a839831ebf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cdbbb02-8433-42b7-af46-85a839831ebf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3f2b0773-d2bc-47bf-9422-b95406fab4df> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cdbbb02-8433-42b7-af46-85a839831ebf>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201507-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201507-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201507-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201507-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/0cd98b32-b11c-439a-8e56-205d1cf7ff67> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0cd98b32-b11c-439a-8e56-205d1cf7ff67";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2a677b33-17cf-401f-a95d-70401cbc369c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/111cf44a-fd18-4013-a46b-3c2bdc11ece2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "111cf44a-fd18-4013-a46b-3c2bdc11ece2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c>.
+
+  <http://redpencil.data.gift/id/task/5f9c9649-8005-4387-93ac-166b8c0c1c04> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5f9c9649-8005-4387-93ac-166b8c0c1c04";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/0cd98b32-b11c-439a-8e56-205d1cf7ff67>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/111cf44a-fd18-4013-a46b-3c2bdc11ece2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b1ddf22d-57fb-44af-b327-67949b18cdcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1ddf22d-57fb-44af-b327-67949b18cdcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1ddf22d-57fb-44af-b327-67949b18cdcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef491f23-e7bc-4142-b442-0e7488eeaecf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef491f23-e7bc-4142-b442-0e7488eeaecf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef491f23-e7bc-4142-b442-0e7488eeaecf>.
+    
+<http://data.lblod.info/id/remote-data-objects/db7530f4-d434-40bd-95b7-ff9a43b58570> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db7530f4-d434-40bd-95b7-ff9a43b58570";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db7530f4-d434-40bd-95b7-ff9a43b58570>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b5761e8-3942-419a-b162-22e2d86f07a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b5761e8-3942-419a-b162-22e2d86f07a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b5761e8-3942-419a-b162-22e2d86f07a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef737e4d-2f76-4716-9a0e-ef66bcb8ef47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef737e4d-2f76-4716-9a0e-ef66bcb8ef47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef737e4d-2f76-4716-9a0e-ef66bcb8ef47>.
+    
+<http://data.lblod.info/id/remote-data-objects/376105c7-db39-48ec-90b5-89cf54484842> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "376105c7-db39-48ec-90b5-89cf54484842";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/376105c7-db39-48ec-90b5-89cf54484842>.
+    
+<http://data.lblod.info/id/remote-data-objects/801384a1-d3d9-452f-8be8-610372a1b7f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "801384a1-d3d9-452f-8be8-610372a1b7f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/801384a1-d3d9-452f-8be8-610372a1b7f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e159cba-f1f3-44a7-b859-90a00a85fe79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e159cba-f1f3-44a7-b859-90a00a85fe79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e159cba-f1f3-44a7-b859-90a00a85fe79>.
+    
+<http://data.lblod.info/id/remote-data-objects/66f1bd16-2e38-451b-8d5a-95f94e9002f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66f1bd16-2e38-451b-8d5a-95f94e9002f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66f1bd16-2e38-451b-8d5a-95f94e9002f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f561f07c-6f61-46ba-83a1-e838984fdd13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f561f07c-6f61-46ba-83a1-e838984fdd13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f561f07c-6f61-46ba-83a1-e838984fdd13>.
+    
+<http://data.lblod.info/id/remote-data-objects/c505e8f3-4783-4869-a29f-9faf86f43a09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c505e8f3-4783-4869-a29f-9faf86f43a09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c505e8f3-4783-4869-a29f-9faf86f43a09>.
+    
+<http://data.lblod.info/id/remote-data-objects/142d587f-0994-4911-bbb4-ccbf7ffeb6e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "142d587f-0994-4911-bbb4-ccbf7ffeb6e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/142d587f-0994-4911-bbb4-ccbf7ffeb6e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d89fe1b9-3e58-45eb-84db-43cc0045afbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d89fe1b9-3e58-45eb-84db-43cc0045afbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d89fe1b9-3e58-45eb-84db-43cc0045afbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/c119e93f-cb20-4d3c-aa9d-9b19bbea867f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c119e93f-cb20-4d3c-aa9d-9b19bbea867f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c119e93f-cb20-4d3c-aa9d-9b19bbea867f>.
+    
+<http://data.lblod.info/id/remote-data-objects/00b12a42-92da-40a6-aca1-37614def664e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00b12a42-92da-40a6-aca1-37614def664e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00b12a42-92da-40a6-aca1-37614def664e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d1de1f1-87a5-4c04-a978-77973e840863> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d1de1f1-87a5-4c04-a978-77973e840863";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d1de1f1-87a5-4c04-a978-77973e840863>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c095a3c-1bc5-4efb-80eb-1b13bb2a5af5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c095a3c-1bc5-4efb-80eb-1b13bb2a5af5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c095a3c-1bc5-4efb-80eb-1b13bb2a5af5>.
+    
+<http://data.lblod.info/id/remote-data-objects/750c082d-f575-4efb-949c-f81494bd63c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "750c082d-f575-4efb-949c-f81494bd63c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/750c082d-f575-4efb-949c-f81494bd63c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/833c475e-c2e4-4c74-936b-a66f4c45c72d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "833c475e-c2e4-4c74-936b-a66f4c45c72d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/833c475e-c2e4-4c74-936b-a66f4c45c72d>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fa2a74d-52cb-42f3-a5d1-445db0863d4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fa2a74d-52cb-42f3-a5d1-445db0863d4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fa2a74d-52cb-42f3-a5d1-445db0863d4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e17a3d2-6839-4b07-ba31-f5fe1173bd41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e17a3d2-6839-4b07-ba31-f5fe1173bd41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e17a3d2-6839-4b07-ba31-f5fe1173bd41>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f75b58a-0f06-42e8-835b-40f8dcdfa7c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f75b58a-0f06-42e8-835b-40f8dcdfa7c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f75b58a-0f06-42e8-835b-40f8dcdfa7c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5264e28f-5c02-41f7-af84-3cf74b90fbc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5264e28f-5c02-41f7-af84-3cf74b90fbc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5264e28f-5c02-41f7-af84-3cf74b90fbc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1374a775-d17a-49c3-bbb0-bc18b8398b06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1374a775-d17a-49c3-bbb0-bc18b8398b06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1374a775-d17a-49c3-bbb0-bc18b8398b06>.
+    
+<http://data.lblod.info/id/remote-data-objects/349bda93-3595-494c-bf87-9f0fab8676c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "349bda93-3595-494c-bf87-9f0fab8676c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/349bda93-3595-494c-bf87-9f0fab8676c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/13c49021-9464-4484-bfb3-d89902bc0c47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13c49021-9464-4484-bfb3-d89902bc0c47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13c49021-9464-4484-bfb3-d89902bc0c47>.
+    
+<http://data.lblod.info/id/remote-data-objects/8eda39a8-31e1-474b-b805-0dcc0fbf91cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8eda39a8-31e1-474b-b805-0dcc0fbf91cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8eda39a8-31e1-474b-b805-0dcc0fbf91cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/494cd59e-66c4-4ca9-b44d-dcbe301e69e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "494cd59e-66c4-4ca9-b44d-dcbe301e69e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/494cd59e-66c4-4ca9-b44d-dcbe301e69e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2ea1778-934a-402c-9d7c-b6525a19eeda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2ea1778-934a-402c-9d7c-b6525a19eeda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2ea1778-934a-402c-9d7c-b6525a19eeda>.
+    
+<http://data.lblod.info/id/remote-data-objects/af8f800a-b10d-4075-b278-4fb510995f0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af8f800a-b10d-4075-b278-4fb510995f0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af8f800a-b10d-4075-b278-4fb510995f0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f1c7a72-12d2-410a-94b9-a949c760e082> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f1c7a72-12d2-410a-94b9-a949c760e082";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f1c7a72-12d2-410a-94b9-a949c760e082>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e1c2e97-60d3-4bb3-a037-b8486d8f75b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e1c2e97-60d3-4bb3-a037-b8486d8f75b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e1c2e97-60d3-4bb3-a037-b8486d8f75b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7b23e3d-ea89-4676-93e8-6257e1ebfdfd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7b23e3d-ea89-4676-93e8-6257e1ebfdfd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7b23e3d-ea89-4676-93e8-6257e1ebfdfd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad4fbfef-de90-432b-92b5-116a5eb0614a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad4fbfef-de90-432b-92b5-116a5eb0614a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad4fbfef-de90-432b-92b5-116a5eb0614a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f8ba2b9-ab67-46eb-bf2b-107d1c7bc3ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f8ba2b9-ab67-46eb-bf2b-107d1c7bc3ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_05-07-2022_26524.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f8ba2b9-ab67-46eb-bf2b-107d1c7bc3ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/355f7592-6151-40b4-b1be-a16d7deb79e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "355f7592-6151-40b4-b1be-a16d7deb79e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_05-07-2022_26584.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/355f7592-6151-40b4-b1be-a16d7deb79e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f6aec61-9045-42bf-8160-3b35ec3f3c93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f6aec61-9045-42bf-8160-3b35ec3f3c93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_05-07-2022_26593.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f6aec61-9045-42bf-8160-3b35ec3f3c93>.
+    
+<http://data.lblod.info/id/remote-data-objects/2622187b-62e0-446c-b72b-0c12adf02be1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2622187b-62e0-446c-b72b-0c12adf02be1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_05-07-2022_26594.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2622187b-62e0-446c-b72b-0c12adf02be1>.
+    
+<http://data.lblod.info/id/remote-data-objects/975a7475-87f6-4deb-b1a0-12188495000c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "975a7475-87f6-4deb-b1a0-12188495000c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_05-07-2022_26595.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/975a7475-87f6-4deb-b1a0-12188495000c>.
+    
+<http://data.lblod.info/id/remote-data-objects/05ac4b70-e0ac-4b87-a0e1-b6aeda19894b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05ac4b70-e0ac-4b87-a0e1-b6aeda19894b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_05-07-2022_26596.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05ac4b70-e0ac-4b87-a0e1-b6aeda19894b>.
+    
+<http://data.lblod.info/id/remote-data-objects/34598ed8-d6ec-4538-8da9-3d8c6dc52db1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34598ed8-d6ec-4538-8da9-3d8c6dc52db1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_05-07-2022_26597.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34598ed8-d6ec-4538-8da9-3d8c6dc52db1>.
+    
+<http://data.lblod.info/id/remote-data-objects/894c6c45-7ed6-4a2f-b1d0-df7aaa398eda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "894c6c45-7ed6-4a2f-b1d0-df7aaa398eda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_05-10-2021_22833.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/894c6c45-7ed6-4a2f-b1d0-df7aaa398eda>.
+    
+<http://data.lblod.info/id/remote-data-objects/eade57ef-2fc4-4340-b7fb-ff87a5956ac0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eade57ef-2fc4-4340-b7fb-ff87a5956ac0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_09-05-2022_25781.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eade57ef-2fc4-4340-b7fb-ff87a5956ac0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f17a8f2d-94f3-4d90-8d0f-ab269a53ab09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f17a8f2d-94f3-4d90-8d0f-ab269a53ab09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_09-05-2022_25785.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f17a8f2d-94f3-4d90-8d0f-ab269a53ab09>.
+    
+<http://data.lblod.info/id/remote-data-objects/3368db2b-b666-4b93-985f-48b9d3c5def7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3368db2b-b666-4b93-985f-48b9d3c5def7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_11-04-2022_25429.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3368db2b-b666-4b93-985f-48b9d3c5def7>.
+    
+<http://data.lblod.info/id/remote-data-objects/28c501c6-2d23-4937-beae-6fc1281aa9c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28c501c6-2d23-4937-beae-6fc1281aa9c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_14-06-2022_26305.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28c501c6-2d23-4937-beae-6fc1281aa9c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/af490da6-5ecc-4156-9d1e-260f4467d66d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af490da6-5ecc-4156-9d1e-260f4467d66d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_14-06-2022_26306.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af490da6-5ecc-4156-9d1e-260f4467d66d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca65acda-44d6-4663-8372-8d8b404b05db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca65acda-44d6-4663-8372-8d8b404b05db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_14-12-2021_23779.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca65acda-44d6-4663-8372-8d8b404b05db>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f7a5247-4d39-49dd-abb7-72ef5c99221b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f7a5247-4d39-49dd-abb7-72ef5c99221b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_15-02-2022_24625.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f7a5247-4d39-49dd-abb7-72ef5c99221b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ceb7d78-fe9d-4ff7-81cb-6a14628460da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ceb7d78-fe9d-4ff7-81cb-6a14628460da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_15-02-2022_24631.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2a677b33-17cf-401f-a95d-70401cbc369c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ceb7d78-fe9d-4ff7-81cb-6a14628460da>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201508-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201508-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201508-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201508-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b153f302-b114-4a12-9994-90d3b512e656> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b153f302-b114-4a12-9994-90d3b512e656";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "27502095-4141-4fe8-8ef1-bc27ec6f898e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4dd585cb-1ac9-4da9-9606-8ee5f9311fe1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4dd585cb-1ac9-4da9-9606-8ee5f9311fe1";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e>.
+
+  <http://redpencil.data.gift/id/task/847d5e46-b19f-4b67-8944-59dc139960ee> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "847d5e46-b19f-4b67-8944-59dc139960ee";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b153f302-b114-4a12-9994-90d3b512e656>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4dd585cb-1ac9-4da9-9606-8ee5f9311fe1>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c7ac9b18-39f2-413e-a5e2-093308e43fad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7ac9b18-39f2-413e-a5e2-093308e43fad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_15-02-2022_24632.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7ac9b18-39f2-413e-a5e2-093308e43fad>.
+    
+<http://data.lblod.info/id/remote-data-objects/45c0a7ec-38dc-4052-84ca-4f98a4767523> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45c0a7ec-38dc-4052-84ca-4f98a4767523";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_17-05-2022_25965.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45c0a7ec-38dc-4052-84ca-4f98a4767523>.
+    
+<http://data.lblod.info/id/remote-data-objects/e15f088b-6f5e-4e39-8bb5-61c49fa5d41b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e15f088b-6f5e-4e39-8bb5-61c49fa5d41b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_21-06-2022_26362.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e15f088b-6f5e-4e39-8bb5-61c49fa5d41b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab8e97e3-210d-4c4a-871b-c8a9c227198f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab8e97e3-210d-4c4a-871b-c8a9c227198f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_28-06-2022_26488.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab8e97e3-210d-4c4a-871b-c8a9c227198f>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa4da016-b1dc-4d77-8958-901383edc81d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa4da016-b1dc-4d77-8958-901383edc81d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_29-03-2022_25315.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa4da016-b1dc-4d77-8958-901383edc81d>.
+    
+<http://data.lblod.info/id/remote-data-objects/506bed48-73df-4bbd-9126-02db9f9fa855> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "506bed48-73df-4bbd-9126-02db9f9fa855";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_31-05-2022_26078.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/506bed48-73df-4bbd-9126-02db9f9fa855>.
+    
+<http://data.lblod.info/id/remote-data-objects/08edee76-7d51-4215-bb46-7d0ab165e86d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08edee76-7d51-4215-bb46-7d0ab165e86d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_31-05-2022_26081.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08edee76-7d51-4215-bb46-7d0ab165e86d>.
+    
+<http://data.lblod.info/id/remote-data-objects/51625d21-52b6-4101-995c-7481875fc2ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51625d21-52b6-4101-995c-7481875fc2ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_31-05-2022_26082.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51625d21-52b6-4101-995c-7481875fc2ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/4040b7ef-b293-4eb5-ab57-4e485d126e2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4040b7ef-b293-4eb5-ab57-4e485d126e2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/71f2bc9ace4a466c13258de9733acfe3a8a7562b9e259bd8036f62bc1678f3f0/GetPublication?filename=Uittreksels_31-05-2022_26105.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4040b7ef-b293-4eb5-ab57-4e485d126e2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d48c3ef-1a7c-40db-84b0-d6946329662f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d48c3ef-1a7c-40db-84b0-d6946329662f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d48c3ef-1a7c-40db-84b0-d6946329662f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ab860be-d8a4-408e-a3d6-bf96b020606b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ab860be-d8a4-408e-a3d6-bf96b020606b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ab860be-d8a4-408e-a3d6-bf96b020606b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c993ed2-debf-4b86-9aa1-27b11355352b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c993ed2-debf-4b86-9aa1-27b11355352b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c993ed2-debf-4b86-9aa1-27b11355352b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7de9dbf0-84db-41bb-84ca-5a72ede2d4bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7de9dbf0-84db-41bb-84ca-5a72ede2d4bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7de9dbf0-84db-41bb-84ca-5a72ede2d4bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ec12038-5198-4f90-b41b-6eea2f718d7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ec12038-5198-4f90-b41b-6eea2f718d7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ec12038-5198-4f90-b41b-6eea2f718d7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/84e28e45-ea55-4b6f-b963-c072c659e772> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84e28e45-ea55-4b6f-b963-c072c659e772";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84e28e45-ea55-4b6f-b963-c072c659e772>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6bb75b0-4a04-4cb8-bfc7-76366df70025> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6bb75b0-4a04-4cb8-bfc7-76366df70025";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6bb75b0-4a04-4cb8-bfc7-76366df70025>.
+    
+<http://data.lblod.info/id/remote-data-objects/add8c9c1-01bf-4a8a-801a-f72dffc33810> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "add8c9c1-01bf-4a8a-801a-f72dffc33810";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/add8c9c1-01bf-4a8a-801a-f72dffc33810>.
+    
+<http://data.lblod.info/id/remote-data-objects/2641224d-1b1c-4aa2-9afb-73804f46a47d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2641224d-1b1c-4aa2-9afb-73804f46a47d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2641224d-1b1c-4aa2-9afb-73804f46a47d>.
+    
+<http://data.lblod.info/id/remote-data-objects/979674c0-9e1a-40a4-9f55-24bd832bfff6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "979674c0-9e1a-40a4-9f55-24bd832bfff6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/979674c0-9e1a-40a4-9f55-24bd832bfff6>.
+    
+<http://data.lblod.info/id/remote-data-objects/167a6eba-6595-47c6-89bb-7533a575afe6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "167a6eba-6595-47c6-89bb-7533a575afe6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/167a6eba-6595-47c6-89bb-7533a575afe6>.
+    
+<http://data.lblod.info/id/remote-data-objects/be7a99fb-94c6-4245-ab48-7bac34dc6111> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be7a99fb-94c6-4245-ab48-7bac34dc6111";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be7a99fb-94c6-4245-ab48-7bac34dc6111>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0d8e40a-d585-4382-826a-3583775af4a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0d8e40a-d585-4382-826a-3583775af4a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0d8e40a-d585-4382-826a-3583775af4a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b14eeac1-2023-449c-b472-63cb6cc47b99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b14eeac1-2023-449c-b472-63cb6cc47b99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b14eeac1-2023-449c-b472-63cb6cc47b99>.
+    
+<http://data.lblod.info/id/remote-data-objects/350bc6d6-4ce6-440f-a908-49bd98984a77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "350bc6d6-4ce6-440f-a908-49bd98984a77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/350bc6d6-4ce6-440f-a908-49bd98984a77>.
+    
+<http://data.lblod.info/id/remote-data-objects/24e6cc9e-8b91-45be-b808-f4e83b05e60e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24e6cc9e-8b91-45be-b808-f4e83b05e60e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24e6cc9e-8b91-45be-b808-f4e83b05e60e>.
+    
+<http://data.lblod.info/id/remote-data-objects/acaaebcd-9b61-49ba-9460-f004f262aa94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acaaebcd-9b61-49ba-9460-f004f262aa94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acaaebcd-9b61-49ba-9460-f004f262aa94>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7e8a6e6-6eda-4b96-98e7-a38203f75e70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7e8a6e6-6eda-4b96-98e7-a38203f75e70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7e8a6e6-6eda-4b96-98e7-a38203f75e70>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea56d37b-0224-4d39-8a04-d02cc1e4281c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea56d37b-0224-4d39-8a04-d02cc1e4281c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea56d37b-0224-4d39-8a04-d02cc1e4281c>.
+    
+<http://data.lblod.info/id/remote-data-objects/76aff530-b531-4194-bdef-f817d22da641> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76aff530-b531-4194-bdef-f817d22da641";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76aff530-b531-4194-bdef-f817d22da641>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ef1e763-bc26-46c6-867a-b1aeeb3079e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ef1e763-bc26-46c6-867a-b1aeeb3079e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ef1e763-bc26-46c6-867a-b1aeeb3079e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a607a4f8-43e7-492d-934e-56e1d0c0f775> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a607a4f8-43e7-492d-934e-56e1d0c0f775";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a607a4f8-43e7-492d-934e-56e1d0c0f775>.
+    
+<http://data.lblod.info/id/remote-data-objects/76ee7644-15b4-4587-bca1-6ebfa17297af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76ee7644-15b4-4587-bca1-6ebfa17297af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76ee7644-15b4-4587-bca1-6ebfa17297af>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d793868-ac40-4395-93a8-faf54e011105> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d793868-ac40-4395-93a8-faf54e011105";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d793868-ac40-4395-93a8-faf54e011105>.
+    
+<http://data.lblod.info/id/remote-data-objects/f50364ac-ae61-4f7f-9338-05f127786a0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f50364ac-ae61-4f7f-9338-05f127786a0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f50364ac-ae61-4f7f-9338-05f127786a0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/268d06b7-04e6-4b98-a60b-ee6125f6b554> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "268d06b7-04e6-4b98-a60b-ee6125f6b554";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/268d06b7-04e6-4b98-a60b-ee6125f6b554>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cb754b9-74e1-4be9-870a-c9a5657b678b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cb754b9-74e1-4be9-870a-c9a5657b678b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cb754b9-74e1-4be9-870a-c9a5657b678b>.
+    
+<http://data.lblod.info/id/remote-data-objects/14867e72-64ff-4fd3-9145-63c68e9901a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14867e72-64ff-4fd3-9145-63c68e9901a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14867e72-64ff-4fd3-9145-63c68e9901a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/32295987-a6a6-4142-8d80-d421499e7dd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32295987-a6a6-4142-8d80-d421499e7dd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32295987-a6a6-4142-8d80-d421499e7dd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/451e09fb-701d-4495-bdb1-d9ee6b44a6cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "451e09fb-701d-4495-bdb1-d9ee6b44a6cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Uittreksels_16-12-2021_23583.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/451e09fb-701d-4495-bdb1-d9ee6b44a6cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/3729aed2-b49e-4815-b9ee-39b39fa61364> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3729aed2-b49e-4815-b9ee-39b39fa61364";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Uittreksels_17-03-2022_25035.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3729aed2-b49e-4815-b9ee-39b39fa61364>.
+    
+<http://data.lblod.info/id/remote-data-objects/165e4757-5a29-4c68-a018-dff47ebfe3b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "165e4757-5a29-4c68-a018-dff47ebfe3b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lede.be/LBLODWeb/Home/Overzicht/a42b72dc37cc13175fc60bb8d81341b377c4b41a4ef625e1b0859248e8e58722/GetPublication?filename=Uittreksels_19-05-2022_25858.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/165e4757-5a29-4c68-a018-dff47ebfe3b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a307f74-561d-49bc-a2c0-db188173452f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a307f74-561d-49bc-a2c0-db188173452f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a307f74-561d-49bc-a2c0-db188173452f>.
+    
+<http://data.lblod.info/id/remote-data-objects/33b086dc-c2a7-4f38-8904-32ac95d1f766> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33b086dc-c2a7-4f38-8904-32ac95d1f766";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33b086dc-c2a7-4f38-8904-32ac95d1f766>.
+    
+<http://data.lblod.info/id/remote-data-objects/2473693a-1acf-40c0-a7cc-8e61bb5fdc0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2473693a-1acf-40c0-a7cc-8e61bb5fdc0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_04-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2473693a-1acf-40c0-a7cc-8e61bb5fdc0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/16485ca9-7dfe-432c-8b90-317b93862927> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16485ca9-7dfe-432c-8b90-317b93862927";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16485ca9-7dfe-432c-8b90-317b93862927>.
+    
+<http://data.lblod.info/id/remote-data-objects/823c3c97-7ca2-429c-ac2c-5c1da3ad6f19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "823c3c97-7ca2-429c-ac2c-5c1da3ad6f19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/823c3c97-7ca2-429c-ac2c-5c1da3ad6f19>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd24ae38-bcbb-4d5d-85cf-c962fffa406a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd24ae38-bcbb-4d5d-85cf-c962fffa406a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd24ae38-bcbb-4d5d-85cf-c962fffa406a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d3dbac0-2f8d-4062-9b81-87318054a813> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d3dbac0-2f8d-4062-9b81-87318054a813";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d3dbac0-2f8d-4062-9b81-87318054a813>.
+    
+<http://data.lblod.info/id/remote-data-objects/290ecf38-8f19-4264-ac19-7b1caf62c8ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "290ecf38-8f19-4264-ac19-7b1caf62c8ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_07-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/290ecf38-8f19-4264-ac19-7b1caf62c8ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e74ac6c-0df7-42d1-b601-d8d7ec36b3a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e74ac6c-0df7-42d1-b601-d8d7ec36b3a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/27502095-4141-4fe8-8ef1-bc27ec6f898e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e74ac6c-0df7-42d1-b601-d8d7ec36b3a4>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201509-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201509-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201509-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201509-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e667aeb8-924e-4589-ab66-21da52165391> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e667aeb8-924e-4589-ab66-21da52165391";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f94420c4-e194-493b-9bc4-6f385f63efca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f94420c4-e194-493b-9bc4-6f385f63efca";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa>.
+
+  <http://redpencil.data.gift/id/task/8b155546-ea77-4869-acc1-37601b90f95f> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8b155546-ea77-4869-acc1-37601b90f95f";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e667aeb8-924e-4589-ab66-21da52165391>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f94420c4-e194-493b-9bc4-6f385f63efca>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/caaa2f15-a3c3-4db6-bc33-869b5d5793b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "caaa2f15-a3c3-4db6-bc33-869b5d5793b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/caaa2f15-a3c3-4db6-bc33-869b5d5793b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/82f76c7c-0d48-4e36-a0f1-f7d464ced18f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82f76c7c-0d48-4e36-a0f1-f7d464ced18f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82f76c7c-0d48-4e36-a0f1-f7d464ced18f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5c5c320-5310-4327-940b-045ea3390c57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5c5c320-5310-4327-940b-045ea3390c57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5c5c320-5310-4327-940b-045ea3390c57>.
+    
+<http://data.lblod.info/id/remote-data-objects/3da7fab8-679e-4dfb-b821-158399df286a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3da7fab8-679e-4dfb-b821-158399df286a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3da7fab8-679e-4dfb-b821-158399df286a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d71f2507-7608-45b0-85b2-b81369359ada> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d71f2507-7608-45b0-85b2-b81369359ada";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d71f2507-7608-45b0-85b2-b81369359ada>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d15a164-10de-47aa-8cfb-5544dea34291> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d15a164-10de-47aa-8cfb-5544dea34291";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_12-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d15a164-10de-47aa-8cfb-5544dea34291>.
+    
+<http://data.lblod.info/id/remote-data-objects/4242ff49-0e76-4c57-81de-b80328f373a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4242ff49-0e76-4c57-81de-b80328f373a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4242ff49-0e76-4c57-81de-b80328f373a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5818751-b541-4523-ba0e-0b40f4b27778> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5818751-b541-4523-ba0e-0b40f4b27778";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5818751-b541-4523-ba0e-0b40f4b27778>.
+    
+<http://data.lblod.info/id/remote-data-objects/a923d3bb-728a-4b27-b811-62894eb34652> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a923d3bb-728a-4b27-b811-62894eb34652";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a923d3bb-728a-4b27-b811-62894eb34652>.
+    
+<http://data.lblod.info/id/remote-data-objects/73cf9404-9d76-49d5-9973-534a8533a23b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73cf9404-9d76-49d5-9973-534a8533a23b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73cf9404-9d76-49d5-9973-534a8533a23b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b37b5dc3-b100-4044-a73e-81da0cc6cc5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b37b5dc3-b100-4044-a73e-81da0cc6cc5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b37b5dc3-b100-4044-a73e-81da0cc6cc5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/538c72b1-9204-4a06-995c-503b3e0f1362> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "538c72b1-9204-4a06-995c-503b3e0f1362";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/538c72b1-9204-4a06-995c-503b3e0f1362>.
+    
+<http://data.lblod.info/id/remote-data-objects/54d4e924-d4de-4e2c-846b-9fe7a51741ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54d4e924-d4de-4e2c-846b-9fe7a51741ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54d4e924-d4de-4e2c-846b-9fe7a51741ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee75e05e-0b3b-491d-a6f9-f5b106f692fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee75e05e-0b3b-491d-a6f9-f5b106f692fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee75e05e-0b3b-491d-a6f9-f5b106f692fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd0ee6d1-163f-4694-aed3-f0698276f7db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd0ee6d1-163f-4694-aed3-f0698276f7db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd0ee6d1-163f-4694-aed3-f0698276f7db>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6303906-0d3a-48b4-89a7-7d392fcac70e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6303906-0d3a-48b4-89a7-7d392fcac70e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6303906-0d3a-48b4-89a7-7d392fcac70e>.
+    
+<http://data.lblod.info/id/remote-data-objects/521fb7de-c3cf-454d-a117-2e03afd49e97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "521fb7de-c3cf-454d-a117-2e03afd49e97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/521fb7de-c3cf-454d-a117-2e03afd49e97>.
+    
+<http://data.lblod.info/id/remote-data-objects/f73f275d-df78-4a40-9ccb-e2e69d5a29fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f73f275d-df78-4a40-9ccb-e2e69d5a29fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f73f275d-df78-4a40-9ccb-e2e69d5a29fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d8849a6-d8c8-4a95-9d5f-5b6dd176d994> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d8849a6-d8c8-4a95-9d5f-5b6dd176d994";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d8849a6-d8c8-4a95-9d5f-5b6dd176d994>.
+    
+<http://data.lblod.info/id/remote-data-objects/326e17e1-f3ab-4ecd-87df-a7e1957da8bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "326e17e1-f3ab-4ecd-87df-a7e1957da8bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/326e17e1-f3ab-4ecd-87df-a7e1957da8bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/a676e043-c443-4306-a754-a695610cf7fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a676e043-c443-4306-a754-a695610cf7fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a676e043-c443-4306-a754-a695610cf7fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ebb4a26-0b25-44c7-a2b4-385b964ee66f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ebb4a26-0b25-44c7-a2b4-385b964ee66f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ebb4a26-0b25-44c7-a2b4-385b964ee66f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1c7092f-382d-4162-aefd-3ce0b426cec1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1c7092f-382d-4162-aefd-3ce0b426cec1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1c7092f-382d-4162-aefd-3ce0b426cec1>.
+    
+<http://data.lblod.info/id/remote-data-objects/da1b3ef9-6721-49d6-ab8b-1969a3739817> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da1b3ef9-6721-49d6-ab8b-1969a3739817";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da1b3ef9-6721-49d6-ab8b-1969a3739817>.
+    
+<http://data.lblod.info/id/remote-data-objects/f093759b-e3f5-4f75-b50c-b1b66b2ef2d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f093759b-e3f5-4f75-b50c-b1b66b2ef2d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f093759b-e3f5-4f75-b50c-b1b66b2ef2d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c53ab509-c8de-4fef-854e-6696abffbe0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c53ab509-c8de-4fef-854e-6696abffbe0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c53ab509-c8de-4fef-854e-6696abffbe0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/22b84a2b-ebdb-42c3-aa79-fbcfa035f184> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22b84a2b-ebdb-42c3-aa79-fbcfa035f184";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22b84a2b-ebdb-42c3-aa79-fbcfa035f184>.
+    
+<http://data.lblod.info/id/remote-data-objects/cca7e00a-9f88-48b0-b43d-50129c575101> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cca7e00a-9f88-48b0-b43d-50129c575101";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cca7e00a-9f88-48b0-b43d-50129c575101>.
+    
+<http://data.lblod.info/id/remote-data-objects/d948cf68-59b3-447e-9fc0-a36d6a4d64b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d948cf68-59b3-447e-9fc0-a36d6a4d64b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d948cf68-59b3-447e-9fc0-a36d6a4d64b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdda0cb9-292f-4208-876b-aee82f107551> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdda0cb9-292f-4208-876b-aee82f107551";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdda0cb9-292f-4208-876b-aee82f107551>.
+    
+<http://data.lblod.info/id/remote-data-objects/496bbf0d-22c1-4412-a545-35fe425f43a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "496bbf0d-22c1-4412-a545-35fe425f43a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/496bbf0d-22c1-4412-a545-35fe425f43a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5e8c37e-2c2d-4e08-a807-7b4d219604f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5e8c37e-2c2d-4e08-a807-7b4d219604f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=Uittreksels_05-04-2022_28422.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5e8c37e-2c2d-4e08-a807-7b4d219604f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3797d3cc-3355-4c23-a050-157f5b52d93b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3797d3cc-3355-4c23-a050-157f5b52d93b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=Uittreksels_09-02-2022_27754.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3797d3cc-3355-4c23-a050-157f5b52d93b>.
+    
+<http://data.lblod.info/id/remote-data-objects/edd0574d-abb0-44a9-adb6-43a62f449a1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edd0574d-abb0-44a9-adb6-43a62f449a1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=Uittreksels_11-04-2022_28492.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edd0574d-abb0-44a9-adb6-43a62f449a1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cb90bfd-7bd8-4bed-818f-b55b4f8e6511> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cb90bfd-7bd8-4bed-818f-b55b4f8e6511";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=Uittreksels_12-10-2021_26447.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cb90bfd-7bd8-4bed-818f-b55b4f8e6511>.
+    
+<http://data.lblod.info/id/remote-data-objects/1402ef6c-cd4a-457f-93a3-7142b002270e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1402ef6c-cd4a-457f-93a3-7142b002270e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/18160474894abf5bc474615371af0380a4d825e158f1ff2e6160438c468a58a9/GetPublication?filename=Uittreksels_13-01-2022_27439.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1402ef6c-cd4a-457f-93a3-7142b002270e>.
+    
+<http://data.lblod.info/id/remote-data-objects/18ef0c5c-d1bf-437e-bdfe-60401040db3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18ef0c5c-d1bf-437e-bdfe-60401040db3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Agenda_OCMW-raad_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18ef0c5c-d1bf-437e-bdfe-60401040db3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0760a16b-2bde-4a2c-91cb-896d7ca79f27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0760a16b-2bde-4a2c-91cb-896d7ca79f27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Agenda_OCMW-raad_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0760a16b-2bde-4a2c-91cb-896d7ca79f27>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e7dcc39-307a-426a-b936-3b3b3fc2231e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e7dcc39-307a-426a-b936-3b3b3fc2231e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Agenda_OCMW-raad_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e7dcc39-307a-426a-b936-3b3b3fc2231e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3877041-4241-4e56-917a-fb15f6b6130a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3877041-4241-4e56-917a-fb15f6b6130a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Agenda_OCMW-raad_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3877041-4241-4e56-917a-fb15f6b6130a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad5dab64-9a26-4255-ad96-19143ea4da36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad5dab64-9a26-4255-ad96-19143ea4da36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Agenda_OCMW-raad_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad5dab64-9a26-4255-ad96-19143ea4da36>.
+    
+<http://data.lblod.info/id/remote-data-objects/c747f30c-0221-4f28-adaa-8dce15c61d7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c747f30c-0221-4f28-adaa-8dce15c61d7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Agenda_OCMW-raad_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c747f30c-0221-4f28-adaa-8dce15c61d7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/20661381-546d-4d26-9110-37309de6716f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20661381-546d-4d26-9110-37309de6716f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Agenda_OCMW-raad_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20661381-546d-4d26-9110-37309de6716f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f929f80-6049-4945-adf2-3dc3f1e3a952> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f929f80-6049-4945-adf2-3dc3f1e3a952";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Agenda_OCMW-raad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f929f80-6049-4945-adf2-3dc3f1e3a952>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5c93d90-8d00-4f24-856d-2ffa09086424> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5c93d90-8d00-4f24-856d-2ffa09086424";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Agenda_OCMW-raad_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5c93d90-8d00-4f24-856d-2ffa09086424>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9423cad-d207-4ac2-8509-9af0f791280a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9423cad-d207-4ac2-8509-9af0f791280a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9423cad-d207-4ac2-8509-9af0f791280a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a0093a3-e8d6-4f5d-b2a5-03a5d4efe477> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a0093a3-e8d6-4f5d-b2a5-03a5d4efe477";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a0093a3-e8d6-4f5d-b2a5-03a5d4efe477>.
+    
+<http://data.lblod.info/id/remote-data-objects/586f101b-0314-4e0b-8973-3126ccbb36b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "586f101b-0314-4e0b-8973-3126ccbb36b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/586f101b-0314-4e0b-8973-3126ccbb36b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a71420b7-5b88-4435-9754-7b75fd75ecf7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a71420b7-5b88-4435-9754-7b75fd75ecf7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a71420b7-5b88-4435-9754-7b75fd75ecf7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0e1dc26-be22-4f69-86c7-c88200f910af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0e1dc26-be22-4f69-86c7-c88200f910af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/645d0d7a-f2b5-479e-8eb2-c0ec66c36aaa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0e1dc26-be22-4f69-86c7-c88200f910af>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201510-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201510-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201510-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201510-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/65ca3e58-49d8-43f0-a9d8-a3e99743aeac> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "65ca3e58-49d8-43f0-a9d8-a3e99743aeac";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7194930e-e95f-49e4-bcd4-6df7c0ff540e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/60752fb3-7965-406a-af15-5a3a99d9bbf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "60752fb3-7965-406a-af15-5a3a99d9bbf9";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e>.
+
+  <http://redpencil.data.gift/id/task/60fad748-e590-4ca8-939c-0edc42c04b56> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "60fad748-e590-4ca8-939c-0edc42c04b56";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/65ca3e58-49d8-43f0-a9d8-a3e99743aeac>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/60752fb3-7965-406a-af15-5a3a99d9bbf9>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/805e52dd-7e66-4ff5-a96b-bf39778fbb96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "805e52dd-7e66-4ff5-a96b-bf39778fbb96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/805e52dd-7e66-4ff5-a96b-bf39778fbb96>.
+    
+<http://data.lblod.info/id/remote-data-objects/a31a9e4f-7804-4b87-8069-ec8203531d75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a31a9e4f-7804-4b87-8069-ec8203531d75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a31a9e4f-7804-4b87-8069-ec8203531d75>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ad61535-1458-4ac6-99aa-d3baf0a9948a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ad61535-1458-4ac6-99aa-d3baf0a9948a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ad61535-1458-4ac6-99aa-d3baf0a9948a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e591aa69-3ad6-4799-8cc0-bcae57243af2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e591aa69-3ad6-4799-8cc0-bcae57243af2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e591aa69-3ad6-4799-8cc0-bcae57243af2>.
+    
+<http://data.lblod.info/id/remote-data-objects/09bfda0b-2d39-4650-8f57-5171827cf922> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09bfda0b-2d39-4650-8f57-5171827cf922";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Notulen_OCMW-raad_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09bfda0b-2d39-4650-8f57-5171827cf922>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc9c189f-d7bb-4d8d-9f35-5fd8d1346f11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc9c189f-d7bb-4d8d-9f35-5fd8d1346f11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Notulen_OCMW-raad_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc9c189f-d7bb-4d8d-9f35-5fd8d1346f11>.
+    
+<http://data.lblod.info/id/remote-data-objects/1704ec93-2d93-47b9-ac9f-bbc254399bbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1704ec93-2d93-47b9-ac9f-bbc254399bbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Notulen_OCMW-raad_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1704ec93-2d93-47b9-ac9f-bbc254399bbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/2672a05e-d1be-40c2-9375-59cf6cbc3620> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2672a05e-d1be-40c2-9375-59cf6cbc3620";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Notulen_OCMW-raad_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2672a05e-d1be-40c2-9375-59cf6cbc3620>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3c8c232-cd23-4d56-b71f-826e7795cd24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3c8c232-cd23-4d56-b71f-826e7795cd24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Notulen_OCMW-raad_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3c8c232-cd23-4d56-b71f-826e7795cd24>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0485a03-b299-4694-a38e-712f2658703d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0485a03-b299-4694-a38e-712f2658703d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Notulen_OCMW-raad_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0485a03-b299-4694-a38e-712f2658703d>.
+    
+<http://data.lblod.info/id/remote-data-objects/32375b78-cd03-42d2-b0a9-76531a466c42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32375b78-cd03-42d2-b0a9-76531a466c42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Notulen_OCMW-raad_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32375b78-cd03-42d2-b0a9-76531a466c42>.
+    
+<http://data.lblod.info/id/remote-data-objects/68f3c466-2a3f-40bf-9333-18bf3b6366ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68f3c466-2a3f-40bf-9333-18bf3b6366ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Notulen_OCMW-raad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68f3c466-2a3f-40bf-9333-18bf3b6366ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd2c0b72-d51d-4302-8b7e-4fe01f21c371> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd2c0b72-d51d-4302-8b7e-4fe01f21c371";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Notulen_OCMW-raad_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd2c0b72-d51d-4302-8b7e-4fe01f21c371>.
+    
+<http://data.lblod.info/id/remote-data-objects/a54c022c-9d5a-4927-a990-82bbacdbf92e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a54c022c-9d5a-4927-a990-82bbacdbf92e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Uittreksels_10-03-2022_27807.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a54c022c-9d5a-4927-a990-82bbacdbf92e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0860cc30-cbf3-43c2-9b25-dcca07a51aa5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0860cc30-cbf3-43c2-9b25-dcca07a51aa5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Uittreksels_13-01-2022_27303.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0860cc30-cbf3-43c2-9b25-dcca07a51aa5>.
+    
+<http://data.lblod.info/id/remote-data-objects/826ed382-8d98-4f0e-814d-ec336e4e1d83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "826ed382-8d98-4f0e-814d-ec336e4e1d83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Uittreksels_14-10-2021_25567.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/826ed382-8d98-4f0e-814d-ec336e4e1d83>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a799af8-c5fb-46c0-8be7-b890d66fb82d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a799af8-c5fb-46c0-8be7-b890d66fb82d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/7c66a5ff5464e431d97497d38648897280718c140200b5bdf3a75b0b83491e13/GetPublication?filename=Uittreksels_27-06-2022_29326.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a799af8-c5fb-46c0-8be7-b890d66fb82d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0764a940-a8db-4420-80b8-041a35837a55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0764a940-a8db-4420-80b8-041a35837a55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0764a940-a8db-4420-80b8-041a35837a55>.
+    
+<http://data.lblod.info/id/remote-data-objects/2962a525-152d-4666-a8d4-fbe3bc6279d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2962a525-152d-4666-a8d4-fbe3bc6279d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2962a525-152d-4666-a8d4-fbe3bc6279d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/1354a9bb-8e07-444e-87de-b1102952ff3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1354a9bb-8e07-444e-87de-b1102952ff3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1354a9bb-8e07-444e-87de-b1102952ff3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/db8de398-5338-4905-968a-7bb1b01486fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db8de398-5338-4905-968a-7bb1b01486fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db8de398-5338-4905-968a-7bb1b01486fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f31f59ef-860a-4cde-8707-75f2c7c0bede> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f31f59ef-860a-4cde-8707-75f2c7c0bede";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f31f59ef-860a-4cde-8707-75f2c7c0bede>.
+    
+<http://data.lblod.info/id/remote-data-objects/25e4a65c-b12c-4c38-b276-7243b60cce64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25e4a65c-b12c-4c38-b276-7243b60cce64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25e4a65c-b12c-4c38-b276-7243b60cce64>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1d90d27-f7b4-4c91-860b-c1cf633a87d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1d90d27-f7b4-4c91-860b-c1cf633a87d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1d90d27-f7b4-4c91-860b-c1cf633a87d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd470705-9c07-4f52-a679-0d37eaa095cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd470705-9c07-4f52-a679-0d37eaa095cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd470705-9c07-4f52-a679-0d37eaa095cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fd518ad-b9b7-4aa3-abaf-d8598799c102> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fd518ad-b9b7-4aa3-abaf-d8598799c102";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fd518ad-b9b7-4aa3-abaf-d8598799c102>.
+    
+<http://data.lblod.info/id/remote-data-objects/77b9180a-a888-4681-a073-4f6672f8f4aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77b9180a-a888-4681-a073-4f6672f8f4aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77b9180a-a888-4681-a073-4f6672f8f4aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/2db14b98-f72d-4162-a11c-881aa57fee9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2db14b98-f72d-4162-a11c-881aa57fee9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2db14b98-f72d-4162-a11c-881aa57fee9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/232b682e-c357-47a9-af03-8893c0dffe17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "232b682e-c357-47a9-af03-8893c0dffe17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/232b682e-c357-47a9-af03-8893c0dffe17>.
+    
+<http://data.lblod.info/id/remote-data-objects/8089892f-2f3f-4c35-9e52-c0eabef8e3e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8089892f-2f3f-4c35-9e52-c0eabef8e3e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8089892f-2f3f-4c35-9e52-c0eabef8e3e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/73a92dee-6480-484a-960c-1e124ee8e4c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73a92dee-6480-484a-960c-1e124ee8e4c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73a92dee-6480-484a-960c-1e124ee8e4c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/68b6a09d-a72a-4f23-b46b-31c577663592> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68b6a09d-a72a-4f23-b46b-31c577663592";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68b6a09d-a72a-4f23-b46b-31c577663592>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecd10c86-f776-479b-a4f4-e7a595acfd27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecd10c86-f776-479b-a4f4-e7a595acfd27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecd10c86-f776-479b-a4f4-e7a595acfd27>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed8fb06c-a3b8-49e5-9194-8a41e0969cbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed8fb06c-a3b8-49e5-9194-8a41e0969cbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed8fb06c-a3b8-49e5-9194-8a41e0969cbb>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ea4a82f-0584-4596-9fa5-9b5aee62b42a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ea4a82f-0584-4596-9fa5-9b5aee62b42a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ea4a82f-0584-4596-9fa5-9b5aee62b42a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c6a727c-1a17-4f53-9f6c-1533163e09f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c6a727c-1a17-4f53-9f6c-1533163e09f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c6a727c-1a17-4f53-9f6c-1533163e09f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fe437f5-ba1e-46ec-8ad8-c6e0ae79aff4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fe437f5-ba1e-46ec-8ad8-c6e0ae79aff4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fe437f5-ba1e-46ec-8ad8-c6e0ae79aff4>.
+    
+<http://data.lblod.info/id/remote-data-objects/613ebd8a-ed8c-44b0-aaf5-ff8305ddc9ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "613ebd8a-ed8c-44b0-aaf5-ff8305ddc9ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/613ebd8a-ed8c-44b0-aaf5-ff8305ddc9ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/ead503f9-b665-463d-aee2-6ead3e1ed7c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ead503f9-b665-463d-aee2-6ead3e1ed7c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ead503f9-b665-463d-aee2-6ead3e1ed7c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/090566da-6e67-4869-aa70-2f110430ae7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "090566da-6e67-4869-aa70-2f110430ae7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/090566da-6e67-4869-aa70-2f110430ae7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/95a88e15-e151-44df-9d5c-2a4321e082b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95a88e15-e151-44df-9d5c-2a4321e082b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95a88e15-e151-44df-9d5c-2a4321e082b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1d15118-968d-4c8c-a04b-483766cb99a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1d15118-968d-4c8c-a04b-483766cb99a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1d15118-968d-4c8c-a04b-483766cb99a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/00770dd9-23d5-4896-8158-5774dc6b7c7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00770dd9-23d5-4896-8158-5774dc6b7c7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00770dd9-23d5-4896-8158-5774dc6b7c7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/101872f4-bf52-4713-ade0-c35d31cb3f5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "101872f4-bf52-4713-ade0-c35d31cb3f5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/101872f4-bf52-4713-ade0-c35d31cb3f5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/05b6e6ca-cbbe-4110-92b9-b901427c8876> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05b6e6ca-cbbe-4110-92b9-b901427c8876";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05b6e6ca-cbbe-4110-92b9-b901427c8876>.
+    
+<http://data.lblod.info/id/remote-data-objects/3001b90f-f2c2-4321-b4d0-97ead8f7fe3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3001b90f-f2c2-4321-b4d0-97ead8f7fe3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3001b90f-f2c2-4321-b4d0-97ead8f7fe3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/756f10a9-97e3-4d23-aa56-42583ea2c063> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "756f10a9-97e3-4d23-aa56-42583ea2c063";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/756f10a9-97e3-4d23-aa56-42583ea2c063>.
+    
+<http://data.lblod.info/id/remote-data-objects/4af4bcc7-2203-4f21-8873-2b2dda2103f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4af4bcc7-2203-4f21-8873-2b2dda2103f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4af4bcc7-2203-4f21-8873-2b2dda2103f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bb4175a-5b1c-4d66-af0c-a20319dd058d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bb4175a-5b1c-4d66-af0c-a20319dd058d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bb4175a-5b1c-4d66-af0c-a20319dd058d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbf16a49-6d0f-4284-b1c9-12c9b715646f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbf16a49-6d0f-4284-b1c9-12c9b715646f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7194930e-e95f-49e4-bcd4-6df7c0ff540e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbf16a49-6d0f-4284-b1c9-12c9b715646f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201511-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201511-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201511-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201511-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/651ba27a-20fc-4ff2-aec3-3eb10c868d73> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "651ba27a-20fc-4ff2-aec3-3eb10c868d73";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3857a552-a974-4394-a007-7fe1a0ec6e7a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6274070c-9342-453f-84e9-afda9ff55f4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6274070c-9342-453f-84e9-afda9ff55f4d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a>.
+
+  <http://redpencil.data.gift/id/task/27d3fd56-caba-43fe-9a4a-cf44cdba7feb> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "27d3fd56-caba-43fe-9a4a-cf44cdba7feb";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/651ba27a-20fc-4ff2-aec3-3eb10c868d73>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6274070c-9342-453f-84e9-afda9ff55f4d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c42c4dd7-02be-4c0b-9991-a173326592a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c42c4dd7-02be-4c0b-9991-a173326592a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c42c4dd7-02be-4c0b-9991-a173326592a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/df82fab0-deba-413e-8396-a51188fec844> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df82fab0-deba-413e-8396-a51188fec844";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df82fab0-deba-413e-8396-a51188fec844>.
+    
+<http://data.lblod.info/id/remote-data-objects/a922a6d9-046b-479f-a2ec-0192f89d798e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a922a6d9-046b-479f-a2ec-0192f89d798e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a922a6d9-046b-479f-a2ec-0192f89d798e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fd0854a-46be-4d3e-b4be-cc73b4a42494> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fd0854a-46be-4d3e-b4be-cc73b4a42494";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fd0854a-46be-4d3e-b4be-cc73b4a42494>.
+    
+<http://data.lblod.info/id/remote-data-objects/65bc1c71-d538-4323-a81a-36d1aa337c6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65bc1c71-d538-4323-a81a-36d1aa337c6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65bc1c71-d538-4323-a81a-36d1aa337c6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fc2b0bc-face-45ba-859f-292accfe81f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fc2b0bc-face-45ba-859f-292accfe81f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fc2b0bc-face-45ba-859f-292accfe81f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7d9bfeb-691a-446a-b420-092918bdf22e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7d9bfeb-691a-446a-b420-092918bdf22e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7d9bfeb-691a-446a-b420-092918bdf22e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f011bfc-8cae-4ff7-8d40-df059b7504de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f011bfc-8cae-4ff7-8d40-df059b7504de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f011bfc-8cae-4ff7-8d40-df059b7504de>.
+    
+<http://data.lblod.info/id/remote-data-objects/476b3505-1ec3-4f2c-a2f0-9feb7f7e5fbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "476b3505-1ec3-4f2c-a2f0-9feb7f7e5fbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/476b3505-1ec3-4f2c-a2f0-9feb7f7e5fbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d38032fd-746c-4e9a-a5bb-e5cbb7c199ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d38032fd-746c-4e9a-a5bb-e5cbb7c199ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_02-05-2022_28625.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d38032fd-746c-4e9a-a5bb-e5cbb7c199ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e464bfd-7498-44a0-bd53-7dec1961a8a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e464bfd-7498-44a0-bd53-7dec1961a8a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_02-05-2022_28713.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e464bfd-7498-44a0-bd53-7dec1961a8a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee4be969-fc2c-4219-bcfb-d2b76da11810> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee4be969-fc2c-4219-bcfb-d2b76da11810";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_02-05-2022_28720.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee4be969-fc2c-4219-bcfb-d2b76da11810>.
+    
+<http://data.lblod.info/id/remote-data-objects/b841f8a7-08e6-4125-b159-99bfb33f7271> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b841f8a7-08e6-4125-b159-99bfb33f7271";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_02-05-2022_28783.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b841f8a7-08e6-4125-b159-99bfb33f7271>.
+    
+<http://data.lblod.info/id/remote-data-objects/884ba74d-3b71-4fb3-b35b-222fd3d1fd88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "884ba74d-3b71-4fb3-b35b-222fd3d1fd88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_02-05-2022_28806.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/884ba74d-3b71-4fb3-b35b-222fd3d1fd88>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8181bad-ad6d-417d-a51d-d06c2983dd8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8181bad-ad6d-417d-a51d-d06c2983dd8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_04-04-2022_28358.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8181bad-ad6d-417d-a51d-d06c2983dd8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc573a39-4885-4e68-9dff-e5363419484b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc573a39-4885-4e68-9dff-e5363419484b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_04-04-2022_28369.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc573a39-4885-4e68-9dff-e5363419484b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8acbf05-6cd0-4922-a716-3bd4e71c677b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8acbf05-6cd0-4922-a716-3bd4e71c677b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_04-04-2022_28377.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8acbf05-6cd0-4922-a716-3bd4e71c677b>.
+    
+<http://data.lblod.info/id/remote-data-objects/290effa7-e2de-4086-bbc6-ef2f71e3f3c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "290effa7-e2de-4086-bbc6-ef2f71e3f3c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_04-04-2022_28395.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/290effa7-e2de-4086-bbc6-ef2f71e3f3c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0fa9db2-26aa-499a-982e-f8b7db253f46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0fa9db2-26aa-499a-982e-f8b7db253f46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_04-06-2022_29227.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0fa9db2-26aa-499a-982e-f8b7db253f46>.
+    
+<http://data.lblod.info/id/remote-data-objects/40999d7b-4af5-4877-9618-50a28276d838> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40999d7b-4af5-4877-9618-50a28276d838";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_04-06-2022_29233.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40999d7b-4af5-4877-9618-50a28276d838>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a5f3f72-9701-4eb5-9858-a1e8b373d3be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a5f3f72-9701-4eb5-9858-a1e8b373d3be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_04-06-2022_29234.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a5f3f72-9701-4eb5-9858-a1e8b373d3be>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f939768-2402-46ab-b34f-e90ea0696646> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f939768-2402-46ab-b34f-e90ea0696646";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_04-07-2022_29578.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f939768-2402-46ab-b34f-e90ea0696646>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b3ce97f-c268-4765-911c-8aabbba06d64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b3ce97f-c268-4765-911c-8aabbba06d64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_04-07-2022_29580.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b3ce97f-c268-4765-911c-8aabbba06d64>.
+    
+<http://data.lblod.info/id/remote-data-objects/383e173a-57eb-4864-aad2-f94be106c67b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "383e173a-57eb-4864-aad2-f94be106c67b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_04-10-2021_26327.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/383e173a-57eb-4864-aad2-f94be106c67b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2485da3d-f045-475e-84b7-cc0cf1481939> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2485da3d-f045-475e-84b7-cc0cf1481939";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_04-10-2021_26331.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2485da3d-f045-475e-84b7-cc0cf1481939>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f208241-d7b6-49dd-bdbb-f9412d59c7a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f208241-d7b6-49dd-bdbb-f9412d59c7a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_04-10-2021_26332.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f208241-d7b6-49dd-bdbb-f9412d59c7a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/327ec0ce-a6bc-4626-87d4-f503063dbb73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "327ec0ce-a6bc-4626-87d4-f503063dbb73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_07-03-2022_28039.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/327ec0ce-a6bc-4626-87d4-f503063dbb73>.
+    
+<http://data.lblod.info/id/remote-data-objects/da4584e7-f4a1-431c-a0ca-ed85c92a3abf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da4584e7-f4a1-431c-a0ca-ed85c92a3abf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_07-05-2022_28937.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da4584e7-f4a1-431c-a0ca-ed85c92a3abf>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ee9e3c2-1e3a-4d3d-85a9-c6166f6139ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ee9e3c2-1e3a-4d3d-85a9-c6166f6139ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_07-05-2022_28946.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ee9e3c2-1e3a-4d3d-85a9-c6166f6139ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/be091fd5-9112-427c-8c16-12c5ae3d4ea9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be091fd5-9112-427c-8c16-12c5ae3d4ea9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_07-05-2022_28947.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be091fd5-9112-427c-8c16-12c5ae3d4ea9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff70f8d0-22db-4568-8401-83590e3170c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff70f8d0-22db-4568-8401-83590e3170c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_07-05-2022_28948.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff70f8d0-22db-4568-8401-83590e3170c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2af8493-2480-4909-99a4-c6799d920f4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2af8493-2480-4909-99a4-c6799d920f4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_07-05-2022_28950.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2af8493-2480-4909-99a4-c6799d920f4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebe99b0b-9a78-4b17-95bf-813594cecfdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebe99b0b-9a78-4b17-95bf-813594cecfdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_07-05-2022_28954.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebe99b0b-9a78-4b17-95bf-813594cecfdf>.
+    
+<http://data.lblod.info/id/remote-data-objects/48a8f984-d87e-4c11-8dd7-63536e2537d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48a8f984-d87e-4c11-8dd7-63536e2537d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_08-11-2021_26656.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48a8f984-d87e-4c11-8dd7-63536e2537d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/92734073-01e2-4f4a-b6e4-a4426fa845ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92734073-01e2-4f4a-b6e4-a4426fa845ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_11-04-2022_28336.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92734073-01e2-4f4a-b6e4-a4426fa845ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/55e99d20-0333-4c57-94dd-5a588b0145db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55e99d20-0333-4c57-94dd-5a588b0145db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_11-04-2022_28454.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55e99d20-0333-4c57-94dd-5a588b0145db>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f9d5d0a-63cd-4bf8-989a-0f7f59cb72e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f9d5d0a-63cd-4bf8-989a-0f7f59cb72e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_11-04-2022_28461.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f9d5d0a-63cd-4bf8-989a-0f7f59cb72e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c7fef7c-b361-40f3-bae4-9d650dcadaa4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c7fef7c-b361-40f3-bae4-9d650dcadaa4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_11-10-2021_26409.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c7fef7c-b361-40f3-bae4-9d650dcadaa4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7af3274c-bad3-462e-a412-96fe3a7efea8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7af3274c-bad3-462e-a412-96fe3a7efea8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_11-10-2021_26410.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7af3274c-bad3-462e-a412-96fe3a7efea8>.
+    
+<http://data.lblod.info/id/remote-data-objects/27bc8e10-371b-45c8-83ac-3ad3129d752b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27bc8e10-371b-45c8-83ac-3ad3129d752b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_11-10-2021_26411.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27bc8e10-371b-45c8-83ac-3ad3129d752b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0ac4f97-00de-4bcb-9570-8991ce33cb8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0ac4f97-00de-4bcb-9570-8991ce33cb8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_11-10-2021_26412.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0ac4f97-00de-4bcb-9570-8991ce33cb8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1625855c-1124-449d-8511-a72ade93fe05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1625855c-1124-449d-8511-a72ade93fe05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_12-03-2022_28085.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1625855c-1124-449d-8511-a72ade93fe05>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2edadb8-a3b9-4dff-97e5-cc3e2b5150e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2edadb8-a3b9-4dff-97e5-cc3e2b5150e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_12-07-2022_29650.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2edadb8-a3b9-4dff-97e5-cc3e2b5150e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3528be67-0236-4a2a-846e-f39bf9f732c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3528be67-0236-4a2a-846e-f39bf9f732c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_13-06-2022_29243.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3528be67-0236-4a2a-846e-f39bf9f732c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e96aed98-9bf8-46d0-b155-37ad22252c3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e96aed98-9bf8-46d0-b155-37ad22252c3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_13-06-2022_29308.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e96aed98-9bf8-46d0-b155-37ad22252c3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/93ce15cc-4e5f-47c1-b5af-8dfdd1a1a831> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93ce15cc-4e5f-47c1-b5af-8dfdd1a1a831";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_13-06-2022_29313.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93ce15cc-4e5f-47c1-b5af-8dfdd1a1a831>.
+    
+<http://data.lblod.info/id/remote-data-objects/47169a93-34ec-45e1-b3df-3ef6aa623a33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47169a93-34ec-45e1-b3df-3ef6aa623a33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_13-06-2022_29319.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47169a93-34ec-45e1-b3df-3ef6aa623a33>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b56d803-6c2a-4c6d-a39b-2a8dae08b2f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b56d803-6c2a-4c6d-a39b-2a8dae08b2f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_13-12-2021_26999.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b56d803-6c2a-4c6d-a39b-2a8dae08b2f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/eeb5ee9e-c883-4c6e-a6ac-7e2863ee1433> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eeb5ee9e-c883-4c6e-a6ac-7e2863ee1433";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_15-11-2021_26704.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eeb5ee9e-c883-4c6e-a6ac-7e2863ee1433>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c19d90d-704c-4d45-8261-c16d35ae0723> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c19d90d-704c-4d45-8261-c16d35ae0723";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_16-05-2022_29027.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3857a552-a974-4394-a007-7fe1a0ec6e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c19d90d-704c-4d45-8261-c16d35ae0723>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201513-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201513-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201513-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201513-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/5742ecef-0c5d-4e27-99bf-df246546e5cc> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5742ecef-0c5d-4e27-99bf-df246546e5cc";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "01bf14bb-5f47-46b0-a7f5-8479f4e61518";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9a77c9ac-5411-408b-a2cf-b2f5e804c93f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9a77c9ac-5411-408b-a2cf-b2f5e804c93f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518>.
+
+  <http://redpencil.data.gift/id/task/c5a8bd77-6d05-4733-9b11-f883999a7ba5> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c5a8bd77-6d05-4733-9b11-f883999a7ba5";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/5742ecef-0c5d-4e27-99bf-df246546e5cc>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9a77c9ac-5411-408b-a2cf-b2f5e804c93f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e036e99c-9043-400c-a73b-eb6223d1030a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e036e99c-9043-400c-a73b-eb6223d1030a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_16-05-2022_29028.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e036e99c-9043-400c-a73b-eb6223d1030a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd17a2a5-e1e5-49f2-bcf9-a00ea3a1fa38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd17a2a5-e1e5-49f2-bcf9-a00ea3a1fa38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_18-04-2022_28573.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd17a2a5-e1e5-49f2-bcf9-a00ea3a1fa38>.
+    
+<http://data.lblod.info/id/remote-data-objects/c98467b5-efd8-49dc-a56b-7cf912621281> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c98467b5-efd8-49dc-a56b-7cf912621281";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_18-04-2022_28576.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c98467b5-efd8-49dc-a56b-7cf912621281>.
+    
+<http://data.lblod.info/id/remote-data-objects/11a2e635-f04c-4939-8920-523591a7b9a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11a2e635-f04c-4939-8920-523591a7b9a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_18-04-2022_28578.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11a2e635-f04c-4939-8920-523591a7b9a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/f31632f3-1f14-4e5d-8c5a-7d79e28eaa09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f31632f3-1f14-4e5d-8c5a-7d79e28eaa09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_18-07-2022_29800.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f31632f3-1f14-4e5d-8c5a-7d79e28eaa09>.
+    
+<http://data.lblod.info/id/remote-data-objects/49c51cb2-e790-4e93-ba68-ac8a7b8390c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49c51cb2-e790-4e93-ba68-ac8a7b8390c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_21-03-2022_28134.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49c51cb2-e790-4e93-ba68-ac8a7b8390c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/caf7a888-eaca-475f-8cb4-a46df62da7fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "caf7a888-eaca-475f-8cb4-a46df62da7fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_21-03-2022_28218.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/caf7a888-eaca-475f-8cb4-a46df62da7fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/efbdd7ff-0a88-4400-a382-2247576b6e0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efbdd7ff-0a88-4400-a382-2247576b6e0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_21-06-2022_29277.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efbdd7ff-0a88-4400-a382-2247576b6e0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f48c9759-c568-48d9-b33a-463cf8a084a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f48c9759-c568-48d9-b33a-463cf8a084a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_21-06-2022_29347.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f48c9759-c568-48d9-b33a-463cf8a084a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/12b14071-4951-495e-b7c6-9b659352d41d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12b14071-4951-495e-b7c6-9b659352d41d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_21-06-2022_29421.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12b14071-4951-495e-b7c6-9b659352d41d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f0ba7f8-edee-4bff-9785-01d89530fffb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f0ba7f8-edee-4bff-9785-01d89530fffb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_21-06-2022_29450.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f0ba7f8-edee-4bff-9785-01d89530fffb>.
+    
+<http://data.lblod.info/id/remote-data-objects/dccd47de-327a-41d0-89f2-37d5685c050e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dccd47de-327a-41d0-89f2-37d5685c050e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_22-11-2021_26791.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dccd47de-327a-41d0-89f2-37d5685c050e>.
+    
+<http://data.lblod.info/id/remote-data-objects/444fc53f-2bec-408a-b9b3-5b6a5729deee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "444fc53f-2bec-408a-b9b3-5b6a5729deee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_23-05-2022_29063.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/444fc53f-2bec-408a-b9b3-5b6a5729deee>.
+    
+<http://data.lblod.info/id/remote-data-objects/97ea3c23-4027-405d-ac61-d72910695e09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97ea3c23-4027-405d-ac61-d72910695e09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_23-05-2022_29064.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97ea3c23-4027-405d-ac61-d72910695e09>.
+    
+<http://data.lblod.info/id/remote-data-objects/86c6734e-2679-49d4-93b6-83983a27e984> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86c6734e-2679-49d4-93b6-83983a27e984";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_23-05-2022_29104.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86c6734e-2679-49d4-93b6-83983a27e984>.
+    
+<http://data.lblod.info/id/remote-data-objects/afb6375f-e160-441c-8487-7f5a0726321d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afb6375f-e160-441c-8487-7f5a0726321d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_25-04-2022_28607.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afb6375f-e160-441c-8487-7f5a0726321d>.
+    
+<http://data.lblod.info/id/remote-data-objects/828f8832-b512-4bc0-b49b-dd8bef2f04d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "828f8832-b512-4bc0-b49b-dd8bef2f04d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_25-04-2022_28621.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/828f8832-b512-4bc0-b49b-dd8bef2f04d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dc43fe6-8644-44f2-b1a4-a235bca7c2bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dc43fe6-8644-44f2-b1a4-a235bca7c2bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_25-04-2022_28626.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dc43fe6-8644-44f2-b1a4-a235bca7c2bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e4102cc-b1a7-4678-8feb-afa5ec421626> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e4102cc-b1a7-4678-8feb-afa5ec421626";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_25-07-2022_29810.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e4102cc-b1a7-4678-8feb-afa5ec421626>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dcb9051-c5d8-49d5-85e1-cf4522130fcf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dcb9051-c5d8-49d5-85e1-cf4522130fcf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_25-07-2022_29811.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dcb9051-c5d8-49d5-85e1-cf4522130fcf>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea233990-278d-42d6-88b2-8b418b5dcb32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea233990-278d-42d6-88b2-8b418b5dcb32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_25-10-2021_26540.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea233990-278d-42d6-88b2-8b418b5dcb32>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bbd40d6-d657-40ac-b2b3-acd7c42c1589> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bbd40d6-d657-40ac-b2b3-acd7c42c1589";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_25-10-2021_26544.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bbd40d6-d657-40ac-b2b3-acd7c42c1589>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1bf20a9-ae2e-44af-976e-7d7b9f09230b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1bf20a9-ae2e-44af-976e-7d7b9f09230b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_25-10-2021_26547.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1bf20a9-ae2e-44af-976e-7d7b9f09230b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1fb10ea-0d0e-4ed7-a0d1-f4cb4b803bd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1fb10ea-0d0e-4ed7-a0d1-f4cb4b803bd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_27-06-2022_29499.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1fb10ea-0d0e-4ed7-a0d1-f4cb4b803bd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c66836d-8e74-4822-913b-1605e196b6ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c66836d-8e74-4822-913b-1605e196b6ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_27-06-2022_29502.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c66836d-8e74-4822-913b-1605e196b6ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b5845fc-8910-4422-9dd3-28a3e45feccb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b5845fc-8910-4422-9dd3-28a3e45feccb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_27-06-2022_29511.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b5845fc-8910-4422-9dd3-28a3e45feccb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c90b244a-f891-450a-8f0b-a96f304b5d05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c90b244a-f891-450a-8f0b-a96f304b5d05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_27-06-2022_29513.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c90b244a-f891-450a-8f0b-a96f304b5d05>.
+    
+<http://data.lblod.info/id/remote-data-objects/983f1f5f-5b8e-406f-87bd-f33283fa8a26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "983f1f5f-5b8e-406f-87bd-f33283fa8a26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_27-06-2022_29514.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/983f1f5f-5b8e-406f-87bd-f33283fa8a26>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd7eefae-4486-4bfa-8d60-00fc89425d7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd7eefae-4486-4bfa-8d60-00fc89425d7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_27-06-2022_29515.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd7eefae-4486-4bfa-8d60-00fc89425d7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac95554a-5ce3-4ffb-b6c9-1a4b26b6d6b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac95554a-5ce3-4ffb-b6c9-1a4b26b6d6b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_27-06-2022_29524.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac95554a-5ce3-4ffb-b6c9-1a4b26b6d6b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8ace0bc-dd3a-4b6f-8b3a-6cd0ccb27624> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8ace0bc-dd3a-4b6f-8b3a-6cd0ccb27624";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_28-02-2022_27945.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8ace0bc-dd3a-4b6f-8b3a-6cd0ccb27624>.
+    
+<http://data.lblod.info/id/remote-data-objects/586c4db9-b39a-4bea-b215-4cee88ff46af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "586c4db9-b39a-4bea-b215-4cee88ff46af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_28-03-2022_28259.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/586c4db9-b39a-4bea-b215-4cee88ff46af>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5478321-2181-4966-abda-f48adca9601d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5478321-2181-4966-abda-f48adca9601d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_28-03-2022_28269.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5478321-2181-4966-abda-f48adca9601d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b98ba2af-a25a-40d5-af04-e5f041c9f3ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b98ba2af-a25a-40d5-af04-e5f041c9f3ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_28-03-2022_28299.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b98ba2af-a25a-40d5-af04-e5f041c9f3ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/91e42bc6-a06e-4ad8-9e55-2507d2b9c08c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91e42bc6-a06e-4ad8-9e55-2507d2b9c08c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_29-11-2021_26859.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91e42bc6-a06e-4ad8-9e55-2507d2b9c08c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7216742e-ab00-483e-bab7-4766946800eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7216742e-ab00-483e-bab7-4766946800eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_30-05-2022_29146.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7216742e-ab00-483e-bab7-4766946800eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/de62c688-bc27-45d2-aef2-9077c59fe70f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de62c688-bc27-45d2-aef2-9077c59fe70f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_30-05-2022_29149.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de62c688-bc27-45d2-aef2-9077c59fe70f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e45c0b1f-f799-409d-935f-dd2232cc8a9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e45c0b1f-f799-409d-935f-dd2232cc8a9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_30-05-2022_29150.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e45c0b1f-f799-409d-935f-dd2232cc8a9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/dce6818b-3ba3-4fec-b0a7-584c640cb83d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dce6818b-3ba3-4fec-b0a7-584c640cb83d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/9bfb338cc3771064b7c0bc18d0e7f16d0859ed309a7f3b198805661f16b39c51/GetPublication?filename=Uittreksels_30-05-2022_29152.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dce6818b-3ba3-4fec-b0a7-584c640cb83d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9c82b74-7e10-49c8-ac6a-7eec49e6fed7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9c82b74-7e10-49c8-ac6a-7eec49e6fed7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Agenda_Gemeenteraad_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9c82b74-7e10-49c8-ac6a-7eec49e6fed7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b26b20bb-22ec-47f0-b4d8-c125c00c89ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b26b20bb-22ec-47f0-b4d8-c125c00c89ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Agenda_Gemeenteraad_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b26b20bb-22ec-47f0-b4d8-c125c00c89ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/70c20ec1-da98-4379-aff2-ef780e15e51a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70c20ec1-da98-4379-aff2-ef780e15e51a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Agenda_Gemeenteraad_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70c20ec1-da98-4379-aff2-ef780e15e51a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4b24f47-1caa-4f3f-bdbb-d7afd1284703> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4b24f47-1caa-4f3f-bdbb-d7afd1284703";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Agenda_Gemeenteraad_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4b24f47-1caa-4f3f-bdbb-d7afd1284703>.
+    
+<http://data.lblod.info/id/remote-data-objects/6289cb3d-ec2b-4184-bb50-b79dfff195fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6289cb3d-ec2b-4184-bb50-b79dfff195fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Agenda_Gemeenteraad_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6289cb3d-ec2b-4184-bb50-b79dfff195fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/57a29ea2-3018-4b85-aaa0-226fd2647fe3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57a29ea2-3018-4b85-aaa0-226fd2647fe3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Agenda_Gemeenteraad_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57a29ea2-3018-4b85-aaa0-226fd2647fe3>.
+    
+<http://data.lblod.info/id/remote-data-objects/268d6bd6-ac7f-48d7-8472-ec3d75fb4c16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "268d6bd6-ac7f-48d7-8472-ec3d75fb4c16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Agenda_Gemeenteraad_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/268d6bd6-ac7f-48d7-8472-ec3d75fb4c16>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ea7113c-c2f7-485c-a1e9-f42b1a96f483> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ea7113c-c2f7-485c-a1e9-f42b1a96f483";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Agenda_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ea7113c-c2f7-485c-a1e9-f42b1a96f483>.
+    
+<http://data.lblod.info/id/remote-data-objects/81955575-0b9a-4a01-86b7-d4c17873b519> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81955575-0b9a-4a01-86b7-d4c17873b519";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Agenda_Gemeenteraad_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81955575-0b9a-4a01-86b7-d4c17873b519>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce92a516-a593-43eb-a96f-be4480e8f693> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce92a516-a593-43eb-a96f-be4480e8f693";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce92a516-a593-43eb-a96f-be4480e8f693>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ebb13d6-c04a-41b2-a3d4-1a220e2c6867> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ebb13d6-c04a-41b2-a3d4-1a220e2c6867";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/01bf14bb-5f47-46b0-a7f5-8479f4e61518> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ebb13d6-c04a-41b2-a3d4-1a220e2c6867>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201514-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201514-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201514-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201514-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d7eb00c3-a49f-474c-b001-49cb54a31fe9> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d7eb00c3-a49f-474c-b001-49cb54a31fe9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "89544968-b365-444e-949e-cb4c20b314e5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/86ee58cb-bb37-4561-a3dd-62307865a878> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "86ee58cb-bb37-4561-a3dd-62307865a878";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5>.
+
+  <http://redpencil.data.gift/id/task/3051e13c-c00b-4c8d-b599-625bc24ffb61> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3051e13c-c00b-4c8d-b599-625bc24ffb61";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d7eb00c3-a49f-474c-b001-49cb54a31fe9>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/86ee58cb-bb37-4561-a3dd-62307865a878>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/9a42b76d-f20a-44f7-b50c-4672d30f7eec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a42b76d-f20a-44f7-b50c-4672d30f7eec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a42b76d-f20a-44f7-b50c-4672d30f7eec>.
+    
+<http://data.lblod.info/id/remote-data-objects/832bdc92-5561-4f64-983c-e71839bb6554> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "832bdc92-5561-4f64-983c-e71839bb6554";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/832bdc92-5561-4f64-983c-e71839bb6554>.
+    
+<http://data.lblod.info/id/remote-data-objects/18dc742b-02fc-4a1c-b549-3a201d10d2c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18dc742b-02fc-4a1c-b549-3a201d10d2c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18dc742b-02fc-4a1c-b549-3a201d10d2c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/59281e54-cc7b-4738-82da-454ac62a2a0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59281e54-cc7b-4738-82da-454ac62a2a0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59281e54-cc7b-4738-82da-454ac62a2a0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d65e69d3-c97f-49bc-8766-c091430de2d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d65e69d3-c97f-49bc-8766-c091430de2d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d65e69d3-c97f-49bc-8766-c091430de2d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/19a35621-250e-4f9c-8966-252969280264> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19a35621-250e-4f9c-8966-252969280264";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19a35621-250e-4f9c-8966-252969280264>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ec07398-f89a-422c-a865-6ccaddd82608> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ec07398-f89a-422c-a865-6ccaddd82608";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ec07398-f89a-422c-a865-6ccaddd82608>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e834e11-99ea-4796-8bf5-ee9505522be3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e834e11-99ea-4796-8bf5-ee9505522be3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Notulen_Gemeenteraad_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e834e11-99ea-4796-8bf5-ee9505522be3>.
+    
+<http://data.lblod.info/id/remote-data-objects/4db683ac-ff79-4a82-8161-2be6fb72c2e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4db683ac-ff79-4a82-8161-2be6fb72c2e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Notulen_Gemeenteraad_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4db683ac-ff79-4a82-8161-2be6fb72c2e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb2a4594-66b5-4575-bd36-c4ef5af0f887> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb2a4594-66b5-4575-bd36-c4ef5af0f887";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Notulen_Gemeenteraad_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb2a4594-66b5-4575-bd36-c4ef5af0f887>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd43da8e-024d-4042-a575-a99fadfb1009> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd43da8e-024d-4042-a575-a99fadfb1009";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Notulen_Gemeenteraad_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd43da8e-024d-4042-a575-a99fadfb1009>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c002340-ce51-4123-9bb6-26a505bcb978> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c002340-ce51-4123-9bb6-26a505bcb978";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Notulen_Gemeenteraad_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c002340-ce51-4123-9bb6-26a505bcb978>.
+    
+<http://data.lblod.info/id/remote-data-objects/61c136a7-fbcb-4cdd-b54e-5a2e6b6a4971> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61c136a7-fbcb-4cdd-b54e-5a2e6b6a4971";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Notulen_Gemeenteraad_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61c136a7-fbcb-4cdd-b54e-5a2e6b6a4971>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5bab493-7f5b-4165-b357-87740de6d738> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5bab493-7f5b-4165-b357-87740de6d738";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Notulen_Gemeenteraad_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5bab493-7f5b-4165-b357-87740de6d738>.
+    
+<http://data.lblod.info/id/remote-data-objects/87f86789-a692-4d52-b9fd-083520135b52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87f86789-a692-4d52-b9fd-083520135b52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Notulen_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87f86789-a692-4d52-b9fd-083520135b52>.
+    
+<http://data.lblod.info/id/remote-data-objects/06e0a56a-2983-425d-8f31-95cae16a1d07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06e0a56a-2983-425d-8f31-95cae16a1d07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Notulen_Gemeenteraad_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06e0a56a-2983-425d-8f31-95cae16a1d07>.
+    
+<http://data.lblod.info/id/remote-data-objects/27e052a0-59be-4101-ad80-db5d7707be30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27e052a0-59be-4101-ad80-db5d7707be30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_10-02-2022_27568.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27e052a0-59be-4101-ad80-db5d7707be30>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfa573ff-0044-4cc5-b46c-8a1537a040d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfa573ff-0044-4cc5-b46c-8a1537a040d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_10-03-2022_27697.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfa573ff-0044-4cc5-b46c-8a1537a040d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c860c59c-a51d-4f39-8141-93a31680bd29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c860c59c-a51d-4f39-8141-93a31680bd29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_10-03-2022_27806.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c860c59c-a51d-4f39-8141-93a31680bd29>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed3fa84a-6769-4d5a-b4a4-48032ba7827d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed3fa84a-6769-4d5a-b4a4-48032ba7827d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_10-11-2021_26495.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed3fa84a-6769-4d5a-b4a4-48032ba7827d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a4d7995-98e1-4ecf-8b47-a53f2fb399ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a4d7995-98e1-4ecf-8b47-a53f2fb399ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_12-04-2022_28160.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a4d7995-98e1-4ecf-8b47-a53f2fb399ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/42e09231-2c8d-439d-bf8c-c9fb9b0ab09b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42e09231-2c8d-439d-bf8c-c9fb9b0ab09b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_12-05-2022_28564.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42e09231-2c8d-439d-bf8c-c9fb9b0ab09b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e6510c2-39a5-460e-9cb5-bd76e083f863> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e6510c2-39a5-460e-9cb5-bd76e083f863";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_14-10-2021_25963.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e6510c2-39a5-460e-9cb5-bd76e083f863>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb48c863-4485-4615-88fc-54e3a5b4b108> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb48c863-4485-4615-88fc-54e3a5b4b108";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_14-10-2021_25964.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb48c863-4485-4615-88fc-54e3a5b4b108>.
+    
+<http://data.lblod.info/id/remote-data-objects/12de6975-cba0-4a66-b737-a4150201ef4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12de6975-cba0-4a66-b737-a4150201ef4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_14-10-2021_25965.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12de6975-cba0-4a66-b737-a4150201ef4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3262befc-c438-45ed-b09f-6a26e252e2ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3262befc-c438-45ed-b09f-6a26e252e2ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_14-10-2021_25966.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3262befc-c438-45ed-b09f-6a26e252e2ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d04d280-009c-44d1-ad33-02170c389de4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d04d280-009c-44d1-ad33-02170c389de4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_14-10-2021_25967.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d04d280-009c-44d1-ad33-02170c389de4>.
+    
+<http://data.lblod.info/id/remote-data-objects/45da1f12-a587-42fb-981a-c6eeeef90223> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45da1f12-a587-42fb-981a-c6eeeef90223";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_14-10-2021_25969.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45da1f12-a587-42fb-981a-c6eeeef90223>.
+    
+<http://data.lblod.info/id/remote-data-objects/429ee1cb-fe18-4a6d-bd1d-94c2b4506d90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "429ee1cb-fe18-4a6d-bd1d-94c2b4506d90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_27-06-2022_27904.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/429ee1cb-fe18-4a6d-bd1d-94c2b4506d90>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c3c8374-3229-41ff-8bb7-a38fa103f18f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c3c8374-3229-41ff-8bb7-a38fa103f18f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_27-06-2022_27905.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c3c8374-3229-41ff-8bb7-a38fa103f18f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0b0b043-5320-40ac-939f-64cc63b9a58f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0b0b043-5320-40ac-939f-64cc63b9a58f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_27-06-2022_28588.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0b0b043-5320-40ac-939f-64cc63b9a58f>.
+    
+<http://data.lblod.info/id/remote-data-objects/07237cd2-0a96-4ebd-81a4-8f423b0035fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07237cd2-0a96-4ebd-81a4-8f423b0035fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_27-06-2022_29269.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07237cd2-0a96-4ebd-81a4-8f423b0035fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/70601dfb-a6bc-4d40-966b-44aa3a915dd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70601dfb-a6bc-4d40-966b-44aa3a915dd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_27-06-2022_29270.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70601dfb-a6bc-4d40-966b-44aa3a915dd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e716fa56-b8e4-47f2-9554-5c3d2aa3b4b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e716fa56-b8e4-47f2-9554-5c3d2aa3b4b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_27-06-2022_29278.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e716fa56-b8e4-47f2-9554-5c3d2aa3b4b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/88d2971f-e8de-4b22-8477-6c4043f5f04f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88d2971f-e8de-4b22-8477-6c4043f5f04f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_27-06-2022_29281.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88d2971f-e8de-4b22-8477-6c4043f5f04f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f57013d6-8fa6-4255-9cfb-5df88e732554> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f57013d6-8fa6-4255-9cfb-5df88e732554";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_30-12-2021_25783.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f57013d6-8fa6-4255-9cfb-5df88e732554>.
+    
+<http://data.lblod.info/id/remote-data-objects/546fe337-aca8-4e1d-bd24-505f96d3ee1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "546fe337-aca8-4e1d-bd24-505f96d3ee1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_30-12-2021_26507.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/546fe337-aca8-4e1d-bd24-505f96d3ee1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ebf9cdc-d5dc-47b0-9cc8-d9dc41c7403b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ebf9cdc-d5dc-47b0-9cc8-d9dc41c7403b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/c8ef485c8d60af5442dde1153235e4326c5dcc4995f1ca0837bb2ec5a267a62d/GetPublication?filename=Uittreksels_30-12-2021_26724.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ebf9cdc-d5dc-47b0-9cc8-d9dc41c7403b>.
+    
+<http://data.lblod.info/id/remote-data-objects/15a3c5e0-97ef-4b85-875e-f71d4297e72d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15a3c5e0-97ef-4b85-875e-f71d4297e72d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15a3c5e0-97ef-4b85-875e-f71d4297e72d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b65d41d-0ef0-4cf7-b5eb-962cc6b7496c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b65d41d-0ef0-4cf7-b5eb-962cc6b7496c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b65d41d-0ef0-4cf7-b5eb-962cc6b7496c>.
+    
+<http://data.lblod.info/id/remote-data-objects/58543cec-22cb-4be8-b880-75bbbd2dba67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58543cec-22cb-4be8-b880-75bbbd2dba67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58543cec-22cb-4be8-b880-75bbbd2dba67>.
+    
+<http://data.lblod.info/id/remote-data-objects/770fc329-6103-4692-a2a2-0c28fcc9600b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "770fc329-6103-4692-a2a2-0c28fcc9600b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_04-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/770fc329-6103-4692-a2a2-0c28fcc9600b>.
+    
+<http://data.lblod.info/id/remote-data-objects/97959643-9d6d-4b7c-8687-441f5fc00928> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97959643-9d6d-4b7c-8687-441f5fc00928";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97959643-9d6d-4b7c-8687-441f5fc00928>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5e8d5a5-3604-4eb0-88e7-6dbe6f5ddb07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5e8d5a5-3604-4eb0-88e7-6dbe6f5ddb07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5e8d5a5-3604-4eb0-88e7-6dbe6f5ddb07>.
+    
+<http://data.lblod.info/id/remote-data-objects/c51a4d67-49a5-4be0-8556-2ce53ad8a343> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c51a4d67-49a5-4be0-8556-2ce53ad8a343";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c51a4d67-49a5-4be0-8556-2ce53ad8a343>.
+    
+<http://data.lblod.info/id/remote-data-objects/3866cce0-cce9-42b8-86c4-5dfa377cde65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3866cce0-cce9-42b8-86c4-5dfa377cde65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3866cce0-cce9-42b8-86c4-5dfa377cde65>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e021489-69a5-47b5-bdce-f664c77a0e46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e021489-69a5-47b5-bdce-f664c77a0e46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e021489-69a5-47b5-bdce-f664c77a0e46>.
+    
+<http://data.lblod.info/id/remote-data-objects/b237aa0e-bd2d-4d26-bad4-34df488fced6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b237aa0e-bd2d-4d26-bad4-34df488fced6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_07-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b237aa0e-bd2d-4d26-bad4-34df488fced6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c88550b-4c32-4254-9384-234f5e883a83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c88550b-4c32-4254-9384-234f5e883a83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c88550b-4c32-4254-9384-234f5e883a83>.
+    
+<http://data.lblod.info/id/remote-data-objects/000ad841-6c02-4ac6-91ad-abdd9bab9bf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "000ad841-6c02-4ac6-91ad-abdd9bab9bf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89544968-b365-444e-949e-cb4c20b314e5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/000ad841-6c02-4ac6-91ad-abdd9bab9bf9>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201515-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201515-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201515-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201515-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d18cfeb6-c8c4-47c5-9e06-307fc1d191a8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d18cfeb6-c8c4-47c5-9e06-307fc1d191a8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6be67ae6-f7f8-44ad-a3ba-980a26386578";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/541ea2b1-f7d0-4159-ba8a-9480948c805b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "541ea2b1-f7d0-4159-ba8a-9480948c805b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578>.
+
+  <http://redpencil.data.gift/id/task/74a86ed1-e41b-4e99-a5f5-f1b1fdf30d8a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "74a86ed1-e41b-4e99-a5f5-f1b1fdf30d8a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d18cfeb6-c8c4-47c5-9e06-307fc1d191a8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/541ea2b1-f7d0-4159-ba8a-9480948c805b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b16a98a3-4078-4064-b7ce-9832c99c3d64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b16a98a3-4078-4064-b7ce-9832c99c3d64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b16a98a3-4078-4064-b7ce-9832c99c3d64>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0f3e050-4f84-494a-844f-3072f7c55211> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0f3e050-4f84-494a-844f-3072f7c55211";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0f3e050-4f84-494a-844f-3072f7c55211>.
+    
+<http://data.lblod.info/id/remote-data-objects/04a11ff9-cdfb-4d86-8b06-4825d1bb1b74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04a11ff9-cdfb-4d86-8b06-4825d1bb1b74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_12-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04a11ff9-cdfb-4d86-8b06-4825d1bb1b74>.
+    
+<http://data.lblod.info/id/remote-data-objects/df897b50-b8cf-4830-ab6e-b69a57721635> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df897b50-b8cf-4830-ab6e-b69a57721635";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df897b50-b8cf-4830-ab6e-b69a57721635>.
+    
+<http://data.lblod.info/id/remote-data-objects/113fa1be-b7d5-47fc-8c2f-6383f6266179> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "113fa1be-b7d5-47fc-8c2f-6383f6266179";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/113fa1be-b7d5-47fc-8c2f-6383f6266179>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf568d72-ca3f-4427-93b4-633e91a064f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf568d72-ca3f-4427-93b4-633e91a064f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf568d72-ca3f-4427-93b4-633e91a064f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d55069ef-b175-4a32-9cf3-cf0b830b157c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d55069ef-b175-4a32-9cf3-cf0b830b157c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d55069ef-b175-4a32-9cf3-cf0b830b157c>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcb6680d-ad1e-46ac-8b7d-247053b6f458> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcb6680d-ad1e-46ac-8b7d-247053b6f458";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcb6680d-ad1e-46ac-8b7d-247053b6f458>.
+    
+<http://data.lblod.info/id/remote-data-objects/a683c9fe-73df-4fd0-95f8-8facbe006d8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a683c9fe-73df-4fd0-95f8-8facbe006d8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a683c9fe-73df-4fd0-95f8-8facbe006d8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/48d5f172-42ed-409b-9c65-b87b19bf3155> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48d5f172-42ed-409b-9c65-b87b19bf3155";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48d5f172-42ed-409b-9c65-b87b19bf3155>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dd0ea96-92fa-438b-9ae5-4504b0efc562> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dd0ea96-92fa-438b-9ae5-4504b0efc562";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_18-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dd0ea96-92fa-438b-9ae5-4504b0efc562>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e5c2ef0-1489-434b-990d-0838671ab3c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e5c2ef0-1489-434b-990d-0838671ab3c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e5c2ef0-1489-434b-990d-0838671ab3c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/46203d31-b164-4701-8c7f-2ced12010d38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46203d31-b164-4701-8c7f-2ced12010d38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46203d31-b164-4701-8c7f-2ced12010d38>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e8c2697-74ba-4581-aecc-7041689f8dfe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e8c2697-74ba-4581-aecc-7041689f8dfe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e8c2697-74ba-4581-aecc-7041689f8dfe>.
+    
+<http://data.lblod.info/id/remote-data-objects/4beb9983-3b24-496f-aa31-deb879a56efa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4beb9983-3b24-496f-aa31-deb879a56efa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4beb9983-3b24-496f-aa31-deb879a56efa>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae8920ca-2404-4992-be77-d7c2f61fc48c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae8920ca-2404-4992-be77-d7c2f61fc48c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae8920ca-2404-4992-be77-d7c2f61fc48c>.
+    
+<http://data.lblod.info/id/remote-data-objects/47d5b618-de80-4c48-a532-d3418fbe7a60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47d5b618-de80-4c48-a532-d3418fbe7a60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47d5b618-de80-4c48-a532-d3418fbe7a60>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cbd2814-47ad-4e84-97fc-ca783caa0fb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cbd2814-47ad-4e84-97fc-ca783caa0fb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cbd2814-47ad-4e84-97fc-ca783caa0fb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/802cef90-19bb-4e8b-b27a-ae588be3404a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "802cef90-19bb-4e8b-b27a-ae588be3404a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/802cef90-19bb-4e8b-b27a-ae588be3404a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5935b15f-5d5b-44ad-ba7d-0387ab498591> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5935b15f-5d5b-44ad-ba7d-0387ab498591";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5935b15f-5d5b-44ad-ba7d-0387ab498591>.
+    
+<http://data.lblod.info/id/remote-data-objects/78482b13-7c2d-441c-9871-51055236562f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78482b13-7c2d-441c-9871-51055236562f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78482b13-7c2d-441c-9871-51055236562f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f840ee2-66c3-40ee-9baf-2a1e616ce69e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f840ee2-66c3-40ee-9baf-2a1e616ce69e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f840ee2-66c3-40ee-9baf-2a1e616ce69e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e1e817e-eef1-4f9c-b698-9cc2d185d403> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e1e817e-eef1-4f9c-b698-9cc2d185d403";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e1e817e-eef1-4f9c-b698-9cc2d185d403>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d49347a-90d6-4780-b37b-13bc2fa44a9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d49347a-90d6-4780-b37b-13bc2fa44a9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d49347a-90d6-4780-b37b-13bc2fa44a9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c92dc4ee-5572-432d-ad9c-e70f215f8974> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c92dc4ee-5572-432d-ad9c-e70f215f8974";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c92dc4ee-5572-432d-ad9c-e70f215f8974>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1e952ee-c438-4ca9-bfc0-84767dbdd248> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1e952ee-c438-4ca9-bfc0-84767dbdd248";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1e952ee-c438-4ca9-bfc0-84767dbdd248>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a2d0373-6043-412d-b40a-863e7bb3d8e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a2d0373-6043-412d-b40a-863e7bb3d8e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a2d0373-6043-412d-b40a-863e7bb3d8e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c728211-9af1-4df7-96c9-45121366e7e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c728211-9af1-4df7-96c9-45121366e7e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c728211-9af1-4df7-96c9-45121366e7e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcf099c5-7692-4bb6-b266-cc0c7d58d807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcf099c5-7692-4bb6-b266-cc0c7d58d807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcf099c5-7692-4bb6-b266-cc0c7d58d807>.
+    
+<http://data.lblod.info/id/remote-data-objects/af11b52f-fe55-4e8a-bc56-22e42133b12d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af11b52f-fe55-4e8a-bc56-22e42133b12d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ledegem.be/LBLODWeb/Home/Overzicht/debf0892dda0314287b4fba6566767e111d17950cf963ac2ad917a8c53714519/GetPublication?filename=Uittreksels_04-06-2022_29242.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af11b52f-fe55-4e8a-bc56-22e42133b12d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b0357c7-912a-4845-a6a3-d384968084bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b0357c7-912a-4845-a6a3-d384968084bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=BesluitenLijst_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b0357c7-912a-4845-a6a3-d384968084bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/174e8bca-bde1-41b0-a393-c70db5864a1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "174e8bca-bde1-41b0-a393-c70db5864a1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/174e8bca-bde1-41b0-a393-c70db5864a1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/373c9d3f-1999-469b-b184-3b26f721697a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "373c9d3f-1999-469b-b184-3b26f721697a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/373c9d3f-1999-469b-b184-3b26f721697a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5ca22e9-b20c-4e2e-b653-795e0edbc85b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5ca22e9-b20c-4e2e-b653-795e0edbc85b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5ca22e9-b20c-4e2e-b653-795e0edbc85b>.
+    
+<http://data.lblod.info/id/remote-data-objects/82befb43-4e2d-4145-8c9b-900238c88712> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82befb43-4e2d-4145-8c9b-900238c88712";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82befb43-4e2d-4145-8c9b-900238c88712>.
+    
+<http://data.lblod.info/id/remote-data-objects/52788735-7066-4661-bd0f-dd6f9880feea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52788735-7066-4661-bd0f-dd6f9880feea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52788735-7066-4661-bd0f-dd6f9880feea>.
+    
+<http://data.lblod.info/id/remote-data-objects/873c0258-8b55-41a0-9db3-229728073b19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "873c0258-8b55-41a0-9db3-229728073b19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=BesluitenLijst_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/873c0258-8b55-41a0-9db3-229728073b19>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb4c14d7-c456-43eb-9920-577503410204> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb4c14d7-c456-43eb-9920-577503410204";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=BesluitenLijst_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb4c14d7-c456-43eb-9920-577503410204>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8d2e8a9-daaa-491f-83ce-d7716c62a845> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8d2e8a9-daaa-491f-83ce-d7716c62a845";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=BesluitenLijst_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8d2e8a9-daaa-491f-83ce-d7716c62a845>.
+    
+<http://data.lblod.info/id/remote-data-objects/396cd2d4-4d46-4970-8eaa-eb6f85fc337d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "396cd2d4-4d46-4970-8eaa-eb6f85fc337d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_20-12-2021_11564.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/396cd2d4-4d46-4970-8eaa-eb6f85fc337d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcff609d-29b9-47c8-95ed-18e14b1ac93b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcff609d-29b9-47c8-95ed-18e14b1ac93b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_20-12-2021_11592.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcff609d-29b9-47c8-95ed-18e14b1ac93b>.
+    
+<http://data.lblod.info/id/remote-data-objects/34f23f92-e21c-4a8d-83b8-9992db944926> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34f23f92-e21c-4a8d-83b8-9992db944926";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_20-12-2021_11599.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34f23f92-e21c-4a8d-83b8-9992db944926>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec368d76-81fa-4a62-a3f0-6dcc2ab0eb16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec368d76-81fa-4a62-a3f0-6dcc2ab0eb16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_20-12-2021_11600.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec368d76-81fa-4a62-a3f0-6dcc2ab0eb16>.
+    
+<http://data.lblod.info/id/remote-data-objects/54caff8c-0a71-47fb-9294-25f9c6aa7708> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54caff8c-0a71-47fb-9294-25f9c6aa7708";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_20-12-2021_11603.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54caff8c-0a71-47fb-9294-25f9c6aa7708>.
+    
+<http://data.lblod.info/id/remote-data-objects/8de1525a-4303-4467-b3c6-61c60c2ec5f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8de1525a-4303-4467-b3c6-61c60c2ec5f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_20-12-2021_11606.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8de1525a-4303-4467-b3c6-61c60c2ec5f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4b4ab63-b5e5-4531-9906-6f21860845b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4b4ab63-b5e5-4531-9906-6f21860845b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_20-12-2021_11627.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4b4ab63-b5e5-4531-9906-6f21860845b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/1327c8bb-bc30-4a5c-bae0-d3439ea9b0e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1327c8bb-bc30-4a5c-bae0-d3439ea9b0e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_20-12-2021_11628.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1327c8bb-bc30-4a5c-bae0-d3439ea9b0e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f633ce8d-9110-4355-bbfd-804c1dc9438f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f633ce8d-9110-4355-bbfd-804c1dc9438f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_20-12-2021_11651.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f633ce8d-9110-4355-bbfd-804c1dc9438f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a7b7687-a810-4810-8580-7004d2c75015> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a7b7687-a810-4810-8580-7004d2c75015";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_21-03-2022_12060.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a7b7687-a810-4810-8580-7004d2c75015>.
+    
+<http://data.lblod.info/id/remote-data-objects/a75fcf87-ed3f-40c5-851e-b19dcb89dd86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a75fcf87-ed3f-40c5-851e-b19dcb89dd86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_25-10-2021_10983.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6be67ae6-f7f8-44ad-a3ba-980a26386578> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a75fcf87-ed3f-40c5-851e-b19dcb89dd86>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201516-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201516-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201516-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201516-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/221faf05-7684-4504-8822-e09138bac675> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "221faf05-7684-4504-8822-e09138bac675";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5f7f52e4-3f24-4d6e-878e-73b876983d12";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6b08c50f-6303-45d2-92df-7c4ffc7dce9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6b08c50f-6303-45d2-92df-7c4ffc7dce9c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12>.
+
+  <http://redpencil.data.gift/id/task/e74382a1-06f5-496d-b5d7-186dab57faba> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e74382a1-06f5-496d-b5d7-186dab57faba";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/221faf05-7684-4504-8822-e09138bac675>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6b08c50f-6303-45d2-92df-7c4ffc7dce9c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/65a06a92-dacf-470c-8f4f-a1051835730e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65a06a92-dacf-470c-8f4f-a1051835730e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_25-10-2021_11039.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65a06a92-dacf-470c-8f4f-a1051835730e>.
+    
+<http://data.lblod.info/id/remote-data-objects/99197188-bce6-485d-874c-4aa777e649a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99197188-bce6-485d-874c-4aa777e649a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_25-10-2021_11344.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99197188-bce6-485d-874c-4aa777e649a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/03c3464e-6ee8-4faf-8c1f-ba36ece86a4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03c3464e-6ee8-4faf-8c1f-ba36ece86a4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_25-10-2021_11387.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03c3464e-6ee8-4faf-8c1f-ba36ece86a4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b8103dc-138c-4377-be74-c7ab56675be4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b8103dc-138c-4377-be74-c7ab56675be4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_25-10-2021_11388.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b8103dc-138c-4377-be74-c7ab56675be4>.
+    
+<http://data.lblod.info/id/remote-data-objects/93b5dc6a-9539-48e1-ae1e-8a79f19e6de1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93b5dc6a-9539-48e1-ae1e-8a79f19e6de1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_25-10-2021_11389.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93b5dc6a-9539-48e1-ae1e-8a79f19e6de1>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b0c8325-bc91-43a6-b76d-bfae9066f930> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b0c8325-bc91-43a6-b76d-bfae9066f930";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_25-10-2021_11390.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b0c8325-bc91-43a6-b76d-bfae9066f930>.
+    
+<http://data.lblod.info/id/remote-data-objects/37ba6931-82b7-467a-9b25-6995532d856d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37ba6931-82b7-467a-9b25-6995532d856d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_25-10-2021_11391.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37ba6931-82b7-467a-9b25-6995532d856d>.
+    
+<http://data.lblod.info/id/remote-data-objects/62380cc0-c67a-4c13-83e5-93bee46362be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62380cc0-c67a-4c13-83e5-93bee46362be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_25-10-2021_11392.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62380cc0-c67a-4c13-83e5-93bee46362be>.
+    
+<http://data.lblod.info/id/remote-data-objects/1336c91d-7e41-4b10-b6b3-d815d0fb3844> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1336c91d-7e41-4b10-b6b3-d815d0fb3844";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_25-10-2021_11426.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1336c91d-7e41-4b10-b6b3-d815d0fb3844>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd2ee5fa-14dc-4fe9-9bc0-84d10377689a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd2ee5fa-14dc-4fe9-9bc0-84d10377689a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_27-06-2022_12375.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd2ee5fa-14dc-4fe9-9bc0-84d10377689a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4185f41c-a6ba-4c90-b49f-651fe1d5d840> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4185f41c-a6ba-4c90-b49f-651fe1d5d840";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_27-06-2022_12376.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4185f41c-a6ba-4c90-b49f-651fe1d5d840>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebc7edf7-aa5f-4071-be98-b455e1fd018c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebc7edf7-aa5f-4071-be98-b455e1fd018c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_27-06-2022_12562.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebc7edf7-aa5f-4071-be98-b455e1fd018c>.
+    
+<http://data.lblod.info/id/remote-data-objects/495ecc48-8375-4664-93ff-a7d333118abe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "495ecc48-8375-4664-93ff-a7d333118abe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_27-06-2022_12572.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/495ecc48-8375-4664-93ff-a7d333118abe>.
+    
+<http://data.lblod.info/id/remote-data-objects/9070420a-cdb5-4abd-ab74-f16e817fc3ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9070420a-cdb5-4abd-ab74-f16e817fc3ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_27-06-2022_12575.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9070420a-cdb5-4abd-ab74-f16e817fc3ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fcdf9da-12ce-463a-8189-f2b939597ff4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fcdf9da-12ce-463a-8189-f2b939597ff4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_27-06-2022_12578.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fcdf9da-12ce-463a-8189-f2b939597ff4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c76edbf-cf7b-437d-9f5d-15ceaaa312f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c76edbf-cf7b-437d-9f5d-15ceaaa312f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_27-06-2022_12579.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c76edbf-cf7b-437d-9f5d-15ceaaa312f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f51e23d-62d4-4b08-ade5-92db451df582> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f51e23d-62d4-4b08-ade5-92db451df582";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_27-06-2022_12580.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f51e23d-62d4-4b08-ade5-92db451df582>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d85f441-735d-400a-9996-6ac417f2a586> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d85f441-735d-400a-9996-6ac417f2a586";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_27-06-2022_12632.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d85f441-735d-400a-9996-6ac417f2a586>.
+    
+<http://data.lblod.info/id/remote-data-objects/a23cf110-38df-41b4-ad75-4eb44ea30467> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a23cf110-38df-41b4-ad75-4eb44ea30467";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_28-02-2022_11957.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a23cf110-38df-41b4-ad75-4eb44ea30467>.
+    
+<http://data.lblod.info/id/remote-data-objects/e89e9960-ac85-49d3-a233-ff068f9533a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e89e9960-ac85-49d3-a233-ff068f9533a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_29-11-2021_11424.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e89e9960-ac85-49d3-a233-ff068f9533a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a199167b-825a-40d3-a4b8-1a5341c1959d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a199167b-825a-40d3-a4b8-1a5341c1959d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_29-11-2021_11535.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a199167b-825a-40d3-a4b8-1a5341c1959d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b17a1dfa-ff05-441f-8822-018a36e8b925> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b17a1dfa-ff05-441f-8822-018a36e8b925";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_29-11-2021_11536.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b17a1dfa-ff05-441f-8822-018a36e8b925>.
+    
+<http://data.lblod.info/id/remote-data-objects/66ad83e9-1985-4749-8404-f21f4732a0e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66ad83e9-1985-4749-8404-f21f4732a0e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_30-05-2022_12235.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66ad83e9-1985-4749-8404-f21f4732a0e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f37401db-3864-44ca-ae25-cfa6f3d7a3be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f37401db-3864-44ca-ae25-cfa6f3d7a3be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_30-05-2022_12236.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f37401db-3864-44ca-ae25-cfa6f3d7a3be>.
+    
+<http://data.lblod.info/id/remote-data-objects/64395919-9a66-495e-9211-63016095b75a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64395919-9a66-495e-9211-63016095b75a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_30-05-2022_12274.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64395919-9a66-495e-9211-63016095b75a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c0427ae-e712-49e8-ba03-da95ea29d780> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c0427ae-e712-49e8-ba03-da95ea29d780";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_30-05-2022_12409.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c0427ae-e712-49e8-ba03-da95ea29d780>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7437aa4-14a3-4922-95ef-9299c152df56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7437aa4-14a3-4922-95ef-9299c152df56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_30-05-2022_12446.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7437aa4-14a3-4922-95ef-9299c152df56>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad466643-775b-456d-a7da-d690ae5e8b6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad466643-775b-456d-a7da-d690ae5e8b6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_30-05-2022_12447.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad466643-775b-456d-a7da-d690ae5e8b6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/507db3de-4b3a-4298-be61-7add9fd3d7cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "507db3de-4b3a-4298-be61-7add9fd3d7cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_30-05-2022_12448.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/507db3de-4b3a-4298-be61-7add9fd3d7cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/79af66e8-7f5f-4daa-b867-55ee7e2bd6bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79af66e8-7f5f-4daa-b867-55ee7e2bd6bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/38b03b31e20e15ab6c843ede4750e2e247ba18b7de69692baa6dbc728ee1bbd2/GetPublication?filename=Uittreksels_31-01-2022_11843.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79af66e8-7f5f-4daa-b867-55ee7e2bd6bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/499a35b3-626d-4565-83cc-a14389935745> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "499a35b3-626d-4565-83cc-a14389935745";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/a8df84267d702e15a0ba2debabfe4679c787f8a71d14207765f29068bea524cb/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/499a35b3-626d-4565-83cc-a14389935745>.
+    
+<http://data.lblod.info/id/remote-data-objects/96605676-c15a-4e4a-b189-a88f9f75409f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96605676-c15a-4e4a-b189-a88f9f75409f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/a8df84267d702e15a0ba2debabfe4679c787f8a71d14207765f29068bea524cb/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96605676-c15a-4e4a-b189-a88f9f75409f>.
+    
+<http://data.lblod.info/id/remote-data-objects/09aedf5d-a9df-4a3c-9ced-8e94ad11e350> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09aedf5d-a9df-4a3c-9ced-8e94ad11e350";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/a8df84267d702e15a0ba2debabfe4679c787f8a71d14207765f29068bea524cb/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09aedf5d-a9df-4a3c-9ced-8e94ad11e350>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c04d3a0-7459-4d00-842c-05665fe0dcae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c04d3a0-7459-4d00-842c-05665fe0dcae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/a8df84267d702e15a0ba2debabfe4679c787f8a71d14207765f29068bea524cb/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c04d3a0-7459-4d00-842c-05665fe0dcae>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb1a52b4-3415-4adc-bc4a-e1eca40f6a8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb1a52b4-3415-4adc-bc4a-e1eca40f6a8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/a8df84267d702e15a0ba2debabfe4679c787f8a71d14207765f29068bea524cb/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb1a52b4-3415-4adc-bc4a-e1eca40f6a8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bde0a862-9cc0-411f-be8d-37aa8bc70b01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bde0a862-9cc0-411f-be8d-37aa8bc70b01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/a8df84267d702e15a0ba2debabfe4679c787f8a71d14207765f29068bea524cb/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bde0a862-9cc0-411f-be8d-37aa8bc70b01>.
+    
+<http://data.lblod.info/id/remote-data-objects/32f801e6-42b9-4027-b10a-51fa3df44479> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32f801e6-42b9-4027-b10a-51fa3df44479";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/a8df84267d702e15a0ba2debabfe4679c787f8a71d14207765f29068bea524cb/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32f801e6-42b9-4027-b10a-51fa3df44479>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e56135d-3582-44f7-97d8-c4490f63c161> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e56135d-3582-44f7-97d8-c4490f63c161";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/a8df84267d702e15a0ba2debabfe4679c787f8a71d14207765f29068bea524cb/GetPublication?filename=Uittreksels_20-12-2021_11601.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e56135d-3582-44f7-97d8-c4490f63c161>.
+    
+<http://data.lblod.info/id/remote-data-objects/79371a62-e60a-48d8-a9a9-5041dffc84a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79371a62-e60a-48d8-a9a9-5041dffc84a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/a8df84267d702e15a0ba2debabfe4679c787f8a71d14207765f29068bea524cb/GetPublication?filename=Uittreksels_20-12-2021_11681.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79371a62-e60a-48d8-a9a9-5041dffc84a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf652201-f1c9-4860-a073-a222cd995eed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf652201-f1c9-4860-a073-a222cd995eed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/a8df84267d702e15a0ba2debabfe4679c787f8a71d14207765f29068bea524cb/GetPublication?filename=Uittreksels_20-12-2021_11682.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf652201-f1c9-4860-a073-a222cd995eed>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5904a1e-61a7-40be-9530-f730f08ea088> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5904a1e-61a7-40be-9530-f730f08ea088";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/a8df84267d702e15a0ba2debabfe4679c787f8a71d14207765f29068bea524cb/GetPublication?filename=Uittreksels_27-06-2022_12377.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5904a1e-61a7-40be-9530-f730f08ea088>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0b422e1-b971-407b-bed3-480a661ef7f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0b422e1-b971-407b-bed3-480a661ef7f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/a8df84267d702e15a0ba2debabfe4679c787f8a71d14207765f29068bea524cb/GetPublication?filename=Uittreksels_28-02-2022_11953.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0b422e1-b971-407b-bed3-480a661ef7f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/651a6787-625b-4808-a490-b6101c3186ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "651a6787-625b-4808-a490-b6101c3186ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/a8df84267d702e15a0ba2debabfe4679c787f8a71d14207765f29068bea524cb/GetPublication?filename=Uittreksels_28-02-2022_11958.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/651a6787-625b-4808-a490-b6101c3186ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/a94460bb-e305-4cb3-97e2-a6c4abe00c7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a94460bb-e305-4cb3-97e2-a6c4abe00c7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lierde.be/LBLODWeb/Home/Overzicht/a8df84267d702e15a0ba2debabfe4679c787f8a71d14207765f29068bea524cb/GetPublication?filename=Uittreksels_29-11-2021_11537.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a94460bb-e305-4cb3-97e2-a6c4abe00c7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f11ee11a-6aeb-4200-ad94-a52fdc583adf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f11ee11a-6aeb-4200-ad94-a52fdc583adf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=Agenda_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f11ee11a-6aeb-4200-ad94-a52fdc583adf>.
+    
+<http://data.lblod.info/id/remote-data-objects/49d9ba6f-2553-4c30-b465-377d9bbdf62f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49d9ba6f-2553-4c30-b465-377d9bbdf62f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=Agenda_Gemeenteraad_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49d9ba6f-2553-4c30-b465-377d9bbdf62f>.
+    
+<http://data.lblod.info/id/remote-data-objects/69cf0a14-4ebe-49d3-86bf-feae1622c3c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69cf0a14-4ebe-49d3-86bf-feae1622c3c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=Agenda_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69cf0a14-4ebe-49d3-86bf-feae1622c3c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7eb5b980-6537-43ef-9ed8-70acee4975a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7eb5b980-6537-43ef-9ed8-70acee4975a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=Agenda_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7eb5b980-6537-43ef-9ed8-70acee4975a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6b798cf-20a3-4834-8946-b23ce2620a9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6b798cf-20a3-4834-8946-b23ce2620a9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=BesluitenLijst_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6b798cf-20a3-4834-8946-b23ce2620a9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f560d98-b98e-426b-a3b0-f8e409103e16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f560d98-b98e-426b-a3b0-f8e409103e16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5f7f52e4-3f24-4d6e-878e-73b876983d12> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f560d98-b98e-426b-a3b0-f8e409103e16>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201518-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201518-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201518-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201518-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/64fe792c-a004-4809-abe2-1846f2047cae> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "64fe792c-a004-4809-abe2-1846f2047cae";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "323d47c5-3c93-46a3-afaa-246841f94f52";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e5116e64-f361-4a3e-86f2-1c05c3f6f08c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e5116e64-f361-4a3e-86f2-1c05c3f6f08c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52>.
+
+  <http://redpencil.data.gift/id/task/e3822003-6c79-4f83-93f0-5f3d771ad2a3> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e3822003-6c79-4f83-93f0-5f3d771ad2a3";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/64fe792c-a004-4809-abe2-1846f2047cae>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e5116e64-f361-4a3e-86f2-1c05c3f6f08c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/248bd038-a2a4-4be0-8dac-e2412443927a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "248bd038-a2a4-4be0-8dac-e2412443927a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/248bd038-a2a4-4be0-8dac-e2412443927a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2632486-e672-4cd9-bf03-25b898cb9a2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2632486-e672-4cd9-bf03-25b898cb9a2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2632486-e672-4cd9-bf03-25b898cb9a2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2298a6b-760d-4edd-81e2-9e22d64b819d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2298a6b-760d-4edd-81e2-9e22d64b819d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=Notulen_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2298a6b-760d-4edd-81e2-9e22d64b819d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8bda2cc-2019-4a07-ba27-84aeb581438b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8bda2cc-2019-4a07-ba27-84aeb581438b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=Notulen_Gemeenteraad_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8bda2cc-2019-4a07-ba27-84aeb581438b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f5c5118-b9c0-4c6b-bc1b-d8b97aa26250> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f5c5118-b9c0-4c6b-bc1b-d8b97aa26250";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=Notulen_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f5c5118-b9c0-4c6b-bc1b-d8b97aa26250>.
+    
+<http://data.lblod.info/id/remote-data-objects/d17d12fa-cc90-498e-b33a-509976c534e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d17d12fa-cc90-498e-b33a-509976c534e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=Notulen_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d17d12fa-cc90-498e-b33a-509976c534e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b2ef869-c482-4232-8944-1edf751c1e51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b2ef869-c482-4232-8944-1edf751c1e51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=Uittreksels_16-12-2021_8102.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b2ef869-c482-4232-8944-1edf751c1e51>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1564767-a923-4767-9476-53de9727f9ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1564767-a923-4767-9476-53de9727f9ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=Uittreksels_16-12-2021_8279.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1564767-a923-4767-9476-53de9727f9ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fca19b3-ad8f-42a9-afc3-ade66cc2ae9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fca19b3-ad8f-42a9-afc3-ade66cc2ae9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=Uittreksels_16-12-2021_8414.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fca19b3-ad8f-42a9-afc3-ade66cc2ae9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/173e735f-109f-423e-9e73-18a5f90276e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "173e735f-109f-423e-9e73-18a5f90276e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=Uittreksels_16-12-2021_8423.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/173e735f-109f-423e-9e73-18a5f90276e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb3d6d26-bd87-4d9b-b8df-f5e648f8078c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb3d6d26-bd87-4d9b-b8df-f5e648f8078c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=Uittreksels_16-12-2021_8424.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb3d6d26-bd87-4d9b-b8df-f5e648f8078c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e62a56b9-7c66-4a70-a4c5-d15135b07b27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e62a56b9-7c66-4a70-a4c5-d15135b07b27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/2f26f14419ccf13cd6aff58f31a1ce518489b17ee5d8066bb6f0586510399c02/GetPublication?filename=Uittreksels_23-06-2022_9639.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e62a56b9-7c66-4a70-a4c5-d15135b07b27>.
+    
+<http://data.lblod.info/id/remote-data-objects/22751046-3a0e-40fc-bb5f-9ab4ab28b26f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22751046-3a0e-40fc-bb5f-9ab4ab28b26f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22751046-3a0e-40fc-bb5f-9ab4ab28b26f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d48e85a-9c54-4f50-8e72-6d69a98d9a8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d48e85a-9c54-4f50-8e72-6d69a98d9a8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d48e85a-9c54-4f50-8e72-6d69a98d9a8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d377e840-17c2-4c88-a49a-a00338333795> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d377e840-17c2-4c88-a49a-a00338333795";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d377e840-17c2-4c88-a49a-a00338333795>.
+    
+<http://data.lblod.info/id/remote-data-objects/566aeab4-4566-4f1c-bd2e-04de318600bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "566aeab4-4566-4f1c-bd2e-04de318600bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/566aeab4-4566-4f1c-bd2e-04de318600bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/76088563-d6cf-4229-9864-818ec5e4267d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76088563-d6cf-4229-9864-818ec5e4267d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76088563-d6cf-4229-9864-818ec5e4267d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c98ae8c9-2747-4221-81c5-af8a50c2123f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c98ae8c9-2747-4221-81c5-af8a50c2123f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c98ae8c9-2747-4221-81c5-af8a50c2123f>.
+    
+<http://data.lblod.info/id/remote-data-objects/52feb64e-6ade-4b8e-b5ac-9b15d7c126a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52feb64e-6ade-4b8e-b5ac-9b15d7c126a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52feb64e-6ade-4b8e-b5ac-9b15d7c126a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/89eea99d-accd-49cc-8130-1379aeaa92dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89eea99d-accd-49cc-8130-1379aeaa92dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89eea99d-accd-49cc-8130-1379aeaa92dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/539d3541-2dc8-4c0a-8446-56251a0a4497> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "539d3541-2dc8-4c0a-8446-56251a0a4497";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/539d3541-2dc8-4c0a-8446-56251a0a4497>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e2cfe56-62f5-4c57-b749-848e3a504dc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e2cfe56-62f5-4c57-b749-848e3a504dc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e2cfe56-62f5-4c57-b749-848e3a504dc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3644bfb-6df5-423b-87b4-1e190132e16f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3644bfb-6df5-423b-87b4-1e190132e16f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3644bfb-6df5-423b-87b4-1e190132e16f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e13b9995-0b16-4503-bdc0-a95e17ccd59f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e13b9995-0b16-4503-bdc0-a95e17ccd59f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e13b9995-0b16-4503-bdc0-a95e17ccd59f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5661d4b-a98a-4c82-9e9f-bf940da40385> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5661d4b-a98a-4c82-9e9f-bf940da40385";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5661d4b-a98a-4c82-9e9f-bf940da40385>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fec65cd-9ea3-48cf-a4b5-48adfe9c351d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fec65cd-9ea3-48cf-a4b5-48adfe9c351d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fec65cd-9ea3-48cf-a4b5-48adfe9c351d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5db2f5f-ea1a-4a0c-a08f-7288b6d304a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5db2f5f-ea1a-4a0c-a08f-7288b6d304a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5db2f5f-ea1a-4a0c-a08f-7288b6d304a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3a4bdb4-c40a-4d6c-8145-b38824eaee8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3a4bdb4-c40a-4d6c-8145-b38824eaee8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3a4bdb4-c40a-4d6c-8145-b38824eaee8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f83dcde0-8bc1-4499-af49-f5c60e88ce53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f83dcde0-8bc1-4499-af49-f5c60e88ce53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f83dcde0-8bc1-4499-af49-f5c60e88ce53>.
+    
+<http://data.lblod.info/id/remote-data-objects/77c7a7e2-9259-4f54-bd36-014b5a08980f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77c7a7e2-9259-4f54-bd36-014b5a08980f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77c7a7e2-9259-4f54-bd36-014b5a08980f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a49567a4-2c81-4ba8-8d6b-98f6b116330c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a49567a4-2c81-4ba8-8d6b-98f6b116330c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a49567a4-2c81-4ba8-8d6b-98f6b116330c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9d9fc08-e0e4-4d03-8d3d-b6a512525377> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9d9fc08-e0e4-4d03-8d3d-b6a512525377";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9d9fc08-e0e4-4d03-8d3d-b6a512525377>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f27ea20-065f-4fff-9a9c-b72e2dbb4866> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f27ea20-065f-4fff-9a9c-b72e2dbb4866";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f27ea20-065f-4fff-9a9c-b72e2dbb4866>.
+    
+<http://data.lblod.info/id/remote-data-objects/81f7892c-a9a6-43b0-8788-ac5dc5778e1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81f7892c-a9a6-43b0-8788-ac5dc5778e1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81f7892c-a9a6-43b0-8788-ac5dc5778e1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/30ec9904-cbab-42e1-83c3-31f9618008fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30ec9904-cbab-42e1-83c3-31f9618008fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30ec9904-cbab-42e1-83c3-31f9618008fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/51e630ae-260f-4d6f-b6a7-7837c3820ed5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51e630ae-260f-4d6f-b6a7-7837c3820ed5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51e630ae-260f-4d6f-b6a7-7837c3820ed5>.
+    
+<http://data.lblod.info/id/remote-data-objects/28834647-86b8-40c1-9afc-00e83b704fad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28834647-86b8-40c1-9afc-00e83b704fad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28834647-86b8-40c1-9afc-00e83b704fad>.
+    
+<http://data.lblod.info/id/remote-data-objects/a161d94c-ae9a-485e-8202-0a3a8394a916> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a161d94c-ae9a-485e-8202-0a3a8394a916";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a161d94c-ae9a-485e-8202-0a3a8394a916>.
+    
+<http://data.lblod.info/id/remote-data-objects/7268989e-06ee-4af9-9449-959eea0cb696> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7268989e-06ee-4af9-9449-959eea0cb696";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7268989e-06ee-4af9-9449-959eea0cb696>.
+    
+<http://data.lblod.info/id/remote-data-objects/46a54583-d102-4b9e-b76a-980a1363fc61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46a54583-d102-4b9e-b76a-980a1363fc61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijst_Vast%20bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46a54583-d102-4b9e-b76a-980a1363fc61>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d41ec8f-7ad3-47c3-be19-a23b5a4718c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d41ec8f-7ad3-47c3-be19-a23b5a4718c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d41ec8f-7ad3-47c3-be19-a23b5a4718c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0604dc9-0350-41ac-af9a-39176133fe85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0604dc9-0350-41ac-af9a-39176133fe85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0604dc9-0350-41ac-af9a-39176133fe85>.
+    
+<http://data.lblod.info/id/remote-data-objects/8452221d-4e14-4de4-9a08-a5da164b8f97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8452221d-4e14-4de4-9a08-a5da164b8f97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/3396c990-9f8e-4ed7-a1da-b12630e947a4/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8452221d-4e14-4de4-9a08-a5da164b8f97>.
+    
+<http://data.lblod.info/id/remote-data-objects/3eac1626-fe03-4409-ab53-d92392e53923> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3eac1626-fe03-4409-ab53-d92392e53923";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/430857ac126dd1195951f6c85402cd409b2993b3dfcb9199dd40343fa57ef3d1/GetPublication?filename=Agenda_OCMW-Raad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3eac1626-fe03-4409-ab53-d92392e53923>.
+    
+<http://data.lblod.info/id/remote-data-objects/34489796-6592-4e98-b61f-2db3649168b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34489796-6592-4e98-b61f-2db3649168b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/430857ac126dd1195951f6c85402cd409b2993b3dfcb9199dd40343fa57ef3d1/GetPublication?filename=Agenda_OCMW-Raad_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34489796-6592-4e98-b61f-2db3649168b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b721bdb-bd0a-4053-a4aa-01e4986992bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b721bdb-bd0a-4053-a4aa-01e4986992bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/430857ac126dd1195951f6c85402cd409b2993b3dfcb9199dd40343fa57ef3d1/GetPublication?filename=Agenda_OCMW-Raad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b721bdb-bd0a-4053-a4aa-01e4986992bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/87f23348-277b-4e21-91bd-a2ca74419291> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87f23348-277b-4e21-91bd-a2ca74419291";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/430857ac126dd1195951f6c85402cd409b2993b3dfcb9199dd40343fa57ef3d1/GetPublication?filename=Agenda_OCMW-Raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87f23348-277b-4e21-91bd-a2ca74419291>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a277790-ad9c-4f46-8d2a-2dabb9d4491e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a277790-ad9c-4f46-8d2a-2dabb9d4491e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/430857ac126dd1195951f6c85402cd409b2993b3dfcb9199dd40343fa57ef3d1/GetPublication?filename=BesluitenLijst_OCMW-Raad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a277790-ad9c-4f46-8d2a-2dabb9d4491e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6634587c-160f-45c1-97f0-9ed19fe2710f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6634587c-160f-45c1-97f0-9ed19fe2710f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/430857ac126dd1195951f6c85402cd409b2993b3dfcb9199dd40343fa57ef3d1/GetPublication?filename=BesluitenLijst_OCMW-Raad_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6634587c-160f-45c1-97f0-9ed19fe2710f>.
+    
+<http://data.lblod.info/id/remote-data-objects/aac06a59-cf90-4b3a-93f4-940f31c760b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aac06a59-cf90-4b3a-93f4-940f31c760b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/430857ac126dd1195951f6c85402cd409b2993b3dfcb9199dd40343fa57ef3d1/GetPublication?filename=BesluitenLijst_OCMW-Raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/323d47c5-3c93-46a3-afaa-246841f94f52> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aac06a59-cf90-4b3a-93f4-940f31c760b4>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201519-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201519-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201519-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201519-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d513f69b-c8e0-4d94-b5c1-a6d2a721164e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d513f69b-c8e0-4d94-b5c1-a6d2a721164e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ce6cba26-93b8-450a-a392-35a147b650f0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/33dd46d9-3be0-41a0-8658-072be40b08c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "33dd46d9-3be0-41a0-8658-072be40b08c4";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0>.
+
+  <http://redpencil.data.gift/id/task/8b918902-17f7-4fef-8b1f-edc15f1fbb2a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8b918902-17f7-4fef-8b1f-edc15f1fbb2a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d513f69b-c8e0-4d94-b5c1-a6d2a721164e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/33dd46d9-3be0-41a0-8658-072be40b08c4>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/9b2f9955-2bbd-4e7e-a463-f93c92d10f2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b2f9955-2bbd-4e7e-a463-f93c92d10f2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/430857ac126dd1195951f6c85402cd409b2993b3dfcb9199dd40343fa57ef3d1/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b2f9955-2bbd-4e7e-a463-f93c92d10f2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2dd243ee-2a88-4f4d-91a4-8a8d70d8806e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2dd243ee-2a88-4f4d-91a4-8a8d70d8806e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/430857ac126dd1195951f6c85402cd409b2993b3dfcb9199dd40343fa57ef3d1/GetPublication?filename=Notulen_OCMW-Raad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2dd243ee-2a88-4f4d-91a4-8a8d70d8806e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ab6de84-e0ad-45c9-ad23-a2deff314159> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ab6de84-e0ad-45c9-ad23-a2deff314159";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/430857ac126dd1195951f6c85402cd409b2993b3dfcb9199dd40343fa57ef3d1/GetPublication?filename=Notulen_OCMW-Raad_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ab6de84-e0ad-45c9-ad23-a2deff314159>.
+    
+<http://data.lblod.info/id/remote-data-objects/68848b4b-598b-4869-90dc-fb950e0e0efd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68848b4b-598b-4869-90dc-fb950e0e0efd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/430857ac126dd1195951f6c85402cd409b2993b3dfcb9199dd40343fa57ef3d1/GetPublication?filename=Notulen_OCMW-Raad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68848b4b-598b-4869-90dc-fb950e0e0efd>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f607a5c-d652-4e84-a47b-add173a6c052> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f607a5c-d652-4e84-a47b-add173a6c052";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/430857ac126dd1195951f6c85402cd409b2993b3dfcb9199dd40343fa57ef3d1/GetPublication?filename=Notulen_OCMW-Raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f607a5c-d652-4e84-a47b-add173a6c052>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6d191d1-ea25-4ac7-86e0-9c420b4b92ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6d191d1-ea25-4ac7-86e0-9c420b4b92ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/430857ac126dd1195951f6c85402cd409b2993b3dfcb9199dd40343fa57ef3d1/GetPublication?filename=Uittreksels_16-12-2021_8431.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6d191d1-ea25-4ac7-86e0-9c420b4b92ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/75b64dd6-4e6d-47f2-94e9-2e17e420901a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75b64dd6-4e6d-47f2-94e9-2e17e420901a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/430857ac126dd1195951f6c85402cd409b2993b3dfcb9199dd40343fa57ef3d1/GetPublication?filename=Uittreksels_23-06-2022_9645.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75b64dd6-4e6d-47f2-94e9-2e17e420901a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc457864-47b1-4ad6-a2f6-c06c22763593> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc457864-47b1-4ad6-a2f6-c06c22763593";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc457864-47b1-4ad6-a2f6-c06c22763593>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1906019-3f2a-4658-93a3-b8ced1df6817> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1906019-3f2a-4658-93a3-b8ced1df6817";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1906019-3f2a-4658-93a3-b8ced1df6817>.
+    
+<http://data.lblod.info/id/remote-data-objects/6553e0eb-6129-484f-9b75-50af8f2e83b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6553e0eb-6129-484f-9b75-50af8f2e83b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6553e0eb-6129-484f-9b75-50af8f2e83b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/99456f76-169c-4bab-bc1a-dba880788377> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99456f76-169c-4bab-bc1a-dba880788377";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99456f76-169c-4bab-bc1a-dba880788377>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1f78ab8-fd08-4d51-91cc-cf1a8f036fe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1f78ab8-fd08-4d51-91cc-cf1a8f036fe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1f78ab8-fd08-4d51-91cc-cf1a8f036fe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/2663f832-0edd-4022-a7d6-99f5ccae828d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2663f832-0edd-4022-a7d6-99f5ccae828d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2663f832-0edd-4022-a7d6-99f5ccae828d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e71e68a7-6de5-4f13-9d68-d90b5d0eeae1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e71e68a7-6de5-4f13-9d68-d90b5d0eeae1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e71e68a7-6de5-4f13-9d68-d90b5d0eeae1>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc90e8c3-e142-431c-91f6-6ca4682ff0a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc90e8c3-e142-431c-91f6-6ca4682ff0a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc90e8c3-e142-431c-91f6-6ca4682ff0a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d764f13-1cbf-4773-9f2a-c1c12d2ad65a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d764f13-1cbf-4773-9f2a-c1c12d2ad65a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d764f13-1cbf-4773-9f2a-c1c12d2ad65a>.
+    
+<http://data.lblod.info/id/remote-data-objects/baa0b879-d276-4ae7-bf2e-abc706793ff3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "baa0b879-d276-4ae7-bf2e-abc706793ff3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/baa0b879-d276-4ae7-bf2e-abc706793ff3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7551641-9aaa-47fd-99c4-aed103ab66d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7551641-9aaa-47fd-99c4-aed103ab66d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7551641-9aaa-47fd-99c4-aed103ab66d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/949fe7d4-87fb-43ca-8800-f75f79e51a6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "949fe7d4-87fb-43ca-8800-f75f79e51a6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/949fe7d4-87fb-43ca-8800-f75f79e51a6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dd07d47-725a-419f-a23a-166c25795be1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dd07d47-725a-419f-a23a-166c25795be1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dd07d47-725a-419f-a23a-166c25795be1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a7dbfda-9f9c-4e3c-bc3a-65632b818730> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a7dbfda-9f9c-4e3c-bc3a-65632b818730";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a7dbfda-9f9c-4e3c-bc3a-65632b818730>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c8551ef-ef4f-46d7-8c5f-7e8b106ed597> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c8551ef-ef4f-46d7-8c5f-7e8b106ed597";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c8551ef-ef4f-46d7-8c5f-7e8b106ed597>.
+    
+<http://data.lblod.info/id/remote-data-objects/717d2acb-1d37-4ebb-b11c-cb7432c06c27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "717d2acb-1d37-4ebb-b11c-cb7432c06c27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/717d2acb-1d37-4ebb-b11c-cb7432c06c27>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fc0dcaf-09b0-49ac-b965-54dfc0fd0802> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fc0dcaf-09b0-49ac-b965-54dfc0fd0802";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fc0dcaf-09b0-49ac-b965-54dfc0fd0802>.
+    
+<http://data.lblod.info/id/remote-data-objects/e34a80d2-5f01-42bd-a7d7-ae24222f36b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e34a80d2-5f01-42bd-a7d7-ae24222f36b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e34a80d2-5f01-42bd-a7d7-ae24222f36b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4784442-26ae-4ad6-8038-9fb28731aced> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4784442-26ae-4ad6-8038-9fb28731aced";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4784442-26ae-4ad6-8038-9fb28731aced>.
+    
+<http://data.lblod.info/id/remote-data-objects/523f0990-c0de-4afb-825c-c47860732e7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "523f0990-c0de-4afb-825c-c47860732e7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/523f0990-c0de-4afb-825c-c47860732e7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5219478c-eb56-4ee8-a452-334032526798> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5219478c-eb56-4ee8-a452-334032526798";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5219478c-eb56-4ee8-a452-334032526798>.
+    
+<http://data.lblod.info/id/remote-data-objects/d502189f-35a5-4d5f-b883-b8e52389e31e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d502189f-35a5-4d5f-b883-b8e52389e31e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d502189f-35a5-4d5f-b883-b8e52389e31e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bcde84c-9362-4481-9c63-492e3ee49486> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bcde84c-9362-4481-9c63-492e3ee49486";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bcde84c-9362-4481-9c63-492e3ee49486>.
+    
+<http://data.lblod.info/id/remote-data-objects/24184baf-20d7-4396-a70b-40eebc858c40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24184baf-20d7-4396-a70b-40eebc858c40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24184baf-20d7-4396-a70b-40eebc858c40>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a3ce889-48d4-4d1e-b127-0efc7059629c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a3ce889-48d4-4d1e-b127-0efc7059629c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a3ce889-48d4-4d1e-b127-0efc7059629c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a3b0dbd-0cb4-420a-9188-95d8c0b09983> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a3b0dbd-0cb4-420a-9188-95d8c0b09983";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a3b0dbd-0cb4-420a-9188-95d8c0b09983>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc7078b4-fda4-4b31-9ae0-8b64af43cd8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc7078b4-fda4-4b31-9ae0-8b64af43cd8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc7078b4-fda4-4b31-9ae0-8b64af43cd8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/15f76297-cff9-47e5-a728-b310364d258e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15f76297-cff9-47e5-a728-b310364d258e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15f76297-cff9-47e5-a728-b310364d258e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a636fdd-a378-45ff-9f62-a8a859373283> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a636fdd-a378-45ff-9f62-a8a859373283";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a636fdd-a378-45ff-9f62-a8a859373283>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6288e87-b938-47e8-a47e-3cdcdc95b07c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6288e87-b938-47e8-a47e-3cdcdc95b07c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6288e87-b938-47e8-a47e-3cdcdc95b07c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2990f777-0277-49e5-b3fa-35a59316b669> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2990f777-0277-49e5-b3fa-35a59316b669";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2990f777-0277-49e5-b3fa-35a59316b669>.
+    
+<http://data.lblod.info/id/remote-data-objects/7be83464-68f2-44fd-a9ce-95b9d2b3c44e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7be83464-68f2-44fd-a9ce-95b9d2b3c44e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7be83464-68f2-44fd-a9ce-95b9d2b3c44e>.
+    
+<http://data.lblod.info/id/remote-data-objects/11d837d6-002a-4f6d-94c2-4e92e57f712a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11d837d6-002a-4f6d-94c2-4e92e57f712a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11d837d6-002a-4f6d-94c2-4e92e57f712a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1eb180b0-b99c-4541-9e15-2fb7dab6a34c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1eb180b0-b99c-4541-9e15-2fb7dab6a34c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1eb180b0-b99c-4541-9e15-2fb7dab6a34c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa44d2bc-be05-444e-a938-b8d861eacabc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa44d2bc-be05-444e-a938-b8d861eacabc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lo-reninge.be/LBLODWeb/Home/Overzicht/c1e2d9df07d78639fadec49356c73d8343fa4288152436b4b0ceb24c8e87fbb0/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa44d2bc-be05-444e-a938-b8d861eacabc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f66365e3-ae2b-490c-b90a-3c464817e2c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f66365e3-ae2b-490c-b90a-3c464817e2c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f66365e3-ae2b-490c-b90a-3c464817e2c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/943d575d-3076-425d-92ba-8fbc80378c88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "943d575d-3076-425d-92ba-8fbc80378c88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/943d575d-3076-425d-92ba-8fbc80378c88>.
+    
+<http://data.lblod.info/id/remote-data-objects/332f8717-4927-429e-92b5-03a8c080fc32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "332f8717-4927-429e-92b5-03a8c080fc32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/332f8717-4927-429e-92b5-03a8c080fc32>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b7a46dc-489f-46c3-b18f-f8da1415f7a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b7a46dc-489f-46c3-b18f-f8da1415f7a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b7a46dc-489f-46c3-b18f-f8da1415f7a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/104f44e7-478b-4122-82ab-8b27e751bd52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "104f44e7-478b-4122-82ab-8b27e751bd52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/104f44e7-478b-4122-82ab-8b27e751bd52>.
+    
+<http://data.lblod.info/id/remote-data-objects/f320bb35-f4d1-403d-9310-a1d9643875ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f320bb35-f4d1-403d-9310-a1d9643875ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f320bb35-f4d1-403d-9310-a1d9643875ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/2abbae05-c208-4c8b-b91f-7a80fce79342> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2abbae05-c208-4c8b-b91f-7a80fce79342";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2abbae05-c208-4c8b-b91f-7a80fce79342>.
+    
+<http://data.lblod.info/id/remote-data-objects/45cceb5c-abf7-44e8-81ee-2eb15052fa5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45cceb5c-abf7-44e8-81ee-2eb15052fa5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ce6cba26-93b8-450a-a392-35a147b650f0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45cceb5c-abf7-44e8-81ee-2eb15052fa5b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201520-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201520-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201520-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201520-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/496f7390-097d-4579-b514-f3b456a20b42> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "496f7390-097d-4579-b514-f3b456a20b42";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b98524cb-cffc-45cd-b93e-fe6cdfaa076b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ac13f023-ac5c-4221-9bd8-dd2383baa20f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ac13f023-ac5c-4221-9bd8-dd2383baa20f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b>.
+
+  <http://redpencil.data.gift/id/task/c7be3d7c-a338-48d5-80ab-5bacd406fe57> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c7be3d7c-a338-48d5-80ab-5bacd406fe57";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/496f7390-097d-4579-b514-f3b456a20b42>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ac13f023-ac5c-4221-9bd8-dd2383baa20f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/17b3f182-995b-407a-8990-68a67f06e716> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17b3f182-995b-407a-8990-68a67f06e716";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17b3f182-995b-407a-8990-68a67f06e716>.
+    
+<http://data.lblod.info/id/remote-data-objects/99df776e-1353-4ca4-9569-5bb1df7e095d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99df776e-1353-4ca4-9569-5bb1df7e095d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99df776e-1353-4ca4-9569-5bb1df7e095d>.
+    
+<http://data.lblod.info/id/remote-data-objects/960b7f5c-f947-4a20-9837-a8495447a83d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "960b7f5c-f947-4a20-9837-a8495447a83d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/960b7f5c-f947-4a20-9837-a8495447a83d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5334b2f7-0cb7-490c-8a97-9fae6f148771> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5334b2f7-0cb7-490c-8a97-9fae6f148771";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5334b2f7-0cb7-490c-8a97-9fae6f148771>.
+    
+<http://data.lblod.info/id/remote-data-objects/084b5556-ef9a-4080-b14c-d35d8f644282> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "084b5556-ef9a-4080-b14c-d35d8f644282";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/084b5556-ef9a-4080-b14c-d35d8f644282>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a08bffb-efa3-4807-b204-5c61dd59682a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a08bffb-efa3-4807-b204-5c61dd59682a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a08bffb-efa3-4807-b204-5c61dd59682a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e35c140c-00ac-48ac-887c-90876638ae0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e35c140c-00ac-48ac-887c-90876638ae0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e35c140c-00ac-48ac-887c-90876638ae0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1933a14-72cf-465b-9719-d751102913b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1933a14-72cf-465b-9719-d751102913b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1933a14-72cf-465b-9719-d751102913b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7f0deb1-ccb6-4c9c-9954-ab8c921b69a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7f0deb1-ccb6-4c9c-9954-ab8c921b69a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7f0deb1-ccb6-4c9c-9954-ab8c921b69a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5dd6269-ba22-42e1-be57-e2f87ef7ec40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5dd6269-ba22-42e1-be57-e2f87ef7ec40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5dd6269-ba22-42e1-be57-e2f87ef7ec40>.
+    
+<http://data.lblod.info/id/remote-data-objects/061b2940-fd93-4ee6-adcd-6ada240b7c54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "061b2940-fd93-4ee6-adcd-6ada240b7c54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/061b2940-fd93-4ee6-adcd-6ada240b7c54>.
+    
+<http://data.lblod.info/id/remote-data-objects/7129ecd1-8072-498a-977f-cca11edbca86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7129ecd1-8072-498a-977f-cca11edbca86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7129ecd1-8072-498a-977f-cca11edbca86>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1015822-8c0f-4b04-b72f-92fead8b776c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1015822-8c0f-4b04-b72f-92fead8b776c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1015822-8c0f-4b04-b72f-92fead8b776c>.
+    
+<http://data.lblod.info/id/remote-data-objects/90627357-3396-43b9-a799-81409d327fc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90627357-3396-43b9-a799-81409d327fc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90627357-3396-43b9-a799-81409d327fc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/81a1a229-672f-4295-8308-127d48d492fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81a1a229-672f-4295-8308-127d48d492fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81a1a229-672f-4295-8308-127d48d492fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d223f95-d847-4414-97a4-20c60c0d7505> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d223f95-d847-4414-97a4-20c60c0d7505";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d223f95-d847-4414-97a4-20c60c0d7505>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4878ec2-3bf9-4f49-a99c-c7053752b7ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4878ec2-3bf9-4f49-a99c-c7053752b7ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4878ec2-3bf9-4f49-a99c-c7053752b7ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/71c72fb0-41c5-4cc1-8f35-18f5a09dd6c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71c72fb0-41c5-4cc1-8f35-18f5a09dd6c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71c72fb0-41c5-4cc1-8f35-18f5a09dd6c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f067d2cd-0adb-4894-98d6-d605d59c3e06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f067d2cd-0adb-4894-98d6-d605d59c3e06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f067d2cd-0adb-4894-98d6-d605d59c3e06>.
+    
+<http://data.lblod.info/id/remote-data-objects/537727de-8c2d-4157-a735-4483202d4021> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "537727de-8c2d-4157-a735-4483202d4021";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/537727de-8c2d-4157-a735-4483202d4021>.
+    
+<http://data.lblod.info/id/remote-data-objects/5feb798b-e799-4287-b9ef-135cedd3fecd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5feb798b-e799-4287-b9ef-135cedd3fecd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5feb798b-e799-4287-b9ef-135cedd3fecd>.
+    
+<http://data.lblod.info/id/remote-data-objects/b95cf2af-3513-4dc3-8927-163ea12fa1e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b95cf2af-3513-4dc3-8927-163ea12fa1e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b95cf2af-3513-4dc3-8927-163ea12fa1e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a136bb7-477c-40be-a85d-121ad6e49595> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a136bb7-477c-40be-a85d-121ad6e49595";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a136bb7-477c-40be-a85d-121ad6e49595>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0655dfd-2712-4b47-9f4e-2821028b80e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0655dfd-2712-4b47-9f4e-2821028b80e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0655dfd-2712-4b47-9f4e-2821028b80e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f747b7ae-dcfd-49f5-8993-b312f151e66c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f747b7ae-dcfd-49f5-8993-b312f151e66c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f747b7ae-dcfd-49f5-8993-b312f151e66c>.
+    
+<http://data.lblod.info/id/remote-data-objects/63543f89-a546-41e3-96cf-df9bc54f8ed9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63543f89-a546-41e3-96cf-df9bc54f8ed9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_26-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63543f89-a546-41e3-96cf-df9bc54f8ed9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f36b0a81-ab85-4cd6-985b-fbbdea1da1ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f36b0a81-ab85-4cd6-985b-fbbdea1da1ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f36b0a81-ab85-4cd6-985b-fbbdea1da1ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c62b66e-9ddf-49b3-922b-ca4d03778f82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c62b66e-9ddf-49b3-922b-ca4d03778f82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c62b66e-9ddf-49b3-922b-ca4d03778f82>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f216cc7-8a60-4d7e-bd49-fdb502194926> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f216cc7-8a60-4d7e-bd49-fdb502194926";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f216cc7-8a60-4d7e-bd49-fdb502194926>.
+    
+<http://data.lblod.info/id/remote-data-objects/34b943b5-9884-422e-929d-2090ef183489> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34b943b5-9884-422e-929d-2090ef183489";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34b943b5-9884-422e-929d-2090ef183489>.
+    
+<http://data.lblod.info/id/remote-data-objects/19dd4e90-baff-46cc-913b-3bdcf1b245b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19dd4e90-baff-46cc-913b-3bdcf1b245b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_03-06-2022_7602.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19dd4e90-baff-46cc-913b-3bdcf1b245b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/6590bd87-3720-4114-9482-834ff5af5bc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6590bd87-3720-4114-9482-834ff5af5bc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_04-02-2022_3390.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6590bd87-3720-4114-9482-834ff5af5bc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/01b7c25a-2fbf-4a37-9bd5-1c157d6531b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01b7c25a-2fbf-4a37-9bd5-1c157d6531b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_07-01-2022_3211.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01b7c25a-2fbf-4a37-9bd5-1c157d6531b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a5e3afd-f086-43bc-84f1-ed330cae1144> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a5e3afd-f086-43bc-84f1-ed330cae1144";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_10-06-2022_7657.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a5e3afd-f086-43bc-84f1-ed330cae1144>.
+    
+<http://data.lblod.info/id/remote-data-objects/36d23c3a-0f25-4530-8881-59e2614cab15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36d23c3a-0f25-4530-8881-59e2614cab15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_11-02-2022_3550.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36d23c3a-0f25-4530-8881-59e2614cab15>.
+    
+<http://data.lblod.info/id/remote-data-objects/42af74cf-998d-49bf-b1fd-b4c4ff8fac3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42af74cf-998d-49bf-b1fd-b4c4ff8fac3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_11-02-2022_3646.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42af74cf-998d-49bf-b1fd-b4c4ff8fac3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/360029df-35eb-4ae6-9bca-e295ed8dd281> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "360029df-35eb-4ae6-9bca-e295ed8dd281";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_11-03-2022_5208.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/360029df-35eb-4ae6-9bca-e295ed8dd281>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfed0fa5-4de6-4386-9962-0fe269b277ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfed0fa5-4de6-4386-9962-0fe269b277ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_11-03-2022_5225.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfed0fa5-4de6-4386-9962-0fe269b277ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/27211a83-39e6-46c1-bb62-9237a5c3497c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27211a83-39e6-46c1-bb62-9237a5c3497c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_13-05-2022_7183.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27211a83-39e6-46c1-bb62-9237a5c3497c>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb169285-5e3e-4180-af84-65279e7274cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb169285-5e3e-4180-af84-65279e7274cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_13-05-2022_7227.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb169285-5e3e-4180-af84-65279e7274cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a73991e-7f8e-403c-b5de-3afa371e1025> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a73991e-7f8e-403c-b5de-3afa371e1025";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_17-06-2022_7841.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a73991e-7f8e-403c-b5de-3afa371e1025>.
+    
+<http://data.lblod.info/id/remote-data-objects/358ff1cc-fe46-4130-b287-d5ae391b66b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "358ff1cc-fe46-4130-b287-d5ae391b66b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_17-06-2022_7880.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/358ff1cc-fe46-4130-b287-d5ae391b66b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/068b3719-1fd8-4719-b7d3-7040a569e0de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "068b3719-1fd8-4719-b7d3-7040a569e0de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_20-05-2022_7285.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/068b3719-1fd8-4719-b7d3-7040a569e0de>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e404b3a-4665-4bd0-bb7f-7a3018e3ed95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e404b3a-4665-4bd0-bb7f-7a3018e3ed95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_20-05-2022_7286.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e404b3a-4665-4bd0-bb7f-7a3018e3ed95>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5f708b8-b259-47e6-b951-b8a40f8d9583> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5f708b8-b259-47e6-b951-b8a40f8d9583";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_21-01-2022_3351.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5f708b8-b259-47e6-b951-b8a40f8d9583>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1859c78-af1f-4481-84e5-8b9d25a21ceb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1859c78-af1f-4481-84e5-8b9d25a21ceb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_22-04-2022_6866.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1859c78-af1f-4481-84e5-8b9d25a21ceb>.
+    
+<http://data.lblod.info/id/remote-data-objects/1eb1bd8c-a3ae-4b85-8700-0a3d26ab82f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1eb1bd8c-a3ae-4b85-8700-0a3d26ab82f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_22-04-2022_6872.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1eb1bd8c-a3ae-4b85-8700-0a3d26ab82f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee7ea1ae-4f86-4490-8fa7-b8db04f36786> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee7ea1ae-4f86-4490-8fa7-b8db04f36786";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_25-02-2022_3832.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee7ea1ae-4f86-4490-8fa7-b8db04f36786>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c1204de-fe54-4a1b-9029-605782b26f38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c1204de-fe54-4a1b-9029-605782b26f38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_25-03-2022_5291.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c1204de-fe54-4a1b-9029-605782b26f38>.
+    
+<http://data.lblod.info/id/remote-data-objects/558c1ddf-3334-4cf2-b85d-3452deb1ed4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "558c1ddf-3334-4cf2-b85d-3452deb1ed4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_25-03-2022_5303.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b98524cb-cffc-45cd-b93e-fe6cdfaa076b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/558c1ddf-3334-4cf2-b85d-3452deb1ed4c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201521-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201521-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201521-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201521-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/adc36a28-3a64-487e-b330-90ef019c4ba4> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "adc36a28-3a64-487e-b330-90ef019c4ba4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3708a6f0-cf5a-49cf-a627-ef8735e9196c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6adce8da-9fb1-4fbc-9a11-b6049f8e2855> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6adce8da-9fb1-4fbc-9a11-b6049f8e2855";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c>.
+
+  <http://redpencil.data.gift/id/task/4cb62a31-11fd-43f2-a8f7-625c1983d8b7> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4cb62a31-11fd-43f2-a8f7-625c1983d8b7";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/adc36a28-3a64-487e-b330-90ef019c4ba4>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6adce8da-9fb1-4fbc-9a11-b6049f8e2855>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/be38b07e-9f79-418e-9aaf-8078557212d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be38b07e-9f79-418e-9aaf-8078557212d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_25-03-2022_5305.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be38b07e-9f79-418e-9aaf-8078557212d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8d62164-5a24-4308-8ba9-6c8cfffec59e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8d62164-5a24-4308-8ba9-6c8cfffec59e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/2a5ca4c2e2d474d14703725ad8f35b55ba27c8cbe3938cdd1fa6a4c6656ab9c5/GetPublication?filename=Uittreksels_29-04-2022_6997.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8d62164-5a24-4308-8ba9-6c8cfffec59e>.
+    
+<http://data.lblod.info/id/remote-data-objects/324a191e-dc18-44ec-a700-081e158d471a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "324a191e-dc18-44ec-a700-081e158d471a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Agenda_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/324a191e-dc18-44ec-a700-081e158d471a>.
+    
+<http://data.lblod.info/id/remote-data-objects/809c0dba-edb2-4c75-8993-f106efcc9779> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "809c0dba-edb2-4c75-8993-f106efcc9779";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Agenda_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/809c0dba-edb2-4c75-8993-f106efcc9779>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e8290df-7802-4a93-b4d2-37c7f6e5ab57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e8290df-7802-4a93-b4d2-37c7f6e5ab57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Agenda_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e8290df-7802-4a93-b4d2-37c7f6e5ab57>.
+    
+<http://data.lblod.info/id/remote-data-objects/def16d0c-5765-4722-916c-37043051da12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "def16d0c-5765-4722-916c-37043051da12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Agenda_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/def16d0c-5765-4722-916c-37043051da12>.
+    
+<http://data.lblod.info/id/remote-data-objects/68418a5d-e9da-4ec0-8c78-fedc0b6c3843> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68418a5d-e9da-4ec0-8c78-fedc0b6c3843";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Agenda_Gemeenteraad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68418a5d-e9da-4ec0-8c78-fedc0b6c3843>.
+    
+<http://data.lblod.info/id/remote-data-objects/031ee01c-80e1-4ba1-a885-41198970652e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "031ee01c-80e1-4ba1-a885-41198970652e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Agenda_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/031ee01c-80e1-4ba1-a885-41198970652e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe75f9fb-eeb2-4e99-8981-8a4cc6079cee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe75f9fb-eeb2-4e99-8981-8a4cc6079cee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Agenda_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe75f9fb-eeb2-4e99-8981-8a4cc6079cee>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ce35b70-f9ab-407c-a6b8-12a244462298> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ce35b70-f9ab-407c-a6b8-12a244462298";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Agenda_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ce35b70-f9ab-407c-a6b8-12a244462298>.
+    
+<http://data.lblod.info/id/remote-data-objects/47d7a468-cf3e-483b-9161-2b12b5e55462> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47d7a468-cf3e-483b-9161-2b12b5e55462";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47d7a468-cf3e-483b-9161-2b12b5e55462>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2a8af31-43be-4ef3-9310-076d0c83cbb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2a8af31-43be-4ef3-9310-076d0c83cbb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2a8af31-43be-4ef3-9310-076d0c83cbb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b4c31d1-af30-4a72-a740-7f66f501e9dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b4c31d1-af30-4a72-a740-7f66f501e9dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b4c31d1-af30-4a72-a740-7f66f501e9dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/71b60bcb-0d4b-4a8f-8bf1-0c6042432466> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71b60bcb-0d4b-4a8f-8bf1-0c6042432466";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71b60bcb-0d4b-4a8f-8bf1-0c6042432466>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9751c57-a7a7-4004-9f33-dceca709adbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9751c57-a7a7-4004-9f33-dceca709adbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9751c57-a7a7-4004-9f33-dceca709adbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f2914f4-9384-47e6-a6d1-d8fb75c37368> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f2914f4-9384-47e6-a6d1-d8fb75c37368";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f2914f4-9384-47e6-a6d1-d8fb75c37368>.
+    
+<http://data.lblod.info/id/remote-data-objects/030e5c72-2ca3-4108-9bbc-d2e75bf1be6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "030e5c72-2ca3-4108-9bbc-d2e75bf1be6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/030e5c72-2ca3-4108-9bbc-d2e75bf1be6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/68f8e40e-964f-4ea9-aa4c-126a2f333800> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68f8e40e-964f-4ea9-aa4c-126a2f333800";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Notulen_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68f8e40e-964f-4ea9-aa4c-126a2f333800>.
+    
+<http://data.lblod.info/id/remote-data-objects/5066691b-c917-4781-905e-867cf94a5748> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5066691b-c917-4781-905e-867cf94a5748";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Notulen_Gemeenteraad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5066691b-c917-4781-905e-867cf94a5748>.
+    
+<http://data.lblod.info/id/remote-data-objects/f506f5d1-2257-4ff3-81fb-4132b565d424> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f506f5d1-2257-4ff3-81fb-4132b565d424";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Notulen_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f506f5d1-2257-4ff3-81fb-4132b565d424>.
+    
+<http://data.lblod.info/id/remote-data-objects/a35900be-b685-4189-9eb5-46c22c7d2d43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a35900be-b685-4189-9eb5-46c22c7d2d43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_20-12-2021_2633.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a35900be-b685-4189-9eb5-46c22c7d2d43>.
+    
+<http://data.lblod.info/id/remote-data-objects/105ed6c6-48d9-459a-9097-51af64573ab9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "105ed6c6-48d9-459a-9097-51af64573ab9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_20-12-2021_2635.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/105ed6c6-48d9-459a-9097-51af64573ab9>.
+    
+<http://data.lblod.info/id/remote-data-objects/096d1f51-ee7f-4de1-adad-de2f1c8376b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "096d1f51-ee7f-4de1-adad-de2f1c8376b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_20-12-2021_2707.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/096d1f51-ee7f-4de1-adad-de2f1c8376b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f5f266f-4747-44ac-b4ec-2b6d2cb6623d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f5f266f-4747-44ac-b4ec-2b6d2cb6623d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_20-12-2021_2710.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f5f266f-4747-44ac-b4ec-2b6d2cb6623d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2abcc02-19ec-4415-b94b-4f267897b1f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2abcc02-19ec-4415-b94b-4f267897b1f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_20-12-2021_2713.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2abcc02-19ec-4415-b94b-4f267897b1f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/136860e8-1eeb-4d59-ba07-4cfc755cbe11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "136860e8-1eeb-4d59-ba07-4cfc755cbe11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_20-12-2021_2717.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/136860e8-1eeb-4d59-ba07-4cfc755cbe11>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d4685eb-f9fe-4636-b874-2d032e3b8616> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d4685eb-f9fe-4636-b874-2d032e3b8616";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_20-12-2021_2750.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d4685eb-f9fe-4636-b874-2d032e3b8616>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee4949e7-c8f1-47a9-9adb-75cc0eb2d8c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee4949e7-c8f1-47a9-9adb-75cc0eb2d8c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_20-12-2021_2787.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee4949e7-c8f1-47a9-9adb-75cc0eb2d8c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/103ec014-3e9b-46a7-9909-6b5832770076> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "103ec014-3e9b-46a7-9909-6b5832770076";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_20-12-2021_2789.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/103ec014-3e9b-46a7-9909-6b5832770076>.
+    
+<http://data.lblod.info/id/remote-data-objects/d477abfd-5473-487f-adfa-ec61de5fde0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d477abfd-5473-487f-adfa-ec61de5fde0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_20-12-2021_2821.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d477abfd-5473-487f-adfa-ec61de5fde0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e2a2026-545a-4363-87bb-5ae790ff76c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e2a2026-545a-4363-87bb-5ae790ff76c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_23-05-2022_7136.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e2a2026-545a-4363-87bb-5ae790ff76c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/8309bbe3-917f-49ea-b03a-a718d90ef984> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8309bbe3-917f-49ea-b03a-a718d90ef984";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_25-04-2022_6739.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8309bbe3-917f-49ea-b03a-a718d90ef984>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b84cae3-46bb-41c0-96d6-6b3c09329e8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b84cae3-46bb-41c0-96d6-6b3c09329e8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_25-10-2021_1964.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b84cae3-46bb-41c0-96d6-6b3c09329e8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/75fc17f7-97d6-4960-a750-8456792d2fec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75fc17f7-97d6-4960-a750-8456792d2fec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_25-10-2021_1967.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75fc17f7-97d6-4960-a750-8456792d2fec>.
+    
+<http://data.lblod.info/id/remote-data-objects/30537635-2fe1-40ba-b5c9-3a278fb9b688> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30537635-2fe1-40ba-b5c9-3a278fb9b688";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_25-10-2021_1968.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30537635-2fe1-40ba-b5c9-3a278fb9b688>.
+    
+<http://data.lblod.info/id/remote-data-objects/018cb94f-7044-4cd4-92dd-a7e6b85a4d99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "018cb94f-7044-4cd4-92dd-a7e6b85a4d99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_25-10-2021_1969.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/018cb94f-7044-4cd4-92dd-a7e6b85a4d99>.
+    
+<http://data.lblod.info/id/remote-data-objects/132d1da0-dafc-4040-8fe1-268b196e87f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "132d1da0-dafc-4040-8fe1-268b196e87f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_27-06-2022_7454.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/132d1da0-dafc-4040-8fe1-268b196e87f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1850d3b6-e222-42d4-b761-f061dc92af51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1850d3b6-e222-42d4-b761-f061dc92af51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_27-06-2022_7455.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1850d3b6-e222-42d4-b761-f061dc92af51>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9ab20aa-1118-4fd8-993f-8a4210520ae9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9ab20aa-1118-4fd8-993f-8a4210520ae9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_27-06-2022_7456.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9ab20aa-1118-4fd8-993f-8a4210520ae9>.
+    
+<http://data.lblod.info/id/remote-data-objects/15aa3626-5ce9-483b-8be5-1c1bbfbb2662> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15aa3626-5ce9-483b-8be5-1c1bbfbb2662";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_27-06-2022_7458.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15aa3626-5ce9-483b-8be5-1c1bbfbb2662>.
+    
+<http://data.lblod.info/id/remote-data-objects/c36c6eb0-6d66-4993-868a-964c160c5bc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c36c6eb0-6d66-4993-868a-964c160c5bc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_27-06-2022_7833.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c36c6eb0-6d66-4993-868a-964c160c5bc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/abf3a334-5306-44e4-ba91-8da6ef7b0953> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abf3a334-5306-44e4-ba91-8da6ef7b0953";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-02-2022_3680.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abf3a334-5306-44e4-ba91-8da6ef7b0953>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c991348-caa4-4b8d-90ef-4f9c6276b9c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c991348-caa4-4b8d-90ef-4f9c6276b9c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-02-2022_3703.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c991348-caa4-4b8d-90ef-4f9c6276b9c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1af62de8-a1a3-4661-b09a-f071d45588d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1af62de8-a1a3-4661-b09a-f071d45588d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-02-2022_3704.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1af62de8-a1a3-4661-b09a-f071d45588d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf7f9399-4e17-44eb-95e4-36694d146580> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf7f9399-4e17-44eb-95e4-36694d146580";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-02-2022_3705.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf7f9399-4e17-44eb-95e4-36694d146580>.
+    
+<http://data.lblod.info/id/remote-data-objects/4716ea97-6111-4f7a-8e24-99811aca5a23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4716ea97-6111-4f7a-8e24-99811aca5a23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-02-2022_3706.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4716ea97-6111-4f7a-8e24-99811aca5a23>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8521dbb-e345-456a-81dd-dff46718eb09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8521dbb-e345-456a-81dd-dff46718eb09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-02-2022_3707.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8521dbb-e345-456a-81dd-dff46718eb09>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4606fc3-eef2-4193-9a59-3df8195a29a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4606fc3-eef2-4193-9a59-3df8195a29a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-02-2022_3708.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4606fc3-eef2-4193-9a59-3df8195a29a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b0255ef-3b80-4ab2-b0ed-6e95e79cff27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b0255ef-3b80-4ab2-b0ed-6e95e79cff27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-02-2022_3709.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b0255ef-3b80-4ab2-b0ed-6e95e79cff27>.
+    
+<http://data.lblod.info/id/remote-data-objects/84bb3608-1270-4788-a682-0ac24fe1d980> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84bb3608-1270-4788-a682-0ac24fe1d980";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-02-2022_3711.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3708a6f0-cf5a-49cf-a627-ef8735e9196c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84bb3608-1270-4788-a682-0ac24fe1d980>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201523-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201523-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201523-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201523-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3f101628-94ec-43b0-9495-bc6905f2acc9> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3f101628-94ec-43b0-9495-bc6905f2acc9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6ef23afb-18f0-48d1-bf41-8b39f39ca142";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/8f35655c-10b1-4d94-b015-e7cf5c55e498> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8f35655c-10b1-4d94-b015-e7cf5c55e498";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142>.
+
+  <http://redpencil.data.gift/id/task/600f62a2-d33d-4b73-9dd3-516d0cefa873> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "600f62a2-d33d-4b73-9dd3-516d0cefa873";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3f101628-94ec-43b0-9495-bc6905f2acc9>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/8f35655c-10b1-4d94-b015-e7cf5c55e498>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b9fee76b-e996-4814-8e18-65acc08f64e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9fee76b-e996-4814-8e18-65acc08f64e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-02-2022_3712.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9fee76b-e996-4814-8e18-65acc08f64e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a89382c1-4e02-4fe3-b72d-bc6eb26d119a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a89382c1-4e02-4fe3-b72d-bc6eb26d119a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-02-2022_3713.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a89382c1-4e02-4fe3-b72d-bc6eb26d119a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a93e9e74-a2da-46b0-99a3-16a0a3379e9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a93e9e74-a2da-46b0-99a3-16a0a3379e9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-02-2022_3744.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a93e9e74-a2da-46b0-99a3-16a0a3379e9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/27f11d7e-05a1-48aa-b944-06a89e1c26a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27f11d7e-05a1-48aa-b944-06a89e1c26a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-03-2022_4961.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27f11d7e-05a1-48aa-b944-06a89e1c26a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/daa66858-951c-45cc-ada4-f1fb349c2169> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "daa66858-951c-45cc-ada4-f1fb349c2169";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-03-2022_5218.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/daa66858-951c-45cc-ada4-f1fb349c2169>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6fb37df-45c4-4019-b763-761a801b2409> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6fb37df-45c4-4019-b763-761a801b2409";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-03-2022_5220.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6fb37df-45c4-4019-b763-761a801b2409>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c5cb531-0e9f-4ab8-80a9-09fdfc694e9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c5cb531-0e9f-4ab8-80a9-09fdfc694e9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-03-2022_5221.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c5cb531-0e9f-4ab8-80a9-09fdfc694e9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d6a36e2-966d-4be4-8d52-f3d5f5b10f99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d6a36e2-966d-4be4-8d52-f3d5f5b10f99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-03-2022_5222.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d6a36e2-966d-4be4-8d52-f3d5f5b10f99>.
+    
+<http://data.lblod.info/id/remote-data-objects/9bbfaf1b-1ae2-4296-9a01-0417b1cf2169> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9bbfaf1b-1ae2-4296-9a01-0417b1cf2169";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-03-2022_5233.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9bbfaf1b-1ae2-4296-9a01-0417b1cf2169>.
+    
+<http://data.lblod.info/id/remote-data-objects/21418dbf-a3cf-4da4-a775-56225953be9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21418dbf-a3cf-4da4-a775-56225953be9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/4d4541a07717e84e183b13c4400212d9dd708c2c470b0854e5631ef278d8dbf7/GetPublication?filename=Uittreksels_28-03-2022_5247.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21418dbf-a3cf-4da4-a775-56225953be9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/92e825b0-24d3-413a-99a2-e385e93e85ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92e825b0-24d3-413a-99a2-e385e93e85ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92e825b0-24d3-413a-99a2-e385e93e85ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f7766ed-76cb-4e4f-9f0c-5b2e0b55f1a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f7766ed-76cb-4e4f-9f0c-5b2e0b55f1a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f7766ed-76cb-4e4f-9f0c-5b2e0b55f1a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d0926d1-569b-408d-bfbc-7fad63f14408> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d0926d1-569b-408d-bfbc-7fad63f14408";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_03-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d0926d1-569b-408d-bfbc-7fad63f14408>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ca080c6-61ed-43d4-90c6-c5e1f1ae51af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ca080c6-61ed-43d4-90c6-c5e1f1ae51af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ca080c6-61ed-43d4-90c6-c5e1f1ae51af>.
+    
+<http://data.lblod.info/id/remote-data-objects/78f16bcf-b1dc-4c53-b023-92fe28cf9635> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78f16bcf-b1dc-4c53-b023-92fe28cf9635";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_04-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78f16bcf-b1dc-4c53-b023-92fe28cf9635>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa063931-77c4-4846-85a1-75b9b0080f8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa063931-77c4-4846-85a1-75b9b0080f8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_08-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa063931-77c4-4846-85a1-75b9b0080f8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c545a3c5-4f99-4aac-8613-ee42ab32f07d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c545a3c5-4f99-4aac-8613-ee42ab32f07d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c545a3c5-4f99-4aac-8613-ee42ab32f07d>.
+    
+<http://data.lblod.info/id/remote-data-objects/307afd13-d4d4-4642-b88b-6bed782b678d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "307afd13-d4d4-4642-b88b-6bed782b678d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_08-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/307afd13-d4d4-4642-b88b-6bed782b678d>.
+    
+<http://data.lblod.info/id/remote-data-objects/cad89b20-4849-45cc-94fe-ebd01ce4b4b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cad89b20-4849-45cc-94fe-ebd01ce4b4b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_10-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cad89b20-4849-45cc-94fe-ebd01ce4b4b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae906971-6b8f-46bb-8d47-4bc259cbbb4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae906971-6b8f-46bb-8d47-4bc259cbbb4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae906971-6b8f-46bb-8d47-4bc259cbbb4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7b81a3b-f4aa-43ae-85a8-d9ae61d0cf75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7b81a3b-f4aa-43ae-85a8-d9ae61d0cf75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_10-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7b81a3b-f4aa-43ae-85a8-d9ae61d0cf75>.
+    
+<http://data.lblod.info/id/remote-data-objects/599f51d1-a522-4a15-a51c-aab2cefba39f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "599f51d1-a522-4a15-a51c-aab2cefba39f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_11-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/599f51d1-a522-4a15-a51c-aab2cefba39f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea31487b-c111-4be6-bad8-f836f763014b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea31487b-c111-4be6-bad8-f836f763014b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_15-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea31487b-c111-4be6-bad8-f836f763014b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca968bd5-0bdf-428a-b79b-f314f4f8cccf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca968bd5-0bdf-428a-b79b-f314f4f8cccf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca968bd5-0bdf-428a-b79b-f314f4f8cccf>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b92d01f-cb96-4152-a28b-0e101e609c70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b92d01f-cb96-4152-a28b-0e101e609c70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_17-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b92d01f-cb96-4152-a28b-0e101e609c70>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ae30c77-cdda-4e40-a7bf-901206059616> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ae30c77-cdda-4e40-a7bf-901206059616";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ae30c77-cdda-4e40-a7bf-901206059616>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0c79509-22b3-49bf-8346-f0725c2eaee4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0c79509-22b3-49bf-8346-f0725c2eaee4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0c79509-22b3-49bf-8346-f0725c2eaee4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e36fb31-48d9-4169-a0a6-6da283d87d6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e36fb31-48d9-4169-a0a6-6da283d87d6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_22-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e36fb31-48d9-4169-a0a6-6da283d87d6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/19080514-f9e5-417e-b5c7-a468f8e8bc9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19080514-f9e5-417e-b5c7-a468f8e8bc9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_22-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19080514-f9e5-417e-b5c7-a468f8e8bc9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c90a544-5a61-4e92-b4e3-5daecdba2c51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c90a544-5a61-4e92-b4e3-5daecdba2c51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c90a544-5a61-4e92-b4e3-5daecdba2c51>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a67f7fe-769a-44ce-aee8-22612421efef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a67f7fe-769a-44ce-aee8-22612421efef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_25-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a67f7fe-769a-44ce-aee8-22612421efef>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d56cdab-8bec-4213-aa4a-422a80662da1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d56cdab-8bec-4213-aa4a-422a80662da1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_25-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d56cdab-8bec-4213-aa4a-422a80662da1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6369d86-6ae9-476d-a384-f695cabc1622> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6369d86-6ae9-476d-a384-f695cabc1622";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6369d86-6ae9-476d-a384-f695cabc1622>.
+    
+<http://data.lblod.info/id/remote-data-objects/dddfc213-bbe8-4b57-8011-9e6be8b55bc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dddfc213-bbe8-4b57-8011-9e6be8b55bc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dddfc213-bbe8-4b57-8011-9e6be8b55bc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f0839df-7f5a-4b4c-8116-79fedce4f547> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f0839df-7f5a-4b4c-8116-79fedce4f547";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/93fcbb091dc3a49c22556ce77a767c20de4625163e32ebf370e4c0ab3b054b90/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_29-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f0839df-7f5a-4b4c-8116-79fedce4f547>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a9db780-1ff3-4964-8bdf-e73bd99ec525> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a9db780-1ff3-4964-8bdf-e73bd99ec525";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/a96cf48774019ba29fc49b3f8b3e6cc65f68f74fe90569a4389037fb99b674f3/GetPublication?filename=Agenda_OCMW-Raad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a9db780-1ff3-4964-8bdf-e73bd99ec525>.
+    
+<http://data.lblod.info/id/remote-data-objects/b04bf546-0bc1-4403-836f-f83cb2924bc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b04bf546-0bc1-4403-836f-f83cb2924bc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/a96cf48774019ba29fc49b3f8b3e6cc65f68f74fe90569a4389037fb99b674f3/GetPublication?filename=Agenda_OCMW-Raad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b04bf546-0bc1-4403-836f-f83cb2924bc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2afe3a3-f716-474b-84f1-91d3df0547c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2afe3a3-f716-474b-84f1-91d3df0547c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/a96cf48774019ba29fc49b3f8b3e6cc65f68f74fe90569a4389037fb99b674f3/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2afe3a3-f716-474b-84f1-91d3df0547c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c0e4a03-9fd8-4f96-9f25-e7bd0f075aa8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c0e4a03-9fd8-4f96-9f25-e7bd0f075aa8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/a96cf48774019ba29fc49b3f8b3e6cc65f68f74fe90569a4389037fb99b674f3/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c0e4a03-9fd8-4f96-9f25-e7bd0f075aa8>.
+    
+<http://data.lblod.info/id/remote-data-objects/652c17f3-10bb-4221-b3f4-cc1c12e669c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "652c17f3-10bb-4221-b3f4-cc1c12e669c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/a96cf48774019ba29fc49b3f8b3e6cc65f68f74fe90569a4389037fb99b674f3/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/652c17f3-10bb-4221-b3f4-cc1c12e669c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc3872fc-014b-449a-8b59-6dfe78662c39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc3872fc-014b-449a-8b59-6dfe78662c39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/a96cf48774019ba29fc49b3f8b3e6cc65f68f74fe90569a4389037fb99b674f3/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc3872fc-014b-449a-8b59-6dfe78662c39>.
+    
+<http://data.lblod.info/id/remote-data-objects/31153bcf-6051-4163-bbdf-4d55121ec286> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31153bcf-6051-4163-bbdf-4d55121ec286";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/a96cf48774019ba29fc49b3f8b3e6cc65f68f74fe90569a4389037fb99b674f3/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31153bcf-6051-4163-bbdf-4d55121ec286>.
+    
+<http://data.lblod.info/id/remote-data-objects/b32ca8ba-88f9-4161-87ac-4d0138aec9be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b32ca8ba-88f9-4161-87ac-4d0138aec9be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/a96cf48774019ba29fc49b3f8b3e6cc65f68f74fe90569a4389037fb99b674f3/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b32ca8ba-88f9-4161-87ac-4d0138aec9be>.
+    
+<http://data.lblod.info/id/remote-data-objects/711ff486-c4db-4fe4-a24c-7dcd1dcf1cba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "711ff486-c4db-4fe4-a24c-7dcd1dcf1cba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/a96cf48774019ba29fc49b3f8b3e6cc65f68f74fe90569a4389037fb99b674f3/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/711ff486-c4db-4fe4-a24c-7dcd1dcf1cba>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea2fff3a-4d6d-4ee8-8f12-f4228b2eb65b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea2fff3a-4d6d-4ee8-8f12-f4228b2eb65b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/a96cf48774019ba29fc49b3f8b3e6cc65f68f74fe90569a4389037fb99b674f3/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea2fff3a-4d6d-4ee8-8f12-f4228b2eb65b>.
+    
+<http://data.lblod.info/id/remote-data-objects/509abfeb-519d-4003-9578-1ebb8e0803c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "509abfeb-519d-4003-9578-1ebb8e0803c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/a96cf48774019ba29fc49b3f8b3e6cc65f68f74fe90569a4389037fb99b674f3/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/509abfeb-519d-4003-9578-1ebb8e0803c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac8e243f-8642-42dc-aade-8ef89427a044> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac8e243f-8642-42dc-aade-8ef89427a044";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/a96cf48774019ba29fc49b3f8b3e6cc65f68f74fe90569a4389037fb99b674f3/GetPublication?filename=Uittreksels_25-04-2022_5056.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac8e243f-8642-42dc-aade-8ef89427a044>.
+    
+<http://data.lblod.info/id/remote-data-objects/3206d56e-0f45-417c-889a-70cdd3698490> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3206d56e-0f45-417c-889a-70cdd3698490";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/a96cf48774019ba29fc49b3f8b3e6cc65f68f74fe90569a4389037fb99b674f3/GetPublication?filename=Uittreksels_27-06-2022_7452.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3206d56e-0f45-417c-889a-70cdd3698490>.
+    
+<http://data.lblod.info/id/remote-data-objects/e212d96a-ec74-493e-b4bd-1119ce00a114> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e212d96a-ec74-493e-b4bd-1119ce00a114";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.lochristi.be/LBLODWeb/Home/Overzicht/a96cf48774019ba29fc49b3f8b3e6cc65f68f74fe90569a4389037fb99b674f3/GetPublication?filename=Uittreksels_27-06-2022_7453.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e212d96a-ec74-493e-b4bd-1119ce00a114>.
+    
+<http://data.lblod.info/id/remote-data-objects/540905c2-158d-4053-9f88-15b3ef59ba88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "540905c2-158d-4053-9f88-15b3ef59ba88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Agenda_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6ef23afb-18f0-48d1-bf41-8b39f39ca142> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/540905c2-158d-4053-9f88-15b3ef59ba88>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201524-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201524-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201524-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201524-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/4909fe13-d4ea-41dd-861c-f20a3e1abcd8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4909fe13-d4ea-41dd-861c-f20a3e1abcd8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "49e9713f-dc1c-445b-b721-3d7efaa221bb";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/3abb652f-766f-4b36-9289-1425670c1a6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3abb652f-766f-4b36-9289-1425670c1a6c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb>.
+
+  <http://redpencil.data.gift/id/task/e6c95667-e429-4a56-914e-b44aef1e837d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e6c95667-e429-4a56-914e-b44aef1e837d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/4909fe13-d4ea-41dd-861c-f20a3e1abcd8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/3abb652f-766f-4b36-9289-1425670c1a6c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d974180f-9ff9-46b2-81e2-9f1e16f29e51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d974180f-9ff9-46b2-81e2-9f1e16f29e51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Agenda_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d974180f-9ff9-46b2-81e2-9f1e16f29e51>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e192b9e-26a5-4bdb-92e6-771b4db734f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e192b9e-26a5-4bdb-92e6-771b4db734f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Agenda_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e192b9e-26a5-4bdb-92e6-771b4db734f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8b1d7ce-351c-41a5-a9a8-9088be53fa8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8b1d7ce-351c-41a5-a9a8-9088be53fa8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Agenda_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8b1d7ce-351c-41a5-a9a8-9088be53fa8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c079de23-ca4d-4ead-be15-eeaacd2be1a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c079de23-ca4d-4ead-be15-eeaacd2be1a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Agenda_Gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c079de23-ca4d-4ead-be15-eeaacd2be1a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/316f62bf-64de-4bc0-97e2-eedcfbb69002> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "316f62bf-64de-4bc0-97e2-eedcfbb69002";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Agenda_Gemeenteraad_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/316f62bf-64de-4bc0-97e2-eedcfbb69002>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5b4fb87-2f13-4957-b4ad-5de519068965> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5b4fb87-2f13-4957-b4ad-5de519068965";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Agenda_Gemeenteraad_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5b4fb87-2f13-4957-b4ad-5de519068965>.
+    
+<http://data.lblod.info/id/remote-data-objects/23863a07-58a0-42bd-830d-48375fc74a3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23863a07-58a0-42bd-830d-48375fc74a3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Agenda_Gemeenteraad_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23863a07-58a0-42bd-830d-48375fc74a3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ba97037-d900-4bc2-b045-9624204803c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ba97037-d900-4bc2-b045-9624204803c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Agenda_Gemeenteraad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ba97037-d900-4bc2-b045-9624204803c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/409185bb-588d-4561-88f3-9cbda1b5ea7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "409185bb-588d-4561-88f3-9cbda1b5ea7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/409185bb-588d-4561-88f3-9cbda1b5ea7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/609268c2-3c64-4830-b5a9-8dd79dbcb05d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "609268c2-3c64-4830-b5a9-8dd79dbcb05d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=BesluitenLijst_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/609268c2-3c64-4830-b5a9-8dd79dbcb05d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b26be2d7-6587-4704-a338-b04d8d969de1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b26be2d7-6587-4704-a338-b04d8d969de1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b26be2d7-6587-4704-a338-b04d8d969de1>.
+    
+<http://data.lblod.info/id/remote-data-objects/085a545e-bc88-434b-b4c9-0d052a2a1180> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "085a545e-bc88-434b-b4c9-0d052a2a1180";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=BesluitenLijst_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/085a545e-bc88-434b-b4c9-0d052a2a1180>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e3696ed-6e21-4324-b5cd-04c0e1d40da4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e3696ed-6e21-4324-b5cd-04c0e1d40da4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=BesluitenLijst_Gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e3696ed-6e21-4324-b5cd-04c0e1d40da4>.
+    
+<http://data.lblod.info/id/remote-data-objects/48d379a0-8102-4f45-ae9d-8fcda4617f6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48d379a0-8102-4f45-ae9d-8fcda4617f6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48d379a0-8102-4f45-ae9d-8fcda4617f6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e8a519d-03ba-464e-8097-f5f4ca3c2f68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e8a519d-03ba-464e-8097-f5f4ca3c2f68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=BesluitenLijst_Gemeenteraad_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e8a519d-03ba-464e-8097-f5f4ca3c2f68>.
+    
+<http://data.lblod.info/id/remote-data-objects/81075bf0-700a-4877-afd1-2b737dcdf0cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81075bf0-700a-4877-afd1-2b737dcdf0cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=BesluitenLijst_Gemeenteraad_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81075bf0-700a-4877-afd1-2b737dcdf0cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2f9eee6-9199-461f-8db3-74b4437c3600> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2f9eee6-9199-461f-8db3-74b4437c3600";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=BesluitenLijst_Gemeenteraad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2f9eee6-9199-461f-8db3-74b4437c3600>.
+    
+<http://data.lblod.info/id/remote-data-objects/46822a7f-a19d-4de9-9e5d-a6794a901d19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46822a7f-a19d-4de9-9e5d-a6794a901d19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Notulen_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46822a7f-a19d-4de9-9e5d-a6794a901d19>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d2bc941-3d87-4051-af60-f19492da9651> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d2bc941-3d87-4051-af60-f19492da9651";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Notulen_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d2bc941-3d87-4051-af60-f19492da9651>.
+    
+<http://data.lblod.info/id/remote-data-objects/870dbb64-1c75-45df-8743-f88ca35c7ff0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "870dbb64-1c75-45df-8743-f88ca35c7ff0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Notulen_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/870dbb64-1c75-45df-8743-f88ca35c7ff0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1dab11f4-f97d-4ec3-8623-b044748debe8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1dab11f4-f97d-4ec3-8623-b044748debe8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Notulen_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1dab11f4-f97d-4ec3-8623-b044748debe8>.
+    
+<http://data.lblod.info/id/remote-data-objects/fefb49f1-4438-41bd-9366-96771e5e905f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fefb49f1-4438-41bd-9366-96771e5e905f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Notulen_Gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fefb49f1-4438-41bd-9366-96771e5e905f>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcb3c4fc-926b-4146-b000-8509847120cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcb3c4fc-926b-4146-b000-8509847120cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Notulen_Gemeenteraad_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcb3c4fc-926b-4146-b000-8509847120cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/99a833aa-c18e-4d7b-b87c-f84d65bb4e77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99a833aa-c18e-4d7b-b87c-f84d65bb4e77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Notulen_Gemeenteraad_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99a833aa-c18e-4d7b-b87c-f84d65bb4e77>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2ad79a4-99ac-4dc8-9ff1-394fdee1fc2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2ad79a4-99ac-4dc8-9ff1-394fdee1fc2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Notulen_Gemeenteraad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2ad79a4-99ac-4dc8-9ff1-394fdee1fc2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/57694e7f-1ce8-4acf-bc40-02f89d5f8de3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57694e7f-1ce8-4acf-bc40-02f89d5f8de3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Uittreksels_21-12-2021_18148.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57694e7f-1ce8-4acf-bc40-02f89d5f8de3>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b1d7a71-c0c0-4bfb-b3b8-ec1509839014> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b1d7a71-c0c0-4bfb-b3b8-ec1509839014";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Uittreksels_21-12-2021_18160.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b1d7a71-c0c0-4bfb-b3b8-ec1509839014>.
+    
+<http://data.lblod.info/id/remote-data-objects/86079c5c-3c11-4e4c-9cc4-cbd1647212ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86079c5c-3c11-4e4c-9cc4-cbd1647212ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Uittreksels_22-02-2022_18902.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86079c5c-3c11-4e4c-9cc4-cbd1647212ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f1bae71-86fe-43ba-87e7-feb1e5ef861d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f1bae71-86fe-43ba-87e7-feb1e5ef861d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Uittreksels_26-04-2022_19163.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f1bae71-86fe-43ba-87e7-feb1e5ef861d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6c86b9a-f6a5-4285-978b-8d8732158004> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6c86b9a-f6a5-4285-978b-8d8732158004";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Uittreksels_26-10-2021_17596.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6c86b9a-f6a5-4285-978b-8d8732158004>.
+    
+<http://data.lblod.info/id/remote-data-objects/d741693d-61a9-4a16-aa8d-1c5feb814374> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d741693d-61a9-4a16-aa8d-1c5feb814374";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Uittreksels_28-06-2022_19532.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d741693d-61a9-4a16-aa8d-1c5feb814374>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a0b4e3b-58eb-4cb9-a778-dabc9b72996f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a0b4e3b-58eb-4cb9-a778-dabc9b72996f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Uittreksels_28-06-2022_19624.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a0b4e3b-58eb-4cb9-a778-dabc9b72996f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b441d5b-31ba-4f75-ac42-1677172de665> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b441d5b-31ba-4f75-ac42-1677172de665";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Uittreksels_28-06-2022_19726.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b441d5b-31ba-4f75-ac42-1677172de665>.
+    
+<http://data.lblod.info/id/remote-data-objects/629d4f2c-18bf-4788-9007-56e74bad926b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "629d4f2c-18bf-4788-9007-56e74bad926b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Uittreksels_30-11-2021_17572.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/629d4f2c-18bf-4788-9007-56e74bad926b>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb0f9d89-7d2b-43d1-b765-dfcac4f37ca4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb0f9d89-7d2b-43d1-b765-dfcac4f37ca4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Uittreksels_30-11-2021_17688.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb0f9d89-7d2b-43d1-b765-dfcac4f37ca4>.
+    
+<http://data.lblod.info/id/remote-data-objects/da459699-7088-4547-af0e-2bcf2de6ecc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da459699-7088-4547-af0e-2bcf2de6ecc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Uittreksels_30-11-2021_18065.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da459699-7088-4547-af0e-2bcf2de6ecc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b44458b-eb28-4818-9564-01a767756555> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b44458b-eb28-4818-9564-01a767756555";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Uittreksels_31-05-2022_19257.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b44458b-eb28-4818-9564-01a767756555>.
+    
+<http://data.lblod.info/id/remote-data-objects/f64202d9-3e23-4a33-a563-99417e537698> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f64202d9-3e23-4a33-a563-99417e537698";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/0b4dc3be2eb3704594fd6288b364ff05edac1ef1476db692dd2df3b8473ffcfe/GetPublication?filename=Uittreksels_31-05-2022_19350.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f64202d9-3e23-4a33-a563-99417e537698>.
+    
+<http://data.lblod.info/id/remote-data-objects/da96b68f-8e50-45e4-8d72-3041d7d0fda1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da96b68f-8e50-45e4-8d72-3041d7d0fda1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da96b68f-8e50-45e4-8d72-3041d7d0fda1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7300cedf-db78-4708-b449-a2c50ee0dd17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7300cedf-db78-4708-b449-a2c50ee0dd17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7300cedf-db78-4708-b449-a2c50ee0dd17>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c8b1a99-d6b1-4052-a1f9-b25378963c0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c8b1a99-d6b1-4052-a1f9-b25378963c0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c8b1a99-d6b1-4052-a1f9-b25378963c0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/664afcc0-8f4e-4d17-b29f-c7c387b1c2af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "664afcc0-8f4e-4d17-b29f-c7c387b1c2af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_02-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/664afcc0-8f4e-4d17-b29f-c7c387b1c2af>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d63bd52-b8f6-48d2-8a84-1cbcdcfe074d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d63bd52-b8f6-48d2-8a84-1cbcdcfe074d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d63bd52-b8f6-48d2-8a84-1cbcdcfe074d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ec04edb-3aa6-482f-b2e5-727ee32c3e80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ec04edb-3aa6-482f-b2e5-727ee32c3e80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ec04edb-3aa6-482f-b2e5-727ee32c3e80>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac3748c0-f0d1-4690-b020-c0c43550555f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac3748c0-f0d1-4690-b020-c0c43550555f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac3748c0-f0d1-4690-b020-c0c43550555f>.
+    
+<http://data.lblod.info/id/remote-data-objects/604925a2-9c59-4500-b282-513d4dd48a32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "604925a2-9c59-4500-b282-513d4dd48a32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/604925a2-9c59-4500-b282-513d4dd48a32>.
+    
+<http://data.lblod.info/id/remote-data-objects/74dd3307-3040-43f3-ae50-2b40673a7aa0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74dd3307-3040-43f3-ae50-2b40673a7aa0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74dd3307-3040-43f3-ae50-2b40673a7aa0>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d39c1d6-ecc4-49f9-abaa-4448e7ad494c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d39c1d6-ecc4-49f9-abaa-4448e7ad494c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d39c1d6-ecc4-49f9-abaa-4448e7ad494c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0998f74-7c10-489b-802d-1b088aa228a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0998f74-7c10-489b-802d-1b088aa228a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0998f74-7c10-489b-802d-1b088aa228a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f37b2b2-f56d-42e4-9541-7c22c53ca04f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f37b2b2-f56d-42e4-9541-7c22c53ca04f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/49e9713f-dc1c-445b-b721-3d7efaa221bb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f37b2b2-f56d-42e4-9541-7c22c53ca04f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201525-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201525-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201525-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201525-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/8b4492e9-2dfd-44ce-9700-b6fb939a919b> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8b4492e9-2dfd-44ce-9700-b6fb939a919b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f47283ca-f2a8-41b3-b024-3836140b1224";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f48535c2-cca5-4edf-a6c5-2c8a2cdf866d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f48535c2-cca5-4edf-a6c5-2c8a2cdf866d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224>.
+
+  <http://redpencil.data.gift/id/task/90c29e2a-a589-45d2-9540-a90d44e30335> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "90c29e2a-a589-45d2-9540-a90d44e30335";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/8b4492e9-2dfd-44ce-9700-b6fb939a919b>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f48535c2-cca5-4edf-a6c5-2c8a2cdf866d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/62ff0585-154d-453b-8374-a48f980962ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62ff0585-154d-453b-8374-a48f980962ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62ff0585-154d-453b-8374-a48f980962ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/a06b9333-5346-4f4c-bf35-e3379025c1dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a06b9333-5346-4f4c-bf35-e3379025c1dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_09-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a06b9333-5346-4f4c-bf35-e3379025c1dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e69c392-fc02-4e50-821d-0f35b434420b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e69c392-fc02-4e50-821d-0f35b434420b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e69c392-fc02-4e50-821d-0f35b434420b>.
+    
+<http://data.lblod.info/id/remote-data-objects/485eab5a-47b9-49c2-8330-130b8f866878> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "485eab5a-47b9-49c2-8330-130b8f866878";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/485eab5a-47b9-49c2-8330-130b8f866878>.
+    
+<http://data.lblod.info/id/remote-data-objects/31839490-cf6f-436e-9308-2a76ee3c0868> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31839490-cf6f-436e-9308-2a76ee3c0868";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31839490-cf6f-436e-9308-2a76ee3c0868>.
+    
+<http://data.lblod.info/id/remote-data-objects/e35241ef-599c-4155-9ef3-5cf43b06bff6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e35241ef-599c-4155-9ef3-5cf43b06bff6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e35241ef-599c-4155-9ef3-5cf43b06bff6>.
+    
+<http://data.lblod.info/id/remote-data-objects/8599049b-076c-49e8-9ef5-1832b1b47fa0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8599049b-076c-49e8-9ef5-1832b1b47fa0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8599049b-076c-49e8-9ef5-1832b1b47fa0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1bb50f8-62a1-4c03-a002-3b734c908379> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1bb50f8-62a1-4c03-a002-3b734c908379";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1bb50f8-62a1-4c03-a002-3b734c908379>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6f0814a-3e51-4671-9292-e2f70d0a32cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6f0814a-3e51-4671-9292-e2f70d0a32cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6f0814a-3e51-4671-9292-e2f70d0a32cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/832ca4b5-7c26-494e-a313-401eff605686> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "832ca4b5-7c26-494e-a313-401eff605686";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/832ca4b5-7c26-494e-a313-401eff605686>.
+    
+<http://data.lblod.info/id/remote-data-objects/47c7de71-ab17-4c00-bf4e-2bd953fdbec5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47c7de71-ab17-4c00-bf4e-2bd953fdbec5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47c7de71-ab17-4c00-bf4e-2bd953fdbec5>.
+    
+<http://data.lblod.info/id/remote-data-objects/d09b2d7f-8fff-40e6-9b09-4d9f43e3d71d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d09b2d7f-8fff-40e6-9b09-4d9f43e3d71d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_15-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d09b2d7f-8fff-40e6-9b09-4d9f43e3d71d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8f53470-5dd0-40c2-95a5-69924b347a2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8f53470-5dd0-40c2-95a5-69924b347a2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8f53470-5dd0-40c2-95a5-69924b347a2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd817bc1-f8e2-40ea-a167-3eb4933dea87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd817bc1-f8e2-40ea-a167-3eb4933dea87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd817bc1-f8e2-40ea-a167-3eb4933dea87>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd800924-b06d-4ef7-b415-25c188c590a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd800924-b06d-4ef7-b415-25c188c590a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd800924-b06d-4ef7-b415-25c188c590a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9079824-11c6-4d53-8d52-1a7485f82a32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9079824-11c6-4d53-8d52-1a7485f82a32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9079824-11c6-4d53-8d52-1a7485f82a32>.
+    
+<http://data.lblod.info/id/remote-data-objects/81badd27-ce22-4188-bee4-7d2cbae4633b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81badd27-ce22-4188-bee4-7d2cbae4633b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81badd27-ce22-4188-bee4-7d2cbae4633b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a189ac8f-bd71-42b1-b2cb-babcde1e73f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a189ac8f-bd71-42b1-b2cb-babcde1e73f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a189ac8f-bd71-42b1-b2cb-babcde1e73f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed06426f-edd8-4051-a730-7ed86c70d8b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed06426f-edd8-4051-a730-7ed86c70d8b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed06426f-edd8-4051-a730-7ed86c70d8b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7db4daf4-def9-44d0-9193-f485397193e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7db4daf4-def9-44d0-9193-f485397193e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7db4daf4-def9-44d0-9193-f485397193e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a1edf33-cbfd-4d2d-9f93-a24048bc0d7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a1edf33-cbfd-4d2d-9f93-a24048bc0d7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a1edf33-cbfd-4d2d-9f93-a24048bc0d7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/728a09fd-4027-4c88-9fda-12aa93d47b6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "728a09fd-4027-4c88-9fda-12aa93d47b6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/728a09fd-4027-4c88-9fda-12aa93d47b6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b975030-72e8-41dc-9b09-5842387fda02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b975030-72e8-41dc-9b09-5842387fda02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b975030-72e8-41dc-9b09-5842387fda02>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9ac289d-4f4b-4e66-8b79-b3c1792131bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9ac289d-4f4b-4e66-8b79-b3c1792131bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_20-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9ac289d-4f4b-4e66-8b79-b3c1792131bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/84628e46-5f6b-4e58-8efb-2e5f65aab2c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84628e46-5f6b-4e58-8efb-2e5f65aab2c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84628e46-5f6b-4e58-8efb-2e5f65aab2c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/db1a985d-5bd2-43a5-95a0-9c87d1b450f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db1a985d-5bd2-43a5-95a0-9c87d1b450f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db1a985d-5bd2-43a5-95a0-9c87d1b450f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/00b9c82f-c63d-446f-89df-415459838b31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00b9c82f-c63d-446f-89df-415459838b31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00b9c82f-c63d-446f-89df-415459838b31>.
+    
+<http://data.lblod.info/id/remote-data-objects/0204f717-5fed-4c12-8b0d-cb77bdf559bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0204f717-5fed-4c12-8b0d-cb77bdf559bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0204f717-5fed-4c12-8b0d-cb77bdf559bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c51a007b-69d3-40eb-88ca-c04b407316f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c51a007b-69d3-40eb-88ca-c04b407316f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c51a007b-69d3-40eb-88ca-c04b407316f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4570021-109e-4e73-9c88-74d5863e7b11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4570021-109e-4e73-9c88-74d5863e7b11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4570021-109e-4e73-9c88-74d5863e7b11>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a9756ec-9b42-45d6-882f-ee8b90b3e142> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a9756ec-9b42-45d6-882f-ee8b90b3e142";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a9756ec-9b42-45d6-882f-ee8b90b3e142>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d217b6d-ea32-424d-a687-158838b40a5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d217b6d-ea32-424d-a687-158838b40a5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d217b6d-ea32-424d-a687-158838b40a5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3aa47c48-46e5-43b3-96d7-713d42873f22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3aa47c48-46e5-43b3-96d7-713d42873f22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3aa47c48-46e5-43b3-96d7-713d42873f22>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c1f9f99-0ddd-45cc-8e86-4539d85c411b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c1f9f99-0ddd-45cc-8e86-4539d85c411b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c1f9f99-0ddd-45cc-8e86-4539d85c411b>.
+    
+<http://data.lblod.info/id/remote-data-objects/64f3946c-52c2-40f0-9497-05645b655644> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64f3946c-52c2-40f0-9497-05645b655644";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64f3946c-52c2-40f0-9497-05645b655644>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2653617-3617-404d-93fe-86499378604b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2653617-3617-404d-93fe-86499378604b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2653617-3617-404d-93fe-86499378604b>.
+    
+<http://data.lblod.info/id/remote-data-objects/afd513d1-f572-4a85-843a-3e62dc922183> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afd513d1-f572-4a85-843a-3e62dc922183";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afd513d1-f572-4a85-843a-3e62dc922183>.
+    
+<http://data.lblod.info/id/remote-data-objects/45c0db81-906a-4016-95b9-d2f2f8e58533> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45c0db81-906a-4016-95b9-d2f2f8e58533";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45c0db81-906a-4016-95b9-d2f2f8e58533>.
+    
+<http://data.lblod.info/id/remote-data-objects/b652e1a1-90e7-44c7-b413-4b2216c27d88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b652e1a1-90e7-44c7-b413-4b2216c27d88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b652e1a1-90e7-44c7-b413-4b2216c27d88>.
+    
+<http://data.lblod.info/id/remote-data-objects/8eb14da9-fc23-4c44-b626-7d0a449fbb99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8eb14da9-fc23-4c44-b626-7d0a449fbb99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8eb14da9-fc23-4c44-b626-7d0a449fbb99>.
+    
+<http://data.lblod.info/id/remote-data-objects/c23617b5-017c-4a30-ae49-1eb7eda2f001> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c23617b5-017c-4a30-ae49-1eb7eda2f001";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c23617b5-017c-4a30-ae49-1eb7eda2f001>.
+    
+<http://data.lblod.info/id/remote-data-objects/54c4ef93-3fde-4c52-b111-d1fb17cabfc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54c4ef93-3fde-4c52-b111-d1fb17cabfc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54c4ef93-3fde-4c52-b111-d1fb17cabfc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/89a948e4-a04b-4ee6-9b12-c9590c93b312> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89a948e4-a04b-4ee6-9b12-c9590c93b312";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89a948e4-a04b-4ee6-9b12-c9590c93b312>.
+    
+<http://data.lblod.info/id/remote-data-objects/cda68e00-b734-4842-aaad-014584f244a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cda68e00-b734-4842-aaad-014584f244a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cda68e00-b734-4842-aaad-014584f244a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ba2d769-a2d0-4852-8bf2-b5d37f5ed6d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ba2d769-a2d0-4852-8bf2-b5d37f5ed6d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ba2d769-a2d0-4852-8bf2-b5d37f5ed6d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb599b79-d75d-4a24-85a6-49d5c1924986> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb599b79-d75d-4a24-85a6-49d5c1924986";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=BesluitenLijst_Burgemeester_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb599b79-d75d-4a24-85a6-49d5c1924986>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f3ce7fb-4cbd-477c-837d-5d2df5fed223> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f3ce7fb-4cbd-477c-837d-5d2df5fed223";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_04-02-2022_18692.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f3ce7fb-4cbd-477c-837d-5d2df5fed223>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c3ddfa7-0102-49dc-9af2-906fdacc6b05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c3ddfa7-0102-49dc-9af2-906fdacc6b05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_04-07-2022_19928.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c3ddfa7-0102-49dc-9af2-906fdacc6b05>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c5b49ab-7024-4205-9bae-c6cf6d20b054> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c5b49ab-7024-4205-9bae-c6cf6d20b054";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_04-07-2022_19930.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c5b49ab-7024-4205-9bae-c6cf6d20b054>.
+    
+<http://data.lblod.info/id/remote-data-objects/afe432ca-0aa0-49ea-a3a1-a87b2fefc7c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afe432ca-0aa0-49ea-a3a1-a87b2fefc7c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_05-05-2022_19428.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f47283ca-f2a8-41b3-b024-3836140b1224> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afe432ca-0aa0-49ea-a3a1-a87b2fefc7c3>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201526-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201526-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201526-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201526-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7021ef1f-60e5-48c9-b6fc-bf51bc373648> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7021ef1f-60e5-48c9-b6fc-bf51bc373648";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "34bd4609-aadf-44db-a163-458d440c94ae";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/20f569d2-05a9-479e-bf0b-16806718a1ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "20f569d2-05a9-479e-bf0b-16806718a1ba";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae>.
+
+  <http://redpencil.data.gift/id/task/dff6aa0a-cee9-4ade-a8ee-f72a5fbbf1a7> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dff6aa0a-cee9-4ade-a8ee-f72a5fbbf1a7";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7021ef1f-60e5-48c9-b6fc-bf51bc373648>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/20f569d2-05a9-479e-bf0b-16806718a1ba>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a6f723f7-1473-484d-96a7-d9a5edcdcad5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6f723f7-1473-484d-96a7-d9a5edcdcad5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_07-02-2022_18781.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6f723f7-1473-484d-96a7-d9a5edcdcad5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e83f6dd-803a-42e6-aa81-0fa972da80ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e83f6dd-803a-42e6-aa81-0fa972da80ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_11-04-2022_19248.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e83f6dd-803a-42e6-aa81-0fa972da80ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe1f1398-2ccf-4a1d-8298-e3b701ee6891> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe1f1398-2ccf-4a1d-8298-e3b701ee6891";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_14-04-2022_19261.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe1f1398-2ccf-4a1d-8298-e3b701ee6891>.
+    
+<http://data.lblod.info/id/remote-data-objects/77aab788-7d17-48a6-99b1-8a8a7bd6a833> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77aab788-7d17-48a6-99b1-8a8a7bd6a833";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_14-04-2022_19262.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77aab788-7d17-48a6-99b1-8a8a7bd6a833>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d6da7e7-47b1-4a41-9420-fbc2c36db620> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d6da7e7-47b1-4a41-9420-fbc2c36db620";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_14-04-2022_19264.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d6da7e7-47b1-4a41-9420-fbc2c36db620>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2fdbc61-681c-4059-befc-4984c881d48f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2fdbc61-681c-4059-befc-4984c881d48f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_14-07-2022_20002.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2fdbc61-681c-4059-befc-4984c881d48f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d359356-e6f8-486c-94c2-f0df64e4c60f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d359356-e6f8-486c-94c2-f0df64e4c60f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_18-01-2022_18542.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d359356-e6f8-486c-94c2-f0df64e4c60f>.
+    
+<http://data.lblod.info/id/remote-data-objects/00b5a061-b276-4a18-9f2f-43b33044fb42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00b5a061-b276-4a18-9f2f-43b33044fb42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_18-07-2022_20013.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00b5a061-b276-4a18-9f2f-43b33044fb42>.
+    
+<http://data.lblod.info/id/remote-data-objects/4db35215-fadd-4017-82de-1d9096db889a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4db35215-fadd-4017-82de-1d9096db889a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_20-06-2022_19799.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4db35215-fadd-4017-82de-1d9096db889a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f4765f6-dbbd-4b2a-846e-e4d3c42b9e93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f4765f6-dbbd-4b2a-846e-e4d3c42b9e93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_20-06-2022_19800.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f4765f6-dbbd-4b2a-846e-e4d3c42b9e93>.
+    
+<http://data.lblod.info/id/remote-data-objects/603d60f8-9cb0-42c2-a430-4e6caa70d1da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "603d60f8-9cb0-42c2-a430-4e6caa70d1da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_20-06-2022_19802.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/603d60f8-9cb0-42c2-a430-4e6caa70d1da>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd28f5df-de5e-47ce-9d58-bf85185e2358> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd28f5df-de5e-47ce-9d58-bf85185e2358";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_20-06-2022_19804.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd28f5df-de5e-47ce-9d58-bf85185e2358>.
+    
+<http://data.lblod.info/id/remote-data-objects/57012121-27fd-4086-b3b0-441c41b668a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57012121-27fd-4086-b3b0-441c41b668a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_20-06-2022_19806.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57012121-27fd-4086-b3b0-441c41b668a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d074e91-bf15-4c70-88b7-d55bdef516d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d074e91-bf15-4c70-88b7-d55bdef516d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_20-06-2022_19807.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d074e91-bf15-4c70-88b7-d55bdef516d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/df5ea239-c1fc-47e0-992d-f968ba55a3a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df5ea239-c1fc-47e0-992d-f968ba55a3a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_20-06-2022_19808.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df5ea239-c1fc-47e0-992d-f968ba55a3a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/268ed2b1-8a2a-41b5-b01b-508ec82d4f56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "268ed2b1-8a2a-41b5-b01b-508ec82d4f56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_20-07-2022_20057.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/268ed2b1-8a2a-41b5-b01b-508ec82d4f56>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9ce0de4-f19b-4b6e-9255-ff56fd82e1e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9ce0de4-f19b-4b6e-9255-ff56fd82e1e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_21-04-2022_19341.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9ce0de4-f19b-4b6e-9255-ff56fd82e1e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cbf725a-8853-4913-90eb-271b504ebd44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cbf725a-8853-4913-90eb-271b504ebd44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_24-03-2022_19094.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cbf725a-8853-4913-90eb-271b504ebd44>.
+    
+<http://data.lblod.info/id/remote-data-objects/0029bc88-f4fb-4cde-855d-6b03acd788c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0029bc88-f4fb-4cde-855d-6b03acd788c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_25-05-2022_19613.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0029bc88-f4fb-4cde-855d-6b03acd788c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/15f9f16f-b484-4a6e-9d80-e95cd7bd0d62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15f9f16f-b484-4a6e-9d80-e95cd7bd0d62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_25-07-2022_20069.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15f9f16f-b484-4a6e-9d80-e95cd7bd0d62>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc479ffe-802c-4b59-861c-1056e74f3d94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc479ffe-802c-4b59-861c-1056e74f3d94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_25-11-2021_18099.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc479ffe-802c-4b59-861c-1056e74f3d94>.
+    
+<http://data.lblod.info/id/remote-data-objects/dab58f9f-3406-4e58-ac4b-161d5c056cf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dab58f9f-3406-4e58-ac4b-161d5c056cf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_25-11-2021_18100.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dab58f9f-3406-4e58-ac4b-161d5c056cf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/2de2faa6-213f-41ce-a5dd-314f204acf5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2de2faa6-213f-41ce-a5dd-314f204acf5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_27-06-2022_19855.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2de2faa6-213f-41ce-a5dd-314f204acf5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c79e54e6-7213-463c-bfe8-00424b03e82a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c79e54e6-7213-463c-bfe8-00424b03e82a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_30-06-2022_19892.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c79e54e6-7213-463c-bfe8-00424b03e82a>.
+    
+<http://data.lblod.info/id/remote-data-objects/210e0fa4-6c33-49ce-8d2e-0638f8a13e2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "210e0fa4-6c33-49ce-8d2e-0638f8a13e2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_30-06-2022_19893.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/210e0fa4-6c33-49ce-8d2e-0638f8a13e2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/991ab0e3-61d2-4b44-8050-4a4791fb3c01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "991ab0e3-61d2-4b44-8050-4a4791fb3c01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/27c5a244b9a1b02dbd3353114ffdb840f40e0f3fac029d35b425ec005067004a/GetPublication?filename=Uittreksels_30-06-2022_19894.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/991ab0e3-61d2-4b44-8050-4a4791fb3c01>.
+    
+<http://data.lblod.info/id/remote-data-objects/05293af8-55e4-4316-9e6e-c51195245980> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05293af8-55e4-4316-9e6e-c51195245980";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05293af8-55e4-4316-9e6e-c51195245980>.
+    
+<http://data.lblod.info/id/remote-data-objects/625aa336-7ad1-486d-a6fd-b693fcbe306d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "625aa336-7ad1-486d-a6fd-b693fcbe306d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/625aa336-7ad1-486d-a6fd-b693fcbe306d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d16b3a7d-9e82-4d40-891c-ff2fd697da5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d16b3a7d-9e82-4d40-891c-ff2fd697da5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d16b3a7d-9e82-4d40-891c-ff2fd697da5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1af2e854-245a-4ab1-97cd-90eccc9752fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1af2e854-245a-4ab1-97cd-90eccc9752fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1af2e854-245a-4ab1-97cd-90eccc9752fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dbfe053-457e-4d8c-aa68-2e5408ebd7f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dbfe053-457e-4d8c-aa68-2e5408ebd7f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dbfe053-457e-4d8c-aa68-2e5408ebd7f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a4ae7a8-e9c5-42f2-895b-f204c9b0d925> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a4ae7a8-e9c5-42f2-895b-f204c9b0d925";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a4ae7a8-e9c5-42f2-895b-f204c9b0d925>.
+    
+<http://data.lblod.info/id/remote-data-objects/5585b18e-972c-48f7-a87b-de7274a68d4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5585b18e-972c-48f7-a87b-de7274a68d4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5585b18e-972c-48f7-a87b-de7274a68d4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cf5b750-9faf-45b8-8d7b-05f7c1d1b7b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cf5b750-9faf-45b8-8d7b-05f7c1d1b7b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cf5b750-9faf-45b8-8d7b-05f7c1d1b7b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5644b19-eb82-419c-aa37-c6f810e35e0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5644b19-eb82-419c-aa37-c6f810e35e0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5644b19-eb82-419c-aa37-c6f810e35e0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d469c66c-1983-4792-a813-035a0c218e26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d469c66c-1983-4792-a813-035a0c218e26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d469c66c-1983-4792-a813-035a0c218e26>.
+    
+<http://data.lblod.info/id/remote-data-objects/c869db06-8b30-4c93-af31-b6b154a8a894> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c869db06-8b30-4c93-af31-b6b154a8a894";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c869db06-8b30-4c93-af31-b6b154a8a894>.
+    
+<http://data.lblod.info/id/remote-data-objects/31235205-c307-4d48-b557-a34858155413> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31235205-c307-4d48-b557-a34858155413";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31235205-c307-4d48-b557-a34858155413>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0f19c0a-4c0b-46c1-8af8-0920545bdd3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0f19c0a-4c0b-46c1-8af8-0920545bdd3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0f19c0a-4c0b-46c1-8af8-0920545bdd3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b7edf28-40e4-4f40-b08f-d195f2c82523> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b7edf28-40e4-4f40-b08f-d195f2c82523";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b7edf28-40e4-4f40-b08f-d195f2c82523>.
+    
+<http://data.lblod.info/id/remote-data-objects/32d4abae-07c1-4447-b0e4-d860ee2d9fbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32d4abae-07c1-4447-b0e4-d860ee2d9fbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32d4abae-07c1-4447-b0e4-d860ee2d9fbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/fffa5e55-6237-4183-838f-26d31085b8a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fffa5e55-6237-4183-838f-26d31085b8a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fffa5e55-6237-4183-838f-26d31085b8a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f33ab799-2dc5-4285-ac8c-33f641c70b7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f33ab799-2dc5-4285-ac8c-33f641c70b7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f33ab799-2dc5-4285-ac8c-33f641c70b7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb774a36-720f-4924-966c-65c18c1add20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb774a36-720f-4924-966c-65c18c1add20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb774a36-720f-4924-966c-65c18c1add20>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fd1a617-ca1b-4a97-a256-caef767a57fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fd1a617-ca1b-4a97-a256-caef767a57fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fd1a617-ca1b-4a97-a256-caef767a57fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c2b570f-5b6c-40e4-a373-7b0de065318e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c2b570f-5b6c-40e4-a373-7b0de065318e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c2b570f-5b6c-40e4-a373-7b0de065318e>.
+    
+<http://data.lblod.info/id/remote-data-objects/67899191-6553-4424-905a-7f0215c54a9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67899191-6553-4424-905a-7f0215c54a9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67899191-6553-4424-905a-7f0215c54a9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa9ad1e3-8907-4892-a0ef-c26828ea8011> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa9ad1e3-8907-4892-a0ef-c26828ea8011";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa9ad1e3-8907-4892-a0ef-c26828ea8011>.
+    
+<http://data.lblod.info/id/remote-data-objects/66400d0f-da3d-4d5d-bd4f-94cfb461b4ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66400d0f-da3d-4d5d-bd4f-94cfb461b4ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66400d0f-da3d-4d5d-bd4f-94cfb461b4ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/151bf611-793e-4465-b736-18dca4d3c099> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "151bf611-793e-4465-b736-18dca4d3c099";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Uittreksels_21-12-2021_18157.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34bd4609-aadf-44db-a163-458d440c94ae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/151bf611-793e-4465-b736-18dca4d3c099>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201527-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201527-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201527-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201527-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a7211ba6-a47c-44d5-b43d-0b694b5d0e29> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a7211ba6-a47c-44d5-b43d-0b694b5d0e29";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "73924c43-1598-44e7-a431-1a835d81104d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/eba1db73-76f3-4202-bdf1-68d2c3ec5fbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "eba1db73-76f3-4202-bdf1-68d2c3ec5fbf";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d>.
+
+  <http://redpencil.data.gift/id/task/7f189102-e0ad-46db-9924-dd305f3c7081> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7f189102-e0ad-46db-9924-dd305f3c7081";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a7211ba6-a47c-44d5-b43d-0b694b5d0e29>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/eba1db73-76f3-4202-bdf1-68d2c3ec5fbf>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/f13d61e1-7f0b-4ea8-8830-48d8e2adbfc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f13d61e1-7f0b-4ea8-8830-48d8e2adbfc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Uittreksels_26-10-2021_17597.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f13d61e1-7f0b-4ea8-8830-48d8e2adbfc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/f360b5f9-b904-4afd-867b-c39e43f42242> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f360b5f9-b904-4afd-867b-c39e43f42242";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Uittreksels_28-06-2022_19534.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f360b5f9-b904-4afd-867b-c39e43f42242>.
+    
+<http://data.lblod.info/id/remote-data-objects/bad8a222-5490-42f4-b1c2-8bcbfe983379> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bad8a222-5490-42f4-b1c2-8bcbfe983379";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/8df4a6a0ee32ce4f13d53f19c1f526764da716d45f80d8d59d3fe93f54551679/GetPublication?filename=Uittreksels_28-06-2022_19727.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bad8a222-5490-42f4-b1c2-8bcbfe983379>.
+    
+<http://data.lblod.info/id/remote-data-objects/175abe0c-9631-47ff-938d-df1bbdc51b5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "175abe0c-9631-47ff-938d-df1bbdc51b5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/175abe0c-9631-47ff-938d-df1bbdc51b5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d258324-6b85-4d75-935f-a5a91bb967d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d258324-6b85-4d75-935f-a5a91bb967d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_02-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d258324-6b85-4d75-935f-a5a91bb967d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0aee39cc-ab69-4a8f-b977-bb9c055664e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0aee39cc-ab69-4a8f-b977-bb9c055664e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0aee39cc-ab69-4a8f-b977-bb9c055664e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e26aa6f2-b6b3-46bc-ad9e-4043dd94e475> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e26aa6f2-b6b3-46bc-ad9e-4043dd94e475";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e26aa6f2-b6b3-46bc-ad9e-4043dd94e475>.
+    
+<http://data.lblod.info/id/remote-data-objects/4986f904-2b95-4c9b-b8b3-84986e0f6c91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4986f904-2b95-4c9b-b8b3-84986e0f6c91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4986f904-2b95-4c9b-b8b3-84986e0f6c91>.
+    
+<http://data.lblod.info/id/remote-data-objects/2896732a-49ea-486f-944a-c98a34855757> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2896732a-49ea-486f-944a-c98a34855757";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2896732a-49ea-486f-944a-c98a34855757>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf33aebf-799f-4604-a367-bc66e6a78aae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf33aebf-799f-4604-a367-bc66e6a78aae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf33aebf-799f-4604-a367-bc66e6a78aae>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e994ab0-c7fe-4a3d-8880-eb4485f63c78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e994ab0-c7fe-4a3d-8880-eb4485f63c78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e994ab0-c7fe-4a3d-8880-eb4485f63c78>.
+    
+<http://data.lblod.info/id/remote-data-objects/733f1d18-94af-4b82-b6f2-fef28c48de61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "733f1d18-94af-4b82-b6f2-fef28c48de61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/733f1d18-94af-4b82-b6f2-fef28c48de61>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8ccc835-7c00-4a1a-9993-3e0acf23b98e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8ccc835-7c00-4a1a-9993-3e0acf23b98e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8ccc835-7c00-4a1a-9993-3e0acf23b98e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8d9dc40-5c44-4335-9740-21e71f4ad506> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8d9dc40-5c44-4335-9740-21e71f4ad506";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8d9dc40-5c44-4335-9740-21e71f4ad506>.
+    
+<http://data.lblod.info/id/remote-data-objects/f11d8a8b-5514-4c43-8d07-1e615a46a35c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f11d8a8b-5514-4c43-8d07-1e615a46a35c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f11d8a8b-5514-4c43-8d07-1e615a46a35c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5271efc-88cc-426b-adf8-624b8d5d4f22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5271efc-88cc-426b-adf8-624b8d5d4f22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5271efc-88cc-426b-adf8-624b8d5d4f22>.
+    
+<http://data.lblod.info/id/remote-data-objects/330b9d45-a861-4dbf-8a7f-dfc038b9bae7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "330b9d45-a861-4dbf-8a7f-dfc038b9bae7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/330b9d45-a861-4dbf-8a7f-dfc038b9bae7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0c014d3-8da9-428e-a5de-4d7366610cd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0c014d3-8da9-428e-a5de-4d7366610cd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0c014d3-8da9-428e-a5de-4d7366610cd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d16677d3-7d70-485f-a19c-2ff022e5eb0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d16677d3-7d70-485f-a19c-2ff022e5eb0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d16677d3-7d70-485f-a19c-2ff022e5eb0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e1bb7df-1f0d-4df5-9751-592497ab84f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e1bb7df-1f0d-4df5-9751-592497ab84f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e1bb7df-1f0d-4df5-9751-592497ab84f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a700c443-26eb-4bce-b023-52ed5afc6b6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a700c443-26eb-4bce-b023-52ed5afc6b6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a700c443-26eb-4bce-b023-52ed5afc6b6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/112b9f0c-f74c-4c1d-b199-efa7341aa793> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "112b9f0c-f74c-4c1d-b199-efa7341aa793";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/112b9f0c-f74c-4c1d-b199-efa7341aa793>.
+    
+<http://data.lblod.info/id/remote-data-objects/28f049de-cf77-40b0-9032-4271086a47d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28f049de-cf77-40b0-9032-4271086a47d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28f049de-cf77-40b0-9032-4271086a47d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/87b57421-3ede-46fe-b8aa-70a381e4ba46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87b57421-3ede-46fe-b8aa-70a381e4ba46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87b57421-3ede-46fe-b8aa-70a381e4ba46>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd82a2e8-7a8e-4fc7-8272-69f89acc1825> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd82a2e8-7a8e-4fc7-8272-69f89acc1825";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd82a2e8-7a8e-4fc7-8272-69f89acc1825>.
+    
+<http://data.lblod.info/id/remote-data-objects/7344a15d-7e30-45d3-809c-9e592b94288e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7344a15d-7e30-45d3-809c-9e592b94288e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7344a15d-7e30-45d3-809c-9e592b94288e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c05f79d-377f-490f-a418-ab8213d10937> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c05f79d-377f-490f-a418-ab8213d10937";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c05f79d-377f-490f-a418-ab8213d10937>.
+    
+<http://data.lblod.info/id/remote-data-objects/c10c96c3-68c9-4df2-8e6e-8a97c6c93e8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c10c96c3-68c9-4df2-8e6e-8a97c6c93e8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c10c96c3-68c9-4df2-8e6e-8a97c6c93e8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f227bfa3-c9f6-454e-8a45-27e20a792d61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f227bfa3-c9f6-454e-8a45-27e20a792d61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f227bfa3-c9f6-454e-8a45-27e20a792d61>.
+    
+<http://data.lblod.info/id/remote-data-objects/f74bba08-41c2-458b-9506-e35cdc7069db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f74bba08-41c2-458b-9506-e35cdc7069db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f74bba08-41c2-458b-9506-e35cdc7069db>.
+    
+<http://data.lblod.info/id/remote-data-objects/415de640-600d-4cb7-8e65-627573685864> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "415de640-600d-4cb7-8e65-627573685864";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/415de640-600d-4cb7-8e65-627573685864>.
+    
+<http://data.lblod.info/id/remote-data-objects/5125e803-e6b3-4ffd-888e-047ebf13c39d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5125e803-e6b3-4ffd-888e-047ebf13c39d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5125e803-e6b3-4ffd-888e-047ebf13c39d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d22ae9bf-d302-4e23-9db5-c62e649866e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d22ae9bf-d302-4e23-9db5-c62e649866e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d22ae9bf-d302-4e23-9db5-c62e649866e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/65e3ca4f-aa17-42af-8ab7-9d16919110dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65e3ca4f-aa17-42af-8ab7-9d16919110dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65e3ca4f-aa17-42af-8ab7-9d16919110dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/15a33c56-bbc2-44dc-9057-96e6495d22a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15a33c56-bbc2-44dc-9057-96e6495d22a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15a33c56-bbc2-44dc-9057-96e6495d22a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a756040-07c0-4dcf-83a1-efba9af63fa7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a756040-07c0-4dcf-83a1-efba9af63fa7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a756040-07c0-4dcf-83a1-efba9af63fa7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a50f045a-c989-414a-ae4f-beea4880efbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a50f045a-c989-414a-ae4f-beea4880efbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a50f045a-c989-414a-ae4f-beea4880efbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cf2dacd-376a-4a73-ad41-14e421cbaa29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cf2dacd-376a-4a73-ad41-14e421cbaa29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cf2dacd-376a-4a73-ad41-14e421cbaa29>.
+    
+<http://data.lblod.info/id/remote-data-objects/56d4ff3f-255c-4ddf-90e4-ee2cd0cf42f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56d4ff3f-255c-4ddf-90e4-ee2cd0cf42f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56d4ff3f-255c-4ddf-90e4-ee2cd0cf42f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a600a12d-c37d-4ce6-9982-c161c398265f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a600a12d-c37d-4ce6-9982-c161c398265f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a600a12d-c37d-4ce6-9982-c161c398265f>.
+    
+<http://data.lblod.info/id/remote-data-objects/96282a25-c332-4673-840a-6c60f99b8f79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96282a25-c332-4673-840a-6c60f99b8f79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96282a25-c332-4673-840a-6c60f99b8f79>.
+    
+<http://data.lblod.info/id/remote-data-objects/d79fa045-af71-499e-8a74-6e575288c8ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d79fa045-af71-499e-8a74-6e575288c8ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d79fa045-af71-499e-8a74-6e575288c8ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b8a0bba-77e4-4f69-8af3-e73f50bf8487> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b8a0bba-77e4-4f69-8af3-e73f50bf8487";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b8a0bba-77e4-4f69-8af3-e73f50bf8487>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1f4f13b-9162-480e-9a70-55b12235086e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1f4f13b-9162-480e-9a70-55b12235086e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_03-01-2022_18413.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1f4f13b-9162-480e-9a70-55b12235086e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d25a7b5-2f69-49cf-8e06-03e82eb7dad0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d25a7b5-2f69-49cf-8e06-03e82eb7dad0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_04-04-2022_19171.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d25a7b5-2f69-49cf-8e06-03e82eb7dad0>.
+    
+<http://data.lblod.info/id/remote-data-objects/6962f542-3ecf-4601-92e5-62d34dbf9dcf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6962f542-3ecf-4601-92e5-62d34dbf9dcf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_04-07-2022_19919.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6962f542-3ecf-4601-92e5-62d34dbf9dcf>.
+    
+<http://data.lblod.info/id/remote-data-objects/f04b7734-6e2e-40a9-a713-2d8845929d68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f04b7734-6e2e-40a9-a713-2d8845929d68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_09-05-2022_19416.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f04b7734-6e2e-40a9-a713-2d8845929d68>.
+    
+<http://data.lblod.info/id/remote-data-objects/23b5f5a4-d0bd-400b-9495-c9c4e581474a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23b5f5a4-d0bd-400b-9495-c9c4e581474a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_09-05-2022_19437.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23b5f5a4-d0bd-400b-9495-c9c4e581474a>.
+    
+<http://data.lblod.info/id/remote-data-objects/190588eb-bdaf-45a6-901e-58cdab51effa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "190588eb-bdaf-45a6-901e-58cdab51effa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_09-05-2022_19439.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/190588eb-bdaf-45a6-901e-58cdab51effa>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7bd259b-7942-49a7-815e-9c97f5581c57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7bd259b-7942-49a7-815e-9c97f5581c57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_09-05-2022_19444.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/73924c43-1598-44e7-a431-1a835d81104d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7bd259b-7942-49a7-815e-9c97f5581c57>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201529-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201529-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201529-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201529-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/8eec9d22-d326-4925-9804-fea6948e483f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8eec9d22-d326-4925-9804-fea6948e483f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fd515532-c9f1-4db7-ba24-adf3b8cdb416";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/1ddd61ca-2ee1-4582-979d-154629a0cfb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1ddd61ca-2ee1-4582-979d-154629a0cfb5";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416>.
+
+  <http://redpencil.data.gift/id/task/11d226ac-18c5-42ed-a354-0ec32d3a487c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "11d226ac-18c5-42ed-a354-0ec32d3a487c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/8eec9d22-d326-4925-9804-fea6948e483f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/1ddd61ca-2ee1-4582-979d-154629a0cfb5>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a5f2ad4e-945e-4452-9cdb-27fb092a7985> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5f2ad4e-945e-4452-9cdb-27fb092a7985";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_14-03-2022_18942.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5f2ad4e-945e-4452-9cdb-27fb092a7985>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa1b9e03-51d0-4c15-bb4b-d83d174dc139> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa1b9e03-51d0-4c15-bb4b-d83d174dc139";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_17-01-2022_18502.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa1b9e03-51d0-4c15-bb4b-d83d174dc139>.
+    
+<http://data.lblod.info/id/remote-data-objects/733e6d19-0ac3-4fe8-95b6-506ad59bc93d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "733e6d19-0ac3-4fe8-95b6-506ad59bc93d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_17-01-2022_18506.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/733e6d19-0ac3-4fe8-95b6-506ad59bc93d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4002c7e9-41e2-4b86-b7f9-da3d082a277f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4002c7e9-41e2-4b86-b7f9-da3d082a277f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_18-07-2022_20004.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4002c7e9-41e2-4b86-b7f9-da3d082a277f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b681746c-7740-45c7-b4fa-8de5aa260b31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b681746c-7740-45c7-b4fa-8de5aa260b31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_18-07-2022_20008.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b681746c-7740-45c7-b4fa-8de5aa260b31>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f54c53b-eeb1-457f-ae80-83e44b179b5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f54c53b-eeb1-457f-ae80-83e44b179b5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_24-01-2022_18520.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f54c53b-eeb1-457f-ae80-83e44b179b5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/17bbc177-1933-4c7d-b3f4-5e50d540067f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17bbc177-1933-4c7d-b3f4-5e50d540067f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_24-01-2022_18521.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17bbc177-1933-4c7d-b3f4-5e50d540067f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dc1f918-51e0-4c54-9b02-b78057641018> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dc1f918-51e0-4c54-9b02-b78057641018";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_24-01-2022_18522.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dc1f918-51e0-4c54-9b02-b78057641018>.
+    
+<http://data.lblod.info/id/remote-data-objects/daa0fa75-8006-4e84-a0cb-6be4a3fc5686> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "daa0fa75-8006-4e84-a0cb-6be4a3fc5686";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_24-01-2022_18540.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/daa0fa75-8006-4e84-a0cb-6be4a3fc5686>.
+    
+<http://data.lblod.info/id/remote-data-objects/91fb9e6e-9734-4123-88d5-51be48aee5cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91fb9e6e-9734-4123-88d5-51be48aee5cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_24-01-2022_18549.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91fb9e6e-9734-4123-88d5-51be48aee5cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/c02e8c8a-b619-4118-9aae-a618d4b2ff46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c02e8c8a-b619-4118-9aae-a618d4b2ff46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_24-01-2022_18573.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c02e8c8a-b619-4118-9aae-a618d4b2ff46>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b553e56-1815-4c72-bd48-f833e5a7ffdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b553e56-1815-4c72-bd48-f833e5a7ffdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_25-04-2022_19246.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b553e56-1815-4c72-bd48-f833e5a7ffdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/037eed3f-ac3a-4fec-adc9-7865c8cf6333> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "037eed3f-ac3a-4fec-adc9-7865c8cf6333";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_25-04-2022_19247.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/037eed3f-ac3a-4fec-adc9-7865c8cf6333>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa391d8b-81b2-43aa-bb17-4966735c4a18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa391d8b-81b2-43aa-bb17-4966735c4a18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_28-02-2022_18864.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa391d8b-81b2-43aa-bb17-4966735c4a18>.
+    
+<http://data.lblod.info/id/remote-data-objects/3955ef0a-3185-411c-a0a5-2825721cb3ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3955ef0a-3185-411c-a0a5-2825721cb3ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_28-02-2022_18885.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3955ef0a-3185-411c-a0a5-2825721cb3ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cb98f87-61d0-4f7e-97c0-fe8e8bf4baff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cb98f87-61d0-4f7e-97c0-fe8e8bf4baff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_28-02-2022_18893.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cb98f87-61d0-4f7e-97c0-fe8e8bf4baff>.
+    
+<http://data.lblod.info/id/remote-data-objects/d65ec1a8-c3b8-4fa1-b508-acdfb700ebbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d65ec1a8-c3b8-4fa1-b508-acdfb700ebbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_28-03-2022_18951.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d65ec1a8-c3b8-4fa1-b508-acdfb700ebbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/d69a953a-46fb-4691-8870-87bb8fed08a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d69a953a-46fb-4691-8870-87bb8fed08a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_28-03-2022_19079.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d69a953a-46fb-4691-8870-87bb8fed08a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c24f502-e322-493d-9699-df45c93fa09d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c24f502-e322-493d-9699-df45c93fa09d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_28-03-2022_19084.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c24f502-e322-493d-9699-df45c93fa09d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ada3cfa-b59e-45e5-ac96-763830290ce2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ada3cfa-b59e-45e5-ac96-763830290ce2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a28a17f8ab92e4d984339121eba50a6ddba200b8af81e9de9c2e08a92900e362/GetPublication?filename=Uittreksels_28-03-2022_19085.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ada3cfa-b59e-45e5-ac96-763830290ce2>.
+    
+<http://data.lblod.info/id/remote-data-objects/10e8fc73-ee57-4ddf-9315-c65530911cbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10e8fc73-ee57-4ddf-9315-c65530911cbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10e8fc73-ee57-4ddf-9315-c65530911cbb>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d89e998-69cf-4bff-accf-13e4e0a4ce86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d89e998-69cf-4bff-accf-13e4e0a4ce86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_02-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d89e998-69cf-4bff-accf-13e4e0a4ce86>.
+    
+<http://data.lblod.info/id/remote-data-objects/9eca526f-5590-4be1-9489-910434e8639b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9eca526f-5590-4be1-9489-910434e8639b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9eca526f-5590-4be1-9489-910434e8639b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb5f8d29-ca55-47e8-89c9-b43a98dd7597> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb5f8d29-ca55-47e8-89c9-b43a98dd7597";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb5f8d29-ca55-47e8-89c9-b43a98dd7597>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0af6b73-2fec-4eb1-bdef-e552750e7726> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0af6b73-2fec-4eb1-bdef-e552750e7726";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0af6b73-2fec-4eb1-bdef-e552750e7726>.
+    
+<http://data.lblod.info/id/remote-data-objects/362cce7c-4b11-479c-8c6e-ad863650652e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "362cce7c-4b11-479c-8c6e-ad863650652e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/362cce7c-4b11-479c-8c6e-ad863650652e>.
+    
+<http://data.lblod.info/id/remote-data-objects/01c761c4-a55e-46e6-82c7-cb34741184a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01c761c4-a55e-46e6-82c7-cb34741184a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01c761c4-a55e-46e6-82c7-cb34741184a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7040d47a-7c86-4897-9653-c41be9745d14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7040d47a-7c86-4897-9653-c41be9745d14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7040d47a-7c86-4897-9653-c41be9745d14>.
+    
+<http://data.lblod.info/id/remote-data-objects/6210dd13-9a71-4d38-9f8e-5197d0232779> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6210dd13-9a71-4d38-9f8e-5197d0232779";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6210dd13-9a71-4d38-9f8e-5197d0232779>.
+    
+<http://data.lblod.info/id/remote-data-objects/92acb3b2-5f80-4783-a51a-75b7cd931f7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92acb3b2-5f80-4783-a51a-75b7cd931f7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92acb3b2-5f80-4783-a51a-75b7cd931f7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2a0d5b3-b286-4157-b7d2-07c02730113d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2a0d5b3-b286-4157-b7d2-07c02730113d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2a0d5b3-b286-4157-b7d2-07c02730113d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c913411e-116a-4f02-91d3-1646f92a82bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c913411e-116a-4f02-91d3-1646f92a82bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c913411e-116a-4f02-91d3-1646f92a82bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c602a11-10df-4465-aefa-2f9b8f4966bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c602a11-10df-4465-aefa-2f9b8f4966bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c602a11-10df-4465-aefa-2f9b8f4966bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/99735bd2-ba29-4f66-94bb-f23ec3ade767> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99735bd2-ba29-4f66-94bb-f23ec3ade767";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99735bd2-ba29-4f66-94bb-f23ec3ade767>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a04f517-6225-48f8-b07d-7b567d710f1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a04f517-6225-48f8-b07d-7b567d710f1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a04f517-6225-48f8-b07d-7b567d710f1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/28e022fa-506a-4a4e-8808-432d6e65e00e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28e022fa-506a-4a4e-8808-432d6e65e00e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28e022fa-506a-4a4e-8808-432d6e65e00e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e7308d0-2634-4000-a5ff-628dc3d1151c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e7308d0-2634-4000-a5ff-628dc3d1151c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e7308d0-2634-4000-a5ff-628dc3d1151c>.
+    
+<http://data.lblod.info/id/remote-data-objects/556a416a-524e-41b8-bc50-8c16a2b4160f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "556a416a-524e-41b8-bc50-8c16a2b4160f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/556a416a-524e-41b8-bc50-8c16a2b4160f>.
+    
+<http://data.lblod.info/id/remote-data-objects/edd39dc1-719e-475b-8a2f-a796a3db228c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edd39dc1-719e-475b-8a2f-a796a3db228c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edd39dc1-719e-475b-8a2f-a796a3db228c>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd09698b-dc8b-4be5-87ce-df0f8834e3f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd09698b-dc8b-4be5-87ce-df0f8834e3f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd09698b-dc8b-4be5-87ce-df0f8834e3f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/12842321-96f2-4839-b726-5441d8cb7998> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12842321-96f2-4839-b726-5441d8cb7998";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12842321-96f2-4839-b726-5441d8cb7998>.
+    
+<http://data.lblod.info/id/remote-data-objects/7db9e205-9524-4b90-8c02-9d974a2d403c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7db9e205-9524-4b90-8c02-9d974a2d403c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7db9e205-9524-4b90-8c02-9d974a2d403c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f3361f5-5e35-413b-b5cc-d94f09b7745d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f3361f5-5e35-413b-b5cc-d94f09b7745d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f3361f5-5e35-413b-b5cc-d94f09b7745d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ce85fbd-5f37-412c-9690-e173ab506c9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ce85fbd-5f37-412c-9690-e173ab506c9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ce85fbd-5f37-412c-9690-e173ab506c9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fe060c8-4f34-4540-adea-d18dd72160f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fe060c8-4f34-4540-adea-d18dd72160f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fe060c8-4f34-4540-adea-d18dd72160f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/807aa58d-1016-4c3d-84b2-9acee7496b24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "807aa58d-1016-4c3d-84b2-9acee7496b24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/807aa58d-1016-4c3d-84b2-9acee7496b24>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c5383a2-5c00-4cac-9e4a-760ff6f3baa2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c5383a2-5c00-4cac-9e4a-760ff6f3baa2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c5383a2-5c00-4cac-9e4a-760ff6f3baa2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8b91782-9307-46d4-8e48-9e591cffc344> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8b91782-9307-46d4-8e48-9e591cffc344";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8b91782-9307-46d4-8e48-9e591cffc344>.
+    
+<http://data.lblod.info/id/remote-data-objects/d87a2aef-6e3c-4520-9653-b60d3dfa33cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d87a2aef-6e3c-4520-9653-b60d3dfa33cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d87a2aef-6e3c-4520-9653-b60d3dfa33cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/bffce495-9005-4e65-83b2-edc6834d18ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bffce495-9005-4e65-83b2-edc6834d18ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fd515532-c9f1-4db7-ba24-adf3b8cdb416> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bffce495-9005-4e65-83b2-edc6834d18ab>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201530-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201530-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201530-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201530-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/0b5903d9-ea57-4f04-beca-6b81b55c93d3> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0b5903d9-ea57-4f04-beca-6b81b55c93d3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e6870074-8cc8-4f3f-90d7-f892b9523d7f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/89cebc3d-b7da-4d90-8d31-86b32666b30e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "89cebc3d-b7da-4d90-8d31-86b32666b30e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f>.
+
+  <http://redpencil.data.gift/id/task/06f22163-f14c-4715-85e0-98c50cf842fa> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "06f22163-f14c-4715-85e0-98c50cf842fa";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/0b5903d9-ea57-4f04-beca-6b81b55c93d3>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/89cebc3d-b7da-4d90-8d31-86b32666b30e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a800384a-2818-429b-b143-bc48addccb48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a800384a-2818-429b-b143-bc48addccb48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a800384a-2818-429b-b143-bc48addccb48>.
+    
+<http://data.lblod.info/id/remote-data-objects/775cb566-95e2-4e7b-af34-7f2201e817cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "775cb566-95e2-4e7b-af34-7f2201e817cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/775cb566-95e2-4e7b-af34-7f2201e817cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/fed8ec04-4c76-42d5-8be0-5385305b8207> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fed8ec04-4c76-42d5-8be0-5385305b8207";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fed8ec04-4c76-42d5-8be0-5385305b8207>.
+    
+<http://data.lblod.info/id/remote-data-objects/e31a590e-9a5d-45dd-8143-ae3baa19314b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e31a590e-9a5d-45dd-8143-ae3baa19314b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e31a590e-9a5d-45dd-8143-ae3baa19314b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2d6962d-a667-43ae-8c6a-2e99aa80cf17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2d6962d-a667-43ae-8c6a-2e99aa80cf17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2d6962d-a667-43ae-8c6a-2e99aa80cf17>.
+    
+<http://data.lblod.info/id/remote-data-objects/c95c519c-7f68-4bfe-a489-4b8f70c98c33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c95c519c-7f68-4bfe-a489-4b8f70c98c33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c95c519c-7f68-4bfe-a489-4b8f70c98c33>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca841a9f-4edc-4377-b186-dbb83a696cd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca841a9f-4edc-4377-b186-dbb83a696cd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca841a9f-4edc-4377-b186-dbb83a696cd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed62bb19-5e77-4a81-9fde-8153330d2a0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed62bb19-5e77-4a81-9fde-8153330d2a0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.maarkedal.be/LBLODWeb/Home/Overzicht/a8f2f59d65cd53a6471b39ba216351e749975cca8c73d707369530bd2270a35e/GetPublication?filename=BesluitenLijst_Vast%20bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed62bb19-5e77-4a81-9fde-8153330d2a0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f850d2d4-2e95-43cb-afb9-8befc54291e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f850d2d4-2e95-43cb-afb9-8befc54291e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Agenda_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f850d2d4-2e95-43cb-afb9-8befc54291e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/eac10f4f-b10f-434c-9191-aaeced0f11b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eac10f4f-b10f-434c-9191-aaeced0f11b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Agenda_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eac10f4f-b10f-434c-9191-aaeced0f11b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5069beb5-3c2b-4c58-8ed3-362ae55b512f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5069beb5-3c2b-4c58-8ed3-362ae55b512f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Agenda_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5069beb5-3c2b-4c58-8ed3-362ae55b512f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f54f34be-49f8-485e-8eab-cd6e10515f3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f54f34be-49f8-485e-8eab-cd6e10515f3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Agenda_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f54f34be-49f8-485e-8eab-cd6e10515f3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/12daf5d1-6b5c-4110-98b1-ae8edeccc9d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12daf5d1-6b5c-4110-98b1-ae8edeccc9d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Agenda_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12daf5d1-6b5c-4110-98b1-ae8edeccc9d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/90c94d24-5f18-4b27-abe7-8b4b0c55675f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90c94d24-5f18-4b27-abe7-8b4b0c55675f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Agenda_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90c94d24-5f18-4b27-abe7-8b4b0c55675f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1dd382b-3fd6-4de7-aa05-43807db738f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1dd382b-3fd6-4de7-aa05-43807db738f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Agenda_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1dd382b-3fd6-4de7-aa05-43807db738f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/346a95f2-5688-480e-a2e8-d827ab06a030> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "346a95f2-5688-480e-a2e8-d827ab06a030";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Agenda_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/346a95f2-5688-480e-a2e8-d827ab06a030>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d896e8f-c631-464d-b002-173ae6067cd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d896e8f-c631-464d-b002-173ae6067cd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Agenda_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d896e8f-c631-464d-b002-173ae6067cd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/7854f80e-88f6-4f1e-b107-2772ee11dd12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7854f80e-88f6-4f1e-b107-2772ee11dd12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7854f80e-88f6-4f1e-b107-2772ee11dd12>.
+    
+<http://data.lblod.info/id/remote-data-objects/af46bbac-4f2f-42d6-aa0d-2bb07293bbf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af46bbac-4f2f-42d6-aa0d-2bb07293bbf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af46bbac-4f2f-42d6-aa0d-2bb07293bbf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/08ee96f2-72d7-4485-b670-f934567f8214> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08ee96f2-72d7-4485-b670-f934567f8214";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08ee96f2-72d7-4485-b670-f934567f8214>.
+    
+<http://data.lblod.info/id/remote-data-objects/8aca3842-1c03-49d9-be16-1c706b87b704> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8aca3842-1c03-49d9-be16-1c706b87b704";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8aca3842-1c03-49d9-be16-1c706b87b704>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ab11df5-1982-4484-9b5f-7ba416cf8611> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ab11df5-1982-4484-9b5f-7ba416cf8611";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ab11df5-1982-4484-9b5f-7ba416cf8611>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b739a88-1096-4afa-a2a4-077edd830ad1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b739a88-1096-4afa-a2a4-077edd830ad1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b739a88-1096-4afa-a2a4-077edd830ad1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f5dee2d-a520-4be1-bd27-625185f7eafb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f5dee2d-a520-4be1-bd27-625185f7eafb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f5dee2d-a520-4be1-bd27-625185f7eafb>.
+    
+<http://data.lblod.info/id/remote-data-objects/a98720d1-0ed3-46b0-a806-6eb72980fbb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a98720d1-0ed3-46b0-a806-6eb72980fbb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a98720d1-0ed3-46b0-a806-6eb72980fbb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1800842-d8a9-48ef-b895-cc7bb153ae5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1800842-d8a9-48ef-b895-cc7bb153ae5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1800842-d8a9-48ef-b895-cc7bb153ae5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9efae34-98f5-449c-8410-37289deac357> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9efae34-98f5-449c-8410-37289deac357";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Notulen_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9efae34-98f5-449c-8410-37289deac357>.
+    
+<http://data.lblod.info/id/remote-data-objects/519c91a6-5990-444a-b3dd-8f0d9d421e54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "519c91a6-5990-444a-b3dd-8f0d9d421e54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Notulen_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/519c91a6-5990-444a-b3dd-8f0d9d421e54>.
+    
+<http://data.lblod.info/id/remote-data-objects/91b599e4-a295-4645-aa56-b54cf41be860> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91b599e4-a295-4645-aa56-b54cf41be860";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Notulen_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91b599e4-a295-4645-aa56-b54cf41be860>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1e249ed-3455-410d-b8df-5e4500127307> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1e249ed-3455-410d-b8df-5e4500127307";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Notulen_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1e249ed-3455-410d-b8df-5e4500127307>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2d07b99-3684-494b-bf7e-6ca1d3235a2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2d07b99-3684-494b-bf7e-6ca1d3235a2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Notulen_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2d07b99-3684-494b-bf7e-6ca1d3235a2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e77075bc-545f-41d8-b7fa-a28fe8fbb34f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e77075bc-545f-41d8-b7fa-a28fe8fbb34f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Notulen_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e77075bc-545f-41d8-b7fa-a28fe8fbb34f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec73c4a3-1bb1-41a7-a5bc-d3f2870bcdfb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec73c4a3-1bb1-41a7-a5bc-d3f2870bcdfb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Notulen_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec73c4a3-1bb1-41a7-a5bc-d3f2870bcdfb>.
+    
+<http://data.lblod.info/id/remote-data-objects/adde8da7-1ff5-44c5-a7c1-48bbeb1c6ccf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "adde8da7-1ff5-44c5-a7c1-48bbeb1c6ccf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Notulen_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/adde8da7-1ff5-44c5-a7c1-48bbeb1c6ccf>.
+    
+<http://data.lblod.info/id/remote-data-objects/cca9fd29-3362-484c-8683-f985685b9fa0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cca9fd29-3362-484c-8683-f985685b9fa0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_20-12-2021_80060.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cca9fd29-3362-484c-8683-f985685b9fa0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad18c674-7195-4691-90b8-3b028b8174c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad18c674-7195-4691-90b8-3b028b8174c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_20-12-2021_80394.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad18c674-7195-4691-90b8-3b028b8174c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ce3f640-cf3c-4714-9e3a-34c80d1eba01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ce3f640-cf3c-4714-9e3a-34c80d1eba01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_20-12-2021_80395.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ce3f640-cf3c-4714-9e3a-34c80d1eba01>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff9e5aa1-0ab0-4087-9d01-09859f25a776> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff9e5aa1-0ab0-4087-9d01-09859f25a776";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_20-12-2021_80396.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff9e5aa1-0ab0-4087-9d01-09859f25a776>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cf402b1-c8c6-496d-8c16-ee6c3c3586f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cf402b1-c8c6-496d-8c16-ee6c3c3586f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_20-12-2021_80461.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cf402b1-c8c6-496d-8c16-ee6c3c3586f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/50755132-921d-474e-beb3-f273072fcc6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50755132-921d-474e-beb3-f273072fcc6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_20-12-2021_80464.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50755132-921d-474e-beb3-f273072fcc6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fb55ee9-3a71-4890-8c57-baeda5ed29d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fb55ee9-3a71-4890-8c57-baeda5ed29d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_20-12-2021_80465.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fb55ee9-3a71-4890-8c57-baeda5ed29d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddaa2a9e-24eb-43c2-b677-1c1aea280216> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddaa2a9e-24eb-43c2-b677-1c1aea280216";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_20-12-2021_80469.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddaa2a9e-24eb-43c2-b677-1c1aea280216>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff387b1b-23bb-4656-824c-0cf21c4eeabf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff387b1b-23bb-4656-824c-0cf21c4eeabf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_20-12-2021_80485.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff387b1b-23bb-4656-824c-0cf21c4eeabf>.
+    
+<http://data.lblod.info/id/remote-data-objects/56bda549-b218-4646-a3b3-9244f0f5517c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56bda549-b218-4646-a3b3-9244f0f5517c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_20-12-2021_80628.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56bda549-b218-4646-a3b3-9244f0f5517c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f6d52f1-72e4-41ac-a711-4cf7ad44f8eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f6d52f1-72e4-41ac-a711-4cf7ad44f8eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_21-02-2022_81726.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f6d52f1-72e4-41ac-a711-4cf7ad44f8eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1e5e060-794a-4768-8d3c-ca28b334c996> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1e5e060-794a-4768-8d3c-ca28b334c996";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_21-02-2022_81728.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1e5e060-794a-4768-8d3c-ca28b334c996>.
+    
+<http://data.lblod.info/id/remote-data-objects/e261b4f0-0b9e-44f2-a8e6-d5d004266303> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e261b4f0-0b9e-44f2-a8e6-d5d004266303";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_21-02-2022_81732.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e261b4f0-0b9e-44f2-a8e6-d5d004266303>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4376114-1cc0-470f-91fa-48a56a7d4a0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4376114-1cc0-470f-91fa-48a56a7d4a0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_21-02-2022_81760.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4376114-1cc0-470f-91fa-48a56a7d4a0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4accdb35-bc1e-4c2a-8a42-fc5cb1985937> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4accdb35-bc1e-4c2a-8a42-fc5cb1985937";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_23-05-2022_83331.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4accdb35-bc1e-4c2a-8a42-fc5cb1985937>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa43d76c-2bf5-4292-bec8-0eb4b81b9014> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa43d76c-2bf5-4292-bec8-0eb4b81b9014";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_23-05-2022_83476.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e6870074-8cc8-4f3f-90d7-f892b9523d7f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa43d76c-2bf5-4292-bec8-0eb4b81b9014>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201531-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201531-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201531-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201531-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d253e577-f8aa-477d-900d-1e20334d9f8a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d253e577-f8aa-477d-900d-1e20334d9f8a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "aec5aa95-1e63-45ce-a339-f6f464829774";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/79766047-646d-4faa-907a-2a068f3eff41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "79766047-646d-4faa-907a-2a068f3eff41";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774>.
+
+  <http://redpencil.data.gift/id/task/f6988ce1-d586-4040-847f-9ac92e501565> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f6988ce1-d586-4040-847f-9ac92e501565";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d253e577-f8aa-477d-900d-1e20334d9f8a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/79766047-646d-4faa-907a-2a068f3eff41>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/04b93117-79d5-4a6f-84a7-f4e9025f590b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04b93117-79d5-4a6f-84a7-f4e9025f590b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_23-05-2022_83528.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04b93117-79d5-4a6f-84a7-f4e9025f590b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f38794ee-be1a-48aa-bb71-b48e377517e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f38794ee-be1a-48aa-bb71-b48e377517e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_23-05-2022_83531.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f38794ee-be1a-48aa-bb71-b48e377517e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/38faad32-7a86-456a-9ef6-adea28be3ed2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38faad32-7a86-456a-9ef6-adea28be3ed2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_23-05-2022_83534.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38faad32-7a86-456a-9ef6-adea28be3ed2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c01428fb-07e4-4972-a08b-02597572bb38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c01428fb-07e4-4972-a08b-02597572bb38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_23-05-2022_83538.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c01428fb-07e4-4972-a08b-02597572bb38>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab57f5cb-6892-45e8-a3de-9c72f6ea4957> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab57f5cb-6892-45e8-a3de-9c72f6ea4957";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_24-01-2022_81229.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab57f5cb-6892-45e8-a3de-9c72f6ea4957>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9948549-a718-4bf3-aa29-67a2135fe44f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9948549-a718-4bf3-aa29-67a2135fe44f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_25-04-2022_82879.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9948549-a718-4bf3-aa29-67a2135fe44f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a489a86-8a2d-4efb-83ca-4ac31547129e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a489a86-8a2d-4efb-83ca-4ac31547129e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_25-04-2022_82881.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a489a86-8a2d-4efb-83ca-4ac31547129e>.
+    
+<http://data.lblod.info/id/remote-data-objects/01648eca-5398-4d9f-93f9-f080bf5bd4ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01648eca-5398-4d9f-93f9-f080bf5bd4ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_25-04-2022_83005.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01648eca-5398-4d9f-93f9-f080bf5bd4ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/eca9bd59-4651-4833-8265-ef2e12236aef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eca9bd59-4651-4833-8265-ef2e12236aef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_25-04-2022_83006.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eca9bd59-4651-4833-8265-ef2e12236aef>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0d093b6-703f-40d8-adba-5076c1a59530> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0d093b6-703f-40d8-adba-5076c1a59530";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_25-04-2022_83007.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0d093b6-703f-40d8-adba-5076c1a59530>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd229077-31d7-4585-8a88-f0494d12bffa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd229077-31d7-4585-8a88-f0494d12bffa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_25-04-2022_83013.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd229077-31d7-4585-8a88-f0494d12bffa>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f4d26f7-532d-4dc0-b09e-47d53d208cb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f4d26f7-532d-4dc0-b09e-47d53d208cb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_25-04-2022_83020.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f4d26f7-532d-4dc0-b09e-47d53d208cb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/6473ad59-35e3-4519-b74b-1d6682ea93d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6473ad59-35e3-4519-b74b-1d6682ea93d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_25-04-2022_83021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6473ad59-35e3-4519-b74b-1d6682ea93d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/58ff7dd8-2ba1-4438-bc39-625edd6456d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58ff7dd8-2ba1-4438-bc39-625edd6456d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_27-06-2022_83873.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58ff7dd8-2ba1-4438-bc39-625edd6456d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/09325412-ab6a-4541-92bd-463e37229358> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09325412-ab6a-4541-92bd-463e37229358";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_27-06-2022_83972.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09325412-ab6a-4541-92bd-463e37229358>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b746e0f-089b-44f2-a444-aab872422086> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b746e0f-089b-44f2-a444-aab872422086";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_27-06-2022_84237.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b746e0f-089b-44f2-a444-aab872422086>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f489f34-6498-4252-9510-d4e6826b708c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f489f34-6498-4252-9510-d4e6826b708c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_27-06-2022_84240.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f489f34-6498-4252-9510-d4e6826b708c>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb9a5225-d320-4bb3-8131-3dfcb3d3d2f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb9a5225-d320-4bb3-8131-3dfcb3d3d2f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_27-06-2022_84244.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb9a5225-d320-4bb3-8131-3dfcb3d3d2f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/446a8e36-f51d-4cc1-84c1-1ac6da808903> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "446a8e36-f51d-4cc1-84c1-1ac6da808903";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_27-06-2022_84328.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/446a8e36-f51d-4cc1-84c1-1ac6da808903>.
+    
+<http://data.lblod.info/id/remote-data-objects/afc3f29d-89f7-464a-b875-c0cae13518a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afc3f29d-89f7-464a-b875-c0cae13518a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_27-06-2022_84331.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afc3f29d-89f7-464a-b875-c0cae13518a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/be4e97a5-e0f6-4974-b3cf-50d8b203a3e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be4e97a5-e0f6-4974-b3cf-50d8b203a3e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_27-06-2022_84332.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be4e97a5-e0f6-4974-b3cf-50d8b203a3e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d901047-ad5d-48ce-8d51-4273d49128f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d901047-ad5d-48ce-8d51-4273d49128f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_28-03-2022_82165.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d901047-ad5d-48ce-8d51-4273d49128f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/90a9c7aa-f761-4e71-b8e4-d70fe6f8e977> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90a9c7aa-f761-4e71-b8e4-d70fe6f8e977";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_28-03-2022_82401.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90a9c7aa-f761-4e71-b8e4-d70fe6f8e977>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dec849c-15d4-42f2-a990-a583b25f0ad9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dec849c-15d4-42f2-a990-a583b25f0ad9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_28-03-2022_82442.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dec849c-15d4-42f2-a990-a583b25f0ad9>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c8f5fe2-893d-49fa-8c4e-5127d53130bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c8f5fe2-893d-49fa-8c4e-5127d53130bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_28-03-2022_82449.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c8f5fe2-893d-49fa-8c4e-5127d53130bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/a003bcac-6b7e-4642-9a4f-0a6c0cc6996b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a003bcac-6b7e-4642-9a4f-0a6c0cc6996b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/06c2b56ed7b49d146337f6db044204f19c34c4242deb3b4e142dbf925d733eda/GetPublication?filename=Uittreksels_29-11-2021_80088.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a003bcac-6b7e-4642-9a4f-0a6c0cc6996b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee12623d-c4f2-442b-a025-dfa23d269a63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee12623d-c4f2-442b-a025-dfa23d269a63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=Agenda_SH%20-%20Raad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee12623d-c4f2-442b-a025-dfa23d269a63>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e23513c-7ee3-4771-9978-23e4577ce7bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e23513c-7ee3-4771-9978-23e4577ce7bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=Agenda_SH%20-%20Raad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e23513c-7ee3-4771-9978-23e4577ce7bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c12bf0b-e157-4d33-8268-1a0cf287e991> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c12bf0b-e157-4d33-8268-1a0cf287e991";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=Agenda_SH%20-%20Raad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c12bf0b-e157-4d33-8268-1a0cf287e991>.
+    
+<http://data.lblod.info/id/remote-data-objects/f427e022-a315-44c7-9d8a-974b2c37c4a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f427e022-a315-44c7-9d8a-974b2c37c4a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=Agenda_SH%20-%20Raad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f427e022-a315-44c7-9d8a-974b2c37c4a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbaf3888-2b3b-43bd-9d26-a47d426d3af6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbaf3888-2b3b-43bd-9d26-a47d426d3af6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=Agenda_SH%20-%20Raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbaf3888-2b3b-43bd-9d26-a47d426d3af6>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ff8b515-96b2-43e2-bfdb-2cc65ee86eb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ff8b515-96b2-43e2-bfdb-2cc65ee86eb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=Agenda_SH%20-%20Raad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ff8b515-96b2-43e2-bfdb-2cc65ee86eb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3516d81-9daf-4dd2-808f-dd271d984e14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3516d81-9daf-4dd2-808f-dd271d984e14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=Agenda_SH%20-%20Raad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3516d81-9daf-4dd2-808f-dd271d984e14>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dbedcee-2b87-4466-8597-3dd44a0b6da8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dbedcee-2b87-4466-8597-3dd44a0b6da8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=Agenda_SH%20-%20Raad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dbedcee-2b87-4466-8597-3dd44a0b6da8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f190372-3108-44f8-ab6b-59f6613c8d96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f190372-3108-44f8-ab6b-59f6613c8d96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=Agenda_SH%20-%20Raad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f190372-3108-44f8-ab6b-59f6613c8d96>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ff3f695-c6be-4bee-a34c-dca2d707b4f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ff3f695-c6be-4bee-a34c-dca2d707b4f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Raad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ff3f695-c6be-4bee-a34c-dca2d707b4f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e79dc18-3c94-4965-88e1-2d683f45532e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e79dc18-3c94-4965-88e1-2d683f45532e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Raad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e79dc18-3c94-4965-88e1-2d683f45532e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e0c3984-d531-4420-a7d8-7cabaaea8296> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e0c3984-d531-4420-a7d8-7cabaaea8296";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Raad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e0c3984-d531-4420-a7d8-7cabaaea8296>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd6261f6-e2e1-44f0-9009-e24d5c9e4794> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd6261f6-e2e1-44f0-9009-e24d5c9e4794";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Raad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd6261f6-e2e1-44f0-9009-e24d5c9e4794>.
+    
+<http://data.lblod.info/id/remote-data-objects/47359953-f89f-46fc-b6fc-cab83f243706> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47359953-f89f-46fc-b6fc-cab83f243706";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47359953-f89f-46fc-b6fc-cab83f243706>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9447879-3e15-4bfc-86dd-07acb071c838> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9447879-3e15-4bfc-86dd-07acb071c838";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Raad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9447879-3e15-4bfc-86dd-07acb071c838>.
+    
+<http://data.lblod.info/id/remote-data-objects/c243f277-aaa3-4e89-a0c8-8366a516fbf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c243f277-aaa3-4e89-a0c8-8366a516fbf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Raad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c243f277-aaa3-4e89-a0c8-8366a516fbf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d816d38b-aa8b-4d7f-a3d3-9f2bad72f905> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d816d38b-aa8b-4d7f-a3d3-9f2bad72f905";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Raad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d816d38b-aa8b-4d7f-a3d3-9f2bad72f905>.
+    
+<http://data.lblod.info/id/remote-data-objects/93634598-fff7-4791-b095-3797789cc3ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93634598-fff7-4791-b095-3797789cc3ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Raad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93634598-fff7-4791-b095-3797789cc3ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9767852-f152-4d7f-ac46-cefa431b3809> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9767852-f152-4d7f-ac46-cefa431b3809";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=Notulen_SH%20-%20Raad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9767852-f152-4d7f-ac46-cefa431b3809>.
+    
+<http://data.lblod.info/id/remote-data-objects/1729793b-4a05-41e6-b7c5-2a859a69e8b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1729793b-4a05-41e6-b7c5-2a859a69e8b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=Notulen_SH%20-%20Raad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1729793b-4a05-41e6-b7c5-2a859a69e8b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/75daf64c-f2ef-4a57-9df4-df950d5515b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75daf64c-f2ef-4a57-9df4-df950d5515b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=Notulen_SH%20-%20Raad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75daf64c-f2ef-4a57-9df4-df950d5515b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/34ede524-23e2-4574-ac93-9b040f28c1d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34ede524-23e2-4574-ac93-9b040f28c1d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=Notulen_SH%20-%20Raad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34ede524-23e2-4574-ac93-9b040f28c1d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/224fd576-8cc7-4914-a132-0d8705ef403b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "224fd576-8cc7-4914-a132-0d8705ef403b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=Notulen_SH%20-%20Raad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/224fd576-8cc7-4914-a132-0d8705ef403b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7788a2f7-5825-493c-a0f7-33cd1703e8b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7788a2f7-5825-493c-a0f7-33cd1703e8b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/3ee5544b66963ad499afb4fe84f3de9995e6f0244f2fda120fa337e43d914f4c/GetPublication?filename=Uittreksels_24-01-2022_81264.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aec5aa95-1e63-45ce-a339-f6f464829774> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7788a2f7-5825-493c-a0f7-33cd1703e8b6>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201532-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201532-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201532-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201532-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/465e7af1-1afe-42bb-8d6d-ef19492df387> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "465e7af1-1afe-42bb-8d6d-ef19492df387";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f1f9b77e-20d1-4d4c-8383-2b5363557846";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f0fd3c61-08d2-4293-a77b-496656bb9c51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f0fd3c61-08d2-4293-a77b-496656bb9c51";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846>.
+
+  <http://redpencil.data.gift/id/task/9c764146-4e4c-47c4-ab03-efc2605d4616> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9c764146-4e4c-47c4-ab03-efc2605d4616";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/465e7af1-1afe-42bb-8d6d-ef19492df387>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f0fd3c61-08d2-4293-a77b-496656bb9c51>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/05f4ae4d-bb78-4d5d-a52b-9692bab6106f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05f4ae4d-bb78-4d5d-a52b-9692bab6106f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05f4ae4d-bb78-4d5d-a52b-9692bab6106f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7907eadc-cdd1-44a1-9e22-a407e7a55bd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7907eadc-cdd1-44a1-9e22-a407e7a55bd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_01-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7907eadc-cdd1-44a1-9e22-a407e7a55bd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/61545dd6-fbca-47f3-b47d-fa90ebab36e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61545dd6-fbca-47f3-b47d-fa90ebab36e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61545dd6-fbca-47f3-b47d-fa90ebab36e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/99c583c7-9870-4c37-aec0-c2e35d5df471> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99c583c7-9870-4c37-aec0-c2e35d5df471";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99c583c7-9870-4c37-aec0-c2e35d5df471>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9b9dcaf-64a1-492b-931b-6703ad4d22e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9b9dcaf-64a1-492b-931b-6703ad4d22e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9b9dcaf-64a1-492b-931b-6703ad4d22e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/5958b5fb-b2a3-4913-8877-c742666fbc82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5958b5fb-b2a3-4913-8877-c742666fbc82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_08-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5958b5fb-b2a3-4913-8877-c742666fbc82>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e26f050-9dbb-4362-9cd1-aaa1ddac049e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e26f050-9dbb-4362-9cd1-aaa1ddac049e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e26f050-9dbb-4362-9cd1-aaa1ddac049e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbd7c1c3-bb77-40d8-b82a-76a250c520ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbd7c1c3-bb77-40d8-b82a-76a250c520ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbd7c1c3-bb77-40d8-b82a-76a250c520ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0c0886c-e64b-4eae-badc-12f15066b56d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0c0886c-e64b-4eae-badc-12f15066b56d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_10-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0c0886c-e64b-4eae-badc-12f15066b56d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f2fa1e9-169f-42e5-8716-d9e273a641cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f2fa1e9-169f-42e5-8716-d9e273a641cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f2fa1e9-169f-42e5-8716-d9e273a641cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/446dd135-136f-4623-9ded-7a19f2372418> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "446dd135-136f-4623-9ded-7a19f2372418";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/446dd135-136f-4623-9ded-7a19f2372418>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9d607fc-bdc6-4322-a5f1-e3467f9e526a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9d607fc-bdc6-4322-a5f1-e3467f9e526a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9d607fc-bdc6-4322-a5f1-e3467f9e526a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1b983ed-31ec-4c2d-9bc8-8d70d81561d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1b983ed-31ec-4c2d-9bc8-8d70d81561d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1b983ed-31ec-4c2d-9bc8-8d70d81561d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6be1994d-44de-48f9-ac3e-83a9c5348864> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6be1994d-44de-48f9-ac3e-83a9c5348864";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6be1994d-44de-48f9-ac3e-83a9c5348864>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d5c45f0-7eb6-4f7f-a816-88c261df4bd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d5c45f0-7eb6-4f7f-a816-88c261df4bd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d5c45f0-7eb6-4f7f-a816-88c261df4bd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/765a74f8-4194-438e-ad10-ebbc76435ebf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "765a74f8-4194-438e-ad10-ebbc76435ebf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/765a74f8-4194-438e-ad10-ebbc76435ebf>.
+    
+<http://data.lblod.info/id/remote-data-objects/41b35a71-a1c2-4af3-a406-5efdbcac46cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41b35a71-a1c2-4af3-a406-5efdbcac46cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41b35a71-a1c2-4af3-a406-5efdbcac46cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/571ffcd2-d15a-4e56-a88f-4d3c77fbd4aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "571ffcd2-d15a-4e56-a88f-4d3c77fbd4aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/571ffcd2-d15a-4e56-a88f-4d3c77fbd4aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/3670d945-3b9e-45f7-924f-8f9bf6565cd4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3670d945-3b9e-45f7-924f-8f9bf6565cd4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3670d945-3b9e-45f7-924f-8f9bf6565cd4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0841c094-0ce1-45a1-b00c-15b10e2c77d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0841c094-0ce1-45a1-b00c-15b10e2c77d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0841c094-0ce1-45a1-b00c-15b10e2c77d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cf17f90-399c-4466-be66-6cf56ddfae8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cf17f90-399c-4466-be66-6cf56ddfae8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_22-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cf17f90-399c-4466-be66-6cf56ddfae8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f538de0a-18e6-4ac0-893b-5c60145edb10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f538de0a-18e6-4ac0-893b-5c60145edb10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f538de0a-18e6-4ac0-893b-5c60145edb10>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b19609f-612e-46ad-a2c7-f52d2d980f9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b19609f-612e-46ad-a2c7-f52d2d980f9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_24-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b19609f-612e-46ad-a2c7-f52d2d980f9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/427b6d14-f690-4925-963e-e6edce41ab53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "427b6d14-f690-4925-963e-e6edce41ab53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/427b6d14-f690-4925-963e-e6edce41ab53>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfa037af-676c-4233-935a-38b3fc0184d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfa037af-676c-4233-935a-38b3fc0184d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfa037af-676c-4233-935a-38b3fc0184d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/03c9cd7d-307a-4baa-8b41-21dcffce769c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03c9cd7d-307a-4baa-8b41-21dcffce769c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03c9cd7d-307a-4baa-8b41-21dcffce769c>.
+    
+<http://data.lblod.info/id/remote-data-objects/62d6d9f9-be63-4ac3-a81d-25166049f750> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62d6d9f9-be63-4ac3-a81d-25166049f750";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_28-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62d6d9f9-be63-4ac3-a81d-25166049f750>.
+    
+<http://data.lblod.info/id/remote-data-objects/42bd17e2-09f5-4b1d-8566-a68f9d16fe5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42bd17e2-09f5-4b1d-8566-a68f9d16fe5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42bd17e2-09f5-4b1d-8566-a68f9d16fe5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fb575cb-5633-4d1f-a551-af4a6fa13d30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fb575cb-5633-4d1f-a551-af4a6fa13d30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=Uittreksels_10-12-2021_80609.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fb575cb-5633-4d1f-a551-af4a6fa13d30>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bf3299a-091e-41a1-8075-b36ce2836672> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bf3299a-091e-41a1-8075-b36ce2836672";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=Uittreksels_19-04-2022_83171.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bf3299a-091e-41a1-8075-b36ce2836672>.
+    
+<http://data.lblod.info/id/remote-data-objects/443eeb62-305d-4254-81c0-769558f18bae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "443eeb62-305d-4254-81c0-769558f18bae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=Uittreksels_19-05-2022_83845.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/443eeb62-305d-4254-81c0-769558f18bae>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebfe9d6e-ec91-4c18-b0ac-43a026e71cd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebfe9d6e-ec91-4c18-b0ac-43a026e71cd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=Uittreksels_24-12-2021_81140.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebfe9d6e-ec91-4c18-b0ac-43a026e71cd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/26f42a79-879b-46f5-96e1-c0398ae3495f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26f42a79-879b-46f5-96e1-c0398ae3495f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/61b5f831241a25e43c4acf4cdf620769f334514de906151dfa1ac01146ecd971/GetPublication?filename=Uittreksels_25-10-2021_79652.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26f42a79-879b-46f5-96e1-c0398ae3495f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1a4356e-8200-4741-9c0c-9d1cedd50b14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1a4356e-8200-4741-9c0c-9d1cedd50b14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1a4356e-8200-4741-9c0c-9d1cedd50b14>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ca63b17-3bdc-4de7-bf43-3855943dcad0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ca63b17-3bdc-4de7-bf43-3855943dcad0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ca63b17-3bdc-4de7-bf43-3855943dcad0>.
+    
+<http://data.lblod.info/id/remote-data-objects/99a13f1b-9a5b-46f4-aeb9-d1095b562af3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99a13f1b-9a5b-46f4-aeb9-d1095b562af3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99a13f1b-9a5b-46f4-aeb9-d1095b562af3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8dd3fa39-8a5e-4f6f-b64d-9a5df47640ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8dd3fa39-8a5e-4f6f-b64d-9a5df47640ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8dd3fa39-8a5e-4f6f-b64d-9a5df47640ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/0934b192-7709-4545-b90d-3ca72a2ca158> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0934b192-7709-4545-b90d-3ca72a2ca158";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0934b192-7709-4545-b90d-3ca72a2ca158>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0266dc4-2cdd-4f24-83b8-52a4364e4c6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0266dc4-2cdd-4f24-83b8-52a4364e4c6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0266dc4-2cdd-4f24-83b8-52a4364e4c6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4f5a3be-63f6-41a4-9059-1eac6b75158e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4f5a3be-63f6-41a4-9059-1eac6b75158e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4f5a3be-63f6-41a4-9059-1eac6b75158e>.
+    
+<http://data.lblod.info/id/remote-data-objects/712c18e9-8de6-4e6f-ac03-18e377c8ce45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "712c18e9-8de6-4e6f-ac03-18e377c8ce45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/712c18e9-8de6-4e6f-ac03-18e377c8ce45>.
+    
+<http://data.lblod.info/id/remote-data-objects/07cdcb1f-7463-4e12-9734-7acf5958ab30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07cdcb1f-7463-4e12-9734-7acf5958ab30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07cdcb1f-7463-4e12-9734-7acf5958ab30>.
+    
+<http://data.lblod.info/id/remote-data-objects/636cf476-4dd0-4849-b6ef-dfee6cb84450> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "636cf476-4dd0-4849-b6ef-dfee6cb84450";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/636cf476-4dd0-4849-b6ef-dfee6cb84450>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e1c44a0-bd25-49b5-90bc-ef05d6f0fd24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e1c44a0-bd25-49b5-90bc-ef05d6f0fd24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e1c44a0-bd25-49b5-90bc-ef05d6f0fd24>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fde692c-b973-4b30-ba17-0b2cfd2d78c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fde692c-b973-4b30-ba17-0b2cfd2d78c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fde692c-b973-4b30-ba17-0b2cfd2d78c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4837d60-dcfe-4550-bc9a-3087f57cec1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4837d60-dcfe-4550-bc9a-3087f57cec1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4837d60-dcfe-4550-bc9a-3087f57cec1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dac0df7-5601-4507-9dd7-c717c9b4d26e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dac0df7-5601-4507-9dd7-c717c9b4d26e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dac0df7-5601-4507-9dd7-c717c9b4d26e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a0c3017-fb5d-40a8-b2b2-6cfb7ff9c11f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a0c3017-fb5d-40a8-b2b2-6cfb7ff9c11f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a0c3017-fb5d-40a8-b2b2-6cfb7ff9c11f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c2721c3-7b68-4409-876d-db99afdbe988> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c2721c3-7b68-4409-876d-db99afdbe988";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c2721c3-7b68-4409-876d-db99afdbe988>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad4cf0a6-49bd-44d3-bcc2-b0875aabacf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad4cf0a6-49bd-44d3-bcc2-b0875aabacf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1f9b77e-20d1-4d4c-8383-2b5363557846> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad4cf0a6-49bd-44d3-bcc2-b0875aabacf5>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201534-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201534-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201534-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201534-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e95553f1-339c-496b-ab78-3947eb3f8d0c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e95553f1-339c-496b-ab78-3947eb3f8d0c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fc5c2aee-a3f9-4818-b015-debef8dd6377";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/3421a73b-82a8-4188-8a85-a2bff4490dde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3421a73b-82a8-4188-8a85-a2bff4490dde";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377>.
+
+  <http://redpencil.data.gift/id/task/a3a8d94c-4fc4-4270-aa4d-ff0ed8dc8b6d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a3a8d94c-4fc4-4270-aa4d-ff0ed8dc8b6d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e95553f1-339c-496b-ab78-3947eb3f8d0c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/3421a73b-82a8-4188-8a85-a2bff4490dde>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/168877b7-2a39-42eb-987f-65b9fed6f5e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "168877b7-2a39-42eb-987f-65b9fed6f5e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/168877b7-2a39-42eb-987f-65b9fed6f5e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/84e59756-c129-44c5-97c8-d0700b505c07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84e59756-c129-44c5-97c8-d0700b505c07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84e59756-c129-44c5-97c8-d0700b505c07>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cab3da3-abb9-4162-9bf3-ab924614cf75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cab3da3-abb9-4162-9bf3-ab924614cf75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cab3da3-abb9-4162-9bf3-ab924614cf75>.
+    
+<http://data.lblod.info/id/remote-data-objects/34f2a70d-ea16-4ae0-9558-41fa6690c694> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34f2a70d-ea16-4ae0-9558-41fa6690c694";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34f2a70d-ea16-4ae0-9558-41fa6690c694>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb77ca8e-969b-4a74-b0ff-88c66874d204> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb77ca8e-969b-4a74-b0ff-88c66874d204";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb77ca8e-969b-4a74-b0ff-88c66874d204>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b55e807-1ed4-43c8-b7c9-92fc23040fe0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b55e807-1ed4-43c8-b7c9-92fc23040fe0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b55e807-1ed4-43c8-b7c9-92fc23040fe0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6277e54-b0ce-4301-bce5-15e202c85821> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6277e54-b0ce-4301-bce5-15e202c85821";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6277e54-b0ce-4301-bce5-15e202c85821>.
+    
+<http://data.lblod.info/id/remote-data-objects/98507cd4-0319-4210-93f1-08c4ce4f60bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98507cd4-0319-4210-93f1-08c4ce4f60bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98507cd4-0319-4210-93f1-08c4ce4f60bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/db613032-ab2e-420f-b61e-9dd4437bad1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db613032-ab2e-420f-b61e-9dd4437bad1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db613032-ab2e-420f-b61e-9dd4437bad1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/561c443a-3290-4fbe-b233-d9ac404ee7f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "561c443a-3290-4fbe-b233-d9ac404ee7f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/561c443a-3290-4fbe-b233-d9ac404ee7f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/b54c9a01-94fa-4cca-a128-85e29ca6fb3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b54c9a01-94fa-4cca-a128-85e29ca6fb3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b54c9a01-94fa-4cca-a128-85e29ca6fb3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3799286-1f5c-434f-a3e3-895f4d29d99b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3799286-1f5c-434f-a3e3-895f4d29d99b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3799286-1f5c-434f-a3e3-895f4d29d99b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ceb2f82f-aa8c-4865-80f7-f427cacbe45c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ceb2f82f-aa8c-4865-80f7-f427cacbe45c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ceb2f82f-aa8c-4865-80f7-f427cacbe45c>.
+    
+<http://data.lblod.info/id/remote-data-objects/78bd5d63-b3cd-4b69-82f1-4be776226903> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78bd5d63-b3cd-4b69-82f1-4be776226903";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78bd5d63-b3cd-4b69-82f1-4be776226903>.
+    
+<http://data.lblod.info/id/remote-data-objects/8271d5f1-7de8-4192-a1f5-d40dfadd9187> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8271d5f1-7de8-4192-a1f5-d40dfadd9187";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8271d5f1-7de8-4192-a1f5-d40dfadd9187>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4a6ec1b-358c-4417-bc03-24671501b98c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4a6ec1b-358c-4417-bc03-24671501b98c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4a6ec1b-358c-4417-bc03-24671501b98c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d7d19ca-1a7c-4ba2-94cb-6c5246f11258> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d7d19ca-1a7c-4ba2-94cb-6c5246f11258";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d7d19ca-1a7c-4ba2-94cb-6c5246f11258>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6e69ab9-7a2b-40d6-8d20-9c92f82c6514> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6e69ab9-7a2b-40d6-8d20-9c92f82c6514";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6e69ab9-7a2b-40d6-8d20-9c92f82c6514>.
+    
+<http://data.lblod.info/id/remote-data-objects/92eddc4b-1305-4a1a-89db-8a8ba96b376f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92eddc4b-1305-4a1a-89db-8a8ba96b376f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92eddc4b-1305-4a1a-89db-8a8ba96b376f>.
+    
+<http://data.lblod.info/id/remote-data-objects/644d1573-c86a-4c65-9248-998851d04edf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "644d1573-c86a-4c65-9248-998851d04edf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/644d1573-c86a-4c65-9248-998851d04edf>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fcbafcf-17d7-462c-baa4-1c7e0ac3a242> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fcbafcf-17d7-462c-baa4-1c7e0ac3a242";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fcbafcf-17d7-462c-baa4-1c7e0ac3a242>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f54f215-ae57-4114-b059-67d8bf4eb3e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f54f215-ae57-4114-b059-67d8bf4eb3e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f54f215-ae57-4114-b059-67d8bf4eb3e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/198be6b0-346a-4eb1-bb6f-330bf632b893> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "198be6b0-346a-4eb1-bb6f-330bf632b893";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/198be6b0-346a-4eb1-bb6f-330bf632b893>.
+    
+<http://data.lblod.info/id/remote-data-objects/f61ccc6e-e9db-43ea-ba23-b4ae7adc608f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f61ccc6e-e9db-43ea-ba23-b4ae7adc608f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f61ccc6e-e9db-43ea-ba23-b4ae7adc608f>.
+    
+<http://data.lblod.info/id/remote-data-objects/667543b0-da93-4d07-8db9-6b8d70db8f57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "667543b0-da93-4d07-8db9-6b8d70db8f57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/667543b0-da93-4d07-8db9-6b8d70db8f57>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc19d34e-3f20-4120-8bfb-2b118b351efd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc19d34e-3f20-4120-8bfb-2b118b351efd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc19d34e-3f20-4120-8bfb-2b118b351efd>.
+    
+<http://data.lblod.info/id/remote-data-objects/c77e9a2d-e486-47be-a7f6-e50f476cd581> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c77e9a2d-e486-47be-a7f6-e50f476cd581";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20Burgemeester%20en%20Schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c77e9a2d-e486-47be-a7f6-e50f476cd581>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebf8a93a-0bb9-4aba-817d-c083406bc604> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebf8a93a-0bb9-4aba-817d-c083406bc604";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_02-05-2022_83422.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebf8a93a-0bb9-4aba-817d-c083406bc604>.
+    
+<http://data.lblod.info/id/remote-data-objects/29adf60a-6528-4824-839f-ec8aa77cbae9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29adf60a-6528-4824-839f-ec8aa77cbae9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_02-05-2022_83423.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29adf60a-6528-4824-839f-ec8aa77cbae9>.
+    
+<http://data.lblod.info/id/remote-data-objects/50787100-d30f-4dc1-9fb6-1889c430f2b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50787100-d30f-4dc1-9fb6-1889c430f2b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_02-05-2022_83424.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50787100-d30f-4dc1-9fb6-1889c430f2b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/599790f1-d588-4ad6-8b82-f58796a86be6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "599790f1-d588-4ad6-8b82-f58796a86be6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_02-05-2022_83425.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/599790f1-d588-4ad6-8b82-f58796a86be6>.
+    
+<http://data.lblod.info/id/remote-data-objects/33093f79-16f5-4b43-ab40-499aa48b2fba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33093f79-16f5-4b43-ab40-499aa48b2fba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_02-05-2022_83426.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33093f79-16f5-4b43-ab40-499aa48b2fba>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d74ae87-58c2-4b26-9341-6dbcf41591dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d74ae87-58c2-4b26-9341-6dbcf41591dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_04-04-2022_82781.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d74ae87-58c2-4b26-9341-6dbcf41591dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3f903f1-3d1a-4eb8-bc94-24235c918d3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3f903f1-3d1a-4eb8-bc94-24235c918d3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_04-04-2022_82929.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3f903f1-3d1a-4eb8-bc94-24235c918d3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/048019d9-1dbb-4b79-814a-dfbf92648673> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "048019d9-1dbb-4b79-814a-dfbf92648673";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_04-04-2022_82930.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/048019d9-1dbb-4b79-814a-dfbf92648673>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ff8f2f0-8345-45b2-a263-bc8e8de7afac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ff8f2f0-8345-45b2-a263-bc8e8de7afac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_04-04-2022_82931.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ff8f2f0-8345-45b2-a263-bc8e8de7afac>.
+    
+<http://data.lblod.info/id/remote-data-objects/894f093a-deb2-4d2d-8bd9-c3e6cb594ecc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "894f093a-deb2-4d2d-8bd9-c3e6cb594ecc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_04-07-2022_84819.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/894f093a-deb2-4d2d-8bd9-c3e6cb594ecc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9224b66-8baf-4079-92f7-d14d99f01919> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9224b66-8baf-4079-92f7-d14d99f01919";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_04-07-2022_84820.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9224b66-8baf-4079-92f7-d14d99f01919>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa06c712-1669-4992-a538-92e216ae7455> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa06c712-1669-4992-a538-92e216ae7455";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_04-07-2022_84821.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa06c712-1669-4992-a538-92e216ae7455>.
+    
+<http://data.lblod.info/id/remote-data-objects/70ac5a17-8369-42a7-a6b4-6c33c88c2e0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70ac5a17-8369-42a7-a6b4-6c33c88c2e0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_04-07-2022_84822.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70ac5a17-8369-42a7-a6b4-6c33c88c2e0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a46e4a2-ebf3-49fd-bbe4-92a8da829c9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a46e4a2-ebf3-49fd-bbe4-92a8da829c9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_04-07-2022_84823.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a46e4a2-ebf3-49fd-bbe4-92a8da829c9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfc6a549-99d5-4b1c-94e8-2d6deb5540fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfc6a549-99d5-4b1c-94e8-2d6deb5540fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_06-12-2021_80213.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfc6a549-99d5-4b1c-94e8-2d6deb5540fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1dbada3-f51a-4eb5-95b2-b204af86726b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1dbada3-f51a-4eb5-95b2-b204af86726b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_06-12-2021_80563.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1dbada3-f51a-4eb5-95b2-b204af86726b>.
+    
+<http://data.lblod.info/id/remote-data-objects/104aeb31-65a4-45b5-b9ea-924a2adad558> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "104aeb31-65a4-45b5-b9ea-924a2adad558";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_06-12-2021_80564.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/104aeb31-65a4-45b5-b9ea-924a2adad558>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a441610-1fc9-40ca-b813-f823a4378e5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a441610-1fc9-40ca-b813-f823a4378e5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_07-06-2022_84127.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a441610-1fc9-40ca-b813-f823a4378e5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ea275b6-db55-4cf5-a7b1-1a53fd2140a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ea275b6-db55-4cf5-a7b1-1a53fd2140a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_07-06-2022_84128.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ea275b6-db55-4cf5-a7b1-1a53fd2140a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4164bd4c-efbe-4516-bb4a-61d7a2e94c27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4164bd4c-efbe-4516-bb4a-61d7a2e94c27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_07-06-2022_84131.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4164bd4c-efbe-4516-bb4a-61d7a2e94c27>.
+    
+<http://data.lblod.info/id/remote-data-objects/55763985-bff7-43ff-bfbc-3cbcdf9d3cf3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55763985-bff7-43ff-bfbc-3cbcdf9d3cf3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_07-06-2022_84132.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55763985-bff7-43ff-bfbc-3cbcdf9d3cf3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3cc839a-1cb4-4297-b907-603812d475bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3cc839a-1cb4-4297-b907-603812d475bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_07-06-2022_84135.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3cc839a-1cb4-4297-b907-603812d475bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6262427-510f-480d-aa20-44001b736063> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6262427-510f-480d-aa20-44001b736063";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_08-11-2021_79927.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc5c2aee-a3f9-4818-b015-debef8dd6377> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6262427-510f-480d-aa20-44001b736063>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201535-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201535-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201535-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201535-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/4f738b29-55bd-4f1a-b4f7-1835afd3fcd8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4f738b29-55bd-4f1a-b4f7-1835afd3fcd8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c21c9119-3259-4785-ac4d-426cddf2461b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a337d65a-7671-4e82-9f14-32b9e4d18a5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a337d65a-7671-4e82-9f14-32b9e4d18a5a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b>.
+
+  <http://redpencil.data.gift/id/task/5207df23-c376-45ed-8b16-778b36e716d3> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5207df23-c376-45ed-8b16-778b36e716d3";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/4f738b29-55bd-4f1a-b4f7-1835afd3fcd8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a337d65a-7671-4e82-9f14-32b9e4d18a5a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a9d75a44-8732-47f1-a9d5-7da736161047> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9d75a44-8732-47f1-a9d5-7da736161047";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_08-11-2021_79928.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9d75a44-8732-47f1-a9d5-7da736161047>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc84ee82-a06e-4296-80c7-279ba0100cee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc84ee82-a06e-4296-80c7-279ba0100cee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_08-11-2021_79929.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc84ee82-a06e-4296-80c7-279ba0100cee>.
+    
+<http://data.lblod.info/id/remote-data-objects/87187796-50f3-49b0-a53f-5ebedc9e75a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87187796-50f3-49b0-a53f-5ebedc9e75a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_09-05-2022_83596.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87187796-50f3-49b0-a53f-5ebedc9e75a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b40ec25-51d2-4663-9115-7fddcf67be3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b40ec25-51d2-4663-9115-7fddcf67be3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_09-05-2022_83597.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b40ec25-51d2-4663-9115-7fddcf67be3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f958374a-0667-418c-be42-e7d645cabff4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f958374a-0667-418c-be42-e7d645cabff4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_09-05-2022_83598.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f958374a-0667-418c-be42-e7d645cabff4>.
+    
+<http://data.lblod.info/id/remote-data-objects/924bc91c-b815-4294-89d4-5b605fe16d2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "924bc91c-b815-4294-89d4-5b605fe16d2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_09-05-2022_83599.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/924bc91c-b815-4294-89d4-5b605fe16d2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bdc74fb-5e05-485d-82ab-480110f9de26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bdc74fb-5e05-485d-82ab-480110f9de26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_09-05-2022_83600.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bdc74fb-5e05-485d-82ab-480110f9de26>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6791734-9f8a-4582-9a71-0235474cbc33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6791734-9f8a-4582-9a71-0235474cbc33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_09-05-2022_83601.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6791734-9f8a-4582-9a71-0235474cbc33>.
+    
+<http://data.lblod.info/id/remote-data-objects/50ecbe4c-79e3-48fe-a2f8-b3107e6d9c8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50ecbe4c-79e3-48fe-a2f8-b3107e6d9c8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_09-05-2022_83602.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50ecbe4c-79e3-48fe-a2f8-b3107e6d9c8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f907e304-e724-4de6-8d79-9b4f8b0579d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f907e304-e724-4de6-8d79-9b4f8b0579d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_11-04-2022_83061.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f907e304-e724-4de6-8d79-9b4f8b0579d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4c87737-c489-445d-9f2c-9d5ed86fa876> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4c87737-c489-445d-9f2c-9d5ed86fa876";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_11-04-2022_83062.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4c87737-c489-445d-9f2c-9d5ed86fa876>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba94a722-c1d0-4c34-8099-c9e5d38c2dd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba94a722-c1d0-4c34-8099-c9e5d38c2dd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_11-04-2022_83063.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba94a722-c1d0-4c34-8099-c9e5d38c2dd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f285e70-012c-4971-9929-8b1cea09b8f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f285e70-012c-4971-9929-8b1cea09b8f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_11-10-2021_79417.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f285e70-012c-4971-9929-8b1cea09b8f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdffbc1b-fff2-4f43-af0d-88820f7383f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdffbc1b-fff2-4f43-af0d-88820f7383f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_12-07-2022_84936.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdffbc1b-fff2-4f43-af0d-88820f7383f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/3291d6bf-b098-46c9-bb4a-71a3402de886> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3291d6bf-b098-46c9-bb4a-71a3402de886";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_13-06-2022_84059.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3291d6bf-b098-46c9-bb4a-71a3402de886>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9fce503-85d5-48a4-a272-602cc6b9d235> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9fce503-85d5-48a4-a272-602cc6b9d235";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_13-06-2022_84061.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9fce503-85d5-48a4-a272-602cc6b9d235>.
+    
+<http://data.lblod.info/id/remote-data-objects/95281e82-0d57-44d1-ac43-09d4ba94271e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95281e82-0d57-44d1-ac43-09d4ba94271e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_13-06-2022_84397.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95281e82-0d57-44d1-ac43-09d4ba94271e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d45b2f8a-f823-412c-b12c-816e9c5ca9d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d45b2f8a-f823-412c-b12c-816e9c5ca9d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_13-06-2022_84398.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d45b2f8a-f823-412c-b12c-816e9c5ca9d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/761d3298-d08f-4c89-8803-294e95e40f9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "761d3298-d08f-4c89-8803-294e95e40f9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_13-06-2022_84399.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/761d3298-d08f-4c89-8803-294e95e40f9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/beab45a9-a520-44bc-9822-f3451615f80f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "beab45a9-a520-44bc-9822-f3451615f80f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_13-06-2022_84400.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/beab45a9-a520-44bc-9822-f3451615f80f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b3d1e3b-9e13-4a87-8023-5a221e6b0aea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b3d1e3b-9e13-4a87-8023-5a221e6b0aea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_14-02-2022_81925.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b3d1e3b-9e13-4a87-8023-5a221e6b0aea>.
+    
+<http://data.lblod.info/id/remote-data-objects/a291e69d-dde5-4e8a-b7ac-97b793bddd87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a291e69d-dde5-4e8a-b7ac-97b793bddd87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_14-02-2022_81926.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a291e69d-dde5-4e8a-b7ac-97b793bddd87>.
+    
+<http://data.lblod.info/id/remote-data-objects/08faa9eb-75df-4263-b6bf-e7cd90c202cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08faa9eb-75df-4263-b6bf-e7cd90c202cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_14-02-2022_81929.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08faa9eb-75df-4263-b6bf-e7cd90c202cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/dea74103-8f28-4145-b4a2-6987b8f18925> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dea74103-8f28-4145-b4a2-6987b8f18925";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_14-02-2022_81930.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dea74103-8f28-4145-b4a2-6987b8f18925>.
+    
+<http://data.lblod.info/id/remote-data-objects/85b517b3-4a06-4643-ab2b-17323ac85546> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85b517b3-4a06-4643-ab2b-17323ac85546";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_14-03-2022_82514.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85b517b3-4a06-4643-ab2b-17323ac85546>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7de4f94-5979-4cab-88f5-c3dc4218c916> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7de4f94-5979-4cab-88f5-c3dc4218c916";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_16-05-2022_83791.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7de4f94-5979-4cab-88f5-c3dc4218c916>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c44ce89-689a-4b8e-9e82-85cd202bddef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c44ce89-689a-4b8e-9e82-85cd202bddef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_16-05-2022_83792.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c44ce89-689a-4b8e-9e82-85cd202bddef>.
+    
+<http://data.lblod.info/id/remote-data-objects/da6c1bf4-a69e-48f4-9caf-8622e51f3f75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da6c1bf4-a69e-48f4-9caf-8622e51f3f75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_16-05-2022_83793.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da6c1bf4-a69e-48f4-9caf-8622e51f3f75>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dbaaeab-b9dd-489f-81c9-ae65c327a768> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dbaaeab-b9dd-489f-81c9-ae65c327a768";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_16-05-2022_83794.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dbaaeab-b9dd-489f-81c9-ae65c327a768>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ed1a8b9-41cc-4876-826c-e215063484f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ed1a8b9-41cc-4876-826c-e215063484f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_17-01-2022_81387.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ed1a8b9-41cc-4876-826c-e215063484f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/31f5557c-c779-4308-a81b-02915f62d4f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31f5557c-c779-4308-a81b-02915f62d4f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_18-07-2022_84837.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31f5557c-c779-4308-a81b-02915f62d4f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/da382af0-4cff-4f34-a48f-ddf06f82fb40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da382af0-4cff-4f34-a48f-ddf06f82fb40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_18-07-2022_84989.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da382af0-4cff-4f34-a48f-ddf06f82fb40>.
+    
+<http://data.lblod.info/id/remote-data-objects/801dc584-324f-4270-b1aa-030ea20f58f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "801dc584-324f-4270-b1aa-030ea20f58f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_18-07-2022_84990.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/801dc584-324f-4270-b1aa-030ea20f58f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/dab81cef-5c5b-4d1a-9a14-66397bacfe76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dab81cef-5c5b-4d1a-9a14-66397bacfe76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_18-07-2022_84991.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dab81cef-5c5b-4d1a-9a14-66397bacfe76>.
+    
+<http://data.lblod.info/id/remote-data-objects/83da83f0-1142-4a3f-b9c6-55c3f0cae494> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83da83f0-1142-4a3f-b9c6-55c3f0cae494";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_18-10-2021_79531.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83da83f0-1142-4a3f-b9c6-55c3f0cae494>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e72b018-a41c-47c2-9620-a834cb80845c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e72b018-a41c-47c2-9620-a834cb80845c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_18-10-2021_79532.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e72b018-a41c-47c2-9620-a834cb80845c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2305213-53f4-4882-a8f1-9d8488501c0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2305213-53f4-4882-a8f1-9d8488501c0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_20-06-2022_84521.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2305213-53f4-4882-a8f1-9d8488501c0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c8ebb0f-c050-46be-9cfa-907615535bfd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c8ebb0f-c050-46be-9cfa-907615535bfd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_20-06-2022_84522.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c8ebb0f-c050-46be-9cfa-907615535bfd>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b50ad91-cc55-45d8-9283-ede15044e765> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b50ad91-cc55-45d8-9283-ede15044e765";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_20-06-2022_84523.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b50ad91-cc55-45d8-9283-ede15044e765>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ee6fd9a-04cd-4bef-9a8e-59716f2d4722> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ee6fd9a-04cd-4bef-9a8e-59716f2d4722";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_21-02-2022_82101.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ee6fd9a-04cd-4bef-9a8e-59716f2d4722>.
+    
+<http://data.lblod.info/id/remote-data-objects/03901f49-722c-476a-9f41-31a899154b51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03901f49-722c-476a-9f41-31a899154b51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_21-02-2022_82102.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03901f49-722c-476a-9f41-31a899154b51>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cb13f15-a91b-4719-b81c-0c9dbbdfaef0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cb13f15-a91b-4719-b81c-0c9dbbdfaef0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_21-02-2022_82103.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cb13f15-a91b-4719-b81c-0c9dbbdfaef0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d863f728-ff2e-4a71-b62d-476550eb0734> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d863f728-ff2e-4a71-b62d-476550eb0734";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_21-03-2022_82699.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d863f728-ff2e-4a71-b62d-476550eb0734>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6dbfc37-1f15-4934-9ff5-446d8a3f5c8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6dbfc37-1f15-4934-9ff5-446d8a3f5c8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_21-03-2022_82707.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6dbfc37-1f15-4934-9ff5-446d8a3f5c8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac8f7832-da37-4a18-82b2-4fb73aa55679> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac8f7832-da37-4a18-82b2-4fb73aa55679";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_21-03-2022_82709.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac8f7832-da37-4a18-82b2-4fb73aa55679>.
+    
+<http://data.lblod.info/id/remote-data-objects/d69202e9-1e6c-4c99-bb13-e54833c102d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d69202e9-1e6c-4c99-bb13-e54833c102d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_22-11-2021_80264.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d69202e9-1e6c-4c99-bb13-e54833c102d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/39cbba8a-0ef4-40b1-86c5-052d089b4092> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39cbba8a-0ef4-40b1-86c5-052d089b4092";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_22-11-2021_80265.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39cbba8a-0ef4-40b1-86c5-052d089b4092>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c92da0d-9cff-4577-9700-8fe3afd469c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c92da0d-9cff-4577-9700-8fe3afd469c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_23-05-2022_83893.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c92da0d-9cff-4577-9700-8fe3afd469c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd44fddd-39a6-4fe5-a888-7db2d0cb9208> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd44fddd-39a6-4fe5-a888-7db2d0cb9208";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_23-05-2022_83894.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd44fddd-39a6-4fe5-a888-7db2d0cb9208>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce693507-2a81-42fc-95d7-abf1605f8e09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce693507-2a81-42fc-95d7-abf1605f8e09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_23-05-2022_83895.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c21c9119-3259-4785-ac4d-426cddf2461b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce693507-2a81-42fc-95d7-abf1605f8e09>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201536-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201536-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201536-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201536-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/023b355e-b19a-441a-bd7b-80e2d44cbf96> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "023b355e-b19a-441a-bd7b-80e2d44cbf96";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1a532e73-eda1-4bff-837a-eed53f78f572";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/3f3343d0-8cf3-4c08-a0cd-014d0f25c39c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3f3343d0-8cf3-4c08-a0cd-014d0f25c39c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572>.
+
+  <http://redpencil.data.gift/id/task/f63d2e28-a3f9-4ec6-9f28-eab73e479e2d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f63d2e28-a3f9-4ec6-9f28-eab73e479e2d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/023b355e-b19a-441a-bd7b-80e2d44cbf96>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/3f3343d0-8cf3-4c08-a0cd-014d0f25c39c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4714c7ca-ae69-46f4-b53a-7c1bd6adf797> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4714c7ca-ae69-46f4-b53a-7c1bd6adf797";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_23-05-2022_83896.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4714c7ca-ae69-46f4-b53a-7c1bd6adf797>.
+    
+<http://data.lblod.info/id/remote-data-objects/06484eb4-a161-465e-9b46-f83a9d9c16b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06484eb4-a161-465e-9b46-f83a9d9c16b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_23-05-2022_83897.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06484eb4-a161-465e-9b46-f83a9d9c16b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/46173dd4-a9d7-4fa7-8311-9e6cc54cad91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46173dd4-a9d7-4fa7-8311-9e6cc54cad91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_23-05-2022_83898.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46173dd4-a9d7-4fa7-8311-9e6cc54cad91>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b353de1-89a6-4de9-aa35-3292f1e7ef7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b353de1-89a6-4de9-aa35-3292f1e7ef7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_24-01-2022_81550.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b353de1-89a6-4de9-aa35-3292f1e7ef7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/96f22c37-3167-4813-ba4a-0bc60e7aca0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96f22c37-3167-4813-ba4a-0bc60e7aca0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_25-04-2022_83127.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96f22c37-3167-4813-ba4a-0bc60e7aca0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/baded255-8333-46f9-8688-b33a49860286> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "baded255-8333-46f9-8688-b33a49860286";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_25-04-2022_83302.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/baded255-8333-46f9-8688-b33a49860286>.
+    
+<http://data.lblod.info/id/remote-data-objects/308a69b1-f1bb-44c8-a944-191480a0d391> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "308a69b1-f1bb-44c8-a944-191480a0d391";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_25-10-2021_79517.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/308a69b1-f1bb-44c8-a944-191480a0d391>.
+    
+<http://data.lblod.info/id/remote-data-objects/84e2e030-ec41-4a26-9239-156aa39761d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84e2e030-ec41-4a26-9239-156aa39761d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_25-10-2021_79659.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84e2e030-ec41-4a26-9239-156aa39761d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b2ef9e5-7e47-441a-a28f-31164020b83c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b2ef9e5-7e47-441a-a28f-31164020b83c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_25-10-2021_79660.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b2ef9e5-7e47-441a-a28f-31164020b83c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5394b61-985b-4b5f-a5ca-53fb357d5bdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5394b61-985b-4b5f-a5ca-53fb357d5bdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_27-06-2022_84672.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5394b61-985b-4b5f-a5ca-53fb357d5bdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/210ce4dc-4d88-4402-816b-358976c8172e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "210ce4dc-4d88-4402-816b-358976c8172e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_27-12-2021_81181.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/210ce4dc-4d88-4402-816b-358976c8172e>.
+    
+<http://data.lblod.info/id/remote-data-objects/097423da-9733-4ac3-b2f2-630992ce4595> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "097423da-9733-4ac3-b2f2-630992ce4595";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_28-03-2022_82804.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/097423da-9733-4ac3-b2f2-630992ce4595>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee6de386-fac8-4f16-a446-7c8f6c0ce654> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee6de386-fac8-4f16-a446-7c8f6c0ce654";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_30-05-2022_84039.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee6de386-fac8-4f16-a446-7c8f6c0ce654>.
+    
+<http://data.lblod.info/id/remote-data-objects/a68d26b5-0e3a-4233-b7a3-9bb4c9e675bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a68d26b5-0e3a-4233-b7a3-9bb4c9e675bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_30-05-2022_84040.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a68d26b5-0e3a-4233-b7a3-9bb4c9e675bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad143788-4560-417e-b6d4-bdea006bd67b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad143788-4560-417e-b6d4-bdea006bd67b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/7b0258ec55a77ef7f521548d8252c8895243b28ba2247e8658a3bc02c4c09348/GetPublication?filename=Uittreksels_31-01-2022_81663.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad143788-4560-417e-b6d4-bdea006bd67b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9646b59a-a849-4260-8290-b38e40b5fd80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9646b59a-a849-4260-8290-b38e40b5fd80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9646b59a-a849-4260-8290-b38e40b5fd80>.
+    
+<http://data.lblod.info/id/remote-data-objects/db31bfc1-b822-443b-91d0-690e1b6b1f31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db31bfc1-b822-443b-91d0-690e1b6b1f31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db31bfc1-b822-443b-91d0-690e1b6b1f31>.
+    
+<http://data.lblod.info/id/remote-data-objects/ead6bd97-ac11-4211-b8f1-0b80f6e2bd9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ead6bd97-ac11-4211-b8f1-0b80f6e2bd9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ead6bd97-ac11-4211-b8f1-0b80f6e2bd9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2c586b3-98e6-43c2-9db0-b880e914ef85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2c586b3-98e6-43c2-9db0-b880e914ef85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2c586b3-98e6-43c2-9db0-b880e914ef85>.
+    
+<http://data.lblod.info/id/remote-data-objects/5eeba64c-e4ca-4ccc-9c01-3f4e3aa448ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5eeba64c-e4ca-4ccc-9c01-3f4e3aa448ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5eeba64c-e4ca-4ccc-9c01-3f4e3aa448ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/32cb3975-3c26-47e4-ad43-7014dea35d48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32cb3975-3c26-47e4-ad43-7014dea35d48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32cb3975-3c26-47e4-ad43-7014dea35d48>.
+    
+<http://data.lblod.info/id/remote-data-objects/07f6abd5-83f6-4fb1-bb66-9ac4258a0cce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07f6abd5-83f6-4fb1-bb66-9ac4258a0cce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07f6abd5-83f6-4fb1-bb66-9ac4258a0cce>.
+    
+<http://data.lblod.info/id/remote-data-objects/df4a7d95-3adc-40b9-8d36-e5a94c44f104> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df4a7d95-3adc-40b9-8d36-e5a94c44f104";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df4a7d95-3adc-40b9-8d36-e5a94c44f104>.
+    
+<http://data.lblod.info/id/remote-data-objects/44b506d9-35c8-4760-89e4-94041e937b71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44b506d9-35c8-4760-89e4-94041e937b71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44b506d9-35c8-4760-89e4-94041e937b71>.
+    
+<http://data.lblod.info/id/remote-data-objects/9487771a-b9cb-4737-bf29-b9433c510d09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9487771a-b9cb-4737-bf29-b9433c510d09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9487771a-b9cb-4737-bf29-b9433c510d09>.
+    
+<http://data.lblod.info/id/remote-data-objects/a49ae65f-7e48-4441-8edb-b56a2da40365> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a49ae65f-7e48-4441-8edb-b56a2da40365";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a49ae65f-7e48-4441-8edb-b56a2da40365>.
+    
+<http://data.lblod.info/id/remote-data-objects/b68424b1-b18c-4df6-ae8c-68b79cc1c5ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b68424b1-b18c-4df6-ae8c-68b79cc1c5ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b68424b1-b18c-4df6-ae8c-68b79cc1c5ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/384a8fdd-0583-4805-8491-9c1a5d41b5cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "384a8fdd-0583-4805-8491-9c1a5d41b5cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/384a8fdd-0583-4805-8491-9c1a5d41b5cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f27b7026-43a7-495b-8968-80c4f38e5e96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f27b7026-43a7-495b-8968-80c4f38e5e96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f27b7026-43a7-495b-8968-80c4f38e5e96>.
+    
+<http://data.lblod.info/id/remote-data-objects/36115606-0f36-4fa1-b406-1bb1ad00dc54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36115606-0f36-4fa1-b406-1bb1ad00dc54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36115606-0f36-4fa1-b406-1bb1ad00dc54>.
+    
+<http://data.lblod.info/id/remote-data-objects/aac095cd-93f9-4161-856e-fe28e76ecf3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aac095cd-93f9-4161-856e-fe28e76ecf3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aac095cd-93f9-4161-856e-fe28e76ecf3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2930d1ce-831d-4754-acac-c82475fee4e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2930d1ce-831d-4754-acac-c82475fee4e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2930d1ce-831d-4754-acac-c82475fee4e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/29ed0f39-b1d5-447d-b964-298f3e279a59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29ed0f39-b1d5-447d-b964-298f3e279a59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29ed0f39-b1d5-447d-b964-298f3e279a59>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1f13d70-acfe-4ab7-8cf7-f5a652daf9c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1f13d70-acfe-4ab7-8cf7-f5a652daf9c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1f13d70-acfe-4ab7-8cf7-f5a652daf9c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c506656-e6e1-4da1-b284-69a56511172c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c506656-e6e1-4da1-b284-69a56511172c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c506656-e6e1-4da1-b284-69a56511172c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ab0e472-ba84-4849-b3c4-bcb7c2acaaab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ab0e472-ba84-4849-b3c4-bcb7c2acaaab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ab0e472-ba84-4849-b3c4-bcb7c2acaaab>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a572180-9591-4a8c-be19-9f83f6650e35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a572180-9591-4a8c-be19-9f83f6650e35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a572180-9591-4a8c-be19-9f83f6650e35>.
+    
+<http://data.lblod.info/id/remote-data-objects/62de3954-e8cb-416c-b596-155f861cee69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62de3954-e8cb-416c-b596-155f861cee69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62de3954-e8cb-416c-b596-155f861cee69>.
+    
+<http://data.lblod.info/id/remote-data-objects/64ad525c-cd07-402f-8391-26ee7980ca0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64ad525c-cd07-402f-8391-26ee7980ca0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64ad525c-cd07-402f-8391-26ee7980ca0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dd72b42-c1b0-4105-93d9-aaa2b3564fd6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dd72b42-c1b0-4105-93d9-aaa2b3564fd6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dd72b42-c1b0-4105-93d9-aaa2b3564fd6>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdc16521-e529-4683-8563-b94a5a230f8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdc16521-e529-4683-8563-b94a5a230f8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdc16521-e529-4683-8563-b94a5a230f8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d79e87c-9697-46c4-a9c6-f5520fb21413> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d79e87c-9697-46c4-a9c6-f5520fb21413";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d79e87c-9697-46c4-a9c6-f5520fb21413>.
+    
+<http://data.lblod.info/id/remote-data-objects/625d9801-0964-4e73-bb28-17188ea011b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "625d9801-0964-4e73-bb28-17188ea011b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/625d9801-0964-4e73-bb28-17188ea011b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0b844fe-82f0-4bcf-bc20-a7ebff8c0c1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0b844fe-82f0-4bcf-bc20-a7ebff8c0c1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0b844fe-82f0-4bcf-bc20-a7ebff8c0c1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e395493-1d82-4e02-adca-bb7440719dc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e395493-1d82-4e02-adca-bb7440719dc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e395493-1d82-4e02-adca-bb7440719dc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad3c63d7-7794-49d6-8780-17eca0a2803b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad3c63d7-7794-49d6-8780-17eca0a2803b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad3c63d7-7794-49d6-8780-17eca0a2803b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c1d1764-f183-4a3d-bee3-170b5369658a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c1d1764-f183-4a3d-bee3-170b5369658a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c1d1764-f183-4a3d-bee3-170b5369658a>.
+    
+<http://data.lblod.info/id/remote-data-objects/28abcc8e-569c-4e07-8fd3-5e87e756101d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28abcc8e-569c-4e07-8fd3-5e87e756101d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28abcc8e-569c-4e07-8fd3-5e87e756101d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6ebcfd8-e734-4bdd-b0d2-202d6b8b144b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6ebcfd8-e734-4bdd-b0d2-202d6b8b144b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6ebcfd8-e734-4bdd-b0d2-202d6b8b144b>.
+    
+<http://data.lblod.info/id/remote-data-objects/19e47b45-3c8c-4010-8ef8-df22cd5ae688> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19e47b45-3c8c-4010-8ef8-df22cd5ae688";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a532e73-eda1-4bff-837a-eed53f78f572> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19e47b45-3c8c-4010-8ef8-df22cd5ae688>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201537-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201537-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201537-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201537-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/12996e85-87c0-493d-a0d3-a4f242619699> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "12996e85-87c0-493d-a0d3-a4f242619699";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ee9683db-6986-465b-a487-58caf022220f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/5c039442-27c1-4108-8be1-a291dec44b1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5c039442-27c1-4108-8be1-a291dec44b1a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f>.
+
+  <http://redpencil.data.gift/id/task/56bed30c-ff12-428f-b02f-8121334f7a1d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "56bed30c-ff12-428f-b02f-8121334f7a1d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/12996e85-87c0-493d-a0d3-a4f242619699>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/5c039442-27c1-4108-8be1-a291dec44b1a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/df570716-16c9-47c6-ae19-6db40e98ba01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df570716-16c9-47c6-ae19-6db40e98ba01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df570716-16c9-47c6-ae19-6db40e98ba01>.
+    
+<http://data.lblod.info/id/remote-data-objects/99a8d3a4-c9f8-4571-b7c1-ec23cb173990> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99a8d3a4-c9f8-4571-b7c1-ec23cb173990";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99a8d3a4-c9f8-4571-b7c1-ec23cb173990>.
+    
+<http://data.lblod.info/id/remote-data-objects/9df19495-df5d-4eab-8c63-9b14d630ad84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9df19495-df5d-4eab-8c63-9b14d630ad84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9df19495-df5d-4eab-8c63-9b14d630ad84>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9137665-a840-419c-b9a3-a991a89148a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9137665-a840-419c-b9a3-a991a89148a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=BesluitenLijstUitspraak_SH%20-%20Vast%20Bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9137665-a840-419c-b9a3-a991a89148a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/30e3b3dc-ffaf-4d8c-8aba-456c7319845f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30e3b3dc-ffaf-4d8c-8aba-456c7319845f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.mechelen.be/LBLODWeb/Home/Overzicht/af18b761c4c27f366dee0446bdefdcbe54b292c26ae543c5671d6844d5df164d/GetPublication?filename=Uittreksels_25-10-2021_79573.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30e3b3dc-ffaf-4d8c-8aba-456c7319845f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5d073c4-aec3-4743-8e86-3a21c188f278> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5d073c4-aec3-4743-8e86-3a21c188f278";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5d073c4-aec3-4743-8e86-3a21c188f278>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3e9024f-5cd6-404d-8991-5e1e64a753c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3e9024f-5cd6-404d-8991-5e1e64a753c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3e9024f-5cd6-404d-8991-5e1e64a753c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/74df86cf-769c-4dbd-9403-7186a70623eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74df86cf-769c-4dbd-9403-7186a70623eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74df86cf-769c-4dbd-9403-7186a70623eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbbd2a06-8879-468c-935c-78178da91df2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbbd2a06-8879-468c-935c-78178da91df2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbbd2a06-8879-468c-935c-78178da91df2>.
+    
+<http://data.lblod.info/id/remote-data-objects/972d9284-68d7-4aef-863a-3837279bf570> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "972d9284-68d7-4aef-863a-3837279bf570";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/972d9284-68d7-4aef-863a-3837279bf570>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c825582-3826-4e7c-9b7c-e3c9bdf2a778> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c825582-3826-4e7c-9b7c-e3c9bdf2a778";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c825582-3826-4e7c-9b7c-e3c9bdf2a778>.
+    
+<http://data.lblod.info/id/remote-data-objects/a34e3777-e61e-4515-a4f4-f850cf973fd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a34e3777-e61e-4515-a4f4-f850cf973fd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a34e3777-e61e-4515-a4f4-f850cf973fd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/634d2b69-5f3b-4931-bb96-3e55b676c266> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "634d2b69-5f3b-4931-bb96-3e55b676c266";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/634d2b69-5f3b-4931-bb96-3e55b676c266>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6907f3d-4370-4c48-ba10-937f6a8cde8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6907f3d-4370-4c48-ba10-937f6a8cde8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6907f3d-4370-4c48-ba10-937f6a8cde8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/11fb12a1-216a-425a-a6eb-58d030f18895> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11fb12a1-216a-425a-a6eb-58d030f18895";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11fb12a1-216a-425a-a6eb-58d030f18895>.
+    
+<http://data.lblod.info/id/remote-data-objects/c97079c2-1840-4136-808b-e635816a784d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c97079c2-1840-4136-808b-e635816a784d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c97079c2-1840-4136-808b-e635816a784d>.
+    
+<http://data.lblod.info/id/remote-data-objects/53101580-d282-4b9c-80de-64682bdf8a2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53101580-d282-4b9c-80de-64682bdf8a2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53101580-d282-4b9c-80de-64682bdf8a2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a37a13c8-b998-4169-a234-c8ceb2dbf324> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a37a13c8-b998-4169-a234-c8ceb2dbf324";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a37a13c8-b998-4169-a234-c8ceb2dbf324>.
+    
+<http://data.lblod.info/id/remote-data-objects/082af230-2c43-4988-bc89-4b0d377b8824> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "082af230-2c43-4988-bc89-4b0d377b8824";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/082af230-2c43-4988-bc89-4b0d377b8824>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2d2d5c0-540f-40c4-80c3-1066966c7152> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2d2d5c0-540f-40c4-80c3-1066966c7152";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2d2d5c0-540f-40c4-80c3-1066966c7152>.
+    
+<http://data.lblod.info/id/remote-data-objects/d421b759-f44c-46f6-8506-eadb0427cf82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d421b759-f44c-46f6-8506-eadb0427cf82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d421b759-f44c-46f6-8506-eadb0427cf82>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b23492e-923a-479a-8098-44bf7a920d58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b23492e-923a-479a-8098-44bf7a920d58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b23492e-923a-479a-8098-44bf7a920d58>.
+    
+<http://data.lblod.info/id/remote-data-objects/71bd3d43-f754-4076-aa54-0f1e68a6fcf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71bd3d43-f754-4076-aa54-0f1e68a6fcf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71bd3d43-f754-4076-aa54-0f1e68a6fcf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9f0cda7-5b0f-4764-8cec-e781f1e26e16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9f0cda7-5b0f-4764-8cec-e781f1e26e16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9f0cda7-5b0f-4764-8cec-e781f1e26e16>.
+    
+<http://data.lblod.info/id/remote-data-objects/907eaf7e-aebc-4ecb-8fcd-ba0e13065aef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "907eaf7e-aebc-4ecb-8fcd-ba0e13065aef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/907eaf7e-aebc-4ecb-8fcd-ba0e13065aef>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e6bd7d3-d827-4370-97a9-bb6dc42c9d4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e6bd7d3-d827-4370-97a9-bb6dc42c9d4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e6bd7d3-d827-4370-97a9-bb6dc42c9d4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ca74d3b-f76d-4c47-8289-565776560793> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ca74d3b-f76d-4c47-8289-565776560793";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ca74d3b-f76d-4c47-8289-565776560793>.
+    
+<http://data.lblod.info/id/remote-data-objects/329dec8f-a58f-4061-8d58-026d40511ca8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "329dec8f-a58f-4061-8d58-026d40511ca8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/329dec8f-a58f-4061-8d58-026d40511ca8>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a16056b-46c1-48e2-a010-213c5e3d4662> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a16056b-46c1-48e2-a010-213c5e3d4662";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/60831f24dee249897e437179a578ac0fd5f785a7e3e9b5a20520f2c3bdfa5efc/GetPublication?filename=BesluitenLijst_vast%20bureau_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a16056b-46c1-48e2-a010-213c5e3d4662>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd5322c4-1d2e-4814-acb8-7aeb205786ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd5322c4-1d2e-4814-acb8-7aeb205786ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Agenda_gemeenteraad_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd5322c4-1d2e-4814-acb8-7aeb205786ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/1059f8bb-f922-4fd6-86cf-176f0041da36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1059f8bb-f922-4fd6-86cf-176f0041da36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Agenda_gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1059f8bb-f922-4fd6-86cf-176f0041da36>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ce59877-591c-40fa-9ea2-adc2b2fdbf23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ce59877-591c-40fa-9ea2-adc2b2fdbf23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Agenda_gemeenteraad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ce59877-591c-40fa-9ea2-adc2b2fdbf23>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cecf383-d417-4e4d-870e-66444503b387> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cecf383-d417-4e4d-870e-66444503b387";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Agenda_gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cecf383-d417-4e4d-870e-66444503b387>.
+    
+<http://data.lblod.info/id/remote-data-objects/c67a13c8-aa4c-44b0-be76-437cd501f77e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c67a13c8-aa4c-44b0-be76-437cd501f77e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Agenda_gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c67a13c8-aa4c-44b0-be76-437cd501f77e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b17cc6b2-8d2e-49ff-8223-ed4cd443139a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b17cc6b2-8d2e-49ff-8223-ed4cd443139a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Agenda_gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b17cc6b2-8d2e-49ff-8223-ed4cd443139a>.
+    
+<http://data.lblod.info/id/remote-data-objects/911f2130-8a18-4dfa-a193-6534f43e12d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "911f2130-8a18-4dfa-a193-6534f43e12d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=BesluitenLijst_gemeenteraad_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/911f2130-8a18-4dfa-a193-6534f43e12d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6457bf6-e8d7-4c53-8875-4f39bc07ec6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6457bf6-e8d7-4c53-8875-4f39bc07ec6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=BesluitenLijst_gemeenteraad_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6457bf6-e8d7-4c53-8875-4f39bc07ec6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab19527e-d804-4e45-aff0-8d60fb9c269c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab19527e-d804-4e45-aff0-8d60fb9c269c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=BesluitenLijst_gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab19527e-d804-4e45-aff0-8d60fb9c269c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fe633bf-3e27-49ae-a242-29265c1eb65a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fe633bf-3e27-49ae-a242-29265c1eb65a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=BesluitenLijst_gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fe633bf-3e27-49ae-a242-29265c1eb65a>.
+    
+<http://data.lblod.info/id/remote-data-objects/58af0685-072a-4d0e-baa2-b774acc49bf4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58af0685-072a-4d0e-baa2-b774acc49bf4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=BesluitenLijst_gemeenteraad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58af0685-072a-4d0e-baa2-b774acc49bf4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3750e681-28cc-4c29-be94-e1db703cb976> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3750e681-28cc-4c29-be94-e1db703cb976";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=BesluitenLijst_gemeenteraad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3750e681-28cc-4c29-be94-e1db703cb976>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c167967-17c4-48b8-8c34-b08a5d62cc40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c167967-17c4-48b8-8c34-b08a5d62cc40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=BesluitenLijst_gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c167967-17c4-48b8-8c34-b08a5d62cc40>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6200bcb-1dcf-47c4-af49-c6a2a9af77cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6200bcb-1dcf-47c4-af49-c6a2a9af77cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=BesluitenLijst_gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6200bcb-1dcf-47c4-af49-c6a2a9af77cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/53c70f05-c8cc-4d06-a8b8-3432a4b2c567> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53c70f05-c8cc-4d06-a8b8-3432a4b2c567";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=BesluitenLijst_gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53c70f05-c8cc-4d06-a8b8-3432a4b2c567>.
+    
+<http://data.lblod.info/id/remote-data-objects/250b45a7-ad3c-4e79-84f5-79483dbf1f9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "250b45a7-ad3c-4e79-84f5-79483dbf1f9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Notulen_gemeenteraad_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/250b45a7-ad3c-4e79-84f5-79483dbf1f9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/87e537d0-586f-4f9e-a592-708e1c775827> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87e537d0-586f-4f9e-a592-708e1c775827";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Notulen_gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87e537d0-586f-4f9e-a592-708e1c775827>.
+    
+<http://data.lblod.info/id/remote-data-objects/3efe9a6f-233f-4cce-b52c-db0eb8678753> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3efe9a6f-233f-4cce-b52c-db0eb8678753";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Notulen_gemeenteraad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3efe9a6f-233f-4cce-b52c-db0eb8678753>.
+    
+<http://data.lblod.info/id/remote-data-objects/6556458d-b7df-479b-be4f-1bbc930ae959> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6556458d-b7df-479b-be4f-1bbc930ae959";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Notulen_gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6556458d-b7df-479b-be4f-1bbc930ae959>.
+    
+<http://data.lblod.info/id/remote-data-objects/45ddecc4-f02e-48e9-aeaa-26b8f1f98762> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45ddecc4-f02e-48e9-aeaa-26b8f1f98762";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Notulen_gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45ddecc4-f02e-48e9-aeaa-26b8f1f98762>.
+    
+<http://data.lblod.info/id/remote-data-objects/f823354b-f188-4845-89a9-a5b0b4da2e70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f823354b-f188-4845-89a9-a5b0b4da2e70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Uittreksels_20-12-2021_13504.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee9683db-6986-465b-a487-58caf022220f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f823354b-f188-4845-89a9-a5b0b4da2e70>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201538-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201538-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201538-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201538-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/47ffd840-ccf9-4461-a77e-220424491edb> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "47ffd840-ccf9-4461-a77e-220424491edb";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9f2fa566-3c79-431d-a82c-4b09819ec508";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/3bf4b951-75c0-46a2-ae6d-500e9c6386ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3bf4b951-75c0-46a2-ae6d-500e9c6386ad";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508>.
+
+  <http://redpencil.data.gift/id/task/23afb800-ad99-45cb-96cb-436929f4a013> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "23afb800-ad99-45cb-96cb-436929f4a013";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/47ffd840-ccf9-4461-a77e-220424491edb>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/3bf4b951-75c0-46a2-ae6d-500e9c6386ad>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/91d8705d-9fc8-4281-a655-ec8042abe7f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91d8705d-9fc8-4281-a655-ec8042abe7f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Uittreksels_20-12-2021_13541.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91d8705d-9fc8-4281-a655-ec8042abe7f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/29322fa9-b848-4287-89a3-eb0403415f56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29322fa9-b848-4287-89a3-eb0403415f56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Uittreksels_20-12-2021_13571.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29322fa9-b848-4287-89a3-eb0403415f56>.
+    
+<http://data.lblod.info/id/remote-data-objects/396d819f-1286-4e0b-af41-16d5db96ea0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "396d819f-1286-4e0b-af41-16d5db96ea0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Uittreksels_20-12-2021_13572.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/396d819f-1286-4e0b-af41-16d5db96ea0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ddcf56c-f2c4-4814-8d13-38c3ac4b929d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ddcf56c-f2c4-4814-8d13-38c3ac4b929d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Uittreksels_22-11-2021_13255.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ddcf56c-f2c4-4814-8d13-38c3ac4b929d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9131f330-24a7-4a88-a394-d57a2cb44236> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9131f330-24a7-4a88-a394-d57a2cb44236";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Uittreksels_23-05-2022_15281.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9131f330-24a7-4a88-a394-d57a2cb44236>.
+    
+<http://data.lblod.info/id/remote-data-objects/e463ac95-ac28-4452-b3aa-0ff982245b87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e463ac95-ac28-4452-b3aa-0ff982245b87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Uittreksels_23-05-2022_15284.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e463ac95-ac28-4452-b3aa-0ff982245b87>.
+    
+<http://data.lblod.info/id/remote-data-objects/9059aa9a-8d2a-4daf-9fd3-8d8cdc1ae26b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9059aa9a-8d2a-4daf-9fd3-8d8cdc1ae26b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/8d8072a8de7040475ccee682dcc823a4bca4eccdd175433efec8be89488ec863/GetPublication?filename=Uittreksels_27-06-2022_15930.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9059aa9a-8d2a-4daf-9fd3-8d8cdc1ae26b>.
+    
+<http://data.lblod.info/id/remote-data-objects/30ffb468-64f3-434b-866a-d493f7c55a8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30ffb468-64f3-434b-866a-d493f7c55a8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30ffb468-64f3-434b-866a-d493f7c55a8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/622c91f3-d647-4128-bb99-760eef136714> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "622c91f3-d647-4128-bb99-760eef136714";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/622c91f3-d647-4128-bb99-760eef136714>.
+    
+<http://data.lblod.info/id/remote-data-objects/a37fc04f-e3ec-4df9-a240-7640abd20f59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a37fc04f-e3ec-4df9-a240-7640abd20f59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a37fc04f-e3ec-4df9-a240-7640abd20f59>.
+    
+<http://data.lblod.info/id/remote-data-objects/2446da6e-0bb3-47ce-8edb-c144487f2c91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2446da6e-0bb3-47ce-8edb-c144487f2c91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2446da6e-0bb3-47ce-8edb-c144487f2c91>.
+    
+<http://data.lblod.info/id/remote-data-objects/59108699-327e-4130-967f-c922bd126dc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59108699-327e-4130-967f-c922bd126dc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59108699-327e-4130-967f-c922bd126dc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9ad5989-c123-4d96-ab85-f0020196222a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9ad5989-c123-4d96-ab85-f0020196222a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9ad5989-c123-4d96-ab85-f0020196222a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9653a669-38fa-4d83-b121-11bd48c99350> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9653a669-38fa-4d83-b121-11bd48c99350";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9653a669-38fa-4d83-b121-11bd48c99350>.
+    
+<http://data.lblod.info/id/remote-data-objects/2df1186d-d6eb-4383-88a4-e3a9ccd39395> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2df1186d-d6eb-4383-88a4-e3a9ccd39395";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2df1186d-d6eb-4383-88a4-e3a9ccd39395>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b63a9bb-3781-4fc4-abdc-7324efd67a96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b63a9bb-3781-4fc4-abdc-7324efd67a96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b63a9bb-3781-4fc4-abdc-7324efd67a96>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ed92637-f29e-4e8c-b148-653d24976e3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ed92637-f29e-4e8c-b148-653d24976e3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ed92637-f29e-4e8c-b148-653d24976e3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/76cb149b-7d28-45b5-bb2a-fdd0b358c5a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76cb149b-7d28-45b5-bb2a-fdd0b358c5a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76cb149b-7d28-45b5-bb2a-fdd0b358c5a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e98307dd-5654-461a-9bcd-6dc08e9e474f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e98307dd-5654-461a-9bcd-6dc08e9e474f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e98307dd-5654-461a-9bcd-6dc08e9e474f>.
+    
+<http://data.lblod.info/id/remote-data-objects/307ecdba-a8e6-4cf3-ad04-7705ae20c030> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "307ecdba-a8e6-4cf3-ad04-7705ae20c030";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/307ecdba-a8e6-4cf3-ad04-7705ae20c030>.
+    
+<http://data.lblod.info/id/remote-data-objects/e36330ee-07a1-4dba-9ea3-5141e1179889> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e36330ee-07a1-4dba-9ea3-5141e1179889";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e36330ee-07a1-4dba-9ea3-5141e1179889>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a6b627f-c73b-4ec5-951c-2ff5a723f32b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a6b627f-c73b-4ec5-951c-2ff5a723f32b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a6b627f-c73b-4ec5-951c-2ff5a723f32b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ccedc4a-7cbc-49a1-afdc-d3d83537754b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ccedc4a-7cbc-49a1-afdc-d3d83537754b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ccedc4a-7cbc-49a1-afdc-d3d83537754b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fb29091-5212-4862-af14-fd9a825060c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fb29091-5212-4862-af14-fd9a825060c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fb29091-5212-4862-af14-fd9a825060c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/568e1459-844b-4eda-a48b-ad1a10c37a6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "568e1459-844b-4eda-a48b-ad1a10c37a6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/568e1459-844b-4eda-a48b-ad1a10c37a6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c060e37-4bce-4cd0-92b8-9be5b1eb2197> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c060e37-4bce-4cd0-92b8-9be5b1eb2197";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c060e37-4bce-4cd0-92b8-9be5b1eb2197>.
+    
+<http://data.lblod.info/id/remote-data-objects/af594359-e271-4821-a719-730c31e744bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af594359-e271-4821-a719-730c31e744bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af594359-e271-4821-a719-730c31e744bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d6b5b67-379b-4d19-9663-6ca1d855069f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d6b5b67-379b-4d19-9663-6ca1d855069f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d6b5b67-379b-4d19-9663-6ca1d855069f>.
+    
+<http://data.lblod.info/id/remote-data-objects/422263d7-fe56-4eba-aa79-495143644182> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "422263d7-fe56-4eba-aa79-495143644182";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/422263d7-fe56-4eba-aa79-495143644182>.
+    
+<http://data.lblod.info/id/remote-data-objects/82016960-586f-4703-a276-7e9f09888b66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82016960-586f-4703-a276-7e9f09888b66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82016960-586f-4703-a276-7e9f09888b66>.
+    
+<http://data.lblod.info/id/remote-data-objects/62796d9e-de69-42a3-af7a-2ffe76ad6405> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62796d9e-de69-42a3-af7a-2ffe76ad6405";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62796d9e-de69-42a3-af7a-2ffe76ad6405>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea25ddc7-38c4-43e8-ba8e-d8414d3cf9c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea25ddc7-38c4-43e8-ba8e-d8414d3cf9c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea25ddc7-38c4-43e8-ba8e-d8414d3cf9c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/46575487-ee42-42d8-a7ab-d9bc1b014e07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46575487-ee42-42d8-a7ab-d9bc1b014e07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46575487-ee42-42d8-a7ab-d9bc1b014e07>.
+    
+<http://data.lblod.info/id/remote-data-objects/29da41a4-5432-4c2c-a28d-a7bee5282c6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29da41a4-5432-4c2c-a28d-a7bee5282c6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29da41a4-5432-4c2c-a28d-a7bee5282c6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b149990-6484-48a6-ba0a-168cf7712d4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b149990-6484-48a6-ba0a-168cf7712d4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b149990-6484-48a6-ba0a-168cf7712d4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bbe7eff-1592-40c9-864d-b97bce10233a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bbe7eff-1592-40c9-864d-b97bce10233a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bbe7eff-1592-40c9-864d-b97bce10233a>.
+    
+<http://data.lblod.info/id/remote-data-objects/009c99b3-56f1-4e8b-a026-425b1f0c9935> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "009c99b3-56f1-4e8b-a026-425b1f0c9935";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/009c99b3-56f1-4e8b-a026-425b1f0c9935>.
+    
+<http://data.lblod.info/id/remote-data-objects/a71298bf-ad83-4b12-943c-673446d99650> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a71298bf-ad83-4b12-943c-673446d99650";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a71298bf-ad83-4b12-943c-673446d99650>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bed5414-e56c-4004-b1d6-5b5871ce0f9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bed5414-e56c-4004-b1d6-5b5871ce0f9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bed5414-e56c-4004-b1d6-5b5871ce0f9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/29c54e5c-800d-4ca4-8b07-95c8088fdf16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29c54e5c-800d-4ca4-8b07-95c8088fdf16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29c54e5c-800d-4ca4-8b07-95c8088fdf16>.
+    
+<http://data.lblod.info/id/remote-data-objects/679c273b-8a67-401a-a020-291faa4bac96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "679c273b-8a67-401a-a020-291faa4bac96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/679c273b-8a67-401a-a020-291faa4bac96>.
+    
+<http://data.lblod.info/id/remote-data-objects/92fb4bcc-e061-473d-8954-5775c6967d85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92fb4bcc-e061-473d-8954-5775c6967d85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92fb4bcc-e061-473d-8954-5775c6967d85>.
+    
+<http://data.lblod.info/id/remote-data-objects/a861f398-362c-4427-b520-1eb989000377> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a861f398-362c-4427-b520-1eb989000377";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a861f398-362c-4427-b520-1eb989000377>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbd592e1-cb83-4e95-a395-5f8f65e55c31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbd592e1-cb83-4e95-a395-5f8f65e55c31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbd592e1-cb83-4e95-a395-5f8f65e55c31>.
+    
+<http://data.lblod.info/id/remote-data-objects/592b2936-6a61-4e44-894a-083edabbcd3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "592b2936-6a61-4e44-894a-083edabbcd3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=BesluitenLijst_college%20van%20burgemeester%20en%20schepenen_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/592b2936-6a61-4e44-894a-083edabbcd3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3fe39c1-5be8-491f-961f-3f21cc19f9bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3fe39c1-5be8-491f-961f-3f21cc19f9bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_03-05-2022_15313.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3fe39c1-5be8-491f-961f-3f21cc19f9bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/74d5586d-e3db-4ea1-bd11-716e843b4a35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74d5586d-e3db-4ea1-bd11-716e843b4a35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_04-01-2022_13899.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74d5586d-e3db-4ea1-bd11-716e843b4a35>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a87063e-d3a9-45b2-91e1-5f7faec4f193> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a87063e-d3a9-45b2-91e1-5f7faec4f193";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_04-01-2022_13901.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a87063e-d3a9-45b2-91e1-5f7faec4f193>.
+    
+<http://data.lblod.info/id/remote-data-objects/c099943f-16c2-451a-932a-16cd10f2bbc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c099943f-16c2-451a-932a-16cd10f2bbc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_05-04-2022_15015.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c099943f-16c2-451a-932a-16cd10f2bbc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/3407e6c8-a03c-41dd-bf28-e74878feb49f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3407e6c8-a03c-41dd-bf28-e74878feb49f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_07-06-2022_15786.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9f2fa566-3c79-431d-a82c-4b09819ec508> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3407e6c8-a03c-41dd-bf28-e74878feb49f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201540-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201540-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201540-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201540-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/372720a3-2f71-4424-8367-ad183e9a0c09> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "372720a3-2f71-4424-8367-ad183e9a0c09";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "928c2a6a-f63b-4f03-ae40-4a3f4af799ff";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/411c2813-646c-44a2-8a0a-6d851a8a2c37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "411c2813-646c-44a2-8a0a-6d851a8a2c37";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff>.
+
+  <http://redpencil.data.gift/id/task/d5168b5f-a11b-40d2-b89f-2379f4d77f5e> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d5168b5f-a11b-40d2-b89f-2379f4d77f5e";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/372720a3-2f71-4424-8367-ad183e9a0c09>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/411c2813-646c-44a2-8a0a-6d851a8a2c37>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/abb7377a-d7fb-43a3-a37e-3ae3c5c09757> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abb7377a-d7fb-43a3-a37e-3ae3c5c09757";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_07-12-2021_13677.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abb7377a-d7fb-43a3-a37e-3ae3c5c09757>.
+    
+<http://data.lblod.info/id/remote-data-objects/e597b3cf-eabd-4a54-8e51-5d5651d7e586> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e597b3cf-eabd-4a54-8e51-5d5651d7e586";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_07-12-2021_13701.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e597b3cf-eabd-4a54-8e51-5d5651d7e586>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4d85651-119c-4c78-9396-2cc3475073ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4d85651-119c-4c78-9396-2cc3475073ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_08-02-2022_14267.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4d85651-119c-4c78-9396-2cc3475073ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/731645aa-7b6e-454a-9e44-71becf5d7eca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "731645aa-7b6e-454a-9e44-71becf5d7eca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_08-03-2022_14598.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/731645aa-7b6e-454a-9e44-71becf5d7eca>.
+    
+<http://data.lblod.info/id/remote-data-objects/71ad005d-271f-4831-ad43-6dba09a89b27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71ad005d-271f-4831-ad43-6dba09a89b27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_08-03-2022_14719.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71ad005d-271f-4831-ad43-6dba09a89b27>.
+    
+<http://data.lblod.info/id/remote-data-objects/eec6d755-c80a-494d-99d0-abf42c8b101f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eec6d755-c80a-494d-99d0-abf42c8b101f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_10-05-2022_15448.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eec6d755-c80a-494d-99d0-abf42c8b101f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6cb3572-4f87-4660-aa06-0464003fa839> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6cb3572-4f87-4660-aa06-0464003fa839";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_12-10-2021_12983.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6cb3572-4f87-4660-aa06-0464003fa839>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8498dbb-4981-4ced-b439-a661bb08c29a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8498dbb-4981-4ced-b439-a661bb08c29a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_12-10-2021_13039.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8498dbb-4981-4ced-b439-a661bb08c29a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c0ad1f8-b2f3-4cdb-8d25-a37bfafeab90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c0ad1f8-b2f3-4cdb-8d25-a37bfafeab90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_14-12-2021_13747.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c0ad1f8-b2f3-4cdb-8d25-a37bfafeab90>.
+    
+<http://data.lblod.info/id/remote-data-objects/c758733f-7c80-4e0b-b9de-2c4765c913f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c758733f-7c80-4e0b-b9de-2c4765c913f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_14-12-2021_13821.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c758733f-7c80-4e0b-b9de-2c4765c913f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/796fd27b-3a11-4007-9a3d-95709bd8ada0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "796fd27b-3a11-4007-9a3d-95709bd8ada0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_15-02-2022_14380.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/796fd27b-3a11-4007-9a3d-95709bd8ada0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f83581c9-c6fb-4e09-a8fe-b0d07c342e5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f83581c9-c6fb-4e09-a8fe-b0d07c342e5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_15-02-2022_14387.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f83581c9-c6fb-4e09-a8fe-b0d07c342e5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/36fec32f-e998-4790-b237-828b5b67423c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36fec32f-e998-4790-b237-828b5b67423c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_15-02-2022_14432.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36fec32f-e998-4790-b237-828b5b67423c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba22774d-1a20-47e1-bbce-c272885ba498> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba22774d-1a20-47e1-bbce-c272885ba498";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_15-02-2022_14446.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba22774d-1a20-47e1-bbce-c272885ba498>.
+    
+<http://data.lblod.info/id/remote-data-objects/511e916f-83e0-498c-8012-8f5f2a02289b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "511e916f-83e0-498c-8012-8f5f2a02289b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_15-03-2022_14755.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/511e916f-83e0-498c-8012-8f5f2a02289b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e987740-5006-40cf-bbe5-4a9a8201a679> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e987740-5006-40cf-bbe5-4a9a8201a679";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_15-03-2022_14759.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e987740-5006-40cf-bbe5-4a9a8201a679>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd7e12e6-6d44-4c94-b20c-a57e16868811> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd7e12e6-6d44-4c94-b20c-a57e16868811";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_28-06-2022_16012.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd7e12e6-6d44-4c94-b20c-a57e16868811>.
+    
+<http://data.lblod.info/id/remote-data-objects/793b4e06-1c58-48e4-bd09-39fde4457d1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "793b4e06-1c58-48e4-bd09-39fde4457d1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_29-03-2022_14917.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/793b4e06-1c58-48e4-bd09-39fde4457d1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2f999af-3c1f-46c2-aacb-e49379a67ecf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2f999af-3c1f-46c2-aacb-e49379a67ecf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_29-03-2022_14990.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2f999af-3c1f-46c2-aacb-e49379a67ecf>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2252acf-971e-4340-8d8b-3d7ded7c6c1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2252acf-971e-4340-8d8b-3d7ded7c6c1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/973a2923eacc0e8f11d5ece4678a09a5ae3ef436165fe841126efc4daee59ec0/GetPublication?filename=Uittreksels_30-11-2021_13587.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2252acf-971e-4340-8d8b-3d7ded7c6c1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4cd1c0b-7efc-46a3-9edf-415bc62f8e77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4cd1c0b-7efc-46a3-9edf-415bc62f8e77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4cd1c0b-7efc-46a3-9edf-415bc62f8e77>.
+    
+<http://data.lblod.info/id/remote-data-objects/78f62361-cac1-4b3f-9277-29de39547255> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78f62361-cac1-4b3f-9277-29de39547255";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78f62361-cac1-4b3f-9277-29de39547255>.
+    
+<http://data.lblod.info/id/remote-data-objects/9882f718-acef-45a2-9f17-df152c17ba07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9882f718-acef-45a2-9f17-df152c17ba07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9882f718-acef-45a2-9f17-df152c17ba07>.
+    
+<http://data.lblod.info/id/remote-data-objects/67dfce24-b833-4f2f-bd82-3f81b0b7a072> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67dfce24-b833-4f2f-bd82-3f81b0b7a072";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67dfce24-b833-4f2f-bd82-3f81b0b7a072>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef703524-5716-4014-9826-322b7ac1fba1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef703524-5716-4014-9826-322b7ac1fba1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef703524-5716-4014-9826-322b7ac1fba1>.
+    
+<http://data.lblod.info/id/remote-data-objects/680bf3c6-2574-4089-b64e-5f754dc42277> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "680bf3c6-2574-4089-b64e-5f754dc42277";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/680bf3c6-2574-4089-b64e-5f754dc42277>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dfe4e0c-8a07-4a78-aae5-dfd1c1a39b90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dfe4e0c-8a07-4a78-aae5-dfd1c1a39b90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dfe4e0c-8a07-4a78-aae5-dfd1c1a39b90>.
+    
+<http://data.lblod.info/id/remote-data-objects/845f20fa-6c2c-43e3-8f00-94c0e03361e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "845f20fa-6c2c-43e3-8f00-94c0e03361e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/845f20fa-6c2c-43e3-8f00-94c0e03361e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6974aad5-e8ba-40c7-a245-21df62ba8a3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6974aad5-e8ba-40c7-a245-21df62ba8a3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6974aad5-e8ba-40c7-a245-21df62ba8a3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/40532a17-bd17-4cfc-8414-2610adb6abc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40532a17-bd17-4cfc-8414-2610adb6abc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40532a17-bd17-4cfc-8414-2610adb6abc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6037f5e-281f-4056-b52c-aecafebeec46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6037f5e-281f-4056-b52c-aecafebeec46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6037f5e-281f-4056-b52c-aecafebeec46>.
+    
+<http://data.lblod.info/id/remote-data-objects/25332dcc-b3f3-47e9-8303-ead688b5fad1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25332dcc-b3f3-47e9-8303-ead688b5fad1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25332dcc-b3f3-47e9-8303-ead688b5fad1>.
+    
+<http://data.lblod.info/id/remote-data-objects/19a4664f-a029-4005-9289-4fc4c666a949> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19a4664f-a029-4005-9289-4fc4c666a949";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19a4664f-a029-4005-9289-4fc4c666a949>.
+    
+<http://data.lblod.info/id/remote-data-objects/34974b3a-317e-4d74-aa86-bc22ed8f40fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34974b3a-317e-4d74-aa86-bc22ed8f40fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34974b3a-317e-4d74-aa86-bc22ed8f40fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9bca50e-da27-4de1-b52e-e5955668fae7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9bca50e-da27-4de1-b52e-e5955668fae7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9bca50e-da27-4de1-b52e-e5955668fae7>.
+    
+<http://data.lblod.info/id/remote-data-objects/11e6cc47-a7a9-4951-bf20-284649030d73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11e6cc47-a7a9-4951-bf20-284649030d73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11e6cc47-a7a9-4951-bf20-284649030d73>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4c0e225-3d3b-4d2d-948a-9b3c5eb55cb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4c0e225-3d3b-4d2d-948a-9b3c5eb55cb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4c0e225-3d3b-4d2d-948a-9b3c5eb55cb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7397b3a-2494-40d7-a2d8-af61ef9333f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7397b3a-2494-40d7-a2d8-af61ef9333f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7397b3a-2494-40d7-a2d8-af61ef9333f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/416c3927-7afa-4369-9b69-d1e05486dbd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "416c3927-7afa-4369-9b69-d1e05486dbd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/416c3927-7afa-4369-9b69-d1e05486dbd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/168fb850-93fb-4782-8b0f-bd914a272ee0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "168fb850-93fb-4782-8b0f-bd914a272ee0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/168fb850-93fb-4782-8b0f-bd914a272ee0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f916acf0-b2ec-4999-b8c0-504a9894876e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f916acf0-b2ec-4999-b8c0-504a9894876e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f916acf0-b2ec-4999-b8c0-504a9894876e>.
+    
+<http://data.lblod.info/id/remote-data-objects/13b48410-07a0-4cbf-b679-9dbddf7522c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13b48410-07a0-4cbf-b679-9dbddf7522c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=Uittreksels_20-12-2021_13573.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13b48410-07a0-4cbf-b679-9dbddf7522c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a34d9461-11c6-4934-96f6-903a70deaf59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a34d9461-11c6-4934-96f6-903a70deaf59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=Uittreksels_27-06-2022_14475.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a34d9461-11c6-4934-96f6-903a70deaf59>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ee7698b-bc96-413b-baf5-ceadbd49eefa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ee7698b-bc96-413b-baf5-ceadbd49eefa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.melle.be/LBLODWeb/Home/Overzicht/a13ec6e428200cf40c788378a46bb852ba8d46acef8f105937529c2de3347799/GetPublication?filename=Uittreksels_27-06-2022_16002.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ee7698b-bc96-413b-baf5-ceadbd49eefa>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2ebbbb3-ebf9-4c46-88f8-b159d7296c11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2ebbbb3-ebf9-4c46-88f8-b159d7296c11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2ebbbb3-ebf9-4c46-88f8-b159d7296c11>.
+    
+<http://data.lblod.info/id/remote-data-objects/923bf0be-5772-464e-a372-17ce76be3f71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "923bf0be-5772-464e-a372-17ce76be3f71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/923bf0be-5772-464e-a372-17ce76be3f71>.
+    
+<http://data.lblod.info/id/remote-data-objects/48fb092e-63ad-4ce0-9570-9561340a5495> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48fb092e-63ad-4ce0-9570-9561340a5495";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48fb092e-63ad-4ce0-9570-9561340a5495>.
+    
+<http://data.lblod.info/id/remote-data-objects/4804a70f-6a36-4b37-b804-9120b4cc8bd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4804a70f-6a36-4b37-b804-9120b4cc8bd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4804a70f-6a36-4b37-b804-9120b4cc8bd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/80ab11f1-f428-4565-8595-a0fee3ba18c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80ab11f1-f428-4565-8595-a0fee3ba18c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80ab11f1-f428-4565-8595-a0fee3ba18c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/72964350-772b-4069-a8e3-d81a8b4ca551> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72964350-772b-4069-a8e3-d81a8b4ca551";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/928c2a6a-f63b-4f03-ae40-4a3f4af799ff> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72964350-772b-4069-a8e3-d81a8b4ca551>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201541-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201541-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201541-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201541-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c9e32c44-6339-430c-a215-32a19610cf81> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c9e32c44-6339-430c-a215-32a19610cf81";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cac84ff2-3b45-4af3-a808-e8560de709b7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/be0f82dd-b6a5-4c58-ace4-a0e9c4b02a68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "be0f82dd-b6a5-4c58-ace4-a0e9c4b02a68";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7>.
+
+  <http://redpencil.data.gift/id/task/81b0d99b-b36e-40a9-b7a1-c32fd487ddc2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "81b0d99b-b36e-40a9-b7a1-c32fd487ddc2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c9e32c44-6339-430c-a215-32a19610cf81>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/be0f82dd-b6a5-4c58-ace4-a0e9c4b02a68>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/fcd9e1b2-65bd-4fb2-a2d3-d0988ee2b88d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcd9e1b2-65bd-4fb2-a2d3-d0988ee2b88d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcd9e1b2-65bd-4fb2-a2d3-d0988ee2b88d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8af2c8b8-d1b7-4d7b-9c49-d9e612515126> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8af2c8b8-d1b7-4d7b-9c49-d9e612515126";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8af2c8b8-d1b7-4d7b-9c49-d9e612515126>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a7da577-e8cd-4faf-9d30-ccb92237a547> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a7da577-e8cd-4faf-9d30-ccb92237a547";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a7da577-e8cd-4faf-9d30-ccb92237a547>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0326ecd-e999-40f6-a2f0-ed68c73fffd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0326ecd-e999-40f6-a2f0-ed68c73fffd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0326ecd-e999-40f6-a2f0-ed68c73fffd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/2489c02b-2049-495c-9ff4-a9d34765d0e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2489c02b-2049-495c-9ff4-a9d34765d0e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2489c02b-2049-495c-9ff4-a9d34765d0e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2453a709-e8ab-4f63-8a50-3279e6eabd3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2453a709-e8ab-4f63-8a50-3279e6eabd3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2453a709-e8ab-4f63-8a50-3279e6eabd3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f82aacf-61d3-4d7f-81af-09bd29f7f2f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f82aacf-61d3-4d7f-81af-09bd29f7f2f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f82aacf-61d3-4d7f-81af-09bd29f7f2f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9352e6f-2c65-4490-82fb-5ab5198c635f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9352e6f-2c65-4490-82fb-5ab5198c635f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9352e6f-2c65-4490-82fb-5ab5198c635f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3684ae3d-45f7-441e-afd1-5833f9e4dcfc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3684ae3d-45f7-441e-afd1-5833f9e4dcfc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3684ae3d-45f7-441e-afd1-5833f9e4dcfc>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e164623-9213-4bdb-a268-033347901882> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e164623-9213-4bdb-a268-033347901882";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e164623-9213-4bdb-a268-033347901882>.
+    
+<http://data.lblod.info/id/remote-data-objects/61a8f23d-cd38-4bd8-9c63-5280ae0428fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61a8f23d-cd38-4bd8-9c63-5280ae0428fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61a8f23d-cd38-4bd8-9c63-5280ae0428fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/96d037cf-9fbe-433f-a570-3a6713fa98ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96d037cf-9fbe-433f-a570-3a6713fa98ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_13-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96d037cf-9fbe-433f-a570-3a6713fa98ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/6240980d-64c3-48e0-941a-15ad898f2b0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6240980d-64c3-48e0-941a-15ad898f2b0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6240980d-64c3-48e0-941a-15ad898f2b0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/34ab1eee-05dc-4c50-824f-d941a0fb9aa4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34ab1eee-05dc-4c50-824f-d941a0fb9aa4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34ab1eee-05dc-4c50-824f-d941a0fb9aa4>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ac6c7c6-a2bc-4ee8-a6a9-3fc8b444fb32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ac6c7c6-a2bc-4ee8-a6a9-3fc8b444fb32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ac6c7c6-a2bc-4ee8-a6a9-3fc8b444fb32>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a890329-2ef9-4c11-ab13-d8a258d7cabf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a890329-2ef9-4c11-ab13-d8a258d7cabf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a890329-2ef9-4c11-ab13-d8a258d7cabf>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ad9c710-bd9c-4717-8df0-b0c09a6d525d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ad9c710-bd9c-4717-8df0-b0c09a6d525d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ad9c710-bd9c-4717-8df0-b0c09a6d525d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f85d84bc-62b6-442f-9b7d-020d5db40699> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f85d84bc-62b6-442f-9b7d-020d5db40699";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f85d84bc-62b6-442f-9b7d-020d5db40699>.
+    
+<http://data.lblod.info/id/remote-data-objects/88a42d17-8b1a-4e4d-a750-8b7662d0e515> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88a42d17-8b1a-4e4d-a750-8b7662d0e515";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88a42d17-8b1a-4e4d-a750-8b7662d0e515>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6c33fc2-a8b1-497f-a2bb-3499c4f06741> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6c33fc2-a8b1-497f-a2bb-3499c4f06741";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6c33fc2-a8b1-497f-a2bb-3499c4f06741>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbfac23b-de22-4941-817b-73325b30c85b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbfac23b-de22-4941-817b-73325b30c85b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbfac23b-de22-4941-817b-73325b30c85b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b473f81-9e7d-4278-9b21-107f120ae60b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b473f81-9e7d-4278-9b21-107f120ae60b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b473f81-9e7d-4278-9b21-107f120ae60b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9135dd92-098a-4011-b8b8-2dcafdb59921> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9135dd92-098a-4011-b8b8-2dcafdb59921";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9135dd92-098a-4011-b8b8-2dcafdb59921>.
+    
+<http://data.lblod.info/id/remote-data-objects/b48344ee-668c-4f92-982c-6623f926df88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b48344ee-668c-4f92-982c-6623f926df88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b48344ee-668c-4f92-982c-6623f926df88>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b868b2c-96c2-4c67-b8a4-b70bbfc56d6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b868b2c-96c2-4c67-b8a4-b70bbfc56d6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b868b2c-96c2-4c67-b8a4-b70bbfc56d6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb1d232a-8142-4fdc-a7bb-7c3e67c909b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb1d232a-8142-4fdc-a7bb-7c3e67c909b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb1d232a-8142-4fdc-a7bb-7c3e67c909b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8b24b33-a11c-44fd-a408-9e9291c108ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8b24b33-a11c-44fd-a408-9e9291c108ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8b24b33-a11c-44fd-a408-9e9291c108ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/ece0b877-17f2-434e-bf2c-071360bd07f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ece0b877-17f2-434e-bf2c-071360bd07f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ece0b877-17f2-434e-bf2c-071360bd07f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/13dbeb66-e80a-4f2a-a215-f0406a0c507f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13dbeb66-e80a-4f2a-a215-f0406a0c507f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13dbeb66-e80a-4f2a-a215-f0406a0c507f>.
+    
+<http://data.lblod.info/id/remote-data-objects/74789388-dae9-49fd-95a9-fad4d2b27eb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74789388-dae9-49fd-95a9-fad4d2b27eb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74789388-dae9-49fd-95a9-fad4d2b27eb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2cb92b7-4ea0-4bfd-aa6f-4a27b94abdeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2cb92b7-4ea0-4bfd-aa6f-4a27b94abdeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2cb92b7-4ea0-4bfd-aa6f-4a27b94abdeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b450b2d-8c16-4c85-84a7-c17fc5b0c9c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b450b2d-8c16-4c85-84a7-c17fc5b0c9c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b450b2d-8c16-4c85-84a7-c17fc5b0c9c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/66273385-cb51-4ee9-9f2c-304724fe2145> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66273385-cb51-4ee9-9f2c-304724fe2145";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66273385-cb51-4ee9-9f2c-304724fe2145>.
+    
+<http://data.lblod.info/id/remote-data-objects/83da457c-449b-4a32-aedf-8c3b69b30f72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83da457c-449b-4a32-aedf-8c3b69b30f72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83da457c-449b-4a32-aedf-8c3b69b30f72>.
+    
+<http://data.lblod.info/id/remote-data-objects/79d7951c-e413-4547-8873-dbb37616e166> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79d7951c-e413-4547-8873-dbb37616e166";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79d7951c-e413-4547-8873-dbb37616e166>.
+    
+<http://data.lblod.info/id/remote-data-objects/3eb51bca-7f94-432f-bbac-4d9ad46ba423> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3eb51bca-7f94-432f-bbac-4d9ad46ba423";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3eb51bca-7f94-432f-bbac-4d9ad46ba423>.
+    
+<http://data.lblod.info/id/remote-data-objects/99be74c5-9c2c-42e1-9c3e-c202a5739e7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99be74c5-9c2c-42e1-9c3e-c202a5739e7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99be74c5-9c2c-42e1-9c3e-c202a5739e7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/753e98eb-b08c-411a-864a-1eb47c5fa52a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "753e98eb-b08c-411a-864a-1eb47c5fa52a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/753e98eb-b08c-411a-864a-1eb47c5fa52a>.
+    
+<http://data.lblod.info/id/remote-data-objects/aac1ce4a-da9c-432a-88c6-1a1b12d0df72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aac1ce4a-da9c-432a-88c6-1a1b12d0df72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aac1ce4a-da9c-432a-88c6-1a1b12d0df72>.
+    
+<http://data.lblod.info/id/remote-data-objects/33481272-a762-4e48-8379-5eacf54354e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33481272-a762-4e48-8379-5eacf54354e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33481272-a762-4e48-8379-5eacf54354e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/770ebdde-68fd-473d-a515-788498482cd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "770ebdde-68fd-473d-a515-788498482cd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/770ebdde-68fd-473d-a515-788498482cd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6a6ab46-abba-4cf7-9cb2-494ad76cdbde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6a6ab46-abba-4cf7-9cb2-494ad76cdbde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=Uittreksels_06-07-2022_49155.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6a6ab46-abba-4cf7-9cb2-494ad76cdbde>.
+    
+<http://data.lblod.info/id/remote-data-objects/eaf983a4-efd5-4a37-af65-674a7e293d12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eaf983a4-efd5-4a37-af65-674a7e293d12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=Uittreksels_13-04-2022_47494.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eaf983a4-efd5-4a37-af65-674a7e293d12>.
+    
+<http://data.lblod.info/id/remote-data-objects/6569a9d6-848a-4614-86d3-c4001ede88c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6569a9d6-848a-4614-86d3-c4001ede88c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=Uittreksels_21-06-2022_48768.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6569a9d6-848a-4614-86d3-c4001ede88c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e70ff5ae-53cf-4bb2-9079-8c8f12184413> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e70ff5ae-53cf-4bb2-9079-8c8f12184413";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=Uittreksels_23-05-2022_48190.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e70ff5ae-53cf-4bb2-9079-8c8f12184413>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fcf2b60-1b79-459b-b687-b806f7886465> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fcf2b60-1b79-459b-b687-b806f7886465";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/01fbad8ce92fc83a1e536fd16a187fcf8982ec08b9e89cfccd47fb0df804fff3/GetPublication?filename=Uittreksels_31-05-2022_48295.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fcf2b60-1b79-459b-b687-b806f7886465>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cfeaa38-bb4c-4eb7-b582-c1a757ab5e6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cfeaa38-bb4c-4eb7-b582-c1a757ab5e6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Agenda_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cfeaa38-bb4c-4eb7-b582-c1a757ab5e6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5373fc5-54b1-4f87-9a8a-4f35254b5caa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5373fc5-54b1-4f87-9a8a-4f35254b5caa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Agenda_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5373fc5-54b1-4f87-9a8a-4f35254b5caa>.
+    
+<http://data.lblod.info/id/remote-data-objects/54e5829d-d672-4f56-a5fd-751d40e85944> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54e5829d-d672-4f56-a5fd-751d40e85944";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Agenda_Gemeenteraad_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54e5829d-d672-4f56-a5fd-751d40e85944>.
+    
+<http://data.lblod.info/id/remote-data-objects/d184e3c3-a28d-447b-a2be-d8746a04580f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d184e3c3-a28d-447b-a2be-d8746a04580f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Agenda_Gemeenteraad_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cac84ff2-3b45-4af3-a808-e8560de709b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d184e3c3-a28d-447b-a2be-d8746a04580f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201542-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201542-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201542-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201542-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/86fd2bb4-d00d-42fd-a6f7-2211aaa5ea47> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "86fd2bb4-d00d-42fd-a6f7-2211aaa5ea47";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fe315643-3e90-4748-8868-16612cc362ba";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/aacc1191-8b68-4bb1-9f25-788a4e00df5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "aacc1191-8b68-4bb1-9f25-788a4e00df5e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba>.
+
+  <http://redpencil.data.gift/id/task/783e429e-575e-4f11-9c7b-9ead171d7498> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "783e429e-575e-4f11-9c7b-9ead171d7498";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/86fd2bb4-d00d-42fd-a6f7-2211aaa5ea47>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/aacc1191-8b68-4bb1-9f25-788a4e00df5e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/84487338-d368-474e-be24-1ddf41837d8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84487338-d368-474e-be24-1ddf41837d8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Agenda_Gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84487338-d368-474e-be24-1ddf41837d8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2aaaf80b-e1f6-4fbd-8813-e2fb07472551> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2aaaf80b-e1f6-4fbd-8813-e2fb07472551";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Agenda_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2aaaf80b-e1f6-4fbd-8813-e2fb07472551>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2ba92db-1c3d-48d5-82c3-8d8f1f9e2923> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2ba92db-1c3d-48d5-82c3-8d8f1f9e2923";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Agenda_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2ba92db-1c3d-48d5-82c3-8d8f1f9e2923>.
+    
+<http://data.lblod.info/id/remote-data-objects/488b1208-82d9-4a84-a26c-5d076847035c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "488b1208-82d9-4a84-a26c-5d076847035c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Agenda_Gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/488b1208-82d9-4a84-a26c-5d076847035c>.
+    
+<http://data.lblod.info/id/remote-data-objects/58a826b0-7ddb-4002-9b21-0ac8576d40a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58a826b0-7ddb-4002-9b21-0ac8576d40a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Agenda_Gemeenteraad_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58a826b0-7ddb-4002-9b21-0ac8576d40a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/da2f0d14-db06-4fa7-922a-e4414afccd9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da2f0d14-db06-4fa7-922a-e4414afccd9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da2f0d14-db06-4fa7-922a-e4414afccd9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f45583bb-5dbb-4294-9e5e-5e32984e435c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f45583bb-5dbb-4294-9e5e-5e32984e435c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=BesluitenLijst_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f45583bb-5dbb-4294-9e5e-5e32984e435c>.
+    
+<http://data.lblod.info/id/remote-data-objects/81a13d0f-e539-4f2c-a1fb-37059df54070> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81a13d0f-e539-4f2c-a1fb-37059df54070";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=BesluitenLijst_Gemeenteraad_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81a13d0f-e539-4f2c-a1fb-37059df54070>.
+    
+<http://data.lblod.info/id/remote-data-objects/8915c75c-7a97-406a-a5b5-8715b5599062> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8915c75c-7a97-406a-a5b5-8715b5599062";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8915c75c-7a97-406a-a5b5-8715b5599062>.
+    
+<http://data.lblod.info/id/remote-data-objects/a360bcae-a285-4bc3-be25-40dfbca313eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a360bcae-a285-4bc3-be25-40dfbca313eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a360bcae-a285-4bc3-be25-40dfbca313eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/be44dfee-a82d-4f2e-9e9f-b337bf74636c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be44dfee-a82d-4f2e-9e9f-b337bf74636c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be44dfee-a82d-4f2e-9e9f-b337bf74636c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f691a6ec-9932-49e0-b0ed-c915f7469c16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f691a6ec-9932-49e0-b0ed-c915f7469c16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=BesluitenLijst_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f691a6ec-9932-49e0-b0ed-c915f7469c16>.
+    
+<http://data.lblod.info/id/remote-data-objects/aea0895c-1d63-4e00-b342-375db318e496> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aea0895c-1d63-4e00-b342-375db318e496";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=BesluitenLijst_Gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aea0895c-1d63-4e00-b342-375db318e496>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f5da088-34ec-46a0-b9e4-c3bc5d96725f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f5da088-34ec-46a0-b9e4-c3bc5d96725f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f5da088-34ec-46a0-b9e4-c3bc5d96725f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2165983-5688-4893-808c-c9a506fd176d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2165983-5688-4893-808c-c9a506fd176d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Notulen_Gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2165983-5688-4893-808c-c9a506fd176d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cdc8dc4-0feb-41bc-8f18-0ad8a7e370be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cdc8dc4-0feb-41bc-8f18-0ad8a7e370be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Notulen_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cdc8dc4-0feb-41bc-8f18-0ad8a7e370be>.
+    
+<http://data.lblod.info/id/remote-data-objects/96d2c439-ffdc-468f-98c0-451236ef0f95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96d2c439-ffdc-468f-98c0-451236ef0f95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_21-12-2021_42484.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96d2c439-ffdc-468f-98c0-451236ef0f95>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc3ad412-48bb-4f93-adcc-9dcef630a293> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc3ad412-48bb-4f93-adcc-9dcef630a293";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_21-12-2021_42919.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc3ad412-48bb-4f93-adcc-9dcef630a293>.
+    
+<http://data.lblod.info/id/remote-data-objects/05cc6f05-d41a-45a6-93b3-dbed737a3e79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05cc6f05-d41a-45a6-93b3-dbed737a3e79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_21-12-2021_43401.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05cc6f05-d41a-45a6-93b3-dbed737a3e79>.
+    
+<http://data.lblod.info/id/remote-data-objects/40b082af-d59f-4ab5-8298-45b02bf54f07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40b082af-d59f-4ab5-8298-45b02bf54f07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_21-12-2021_43504.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40b082af-d59f-4ab5-8298-45b02bf54f07>.
+    
+<http://data.lblod.info/id/remote-data-objects/03b9fb2b-cae1-4e16-8f5c-0930e25557b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03b9fb2b-cae1-4e16-8f5c-0930e25557b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_21-12-2021_43556.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03b9fb2b-cae1-4e16-8f5c-0930e25557b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d33a905-2898-4580-9537-207c965667ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d33a905-2898-4580-9537-207c965667ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_22-02-2022_45144.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d33a905-2898-4580-9537-207c965667ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/e16142ac-7a6c-466e-9a5c-8a776fdfa693> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e16142ac-7a6c-466e-9a5c-8a776fdfa693";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_22-02-2022_45204.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e16142ac-7a6c-466e-9a5c-8a776fdfa693>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dbf49c8-89cc-4cd2-ae54-291812127e83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dbf49c8-89cc-4cd2-ae54-291812127e83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_22-02-2022_45231.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dbf49c8-89cc-4cd2-ae54-291812127e83>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0847674-3354-4d2d-a79a-002bb86aa694> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0847674-3354-4d2d-a79a-002bb86aa694";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_22-02-2022_45232.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0847674-3354-4d2d-a79a-002bb86aa694>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7c53c87-d475-4ac2-89d3-3a726c7974f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7c53c87-d475-4ac2-89d3-3a726c7974f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_22-02-2022_45350.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7c53c87-d475-4ac2-89d3-3a726c7974f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7559206-4039-4430-a07d-58650aa47449> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7559206-4039-4430-a07d-58650aa47449";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_22-03-2022_45343.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7559206-4039-4430-a07d-58650aa47449>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4dc913b-195d-459a-bff5-ebe63f938d5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4dc913b-195d-459a-bff5-ebe63f938d5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_23-11-2021_39834.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4dc913b-195d-459a-bff5-ebe63f938d5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6164871-c0ce-4814-a530-eea1d8ebb4c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6164871-c0ce-4814-a530-eea1d8ebb4c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_23-11-2021_42291.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6164871-c0ce-4814-a530-eea1d8ebb4c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/24da3186-9b62-4eac-bb2e-fa9ccb101ae0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24da3186-9b62-4eac-bb2e-fa9ccb101ae0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_23-11-2021_43061.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24da3186-9b62-4eac-bb2e-fa9ccb101ae0>.
+    
+<http://data.lblod.info/id/remote-data-objects/96c4c735-a8d2-4ab0-b29c-c18f296726c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96c4c735-a8d2-4ab0-b29c-c18f296726c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_23-11-2021_43088.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96c4c735-a8d2-4ab0-b29c-c18f296726c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/335ca4e1-8a40-462e-84fd-553e77cf3b28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "335ca4e1-8a40-462e-84fd-553e77cf3b28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_24-05-2022_47589.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/335ca4e1-8a40-462e-84fd-553e77cf3b28>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a2fa0df-3f12-40c6-8e2c-16a9fa57e32f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a2fa0df-3f12-40c6-8e2c-16a9fa57e32f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_24-05-2022_47592.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a2fa0df-3f12-40c6-8e2c-16a9fa57e32f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7a2291f-7013-4a00-9f7a-bf16cb4048fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7a2291f-7013-4a00-9f7a-bf16cb4048fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_24-05-2022_47593.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7a2291f-7013-4a00-9f7a-bf16cb4048fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ab435c1-3dbf-43ab-bcf9-98a8ef7beba4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ab435c1-3dbf-43ab-bcf9-98a8ef7beba4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_24-05-2022_47868.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ab435c1-3dbf-43ab-bcf9-98a8ef7beba4>.
+    
+<http://data.lblod.info/id/remote-data-objects/29151509-d262-4865-b342-8749da0fded3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29151509-d262-4865-b342-8749da0fded3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_24-05-2022_48049.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29151509-d262-4865-b342-8749da0fded3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0afdc8d-dc1a-4384-9cc2-41f05df9e735> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0afdc8d-dc1a-4384-9cc2-41f05df9e735";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_26-04-2022_45305.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0afdc8d-dc1a-4384-9cc2-41f05df9e735>.
+    
+<http://data.lblod.info/id/remote-data-objects/be284ed4-37ac-4415-bbc2-abe7eee999ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be284ed4-37ac-4415-bbc2-abe7eee999ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_26-10-2021_38865.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be284ed4-37ac-4415-bbc2-abe7eee999ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/306c8b29-4704-4e4d-8e11-7fd3bcdf9977> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "306c8b29-4704-4e4d-8e11-7fd3bcdf9977";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_26-10-2021_42686.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/306c8b29-4704-4e4d-8e11-7fd3bcdf9977>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e776315-4120-4685-81d7-853e9ce2e139> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e776315-4120-4685-81d7-853e9ce2e139";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_28-06-2022_48124.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e776315-4120-4685-81d7-853e9ce2e139>.
+    
+<http://data.lblod.info/id/remote-data-objects/d57bac93-52bc-41b1-b23a-a6e686c0ce80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d57bac93-52bc-41b1-b23a-a6e686c0ce80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_28-06-2022_48162.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d57bac93-52bc-41b1-b23a-a6e686c0ce80>.
+    
+<http://data.lblod.info/id/remote-data-objects/5881f2a8-0f1e-4d10-9f88-98336064b06b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5881f2a8-0f1e-4d10-9f88-98336064b06b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_28-06-2022_48465.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5881f2a8-0f1e-4d10-9f88-98336064b06b>.
+    
+<http://data.lblod.info/id/remote-data-objects/66944ff4-b3cf-4406-aa8a-0442c74222ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66944ff4-b3cf-4406-aa8a-0442c74222ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_28-06-2022_48530.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66944ff4-b3cf-4406-aa8a-0442c74222ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e9d4087-893e-4901-b86b-bff016d82d02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e9d4087-893e-4901-b86b-bff016d82d02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_28-06-2022_48605.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e9d4087-893e-4901-b86b-bff016d82d02>.
+    
+<http://data.lblod.info/id/remote-data-objects/eeeb45e3-b8d1-4020-89f4-adfe96b61f3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eeeb45e3-b8d1-4020-89f4-adfe96b61f3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_28-06-2022_48639.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eeeb45e3-b8d1-4020-89f4-adfe96b61f3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/111e0eeb-c2e2-45ac-9a37-7906e2b6e58b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "111e0eeb-c2e2-45ac-9a37-7906e2b6e58b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_28-06-2022_48665.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/111e0eeb-c2e2-45ac-9a37-7906e2b6e58b>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf1c4998-6167-4945-83b0-6e14ec58e627> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf1c4998-6167-4945-83b0-6e14ec58e627";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_28-06-2022_48683.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf1c4998-6167-4945-83b0-6e14ec58e627>.
+    
+<http://data.lblod.info/id/remote-data-objects/a000d6db-f3be-4a6e-8da6-e2cfa12a5da8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a000d6db-f3be-4a6e-8da6-e2cfa12a5da8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/31cdfe166bd08ca77ef5b66d1e72107c94846def897f13d52c821668afe5d9c1/GetPublication?filename=Uittreksels_28-06-2022_48684.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a000d6db-f3be-4a6e-8da6-e2cfa12a5da8>.
+    
+<http://data.lblod.info/id/remote-data-objects/85b69420-5dbb-480f-ad5c-1f79f1461a02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85b69420-5dbb-480f-ad5c-1f79f1461a02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85b69420-5dbb-480f-ad5c-1f79f1461a02>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fbdba50-7700-4551-8bd3-8641cf9ea13f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fbdba50-7700-4551-8bd3-8641cf9ea13f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fe315643-3e90-4748-8868-16612cc362ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fbdba50-7700-4551-8bd3-8641cf9ea13f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201543-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201543-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201543-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201543-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/5ff58201-48ee-4fe8-98c0-1304dd9a45ea> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5ff58201-48ee-4fe8-98c0-1304dd9a45ea";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "383cd482-b809-4831-bbdd-7728fd87fd6a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/7db44346-9120-45ac-b759-c0290e889da3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7db44346-9120-45ac-b759-c0290e889da3";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a>.
+
+  <http://redpencil.data.gift/id/task/fdbe7071-065c-4bab-849c-a5af778bfccb> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fdbe7071-065c-4bab-849c-a5af778bfccb";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/5ff58201-48ee-4fe8-98c0-1304dd9a45ea>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/7db44346-9120-45ac-b759-c0290e889da3>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/3597f40a-6c6f-4f4f-98e0-d6f281cd5546> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3597f40a-6c6f-4f4f-98e0-d6f281cd5546";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3597f40a-6c6f-4f4f-98e0-d6f281cd5546>.
+    
+<http://data.lblod.info/id/remote-data-objects/efcf95e1-a414-4e8e-a77f-6645052af98e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efcf95e1-a414-4e8e-a77f-6645052af98e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efcf95e1-a414-4e8e-a77f-6645052af98e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f736755a-2ba2-487a-a467-9892ee7161d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f736755a-2ba2-487a-a467-9892ee7161d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f736755a-2ba2-487a-a467-9892ee7161d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/72f64810-0d73-4446-a06d-2e9730154388> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72f64810-0d73-4446-a06d-2e9730154388";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72f64810-0d73-4446-a06d-2e9730154388>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6e79215-d0a5-4912-8109-88ca3ce074d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6e79215-d0a5-4912-8109-88ca3ce074d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6e79215-d0a5-4912-8109-88ca3ce074d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4c9911b-bd10-430a-8cc1-902c512195f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4c9911b-bd10-430a-8cc1-902c512195f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4c9911b-bd10-430a-8cc1-902c512195f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/434923a5-50fe-41c7-909d-1862ad30b506> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "434923a5-50fe-41c7-909d-1862ad30b506";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/434923a5-50fe-41c7-909d-1862ad30b506>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb6531b6-5274-41b6-9c16-110985d5111d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb6531b6-5274-41b6-9c16-110985d5111d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb6531b6-5274-41b6-9c16-110985d5111d>.
+    
+<http://data.lblod.info/id/remote-data-objects/dab08032-9d74-4e2a-a0a4-3bf33b108e85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dab08032-9d74-4e2a-a0a4-3bf33b108e85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dab08032-9d74-4e2a-a0a4-3bf33b108e85>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4f387ba-3f64-411c-92b8-d93a2a65583b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4f387ba-3f64-411c-92b8-d93a2a65583b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4f387ba-3f64-411c-92b8-d93a2a65583b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f980b1cc-21f3-4194-afd8-9f157146c36c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f980b1cc-21f3-4194-afd8-9f157146c36c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f980b1cc-21f3-4194-afd8-9f157146c36c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4495347-c58a-4dc9-b240-de01a1f44e7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4495347-c58a-4dc9-b240-de01a1f44e7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4495347-c58a-4dc9-b240-de01a1f44e7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/be5fbeae-a48b-4c55-918f-3da7236acc5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be5fbeae-a48b-4c55-918f-3da7236acc5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be5fbeae-a48b-4c55-918f-3da7236acc5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/817ed701-60d5-4b26-b893-eabb11ebd15e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "817ed701-60d5-4b26-b893-eabb11ebd15e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/817ed701-60d5-4b26-b893-eabb11ebd15e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8855e3a2-0d34-4b5c-94fe-728df7e51bb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8855e3a2-0d34-4b5c-94fe-728df7e51bb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8855e3a2-0d34-4b5c-94fe-728df7e51bb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/529fac27-820e-45a5-afba-14b0c0b60863> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "529fac27-820e-45a5-afba-14b0c0b60863";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/529fac27-820e-45a5-afba-14b0c0b60863>.
+    
+<http://data.lblod.info/id/remote-data-objects/2765b227-79c7-4c95-8a20-86bbf58fae1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2765b227-79c7-4c95-8a20-86bbf58fae1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2765b227-79c7-4c95-8a20-86bbf58fae1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/60eed23e-1cf7-4ea8-a6a9-6fae74a752dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60eed23e-1cf7-4ea8-a6a9-6fae74a752dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60eed23e-1cf7-4ea8-a6a9-6fae74a752dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/aaa77d04-944e-401c-8b81-24a32e3c4b61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aaa77d04-944e-401c-8b81-24a32e3c4b61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aaa77d04-944e-401c-8b81-24a32e3c4b61>.
+    
+<http://data.lblod.info/id/remote-data-objects/59e1e6cc-5222-42fd-a5e6-d0061f5286d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59e1e6cc-5222-42fd-a5e6-d0061f5286d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59e1e6cc-5222-42fd-a5e6-d0061f5286d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a012519b-3ff8-429b-a07c-4e6c41af433c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a012519b-3ff8-429b-a07c-4e6c41af433c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a012519b-3ff8-429b-a07c-4e6c41af433c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac5f2084-4650-4eb8-8692-086717d9e4f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac5f2084-4650-4eb8-8692-086717d9e4f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac5f2084-4650-4eb8-8692-086717d9e4f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bc333b0-ea30-4834-95f6-52623ffab197> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bc333b0-ea30-4834-95f6-52623ffab197";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bc333b0-ea30-4834-95f6-52623ffab197>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9c440de-f114-4e2c-aa82-90e53e5b5db8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9c440de-f114-4e2c-aa82-90e53e5b5db8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9c440de-f114-4e2c-aa82-90e53e5b5db8>.
+    
+<http://data.lblod.info/id/remote-data-objects/796405a9-c834-4d4b-a5a8-3e302fee4373> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "796405a9-c834-4d4b-a5a8-3e302fee4373";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/796405a9-c834-4d4b-a5a8-3e302fee4373>.
+    
+<http://data.lblod.info/id/remote-data-objects/93b91274-3155-4d64-932f-4347879ebc8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93b91274-3155-4d64-932f-4347879ebc8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93b91274-3155-4d64-932f-4347879ebc8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7dde84f-98f4-4541-a34b-8b7777607257> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7dde84f-98f4-4541-a34b-8b7777607257";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7dde84f-98f4-4541-a34b-8b7777607257>.
+    
+<http://data.lblod.info/id/remote-data-objects/04042045-a47a-4eff-96be-1d959e41b745> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04042045-a47a-4eff-96be-1d959e41b745";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04042045-a47a-4eff-96be-1d959e41b745>.
+    
+<http://data.lblod.info/id/remote-data-objects/2673e792-1970-406b-b8d8-c4f69343cf3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2673e792-1970-406b-b8d8-c4f69343cf3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2673e792-1970-406b-b8d8-c4f69343cf3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/73b4f634-ef6d-4a68-bd34-4837d3e1c11b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73b4f634-ef6d-4a68-bd34-4837d3e1c11b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73b4f634-ef6d-4a68-bd34-4837d3e1c11b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5eafecd-a748-4e05-af0f-2457a5d733b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5eafecd-a748-4e05-af0f-2457a5d733b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5eafecd-a748-4e05-af0f-2457a5d733b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1c0d13a-18b4-44a8-922b-e365c79c7945> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1c0d13a-18b4-44a8-922b-e365c79c7945";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1c0d13a-18b4-44a8-922b-e365c79c7945>.
+    
+<http://data.lblod.info/id/remote-data-objects/054b6fe2-ea24-4399-b1f8-3196fce1600b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "054b6fe2-ea24-4399-b1f8-3196fce1600b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/054b6fe2-ea24-4399-b1f8-3196fce1600b>.
+    
+<http://data.lblod.info/id/remote-data-objects/34ed3b90-cc20-479d-83d6-fff115922f34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34ed3b90-cc20-479d-83d6-fff115922f34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_02-05-2022_47642.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34ed3b90-cc20-479d-83d6-fff115922f34>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7b55237-b2f7-4d16-a299-e641cd58ff96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7b55237-b2f7-4d16-a299-e641cd58ff96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_02-05-2022_47675.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7b55237-b2f7-4d16-a299-e641cd58ff96>.
+    
+<http://data.lblod.info/id/remote-data-objects/68b0b98a-b844-4d28-a6d5-854d0208ba72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68b0b98a-b844-4d28-a6d5-854d0208ba72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_02-05-2022_47797.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68b0b98a-b844-4d28-a6d5-854d0208ba72>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6575283-4aab-401e-9a44-829ce3653202> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6575283-4aab-401e-9a44-829ce3653202";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_02-05-2022_47806.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6575283-4aab-401e-9a44-829ce3653202>.
+    
+<http://data.lblod.info/id/remote-data-objects/932c7671-66d6-40c4-92f1-21db851dfdf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "932c7671-66d6-40c4-92f1-21db851dfdf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_02-05-2022_47825.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/932c7671-66d6-40c4-92f1-21db851dfdf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9e47953-688a-444c-9cad-c43037f4f424> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9e47953-688a-444c-9cad-c43037f4f424";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-04-2022_47150.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9e47953-688a-444c-9cad-c43037f4f424>.
+    
+<http://data.lblod.info/id/remote-data-objects/5133d3cd-7cbe-40c4-937e-9b504b45d1de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5133d3cd-7cbe-40c4-937e-9b504b45d1de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-04-2022_47200.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5133d3cd-7cbe-40c4-937e-9b504b45d1de>.
+    
+<http://data.lblod.info/id/remote-data-objects/97f82cac-56f1-454d-bd73-6fc9af212bef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97f82cac-56f1-454d-bd73-6fc9af212bef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-04-2022_47201.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97f82cac-56f1-454d-bd73-6fc9af212bef>.
+    
+<http://data.lblod.info/id/remote-data-objects/698bab46-054a-420b-963b-f6ae9fb07bb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "698bab46-054a-420b-963b-f6ae9fb07bb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-04-2022_47202.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/698bab46-054a-420b-963b-f6ae9fb07bb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/09489185-460e-41e6-82a6-5619533fb1b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09489185-460e-41e6-82a6-5619533fb1b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-04-2022_47204.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09489185-460e-41e6-82a6-5619533fb1b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/89781ab2-a15d-4f8a-8d0d-47f5d6cfa8ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89781ab2-a15d-4f8a-8d0d-47f5d6cfa8ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-04-2022_47205.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89781ab2-a15d-4f8a-8d0d-47f5d6cfa8ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fd132e9-9943-4b5c-a042-4542b017f6b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fd132e9-9943-4b5c-a042-4542b017f6b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-04-2022_47206.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fd132e9-9943-4b5c-a042-4542b017f6b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1261b4b8-a10a-432b-b2b7-995f331d61e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1261b4b8-a10a-432b-b2b7-995f331d61e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-04-2022_47349.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1261b4b8-a10a-432b-b2b7-995f331d61e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/98389b93-31d2-4c8a-88f5-e7f1af813762> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98389b93-31d2-4c8a-88f5-e7f1af813762";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-07-2022_48891.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98389b93-31d2-4c8a-88f5-e7f1af813762>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ef75fd4-c7e9-440c-baea-467570c966ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ef75fd4-c7e9-440c-baea-467570c966ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-07-2022_49058.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ef75fd4-c7e9-440c-baea-467570c966ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6d2871c-fc68-4e5a-a64a-7b6ab4bf5524> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6d2871c-fc68-4e5a-a64a-7b6ab4bf5524";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-10-2021_42446.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6d2871c-fc68-4e5a-a64a-7b6ab4bf5524>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5f6af72-e665-47bf-9087-2178f5ec5a4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5f6af72-e665-47bf-9087-2178f5ec5a4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-10-2021_42448.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/383cd482-b809-4831-bbdd-7728fd87fd6a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5f6af72-e665-47bf-9087-2178f5ec5a4a>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201545-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201545-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201545-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201545-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/09caa570-c130-415a-be23-743a1b5afed2> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "09caa570-c130-415a-be23-743a1b5afed2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d6bf2b3c-91b9-4dd2-8dbb-93ba8871871c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d6bf2b3c-91b9-4dd2-8dbb-93ba8871871c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a>.
+
+  <http://redpencil.data.gift/id/task/6d6d5f67-b523-4021-b474-eb936dd7c71d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6d6d5f67-b523-4021-b474-eb936dd7c71d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/09caa570-c130-415a-be23-743a1b5afed2>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d6bf2b3c-91b9-4dd2-8dbb-93ba8871871c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/fb920f59-d8e8-438f-b15b-e2b57f8024db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb920f59-d8e8-438f-b15b-e2b57f8024db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-10-2021_42452.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb920f59-d8e8-438f-b15b-e2b57f8024db>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e391a8b-0a88-4662-a252-28f3e35c6d8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e391a8b-0a88-4662-a252-28f3e35c6d8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-10-2021_42485.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e391a8b-0a88-4662-a252-28f3e35c6d8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3782634-85a2-41f5-8ba6-bd405d94f098> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3782634-85a2-41f5-8ba6-bd405d94f098";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-10-2021_42524.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3782634-85a2-41f5-8ba6-bd405d94f098>.
+    
+<http://data.lblod.info/id/remote-data-objects/76fca05c-54ea-4953-8f62-1d1da7bf8ba1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76fca05c-54ea-4953-8f62-1d1da7bf8ba1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-10-2021_42525.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76fca05c-54ea-4953-8f62-1d1da7bf8ba1>.
+    
+<http://data.lblod.info/id/remote-data-objects/598e687a-d0c2-4661-b59b-e7cad4e48621> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "598e687a-d0c2-4661-b59b-e7cad4e48621";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_04-10-2021_42526.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/598e687a-d0c2-4661-b59b-e7cad4e48621>.
+    
+<http://data.lblod.info/id/remote-data-objects/70297735-cefd-4c05-9b72-f0e8a4fdd8e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70297735-cefd-4c05-9b72-f0e8a4fdd8e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_06-12-2021_43830.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70297735-cefd-4c05-9b72-f0e8a4fdd8e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/899d3df7-aa92-40da-842b-206450e3c54f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "899d3df7-aa92-40da-842b-206450e3c54f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_06-12-2021_43835.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/899d3df7-aa92-40da-842b-206450e3c54f>.
+    
+<http://data.lblod.info/id/remote-data-objects/11d27eaa-9fb7-4fd8-b638-7a2e3fdeabd4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11d27eaa-9fb7-4fd8-b638-7a2e3fdeabd4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_06-12-2021_43837.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11d27eaa-9fb7-4fd8-b638-7a2e3fdeabd4>.
+    
+<http://data.lblod.info/id/remote-data-objects/aced8ab8-e1ec-441e-bf03-4b562101049c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aced8ab8-e1ec-441e-bf03-4b562101049c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_07-02-2022_45273.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aced8ab8-e1ec-441e-bf03-4b562101049c>.
+    
+<http://data.lblod.info/id/remote-data-objects/21264e6f-8aeb-48ab-8287-e167b148bddb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21264e6f-8aeb-48ab-8287-e167b148bddb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_07-03-2022_46739.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21264e6f-8aeb-48ab-8287-e167b148bddb>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c1d8ffa-e913-4124-87aa-f51cdbaa4db6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c1d8ffa-e913-4124-87aa-f51cdbaa4db6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_07-03-2022_46741.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c1d8ffa-e913-4124-87aa-f51cdbaa4db6>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc3bdcf9-b514-4658-9696-e9d9e5ec90c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc3bdcf9-b514-4658-9696-e9d9e5ec90c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_07-03-2022_46742.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc3bdcf9-b514-4658-9696-e9d9e5ec90c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c905b6cb-23f9-4ce0-b527-b697d095fe7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c905b6cb-23f9-4ce0-b527-b697d095fe7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_07-03-2022_46756.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c905b6cb-23f9-4ce0-b527-b697d095fe7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c439ef5-99e7-4059-afdd-f9e71c05b419> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c439ef5-99e7-4059-afdd-f9e71c05b419";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_07-03-2022_46759.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c439ef5-99e7-4059-afdd-f9e71c05b419>.
+    
+<http://data.lblod.info/id/remote-data-objects/4431718f-857e-410b-abb1-325803cf3e3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4431718f-857e-410b-abb1-325803cf3e3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_07-03-2022_46798.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4431718f-857e-410b-abb1-325803cf3e3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4c0198b-fb7c-4f73-9633-de831c176019> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4c0198b-fb7c-4f73-9633-de831c176019";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_07-03-2022_46799.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4c0198b-fb7c-4f73-9633-de831c176019>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d4ad156-df6e-41ac-b9d8-79aee6523efc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d4ad156-df6e-41ac-b9d8-79aee6523efc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_07-03-2022_46800.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d4ad156-df6e-41ac-b9d8-79aee6523efc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0813b59-849a-4037-924d-de0642c57d8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0813b59-849a-4037-924d-de0642c57d8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_07-03-2022_46801.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0813b59-849a-4037-924d-de0642c57d8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5112d7e-e7fb-4b2f-b843-488d47d2c56e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5112d7e-e7fb-4b2f-b843-488d47d2c56e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_07-03-2022_46802.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5112d7e-e7fb-4b2f-b843-488d47d2c56e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6941d7ba-512d-43b4-9540-129b9e597668> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6941d7ba-512d-43b4-9540-129b9e597668";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_07-03-2022_46803.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6941d7ba-512d-43b4-9540-129b9e597668>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e651768-5608-4eba-88c8-ca1c65764d32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e651768-5608-4eba-88c8-ca1c65764d32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_07-03-2022_46861.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e651768-5608-4eba-88c8-ca1c65764d32>.
+    
+<http://data.lblod.info/id/remote-data-objects/a168970d-2866-49f9-bd4b-bb2429d236a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a168970d-2866-49f9-bd4b-bb2429d236a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_08-11-2021_42934.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a168970d-2866-49f9-bd4b-bb2429d236a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2012e5b4-aa7f-474b-a930-77840e700ae9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2012e5b4-aa7f-474b-a930-77840e700ae9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_08-11-2021_42937.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2012e5b4-aa7f-474b-a930-77840e700ae9>.
+    
+<http://data.lblod.info/id/remote-data-objects/7604a696-a437-49a2-9713-cf7bd58d2a61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7604a696-a437-49a2-9713-cf7bd58d2a61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_08-11-2021_42969.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7604a696-a437-49a2-9713-cf7bd58d2a61>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f9daabc-6151-40c9-871f-6b7871adb4c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f9daabc-6151-40c9-871f-6b7871adb4c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_08-11-2021_42971.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f9daabc-6151-40c9-871f-6b7871adb4c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/76e83080-1618-47df-ac39-8d02d86c63e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76e83080-1618-47df-ac39-8d02d86c63e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_08-11-2021_43037.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76e83080-1618-47df-ac39-8d02d86c63e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1a7eacd-dde5-4659-a89a-3bcd0625ebcf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1a7eacd-dde5-4659-a89a-3bcd0625ebcf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_08-11-2021_43042.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1a7eacd-dde5-4659-a89a-3bcd0625ebcf>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa789378-9b1a-4516-8d70-45afb2822f8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa789378-9b1a-4516-8d70-45afb2822f8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_08-11-2021_43050.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa789378-9b1a-4516-8d70-45afb2822f8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc2d9b1d-43dc-4c4c-b4b4-28349cbaa5a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc2d9b1d-43dc-4c4c-b4b4-28349cbaa5a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_08-11-2021_43051.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc2d9b1d-43dc-4c4c-b4b4-28349cbaa5a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4738e839-25f5-41e5-a3cd-27f48960f7e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4738e839-25f5-41e5-a3cd-27f48960f7e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_08-11-2021_43052.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4738e839-25f5-41e5-a3cd-27f48960f7e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/38e4f2cb-b4c2-4cf0-9b87-28c94a7af29a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38e4f2cb-b4c2-4cf0-9b87-28c94a7af29a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_08-11-2021_43099.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38e4f2cb-b4c2-4cf0-9b87-28c94a7af29a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d771a7d-9075-418e-af2a-9ea06b0eceea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d771a7d-9075-418e-af2a-9ea06b0eceea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_08-11-2021_43104.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d771a7d-9075-418e-af2a-9ea06b0eceea>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2179fa9-fe78-4811-a620-4c035d67377e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2179fa9-fe78-4811-a620-4c035d67377e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_08-11-2021_43115.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2179fa9-fe78-4811-a620-4c035d67377e>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd757580-a0bc-4134-803a-9203e5f16d46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd757580-a0bc-4134-803a-9203e5f16d46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_08-11-2021_43116.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd757580-a0bc-4134-803a-9203e5f16d46>.
+    
+<http://data.lblod.info/id/remote-data-objects/3104ad0a-2948-4582-beee-ef443c1ef54d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3104ad0a-2948-4582-beee-ef443c1ef54d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_08-11-2021_43120.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3104ad0a-2948-4582-beee-ef443c1ef54d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5084204f-9b0c-4110-a54e-a1c5aa56d5f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5084204f-9b0c-4110-a54e-a1c5aa56d5f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_08-11-2021_43126.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5084204f-9b0c-4110-a54e-a1c5aa56d5f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a15d3663-6dd7-4151-ba54-65b79e808fc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a15d3663-6dd7-4151-ba54-65b79e808fc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_08-11-2021_43206.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a15d3663-6dd7-4151-ba54-65b79e808fc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ca3c668-9f8f-48d2-8b77-a181d801f67a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ca3c668-9f8f-48d2-8b77-a181d801f67a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_09-05-2022_47832.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ca3c668-9f8f-48d2-8b77-a181d801f67a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c53272dd-061e-487b-8646-aa18df6352f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c53272dd-061e-487b-8646-aa18df6352f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_09-05-2022_47833.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c53272dd-061e-487b-8646-aa18df6352f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd29a2bd-08cd-41b8-985e-b18d0b97ac8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd29a2bd-08cd-41b8-985e-b18d0b97ac8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_09-05-2022_47900.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd29a2bd-08cd-41b8-985e-b18d0b97ac8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7fb4a53-fc41-4801-abe0-aa0507e2e627> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7fb4a53-fc41-4801-abe0-aa0507e2e627";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_09-05-2022_47902.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7fb4a53-fc41-4801-abe0-aa0507e2e627>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b2c339d-c3e0-4d7e-ab90-ac2a0dd301d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b2c339d-c3e0-4d7e-ab90-ac2a0dd301d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_09-05-2022_47903.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b2c339d-c3e0-4d7e-ab90-ac2a0dd301d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/c58bd220-2680-4dc6-9f0d-5fd950dc4342> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c58bd220-2680-4dc6-9f0d-5fd950dc4342";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_09-05-2022_47911.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c58bd220-2680-4dc6-9f0d-5fd950dc4342>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9d66c68-4b09-4c5a-9cb8-dbb83c5bf783> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9d66c68-4b09-4c5a-9cb8-dbb83c5bf783";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_09-05-2022_47913.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9d66c68-4b09-4c5a-9cb8-dbb83c5bf783>.
+    
+<http://data.lblod.info/id/remote-data-objects/7768c97d-c6b6-4b53-bf8b-01557a9ef8fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7768c97d-c6b6-4b53-bf8b-01557a9ef8fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_09-05-2022_47915.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7768c97d-c6b6-4b53-bf8b-01557a9ef8fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/398210bc-a958-4b10-bc41-0fb4fbb56a76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "398210bc-a958-4b10-bc41-0fb4fbb56a76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_09-05-2022_47917.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/398210bc-a958-4b10-bc41-0fb4fbb56a76>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fef3de1-c631-4a6e-95d0-5ccae3232901> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fef3de1-c631-4a6e-95d0-5ccae3232901";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_09-05-2022_47926.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fef3de1-c631-4a6e-95d0-5ccae3232901>.
+    
+<http://data.lblod.info/id/remote-data-objects/30c5079b-d6bc-438b-9172-638fac65554c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30c5079b-d6bc-438b-9172-638fac65554c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_10-01-2022_44271.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30c5079b-d6bc-438b-9172-638fac65554c>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa476d37-75f1-4f60-b51a-2d10be07431c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa476d37-75f1-4f60-b51a-2d10be07431c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_10-01-2022_44272.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa476d37-75f1-4f60-b51a-2d10be07431c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab3b5bef-1187-48b7-af72-cf513bcf3f19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab3b5bef-1187-48b7-af72-cf513bcf3f19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_10-01-2022_44706.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/20aaede5-f62a-4b6a-a1b6-ebb68ee6e01a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab3b5bef-1187-48b7-af72-cf513bcf3f19>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201546-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201546-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201546-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201546-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/768b5518-0328-4d1b-92f6-459e762d23fe> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "768b5518-0328-4d1b-92f6-459e762d23fe";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8d493f04-5ca1-4fe8-8228-aaafacbef72d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ba06e14f-283f-454f-bc19-2008bbaabac2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ba06e14f-283f-454f-bc19-2008bbaabac2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d>.
+
+  <http://redpencil.data.gift/id/task/15cb083e-9e63-4be5-ad11-9bbfb1f209d5> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "15cb083e-9e63-4be5-ad11-9bbfb1f209d5";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/768b5518-0328-4d1b-92f6-459e762d23fe>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ba06e14f-283f-454f-bc19-2008bbaabac2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/126580ad-5126-457e-8e2f-8b73978a4930> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "126580ad-5126-457e-8e2f-8b73978a4930";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_10-01-2022_44707.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/126580ad-5126-457e-8e2f-8b73978a4930>.
+    
+<http://data.lblod.info/id/remote-data-objects/eefa8c38-d7d8-4431-8aed-8bd319831456> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eefa8c38-d7d8-4431-8aed-8bd319831456";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_10-01-2022_44708.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eefa8c38-d7d8-4431-8aed-8bd319831456>.
+    
+<http://data.lblod.info/id/remote-data-objects/70247cd7-8eb1-428a-8871-a32a32a910fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70247cd7-8eb1-428a-8871-a32a32a910fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_10-01-2022_44709.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70247cd7-8eb1-428a-8871-a32a32a910fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/198e8dfc-ba59-4458-a9bb-fc9e7ee821d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "198e8dfc-ba59-4458-a9bb-fc9e7ee821d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_10-01-2022_44710.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/198e8dfc-ba59-4458-a9bb-fc9e7ee821d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c35211a8-24aa-4c11-ad05-3d93c77a7c57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c35211a8-24aa-4c11-ad05-3d93c77a7c57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_11-04-2022_47355.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c35211a8-24aa-4c11-ad05-3d93c77a7c57>.
+    
+<http://data.lblod.info/id/remote-data-objects/23da7ecc-e311-4ac6-8073-96eb257ae3f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23da7ecc-e311-4ac6-8073-96eb257ae3f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_11-04-2022_47356.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23da7ecc-e311-4ac6-8073-96eb257ae3f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6648c973-3828-49fd-a82f-34020470cc67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6648c973-3828-49fd-a82f-34020470cc67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_11-04-2022_47360.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6648c973-3828-49fd-a82f-34020470cc67>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4e649f1-753f-41c8-99b0-e41cdcca8ede> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4e649f1-753f-41c8-99b0-e41cdcca8ede";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_11-04-2022_47367.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4e649f1-753f-41c8-99b0-e41cdcca8ede>.
+    
+<http://data.lblod.info/id/remote-data-objects/1df4c6b1-13df-4af6-914d-d1ae43b58a5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1df4c6b1-13df-4af6-914d-d1ae43b58a5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_11-04-2022_47407.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1df4c6b1-13df-4af6-914d-d1ae43b58a5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/94245584-5b89-4da9-ab4b-f4bf067c017e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94245584-5b89-4da9-ab4b-f4bf067c017e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_11-04-2022_47410.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94245584-5b89-4da9-ab4b-f4bf067c017e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c777bf0f-1645-4232-a6f1-2cc7fc1753f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c777bf0f-1645-4232-a6f1-2cc7fc1753f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_11-04-2022_47424.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c777bf0f-1645-4232-a6f1-2cc7fc1753f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/0be73271-b776-4e79-824f-c8b899a131c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0be73271-b776-4e79-824f-c8b899a131c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_11-10-2021_42418.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0be73271-b776-4e79-824f-c8b899a131c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf2ab699-5885-4383-9db7-b4a2b42286ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf2ab699-5885-4383-9db7-b4a2b42286ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_11-10-2021_42627.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf2ab699-5885-4383-9db7-b4a2b42286ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/c61982f4-12e9-490c-a1bc-1db05e1bc666> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c61982f4-12e9-490c-a1bc-1db05e1bc666";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_11-10-2021_42630.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c61982f4-12e9-490c-a1bc-1db05e1bc666>.
+    
+<http://data.lblod.info/id/remote-data-objects/26b7907c-898c-4525-a641-beaeefc69730> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26b7907c-898c-4525-a641-beaeefc69730";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_11-10-2021_42659.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26b7907c-898c-4525-a641-beaeefc69730>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d69016f-769a-4032-a332-23c3fc5bbad9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d69016f-769a-4032-a332-23c3fc5bbad9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_11-10-2021_42673.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d69016f-769a-4032-a332-23c3fc5bbad9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0db49b6b-b433-4027-acb5-077a7b9e9446> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0db49b6b-b433-4027-acb5-077a7b9e9446";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_11-10-2021_42695.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0db49b6b-b433-4027-acb5-077a7b9e9446>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee29a99e-d466-436b-8b05-61d3cb1ec4a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee29a99e-d466-436b-8b05-61d3cb1ec4a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_11-10-2021_42697.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee29a99e-d466-436b-8b05-61d3cb1ec4a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d86724d4-5bdc-4cf2-9de4-4d029f11152c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d86724d4-5bdc-4cf2-9de4-4d029f11152c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_11-10-2021_42718.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d86724d4-5bdc-4cf2-9de4-4d029f11152c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a2ef613-2884-47fb-b48a-81c2de45b484> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a2ef613-2884-47fb-b48a-81c2de45b484";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_13-06-2022_48270.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a2ef613-2884-47fb-b48a-81c2de45b484>.
+    
+<http://data.lblod.info/id/remote-data-objects/5be86c7c-f92a-42f3-9945-d9eb08f932ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5be86c7c-f92a-42f3-9945-d9eb08f932ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_13-06-2022_48495.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5be86c7c-f92a-42f3-9945-d9eb08f932ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/4309bb78-efca-4c7a-893f-7871e5a9853c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4309bb78-efca-4c7a-893f-7871e5a9853c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_13-06-2022_48535.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4309bb78-efca-4c7a-893f-7871e5a9853c>.
+    
+<http://data.lblod.info/id/remote-data-objects/664e9d86-3cb0-49ec-b2a6-855d000c4441> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "664e9d86-3cb0-49ec-b2a6-855d000c4441";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_13-06-2022_48536.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/664e9d86-3cb0-49ec-b2a6-855d000c4441>.
+    
+<http://data.lblod.info/id/remote-data-objects/3160b576-9f60-4034-998b-73588d0f84ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3160b576-9f60-4034-998b-73588d0f84ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_13-06-2022_48537.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3160b576-9f60-4034-998b-73588d0f84ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/741df1d6-5370-42c4-80fa-5f0f8e54cc6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "741df1d6-5370-42c4-80fa-5f0f8e54cc6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_13-06-2022_48548.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/741df1d6-5370-42c4-80fa-5f0f8e54cc6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f079cd7d-7536-4d33-be81-2373cec390db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f079cd7d-7536-4d33-be81-2373cec390db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_13-06-2022_48549.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f079cd7d-7536-4d33-be81-2373cec390db>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee0f17a4-babb-4017-8035-752a00c6a7b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee0f17a4-babb-4017-8035-752a00c6a7b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_13-06-2022_48574.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee0f17a4-babb-4017-8035-752a00c6a7b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/33706427-5650-4e8a-8bff-13acb5d7d4df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33706427-5650-4e8a-8bff-13acb5d7d4df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_13-12-2021_43935.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33706427-5650-4e8a-8bff-13acb5d7d4df>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7f14f4c-6418-4af0-9603-54353c05bdf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7f14f4c-6418-4af0-9603-54353c05bdf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_13-12-2021_43969.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7f14f4c-6418-4af0-9603-54353c05bdf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f9eb6af-4da3-4bb3-9537-6f4c410b4cb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f9eb6af-4da3-4bb3-9537-6f4c410b4cb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_13-12-2021_43970.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f9eb6af-4da3-4bb3-9537-6f4c410b4cb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b64f11a-04e9-4bda-909c-035a4e8f95e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b64f11a-04e9-4bda-909c-035a4e8f95e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_13-12-2021_43972.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b64f11a-04e9-4bda-909c-035a4e8f95e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/90ec8f47-f2ed-46c5-97ba-603314508fb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90ec8f47-f2ed-46c5-97ba-603314508fb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_13-12-2021_43990.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90ec8f47-f2ed-46c5-97ba-603314508fb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e098214f-8a29-4bbc-a739-aefe8eb62e45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e098214f-8a29-4bbc-a739-aefe8eb62e45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_13-12-2021_43991.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e098214f-8a29-4bbc-a739-aefe8eb62e45>.
+    
+<http://data.lblod.info/id/remote-data-objects/76d23978-2aa7-4788-a4ae-78e98eeb6f12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76d23978-2aa7-4788-a4ae-78e98eeb6f12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_13-12-2021_43995.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76d23978-2aa7-4788-a4ae-78e98eeb6f12>.
+    
+<http://data.lblod.info/id/remote-data-objects/5738146e-0c48-477e-be50-9a5475bec902> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5738146e-0c48-477e-be50-9a5475bec902";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_13-12-2021_44004.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5738146e-0c48-477e-be50-9a5475bec902>.
+    
+<http://data.lblod.info/id/remote-data-objects/4263580e-c8e2-46e1-b532-c021bcec5bf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4263580e-c8e2-46e1-b532-c021bcec5bf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_14-02-2022_45426.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4263580e-c8e2-46e1-b532-c021bcec5bf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b302deb-5a67-4b06-9931-871497f244e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b302deb-5a67-4b06-9931-871497f244e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_14-02-2022_45431.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b302deb-5a67-4b06-9931-871497f244e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a46e62f-e6d2-4f2e-ba9f-906269d4bc7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a46e62f-e6d2-4f2e-ba9f-906269d4bc7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_14-02-2022_45432.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a46e62f-e6d2-4f2e-ba9f-906269d4bc7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/07ea9022-09f0-4fed-bfe0-9ff4ec32c6ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07ea9022-09f0-4fed-bfe0-9ff4ec32c6ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_14-03-2022_46846.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07ea9022-09f0-4fed-bfe0-9ff4ec32c6ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/436537c3-ad7c-4570-97dc-4e9df4f173e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "436537c3-ad7c-4570-97dc-4e9df4f173e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_14-03-2022_46848.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/436537c3-ad7c-4570-97dc-4e9df4f173e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/06076f98-0315-42d7-a975-16724ba0f341> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06076f98-0315-42d7-a975-16724ba0f341";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_14-03-2022_46849.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06076f98-0315-42d7-a975-16724ba0f341>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa73dc2e-efcb-403f-94ef-e2ee2255a2dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa73dc2e-efcb-403f-94ef-e2ee2255a2dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_14-03-2022_46871.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa73dc2e-efcb-403f-94ef-e2ee2255a2dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/970313a3-20c8-4608-87f9-4e55a6a4e487> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "970313a3-20c8-4608-87f9-4e55a6a4e487";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_14-03-2022_46872.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/970313a3-20c8-4608-87f9-4e55a6a4e487>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8e0c800-1364-4a13-a11c-04b16ea99638> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8e0c800-1364-4a13-a11c-04b16ea99638";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_14-03-2022_46875.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8e0c800-1364-4a13-a11c-04b16ea99638>.
+    
+<http://data.lblod.info/id/remote-data-objects/83459635-6b00-433d-9c57-5d5ca487fb68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83459635-6b00-433d-9c57-5d5ca487fb68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_14-03-2022_46876.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83459635-6b00-433d-9c57-5d5ca487fb68>.
+    
+<http://data.lblod.info/id/remote-data-objects/805cbe1a-6536-4a74-bb1f-c1a85748dc99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "805cbe1a-6536-4a74-bb1f-c1a85748dc99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_14-03-2022_46877.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/805cbe1a-6536-4a74-bb1f-c1a85748dc99>.
+    
+<http://data.lblod.info/id/remote-data-objects/550e893d-ffe6-4b55-b1d8-abab0504e001> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "550e893d-ffe6-4b55-b1d8-abab0504e001";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_14-03-2022_46883.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/550e893d-ffe6-4b55-b1d8-abab0504e001>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfe8693c-8001-41d0-b75d-8d7e547c7635> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfe8693c-8001-41d0-b75d-8d7e547c7635";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_14-03-2022_46887.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfe8693c-8001-41d0-b75d-8d7e547c7635>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cccc478-6810-4dbc-bf2b-557dc5febfaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cccc478-6810-4dbc-bf2b-557dc5febfaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_14-03-2022_46900.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cccc478-6810-4dbc-bf2b-557dc5febfaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/3398d5bc-7067-4abf-b60e-3aaa8e0197e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3398d5bc-7067-4abf-b60e-3aaa8e0197e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_16-05-2022_47938.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8d493f04-5ca1-4fe8-8228-aaafacbef72d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3398d5bc-7067-4abf-b60e-3aaa8e0197e7>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201547-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201547-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201547-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201547-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c79187dd-6ea6-47ca-a2ae-7a4ffa5745d9> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c79187dd-6ea6-47ca-a2ae-7a4ffa5745d9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/72664775-2667-4fc1-ba17-941a5b70a1da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "72664775-2667-4fc1-ba17-941a5b70a1da";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c>.
+
+  <http://redpencil.data.gift/id/task/b311f972-b25d-43c0-bdfc-9d8f3e7327ef> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b311f972-b25d-43c0-bdfc-9d8f3e7327ef";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c79187dd-6ea6-47ca-a2ae-7a4ffa5745d9>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/72664775-2667-4fc1-ba17-941a5b70a1da>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/53616233-a595-4250-84b7-29fd2b06eee3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53616233-a595-4250-84b7-29fd2b06eee3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_16-05-2022_47946.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53616233-a595-4250-84b7-29fd2b06eee3>.
+    
+<http://data.lblod.info/id/remote-data-objects/56bba339-2a4f-4566-abef-ecfd57ac11c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56bba339-2a4f-4566-abef-ecfd57ac11c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_16-05-2022_47959.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56bba339-2a4f-4566-abef-ecfd57ac11c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/727b4fd1-c949-4e3f-8183-700c4a54f330> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "727b4fd1-c949-4e3f-8183-700c4a54f330";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_16-05-2022_47968.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/727b4fd1-c949-4e3f-8183-700c4a54f330>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc9be214-e5ca-4723-9f1e-ca44ae5a8c2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc9be214-e5ca-4723-9f1e-ca44ae5a8c2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_16-05-2022_47969.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc9be214-e5ca-4723-9f1e-ca44ae5a8c2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3018fd64-d04f-4118-9193-463d87961011> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3018fd64-d04f-4118-9193-463d87961011";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_16-05-2022_47970.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3018fd64-d04f-4118-9193-463d87961011>.
+    
+<http://data.lblod.info/id/remote-data-objects/52630aab-d145-4a1d-b649-4680cbb94667> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52630aab-d145-4a1d-b649-4680cbb94667";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_16-05-2022_47972.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52630aab-d145-4a1d-b649-4680cbb94667>.
+    
+<http://data.lblod.info/id/remote-data-objects/455e443a-0be1-4057-ac7d-21adeab94d3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "455e443a-0be1-4057-ac7d-21adeab94d3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_16-05-2022_48000.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/455e443a-0be1-4057-ac7d-21adeab94d3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d03429df-a47f-4502-ad4b-64bfc7c0d490> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d03429df-a47f-4502-ad4b-64bfc7c0d490";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_16-05-2022_48001.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d03429df-a47f-4502-ad4b-64bfc7c0d490>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ca97eda-7849-43c9-b7a8-296152341861> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ca97eda-7849-43c9-b7a8-296152341861";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_16-05-2022_48002.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ca97eda-7849-43c9-b7a8-296152341861>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc45e334-483c-40f0-9641-691819743209> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc45e334-483c-40f0-9641-691819743209";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_17-01-2022_44813.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc45e334-483c-40f0-9641-691819743209>.
+    
+<http://data.lblod.info/id/remote-data-objects/09e86123-a886-44fd-ad2d-17397a68ae53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09e86123-a886-44fd-ad2d-17397a68ae53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_17-01-2022_44871.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09e86123-a886-44fd-ad2d-17397a68ae53>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bcfa0e9-e3ce-4a35-8a1b-48907279e1ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bcfa0e9-e3ce-4a35-8a1b-48907279e1ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_18-07-2022_49061.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bcfa0e9-e3ce-4a35-8a1b-48907279e1ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/94f173ea-02a2-4a47-a47d-5ec4fbad8b89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94f173ea-02a2-4a47-a47d-5ec4fbad8b89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_18-07-2022_49068.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94f173ea-02a2-4a47-a47d-5ec4fbad8b89>.
+    
+<http://data.lblod.info/id/remote-data-objects/be34e11c-f9f1-49a6-a4ef-fdbcd71f3aa9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be34e11c-f9f1-49a6-a4ef-fdbcd71f3aa9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_18-07-2022_49069.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be34e11c-f9f1-49a6-a4ef-fdbcd71f3aa9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1813048-08f5-4709-ac33-91829e1cb1ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1813048-08f5-4709-ac33-91829e1cb1ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_18-07-2022_49158.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1813048-08f5-4709-ac33-91829e1cb1ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/38d7cdd4-2e75-42ce-bcc1-b87a2537e913> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38d7cdd4-2e75-42ce-bcc1-b87a2537e913";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_18-07-2022_49159.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38d7cdd4-2e75-42ce-bcc1-b87a2537e913>.
+    
+<http://data.lblod.info/id/remote-data-objects/b08bc49b-03c2-430d-87b9-a11d86891ca6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b08bc49b-03c2-430d-87b9-a11d86891ca6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_18-07-2022_49164.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b08bc49b-03c2-430d-87b9-a11d86891ca6>.
+    
+<http://data.lblod.info/id/remote-data-objects/840fc680-0e65-4972-9463-3b0ddaf8a83d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "840fc680-0e65-4972-9463-3b0ddaf8a83d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_18-07-2022_49165.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/840fc680-0e65-4972-9463-3b0ddaf8a83d>.
+    
+<http://data.lblod.info/id/remote-data-objects/273c025b-b316-49af-bd2e-2b8dfd1e8347> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "273c025b-b316-49af-bd2e-2b8dfd1e8347";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_18-07-2022_49181.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/273c025b-b316-49af-bd2e-2b8dfd1e8347>.
+    
+<http://data.lblod.info/id/remote-data-objects/f58990db-b241-4849-844f-f0303c9e0f81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f58990db-b241-4849-844f-f0303c9e0f81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_18-07-2022_49183.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f58990db-b241-4849-844f-f0303c9e0f81>.
+    
+<http://data.lblod.info/id/remote-data-objects/16c66665-a145-41e0-a0f1-9d454d8d5546> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16c66665-a145-41e0-a0f1-9d454d8d5546";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_18-10-2021_42755.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16c66665-a145-41e0-a0f1-9d454d8d5546>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f092a48-5565-4d62-a1ad-7e7addaec994> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f092a48-5565-4d62-a1ad-7e7addaec994";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_18-10-2021_42766.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f092a48-5565-4d62-a1ad-7e7addaec994>.
+    
+<http://data.lblod.info/id/remote-data-objects/480109ab-df68-4c8e-8d0f-79aa900ce8dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "480109ab-df68-4c8e-8d0f-79aa900ce8dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_18-10-2021_42776.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/480109ab-df68-4c8e-8d0f-79aa900ce8dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/863b3cdb-9955-4547-bcef-ec5ca05647d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "863b3cdb-9955-4547-bcef-ec5ca05647d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_18-10-2021_42786.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/863b3cdb-9955-4547-bcef-ec5ca05647d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ae5e46d-076c-4eb1-ab8f-32c843a5460e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ae5e46d-076c-4eb1-ab8f-32c843a5460e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_18-10-2021_42802.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ae5e46d-076c-4eb1-ab8f-32c843a5460e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d3a8070-8d29-4faa-a749-3b9ee6249ab5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d3a8070-8d29-4faa-a749-3b9ee6249ab5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_18-10-2021_42808.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d3a8070-8d29-4faa-a749-3b9ee6249ab5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e06300e-3dcf-4717-95cc-d942654d2803> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e06300e-3dcf-4717-95cc-d942654d2803";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_18-10-2021_42817.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e06300e-3dcf-4717-95cc-d942654d2803>.
+    
+<http://data.lblod.info/id/remote-data-objects/be9e51fe-edb4-4973-99ce-470155e8b0f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be9e51fe-edb4-4973-99ce-470155e8b0f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_20-06-2022_48592.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be9e51fe-edb4-4973-99ce-470155e8b0f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/61c9ae91-131d-451a-9bf4-c6a22ccc3eb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61c9ae91-131d-451a-9bf4-c6a22ccc3eb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_20-06-2022_48601.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61c9ae91-131d-451a-9bf4-c6a22ccc3eb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5aaf8cb1-8ef8-465a-9b4f-25843613f73a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5aaf8cb1-8ef8-465a-9b4f-25843613f73a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_20-06-2022_48638.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5aaf8cb1-8ef8-465a-9b4f-25843613f73a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc4ecc31-ed8d-4b30-b70e-7cc68e5660c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc4ecc31-ed8d-4b30-b70e-7cc68e5660c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_20-06-2022_48678.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc4ecc31-ed8d-4b30-b70e-7cc68e5660c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/52c412be-c8ee-4ac6-bb46-2245bf86f500> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52c412be-c8ee-4ac6-bb46-2245bf86f500";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_20-06-2022_48687.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52c412be-c8ee-4ac6-bb46-2245bf86f500>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2ce6c3c-7a97-42ef-9919-23fd6081687f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2ce6c3c-7a97-42ef-9919-23fd6081687f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_20-12-2021_44036.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2ce6c3c-7a97-42ef-9919-23fd6081687f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d687606-aa57-4a06-80c1-7113056183aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d687606-aa57-4a06-80c1-7113056183aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_20-12-2021_44038.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d687606-aa57-4a06-80c1-7113056183aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/e63af394-5ad0-4e89-a5ea-7645ad8eda68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e63af394-5ad0-4e89-a5ea-7645ad8eda68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_20-12-2021_44039.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e63af394-5ad0-4e89-a5ea-7645ad8eda68>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b57d7e1-70e4-4bb4-a636-134ffba3e665> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b57d7e1-70e4-4bb4-a636-134ffba3e665";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_20-12-2021_44048.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b57d7e1-70e4-4bb4-a636-134ffba3e665>.
+    
+<http://data.lblod.info/id/remote-data-objects/d02b9581-3fca-4d56-9911-733480cb66b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d02b9581-3fca-4d56-9911-733480cb66b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_20-12-2021_44062.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d02b9581-3fca-4d56-9911-733480cb66b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e56233ea-a21a-4ef8-b720-da9490086a46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e56233ea-a21a-4ef8-b720-da9490086a46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_20-12-2021_44172.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e56233ea-a21a-4ef8-b720-da9490086a46>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc096aa3-a9d1-46a9-b387-3a454831c097> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc096aa3-a9d1-46a9-b387-3a454831c097";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_20-12-2021_44173.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc096aa3-a9d1-46a9-b387-3a454831c097>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6d9f38b-aecd-46f5-8c31-055973461f20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6d9f38b-aecd-46f5-8c31-055973461f20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_21-02-2022_46562.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6d9f38b-aecd-46f5-8c31-055973461f20>.
+    
+<http://data.lblod.info/id/remote-data-objects/26c7f898-903c-4359-a367-d8635116ab9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26c7f898-903c-4359-a367-d8635116ab9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_21-03-2022_46954.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26c7f898-903c-4359-a367-d8635116ab9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f60d904-bd07-4368-aa1a-b88d7db40ad9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f60d904-bd07-4368-aa1a-b88d7db40ad9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_21-03-2022_46955.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f60d904-bd07-4368-aa1a-b88d7db40ad9>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbfb3e6e-1a5b-4f28-b517-afa33dea5793> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbfb3e6e-1a5b-4f28-b517-afa33dea5793";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_21-03-2022_46956.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbfb3e6e-1a5b-4f28-b517-afa33dea5793>.
+    
+<http://data.lblod.info/id/remote-data-objects/542fe21b-651f-4aca-8843-9164aa041bf7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "542fe21b-651f-4aca-8843-9164aa041bf7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_21-03-2022_46973.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/542fe21b-651f-4aca-8843-9164aa041bf7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4424533-48f3-4c4b-81a9-7acaf645b576> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4424533-48f3-4c4b-81a9-7acaf645b576";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_21-03-2022_46974.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4424533-48f3-4c4b-81a9-7acaf645b576>.
+    
+<http://data.lblod.info/id/remote-data-objects/e337d556-7dc6-4440-b8df-72f4dd7f59a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e337d556-7dc6-4440-b8df-72f4dd7f59a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_21-03-2022_46985.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e337d556-7dc6-4440-b8df-72f4dd7f59a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/8af5c7b8-67ad-4a30-99bc-33de0593243c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8af5c7b8-67ad-4a30-99bc-33de0593243c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_21-03-2022_46986.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8af5c7b8-67ad-4a30-99bc-33de0593243c>.
+    
+<http://data.lblod.info/id/remote-data-objects/970f56a1-fb72-409e-9a5a-40483b53cba7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "970f56a1-fb72-409e-9a5a-40483b53cba7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_21-03-2022_47001.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/970f56a1-fb72-409e-9a5a-40483b53cba7>.
+    
+<http://data.lblod.info/id/remote-data-objects/07ec1f41-65ea-4fa2-b27b-71adf0c8ae33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07ec1f41-65ea-4fa2-b27b-71adf0c8ae33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_21-03-2022_47003.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07ec1f41-65ea-4fa2-b27b-71adf0c8ae33>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4b88c0e-34be-4f01-99e9-78c8e70049a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4b88c0e-34be-4f01-99e9-78c8e70049a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_21-03-2022_47005.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8b697597-10b4-4a4e-b6dc-10ecb8aa2e5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4b88c0e-34be-4f01-99e9-78c8e70049a6>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201548-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201548-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201548-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201548-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/ba1f76c4-8441-4ed1-af92-25a962427abf> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ba1f76c4-8441-4ed1-af92-25a962427abf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fb38c6d3-467c-4796-9f39-0d0ae065defa";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/82e3ce4c-f917-44a5-8563-75499b6e67de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "82e3ce4c-f917-44a5-8563-75499b6e67de";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa>.
+
+  <http://redpencil.data.gift/id/task/2b8f63c0-f82b-4714-8393-50d1c218c20a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2b8f63c0-f82b-4714-8393-50d1c218c20a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/ba1f76c4-8441-4ed1-af92-25a962427abf>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/82e3ce4c-f917-44a5-8563-75499b6e67de>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d46adcae-5b50-4801-b3d3-42a7aaa0b31e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d46adcae-5b50-4801-b3d3-42a7aaa0b31e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_21-03-2022_47007.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d46adcae-5b50-4801-b3d3-42a7aaa0b31e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ccd6556-4d02-4128-84e8-e0ba11b6cbf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ccd6556-4d02-4128-84e8-e0ba11b6cbf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43212.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ccd6556-4d02-4128-84e8-e0ba11b6cbf9>.
+    
+<http://data.lblod.info/id/remote-data-objects/2feb81fb-da40-4d14-aee1-6a2f997b9bc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2feb81fb-da40-4d14-aee1-6a2f997b9bc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43217.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2feb81fb-da40-4d14-aee1-6a2f997b9bc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/35ecee1c-a8b7-4908-a077-786d7ea22a13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35ecee1c-a8b7-4908-a077-786d7ea22a13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43280.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35ecee1c-a8b7-4908-a077-786d7ea22a13>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b3022b9-2ba3-4eb5-9ea6-5fc27d421ba6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b3022b9-2ba3-4eb5-9ea6-5fc27d421ba6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43281.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b3022b9-2ba3-4eb5-9ea6-5fc27d421ba6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ace3b46a-77c0-4915-a919-e738f4d86411> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ace3b46a-77c0-4915-a919-e738f4d86411";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43298.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ace3b46a-77c0-4915-a919-e738f4d86411>.
+    
+<http://data.lblod.info/id/remote-data-objects/13f2cc8a-f0b0-4800-af4d-ed75f7990beb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13f2cc8a-f0b0-4800-af4d-ed75f7990beb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43305.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13f2cc8a-f0b0-4800-af4d-ed75f7990beb>.
+    
+<http://data.lblod.info/id/remote-data-objects/3239b893-8a7e-46a6-8066-e8b9ad615e52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3239b893-8a7e-46a6-8066-e8b9ad615e52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43343.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3239b893-8a7e-46a6-8066-e8b9ad615e52>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f4c921a-b3cf-4543-9e00-be3ba6a9b191> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f4c921a-b3cf-4543-9e00-be3ba6a9b191";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43346.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f4c921a-b3cf-4543-9e00-be3ba6a9b191>.
+    
+<http://data.lblod.info/id/remote-data-objects/f415609a-2a39-4c57-9df9-a7f2c37e91bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f415609a-2a39-4c57-9df9-a7f2c37e91bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43347.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f415609a-2a39-4c57-9df9-a7f2c37e91bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/5eb238a6-f95e-4f17-9bf6-0975af5d5873> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5eb238a6-f95e-4f17-9bf6-0975af5d5873";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43349.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5eb238a6-f95e-4f17-9bf6-0975af5d5873>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a5f02b8-4802-44dc-8412-73462f142abc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a5f02b8-4802-44dc-8412-73462f142abc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43367.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a5f02b8-4802-44dc-8412-73462f142abc>.
+    
+<http://data.lblod.info/id/remote-data-objects/4de493f4-772e-4987-9e48-fa96a5f57ecb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4de493f4-772e-4987-9e48-fa96a5f57ecb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43368.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4de493f4-772e-4987-9e48-fa96a5f57ecb>.
+    
+<http://data.lblod.info/id/remote-data-objects/33b1d008-a314-4e6c-a248-eaf5fb753293> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33b1d008-a314-4e6c-a248-eaf5fb753293";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43373.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33b1d008-a314-4e6c-a248-eaf5fb753293>.
+    
+<http://data.lblod.info/id/remote-data-objects/cab2bcd9-c26c-476d-af33-d5ce6ee7765f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cab2bcd9-c26c-476d-af33-d5ce6ee7765f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43375.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cab2bcd9-c26c-476d-af33-d5ce6ee7765f>.
+    
+<http://data.lblod.info/id/remote-data-objects/99f22ed5-e375-4102-929a-0680585729c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99f22ed5-e375-4102-929a-0680585729c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43376.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99f22ed5-e375-4102-929a-0680585729c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/724d5dd5-412f-49b9-b236-330320eb3145> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "724d5dd5-412f-49b9-b236-330320eb3145";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43378.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/724d5dd5-412f-49b9-b236-330320eb3145>.
+    
+<http://data.lblod.info/id/remote-data-objects/57474a9e-6973-41f6-ac82-357de5f97a07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57474a9e-6973-41f6-ac82-357de5f97a07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_22-11-2021_43388.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57474a9e-6973-41f6-ac82-357de5f97a07>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b63582f-b38f-4b8a-9b77-72b79fd0505f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b63582f-b38f-4b8a-9b77-72b79fd0505f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_23-05-2022_48058.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b63582f-b38f-4b8a-9b77-72b79fd0505f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f043c6c6-4803-47ea-beb1-8628e75cb794> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f043c6c6-4803-47ea-beb1-8628e75cb794";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_23-05-2022_48059.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f043c6c6-4803-47ea-beb1-8628e75cb794>.
+    
+<http://data.lblod.info/id/remote-data-objects/060fdf52-8157-4ded-9483-c027f544cc6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "060fdf52-8157-4ded-9483-c027f544cc6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_23-05-2022_48106.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/060fdf52-8157-4ded-9483-c027f544cc6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d814090-cd5f-4aec-974d-7ea8a5fd8735> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d814090-cd5f-4aec-974d-7ea8a5fd8735";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_23-05-2022_48107.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d814090-cd5f-4aec-974d-7ea8a5fd8735>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c25da1e-05a4-474e-87b5-f6a5c6d9ad38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c25da1e-05a4-474e-87b5-f6a5c6d9ad38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_23-05-2022_48108.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c25da1e-05a4-474e-87b5-f6a5c6d9ad38>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f80d6bd-6d54-4786-a129-3574220b00d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f80d6bd-6d54-4786-a129-3574220b00d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_23-05-2022_48110.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f80d6bd-6d54-4786-a129-3574220b00d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b35ff9dc-37c3-4209-8cd0-e2753641987c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b35ff9dc-37c3-4209-8cd0-e2753641987c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_23-05-2022_48111.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b35ff9dc-37c3-4209-8cd0-e2753641987c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e6328ee-227c-4c43-9dca-25dd21f19637> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e6328ee-227c-4c43-9dca-25dd21f19637";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_24-01-2022_44958.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e6328ee-227c-4c43-9dca-25dd21f19637>.
+    
+<http://data.lblod.info/id/remote-data-objects/a50f5cba-3b37-438d-bfc2-27364e91ea0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a50f5cba-3b37-438d-bfc2-27364e91ea0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_24-01-2022_44960.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a50f5cba-3b37-438d-bfc2-27364e91ea0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fa3ba4d-a093-4894-8cac-4d8e29a02bdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fa3ba4d-a093-4894-8cac-4d8e29a02bdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_24-01-2022_44961.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fa3ba4d-a093-4894-8cac-4d8e29a02bdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/73c88230-6614-4730-846a-5658f6d2d7a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73c88230-6614-4730-846a-5658f6d2d7a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_24-01-2022_44963.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73c88230-6614-4730-846a-5658f6d2d7a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e73fecbd-28f2-4054-af72-a6af689503b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e73fecbd-28f2-4054-af72-a6af689503b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_24-01-2022_44964.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e73fecbd-28f2-4054-af72-a6af689503b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/3983c6c3-8742-436f-8b47-6c8458cdcf2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3983c6c3-8742-436f-8b47-6c8458cdcf2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_24-01-2022_44965.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3983c6c3-8742-436f-8b47-6c8458cdcf2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/484ada38-d705-42ef-9e7d-a4c9298b17c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "484ada38-d705-42ef-9e7d-a4c9298b17c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-04-2022_47476.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/484ada38-d705-42ef-9e7d-a4c9298b17c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4d676fd-21c6-4e77-b9ee-6bffd8566fec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4d676fd-21c6-4e77-b9ee-6bffd8566fec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-04-2022_47491.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4d676fd-21c6-4e77-b9ee-6bffd8566fec>.
+    
+<http://data.lblod.info/id/remote-data-objects/cca4decd-ad69-44e6-91a7-97712165dbc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cca4decd-ad69-44e6-91a7-97712165dbc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-04-2022_47492.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cca4decd-ad69-44e6-91a7-97712165dbc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b13df8ae-996a-4b44-bcb5-00aa24df99ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b13df8ae-996a-4b44-bcb5-00aa24df99ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-04-2022_47503.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b13df8ae-996a-4b44-bcb5-00aa24df99ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfc97f33-c53a-4d8b-b00a-8737b0291ab4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfc97f33-c53a-4d8b-b00a-8737b0291ab4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-04-2022_47504.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfc97f33-c53a-4d8b-b00a-8737b0291ab4>.
+    
+<http://data.lblod.info/id/remote-data-objects/daf2141a-6f46-4711-9848-fc703a586cab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "daf2141a-6f46-4711-9848-fc703a586cab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-04-2022_47526.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/daf2141a-6f46-4711-9848-fc703a586cab>.
+    
+<http://data.lblod.info/id/remote-data-objects/38fde21a-1f76-4440-b31c-4e8827ca9353> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38fde21a-1f76-4440-b31c-4e8827ca9353";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-04-2022_47536.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38fde21a-1f76-4440-b31c-4e8827ca9353>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4c2d0cd-1bd4-43cf-a3b1-37aaeeb629fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4c2d0cd-1bd4-43cf-a3b1-37aaeeb629fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-04-2022_47539.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4c2d0cd-1bd4-43cf-a3b1-37aaeeb629fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/10dac4f1-4df3-4fc1-9665-33c9d62d667f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10dac4f1-4df3-4fc1-9665-33c9d62d667f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-04-2022_47547.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10dac4f1-4df3-4fc1-9665-33c9d62d667f>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdd8a174-c690-4413-8264-ca07c6128d1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdd8a174-c690-4413-8264-ca07c6128d1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-04-2022_47568.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdd8a174-c690-4413-8264-ca07c6128d1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5874f744-7b64-4097-8abe-09da4dad72e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5874f744-7b64-4097-8abe-09da4dad72e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-04-2022_47573.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5874f744-7b64-4097-8abe-09da4dad72e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/391a4cc9-faea-46c6-9d5e-b1ffcb374279> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "391a4cc9-faea-46c6-9d5e-b1ffcb374279";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-04-2022_47580.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/391a4cc9-faea-46c6-9d5e-b1ffcb374279>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a159d2d-a3ee-4871-ab19-1b669b496009> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a159d2d-a3ee-4871-ab19-1b669b496009";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-04-2022_47582.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a159d2d-a3ee-4871-ab19-1b669b496009>.
+    
+<http://data.lblod.info/id/remote-data-objects/faebb859-e109-4a94-b916-de11abf6bf17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "faebb859-e109-4a94-b916-de11abf6bf17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-10-2021_42858.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/faebb859-e109-4a94-b916-de11abf6bf17>.
+    
+<http://data.lblod.info/id/remote-data-objects/c474f79e-58f9-4563-91b9-56a3f4a991f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c474f79e-58f9-4563-91b9-56a3f4a991f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-10-2021_42859.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c474f79e-58f9-4563-91b9-56a3f4a991f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/abdef68b-3132-40a8-a347-57e1175bffeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abdef68b-3132-40a8-a347-57e1175bffeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-10-2021_42860.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abdef68b-3132-40a8-a347-57e1175bffeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/fed03a85-90ca-4a0f-8ee7-ec4475bf326e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fed03a85-90ca-4a0f-8ee7-ec4475bf326e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-10-2021_42861.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fed03a85-90ca-4a0f-8ee7-ec4475bf326e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6995dad-9b4f-45fd-9b1c-11a52392d75d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6995dad-9b4f-45fd-9b1c-11a52392d75d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-10-2021_42865.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6995dad-9b4f-45fd-9b1c-11a52392d75d>.
+    
+<http://data.lblod.info/id/remote-data-objects/529ec92d-88f8-4a0b-80bc-603676878b34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "529ec92d-88f8-4a0b-80bc-603676878b34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-10-2021_42866.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fb38c6d3-467c-4796-9f39-0d0ae065defa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/529ec92d-88f8-4a0b-80bc-603676878b34>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201550-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201550-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201550-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201550-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/08159b6c-6460-4da4-9f5a-a2ce235e4b60> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "08159b6c-6460-4da4-9f5a-a2ce235e4b60";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c15e50d7-0081-4939-aa51-ae77104b2996";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d699004b-aaf0-4ed6-9b66-3ec9d5f21f0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d699004b-aaf0-4ed6-9b66-3ec9d5f21f0c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996>.
+
+  <http://redpencil.data.gift/id/task/9dc19aca-6050-44cb-9608-ba8a3766e2cb> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9dc19aca-6050-44cb-9608-ba8a3766e2cb";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/08159b6c-6460-4da4-9f5a-a2ce235e4b60>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d699004b-aaf0-4ed6-9b66-3ec9d5f21f0c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/2a34ab7b-be44-482d-b87d-2570def2ffbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a34ab7b-be44-482d-b87d-2570def2ffbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-10-2021_42871.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a34ab7b-be44-482d-b87d-2570def2ffbb>.
+    
+<http://data.lblod.info/id/remote-data-objects/98093be3-a6d9-45d2-8d20-a9c557a81a42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98093be3-a6d9-45d2-8d20-a9c557a81a42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-10-2021_42879.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98093be3-a6d9-45d2-8d20-a9c557a81a42>.
+    
+<http://data.lblod.info/id/remote-data-objects/0df8ebe9-9714-4cb2-af55-8ac7fded1173> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0df8ebe9-9714-4cb2-af55-8ac7fded1173";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-10-2021_42880.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0df8ebe9-9714-4cb2-af55-8ac7fded1173>.
+    
+<http://data.lblod.info/id/remote-data-objects/65fa92bb-4730-450b-b22f-ca652d7cf5cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65fa92bb-4730-450b-b22f-ca652d7cf5cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_25-10-2021_42893.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65fa92bb-4730-450b-b22f-ca652d7cf5cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/49e36cb8-0bac-4cbf-aac9-4ae06da868e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49e36cb8-0bac-4cbf-aac9-4ae06da868e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_27-06-2022_48732.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49e36cb8-0bac-4cbf-aac9-4ae06da868e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6eb07d2-64a4-48ac-9c47-659edcee447c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6eb07d2-64a4-48ac-9c47-659edcee447c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_27-06-2022_48735.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6eb07d2-64a4-48ac-9c47-659edcee447c>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd71f836-2298-4882-a520-8eadae453649> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd71f836-2298-4882-a520-8eadae453649";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_27-06-2022_48736.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd71f836-2298-4882-a520-8eadae453649>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b1921a2-73ee-4b36-8a6d-b6f992663536> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b1921a2-73ee-4b36-8a6d-b6f992663536";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_27-06-2022_48737.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b1921a2-73ee-4b36-8a6d-b6f992663536>.
+    
+<http://data.lblod.info/id/remote-data-objects/3058fdc0-058c-439f-b704-99648a4fef1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3058fdc0-058c-439f-b704-99648a4fef1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_27-06-2022_48759.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3058fdc0-058c-439f-b704-99648a4fef1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5360eb4-7240-4d0c-8232-09490b40922f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5360eb4-7240-4d0c-8232-09490b40922f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_27-06-2022_48765.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5360eb4-7240-4d0c-8232-09490b40922f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec00a5be-f0a4-4618-b1a4-27fec735db27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec00a5be-f0a4-4618-b1a4-27fec735db27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_27-06-2022_48775.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec00a5be-f0a4-4618-b1a4-27fec735db27>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa205436-01f2-457b-9c4a-aa23080a8bc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa205436-01f2-457b-9c4a-aa23080a8bc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_27-06-2022_48778.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa205436-01f2-457b-9c4a-aa23080a8bc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/06347aa8-3c7b-413c-89c1-ce897da3f343> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06347aa8-3c7b-413c-89c1-ce897da3f343";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-02-2022_46567.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06347aa8-3c7b-413c-89c1-ce897da3f343>.
+    
+<http://data.lblod.info/id/remote-data-objects/c94d78ff-efda-42e8-9432-56eb090435da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c94d78ff-efda-42e8-9432-56eb090435da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-02-2022_46602.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c94d78ff-efda-42e8-9432-56eb090435da>.
+    
+<http://data.lblod.info/id/remote-data-objects/999edef6-9f38-42ef-9750-067d29c5d005> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "999edef6-9f38-42ef-9750-067d29c5d005";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-02-2022_46603.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/999edef6-9f38-42ef-9750-067d29c5d005>.
+    
+<http://data.lblod.info/id/remote-data-objects/18a50171-402b-4b69-84a9-5af9b883add3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18a50171-402b-4b69-84a9-5af9b883add3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-02-2022_46608.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18a50171-402b-4b69-84a9-5af9b883add3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7f3c447-763e-4176-b833-34e51d6076da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7f3c447-763e-4176-b833-34e51d6076da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-02-2022_46611.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7f3c447-763e-4176-b833-34e51d6076da>.
+    
+<http://data.lblod.info/id/remote-data-objects/b575bdaa-82b2-45f8-a852-b368a59caeb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b575bdaa-82b2-45f8-a852-b368a59caeb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-02-2022_46614.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b575bdaa-82b2-45f8-a852-b368a59caeb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/1dfa61c6-ffc7-4276-9cf2-af688e92d7e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1dfa61c6-ffc7-4276-9cf2-af688e92d7e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-02-2022_46617.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1dfa61c6-ffc7-4276-9cf2-af688e92d7e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d6fe10a-6fc5-4733-83c2-6dddee812e10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d6fe10a-6fc5-4733-83c2-6dddee812e10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-02-2022_46622.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d6fe10a-6fc5-4733-83c2-6dddee812e10>.
+    
+<http://data.lblod.info/id/remote-data-objects/76ef4545-1367-48d0-a98b-dc936eecef05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76ef4545-1367-48d0-a98b-dc936eecef05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-03-2022_47101.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76ef4545-1367-48d0-a98b-dc936eecef05>.
+    
+<http://data.lblod.info/id/remote-data-objects/5dd579d8-65b4-46fa-8c1b-0df8a2dac602> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5dd579d8-65b4-46fa-8c1b-0df8a2dac602";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-03-2022_47102.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5dd579d8-65b4-46fa-8c1b-0df8a2dac602>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d7b6e8f-021a-4209-8c73-897784f5f832> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d7b6e8f-021a-4209-8c73-897784f5f832";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-03-2022_47103.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d7b6e8f-021a-4209-8c73-897784f5f832>.
+    
+<http://data.lblod.info/id/remote-data-objects/aaea505b-1c06-4393-b814-d777a7da26ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aaea505b-1c06-4393-b814-d777a7da26ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-03-2022_47110.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aaea505b-1c06-4393-b814-d777a7da26ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/59748792-a539-47be-b68f-4305ef7cc741> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59748792-a539-47be-b68f-4305ef7cc741";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-03-2022_47122.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59748792-a539-47be-b68f-4305ef7cc741>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ee391dd-b7ce-4a69-8a76-8c29ab6a2971> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ee391dd-b7ce-4a69-8a76-8c29ab6a2971";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-03-2022_47123.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ee391dd-b7ce-4a69-8a76-8c29ab6a2971>.
+    
+<http://data.lblod.info/id/remote-data-objects/853af413-f69d-4129-a61b-294b90f66da1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "853af413-f69d-4129-a61b-294b90f66da1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-03-2022_47125.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/853af413-f69d-4129-a61b-294b90f66da1>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4c7c109-cac1-49d5-a6d9-e940a36cea16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4c7c109-cac1-49d5-a6d9-e940a36cea16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-03-2022_47128.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4c7c109-cac1-49d5-a6d9-e940a36cea16>.
+    
+<http://data.lblod.info/id/remote-data-objects/501d1e8f-43e0-4a18-876e-01e390a180c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "501d1e8f-43e0-4a18-876e-01e390a180c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_28-03-2022_47131.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/501d1e8f-43e0-4a18-876e-01e390a180c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1f8aa12-09df-4e6a-ac7a-ff1860e7ac32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1f8aa12-09df-4e6a-ac7a-ff1860e7ac32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_29-11-2021_43485.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1f8aa12-09df-4e6a-ac7a-ff1860e7ac32>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e32a50d-bf1b-4fbf-945e-408daf6560a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e32a50d-bf1b-4fbf-945e-408daf6560a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_29-11-2021_43486.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e32a50d-bf1b-4fbf-945e-408daf6560a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/028a3f2c-6a9a-4160-afbc-5bba5c6c3d87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "028a3f2c-6a9a-4160-afbc-5bba5c6c3d87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_29-11-2021_43489.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/028a3f2c-6a9a-4160-afbc-5bba5c6c3d87>.
+    
+<http://data.lblod.info/id/remote-data-objects/f619bb0d-709e-4168-9bdb-dabee7733fb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f619bb0d-709e-4168-9bdb-dabee7733fb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_29-11-2021_43490.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f619bb0d-709e-4168-9bdb-dabee7733fb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2267c909-6cd9-420f-adb6-534db6766b06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2267c909-6cd9-420f-adb6-534db6766b06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_29-11-2021_43509.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2267c909-6cd9-420f-adb6-534db6766b06>.
+    
+<http://data.lblod.info/id/remote-data-objects/12eef599-cf45-4d8d-92a4-ce98546c13d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12eef599-cf45-4d8d-92a4-ce98546c13d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_30-05-2022_48166.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12eef599-cf45-4d8d-92a4-ce98546c13d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a2cf625-9518-482d-b815-1906f2b8d545> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a2cf625-9518-482d-b815-1906f2b8d545";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_30-05-2022_48167.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a2cf625-9518-482d-b815-1906f2b8d545>.
+    
+<http://data.lblod.info/id/remote-data-objects/66997a51-5388-4e2a-b9d8-1d4297cde6bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66997a51-5388-4e2a-b9d8-1d4297cde6bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_30-05-2022_48168.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66997a51-5388-4e2a-b9d8-1d4297cde6bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8060c08-79c2-4a7e-9bd3-cb20a182e73b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8060c08-79c2-4a7e-9bd3-cb20a182e73b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_30-05-2022_48171.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8060c08-79c2-4a7e-9bd3-cb20a182e73b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2297eb9f-8142-4ff2-8b00-4c933af30a97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2297eb9f-8142-4ff2-8b00-4c933af30a97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_30-05-2022_48172.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2297eb9f-8142-4ff2-8b00-4c933af30a97>.
+    
+<http://data.lblod.info/id/remote-data-objects/72358b93-3afa-463f-b13a-644c244691d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72358b93-3afa-463f-b13a-644c244691d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_30-05-2022_48176.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72358b93-3afa-463f-b13a-644c244691d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b70f96f-9c14-4fea-a21c-7528b4fa3e8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b70f96f-9c14-4fea-a21c-7528b4fa3e8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_30-05-2022_48192.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b70f96f-9c14-4fea-a21c-7528b4fa3e8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8795b79-22f2-48e8-b2a1-15bb68782918> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8795b79-22f2-48e8-b2a1-15bb68782918";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_30-05-2022_48194.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8795b79-22f2-48e8-b2a1-15bb68782918>.
+    
+<http://data.lblod.info/id/remote-data-objects/09770a10-2d1b-4efd-ac83-976575b844f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09770a10-2d1b-4efd-ac83-976575b844f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_30-05-2022_48198.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09770a10-2d1b-4efd-ac83-976575b844f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/134a36c3-b4b3-4e80-b967-4317cd2d8ba4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "134a36c3-b4b3-4e80-b967-4317cd2d8ba4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_30-05-2022_48205.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/134a36c3-b4b3-4e80-b967-4317cd2d8ba4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c75f5d8f-8973-411a-a009-4b3c48cddded> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c75f5d8f-8973-411a-a009-4b3c48cddded";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_30-05-2022_48217.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c75f5d8f-8973-411a-a009-4b3c48cddded>.
+    
+<http://data.lblod.info/id/remote-data-objects/364eb234-e753-4c91-8320-313429a2201e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "364eb234-e753-4c91-8320-313429a2201e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_30-05-2022_48219.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/364eb234-e753-4c91-8320-313429a2201e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a0b113d-e6fb-49d3-8ef6-54b81563f843> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a0b113d-e6fb-49d3-8ef6-54b81563f843";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_30-05-2022_48238.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a0b113d-e6fb-49d3-8ef6-54b81563f843>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ec93e6e-1114-44c9-ab78-a5dbb2186fdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ec93e6e-1114-44c9-ab78-a5dbb2186fdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_30-05-2022_48239.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ec93e6e-1114-44c9-ab78-a5dbb2186fdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/2154f2e3-5c3f-4a5b-84bb-a7a87ef1d5f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2154f2e3-5c3f-4a5b-84bb-a7a87ef1d5f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_30-05-2022_48241.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2154f2e3-5c3f-4a5b-84bb-a7a87ef1d5f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d3aa74e-e5ff-4153-823d-089c21e6ff00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d3aa74e-e5ff-4153-823d-089c21e6ff00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_31-01-2022_44238.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c15e50d7-0081-4939-aa51-ae77104b2996> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d3aa74e-e5ff-4153-823d-089c21e6ff00>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201551-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201551-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201551-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201551-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/72b7eeff-87a5-4125-bea1-5ae96280d8c7> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "72b7eeff-87a5-4125-bea1-5ae96280d8c7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f54563a2-6ae0-4866-b50c-d43d80463e37";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/fe69f534-c28e-4c6c-9f13-e4793685b4d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fe69f534-c28e-4c6c-9f13-e4793685b4d6";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37>.
+
+  <http://redpencil.data.gift/id/task/70d83f16-9aa2-4a24-a012-9e0bc9861ffa> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "70d83f16-9aa2-4a24-a012-9e0bc9861ffa";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/72b7eeff-87a5-4125-bea1-5ae96280d8c7>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/fe69f534-c28e-4c6c-9f13-e4793685b4d6>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b037cf35-575e-4be2-aa03-3737054f148c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b037cf35-575e-4be2-aa03-3737054f148c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_31-01-2022_44239.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b037cf35-575e-4be2-aa03-3737054f148c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c42a069-a6be-49f4-be30-1ea43cd55355> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c42a069-a6be-49f4-be30-1ea43cd55355";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_31-01-2022_44873.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c42a069-a6be-49f4-be30-1ea43cd55355>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9ce3c42-139f-4352-87f8-3dca3168cdd6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9ce3c42-139f-4352-87f8-3dca3168cdd6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_31-01-2022_45133.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9ce3c42-139f-4352-87f8-3dca3168cdd6>.
+    
+<http://data.lblod.info/id/remote-data-objects/beaa9ebc-4402-4644-9dc0-0d1e02ecd844> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "beaa9ebc-4402-4644-9dc0-0d1e02ecd844";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/8873575842728dc102e99d0d781a287019424dbfe3f3e14a03813d7b7b350ac7/GetPublication?filename=Uittreksels_31-01-2022_45141.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/beaa9ebc-4402-4644-9dc0-0d1e02ecd844>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b171b11-8db4-4db8-902b-cbb58508b5b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b171b11-8db4-4db8-902b-cbb58508b5b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b171b11-8db4-4db8-902b-cbb58508b5b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/9598fbae-2a02-4bd7-b34b-1244a1a61571> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9598fbae-2a02-4bd7-b34b-1244a1a61571";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9598fbae-2a02-4bd7-b34b-1244a1a61571>.
+    
+<http://data.lblod.info/id/remote-data-objects/571c1426-a1f1-472b-bb7a-3de1f23bbf90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "571c1426-a1f1-472b-bb7a-3de1f23bbf90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/571c1426-a1f1-472b-bb7a-3de1f23bbf90>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e242129-ee6a-455f-bfd1-01dd034ba1b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e242129-ee6a-455f-bfd1-01dd034ba1b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e242129-ee6a-455f-bfd1-01dd034ba1b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e44a688a-ab14-4ada-912c-8a377113f1e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e44a688a-ab14-4ada-912c-8a377113f1e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e44a688a-ab14-4ada-912c-8a377113f1e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d85fd7da-6c84-4508-947e-456053056acf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d85fd7da-6c84-4508-947e-456053056acf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d85fd7da-6c84-4508-947e-456053056acf>.
+    
+<http://data.lblod.info/id/remote-data-objects/4773d25e-1c76-4fb2-87da-175b95857e06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4773d25e-1c76-4fb2-87da-175b95857e06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4773d25e-1c76-4fb2-87da-175b95857e06>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff662edd-c3ca-44d2-b2ba-aab5278e4afe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff662edd-c3ca-44d2-b2ba-aab5278e4afe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff662edd-c3ca-44d2-b2ba-aab5278e4afe>.
+    
+<http://data.lblod.info/id/remote-data-objects/659a882a-9b20-4acc-a1ef-a011b71ad36a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "659a882a-9b20-4acc-a1ef-a011b71ad36a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/659a882a-9b20-4acc-a1ef-a011b71ad36a>.
+    
+<http://data.lblod.info/id/remote-data-objects/74d2e364-d1d9-4c0e-948d-5dabe7d1f0af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74d2e364-d1d9-4c0e-948d-5dabe7d1f0af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74d2e364-d1d9-4c0e-948d-5dabe7d1f0af>.
+    
+<http://data.lblod.info/id/remote-data-objects/1072f2ed-ac24-44c0-bbe7-5eb34e9fa39a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1072f2ed-ac24-44c0-bbe7-5eb34e9fa39a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1072f2ed-ac24-44c0-bbe7-5eb34e9fa39a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfb20793-9cc8-4500-8ff5-f3aebec945dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfb20793-9cc8-4500-8ff5-f3aebec945dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfb20793-9cc8-4500-8ff5-f3aebec945dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/76adcde8-5681-4273-859f-bc43fad08741> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76adcde8-5681-4273-859f-bc43fad08741";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76adcde8-5681-4273-859f-bc43fad08741>.
+    
+<http://data.lblod.info/id/remote-data-objects/519957c7-cea6-4314-9539-e94685558f64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "519957c7-cea6-4314-9539-e94685558f64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/519957c7-cea6-4314-9539-e94685558f64>.
+    
+<http://data.lblod.info/id/remote-data-objects/76b821ad-076f-4163-8d5e-624cd01866c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76b821ad-076f-4163-8d5e-624cd01866c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76b821ad-076f-4163-8d5e-624cd01866c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/7048924b-c424-4942-b902-44a18c262811> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7048924b-c424-4942-b902-44a18c262811";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7048924b-c424-4942-b902-44a18c262811>.
+    
+<http://data.lblod.info/id/remote-data-objects/6362620e-1f3e-433b-94ca-e11fa1c05345> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6362620e-1f3e-433b-94ca-e11fa1c05345";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6362620e-1f3e-433b-94ca-e11fa1c05345>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a6855dc-b64d-4484-af1a-61a9b70731dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a6855dc-b64d-4484-af1a-61a9b70731dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a6855dc-b64d-4484-af1a-61a9b70731dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/78d22090-a936-4987-8cac-5d1c9976c70b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78d22090-a936-4987-8cac-5d1c9976c70b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78d22090-a936-4987-8cac-5d1c9976c70b>.
+    
+<http://data.lblod.info/id/remote-data-objects/33f9171c-8104-461f-96f6-3445658367ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33f9171c-8104-461f-96f6-3445658367ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33f9171c-8104-461f-96f6-3445658367ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9179024-7aac-4e0c-b106-d6f959015929> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9179024-7aac-4e0c-b106-d6f959015929";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9179024-7aac-4e0c-b106-d6f959015929>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bfd1624-bdcb-43e2-9f24-30e22c8a0caf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bfd1624-bdcb-43e2-9f24-30e22c8a0caf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bfd1624-bdcb-43e2-9f24-30e22c8a0caf>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0355af0-f5fa-4275-b233-2d566204aade> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0355af0-f5fa-4275-b233-2d566204aade";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0355af0-f5fa-4275-b233-2d566204aade>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bcad548-1174-4249-9b32-9554de58dc4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bcad548-1174-4249-9b32-9554de58dc4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bcad548-1174-4249-9b32-9554de58dc4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/48aacc52-8b23-4f33-b8b6-47bceaa31195> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48aacc52-8b23-4f33-b8b6-47bceaa31195";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48aacc52-8b23-4f33-b8b6-47bceaa31195>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee848e04-b548-41cd-a791-ab2a5c7c5293> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee848e04-b548-41cd-a791-ab2a5c7c5293";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee848e04-b548-41cd-a791-ab2a5c7c5293>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b82a7f5-2aeb-409a-b512-295187b0dca5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b82a7f5-2aeb-409a-b512-295187b0dca5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b82a7f5-2aeb-409a-b512-295187b0dca5>.
+    
+<http://data.lblod.info/id/remote-data-objects/065b69f6-5c15-4284-ba77-46057bf64dc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "065b69f6-5c15-4284-ba77-46057bf64dc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/065b69f6-5c15-4284-ba77-46057bf64dc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/6048c780-3389-49b0-9805-336dc743853a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6048c780-3389-49b0-9805-336dc743853a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6048c780-3389-49b0-9805-336dc743853a>.
+    
+<http://data.lblod.info/id/remote-data-objects/695833b7-bcc5-46db-be8e-5cc95a55bdff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "695833b7-bcc5-46db-be8e-5cc95a55bdff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/695833b7-bcc5-46db-be8e-5cc95a55bdff>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c916aea-c097-4c4b-996a-356d76ddc334> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c916aea-c097-4c4b-996a-356d76ddc334";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c916aea-c097-4c4b-996a-356d76ddc334>.
+    
+<http://data.lblod.info/id/remote-data-objects/28251a83-3270-43c3-b58e-4d7af1b77f31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28251a83-3270-43c3-b58e-4d7af1b77f31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28251a83-3270-43c3-b58e-4d7af1b77f31>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab22bd9e-f218-47cd-b0ea-b102a472eed7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab22bd9e-f218-47cd-b0ea-b102a472eed7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab22bd9e-f218-47cd-b0ea-b102a472eed7>.
+    
+<http://data.lblod.info/id/remote-data-objects/785962b7-e85d-4538-9833-c1c0073e5ebc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "785962b7-e85d-4538-9833-c1c0073e5ebc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/785962b7-e85d-4538-9833-c1c0073e5ebc>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4959270-2228-4072-a678-199db66513a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4959270-2228-4072-a678-199db66513a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/9a592186754c27657fddc6593313d5e076c064f7fa28b3a944c0338288580732/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau%20_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4959270-2228-4072-a678-199db66513a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec5d2740-77e9-4f19-b307-0994f6217f9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec5d2740-77e9-4f19-b307-0994f6217f9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec5d2740-77e9-4f19-b307-0994f6217f9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f525717-f14f-40b0-bea2-274e4e184c82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f525717-f14f-40b0-bea2-274e4e184c82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f525717-f14f-40b0-bea2-274e4e184c82>.
+    
+<http://data.lblod.info/id/remote-data-objects/65e8f20f-c34f-40b7-aab7-74f73aec9404> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65e8f20f-c34f-40b7-aab7-74f73aec9404";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65e8f20f-c34f-40b7-aab7-74f73aec9404>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef183e12-a3dd-45fa-b972-620b0a95c669> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef183e12-a3dd-45fa-b972-620b0a95c669";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef183e12-a3dd-45fa-b972-620b0a95c669>.
+    
+<http://data.lblod.info/id/remote-data-objects/1abc03a6-f651-45d6-84d0-aa2f0305fbe0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1abc03a6-f651-45d6-84d0-aa2f0305fbe0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1abc03a6-f651-45d6-84d0-aa2f0305fbe0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5b07454-4008-48bc-9942-f0b0199c26ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5b07454-4008-48bc-9942-f0b0199c26ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5b07454-4008-48bc-9942-f0b0199c26ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/881487f9-b637-4912-bd4f-698854f65dd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "881487f9-b637-4912-bd4f-698854f65dd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/881487f9-b637-4912-bd4f-698854f65dd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b58b2364-038b-4f64-ad07-448f63534ff3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b58b2364-038b-4f64-ad07-448f63534ff3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b58b2364-038b-4f64-ad07-448f63534ff3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ce5e7ac-7dbf-47a6-8a41-4024c930a2e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ce5e7ac-7dbf-47a6-8a41-4024c930a2e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ce5e7ac-7dbf-47a6-8a41-4024c930a2e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab40eaf5-fe7c-49d0-b507-4ca47f4c99e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab40eaf5-fe7c-49d0-b507-4ca47f4c99e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab40eaf5-fe7c-49d0-b507-4ca47f4c99e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/12218c84-d89f-432f-9fb4-c2eae1812a0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12218c84-d89f-432f-9fb4-c2eae1812a0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f54563a2-6ae0-4866-b50c-d43d80463e37> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12218c84-d89f-432f-9fb4-c2eae1812a0b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201552-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201552-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201552-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201552-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7d5d571e-a0a6-4bab-ba3c-b699998b7f0b> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7d5d571e-a0a6-4bab-ba3c-b699998b7f0b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8faa15e0-9843-4331-9fb1-1e63787853a2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c36aeef8-8924-481c-9b95-a093ca5ad421> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c36aeef8-8924-481c-9b95-a093ca5ad421";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2>.
+
+  <http://redpencil.data.gift/id/task/4eac0b80-4346-4ef4-8d5b-9296b4546729> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4eac0b80-4346-4ef4-8d5b-9296b4546729";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7d5d571e-a0a6-4bab-ba3c-b699998b7f0b>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c36aeef8-8924-481c-9b95-a093ca5ad421>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e2f77fbf-bcea-4fc0-a9c4-7b9ed44d86c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2f77fbf-bcea-4fc0-a9c4-7b9ed44d86c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2f77fbf-bcea-4fc0-a9c4-7b9ed44d86c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfce84ee-257c-4998-ac39-4d2bda0f3b08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfce84ee-257c-4998-ac39-4d2bda0f3b08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfce84ee-257c-4998-ac39-4d2bda0f3b08>.
+    
+<http://data.lblod.info/id/remote-data-objects/32b0bd88-6be5-4796-a574-cf7106694279> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32b0bd88-6be5-4796-a574-cf7106694279";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32b0bd88-6be5-4796-a574-cf7106694279>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1e782a5-12f1-4195-a3a6-6fb0aba209a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1e782a5-12f1-4195-a3a6-6fb0aba209a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1e782a5-12f1-4195-a3a6-6fb0aba209a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f351e3a-c917-46fa-92f5-56f07a5606ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f351e3a-c917-46fa-92f5-56f07a5606ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f351e3a-c917-46fa-92f5-56f07a5606ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/5791bd4f-791b-4f85-a4ab-dae355fbd1b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5791bd4f-791b-4f85-a4ab-dae355fbd1b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5791bd4f-791b-4f85-a4ab-dae355fbd1b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dfa99e1-fefc-463e-9daf-a7803b505f90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dfa99e1-fefc-463e-9daf-a7803b505f90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dfa99e1-fefc-463e-9daf-a7803b505f90>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0489454-6421-4815-b773-7f45a0517314> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0489454-6421-4815-b773-7f45a0517314";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0489454-6421-4815-b773-7f45a0517314>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bc24c5b-9340-4234-860e-e781589bb0e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bc24c5b-9340-4234-860e-e781589bb0e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bc24c5b-9340-4234-860e-e781589bb0e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/83e03ce4-9701-4438-a955-315e08aba09e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83e03ce4-9701-4438-a955-315e08aba09e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Uittreksels_22-03-2022_46941.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83e03ce4-9701-4438-a955-315e08aba09e>.
+    
+<http://data.lblod.info/id/remote-data-objects/79748d52-4b15-4db0-b579-898fd9910758> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79748d52-4b15-4db0-b579-898fd9910758";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Uittreksels_24-05-2022_47594.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79748d52-4b15-4db0-b579-898fd9910758>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1510fcc-fe98-4e6d-87e3-6777107cdcad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1510fcc-fe98-4e6d-87e3-6777107cdcad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Uittreksels_25-01-2022_44064.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1510fcc-fe98-4e6d-87e3-6777107cdcad>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff7de4c6-a84b-43f5-8025-b798e772d686> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff7de4c6-a84b-43f5-8025-b798e772d686";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Uittreksels_26-04-2022_46521.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff7de4c6-a84b-43f5-8025-b798e772d686>.
+    
+<http://data.lblod.info/id/remote-data-objects/5527ea4a-1b53-40cb-913f-0ec9ab728ea7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5527ea4a-1b53-40cb-913f-0ec9ab728ea7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Uittreksels_26-04-2022_47354.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5527ea4a-1b53-40cb-913f-0ec9ab728ea7>.
+    
+<http://data.lblod.info/id/remote-data-objects/93db6720-6468-408e-bc7a-8e64d08529d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93db6720-6468-408e-bc7a-8e64d08529d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Uittreksels_26-10-2021_39489.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93db6720-6468-408e-bc7a-8e64d08529d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ff332eb-6611-4b0b-8183-720867760f77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ff332eb-6611-4b0b-8183-720867760f77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.merelbeke.be/LBLODWeb/Home/Overzicht/bc629202d91dc626925f64b5b9e8ebe3e6f19003a9c7ec7d11eb2ed94d6eaef2/GetPublication?filename=Uittreksels_28-06-2022_48599.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ff332eb-6611-4b0b-8183-720867760f77>.
+    
+<http://data.lblod.info/id/remote-data-objects/ded544b1-d49b-4ea7-920f-20c4ed6d7256> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ded544b1-d49b-4ea7-920f-20c4ed6d7256";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ded544b1-d49b-4ea7-920f-20c4ed6d7256>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bee253f-b8be-43b9-84b9-2b9636fc39d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bee253f-b8be-43b9-84b9-2b9636fc39d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bee253f-b8be-43b9-84b9-2b9636fc39d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/19fe77ab-c3cc-498b-a4a9-b1a496155051> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19fe77ab-c3cc-498b-a4a9-b1a496155051";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19fe77ab-c3cc-498b-a4a9-b1a496155051>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d161692-faea-4218-9467-af6ac8450866> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d161692-faea-4218-9467-af6ac8450866";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d161692-faea-4218-9467-af6ac8450866>.
+    
+<http://data.lblod.info/id/remote-data-objects/9750b0b7-2d35-4346-9f5e-f9b01830a6bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9750b0b7-2d35-4346-9f5e-f9b01830a6bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9750b0b7-2d35-4346-9f5e-f9b01830a6bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/1caacd22-69cc-4ef3-aed3-7da35c78d667> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1caacd22-69cc-4ef3-aed3-7da35c78d667";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1caacd22-69cc-4ef3-aed3-7da35c78d667>.
+    
+<http://data.lblod.info/id/remote-data-objects/584213fe-2083-4c35-9b7c-df8eb847f80c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "584213fe-2083-4c35-9b7c-df8eb847f80c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/584213fe-2083-4c35-9b7c-df8eb847f80c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2154d5df-7226-44b8-a485-f911b277c357> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2154d5df-7226-44b8-a485-f911b277c357";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2154d5df-7226-44b8-a485-f911b277c357>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2de1264-d037-4312-9ac4-8c6bde328655> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2de1264-d037-4312-9ac4-8c6bde328655";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2de1264-d037-4312-9ac4-8c6bde328655>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3899dab-41a5-46bb-a2f4-e023ae222658> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3899dab-41a5-46bb-a2f4-e023ae222658";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3899dab-41a5-46bb-a2f4-e023ae222658>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b641d9a-e465-48a2-83b0-8f37c68a4214> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b641d9a-e465-48a2-83b0-8f37c68a4214";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b641d9a-e465-48a2-83b0-8f37c68a4214>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa01e97a-46f4-44e1-8a41-1b96ddc02268> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa01e97a-46f4-44e1-8a41-1b96ddc02268";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa01e97a-46f4-44e1-8a41-1b96ddc02268>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3dac4d6-4643-485d-ad25-8b51a6a27bc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3dac4d6-4643-485d-ad25-8b51a6a27bc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3dac4d6-4643-485d-ad25-8b51a6a27bc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/370dd6aa-b3bc-4cb1-a602-17db557541f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "370dd6aa-b3bc-4cb1-a602-17db557541f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/370dd6aa-b3bc-4cb1-a602-17db557541f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a4ee00d-7577-4698-bb09-e50ebaa43b0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a4ee00d-7577-4698-bb09-e50ebaa43b0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_12-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a4ee00d-7577-4698-bb09-e50ebaa43b0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cfe2c54-b278-421c-b930-8650db535816> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cfe2c54-b278-421c-b930-8650db535816";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cfe2c54-b278-421c-b930-8650db535816>.
+    
+<http://data.lblod.info/id/remote-data-objects/69566a8a-77b4-4f80-8977-f58344f6d305> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69566a8a-77b4-4f80-8977-f58344f6d305";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69566a8a-77b4-4f80-8977-f58344f6d305>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfaf8e56-1b08-4c2e-9e07-f10870e773a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfaf8e56-1b08-4c2e-9e07-f10870e773a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfaf8e56-1b08-4c2e-9e07-f10870e773a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/546aebe9-6f54-43e9-9b0d-df252c4b3899> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "546aebe9-6f54-43e9-9b0d-df252c4b3899";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/546aebe9-6f54-43e9-9b0d-df252c4b3899>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b9b760a-9ce3-4b7a-a59b-6c718f6b69a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b9b760a-9ce3-4b7a-a59b-6c718f6b69a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b9b760a-9ce3-4b7a-a59b-6c718f6b69a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/17f2d16c-f786-4314-b80e-ad660acd1a81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17f2d16c-f786-4314-b80e-ad660acd1a81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17f2d16c-f786-4314-b80e-ad660acd1a81>.
+    
+<http://data.lblod.info/id/remote-data-objects/3af4bc21-d0b9-4ddf-8842-f76f835e559d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3af4bc21-d0b9-4ddf-8842-f76f835e559d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3af4bc21-d0b9-4ddf-8842-f76f835e559d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f9e6fcc-5211-485c-adad-bd9b2a684060> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f9e6fcc-5211-485c-adad-bd9b2a684060";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f9e6fcc-5211-485c-adad-bd9b2a684060>.
+    
+<http://data.lblod.info/id/remote-data-objects/83e1f799-345d-4414-aec8-1041e9acd2ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83e1f799-345d-4414-aec8-1041e9acd2ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83e1f799-345d-4414-aec8-1041e9acd2ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/873497ff-799a-40e5-89a9-051205a028e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "873497ff-799a-40e5-89a9-051205a028e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/873497ff-799a-40e5-89a9-051205a028e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c99b4fa-7692-4162-b0a4-187e18d11306> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c99b4fa-7692-4162-b0a4-187e18d11306";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c99b4fa-7692-4162-b0a4-187e18d11306>.
+    
+<http://data.lblod.info/id/remote-data-objects/707f6024-6d81-4753-b3f8-774cc788ec0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "707f6024-6d81-4753-b3f8-774cc788ec0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/707f6024-6d81-4753-b3f8-774cc788ec0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fde05519-a144-4318-8b60-0e12022c072e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fde05519-a144-4318-8b60-0e12022c072e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fde05519-a144-4318-8b60-0e12022c072e>.
+    
+<http://data.lblod.info/id/remote-data-objects/982d7342-181d-43e5-ad6e-c9efe6f1293a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "982d7342-181d-43e5-ad6e-c9efe6f1293a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/982d7342-181d-43e5-ad6e-c9efe6f1293a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a36998d-e375-4ef4-bb1a-8c3a940dac56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a36998d-e375-4ef4-bb1a-8c3a940dac56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a36998d-e375-4ef4-bb1a-8c3a940dac56>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c8519d1-b35d-4be7-8ac7-7d99a580a21e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c8519d1-b35d-4be7-8ac7-7d99a580a21e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c8519d1-b35d-4be7-8ac7-7d99a580a21e>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcd57896-8c6c-4b39-b6ee-9e7460eb9faf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcd57896-8c6c-4b39-b6ee-9e7460eb9faf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcd57896-8c6c-4b39-b6ee-9e7460eb9faf>.
+    
+<http://data.lblod.info/id/remote-data-objects/96bd8cb1-d878-4be3-b99e-e1370518c07b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96bd8cb1-d878-4be3-b99e-e1370518c07b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96bd8cb1-d878-4be3-b99e-e1370518c07b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1f9e8ba-861a-45dc-94fb-24a28ab609bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1f9e8ba-861a-45dc-94fb-24a28ab609bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8faa15e0-9843-4331-9fb1-1e63787853a2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1f9e8ba-861a-45dc-94fb-24a28ab609bb>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201553-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201553-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201553-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201553-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/14d49478-6fe3-4ee1-8bcb-32625e976dbe> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "14d49478-6fe3-4ee1-8bcb-32625e976dbe";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0da82941-2920-4c82-8e03-a5192495ffe7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/286c142a-9b1e-48d3-b10e-cf09b7424730> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "286c142a-9b1e-48d3-b10e-cf09b7424730";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7>.
+
+  <http://redpencil.data.gift/id/task/c39e9c0b-ccfe-4085-a135-9686103fcd17> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c39e9c0b-ccfe-4085-a135-9686103fcd17";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/14d49478-6fe3-4ee1-8bcb-32625e976dbe>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/286c142a-9b1e-48d3-b10e-cf09b7424730>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b1181846-8486-4bcf-b132-efb3d8e8ba0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1181846-8486-4bcf-b132-efb3d8e8ba0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1181846-8486-4bcf-b132-efb3d8e8ba0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/764f348d-d560-4702-b608-c84c6ae135f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "764f348d-d560-4702-b608-c84c6ae135f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/764f348d-d560-4702-b608-c84c6ae135f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/edf742cb-06ac-410d-9886-2c828384d438> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edf742cb-06ac-410d-9886-2c828384d438";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edf742cb-06ac-410d-9886-2c828384d438>.
+    
+<http://data.lblod.info/id/remote-data-objects/6794a4cd-f0c0-48ad-9a32-f093353d9341> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6794a4cd-f0c0-48ad-9a32-f093353d9341";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=BesluitenLijst_Vast%20Bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6794a4cd-f0c0-48ad-9a32-f093353d9341>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ca453de-4807-4344-9c9a-176eb092c0ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ca453de-4807-4344-9c9a-176eb092c0ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=Uittreksels_10-01-2022_36130.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ca453de-4807-4344-9c9a-176eb092c0ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cf17b38-4d73-4d28-aeb8-83f563d88d8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cf17b38-4d73-4d28-aeb8-83f563d88d8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=Uittreksels_28-02-2022_36835.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cf17b38-4d73-4d28-aeb8-83f563d88d8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6f6842a-3566-4db5-a78c-189b0f68d844> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6f6842a-3566-4db5-a78c-189b0f68d844";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=Uittreksels_28-02-2022_36837.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6f6842a-3566-4db5-a78c-189b0f68d844>.
+    
+<http://data.lblod.info/id/remote-data-objects/91f9dd06-53b7-45f6-a1b7-7003c41dd4a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91f9dd06-53b7-45f6-a1b7-7003c41dd4a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=Uittreksels_28-02-2022_36838.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91f9dd06-53b7-45f6-a1b7-7003c41dd4a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/26cb0543-d2ce-4459-9682-e61e38610751> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26cb0543-d2ce-4459-9682-e61e38610751";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/2c32d06743852a57b4c4276b266a542cd26be1f44995fc0a76698aee15326e5d/GetPublication?filename=Uittreksels_28-02-2022_36880.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26cb0543-d2ce-4459-9682-e61e38610751>.
+    
+<http://data.lblod.info/id/remote-data-objects/caf0502a-ac47-4131-b5b1-7dbaf03c7534> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "caf0502a-ac47-4131-b5b1-7dbaf03c7534";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Agenda_Gemeenteraad_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/caf0502a-ac47-4131-b5b1-7dbaf03c7534>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a2f4249-b156-4282-b5cb-0575daf98a01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a2f4249-b156-4282-b5cb-0575daf98a01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Agenda_Gemeenteraad_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a2f4249-b156-4282-b5cb-0575daf98a01>.
+    
+<http://data.lblod.info/id/remote-data-objects/9bbc0d19-93b7-4c25-a4ac-8537776ac2b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9bbc0d19-93b7-4c25-a4ac-8537776ac2b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Agenda_Gemeenteraad_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9bbc0d19-93b7-4c25-a4ac-8537776ac2b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/717a8bb8-022f-4c52-b0b1-ce88308dd611> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "717a8bb8-022f-4c52-b0b1-ce88308dd611";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Agenda_Gemeenteraad_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/717a8bb8-022f-4c52-b0b1-ce88308dd611>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b0bfa18-cc64-4d1c-85ea-bd06cbc096f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b0bfa18-cc64-4d1c-85ea-bd06cbc096f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Agenda_Gemeenteraad_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b0bfa18-cc64-4d1c-85ea-bd06cbc096f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5820d8a-0781-450c-a216-ccd1b953a2d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5820d8a-0781-450c-a216-ccd1b953a2d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Agenda_Gemeenteraad_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5820d8a-0781-450c-a216-ccd1b953a2d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/500f7c74-8427-49a9-af88-b9ce061e0876> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "500f7c74-8427-49a9-af88-b9ce061e0876";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Agenda_Gemeenteraad_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/500f7c74-8427-49a9-af88-b9ce061e0876>.
+    
+<http://data.lblod.info/id/remote-data-objects/de3eaf49-125a-4d7a-89fc-a0d2dab3048a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de3eaf49-125a-4d7a-89fc-a0d2dab3048a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Agenda_Gemeenteraad_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de3eaf49-125a-4d7a-89fc-a0d2dab3048a>.
+    
+<http://data.lblod.info/id/remote-data-objects/77c7183e-a284-4065-a911-a4305f23601f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77c7183e-a284-4065-a911-a4305f23601f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Agenda_Gemeenteraad_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77c7183e-a284-4065-a911-a4305f23601f>.
+    
+<http://data.lblod.info/id/remote-data-objects/55b25ab6-9f72-40a5-a5c1-b167b94e37bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55b25ab6-9f72-40a5-a5c1-b167b94e37bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=BesluitenLijst_Gemeenteraad_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55b25ab6-9f72-40a5-a5c1-b167b94e37bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/22ad88bc-0f0c-4389-aac1-edd33aa7d9be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22ad88bc-0f0c-4389-aac1-edd33aa7d9be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=BesluitenLijst_Gemeenteraad_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22ad88bc-0f0c-4389-aac1-edd33aa7d9be>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ac874fa-496b-4333-b060-24e0a9b40fb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ac874fa-496b-4333-b060-24e0a9b40fb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=BesluitenLijst_Gemeenteraad_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ac874fa-496b-4333-b060-24e0a9b40fb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f914376-f0ce-424d-a8dd-b0fce51037ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f914376-f0ce-424d-a8dd-b0fce51037ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=BesluitenLijst_Gemeenteraad_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f914376-f0ce-424d-a8dd-b0fce51037ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/69571591-48cd-4422-8f0d-91352f3950ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69571591-48cd-4422-8f0d-91352f3950ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=BesluitenLijst_Gemeenteraad_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69571591-48cd-4422-8f0d-91352f3950ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/012e30a3-52a6-4497-96e1-5c2eee27c3f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "012e30a3-52a6-4497-96e1-5c2eee27c3f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=BesluitenLijst_Gemeenteraad_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/012e30a3-52a6-4497-96e1-5c2eee27c3f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb1a3b7a-35df-4a65-8374-8d27daf2b901> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb1a3b7a-35df-4a65-8374-8d27daf2b901";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=BesluitenLijst_Gemeenteraad_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb1a3b7a-35df-4a65-8374-8d27daf2b901>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fd3e008-8957-4133-8b7b-800fbfb5e70a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fd3e008-8957-4133-8b7b-800fbfb5e70a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=BesluitenLijst_Gemeenteraad_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fd3e008-8957-4133-8b7b-800fbfb5e70a>.
+    
+<http://data.lblod.info/id/remote-data-objects/23cc0a7b-01a3-454c-ab1f-771a5fc180f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23cc0a7b-01a3-454c-ab1f-771a5fc180f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=BesluitenLijst_Gemeenteraad_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23cc0a7b-01a3-454c-ab1f-771a5fc180f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/30e54138-9ef1-45c3-88de-103c32747d7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30e54138-9ef1-45c3-88de-103c32747d7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Notulen_Gemeenteraad_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30e54138-9ef1-45c3-88de-103c32747d7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3af3c4e8-f2b3-48d7-a63e-d3eab958070b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3af3c4e8-f2b3-48d7-a63e-d3eab958070b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Notulen_Gemeenteraad_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3af3c4e8-f2b3-48d7-a63e-d3eab958070b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e06fad9-ad30-491a-97f1-af3a3a8985aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e06fad9-ad30-491a-97f1-af3a3a8985aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Notulen_Gemeenteraad_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e06fad9-ad30-491a-97f1-af3a3a8985aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1e5a469-7cf0-4fe9-94fc-ba12b934fbf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1e5a469-7cf0-4fe9-94fc-ba12b934fbf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Notulen_Gemeenteraad_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1e5a469-7cf0-4fe9-94fc-ba12b934fbf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/6203aad3-695c-47e8-bbb0-8361a84aa924> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6203aad3-695c-47e8-bbb0-8361a84aa924";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Notulen_Gemeenteraad_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6203aad3-695c-47e8-bbb0-8361a84aa924>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fb4409c-7cbb-425b-a421-09a9e240f3c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fb4409c-7cbb-425b-a421-09a9e240f3c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Notulen_Gemeenteraad_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fb4409c-7cbb-425b-a421-09a9e240f3c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c4c27f4-caff-4a33-83dd-5f0146f14f6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c4c27f4-caff-4a33-83dd-5f0146f14f6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Notulen_Gemeenteraad_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c4c27f4-caff-4a33-83dd-5f0146f14f6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7dd5799-4861-43f0-b695-ad24da5a8c78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7dd5799-4861-43f0-b695-ad24da5a8c78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Notulen_Gemeenteraad_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7dd5799-4861-43f0-b695-ad24da5a8c78>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bb4c081-3371-47ff-87e5-0885c1d0412b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bb4c081-3371-47ff-87e5-0885c1d0412b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_06-04-2022_36855.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bb4c081-3371-47ff-87e5-0885c1d0412b>.
+    
+<http://data.lblod.info/id/remote-data-objects/98fc5b05-1c35-4e8c-80f7-9abd9d998640> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98fc5b05-1c35-4e8c-80f7-9abd9d998640";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_06-04-2022_37107.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98fc5b05-1c35-4e8c-80f7-9abd9d998640>.
+    
+<http://data.lblod.info/id/remote-data-objects/393c258a-7ee0-412d-a103-591a80db7e59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "393c258a-7ee0-412d-a103-591a80db7e59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_06-04-2022_37130.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/393c258a-7ee0-412d-a103-591a80db7e59>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a74a8a6-f10f-48e3-a634-95189ac6235f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a74a8a6-f10f-48e3-a634-95189ac6235f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_06-04-2022_37253.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a74a8a6-f10f-48e3-a634-95189ac6235f>.
+    
+<http://data.lblod.info/id/remote-data-objects/19674957-7868-4498-949b-e3bb24661ece> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19674957-7868-4498-949b-e3bb24661ece";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_08-06-2022_37981.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19674957-7868-4498-949b-e3bb24661ece>.
+    
+<http://data.lblod.info/id/remote-data-objects/d03d669c-9746-4f51-a355-74801c34f85e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d03d669c-9746-4f51-a355-74801c34f85e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_08-06-2022_38236.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d03d669c-9746-4f51-a355-74801c34f85e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac12b5fd-9163-475b-b3be-e1ce8cd3b433> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac12b5fd-9163-475b-b3be-e1ce8cd3b433";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_08-06-2022_38364.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac12b5fd-9163-475b-b3be-e1ce8cd3b433>.
+    
+<http://data.lblod.info/id/remote-data-objects/db4f9bc8-c708-4eab-b00d-43e410f4506d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db4f9bc8-c708-4eab-b00d-43e410f4506d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_08-06-2022_38365.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db4f9bc8-c708-4eab-b00d-43e410f4506d>.
+    
+<http://data.lblod.info/id/remote-data-objects/83710f3a-06b8-4bcc-b0bb-1c4fd74bfcfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83710f3a-06b8-4bcc-b0bb-1c4fd74bfcfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_08-06-2022_38366.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83710f3a-06b8-4bcc-b0bb-1c4fd74bfcfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/509e0022-e537-4c88-9242-4f5a32596529> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "509e0022-e537-4c88-9242-4f5a32596529";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_08-06-2022_38367.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/509e0022-e537-4c88-9242-4f5a32596529>.
+    
+<http://data.lblod.info/id/remote-data-objects/68385686-f7c2-4bcb-9051-fd133e1991f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68385686-f7c2-4bcb-9051-fd133e1991f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_08-12-2021_35478.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68385686-f7c2-4bcb-9051-fd133e1991f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce6e23fc-323e-4bce-afcf-2ecfe1309566> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce6e23fc-323e-4bce-afcf-2ecfe1309566";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_08-12-2021_35479.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce6e23fc-323e-4bce-afcf-2ecfe1309566>.
+    
+<http://data.lblod.info/id/remote-data-objects/aad9a8db-18ca-4334-ac8d-0d80deea5da0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aad9a8db-18ca-4334-ac8d-0d80deea5da0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_08-12-2021_35481.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aad9a8db-18ca-4334-ac8d-0d80deea5da0>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b02d866-cb64-4722-b5c6-4cfc7ccdb4ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b02d866-cb64-4722-b5c6-4cfc7ccdb4ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_08-12-2021_35531.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b02d866-cb64-4722-b5c6-4cfc7ccdb4ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d8b60e1-9959-4677-b6d2-e3322bf77a17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d8b60e1-9959-4677-b6d2-e3322bf77a17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_09-02-2022_36362.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0da82941-2920-4c82-8e03-a5192495ffe7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d8b60e1-9959-4677-b6d2-e3322bf77a17>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201554-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201554-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201554-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201554-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d606d3e9-ff7d-4a9f-9efd-152685dfce61> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d606d3e9-ff7d-4a9f-9efd-152685dfce61";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bf7f697d-83c7-40d1-a171-f8f70454bad4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c18c96f9-ca69-48e7-8170-e8ea0fc8ccad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c18c96f9-ca69-48e7-8170-e8ea0fc8ccad";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4>.
+
+  <http://redpencil.data.gift/id/task/707f9e7e-cf6f-4881-86db-7cb1e2739518> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "707f9e7e-cf6f-4881-86db-7cb1e2739518";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d606d3e9-ff7d-4a9f-9efd-152685dfce61>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c18c96f9-ca69-48e7-8170-e8ea0fc8ccad>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/be674b9e-7a58-4497-b9fc-cb69021a5221> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be674b9e-7a58-4497-b9fc-cb69021a5221";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_11-05-2022_37687.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be674b9e-7a58-4497-b9fc-cb69021a5221>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0a57625-766a-412b-9f44-339aa7ec0a93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0a57625-766a-412b-9f44-339aa7ec0a93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_11-05-2022_37705.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0a57625-766a-412b-9f44-339aa7ec0a93>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b1b79e1-31c9-4fb9-bd8c-d8512b48f227> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b1b79e1-31c9-4fb9-bd8c-d8512b48f227";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_13-07-2022_38234.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b1b79e1-31c9-4fb9-bd8c-d8512b48f227>.
+    
+<http://data.lblod.info/id/remote-data-objects/662140f5-819c-4b8a-a434-3506b45e2e7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "662140f5-819c-4b8a-a434-3506b45e2e7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_17-11-2021_34903.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/662140f5-819c-4b8a-a434-3506b45e2e7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/983f4334-34dd-400f-80c1-b5a22475391d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "983f4334-34dd-400f-80c1-b5a22475391d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_17-11-2021_34904.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/983f4334-34dd-400f-80c1-b5a22475391d>.
+    
+<http://data.lblod.info/id/remote-data-objects/75a6a86a-7c7c-4d42-8e60-c9c099cbcd13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75a6a86a-7c7c-4d42-8e60-c9c099cbcd13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_17-11-2021_34905.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75a6a86a-7c7c-4d42-8e60-c9c099cbcd13>.
+    
+<http://data.lblod.info/id/remote-data-objects/44e08159-41aa-44c2-8664-421011b6ff86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44e08159-41aa-44c2-8664-421011b6ff86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_17-11-2021_34906.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44e08159-41aa-44c2-8664-421011b6ff86>.
+    
+<http://data.lblod.info/id/remote-data-objects/4419197c-fbdf-4b11-a7e5-7565bc19e647> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4419197c-fbdf-4b11-a7e5-7565bc19e647";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_17-11-2021_35151.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4419197c-fbdf-4b11-a7e5-7565bc19e647>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc9097fc-fd6b-473e-bd4a-036dcc05fb5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc9097fc-fd6b-473e-bd4a-036dcc05fb5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_17-11-2021_35157.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc9097fc-fd6b-473e-bd4a-036dcc05fb5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/654dcf01-bc13-4e26-8020-2087d62fae01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "654dcf01-bc13-4e26-8020-2087d62fae01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_17-11-2021_35158.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/654dcf01-bc13-4e26-8020-2087d62fae01>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f8a77e2-b6b3-4718-b37b-eeae5462e12b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f8a77e2-b6b3-4718-b37b-eeae5462e12b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/6e96282fb0e237354a2ae4a1d0bbdbb9b5777b15a4849663f73152c14f40814c/GetPublication?filename=Uittreksels_17-11-2021_35302.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f8a77e2-b6b3-4718-b37b-eeae5462e12b>.
+    
+<http://data.lblod.info/id/remote-data-objects/41d1f4da-566f-4163-94c7-17387e3bcf43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41d1f4da-566f-4163-94c7-17387e3bcf43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41d1f4da-566f-4163-94c7-17387e3bcf43>.
+    
+<http://data.lblod.info/id/remote-data-objects/71544acd-c60b-456f-b55c-58c9962ab114> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71544acd-c60b-456f-b55c-58c9962ab114";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71544acd-c60b-456f-b55c-58c9962ab114>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e7083b7-7ffa-4986-bd5b-71a3294a70ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e7083b7-7ffa-4986-bd5b-71a3294a70ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e7083b7-7ffa-4986-bd5b-71a3294a70ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/f18a21a8-564c-4990-b7c9-70cd0a75b1cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f18a21a8-564c-4990-b7c9-70cd0a75b1cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f18a21a8-564c-4990-b7c9-70cd0a75b1cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/066d8967-df34-48f6-88c9-c720fa42d8e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "066d8967-df34-48f6-88c9-c720fa42d8e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/066d8967-df34-48f6-88c9-c720fa42d8e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1649a590-c024-4f8c-8b0e-a5c7fe1e6c9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1649a590-c024-4f8c-8b0e-a5c7fe1e6c9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1649a590-c024-4f8c-8b0e-a5c7fe1e6c9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0095c947-8834-46f8-b105-cc34d6c3befb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0095c947-8834-46f8-b105-cc34d6c3befb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0095c947-8834-46f8-b105-cc34d6c3befb>.
+    
+<http://data.lblod.info/id/remote-data-objects/4814e5ab-36d0-45c9-b9e2-4d5c9c9381ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4814e5ab-36d0-45c9-b9e2-4d5c9c9381ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4814e5ab-36d0-45c9-b9e2-4d5c9c9381ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/51189e77-5515-4b75-8173-a853ca6e5f4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51189e77-5515-4b75-8173-a853ca6e5f4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51189e77-5515-4b75-8173-a853ca6e5f4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bc95114-c7ac-4e93-bd6a-929d6bc4d332> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bc95114-c7ac-4e93-bd6a-929d6bc4d332";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bc95114-c7ac-4e93-bd6a-929d6bc4d332>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcdce5e5-d026-4cf5-9c2f-ad57ac3ef169> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcdce5e5-d026-4cf5-9c2f-ad57ac3ef169";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcdce5e5-d026-4cf5-9c2f-ad57ac3ef169>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccc00649-67b2-440b-83d4-30f870659a40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccc00649-67b2-440b-83d4-30f870659a40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccc00649-67b2-440b-83d4-30f870659a40>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c50a09e-d01d-42db-92f4-e6cc452c3fe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c50a09e-d01d-42db-92f4-e6cc452c3fe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c50a09e-d01d-42db-92f4-e6cc452c3fe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4a09edb-5a2c-4120-87ca-2e9c712c54ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4a09edb-5a2c-4120-87ca-2e9c712c54ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4a09edb-5a2c-4120-87ca-2e9c712c54ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/c36a4c41-62a3-4516-9dff-48d6348754bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c36a4c41-62a3-4516-9dff-48d6348754bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c36a4c41-62a3-4516-9dff-48d6348754bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/746fb7a2-2cea-4c4b-b911-9b3901e8ea83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "746fb7a2-2cea-4c4b-b911-9b3901e8ea83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/746fb7a2-2cea-4c4b-b911-9b3901e8ea83>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e5d1b79-97fa-428c-ae75-52e25d0e5040> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e5d1b79-97fa-428c-ae75-52e25d0e5040";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_12-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e5d1b79-97fa-428c-ae75-52e25d0e5040>.
+    
+<http://data.lblod.info/id/remote-data-objects/f901dffa-c16a-4394-ad34-7f3c4f407893> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f901dffa-c16a-4394-ad34-7f3c4f407893";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f901dffa-c16a-4394-ad34-7f3c4f407893>.
+    
+<http://data.lblod.info/id/remote-data-objects/cefba636-47f4-4da6-9d2f-5c93689674ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cefba636-47f4-4da6-9d2f-5c93689674ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cefba636-47f4-4da6-9d2f-5c93689674ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd4c95f9-9c89-4b5b-9940-d87113375f9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd4c95f9-9c89-4b5b-9940-d87113375f9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd4c95f9-9c89-4b5b-9940-d87113375f9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/dac74b1e-08bc-4548-b64f-a39368635536> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dac74b1e-08bc-4548-b64f-a39368635536";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dac74b1e-08bc-4548-b64f-a39368635536>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a87df8a-f908-4fa6-b46a-c6aa593267c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a87df8a-f908-4fa6-b46a-c6aa593267c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a87df8a-f908-4fa6-b46a-c6aa593267c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/367efd01-3636-4a77-b4ee-9cdf95f00795> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "367efd01-3636-4a77-b4ee-9cdf95f00795";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/367efd01-3636-4a77-b4ee-9cdf95f00795>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b44b5bb-450c-4b66-a76d-7226779d7c82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b44b5bb-450c-4b66-a76d-7226779d7c82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b44b5bb-450c-4b66-a76d-7226779d7c82>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6c81153-d8a0-4e52-96b7-04efc7564e73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6c81153-d8a0-4e52-96b7-04efc7564e73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6c81153-d8a0-4e52-96b7-04efc7564e73>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f240ac1-54fe-4fe0-a140-b76df9809dff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f240ac1-54fe-4fe0-a140-b76df9809dff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f240ac1-54fe-4fe0-a140-b76df9809dff>.
+    
+<http://data.lblod.info/id/remote-data-objects/045c1058-26b1-42b0-9ea4-367369539998> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "045c1058-26b1-42b0-9ea4-367369539998";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/045c1058-26b1-42b0-9ea4-367369539998>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3139f02-e15d-4677-9611-a5cadd73b4f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3139f02-e15d-4677-9611-a5cadd73b4f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3139f02-e15d-4677-9611-a5cadd73b4f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f0dec0c-67a1-48ff-86b4-a075ca8250a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f0dec0c-67a1-48ff-86b4-a075ca8250a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f0dec0c-67a1-48ff-86b4-a075ca8250a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcac0ffb-57ba-454d-8468-09ad16bef707> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcac0ffb-57ba-454d-8468-09ad16bef707";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcac0ffb-57ba-454d-8468-09ad16bef707>.
+    
+<http://data.lblod.info/id/remote-data-objects/a14f16bc-277c-44ab-b5bb-5e0cf79f20d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a14f16bc-277c-44ab-b5bb-5e0cf79f20d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a14f16bc-277c-44ab-b5bb-5e0cf79f20d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/2678ec1b-e25a-4528-8271-7fb3310740c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2678ec1b-e25a-4528-8271-7fb3310740c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2678ec1b-e25a-4528-8271-7fb3310740c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4eacb14-5eaf-4d2f-90c3-0f7bbfcdb5b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4eacb14-5eaf-4d2f-90c3-0f7bbfcdb5b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4eacb14-5eaf-4d2f-90c3-0f7bbfcdb5b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/815261b8-9706-4b29-9fb7-4e865f430dd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "815261b8-9706-4b29-9fb7-4e865f430dd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/815261b8-9706-4b29-9fb7-4e865f430dd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/3341d7f0-0706-49ae-8a38-d8a067bc1f04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3341d7f0-0706-49ae-8a38-d8a067bc1f04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3341d7f0-0706-49ae-8a38-d8a067bc1f04>.
+    
+<http://data.lblod.info/id/remote-data-objects/a26dcb7a-5e2f-47d4-b594-5989600ae7cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a26dcb7a-5e2f-47d4-b594-5989600ae7cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a26dcb7a-5e2f-47d4-b594-5989600ae7cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1efbd3b-03a5-467e-ab17-4dacf7858972> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1efbd3b-03a5-467e-ab17-4dacf7858972";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1efbd3b-03a5-467e-ab17-4dacf7858972>.
+    
+<http://data.lblod.info/id/remote-data-objects/c48c03a5-5713-4fba-9fc4-e9b5966e4eae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c48c03a5-5713-4fba-9fc4-e9b5966e4eae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c48c03a5-5713-4fba-9fc4-e9b5966e4eae>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a965485-1e06-4541-85a6-dc00a08e222d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a965485-1e06-4541-85a6-dc00a08e222d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf7f697d-83c7-40d1-a171-f8f70454bad4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a965485-1e06-4541-85a6-dc00a08e222d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201556-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201556-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201556-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201556-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/615deed7-4639-4efd-9958-c0ecbf586568> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "615deed7-4639-4efd-9958-c0ecbf586568";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6cbd4748-a6fb-4739-a86c-be6c33c16368";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/37dfe249-868b-4ec4-9bce-69308338e40b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "37dfe249-868b-4ec4-9bce-69308338e40b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368>.
+
+  <http://redpencil.data.gift/id/task/fd3d23b3-d04a-4299-8405-c3197d0bd6ae> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fd3d23b3-d04a-4299-8405-c3197d0bd6ae";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/615deed7-4639-4efd-9958-c0ecbf586568>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/37dfe249-868b-4ec4-9bce-69308338e40b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e8cef181-afa0-4699-ab27-22fd9b3289d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8cef181-afa0-4699-ab27-22fd9b3289d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8cef181-afa0-4699-ab27-22fd9b3289d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1217facf-c932-4522-acb1-d5187b012f12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1217facf-c932-4522-acb1-d5187b012f12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1217facf-c932-4522-acb1-d5187b012f12>.
+    
+<http://data.lblod.info/id/remote-data-objects/77a7c6cd-bd1d-46bd-b1df-c05caca0e1a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77a7c6cd-bd1d-46bd-b1df-c05caca0e1a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77a7c6cd-bd1d-46bd-b1df-c05caca0e1a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/82fc3bb5-5d92-4a06-91ac-67f4456d778e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82fc3bb5-5d92-4a06-91ac-67f4456d778e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82fc3bb5-5d92-4a06-91ac-67f4456d778e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa08672f-00c9-424b-b2b0-64b7c9701ab9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa08672f-00c9-424b-b2b0-64b7c9701ab9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa08672f-00c9-424b-b2b0-64b7c9701ab9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4c9ff42-4c3a-453b-ae7f-5f90323611c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4c9ff42-4c3a-453b-ae7f-5f90323611c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=BesluitenLijst_College_31-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4c9ff42-4c3a-453b-ae7f-5f90323611c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ee4e29e-7258-43b0-a086-6002d2c9acd4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ee4e29e-7258-43b0-a086-6002d2c9acd4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_02-05-2022_37809.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ee4e29e-7258-43b0-a086-6002d2c9acd4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1cfdde7-592b-4715-8ec1-c2d17c414fd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1cfdde7-592b-4715-8ec1-c2d17c414fd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_02-05-2022_37824.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1cfdde7-592b-4715-8ec1-c2d17c414fd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/090598a0-9940-4617-98a8-abd34af13b39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "090598a0-9940-4617-98a8-abd34af13b39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_02-05-2022_37825.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/090598a0-9940-4617-98a8-abd34af13b39>.
+    
+<http://data.lblod.info/id/remote-data-objects/6de773cb-aba9-474d-8bd0-24269beadc4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6de773cb-aba9-474d-8bd0-24269beadc4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_07-02-2022_36571.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6de773cb-aba9-474d-8bd0-24269beadc4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/717399f3-069e-46c6-a753-6eb4bba7225b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "717399f3-069e-46c6-a753-6eb4bba7225b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_07-02-2022_36583.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/717399f3-069e-46c6-a753-6eb4bba7225b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cb18f44-f846-4c31-a3c1-05edd441ef23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cb18f44-f846-4c31-a3c1-05edd441ef23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_07-03-2022_37001.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cb18f44-f846-4c31-a3c1-05edd441ef23>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb8f9f58-0e14-4cf7-a7a6-19d8e8d71c40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb8f9f58-0e14-4cf7-a7a6-19d8e8d71c40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_07-03-2022_37002.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb8f9f58-0e14-4cf7-a7a6-19d8e8d71c40>.
+    
+<http://data.lblod.info/id/remote-data-objects/efa2d9c9-7051-41bb-8e04-c27eeeab4895> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efa2d9c9-7051-41bb-8e04-c27eeeab4895";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_07-03-2022_37015.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efa2d9c9-7051-41bb-8e04-c27eeeab4895>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ba83a52-c3e9-4fba-8a44-712dae07a778> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ba83a52-c3e9-4fba-8a44-712dae07a778";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_09-05-2022_37926.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ba83a52-c3e9-4fba-8a44-712dae07a778>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fb3955e-30dd-47fd-8db2-265f301726ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fb3955e-30dd-47fd-8db2-265f301726ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_09-05-2022_37928.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fb3955e-30dd-47fd-8db2-265f301726ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/89c70037-e287-409e-a666-7d5f429acd10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89c70037-e287-409e-a666-7d5f429acd10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_10-01-2022_36127.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89c70037-e287-409e-a666-7d5f429acd10>.
+    
+<http://data.lblod.info/id/remote-data-objects/39508824-9514-41d2-8624-fb0d597f6e5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39508824-9514-41d2-8624-fb0d597f6e5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_11-10-2021_34958.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39508824-9514-41d2-8624-fb0d597f6e5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0130e48e-723c-40e3-a738-e33230bca57e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0130e48e-723c-40e3-a738-e33230bca57e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_13-06-2022_38383.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0130e48e-723c-40e3-a738-e33230bca57e>.
+    
+<http://data.lblod.info/id/remote-data-objects/25b9c618-1f4c-42ac-9d18-c31069599956> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25b9c618-1f4c-42ac-9d18-c31069599956";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_13-06-2022_38491.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25b9c618-1f4c-42ac-9d18-c31069599956>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d1b7a47-7e0c-442c-9150-6f52a17aae67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d1b7a47-7e0c-442c-9150-6f52a17aae67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_14-03-2022_37066.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d1b7a47-7e0c-442c-9150-6f52a17aae67>.
+    
+<http://data.lblod.info/id/remote-data-objects/c57cd1f3-3fc3-4f07-89ee-224e81f0b9eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c57cd1f3-3fc3-4f07-89ee-224e81f0b9eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_14-03-2022_37112.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c57cd1f3-3fc3-4f07-89ee-224e81f0b9eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/97915cb3-bb64-4724-a294-bb4703ee781e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97915cb3-bb64-4724-a294-bb4703ee781e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_15-07-2022_39000.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97915cb3-bb64-4724-a294-bb4703ee781e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3605c768-ca88-4458-b15a-e5340354fdea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3605c768-ca88-4458-b15a-e5340354fdea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_15-07-2022_39080.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3605c768-ca88-4458-b15a-e5340354fdea>.
+    
+<http://data.lblod.info/id/remote-data-objects/41699475-ff82-4cb6-adec-8270d2353a62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41699475-ff82-4cb6-adec-8270d2353a62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_16-05-2022_38094.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41699475-ff82-4cb6-adec-8270d2353a62>.
+    
+<http://data.lblod.info/id/remote-data-objects/897ffe88-e53d-458a-823b-cb3f70c3bd83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "897ffe88-e53d-458a-823b-cb3f70c3bd83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_21-02-2022_36731.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/897ffe88-e53d-458a-823b-cb3f70c3bd83>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b86afbf-cc50-4b98-bada-941acd6767eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b86afbf-cc50-4b98-bada-941acd6767eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_21-02-2022_36737.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b86afbf-cc50-4b98-bada-941acd6767eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/efabc4b6-e5f0-4d49-befb-ded79d779fbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efabc4b6-e5f0-4d49-befb-ded79d779fbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_21-03-2022_36985.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efabc4b6-e5f0-4d49-befb-ded79d779fbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/17c41e21-82f5-4441-9f15-9a1f781f3003> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17c41e21-82f5-4441-9f15-9a1f781f3003";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_22-11-2021_35458.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17c41e21-82f5-4441-9f15-9a1f781f3003>.
+    
+<http://data.lblod.info/id/remote-data-objects/b52181b4-1b42-4289-8893-ad132271a94b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b52181b4-1b42-4289-8893-ad132271a94b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_27-06-2022_38646.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b52181b4-1b42-4289-8893-ad132271a94b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f821e3a-f73e-4695-9820-b55e033ebc1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f821e3a-f73e-4695-9820-b55e033ebc1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_27-06-2022_38659.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f821e3a-f73e-4695-9820-b55e033ebc1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b430656-20fa-47d9-b982-3398a0f91b73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b430656-20fa-47d9-b982-3398a0f91b73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_27-06-2022_38856.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b430656-20fa-47d9-b982-3398a0f91b73>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d2db6da-01c9-43ca-9fd9-ab206ba539a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d2db6da-01c9-43ca-9fd9-ab206ba539a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_27-12-2021_36084.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d2db6da-01c9-43ca-9fd9-ab206ba539a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/15bc531c-2645-4c2b-870c-6d67f76da790> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15bc531c-2645-4c2b-870c-6d67f76da790";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_28-02-2022_36840.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15bc531c-2645-4c2b-870c-6d67f76da790>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe215b1d-5bf8-4c03-b7db-25d0453002a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe215b1d-5bf8-4c03-b7db-25d0453002a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_28-02-2022_36841.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe215b1d-5bf8-4c03-b7db-25d0453002a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/625ac9f7-0419-48fe-ac4c-c0deddc0274e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "625ac9f7-0419-48fe-ac4c-c0deddc0274e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_28-02-2022_36842.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/625ac9f7-0419-48fe-ac4c-c0deddc0274e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ded26bd-d4af-4f4a-b432-b522046107ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ded26bd-d4af-4f4a-b432-b522046107ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_28-02-2022_36871.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ded26bd-d4af-4f4a-b432-b522046107ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/c48486d3-7f94-4220-9984-29e76cb54613> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c48486d3-7f94-4220-9984-29e76cb54613";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_28-02-2022_36888.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c48486d3-7f94-4220-9984-29e76cb54613>.
+    
+<http://data.lblod.info/id/remote-data-objects/390a5db8-59f4-407e-9097-6aa53efccb6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "390a5db8-59f4-407e-9097-6aa53efccb6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_28-03-2022_37278.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/390a5db8-59f4-407e-9097-6aa53efccb6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6407c208-4102-484d-a06b-5f9bb9262286> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6407c208-4102-484d-a06b-5f9bb9262286";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_28-03-2022_37373.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6407c208-4102-484d-a06b-5f9bb9262286>.
+    
+<http://data.lblod.info/id/remote-data-objects/a12c9160-76d2-4348-b9ea-e1ec39a3ccb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a12c9160-76d2-4348-b9ea-e1ec39a3ccb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_30-05-2022_38174.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a12c9160-76d2-4348-b9ea-e1ec39a3ccb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1a173f8-509f-423a-9d72-7ac1683f6f11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1a173f8-509f-423a-9d72-7ac1683f6f11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/9c4218200344cd5b7242d3e34ba606fc311aec4070a3d90d9c783284420798b8/GetPublication?filename=Uittreksels_31-01-2022_36467.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1a173f8-509f-423a-9d72-7ac1683f6f11>.
+    
+<http://data.lblod.info/id/remote-data-objects/f12e9f96-4100-41d1-a504-a871dc0f12ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f12e9f96-4100-41d1-a504-a871dc0f12ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/e5b8287d93e22e636931e6e206bff6b7438d51b0f02395a92fcfb5265282d948/GetPublication?filename=BesluitenLijst_Beslissingen%20burgemeester_02-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f12e9f96-4100-41d1-a504-a871dc0f12ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cb38251-7923-4e1a-9b88-6b14499659bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cb38251-7923-4e1a-9b88-6b14499659bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/e5b8287d93e22e636931e6e206bff6b7438d51b0f02395a92fcfb5265282d948/GetPublication?filename=BesluitenLijst_Beslissingen%20burgemeester_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cb38251-7923-4e1a-9b88-6b14499659bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/63e4c880-53fb-460a-a7e9-2a4d41f66aee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63e4c880-53fb-460a-a7e9-2a4d41f66aee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/e5b8287d93e22e636931e6e206bff6b7438d51b0f02395a92fcfb5265282d948/GetPublication?filename=BesluitenLijst_Beslissingen%20burgemeester_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63e4c880-53fb-460a-a7e9-2a4d41f66aee>.
+    
+<http://data.lblod.info/id/remote-data-objects/a64d9c66-a053-4b69-992e-c078721108f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a64d9c66-a053-4b69-992e-c078721108f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/e5b8287d93e22e636931e6e206bff6b7438d51b0f02395a92fcfb5265282d948/GetPublication?filename=BesluitenLijst_Beslissingen%20burgemeester_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a64d9c66-a053-4b69-992e-c078721108f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f5db219-50a2-4995-814c-b857f3f915d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f5db219-50a2-4995-814c-b857f3f915d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/e5b8287d93e22e636931e6e206bff6b7438d51b0f02395a92fcfb5265282d948/GetPublication?filename=BesluitenLijst_Beslissingen%20burgemeester_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f5db219-50a2-4995-814c-b857f3f915d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/23265b93-cbab-4677-8152-06a97c9b964b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23265b93-cbab-4677-8152-06a97c9b964b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/e5b8287d93e22e636931e6e206bff6b7438d51b0f02395a92fcfb5265282d948/GetPublication?filename=BesluitenLijst_Beslissingen%20burgemeester_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23265b93-cbab-4677-8152-06a97c9b964b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e0e73c7-6dde-4468-bd61-333cfe541274> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e0e73c7-6dde-4468-bd61-333cfe541274";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/e5b8287d93e22e636931e6e206bff6b7438d51b0f02395a92fcfb5265282d948/GetPublication?filename=BesluitenLijst_Beslissingen%20burgemeester_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e0e73c7-6dde-4468-bd61-333cfe541274>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1d46046-632b-4996-b08c-1dfbc87c188e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1d46046-632b-4996-b08c-1dfbc87c188e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/e5b8287d93e22e636931e6e206bff6b7438d51b0f02395a92fcfb5265282d948/GetPublication?filename=Uittreksels_08-10-2021_34992.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6cbd4748-a6fb-4739-a86c-be6c33c16368> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1d46046-632b-4996-b08c-1dfbc87c188e>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201557-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201557-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201557-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201557-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b79936c8-779b-4d27-b44e-98048cd5d026> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b79936c8-779b-4d27-b44e-98048cd5d026";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "121bf6f8-e93c-480a-b5c8-e7135d63ee5d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/2c0c7e45-1d81-417f-9e2b-5303da2884c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2c0c7e45-1d81-417f-9e2b-5303da2884c0";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d>.
+
+  <http://redpencil.data.gift/id/task/8b13c3aa-3d04-47d7-a18d-1697bd3e8773> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8b13c3aa-3d04-47d7-a18d-1697bd3e8773";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b79936c8-779b-4d27-b44e-98048cd5d026>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/2c0c7e45-1d81-417f-9e2b-5303da2884c0>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/8d9aa30c-ad45-4400-b4eb-943a7d6f99d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d9aa30c-ad45-4400-b4eb-943a7d6f99d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Agenda_OCMW-Raad_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d9aa30c-ad45-4400-b4eb-943a7d6f99d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/43f072ad-6c7b-469b-a07d-afbf04f84931> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43f072ad-6c7b-469b-a07d-afbf04f84931";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Agenda_OCMW-Raad_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43f072ad-6c7b-469b-a07d-afbf04f84931>.
+    
+<http://data.lblod.info/id/remote-data-objects/325d5996-774a-4e81-979a-f45653f402a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "325d5996-774a-4e81-979a-f45653f402a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Agenda_OCMW-Raad_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/325d5996-774a-4e81-979a-f45653f402a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/21b19938-d973-4e5e-9463-89fa6dfc0d0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21b19938-d973-4e5e-9463-89fa6dfc0d0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Agenda_OCMW-Raad_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21b19938-d973-4e5e-9463-89fa6dfc0d0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b31dccc-62ad-42c1-9ac7-641dfee5770e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b31dccc-62ad-42c1-9ac7-641dfee5770e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Agenda_OCMW-Raad_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b31dccc-62ad-42c1-9ac7-641dfee5770e>.
+    
+<http://data.lblod.info/id/remote-data-objects/12f6d861-8423-4a15-926c-c001c52fe869> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12f6d861-8423-4a15-926c-c001c52fe869";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Agenda_OCMW-Raad_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12f6d861-8423-4a15-926c-c001c52fe869>.
+    
+<http://data.lblod.info/id/remote-data-objects/49eb843d-e20e-440b-9bbc-135922f63dbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49eb843d-e20e-440b-9bbc-135922f63dbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Agenda_OCMW-Raad_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49eb843d-e20e-440b-9bbc-135922f63dbb>.
+    
+<http://data.lblod.info/id/remote-data-objects/b80daa67-3684-4ddd-ad75-31945ab6c571> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b80daa67-3684-4ddd-ad75-31945ab6c571";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Agenda_OCMW-Raad_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b80daa67-3684-4ddd-ad75-31945ab6c571>.
+    
+<http://data.lblod.info/id/remote-data-objects/684024cb-e212-4bfd-9cb2-f408b3f7517e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "684024cb-e212-4bfd-9cb2-f408b3f7517e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Agenda_OCMW-Raad_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/684024cb-e212-4bfd-9cb2-f408b3f7517e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c38e7b4-8ac9-42b5-9100-9d699df46a6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c38e7b4-8ac9-42b5-9100-9d699df46a6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=BesluitenLijst_OCMW-Raad_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c38e7b4-8ac9-42b5-9100-9d699df46a6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1aeeaa9b-1bca-4a3e-915a-96d93f9bfe1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1aeeaa9b-1bca-4a3e-915a-96d93f9bfe1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=BesluitenLijst_OCMW-Raad_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1aeeaa9b-1bca-4a3e-915a-96d93f9bfe1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/84d5f196-4204-4934-afe4-0359382697b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84d5f196-4204-4934-afe4-0359382697b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=BesluitenLijst_OCMW-Raad_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84d5f196-4204-4934-afe4-0359382697b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/d09d5971-906f-496b-a4df-bf1bf5335f42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d09d5971-906f-496b-a4df-bf1bf5335f42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=BesluitenLijst_OCMW-Raad_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d09d5971-906f-496b-a4df-bf1bf5335f42>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd0bb7fa-2155-4fdc-8b79-47fb4b99ed80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd0bb7fa-2155-4fdc-8b79-47fb4b99ed80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=BesluitenLijst_OCMW-Raad_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd0bb7fa-2155-4fdc-8b79-47fb4b99ed80>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac12c30a-ddfa-4393-a53a-3164157e57c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac12c30a-ddfa-4393-a53a-3164157e57c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=BesluitenLijst_OCMW-Raad_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac12c30a-ddfa-4393-a53a-3164157e57c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e910c12-8d81-4415-bed5-d253fb518129> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e910c12-8d81-4415-bed5-d253fb518129";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=BesluitenLijst_OCMW-Raad_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e910c12-8d81-4415-bed5-d253fb518129>.
+    
+<http://data.lblod.info/id/remote-data-objects/10bc0e4b-a110-46db-bf75-4b1db2dc3680> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10bc0e4b-a110-46db-bf75-4b1db2dc3680";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=BesluitenLijst_OCMW-Raad_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10bc0e4b-a110-46db-bf75-4b1db2dc3680>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e634771-2f8f-4424-bcb5-cb620b65e8e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e634771-2f8f-4424-bcb5-cb620b65e8e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=BesluitenLijst_raad%20voor%20maatschappelijk%20welzijn_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e634771-2f8f-4424-bcb5-cb620b65e8e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/37b5deff-b9dc-4536-9372-d7763d5f7e04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37b5deff-b9dc-4536-9372-d7763d5f7e04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Notulen_OCMW-Raad_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37b5deff-b9dc-4536-9372-d7763d5f7e04>.
+    
+<http://data.lblod.info/id/remote-data-objects/af638956-be39-473d-93a0-5925bc148dd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af638956-be39-473d-93a0-5925bc148dd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Notulen_OCMW-Raad_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af638956-be39-473d-93a0-5925bc148dd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/98c6fe9d-85f9-447f-b23e-f78839277668> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98c6fe9d-85f9-447f-b23e-f78839277668";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Notulen_OCMW-Raad_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98c6fe9d-85f9-447f-b23e-f78839277668>.
+    
+<http://data.lblod.info/id/remote-data-objects/7eb770be-8953-4964-be0c-1b8fdad285d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7eb770be-8953-4964-be0c-1b8fdad285d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Notulen_OCMW-Raad_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7eb770be-8953-4964-be0c-1b8fdad285d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/144ed08f-fe93-4940-a35c-086360dba98d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "144ed08f-fe93-4940-a35c-086360dba98d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Notulen_OCMW-Raad_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/144ed08f-fe93-4940-a35c-086360dba98d>.
+    
+<http://data.lblod.info/id/remote-data-objects/64e8c449-81f6-4e4f-97af-c6e54d980240> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64e8c449-81f6-4e4f-97af-c6e54d980240";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Notulen_OCMW-Raad_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64e8c449-81f6-4e4f-97af-c6e54d980240>.
+    
+<http://data.lblod.info/id/remote-data-objects/926ee495-6fc8-4355-912b-e1faa30880be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "926ee495-6fc8-4355-912b-e1faa30880be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Notulen_OCMW-Raad_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/926ee495-6fc8-4355-912b-e1faa30880be>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ff84a80-d08c-4fc6-b8be-74289d86cc6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ff84a80-d08c-4fc6-b8be-74289d86cc6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ff84a80-d08c-4fc6-b8be-74289d86cc6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e17ea9ae-0ee0-4528-9b4c-5b29367cd3c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e17ea9ae-0ee0-4528-9b4c-5b29367cd3c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Uittreksels_06-04-2022_36853.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e17ea9ae-0ee0-4528-9b4c-5b29367cd3c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/53f33f0e-cab6-44fd-bcf9-6f6fa3115baa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53f33f0e-cab6-44fd-bcf9-6f6fa3115baa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Uittreksels_06-04-2022_37478.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53f33f0e-cab6-44fd-bcf9-6f6fa3115baa>.
+    
+<http://data.lblod.info/id/remote-data-objects/07837325-b601-425c-b7d9-e83ce39dd8e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07837325-b601-425c-b7d9-e83ce39dd8e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Uittreksels_17-11-2021_35155.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07837325-b601-425c-b7d9-e83ce39dd8e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/acc22b75-f3db-497e-9fe2-6177af20079f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acc22b75-f3db-497e-9fe2-6177af20079f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Uittreksels_17-11-2021_35301.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acc22b75-f3db-497e-9fe2-6177af20079f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed1f4bc3-8eed-4605-8a0a-2c562ce09dd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed1f4bc3-8eed-4605-8a0a-2c562ce09dd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.meulebeke.be/LBLODWeb/Home/Overzicht/f037131484750120c7d5316a3ecee0132aadd1ff1cb63d7bf51ea51692cdf5ae/GetPublication?filename=Uittreksels_17-11-2021_35303.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed1f4bc3-8eed-4605-8a0a-2c562ce09dd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/99daa9a5-6e3c-45cd-ac14-2eddc6ae7f8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99daa9a5-6e3c-45cd-ac14-2eddc6ae7f8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=BesluitenLijstUitspraak_RMW_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99daa9a5-6e3c-45cd-ac14-2eddc6ae7f8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ff99622-797e-48f2-9579-e2653993100f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ff99622-797e-48f2-9579-e2653993100f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=BesluitenLijstUitspraak_RMW_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ff99622-797e-48f2-9579-e2653993100f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b1e2100-a34f-4da7-85c8-51771ce68957> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b1e2100-a34f-4da7-85c8-51771ce68957";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=BesluitenLijstUitspraak_RMW_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b1e2100-a34f-4da7-85c8-51771ce68957>.
+    
+<http://data.lblod.info/id/remote-data-objects/abdfd181-0e05-487f-a5ee-3c3cc7161d97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abdfd181-0e05-487f-a5ee-3c3cc7161d97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=BesluitenLijstUitspraak_RMW_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abdfd181-0e05-487f-a5ee-3c3cc7161d97>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ef542a0-d07b-45c6-b776-20d00b4155a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ef542a0-d07b-45c6-b776-20d00b4155a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=BesluitenLijstUitspraak_RMW_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ef542a0-d07b-45c6-b776-20d00b4155a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ee28cfc-dc16-441b-bf0e-36e2d92688e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ee28cfc-dc16-441b-bf0e-36e2d92688e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=BesluitenLijstUitspraak_RMW_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ee28cfc-dc16-441b-bf0e-36e2d92688e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a448fde-5edf-4753-9f2a-0ab724c10376> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a448fde-5edf-4753-9f2a-0ab724c10376";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=BesluitenLijstUitspraak_RMW_12-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a448fde-5edf-4753-9f2a-0ab724c10376>.
+    
+<http://data.lblod.info/id/remote-data-objects/b64c833c-2f1f-4ec3-a935-58da11521e37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b64c833c-2f1f-4ec3-a935-58da11521e37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=BesluitenLijstUitspraak_RMW_13-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b64c833c-2f1f-4ec3-a935-58da11521e37>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ce66408-5927-485e-ad43-07fb7f7ce4e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ce66408-5927-485e-ad43-07fb7f7ce4e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=BesluitenLijstUitspraak_RMW_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ce66408-5927-485e-ad43-07fb7f7ce4e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c71717c-a6ba-4f23-8625-a02ec85f042f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c71717c-a6ba-4f23-8625-a02ec85f042f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=BesluitenLijstUitspraak_RMW_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c71717c-a6ba-4f23-8625-a02ec85f042f>.
+    
+<http://data.lblod.info/id/remote-data-objects/86da6d2e-33ed-4b0b-b7ef-5f58715c3fc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86da6d2e-33ed-4b0b-b7ef-5f58715c3fc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=Uittreksels_08-06-2022_80450.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86da6d2e-33ed-4b0b-b7ef-5f58715c3fc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/22e72dd1-df8c-4512-8e0b-403e529eb132> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22e72dd1-df8c-4512-8e0b-403e529eb132";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=Uittreksels_08-12-2021_75628.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22e72dd1-df8c-4512-8e0b-403e529eb132>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c467f36-2092-4488-b1de-d32dee1be26d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c467f36-2092-4488-b1de-d32dee1be26d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=Uittreksels_08-12-2021_76923.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c467f36-2092-4488-b1de-d32dee1be26d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f781f66-335d-4ed2-b019-4fc7c35ebbc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f781f66-335d-4ed2-b019-4fc7c35ebbc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=Uittreksels_08-12-2021_76924.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f781f66-335d-4ed2-b019-4fc7c35ebbc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/780a1f26-ddc5-4028-83f9-19aa023a22cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "780a1f26-ddc5-4028-83f9-19aa023a22cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=Uittreksels_08-12-2021_76935.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/780a1f26-ddc5-4028-83f9-19aa023a22cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/46f23964-961c-4e3b-951b-be593fe37222> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46f23964-961c-4e3b-951b-be593fe37222";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=Uittreksels_08-12-2021_76937.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46f23964-961c-4e3b-951b-be593fe37222>.
+    
+<http://data.lblod.info/id/remote-data-objects/8958cbf0-5a78-4c04-ae89-f097ea1be998> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8958cbf0-5a78-4c04-ae89-f097ea1be998";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=Uittreksels_08-12-2021_76938.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8958cbf0-5a78-4c04-ae89-f097ea1be998>.
+    
+<http://data.lblod.info/id/remote-data-objects/d896682b-eb8d-4357-84da-67b15e0a9be3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d896682b-eb8d-4357-84da-67b15e0a9be3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=Uittreksels_08-12-2021_76939.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d896682b-eb8d-4357-84da-67b15e0a9be3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2da3e0b-e911-4575-ac76-37458646fd81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2da3e0b-e911-4575-ac76-37458646fd81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=Uittreksels_08-12-2021_77306.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/121bf6f8-e93c-480a-b5c8-e7135d63ee5d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2da3e0b-e911-4575-ac76-37458646fd81>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201558-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201558-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201558-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201558-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/68a11d09-1cd4-41c5-ba1c-e0d45c6fe936> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "68a11d09-1cd4-41c5-ba1c-e0d45c6fe936";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "10edd989-fcf4-492d-9e26-5d35dd818ac3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c072247f-1778-4d66-b7d1-36a7cbfda2c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c072247f-1778-4d66-b7d1-36a7cbfda2c9";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3>.
+
+  <http://redpencil.data.gift/id/task/1be4300e-247b-4eff-b699-a8549ccb0cff> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1be4300e-247b-4eff-b699-a8549ccb0cff";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/68a11d09-1cd4-41c5-ba1c-e0d45c6fe936>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c072247f-1778-4d66-b7d1-36a7cbfda2c9>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b3f36b41-975a-4fde-b0e4-1e3d1da7302b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3f36b41-975a-4fde-b0e4-1e3d1da7302b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=Uittreksels_08-12-2021_77313.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3f36b41-975a-4fde-b0e4-1e3d1da7302b>.
+    
+<http://data.lblod.info/id/remote-data-objects/62ee68d7-b1bb-4fbf-b1e6-fe2a0dad4a02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62ee68d7-b1bb-4fbf-b1e6-fe2a0dad4a02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=Uittreksels_09-02-2022_78055.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62ee68d7-b1bb-4fbf-b1e6-fe2a0dad4a02>.
+    
+<http://data.lblod.info/id/remote-data-objects/36d5a6ad-90eb-452a-b406-8989b7e3641f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36d5a6ad-90eb-452a-b406-8989b7e3641f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=Uittreksels_09-02-2022_78386.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36d5a6ad-90eb-452a-b406-8989b7e3641f>.
+    
+<http://data.lblod.info/id/remote-data-objects/10c4fc5c-2e4c-4b9b-8472-de3b5b0c9499> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10c4fc5c-2e4c-4b9b-8472-de3b5b0c9499";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=Uittreksels_09-02-2022_78387.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10c4fc5c-2e4c-4b9b-8472-de3b5b0c9499>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac9b5e32-2037-4ae6-9fff-3098d079d413> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac9b5e32-2037-4ae6-9fff-3098d079d413";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=Uittreksels_09-03-2022_78299.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac9b5e32-2037-4ae6-9fff-3098d079d413>.
+    
+<http://data.lblod.info/id/remote-data-objects/1334cde4-7733-43d6-a979-7e6f8f614bcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1334cde4-7733-43d6-a979-7e6f8f614bcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/1c3aa67a2b9654cebbbc9b2bf319269ba1f4243719400fdd7fcf37b3e7e3a450/GetPublication?filename=Uittreksels_09-03-2022_78300.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1334cde4-7733-43d6-a979-7e6f8f614bcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/84d19c7f-b197-483e-aed4-dccb3e104f4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84d19c7f-b197-483e-aed4-dccb3e104f4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Agenda_Gemeenteraad_12-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84d19c7f-b197-483e-aed4-dccb3e104f4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fb82e1a-c306-4ea0-bd22-3e58e4674db4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fb82e1a-c306-4ea0-bd22-3e58e4674db4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fb82e1a-c306-4ea0-bd22-3e58e4674db4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f31e2eb-0961-4b4d-99e0-f21b6e8278d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f31e2eb-0961-4b4d-99e0-f21b6e8278d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f31e2eb-0961-4b4d-99e0-f21b6e8278d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd190477-7017-41e0-9695-10dc27a90038> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd190477-7017-41e0-9695-10dc27a90038";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd190477-7017-41e0-9695-10dc27a90038>.
+    
+<http://data.lblod.info/id/remote-data-objects/93e1b991-9fa8-45dd-a9ad-cb16c20bbac4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93e1b991-9fa8-45dd-a9ad-cb16c20bbac4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93e1b991-9fa8-45dd-a9ad-cb16c20bbac4>.
+    
+<http://data.lblod.info/id/remote-data-objects/37079bb2-cebd-4350-9125-616bab31f495> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37079bb2-cebd-4350-9125-616bab31f495";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37079bb2-cebd-4350-9125-616bab31f495>.
+    
+<http://data.lblod.info/id/remote-data-objects/add4819b-cd0d-46d3-94e8-2938d975c9b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "add4819b-cd0d-46d3-94e8-2938d975c9b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/add4819b-cd0d-46d3-94e8-2938d975c9b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ee5b2f8-b45b-48d9-8af9-cab1280a76ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ee5b2f8-b45b-48d9-8af9-cab1280a76ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_12-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ee5b2f8-b45b-48d9-8af9-cab1280a76ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/500256f2-ffcf-4826-ae2d-d475f30e03a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "500256f2-ffcf-4826-ae2d-d475f30e03a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_13-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/500256f2-ffcf-4826-ae2d-d475f30e03a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7f29c7b-b963-4be2-9e1f-94dcf071f159> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7f29c7b-b963-4be2-9e1f-94dcf071f159";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7f29c7b-b963-4be2-9e1f-94dcf071f159>.
+    
+<http://data.lblod.info/id/remote-data-objects/db8d02c7-b846-4144-8479-d0ad9b78d01a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db8d02c7-b846-4144-8479-d0ad9b78d01a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db8d02c7-b846-4144-8479-d0ad9b78d01a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6226add4-4f43-4214-b288-6f126205c1ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6226add4-4f43-4214-b288-6f126205c1ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_08-06-2022_80170.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6226add4-4f43-4214-b288-6f126205c1ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2cb4f6b-d77f-4c86-ae92-1f99759321d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2cb4f6b-d77f-4c86-ae92-1f99759321d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_08-06-2022_80445.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2cb4f6b-d77f-4c86-ae92-1f99759321d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/d55e658b-85d0-49a2-8129-d762d8732586> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d55e658b-85d0-49a2-8129-d762d8732586";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_08-06-2022_80447.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d55e658b-85d0-49a2-8129-d762d8732586>.
+    
+<http://data.lblod.info/id/remote-data-objects/1dc17800-73ec-4cbe-b2a4-ea365226c7c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1dc17800-73ec-4cbe-b2a4-ea365226c7c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_08-06-2022_80449.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1dc17800-73ec-4cbe-b2a4-ea365226c7c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfece922-c126-4103-bbcf-1c71fc11ed40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfece922-c126-4103-bbcf-1c71fc11ed40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_08-06-2022_82286.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfece922-c126-4103-bbcf-1c71fc11ed40>.
+    
+<http://data.lblod.info/id/remote-data-objects/19d7c389-1531-4c15-a257-d6340dcfd81c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19d7c389-1531-4c15-a257-d6340dcfd81c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_08-12-2021_75624.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19d7c389-1531-4c15-a257-d6340dcfd81c>.
+    
+<http://data.lblod.info/id/remote-data-objects/803ca5e7-8eaa-4f89-a379-f8c56db81912> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "803ca5e7-8eaa-4f89-a379-f8c56db81912";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_08-12-2021_75625.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/803ca5e7-8eaa-4f89-a379-f8c56db81912>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e647450-9ec9-42f1-91f5-42eb8772016e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e647450-9ec9-42f1-91f5-42eb8772016e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_08-12-2021_75627.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e647450-9ec9-42f1-91f5-42eb8772016e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bc2b79a-74bc-4f57-aa7e-8c2d7b8813e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bc2b79a-74bc-4f57-aa7e-8c2d7b8813e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_08-12-2021_75853.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bc2b79a-74bc-4f57-aa7e-8c2d7b8813e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6667cb0-8298-440e-b0ae-8761aceed844> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6667cb0-8298-440e-b0ae-8761aceed844";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_08-12-2021_77092.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6667cb0-8298-440e-b0ae-8761aceed844>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cb4d51d-6e33-41c4-9ee4-f6e1ffccfb9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cb4d51d-6e33-41c4-9ee4-f6e1ffccfb9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_08-12-2021_77349.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cb4d51d-6e33-41c4-9ee4-f6e1ffccfb9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cc2c843-67ae-4346-96b6-6059064dd092> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cc2c843-67ae-4346-96b6-6059064dd092";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_09-02-2022_77267.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cc2c843-67ae-4346-96b6-6059064dd092>.
+    
+<http://data.lblod.info/id/remote-data-objects/c992654e-b75d-419e-b3b9-8c40e86f8be8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c992654e-b75d-419e-b3b9-8c40e86f8be8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_09-02-2022_77903.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c992654e-b75d-419e-b3b9-8c40e86f8be8>.
+    
+<http://data.lblod.info/id/remote-data-objects/195a475a-5766-413a-bda6-9a031fbd69b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "195a475a-5766-413a-bda6-9a031fbd69b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_09-02-2022_78343.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/195a475a-5766-413a-bda6-9a031fbd69b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c66ef93a-a0fd-4fc8-ac43-173108fe4902> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c66ef93a-a0fd-4fc8-ac43-173108fe4902";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_09-03-2022_78402.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c66ef93a-a0fd-4fc8-ac43-173108fe4902>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ef9fb03-182e-4f2c-af71-8bdac1533a55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ef9fb03-182e-4f2c-af71-8bdac1533a55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_09-03-2022_78684.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ef9fb03-182e-4f2c-af71-8bdac1533a55>.
+    
+<http://data.lblod.info/id/remote-data-objects/87e4b0cd-965c-4569-b6a4-8ef89bf0a10e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87e4b0cd-965c-4569-b6a4-8ef89bf0a10e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_09-03-2022_78687.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87e4b0cd-965c-4569-b6a4-8ef89bf0a10e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b83b394f-d1d5-43bc-80ff-47c2e6d783da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b83b394f-d1d5-43bc-80ff-47c2e6d783da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_11-05-2022_80365.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b83b394f-d1d5-43bc-80ff-47c2e6d783da>.
+    
+<http://data.lblod.info/id/remote-data-objects/80790508-0e34-4ab9-8aa8-b6d193b0bd85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80790508-0e34-4ab9-8aa8-b6d193b0bd85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_12-01-2022_75699.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80790508-0e34-4ab9-8aa8-b6d193b0bd85>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ca7015a-3ca7-4b00-ad15-7356d1b73c1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ca7015a-3ca7-4b00-ad15-7356d1b73c1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_12-01-2022_77106.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ca7015a-3ca7-4b00-ad15-7356d1b73c1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6d633a1-6447-46f1-bb27-211e0a50dd54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6d633a1-6447-46f1-bb27-211e0a50dd54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_12-01-2022_77432.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6d633a1-6447-46f1-bb27-211e0a50dd54>.
+    
+<http://data.lblod.info/id/remote-data-objects/a19564d1-4a5e-45f1-a80c-d16a50141ca6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a19564d1-4a5e-45f1-a80c-d16a50141ca6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-04-2022_78639.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a19564d1-4a5e-45f1-a80c-d16a50141ca6>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b3ba37a-d151-4def-8ccc-5ece4082fc42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b3ba37a-d151-4def-8ccc-5ece4082fc42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-04-2022_78644.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b3ba37a-d151-4def-8ccc-5ece4082fc42>.
+    
+<http://data.lblod.info/id/remote-data-objects/66f149d2-09f5-4649-88ba-e32c605ee308> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66f149d2-09f5-4649-88ba-e32c605ee308";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-04-2022_78650.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66f149d2-09f5-4649-88ba-e32c605ee308>.
+    
+<http://data.lblod.info/id/remote-data-objects/871479a0-6f22-4720-9418-d6e921186a0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "871479a0-6f22-4720-9418-d6e921186a0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-04-2022_78798.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/871479a0-6f22-4720-9418-d6e921186a0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a898f156-b31d-4afe-92f0-f1178eece3b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a898f156-b31d-4afe-92f0-f1178eece3b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-04-2022_79056.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a898f156-b31d-4afe-92f0-f1178eece3b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b207a92-bd60-480b-8081-8500768b36b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b207a92-bd60-480b-8081-8500768b36b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-04-2022_79229.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b207a92-bd60-480b-8081-8500768b36b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/51eaec88-79da-4bc7-9747-678cade32efe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51eaec88-79da-4bc7-9747-678cade32efe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-04-2022_79398.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51eaec88-79da-4bc7-9747-678cade32efe>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a0119fa-dd21-436a-a1c6-1e186a9a3913> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a0119fa-dd21-436a-a1c6-1e186a9a3913";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-04-2022_79497.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a0119fa-dd21-436a-a1c6-1e186a9a3913>.
+    
+<http://data.lblod.info/id/remote-data-objects/39fefe21-ffd3-4efc-a2b2-d4653d438f7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39fefe21-ffd3-4efc-a2b2-d4653d438f7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-04-2022_79498.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39fefe21-ffd3-4efc-a2b2-d4653d438f7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdf804c8-e7e4-45d3-af73-7a0a46618a52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdf804c8-e7e4-45d3-af73-7a0a46618a52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-04-2022_79812.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdf804c8-e7e4-45d3-af73-7a0a46618a52>.
+    
+<http://data.lblod.info/id/remote-data-objects/dacc335a-34c5-4301-8e81-565cf54f8b16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dacc335a-34c5-4301-8e81-565cf54f8b16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-07-2022_80202.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dacc335a-34c5-4301-8e81-565cf54f8b16>.
+    
+<http://data.lblod.info/id/remote-data-objects/91949a94-5fe6-41e9-b0eb-737076e85d5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91949a94-5fe6-41e9-b0eb-737076e85d5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-07-2022_81591.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10edd989-fcf4-492d-9e26-5d35dd818ac3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91949a94-5fe6-41e9-b0eb-737076e85d5c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201559-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201559-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201559-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201559-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/62d4c8ec-7f3e-4e7d-a74e-7ac0a55ceaa1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "62d4c8ec-7f3e-4e7d-a74e-7ac0a55ceaa1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c4c662ba-3bfd-4104-81a6-c8bda7c506c9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d15ee707-0658-4d8e-a90e-9da6311ae185> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d15ee707-0658-4d8e-a90e-9da6311ae185";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9>.
+
+  <http://redpencil.data.gift/id/task/1e32566a-661b-40ec-8a9f-ae2679e49658> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1e32566a-661b-40ec-8a9f-ae2679e49658";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/62d4c8ec-7f3e-4e7d-a74e-7ac0a55ceaa1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d15ee707-0658-4d8e-a90e-9da6311ae185>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/12990dab-0def-499c-a792-f7a5272c9744> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12990dab-0def-499c-a792-f7a5272c9744";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-07-2022_81870.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12990dab-0def-499c-a792-f7a5272c9744>.
+    
+<http://data.lblod.info/id/remote-data-objects/e785f3b0-af8f-44fc-b546-00c858443f4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e785f3b0-af8f-44fc-b546-00c858443f4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-07-2022_82312.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e785f3b0-af8f-44fc-b546-00c858443f4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/28160d41-333f-4e49-98ec-706f439cdae1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28160d41-333f-4e49-98ec-706f439cdae1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-07-2022_82398.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28160d41-333f-4e49-98ec-706f439cdae1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba50a295-6a86-4b23-b9fd-703b4f07ba12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba50a295-6a86-4b23-b9fd-703b4f07ba12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-07-2022_82585.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba50a295-6a86-4b23-b9fd-703b4f07ba12>.
+    
+<http://data.lblod.info/id/remote-data-objects/21caf3b5-e3d2-4cf8-babc-f4824a7cbbe1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21caf3b5-e3d2-4cf8-babc-f4824a7cbbe1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-07-2022_82658.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21caf3b5-e3d2-4cf8-babc-f4824a7cbbe1>.
+    
+<http://data.lblod.info/id/remote-data-objects/206b883e-41db-4848-9714-a62b7b544928> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "206b883e-41db-4848-9714-a62b7b544928";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-07-2022_82736.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/206b883e-41db-4848-9714-a62b7b544928>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa8f81f5-46a2-473e-9c17-378cd39d90b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa8f81f5-46a2-473e-9c17-378cd39d90b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-07-2022_82805.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa8f81f5-46a2-473e-9c17-378cd39d90b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/21ce0960-9c60-4eec-a925-9d56c6507818> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21ce0960-9c60-4eec-a925-9d56c6507818";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-07-2022_82852.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21ce0960-9c60-4eec-a925-9d56c6507818>.
+    
+<http://data.lblod.info/id/remote-data-objects/15881129-cb70-437b-8b0b-7e112a027938> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15881129-cb70-437b-8b0b-7e112a027938";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-10-2021_74551.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15881129-cb70-437b-8b0b-7e112a027938>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e402736-6036-42c7-9074-eeed8baf982a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e402736-6036-42c7-9074-eeed8baf982a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-10-2021_75131.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e402736-6036-42c7-9074-eeed8baf982a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e6e8b84-22c5-4a56-bbc7-8ae30e35f8f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e6e8b84-22c5-4a56-bbc7-8ae30e35f8f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-10-2021_75219.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e6e8b84-22c5-4a56-bbc7-8ae30e35f8f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b724fb94-3eee-4acc-8194-b27cbc78633e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b724fb94-3eee-4acc-8194-b27cbc78633e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/5f55d19c5d9c364e03eaf86bf2f48174eca44f7b43657c7a1881c640a6da1daf/GetPublication?filename=Uittreksels_13-10-2021_75220.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b724fb94-3eee-4acc-8194-b27cbc78633e>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb660c2f-4ebc-47f7-987b-f20771ddb515> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb660c2f-4ebc-47f7-987b-f20771ddb515";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_01-02-2022_78271.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb660c2f-4ebc-47f7-987b-f20771ddb515>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e21be7c-e82c-4de3-b4c1-e6b7c585f1ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e21be7c-e82c-4de3-b4c1-e6b7c585f1ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_01-02-2022_78450.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e21be7c-e82c-4de3-b4c1-e6b7c585f1ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7496162-4a26-44d5-8d09-105feefb845f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7496162-4a26-44d5-8d09-105feefb845f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_01-03-2022_79249.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7496162-4a26-44d5-8d09-105feefb845f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca73be5d-aad5-4d89-ab24-19a3218728ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca73be5d-aad5-4d89-ab24-19a3218728ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_01-03-2022_79369.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca73be5d-aad5-4d89-ab24-19a3218728ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c4a9ac6-df69-4037-baab-5f33f2bc78f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c4a9ac6-df69-4037-baab-5f33f2bc78f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_03-05-2022_81491.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c4a9ac6-df69-4037-baab-5f33f2bc78f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3376be2d-6336-4c1a-ab8c-6d322f062451> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3376be2d-6336-4c1a-ab8c-6d322f062451";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_03-05-2022_81507.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3376be2d-6336-4c1a-ab8c-6d322f062451>.
+    
+<http://data.lblod.info/id/remote-data-objects/250ba429-2900-4404-b546-8e77b80062d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "250ba429-2900-4404-b546-8e77b80062d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_03-05-2022_81522.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/250ba429-2900-4404-b546-8e77b80062d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/03d1fc1f-4a40-4371-bc3f-26fa3eac430c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03d1fc1f-4a40-4371-bc3f-26fa3eac430c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_03-05-2022_81523.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03d1fc1f-4a40-4371-bc3f-26fa3eac430c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a1e62db-4645-4516-85bc-3e2480f3be1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a1e62db-4645-4516-85bc-3e2480f3be1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_03-05-2022_81524.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a1e62db-4645-4516-85bc-3e2480f3be1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/47f0fb2e-cd1e-4235-8094-3e97ba1d36f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47f0fb2e-cd1e-4235-8094-3e97ba1d36f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_03-05-2022_81599.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47f0fb2e-cd1e-4235-8094-3e97ba1d36f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a88a978d-5d30-43b5-961b-62895198189f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a88a978d-5d30-43b5-961b-62895198189f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_04-01-2022_78038.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a88a978d-5d30-43b5-961b-62895198189f>.
+    
+<http://data.lblod.info/id/remote-data-objects/59e2f025-8584-431d-80e7-71e641e5ae08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59e2f025-8584-431d-80e7-71e641e5ae08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_05-07-2022_82261.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59e2f025-8584-431d-80e7-71e641e5ae08>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2f6a23e-870b-4ae8-8156-64f69310541a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2f6a23e-870b-4ae8-8156-64f69310541a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_05-07-2022_82262.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2f6a23e-870b-4ae8-8156-64f69310541a>.
+    
+<http://data.lblod.info/id/remote-data-objects/16744618-04b6-4e3d-8f3a-681698ac6e4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16744618-04b6-4e3d-8f3a-681698ac6e4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_05-07-2022_82763.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16744618-04b6-4e3d-8f3a-681698ac6e4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ed8c5ef-d450-4b00-b072-a8d2ac3194df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ed8c5ef-d450-4b00-b072-a8d2ac3194df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_05-07-2022_82941.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ed8c5ef-d450-4b00-b072-a8d2ac3194df>.
+    
+<http://data.lblod.info/id/remote-data-objects/20a5692b-9a66-4783-9acc-abe54e0f8dfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20a5692b-9a66-4783-9acc-abe54e0f8dfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_05-07-2022_82946.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20a5692b-9a66-4783-9acc-abe54e0f8dfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/43c9853a-5a4d-45df-beff-f50aee7a9bf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43c9853a-5a4d-45df-beff-f50aee7a9bf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_05-07-2022_82948.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43c9853a-5a4d-45df-beff-f50aee7a9bf9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ecf2a37-46cc-48ba-8c02-7ed6ce5411c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ecf2a37-46cc-48ba-8c02-7ed6ce5411c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_05-07-2022_82955.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ecf2a37-46cc-48ba-8c02-7ed6ce5411c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4ca83fb-1cad-4ef5-8c16-a7fbdf809197> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4ca83fb-1cad-4ef5-8c16-a7fbdf809197";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_05-07-2022_82975.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4ca83fb-1cad-4ef5-8c16-a7fbdf809197>.
+    
+<http://data.lblod.info/id/remote-data-objects/788a17a4-5999-4c0f-9de2-8687282c4bf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "788a17a4-5999-4c0f-9de2-8687282c4bf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_05-07-2022_82987.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/788a17a4-5999-4c0f-9de2-8687282c4bf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0ab4d2c-8015-4125-9894-4974ba985452> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0ab4d2c-8015-4125-9894-4974ba985452";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_05-07-2022_82991.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0ab4d2c-8015-4125-9894-4974ba985452>.
+    
+<http://data.lblod.info/id/remote-data-objects/839fa030-b401-4e56-91ae-701942442647> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "839fa030-b401-4e56-91ae-701942442647";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_05-07-2022_83000.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/839fa030-b401-4e56-91ae-701942442647>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c4f6a90-6555-4fcf-8d82-3606468ff82c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c4f6a90-6555-4fcf-8d82-3606468ff82c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_05-07-2022_83081.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c4f6a90-6555-4fcf-8d82-3606468ff82c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a8bb311-1d7e-4cb6-9059-7ece4dd2685d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a8bb311-1d7e-4cb6-9059-7ece4dd2685d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_05-07-2022_83159.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a8bb311-1d7e-4cb6-9059-7ece4dd2685d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a930c708-ef98-469a-ade0-73d90176d7ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a930c708-ef98-469a-ade0-73d90176d7ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_05-10-2021_74734.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a930c708-ef98-469a-ade0-73d90176d7ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e0ab7a0-6fd8-49d3-a88e-85d513437734> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e0ab7a0-6fd8-49d3-a88e-85d513437734";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_07-06-2022_82200.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e0ab7a0-6fd8-49d3-a88e-85d513437734>.
+    
+<http://data.lblod.info/id/remote-data-objects/af63e4b8-aead-400b-a6dd-08e9970f16aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af63e4b8-aead-400b-a6dd-08e9970f16aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_07-06-2022_82366.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af63e4b8-aead-400b-a6dd-08e9970f16aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a07d580-d541-4a5c-8648-bb5fc19a0b81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a07d580-d541-4a5c-8648-bb5fc19a0b81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_07-06-2022_82480.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a07d580-d541-4a5c-8648-bb5fc19a0b81>.
+    
+<http://data.lblod.info/id/remote-data-objects/789fadfb-926b-4350-a102-2dd2a3ac21e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "789fadfb-926b-4350-a102-2dd2a3ac21e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_07-12-2021_77519.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/789fadfb-926b-4350-a102-2dd2a3ac21e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a0b21da-b33d-4b5f-93be-e3cec36d97fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a0b21da-b33d-4b5f-93be-e3cec36d97fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_07-12-2021_77547.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a0b21da-b33d-4b5f-93be-e3cec36d97fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f33c516-d5ff-439c-9669-9c330d3be8e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f33c516-d5ff-439c-9669-9c330d3be8e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78218.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f33c516-d5ff-439c-9669-9c330d3be8e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2d554c1-168a-4082-9e59-b7750cee4925> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2d554c1-168a-4082-9e59-b7750cee4925";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78225.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2d554c1-168a-4082-9e59-b7750cee4925>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b0e0f8c-e3ec-43d2-a7ab-7e8a65d3c623> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b0e0f8c-e3ec-43d2-a7ab-7e8a65d3c623";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78227.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b0e0f8c-e3ec-43d2-a7ab-7e8a65d3c623>.
+    
+<http://data.lblod.info/id/remote-data-objects/34c0437b-ff6b-4d22-8d00-a6a688a87a1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34c0437b-ff6b-4d22-8d00-a6a688a87a1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78228.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34c0437b-ff6b-4d22-8d00-a6a688a87a1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1614e0ef-bf30-4a1f-8413-87a54c46c838> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1614e0ef-bf30-4a1f-8413-87a54c46c838";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78231.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1614e0ef-bf30-4a1f-8413-87a54c46c838>.
+    
+<http://data.lblod.info/id/remote-data-objects/86b6adb7-3377-407f-84e4-a218a9727db3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86b6adb7-3377-407f-84e4-a218a9727db3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78232.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86b6adb7-3377-407f-84e4-a218a9727db3>.
+    
+<http://data.lblod.info/id/remote-data-objects/08dd07bc-6e2a-41a2-9537-ffb1feb940b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08dd07bc-6e2a-41a2-9537-ffb1feb940b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78233.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08dd07bc-6e2a-41a2-9537-ffb1feb940b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/5924615d-f1ef-4446-99a0-d5f4c2ed0a0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5924615d-f1ef-4446-99a0-d5f4c2ed0a0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78235.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:15:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c4c662ba-3bfd-4104-81a6-c8bda7c506c9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5924615d-f1ef-4446-99a0-d5f4c2ed0a0e>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201601-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201601-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201601-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201601-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/06ee7680-b944-44bf-adab-aa28efae87ea> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "06ee7680-b944-44bf-adab-aa28efae87ea";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d7f34c77-cdaf-48a7-84f4-8602aff228a4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/7c16b9aa-7b35-4917-9390-1bc7fac94b47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7c16b9aa-7b35-4917-9390-1bc7fac94b47";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4>.
+
+  <http://redpencil.data.gift/id/task/b5222a61-fcdb-4a28-8104-4a380238fba5> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b5222a61-fcdb-4a28-8104-4a380238fba5";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/06ee7680-b944-44bf-adab-aa28efae87ea>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/7c16b9aa-7b35-4917-9390-1bc7fac94b47>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c6c6fd15-200c-4f70-a042-a6b81e03404c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6c6fd15-200c-4f70-a042-a6b81e03404c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78237.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6c6fd15-200c-4f70-a042-a6b81e03404c>.
+    
+<http://data.lblod.info/id/remote-data-objects/249a2e42-1508-4ea9-9617-320adfb85196> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "249a2e42-1508-4ea9-9617-320adfb85196";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78238.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/249a2e42-1508-4ea9-9617-320adfb85196>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e13ddc1-ca56-4980-a7c5-8eb32224b0f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e13ddc1-ca56-4980-a7c5-8eb32224b0f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78243.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e13ddc1-ca56-4980-a7c5-8eb32224b0f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1393a36e-817f-48e0-b1a4-d8c754d98708> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1393a36e-817f-48e0-b1a4-d8c754d98708";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78248.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1393a36e-817f-48e0-b1a4-d8c754d98708>.
+    
+<http://data.lblod.info/id/remote-data-objects/219eb44e-df28-4e57-8f16-32d856b10547> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "219eb44e-df28-4e57-8f16-32d856b10547";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78401.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/219eb44e-df28-4e57-8f16-32d856b10547>.
+    
+<http://data.lblod.info/id/remote-data-objects/c663f3c9-dbe8-4e6e-81e2-0fa5185c225f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c663f3c9-dbe8-4e6e-81e2-0fa5185c225f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78406.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c663f3c9-dbe8-4e6e-81e2-0fa5185c225f>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd33edca-3a32-4ca0-b14e-b2f11d4287f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd33edca-3a32-4ca0-b14e-b2f11d4287f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78412.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd33edca-3a32-4ca0-b14e-b2f11d4287f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/315cb34d-38ba-4a70-8dfd-0c9382f6aa04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "315cb34d-38ba-4a70-8dfd-0c9382f6aa04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78448.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/315cb34d-38ba-4a70-8dfd-0c9382f6aa04>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3d501dd-c3c9-405d-9747-87abef04cec2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3d501dd-c3c9-405d-9747-87abef04cec2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78530.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3d501dd-c3c9-405d-9747-87abef04cec2>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dffb0c3-fc31-4978-9e6a-cb0fcdeff03c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dffb0c3-fc31-4978-9e6a-cb0fcdeff03c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78575.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dffb0c3-fc31-4978-9e6a-cb0fcdeff03c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cfa6ae3-ebe3-4630-875a-5bd7eb8ab763> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cfa6ae3-ebe3-4630-875a-5bd7eb8ab763";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78592.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cfa6ae3-ebe3-4630-875a-5bd7eb8ab763>.
+    
+<http://data.lblod.info/id/remote-data-objects/18aa8834-3e81-4075-8351-f8cf893319ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18aa8834-3e81-4075-8351-f8cf893319ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-02-2022_78611.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18aa8834-3e81-4075-8351-f8cf893319ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/540020de-ba1b-4025-9eca-72491e23c951> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "540020de-ba1b-4025-9eca-72491e23c951";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-03-2022_79266.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/540020de-ba1b-4025-9eca-72491e23c951>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5099504-343d-4052-a48a-6d9c339ef116> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5099504-343d-4052-a48a-6d9c339ef116";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-03-2022_79298.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5099504-343d-4052-a48a-6d9c339ef116>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd81cbde-f5a5-416b-854f-b61465e58cf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd81cbde-f5a5-416b-854f-b61465e58cf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-03-2022_79380.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd81cbde-f5a5-416b-854f-b61465e58cf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4bfd01d-c75e-447a-a6e6-1f3c94d3548c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4bfd01d-c75e-447a-a6e6-1f3c94d3548c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-03-2022_79388.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4bfd01d-c75e-447a-a6e6-1f3c94d3548c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0c032f8-e97f-4704-beff-28718b5d9ada> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0c032f8-e97f-4704-beff-28718b5d9ada";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_08-03-2022_79446.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0c032f8-e97f-4704-beff-28718b5d9ada>.
+    
+<http://data.lblod.info/id/remote-data-objects/57b18daf-b2dd-4617-800e-7afa55edd370> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57b18daf-b2dd-4617-800e-7afa55edd370";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_09-11-2021_75378.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57b18daf-b2dd-4617-800e-7afa55edd370>.
+    
+<http://data.lblod.info/id/remote-data-objects/4df4ca15-72ab-4960-b21e-196e003e62c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4df4ca15-72ab-4960-b21e-196e003e62c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_10-05-2022_81620.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4df4ca15-72ab-4960-b21e-196e003e62c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/015cc00f-f234-4d89-9e47-974576f43f4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "015cc00f-f234-4d89-9e47-974576f43f4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_10-05-2022_81664.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/015cc00f-f234-4d89-9e47-974576f43f4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdc7dfcc-9154-4c6d-af08-d48d3a179bb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdc7dfcc-9154-4c6d-af08-d48d3a179bb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_10-05-2022_81713.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdc7dfcc-9154-4c6d-af08-d48d3a179bb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f064097a-deb5-4dc8-87b8-6ede27701299> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f064097a-deb5-4dc8-87b8-6ede27701299";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_12-04-2022_79405.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f064097a-deb5-4dc8-87b8-6ede27701299>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e2859ef-421f-4d94-8356-117a191d6748> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e2859ef-421f-4d94-8356-117a191d6748";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_12-04-2022_79566.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e2859ef-421f-4d94-8356-117a191d6748>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3694418-366a-4328-9320-3d2b49c12c8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3694418-366a-4328-9320-3d2b49c12c8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_12-04-2022_79627.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3694418-366a-4328-9320-3d2b49c12c8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c31405e8-f0c6-44ae-af43-42be7ea04ccf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c31405e8-f0c6-44ae-af43-42be7ea04ccf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_12-04-2022_79909.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c31405e8-f0c6-44ae-af43-42be7ea04ccf>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ff5a097-26d8-49e6-a74c-e3d08f623579> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ff5a097-26d8-49e6-a74c-e3d08f623579";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_12-04-2022_79967.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ff5a097-26d8-49e6-a74c-e3d08f623579>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ce686bf-0d8d-4d5c-a77d-27003e3496fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ce686bf-0d8d-4d5c-a77d-27003e3496fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_12-04-2022_80047.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ce686bf-0d8d-4d5c-a77d-27003e3496fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/724cab74-18dd-4a5b-b32f-e3e1989ea802> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "724cab74-18dd-4a5b-b32f-e3e1989ea802";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_12-04-2022_80171.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/724cab74-18dd-4a5b-b32f-e3e1989ea802>.
+    
+<http://data.lblod.info/id/remote-data-objects/45d1dbf4-5d21-4559-8bec-05fe8c0ecacb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45d1dbf4-5d21-4559-8bec-05fe8c0ecacb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_12-04-2022_80223.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45d1dbf4-5d21-4559-8bec-05fe8c0ecacb>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e66561e-61e3-4ff9-b764-aea9a3c59c83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e66561e-61e3-4ff9-b764-aea9a3c59c83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_12-04-2022_80227.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e66561e-61e3-4ff9-b764-aea9a3c59c83>.
+    
+<http://data.lblod.info/id/remote-data-objects/86913743-2389-4ae7-b69e-a0d7fd98f227> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86913743-2389-4ae7-b69e-a0d7fd98f227";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_12-04-2022_80237.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86913743-2389-4ae7-b69e-a0d7fd98f227>.
+    
+<http://data.lblod.info/id/remote-data-objects/57124d0d-97e3-4894-affd-49fbafe52853> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57124d0d-97e3-4894-affd-49fbafe52853";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_12-10-2021_75334.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57124d0d-97e3-4894-affd-49fbafe52853>.
+    
+<http://data.lblod.info/id/remote-data-objects/806dd01b-3588-4b9f-a42e-001f6d3fd2fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "806dd01b-3588-4b9f-a42e-001f6d3fd2fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_12-10-2021_75358.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/806dd01b-3588-4b9f-a42e-001f6d3fd2fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/de8c248f-1104-423b-80c5-b6fe2cf0423e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de8c248f-1104-423b-80c5-b6fe2cf0423e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_12-10-2021_75607.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de8c248f-1104-423b-80c5-b6fe2cf0423e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed5ff47c-16f9-4276-a4ee-d115d59ab6d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed5ff47c-16f9-4276-a4ee-d115d59ab6d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_14-06-2022_82124.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed5ff47c-16f9-4276-a4ee-d115d59ab6d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/59f358fd-5331-4273-87c1-2e152e87185e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59f358fd-5331-4273-87c1-2e152e87185e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_14-06-2022_82367.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59f358fd-5331-4273-87c1-2e152e87185e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b96644b1-3847-4358-8f79-7f3a109054cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b96644b1-3847-4358-8f79-7f3a109054cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_14-06-2022_82380.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b96644b1-3847-4358-8f79-7f3a109054cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/15b66985-e5d2-4acf-b754-7b925eecce70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15b66985-e5d2-4acf-b754-7b925eecce70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_14-06-2022_82521.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15b66985-e5d2-4acf-b754-7b925eecce70>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d3642a5-24c3-407f-892c-5be33c1d55bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d3642a5-24c3-407f-892c-5be33c1d55bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_14-06-2022_82526.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d3642a5-24c3-407f-892c-5be33c1d55bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/090694e9-6d92-47d1-996b-9ebc43a651ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "090694e9-6d92-47d1-996b-9ebc43a651ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_14-12-2021_77465.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/090694e9-6d92-47d1-996b-9ebc43a651ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fcade9b-f7b9-4fe5-93d7-c5095584f547> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fcade9b-f7b9-4fe5-93d7-c5095584f547";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_14-12-2021_77674.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fcade9b-f7b9-4fe5-93d7-c5095584f547>.
+    
+<http://data.lblod.info/id/remote-data-objects/d483270c-c636-42d0-98ce-640fb85d2787> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d483270c-c636-42d0-98ce-640fb85d2787";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_14-12-2021_77706.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d483270c-c636-42d0-98ce-640fb85d2787>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9f23579-d4ad-487f-b39a-dc2ae963f2a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9f23579-d4ad-487f-b39a-dc2ae963f2a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_15-02-2022_78757.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9f23579-d4ad-487f-b39a-dc2ae963f2a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3362797-d043-46fe-b767-5281a3af5799> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3362797-d043-46fe-b767-5281a3af5799";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_16-11-2021_75802.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3362797-d043-46fe-b767-5281a3af5799>.
+    
+<http://data.lblod.info/id/remote-data-objects/7723cd11-accf-4f53-8b54-552b48a9931f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7723cd11-accf-4f53-8b54-552b48a9931f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_16-11-2021_77073.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7723cd11-accf-4f53-8b54-552b48a9931f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b0037c3-bc20-4008-b8bf-5b1ec820f63e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b0037c3-bc20-4008-b8bf-5b1ec820f63e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_17-05-2022_81708.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b0037c3-bc20-4008-b8bf-5b1ec820f63e>.
+    
+<http://data.lblod.info/id/remote-data-objects/49b606c4-e79f-48a8-9d8f-923c63f77612> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49b606c4-e79f-48a8-9d8f-923c63f77612";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_17-05-2022_81859.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49b606c4-e79f-48a8-9d8f-923c63f77612>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d8aa041-d7de-4cc2-ac32-c7de0748a7c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d8aa041-d7de-4cc2-ac32-c7de0748a7c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_17-05-2022_82043.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d8aa041-d7de-4cc2-ac32-c7de0748a7c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e079dc38-fc02-4575-94f0-88aaab3a0091> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e079dc38-fc02-4575-94f0-88aaab3a0091";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_18-01-2022_78134.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e079dc38-fc02-4575-94f0-88aaab3a0091>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e55d58e-7eac-485e-90d2-37d9fdf7005e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e55d58e-7eac-485e-90d2-37d9fdf7005e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_18-07-2022_82803.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d7f34c77-cdaf-48a7-84f4-8602aff228a4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e55d58e-7eac-485e-90d2-37d9fdf7005e>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201602-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201602-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201602-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201602-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/141263c9-d673-47d9-b2b3-a8ebc830f9e0> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "141263c9-d673-47d9-b2b3-a8ebc830f9e0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "277bc1fa-ffd8-4884-a7d6-43b297598498";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/99f86118-c443-41ad-8bbf-a5ee42e2e96a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "99f86118-c443-41ad-8bbf-a5ee42e2e96a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498>.
+
+  <http://redpencil.data.gift/id/task/ba896744-513e-4394-a539-abf2c60a0094> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ba896744-513e-4394-a539-abf2c60a0094";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/141263c9-d673-47d9-b2b3-a8ebc830f9e0>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/99f86118-c443-41ad-8bbf-a5ee42e2e96a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/2d366a5b-ea14-4cc2-8e24-b28d6a00cd56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d366a5b-ea14-4cc2-8e24-b28d6a00cd56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_18-07-2022_83036.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d366a5b-ea14-4cc2-8e24-b28d6a00cd56>.
+    
+<http://data.lblod.info/id/remote-data-objects/aabdaffb-6d36-4d85-9fed-a07111174fac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aabdaffb-6d36-4d85-9fed-a07111174fac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_18-07-2022_83098.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aabdaffb-6d36-4d85-9fed-a07111174fac>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c4a6e7d-db8c-406c-b62e-8e0362c775d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c4a6e7d-db8c-406c-b62e-8e0362c775d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_18-07-2022_83105.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c4a6e7d-db8c-406c-b62e-8e0362c775d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a07767ee-201f-4b58-b4df-ae71fdee8b37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a07767ee-201f-4b58-b4df-ae71fdee8b37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_18-07-2022_83135.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a07767ee-201f-4b58-b4df-ae71fdee8b37>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4b0be2e-1e97-4f6a-b4f8-f47d05748000> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4b0be2e-1e97-4f6a-b4f8-f47d05748000";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_18-07-2022_83138.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4b0be2e-1e97-4f6a-b4f8-f47d05748000>.
+    
+<http://data.lblod.info/id/remote-data-objects/719bd7cf-ce1e-474f-9fac-22a0879fdfd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "719bd7cf-ce1e-474f-9fac-22a0879fdfd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_18-07-2022_83145.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/719bd7cf-ce1e-474f-9fac-22a0879fdfd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/704d5920-490d-48ab-8c27-f3d3fdc1c3ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "704d5920-490d-48ab-8c27-f3d3fdc1c3ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_18-07-2022_83176.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/704d5920-490d-48ab-8c27-f3d3fdc1c3ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/e70f69bf-9c2d-4c90-a50a-04df414da4e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e70f69bf-9c2d-4c90-a50a-04df414da4e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_18-07-2022_83215.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e70f69bf-9c2d-4c90-a50a-04df414da4e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/68d8ae05-5a91-4094-9893-9753b0399af0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68d8ae05-5a91-4094-9893-9753b0399af0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_18-07-2022_84319.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68d8ae05-5a91-4094-9893-9753b0399af0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1b7fa62-4c8c-4bcc-8abe-2859ee4d7d9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1b7fa62-4c8c-4bcc-8abe-2859ee4d7d9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_19-04-2022_80018.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1b7fa62-4c8c-4bcc-8abe-2859ee4d7d9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/642e179c-236c-4ed4-9c19-ea99063cf30f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "642e179c-236c-4ed4-9c19-ea99063cf30f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_19-04-2022_80023.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/642e179c-236c-4ed4-9c19-ea99063cf30f>.
+    
+<http://data.lblod.info/id/remote-data-objects/748b2238-d9f2-479a-9c69-44e08d52106f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "748b2238-d9f2-479a-9c69-44e08d52106f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_19-04-2022_80111.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/748b2238-d9f2-479a-9c69-44e08d52106f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ae28cf9-2cf5-4887-b73f-78f0d27fdca9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ae28cf9-2cf5-4887-b73f-78f0d27fdca9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_19-04-2022_80130.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ae28cf9-2cf5-4887-b73f-78f0d27fdca9>.
+    
+<http://data.lblod.info/id/remote-data-objects/dac46519-01cd-4f1f-9ec0-216ff08ff28b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dac46519-01cd-4f1f-9ec0-216ff08ff28b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_19-04-2022_80258.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dac46519-01cd-4f1f-9ec0-216ff08ff28b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9d77a9a-fca7-4e1d-a19e-38bb63d79803> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9d77a9a-fca7-4e1d-a19e-38bb63d79803";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_19-04-2022_80273.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9d77a9a-fca7-4e1d-a19e-38bb63d79803>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc65eb6e-335d-491c-816d-903b07817dbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc65eb6e-335d-491c-816d-903b07817dbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_19-04-2022_80278.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc65eb6e-335d-491c-816d-903b07817dbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/65405d91-c929-4dc2-a115-d36a721ba96c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65405d91-c929-4dc2-a115-d36a721ba96c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_19-10-2021_75425.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65405d91-c929-4dc2-a115-d36a721ba96c>.
+    
+<http://data.lblod.info/id/remote-data-objects/97b632bb-4b5f-4af3-81ea-abf129109ea4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97b632bb-4b5f-4af3-81ea-abf129109ea4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_19-10-2021_75532.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97b632bb-4b5f-4af3-81ea-abf129109ea4>.
+    
+<http://data.lblod.info/id/remote-data-objects/40ba8e6b-4339-4731-8a68-9f413f35583a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40ba8e6b-4339-4731-8a68-9f413f35583a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_19-10-2021_75556.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40ba8e6b-4339-4731-8a68-9f413f35583a>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfc9e26e-2f4d-4d7e-9926-487067ab0da1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfc9e26e-2f4d-4d7e-9926-487067ab0da1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_19-10-2021_75576.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfc9e26e-2f4d-4d7e-9926-487067ab0da1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4e70608-4920-4a88-8f59-5a3190cfb817> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4e70608-4920-4a88-8f59-5a3190cfb817";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_19-10-2021_75642.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4e70608-4920-4a88-8f59-5a3190cfb817>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b14c943-88ca-478d-ac44-b056a243880a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b14c943-88ca-478d-ac44-b056a243880a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_21-06-2022_82481.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b14c943-88ca-478d-ac44-b056a243880a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1330b99a-ac77-4d63-b02b-38db7c5dbf90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1330b99a-ac77-4d63-b02b-38db7c5dbf90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_21-06-2022_82484.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1330b99a-ac77-4d63-b02b-38db7c5dbf90>.
+    
+<http://data.lblod.info/id/remote-data-objects/39e6c904-3f68-4b56-9d89-6637ef8e97b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39e6c904-3f68-4b56-9d89-6637ef8e97b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_21-06-2022_82534.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39e6c904-3f68-4b56-9d89-6637ef8e97b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/cca5fbfe-6e7c-43ed-91d0-1d812811648a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cca5fbfe-6e7c-43ed-91d0-1d812811648a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_21-06-2022_82621.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cca5fbfe-6e7c-43ed-91d0-1d812811648a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1638d911-5f73-4882-a645-7874cf202c4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1638d911-5f73-4882-a645-7874cf202c4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_21-06-2022_82629.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1638d911-5f73-4882-a645-7874cf202c4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f9efe97-b1a5-4b24-9a1b-28e4644b22b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f9efe97-b1a5-4b24-9a1b-28e4644b22b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_21-06-2022_82799.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f9efe97-b1a5-4b24-9a1b-28e4644b22b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/482a797a-3db1-418d-8922-aa6f4d39290b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "482a797a-3db1-418d-8922-aa6f4d39290b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_21-06-2022_82892.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/482a797a-3db1-418d-8922-aa6f4d39290b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e42187f-21ac-4970-8c8e-515f9011a035> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e42187f-21ac-4970-8c8e-515f9011a035";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_21-12-2021_77342.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e42187f-21ac-4970-8c8e-515f9011a035>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fe6e479-0edb-4c97-944b-369dafc4dbc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fe6e479-0edb-4c97-944b-369dafc4dbc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_22-02-2022_78894.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fe6e479-0edb-4c97-944b-369dafc4dbc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2dd8d32-7969-44b4-ac34-399f7cb2eb84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2dd8d32-7969-44b4-ac34-399f7cb2eb84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_22-02-2022_78949.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2dd8d32-7969-44b4-ac34-399f7cb2eb84>.
+    
+<http://data.lblod.info/id/remote-data-objects/74b2932a-871c-4956-8e70-0c04ba4329ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74b2932a-871c-4956-8e70-0c04ba4329ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_22-02-2022_79052.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74b2932a-871c-4956-8e70-0c04ba4329ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/3045d6c3-3ff0-427e-b627-ceb06cf7b4b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3045d6c3-3ff0-427e-b627-ceb06cf7b4b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_22-02-2022_79053.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3045d6c3-3ff0-427e-b627-ceb06cf7b4b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/87da9080-497e-4750-9ab6-22e616127484> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87da9080-497e-4750-9ab6-22e616127484";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_22-02-2022_79054.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87da9080-497e-4750-9ab6-22e616127484>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1d7bf7c-dcd1-434e-935c-52c4e8646b08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1d7bf7c-dcd1-434e-935c-52c4e8646b08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_22-02-2022_79057.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1d7bf7c-dcd1-434e-935c-52c4e8646b08>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5081673-58dc-4d1e-97aa-9ee82570cc97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5081673-58dc-4d1e-97aa-9ee82570cc97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_22-02-2022_79058.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5081673-58dc-4d1e-97aa-9ee82570cc97>.
+    
+<http://data.lblod.info/id/remote-data-objects/393a333f-b763-4bc2-bf9f-89f5fcc01653> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "393a333f-b763-4bc2-bf9f-89f5fcc01653";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_22-02-2022_79152.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/393a333f-b763-4bc2-bf9f-89f5fcc01653>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab9c5ab1-e022-4c7d-ba01-56442669616f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab9c5ab1-e022-4c7d-ba01-56442669616f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_22-03-2022_79324.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab9c5ab1-e022-4c7d-ba01-56442669616f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0209b40d-4a15-4fa0-b694-9b719e4eaa55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0209b40d-4a15-4fa0-b694-9b719e4eaa55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_22-03-2022_79455.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0209b40d-4a15-4fa0-b694-9b719e4eaa55>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7ae6945-4cd0-4a48-900c-50b7b6ed65d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7ae6945-4cd0-4a48-900c-50b7b6ed65d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_22-03-2022_79619.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7ae6945-4cd0-4a48-900c-50b7b6ed65d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7e04a60-678e-4566-b6c4-07276b682fbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7e04a60-678e-4566-b6c4-07276b682fbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_22-03-2022_79696.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7e04a60-678e-4566-b6c4-07276b682fbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ed3d7fe-8b39-4622-b602-553666219057> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ed3d7fe-8b39-4622-b602-553666219057";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_22-03-2022_79698.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ed3d7fe-8b39-4622-b602-553666219057>.
+    
+<http://data.lblod.info/id/remote-data-objects/8768a5dd-6ee2-478a-8360-a4bf2de81c85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8768a5dd-6ee2-478a-8360-a4bf2de81c85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_23-11-2021_77268.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8768a5dd-6ee2-478a-8360-a4bf2de81c85>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc0a9597-8f86-4825-a3b1-42ed2296b243> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc0a9597-8f86-4825-a3b1-42ed2296b243";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_23-11-2021_77357.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc0a9597-8f86-4825-a3b1-42ed2296b243>.
+    
+<http://data.lblod.info/id/remote-data-objects/db30cd7e-f2bd-4266-a942-2194de3674d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db30cd7e-f2bd-4266-a942-2194de3674d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_24-05-2022_81976.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db30cd7e-f2bd-4266-a942-2194de3674d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/72046a4d-f7a8-4b4b-a3c6-8b8d846b8ed6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72046a4d-f7a8-4b4b-a3c6-8b8d846b8ed6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_24-05-2022_82004.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72046a4d-f7a8-4b4b-a3c6-8b8d846b8ed6>.
+    
+<http://data.lblod.info/id/remote-data-objects/3de9f865-f37f-48b9-a3e0-0fa7a740fc27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3de9f865-f37f-48b9-a3e0-0fa7a740fc27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_24-05-2022_82005.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3de9f865-f37f-48b9-a3e0-0fa7a740fc27>.
+    
+<http://data.lblod.info/id/remote-data-objects/1228d7f8-a9d5-4343-b364-5a5252e9dd97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1228d7f8-a9d5-4343-b364-5a5252e9dd97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_24-05-2022_82088.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1228d7f8-a9d5-4343-b364-5a5252e9dd97>.
+    
+<http://data.lblod.info/id/remote-data-objects/39ded8de-b722-4052-800c-f9312ecf2986> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39ded8de-b722-4052-800c-f9312ecf2986";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_24-05-2022_82121.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39ded8de-b722-4052-800c-f9312ecf2986>.
+    
+<http://data.lblod.info/id/remote-data-objects/cca61b61-61f8-443f-a1a1-905171218872> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cca61b61-61f8-443f-a1a1-905171218872";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_25-01-2022_78093.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/277bc1fa-ffd8-4884-a7d6-43b297598498> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cca61b61-61f8-443f-a1a1-905171218872>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201603-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201603-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201603-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201603-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/1ff5c4a7-0745-43ba-bd1b-b81197cf217d> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1ff5c4a7-0745-43ba-bd1b-b81197cf217d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7402afd0-30a5-4997-a459-c2229f016082";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/221d1fdd-da12-4ecf-a3ec-0c512da8efcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "221d1fdd-da12-4ecf-a3ec-0c512da8efcc";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082>.
+
+  <http://redpencil.data.gift/id/task/77d025ae-a7a8-4f25-996f-fdc0ea1a1fd5> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "77d025ae-a7a8-4f25-996f-fdc0ea1a1fd5";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/1ff5c4a7-0745-43ba-bd1b-b81197cf217d>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/221d1fdd-da12-4ecf-a3ec-0c512da8efcc>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/52f5b4a6-5251-4605-942c-2b7767450028> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52f5b4a6-5251-4605-942c-2b7767450028";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_26-04-2022_80395.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52f5b4a6-5251-4605-942c-2b7767450028>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7c78a55-62d5-4e1a-ad8d-62812490f34b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7c78a55-62d5-4e1a-ad8d-62812490f34b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_26-10-2021_75373.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7c78a55-62d5-4e1a-ad8d-62812490f34b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c0b6e3b-c91d-48a3-847a-98db2c0be186> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c0b6e3b-c91d-48a3-847a-98db2c0be186";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_26-10-2021_75620.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c0b6e3b-c91d-48a3-847a-98db2c0be186>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7f25d55-e453-4a37-bb16-9f233b4f9377> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7f25d55-e453-4a37-bb16-9f233b4f9377";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_28-06-2022_82784.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7f25d55-e453-4a37-bb16-9f233b4f9377>.
+    
+<http://data.lblod.info/id/remote-data-objects/f260e688-d76a-44cc-899d-bcd9c2997b13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f260e688-d76a-44cc-899d-bcd9c2997b13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_28-06-2022_82909.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f260e688-d76a-44cc-899d-bcd9c2997b13>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3e7cab0-e43f-407e-b7f9-7ef9070fc959> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3e7cab0-e43f-407e-b7f9-7ef9070fc959";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_28-06-2022_82953.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3e7cab0-e43f-407e-b7f9-7ef9070fc959>.
+    
+<http://data.lblod.info/id/remote-data-objects/c99e2475-5d1e-4e3a-9b18-2943f77d4384> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c99e2475-5d1e-4e3a-9b18-2943f77d4384";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_29-03-2022_79646.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c99e2475-5d1e-4e3a-9b18-2943f77d4384>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc92cc02-a8e9-4abb-9723-693a961dbfe0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc92cc02-a8e9-4abb-9723-693a961dbfe0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_29-03-2022_79730.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc92cc02-a8e9-4abb-9723-693a961dbfe0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fe8ece8-43d0-43bf-ade5-8286cfcd8438> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fe8ece8-43d0-43bf-ade5-8286cfcd8438";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_29-03-2022_79786.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fe8ece8-43d0-43bf-ade5-8286cfcd8438>.
+    
+<http://data.lblod.info/id/remote-data-objects/1097ac54-0315-4a26-a965-180f37390bc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1097ac54-0315-4a26-a965-180f37390bc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_29-03-2022_79898.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1097ac54-0315-4a26-a965-180f37390bc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/28368df2-ef81-48c6-9bc5-27e366ea360b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28368df2-ef81-48c6-9bc5-27e366ea360b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_30-11-2021_77386.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28368df2-ef81-48c6-9bc5-27e366ea360b>.
+    
+<http://data.lblod.info/id/remote-data-objects/44063525-c077-4b6b-8616-fffd525347c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44063525-c077-4b6b-8616-fffd525347c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_30-11-2021_77392.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44063525-c077-4b6b-8616-fffd525347c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6997357-3574-4a4a-879c-ca53c8e41ff3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6997357-3574-4a4a-879c-ca53c8e41ff3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_31-05-2022_80029.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6997357-3574-4a4a-879c-ca53c8e41ff3>.
+    
+<http://data.lblod.info/id/remote-data-objects/04a221bc-c492-4d92-8abf-cbfa5b9ae929> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04a221bc-c492-4d92-8abf-cbfa5b9ae929";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_31-05-2022_80032.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04a221bc-c492-4d92-8abf-cbfa5b9ae929>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3fa051d-b252-4aef-ae53-474ae01a1b89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3fa051d-b252-4aef-ae53-474ae01a1b89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_31-05-2022_81898.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3fa051d-b252-4aef-ae53-474ae01a1b89>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d47d97c-4a1d-44cc-96fd-e7ec2eabbe6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d47d97c-4a1d-44cc-96fd-e7ec2eabbe6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_31-05-2022_82095.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d47d97c-4a1d-44cc-96fd-e7ec2eabbe6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/61d93006-4a4b-41b8-8ac2-3eb7e24d1d93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61d93006-4a4b-41b8-8ac2-3eb7e24d1d93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_31-05-2022_82130.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61d93006-4a4b-41b8-8ac2-3eb7e24d1d93>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4c342e6-f82e-4de7-a8b5-ae374dfa4024> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4c342e6-f82e-4de7-a8b5-ae374dfa4024";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_31-05-2022_82151.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4c342e6-f82e-4de7-a8b5-ae374dfa4024>.
+    
+<http://data.lblod.info/id/remote-data-objects/c46146f1-ae5a-4fc3-b8a1-75677c93f3e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c46146f1-ae5a-4fc3-b8a1-75677c93f3e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_31-05-2022_82183.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c46146f1-ae5a-4fc3-b8a1-75677c93f3e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f796129-a705-4b69-b360-cf3dc9b02e66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f796129-a705-4b69-b360-cf3dc9b02e66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_31-05-2022_82190.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f796129-a705-4b69-b360-cf3dc9b02e66>.
+    
+<http://data.lblod.info/id/remote-data-objects/6284c2d6-98dd-4d27-9fd5-85a1f4286d10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6284c2d6-98dd-4d27-9fd5-85a1f4286d10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/97d480edf72f7bb943d7ac907e8f05bea5d3ad337b4848b79c4a20e2992d4caa/GetPublication?filename=Uittreksels_31-05-2022_82301.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6284c2d6-98dd-4d27-9fd5-85a1f4286d10>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e21c07a-4ec0-42e3-a740-4158809b6eae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e21c07a-4ec0-42e3-a740-4158809b6eae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/bf1d01870b7feda36c7ebad9ee400d011a9e1437816abd6d086c3eb8e6fec66d/GetPublication?filename=Uittreksels_18-07-2022_84315.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e21c07a-4ec0-42e3-a740-4158809b6eae>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0033eb1-6f34-44c2-8509-ed41b2c1ba2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0033eb1-6f34-44c2-8509-ed41b2c1ba2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/bf1d01870b7feda36c7ebad9ee400d011a9e1437816abd6d086c3eb8e6fec66d/GetPublication?filename=Uittreksels_18-07-2022_84325.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0033eb1-6f34-44c2-8509-ed41b2c1ba2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0860c983-e1e3-48b3-bff7-5666c5e1adc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0860c983-e1e3-48b3-bff7-5666c5e1adc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/bf1d01870b7feda36c7ebad9ee400d011a9e1437816abd6d086c3eb8e6fec66d/GetPublication?filename=Uittreksels_23-11-2021_77355.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0860c983-e1e3-48b3-bff7-5666c5e1adc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd4a4585-0565-42c0-92c0-0c5e0f82eea5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd4a4585-0565-42c0-92c0-0c5e0f82eea5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/f6bdf0c48b28bd22e5445698778646eeae2f83b1e9a132cb3c8cbb7452737dd5/GetPublication?filename=Uittreksels_18-07-2022_83037.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd4a4585-0565-42c0-92c0-0c5e0f82eea5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0531676e-b334-4e10-b75c-dfcf81f464bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0531676e-b334-4e10-b75c-dfcf81f464bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.middelkerke.be/LBLODWeb/Home/Overzicht/f6bdf0c48b28bd22e5445698778646eeae2f83b1e9a132cb3c8cbb7452737dd5/GetPublication?filename=Uittreksels_18-07-2022_83038.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0531676e-b334-4e10-b75c-dfcf81f464bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/54b549ea-32a5-4589-a200-0fc0fa20ae07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54b549ea-32a5-4589-a200-0fc0fa20ae07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Agenda_Gemeenteraad_02-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54b549ea-32a5-4589-a200-0fc0fa20ae07>.
+    
+<http://data.lblod.info/id/remote-data-objects/b69d6e8c-ad3f-4ba2-9ef8-02bf39a9c622> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b69d6e8c-ad3f-4ba2-9ef8-02bf39a9c622";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Agenda_Gemeenteraad_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b69d6e8c-ad3f-4ba2-9ef8-02bf39a9c622>.
+    
+<http://data.lblod.info/id/remote-data-objects/23e91b03-0236-4e23-b4b5-c14f1f5163eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23e91b03-0236-4e23-b4b5-c14f1f5163eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Agenda_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23e91b03-0236-4e23-b4b5-c14f1f5163eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/feacfeaa-0f48-467d-8e3a-5478ad29fa04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "feacfeaa-0f48-467d-8e3a-5478ad29fa04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Agenda_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/feacfeaa-0f48-467d-8e3a-5478ad29fa04>.
+    
+<http://data.lblod.info/id/remote-data-objects/645e959d-47e4-43d5-814c-c90d04e3bd17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "645e959d-47e4-43d5-814c-c90d04e3bd17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Agenda_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/645e959d-47e4-43d5-814c-c90d04e3bd17>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f621b32-0398-4daf-a4d3-298fff0feeab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f621b32-0398-4daf-a4d3-298fff0feeab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Agenda_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f621b32-0398-4daf-a4d3-298fff0feeab>.
+    
+<http://data.lblod.info/id/remote-data-objects/98e49fbf-3807-4728-a5e4-c5989aabeded> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98e49fbf-3807-4728-a5e4-c5989aabeded";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Agenda_Gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98e49fbf-3807-4728-a5e4-c5989aabeded>.
+    
+<http://data.lblod.info/id/remote-data-objects/8593d2b5-4f1c-4630-bb49-0260d41f6598> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8593d2b5-4f1c-4630-bb49-0260d41f6598";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Agenda_Gemeenteraad_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8593d2b5-4f1c-4630-bb49-0260d41f6598>.
+    
+<http://data.lblod.info/id/remote-data-objects/294a5af6-485b-4fa8-bec2-f079e89e366a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "294a5af6-485b-4fa8-bec2-f079e89e366a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Agenda_Gemeenteraad_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/294a5af6-485b-4fa8-bec2-f079e89e366a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cecc6e0-2e2e-4688-9dbf-facd13905208> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cecc6e0-2e2e-4688-9dbf-facd13905208";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Agenda_Gemeenteraad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cecc6e0-2e2e-4688-9dbf-facd13905208>.
+    
+<http://data.lblod.info/id/remote-data-objects/1087ca08-f15f-44d9-ba93-7a48ec371f19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1087ca08-f15f-44d9-ba93-7a48ec371f19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_02-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1087ca08-f15f-44d9-ba93-7a48ec371f19>.
+    
+<http://data.lblod.info/id/remote-data-objects/5874ddde-b10e-4c34-ad1c-b607bde9f539> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5874ddde-b10e-4c34-ad1c-b607bde9f539";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5874ddde-b10e-4c34-ad1c-b607bde9f539>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b6a6ad1-b1df-4922-b202-159913c70617> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b6a6ad1-b1df-4922-b202-159913c70617";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b6a6ad1-b1df-4922-b202-159913c70617>.
+    
+<http://data.lblod.info/id/remote-data-objects/555a7da0-e194-46ee-bdb9-80bda469679a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "555a7da0-e194-46ee-bdb9-80bda469679a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/555a7da0-e194-46ee-bdb9-80bda469679a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c7d9e2c-b929-4c08-8ef8-2945061747b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c7d9e2c-b929-4c08-8ef8-2945061747b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c7d9e2c-b929-4c08-8ef8-2945061747b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdb03ace-1b36-40cd-b088-9fd76bb4a51d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdb03ace-1b36-40cd-b088-9fd76bb4a51d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdb03ace-1b36-40cd-b088-9fd76bb4a51d>.
+    
+<http://data.lblod.info/id/remote-data-objects/25a9b937-cb3e-4bcf-ae11-8d56386e9ebc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25a9b937-cb3e-4bcf-ae11-8d56386e9ebc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25a9b937-cb3e-4bcf-ae11-8d56386e9ebc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c44c2486-b49a-4a95-802e-ca24c02de234> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c44c2486-b49a-4a95-802e-ca24c02de234";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c44c2486-b49a-4a95-802e-ca24c02de234>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d1e2c75-16d6-46d5-80f8-3d54e85a80ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d1e2c75-16d6-46d5-80f8-3d54e85a80ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d1e2c75-16d6-46d5-80f8-3d54e85a80ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3c43f9f-054d-4874-9c58-0c3a105c81f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3c43f9f-054d-4874-9c58-0c3a105c81f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3c43f9f-054d-4874-9c58-0c3a105c81f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2432b995-7f21-44d2-91bf-3695877e4904> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2432b995-7f21-44d2-91bf-3695877e4904";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Uittreksels_21-06-2022_33206.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2432b995-7f21-44d2-91bf-3695877e4904>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c5c5f85-d175-4f7f-b1b9-509b5e28bce5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c5c5f85-d175-4f7f-b1b9-509b5e28bce5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Uittreksels_21-12-2021_32423.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c5c5f85-d175-4f7f-b1b9-509b5e28bce5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a084321b-b6d9-4315-8b8b-4c1567c18c17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a084321b-b6d9-4315-8b8b-4c1567c18c17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Uittreksels_21-12-2021_32424.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a084321b-b6d9-4315-8b8b-4c1567c18c17>.
+    
+<http://data.lblod.info/id/remote-data-objects/96af2a32-0886-43ea-9982-cacd6feb797b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96af2a32-0886-43ea-9982-cacd6feb797b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Uittreksels_21-12-2021_32425.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7402afd0-30a5-4997-a459-c2229f016082> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96af2a32-0886-43ea-9982-cacd6feb797b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201604-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201604-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201604-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201604-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/846f93c0-aab6-4430-8cdf-f69f2f34dfcb> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "846f93c0-aab6-4430-8cdf-f69f2f34dfcb";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a648a8f2-08ec-4963-8d5a-a18a9553ebf9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ac18903e-a7f8-4e0a-a7fe-1ecb6ebef49a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ac18903e-a7f8-4e0a-a7fe-1ecb6ebef49a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9>.
+
+  <http://redpencil.data.gift/id/task/883a6d51-c361-4b72-bd69-fd2de5a0805d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "883a6d51-c361-4b72-bd69-fd2de5a0805d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/846f93c0-aab6-4430-8cdf-f69f2f34dfcb>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ac18903e-a7f8-4e0a-a7fe-1ecb6ebef49a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/63490319-1832-47e2-be9a-54de1603510c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63490319-1832-47e2-be9a-54de1603510c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Uittreksels_26-04-2022_32974.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63490319-1832-47e2-be9a-54de1603510c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b607a1d8-fad0-42c5-a084-1c273abda54e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b607a1d8-fad0-42c5-a084-1c273abda54e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Uittreksels_26-10-2021_32165.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b607a1d8-fad0-42c5-a084-1c273abda54e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d542c925-8e3e-4480-bc10-bb60aee74d34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d542c925-8e3e-4480-bc10-bb60aee74d34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Uittreksels_26-10-2021_32166.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d542c925-8e3e-4480-bc10-bb60aee74d34>.
+    
+<http://data.lblod.info/id/remote-data-objects/2367b609-2c50-48c0-ad72-dc28ddb2eab3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2367b609-2c50-48c0-ad72-dc28ddb2eab3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Uittreksels_26-10-2021_32167.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2367b609-2c50-48c0-ad72-dc28ddb2eab3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a828fde1-a655-483d-8a19-d408a92ed75f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a828fde1-a655-483d-8a19-d408a92ed75f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Uittreksels_26-10-2021_32168.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a828fde1-a655-483d-8a19-d408a92ed75f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7041d182-85ec-465f-88ca-0631c82d8ec4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7041d182-85ec-465f-88ca-0631c82d8ec4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Uittreksels_30-11-2021_32276.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7041d182-85ec-465f-88ca-0631c82d8ec4>.
+    
+<http://data.lblod.info/id/remote-data-objects/77fa30c5-8dec-42cf-8294-b6b1b8222611> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77fa30c5-8dec-42cf-8294-b6b1b8222611";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Uittreksels_31-05-2022_33032.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77fa30c5-8dec-42cf-8294-b6b1b8222611>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0017826-fdb4-437d-943b-b5c7c243a85e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0017826-fdb4-437d-943b-b5c7c243a85e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/01209f00dfb4d1fd5f73882914dd4b3df5bb91409cb0cdd470313c92d46a6bfc/GetPublication?filename=Uittreksels_31-05-2022_33174.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0017826-fdb4-437d-943b-b5c7c243a85e>.
+    
+<http://data.lblod.info/id/remote-data-objects/04ce57f3-97cc-48c0-a7f1-34fa91b6011b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04ce57f3-97cc-48c0-a7f1-34fa91b6011b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/2fea34ca040b3a5f0511bbbc94b9277ffc01cb913254e0a1f0ca05d512626aa9/GetPublication?filename=Uittreksels_22-11-2021_32357.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04ce57f3-97cc-48c0-a7f1-34fa91b6011b>.
+    
+<http://data.lblod.info/id/remote-data-objects/81b2cd21-b48c-4249-a9c7-20bb105444fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81b2cd21-b48c-4249-a9c7-20bb105444fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81b2cd21-b48c-4249-a9c7-20bb105444fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ade5ea0-fc7c-408b-9f91-b18cf4fcdee9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ade5ea0-fc7c-408b-9f91-b18cf4fcdee9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ade5ea0-fc7c-408b-9f91-b18cf4fcdee9>.
+    
+<http://data.lblod.info/id/remote-data-objects/99b7fee3-f144-440b-ad7c-484d2c648359> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99b7fee3-f144-440b-ad7c-484d2c648359";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99b7fee3-f144-440b-ad7c-484d2c648359>.
+    
+<http://data.lblod.info/id/remote-data-objects/115f97cd-2c82-4551-9af5-58626044a9fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "115f97cd-2c82-4551-9af5-58626044a9fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/115f97cd-2c82-4551-9af5-58626044a9fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/2156cc92-6ccf-4371-9f83-125e6263ea06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2156cc92-6ccf-4371-9f83-125e6263ea06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2156cc92-6ccf-4371-9f83-125e6263ea06>.
+    
+<http://data.lblod.info/id/remote-data-objects/667aa0f2-a2dc-429f-bf4e-c723ee6a0bc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "667aa0f2-a2dc-429f-bf4e-c723ee6a0bc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/667aa0f2-a2dc-429f-bf4e-c723ee6a0bc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3abb1650-ed32-4705-9240-f388999ad749> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3abb1650-ed32-4705-9240-f388999ad749";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3abb1650-ed32-4705-9240-f388999ad749>.
+    
+<http://data.lblod.info/id/remote-data-objects/86129b04-a2b0-4da9-b739-53ded7bef78f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86129b04-a2b0-4da9-b739-53ded7bef78f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86129b04-a2b0-4da9-b739-53ded7bef78f>.
+    
+<http://data.lblod.info/id/remote-data-objects/209994bf-8cde-48a5-b7f8-6c2db4d9af0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "209994bf-8cde-48a5-b7f8-6c2db4d9af0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/209994bf-8cde-48a5-b7f8-6c2db4d9af0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf3dfe0d-9201-4420-8038-1cd2b3847e9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf3dfe0d-9201-4420-8038-1cd2b3847e9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf3dfe0d-9201-4420-8038-1cd2b3847e9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a3c3c44-8a0d-406c-98be-e9a2967a46c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a3c3c44-8a0d-406c-98be-e9a2967a46c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a3c3c44-8a0d-406c-98be-e9a2967a46c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/894526c8-d28e-4df8-ba8f-460bedcf5b04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "894526c8-d28e-4df8-ba8f-460bedcf5b04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/894526c8-d28e-4df8-ba8f-460bedcf5b04>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee828196-797f-42e4-a9bd-5112976c91a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee828196-797f-42e4-a9bd-5112976c91a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee828196-797f-42e4-a9bd-5112976c91a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca62ef8e-27df-465f-8056-bec918657a4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca62ef8e-27df-465f-8056-bec918657a4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca62ef8e-27df-465f-8056-bec918657a4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/adee572f-d735-4c68-9285-089ea1c18e22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "adee572f-d735-4c68-9285-089ea1c18e22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/adee572f-d735-4c68-9285-089ea1c18e22>.
+    
+<http://data.lblod.info/id/remote-data-objects/21abbfc2-b54a-4408-92c1-cf7bd520ddf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21abbfc2-b54a-4408-92c1-cf7bd520ddf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21abbfc2-b54a-4408-92c1-cf7bd520ddf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a409d9b8-4ec4-43a6-afb3-0e1580d5bd8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a409d9b8-4ec4-43a6-afb3-0e1580d5bd8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a409d9b8-4ec4-43a6-afb3-0e1580d5bd8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cc7db77-64b5-43ee-adcd-f19b807332ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cc7db77-64b5-43ee-adcd-f19b807332ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cc7db77-64b5-43ee-adcd-f19b807332ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/94eb2ac0-f997-4172-8189-39c71b585d31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94eb2ac0-f997-4172-8189-39c71b585d31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94eb2ac0-f997-4172-8189-39c71b585d31>.
+    
+<http://data.lblod.info/id/remote-data-objects/10e01eb3-987c-407b-8ec2-c14cd0c35264> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10e01eb3-987c-407b-8ec2-c14cd0c35264";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10e01eb3-987c-407b-8ec2-c14cd0c35264>.
+    
+<http://data.lblod.info/id/remote-data-objects/082cb2ef-6ebf-40c8-b7d7-32ab45707856> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "082cb2ef-6ebf-40c8-b7d7-32ab45707856";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/082cb2ef-6ebf-40c8-b7d7-32ab45707856>.
+    
+<http://data.lblod.info/id/remote-data-objects/be1d7c06-acd8-4ecb-b8af-3f2a8112e5fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be1d7c06-acd8-4ecb-b8af-3f2a8112e5fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be1d7c06-acd8-4ecb-b8af-3f2a8112e5fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d41aafcd-b10a-457b-81ad-b62b4378eb43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d41aafcd-b10a-457b-81ad-b62b4378eb43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d41aafcd-b10a-457b-81ad-b62b4378eb43>.
+    
+<http://data.lblod.info/id/remote-data-objects/4670b00b-8cad-47f8-b681-91434493fe3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4670b00b-8cad-47f8-b681-91434493fe3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4670b00b-8cad-47f8-b681-91434493fe3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b056739-5cf7-4e3e-adb0-4744c81207b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b056739-5cf7-4e3e-adb0-4744c81207b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b056739-5cf7-4e3e-adb0-4744c81207b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba2957cf-9078-4a2e-a048-5953f8c01246> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba2957cf-9078-4a2e-a048-5953f8c01246";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba2957cf-9078-4a2e-a048-5953f8c01246>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2f81c42-e8ca-4ff0-965d-84a92346edd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2f81c42-e8ca-4ff0-965d-84a92346edd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2f81c42-e8ca-4ff0-965d-84a92346edd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6c40db3-2882-4ec0-ad82-15928c639e38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6c40db3-2882-4ec0-ad82-15928c639e38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6c40db3-2882-4ec0-ad82-15928c639e38>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cc19260-a925-48cf-b9a3-bc4df3c3f524> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cc19260-a925-48cf-b9a3-bc4df3c3f524";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cc19260-a925-48cf-b9a3-bc4df3c3f524>.
+    
+<http://data.lblod.info/id/remote-data-objects/3430d329-8ad6-4873-89d1-3b3808f8e60f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3430d329-8ad6-4873-89d1-3b3808f8e60f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3430d329-8ad6-4873-89d1-3b3808f8e60f>.
+    
+<http://data.lblod.info/id/remote-data-objects/401652b1-ca94-402f-807b-98cb668ddc0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "401652b1-ca94-402f-807b-98cb668ddc0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/401652b1-ca94-402f-807b-98cb668ddc0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a148743-379e-42c2-b6ed-b57252c6d071> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a148743-379e-42c2-b6ed-b57252c6d071";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a148743-379e-42c2-b6ed-b57252c6d071>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cefa79e-1696-4560-ae60-df523b615aaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cefa79e-1696-4560-ae60-df523b615aaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/30ab43b26166e9c6bb4114a674eba287ca6f10f2116c9da6d3ab48a578083f80/GetPublication?filename=BesluitenLijst_Vast%20Bureau_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cefa79e-1696-4560-ae60-df523b615aaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/6060ff73-fcfe-4009-bf56-356d2a4d7ffe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6060ff73-fcfe-4009-bf56-356d2a4d7ffe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6060ff73-fcfe-4009-bf56-356d2a4d7ffe>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe5d4e93-04dd-4af4-aad1-67c3a561e9e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe5d4e93-04dd-4af4-aad1-67c3a561e9e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe5d4e93-04dd-4af4-aad1-67c3a561e9e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/32c99223-c871-4ade-aa5f-8009e4f85eec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32c99223-c871-4ade-aa5f-8009e4f85eec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32c99223-c871-4ade-aa5f-8009e4f85eec>.
+    
+<http://data.lblod.info/id/remote-data-objects/66f9feb5-5028-45d8-9ea2-a0ec906069ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66f9feb5-5028-45d8-9ea2-a0ec906069ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66f9feb5-5028-45d8-9ea2-a0ec906069ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5e92e3d-020e-4062-aa36-bfdf37b51e8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5e92e3d-020e-4062-aa36-bfdf37b51e8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5e92e3d-020e-4062-aa36-bfdf37b51e8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0aa709f9-e713-4bc6-b85e-109a774b0a57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0aa709f9-e713-4bc6-b85e-109a774b0a57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0aa709f9-e713-4bc6-b85e-109a774b0a57>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9bbed0a-18b1-487d-9154-b9eee9881a7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9bbed0a-18b1-487d-9154-b9eee9881a7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9bbed0a-18b1-487d-9154-b9eee9881a7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b135e2d-4860-4240-aaf7-f33c2ac74b5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b135e2d-4860-4240-aaf7-f33c2ac74b5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a648a8f2-08ec-4963-8d5a-a18a9553ebf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b135e2d-4860-4240-aaf7-f33c2ac74b5b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201606-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201606-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201606-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201606-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/253b2f2a-ec62-4b2a-adbb-353c0a78d781> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "253b2f2a-ec62-4b2a-adbb-353c0a78d781";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "26ef8195-7f99-47c0-ad81-ad7df3fe00eb";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/fa4ac07c-9938-44a7-abb3-0b1f826af4e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fa4ac07c-9938-44a7-abb3-0b1f826af4e6";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb>.
+
+  <http://redpencil.data.gift/id/task/6ccbfbca-214c-4b37-b41d-34e08749def4> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6ccbfbca-214c-4b37-b41d-34e08749def4";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/253b2f2a-ec62-4b2a-adbb-353c0a78d781>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/fa4ac07c-9938-44a7-abb3-0b1f826af4e6>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/3a4b47ad-fe1e-4a1c-90e4-38795d77f6f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a4b47ad-fe1e-4a1c-90e4-38795d77f6f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a4b47ad-fe1e-4a1c-90e4-38795d77f6f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/40503e8b-9991-41cf-8d03-b0cf2c587c08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40503e8b-9991-41cf-8d03-b0cf2c587c08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40503e8b-9991-41cf-8d03-b0cf2c587c08>.
+    
+<http://data.lblod.info/id/remote-data-objects/c47045fd-4c66-42e0-aae7-5c552877d71b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c47045fd-4c66-42e0-aae7-5c552877d71b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c47045fd-4c66-42e0-aae7-5c552877d71b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7bcbdea-5d7e-42ac-8924-828d4956d6a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7bcbdea-5d7e-42ac-8924-828d4956d6a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7bcbdea-5d7e-42ac-8924-828d4956d6a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/82853ee7-e985-4305-aa90-4489f5a2d97e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82853ee7-e985-4305-aa90-4489f5a2d97e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82853ee7-e985-4305-aa90-4489f5a2d97e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7d22695-0a2b-4d5f-8e89-934ca6c363da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7d22695-0a2b-4d5f-8e89-934ca6c363da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7d22695-0a2b-4d5f-8e89-934ca6c363da>.
+    
+<http://data.lblod.info/id/remote-data-objects/87d1c5a3-ac49-424e-b276-b2d532cb9c9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87d1c5a3-ac49-424e-b276-b2d532cb9c9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_11-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87d1c5a3-ac49-424e-b276-b2d532cb9c9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1dcbdb93-12e1-4b2c-93ce-0053609c8497> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1dcbdb93-12e1-4b2c-93ce-0053609c8497";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1dcbdb93-12e1-4b2c-93ce-0053609c8497>.
+    
+<http://data.lblod.info/id/remote-data-objects/0410cd24-5269-4429-90e4-f3c23ca126e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0410cd24-5269-4429-90e4-f3c23ca126e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0410cd24-5269-4429-90e4-f3c23ca126e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/837bc84f-d863-43b6-94ef-7d6f35bf8df3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "837bc84f-d863-43b6-94ef-7d6f35bf8df3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/837bc84f-d863-43b6-94ef-7d6f35bf8df3>.
+    
+<http://data.lblod.info/id/remote-data-objects/29ea1f24-7b83-40d1-b9e7-46e18413f480> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29ea1f24-7b83-40d1-b9e7-46e18413f480";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29ea1f24-7b83-40d1-b9e7-46e18413f480>.
+    
+<http://data.lblod.info/id/remote-data-objects/a161ccf3-ef22-4fb8-a53f-af60098ed5d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a161ccf3-ef22-4fb8-a53f-af60098ed5d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_14-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a161ccf3-ef22-4fb8-a53f-af60098ed5d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c46fa27-e930-4ec5-9015-49bb11362c7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c46fa27-e930-4ec5-9015-49bb11362c7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c46fa27-e930-4ec5-9015-49bb11362c7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/12dbcb8b-e59e-428b-b747-00998af6f3ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12dbcb8b-e59e-428b-b747-00998af6f3ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12dbcb8b-e59e-428b-b747-00998af6f3ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7df29e8-8dad-4e01-b6b8-db1eff41506c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7df29e8-8dad-4e01-b6b8-db1eff41506c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7df29e8-8dad-4e01-b6b8-db1eff41506c>.
+    
+<http://data.lblod.info/id/remote-data-objects/77a6946d-7cf9-4698-b6c7-99b9c8fd5f42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77a6946d-7cf9-4698-b6c7-99b9c8fd5f42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77a6946d-7cf9-4698-b6c7-99b9c8fd5f42>.
+    
+<http://data.lblod.info/id/remote-data-objects/92d4ccd9-ae6a-4cee-9116-25016e195059> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92d4ccd9-ae6a-4cee-9116-25016e195059";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92d4ccd9-ae6a-4cee-9116-25016e195059>.
+    
+<http://data.lblod.info/id/remote-data-objects/225f11e3-7431-4da5-a656-f08f721af4fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "225f11e3-7431-4da5-a656-f08f721af4fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/225f11e3-7431-4da5-a656-f08f721af4fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/61290215-0b12-485a-8b9e-6d720c82cb76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61290215-0b12-485a-8b9e-6d720c82cb76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61290215-0b12-485a-8b9e-6d720c82cb76>.
+    
+<http://data.lblod.info/id/remote-data-objects/88f31f14-72ba-4799-b789-54c1c4bc2320> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88f31f14-72ba-4799-b789-54c1c4bc2320";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88f31f14-72ba-4799-b789-54c1c4bc2320>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d8bd15a-16af-4dbf-80c7-b5fe061cc21a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d8bd15a-16af-4dbf-80c7-b5fe061cc21a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d8bd15a-16af-4dbf-80c7-b5fe061cc21a>.
+    
+<http://data.lblod.info/id/remote-data-objects/55b8425e-751d-462a-9a44-414ab52e90ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55b8425e-751d-462a-9a44-414ab52e90ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55b8425e-751d-462a-9a44-414ab52e90ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/fec3de7d-dcc8-4677-992f-315771c4d545> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fec3de7d-dcc8-4677-992f-315771c4d545";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fec3de7d-dcc8-4677-992f-315771c4d545>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc228155-710d-4103-9a26-09ce9195b028> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc228155-710d-4103-9a26-09ce9195b028";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc228155-710d-4103-9a26-09ce9195b028>.
+    
+<http://data.lblod.info/id/remote-data-objects/24773497-6b8d-43f5-bd6d-052c3bb08b79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24773497-6b8d-43f5-bd6d-052c3bb08b79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24773497-6b8d-43f5-bd6d-052c3bb08b79>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b34b184-99b0-48fd-ad09-4fffa5522931> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b34b184-99b0-48fd-ad09-4fffa5522931";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b34b184-99b0-48fd-ad09-4fffa5522931>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6b61871-3ea9-4623-a27a-bfcee0d7b88e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6b61871-3ea9-4623-a27a-bfcee0d7b88e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6b61871-3ea9-4623-a27a-bfcee0d7b88e>.
+    
+<http://data.lblod.info/id/remote-data-objects/de9f9517-2276-415f-8fef-a537c4934be6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de9f9517-2276-415f-8fef-a537c4934be6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de9f9517-2276-415f-8fef-a537c4934be6>.
+    
+<http://data.lblod.info/id/remote-data-objects/120f8cde-ba0d-4747-b040-22bb91308052> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "120f8cde-ba0d-4747-b040-22bb91308052";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/120f8cde-ba0d-4747-b040-22bb91308052>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ac391ad-b45a-4297-a391-ebe1b33df9c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ac391ad-b45a-4297-a391-ebe1b33df9c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_27-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ac391ad-b45a-4297-a391-ebe1b33df9c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b12c9c6-4de6-4a46-8c90-e1f1df335176> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b12c9c6-4de6-4a46-8c90-e1f1df335176";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b12c9c6-4de6-4a46-8c90-e1f1df335176>.
+    
+<http://data.lblod.info/id/remote-data-objects/affee591-cfca-42e0-b674-a8022ad6001f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "affee591-cfca-42e0-b674-a8022ad6001f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/affee591-cfca-42e0-b674-a8022ad6001f>.
+    
+<http://data.lblod.info/id/remote-data-objects/310a7f93-648e-405d-b213-d0188c46d3fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "310a7f93-648e-405d-b213-d0188c46d3fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/310a7f93-648e-405d-b213-d0188c46d3fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dedb562-e884-4c9c-9fe0-e79930fcfb3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dedb562-e884-4c9c-9fe0-e79930fcfb3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/42502c329c8fc8105011ab3cdc4b62edf880aed257a6134b0716b1fa53de83f6/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dedb562-e884-4c9c-9fe0-e79930fcfb3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c6319b9-547d-4763-9e0e-3721cec5a80e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c6319b9-547d-4763-9e0e-3721cec5a80e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/9c838f3deb9825c6c2049120ca8965d270b8598f162027206d353e1d2afdc8f7/GetPublication?filename=Agenda_OCMW-Raad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c6319b9-547d-4763-9e0e-3721cec5a80e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b39913b-d8ef-4dfc-8080-cf1d09b3341d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b39913b-d8ef-4dfc-8080-cf1d09b3341d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/9c838f3deb9825c6c2049120ca8965d270b8598f162027206d353e1d2afdc8f7/GetPublication?filename=Agenda_OCMW-Raad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b39913b-d8ef-4dfc-8080-cf1d09b3341d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0a8a3b9-77bf-48ae-a368-0296fd8d64a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0a8a3b9-77bf-48ae-a368-0296fd8d64a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/9c838f3deb9825c6c2049120ca8965d270b8598f162027206d353e1d2afdc8f7/GetPublication?filename=Agenda_OCMW-Raad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0a8a3b9-77bf-48ae-a368-0296fd8d64a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb5ce5ba-c46f-4bec-a1a5-13ccfa46bf76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb5ce5ba-c46f-4bec-a1a5-13ccfa46bf76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/9c838f3deb9825c6c2049120ca8965d270b8598f162027206d353e1d2afdc8f7/GetPublication?filename=Agenda_OCMW-Raad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb5ce5ba-c46f-4bec-a1a5-13ccfa46bf76>.
+    
+<http://data.lblod.info/id/remote-data-objects/26199946-6cb0-487e-855e-ae4a7943ef38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26199946-6cb0-487e-855e-ae4a7943ef38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/9c838f3deb9825c6c2049120ca8965d270b8598f162027206d353e1d2afdc8f7/GetPublication?filename=Agenda_OCMW-Raad_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26199946-6cb0-487e-855e-ae4a7943ef38>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f36d1c6-8891-4ecc-a4db-37e55b22354a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f36d1c6-8891-4ecc-a4db-37e55b22354a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/9c838f3deb9825c6c2049120ca8965d270b8598f162027206d353e1d2afdc8f7/GetPublication?filename=Agenda_OCMW-Raad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f36d1c6-8891-4ecc-a4db-37e55b22354a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1c3cedc-3873-4829-9e8a-847869a9c034> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1c3cedc-3873-4829-9e8a-847869a9c034";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/9c838f3deb9825c6c2049120ca8965d270b8598f162027206d353e1d2afdc8f7/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1c3cedc-3873-4829-9e8a-847869a9c034>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d1983b7-d64a-4d73-acef-86cb68ce1993> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d1983b7-d64a-4d73-acef-86cb68ce1993";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/9c838f3deb9825c6c2049120ca8965d270b8598f162027206d353e1d2afdc8f7/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d1983b7-d64a-4d73-acef-86cb68ce1993>.
+    
+<http://data.lblod.info/id/remote-data-objects/8db67b0f-97dd-4dc9-9bd3-2dc64ac904cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8db67b0f-97dd-4dc9-9bd3-2dc64ac904cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/9c838f3deb9825c6c2049120ca8965d270b8598f162027206d353e1d2afdc8f7/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8db67b0f-97dd-4dc9-9bd3-2dc64ac904cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/fde3522f-2df8-4334-86b7-0b9d430a7832> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fde3522f-2df8-4334-86b7-0b9d430a7832";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/9c838f3deb9825c6c2049120ca8965d270b8598f162027206d353e1d2afdc8f7/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fde3522f-2df8-4334-86b7-0b9d430a7832>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5158b95-d139-42ea-ae7a-a9fb07d738ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5158b95-d139-42ea-ae7a-a9fb07d738ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/9c838f3deb9825c6c2049120ca8965d270b8598f162027206d353e1d2afdc8f7/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5158b95-d139-42ea-ae7a-a9fb07d738ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/34ac6481-c514-48ff-804f-d4ee864453e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34ac6481-c514-48ff-804f-d4ee864453e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.niel.be/LBLODWeb/Home/Overzicht/9c838f3deb9825c6c2049120ca8965d270b8598f162027206d353e1d2afdc8f7/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34ac6481-c514-48ff-804f-d4ee864453e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cc9ddfc-e446-4499-bb89-d0cf70e2fb21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cc9ddfc-e446-4499-bb89-d0cf70e2fb21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cc9ddfc-e446-4499-bb89-d0cf70e2fb21>.
+    
+<http://data.lblod.info/id/remote-data-objects/39f7a540-9cfb-4c02-ba5f-59b2753c56ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39f7a540-9cfb-4c02-ba5f-59b2753c56ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39f7a540-9cfb-4c02-ba5f-59b2753c56ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/9343bb0e-8d79-450b-8dac-31247ab18096> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9343bb0e-8d79-450b-8dac-31247ab18096";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9343bb0e-8d79-450b-8dac-31247ab18096>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d13d490-b070-4ab3-a78d-3ed3fcd6c09c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d13d490-b070-4ab3-a78d-3ed3fcd6c09c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/26ef8195-7f99-47c0-ad81-ad7df3fe00eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d13d490-b070-4ab3-a78d-3ed3fcd6c09c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201607-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201607-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201607-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201607-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/451c6d53-9d82-4e75-9599-e09ebe635de2> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "451c6d53-9d82-4e75-9599-e09ebe635de2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "29027139-d76a-4b37-84db-a932d1c2004e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a0fba9e4-275f-4a48-8534-a8242f025a5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a0fba9e4-275f-4a48-8534-a8242f025a5c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e>.
+
+  <http://redpencil.data.gift/id/task/5ff1e096-571b-45a0-bfb8-e739e6ba0c70> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5ff1e096-571b-45a0-bfb8-e739e6ba0c70";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/451c6d53-9d82-4e75-9599-e09ebe635de2>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a0fba9e4-275f-4a48-8534-a8242f025a5c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7d94a43d-bcba-4c7b-9e68-bc737c7cf000> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d94a43d-bcba-4c7b-9e68-bc737c7cf000";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d94a43d-bcba-4c7b-9e68-bc737c7cf000>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b700a18-aaa7-4d5a-b3c2-4dc934be8077> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b700a18-aaa7-4d5a-b3c2-4dc934be8077";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b700a18-aaa7-4d5a-b3c2-4dc934be8077>.
+    
+<http://data.lblod.info/id/remote-data-objects/24c8e7ef-243d-4cc6-b09c-b28adaf704a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24c8e7ef-243d-4cc6-b09c-b28adaf704a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24c8e7ef-243d-4cc6-b09c-b28adaf704a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/bae186ac-78b5-48d5-93fe-3291c20fc300> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bae186ac-78b5-48d5-93fe-3291c20fc300";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bae186ac-78b5-48d5-93fe-3291c20fc300>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec19f097-2383-4020-b2d6-8af8444750e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec19f097-2383-4020-b2d6-8af8444750e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec19f097-2383-4020-b2d6-8af8444750e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b7c49b5-c0ce-413e-9fc5-cdb8e00d28c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b7c49b5-c0ce-413e-9fc5-cdb8e00d28c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b7c49b5-c0ce-413e-9fc5-cdb8e00d28c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ea75382-1774-4175-baac-6492a5d807a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ea75382-1774-4175-baac-6492a5d807a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ea75382-1774-4175-baac-6492a5d807a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d80a1193-f313-4a19-8e23-652809af9bbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d80a1193-f313-4a19-8e23-652809af9bbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d80a1193-f313-4a19-8e23-652809af9bbb>.
+    
+<http://data.lblod.info/id/remote-data-objects/87485bf5-9594-4e36-b279-f1d58f359ec0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87485bf5-9594-4e36-b279-f1d58f359ec0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87485bf5-9594-4e36-b279-f1d58f359ec0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d4d9764-4936-4bf3-9b4a-e47ff24860a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d4d9764-4936-4bf3-9b4a-e47ff24860a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d4d9764-4936-4bf3-9b4a-e47ff24860a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/365ba4e1-21a6-40a4-b1ee-ed451f360913> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "365ba4e1-21a6-40a4-b1ee-ed451f360913";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/365ba4e1-21a6-40a4-b1ee-ed451f360913>.
+    
+<http://data.lblod.info/id/remote-data-objects/085f8cc2-8fbc-415e-b99b-55e97f08b0e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "085f8cc2-8fbc-415e-b99b-55e97f08b0e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/085f8cc2-8fbc-415e-b99b-55e97f08b0e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/370dd1da-bcb1-4544-86eb-47beca719b90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "370dd1da-bcb1-4544-86eb-47beca719b90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/370dd1da-bcb1-4544-86eb-47beca719b90>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4145f21-4376-4756-8052-43290689e90d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4145f21-4376-4756-8052-43290689e90d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4145f21-4376-4756-8052-43290689e90d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3410827c-4594-4ad6-9409-47739963a550> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3410827c-4594-4ad6-9409-47739963a550";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3410827c-4594-4ad6-9409-47739963a550>.
+    
+<http://data.lblod.info/id/remote-data-objects/16572a99-806f-4188-80e3-2d9eafd730ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16572a99-806f-4188-80e3-2d9eafd730ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16572a99-806f-4188-80e3-2d9eafd730ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/c24cabfb-f9e0-4b1c-bb19-24cb5ed6137e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c24cabfb-f9e0-4b1c-bb19-24cb5ed6137e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c24cabfb-f9e0-4b1c-bb19-24cb5ed6137e>.
+    
+<http://data.lblod.info/id/remote-data-objects/23992f1b-4e7b-4166-8138-f35048eb82cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23992f1b-4e7b-4166-8138-f35048eb82cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23992f1b-4e7b-4166-8138-f35048eb82cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1ad98f2-c5a8-4700-99fd-8d01f0446c76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1ad98f2-c5a8-4700-99fd-8d01f0446c76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1ad98f2-c5a8-4700-99fd-8d01f0446c76>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a33b9ec-d7a7-486b-aebd-801ba2c67577> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a33b9ec-d7a7-486b-aebd-801ba2c67577";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a33b9ec-d7a7-486b-aebd-801ba2c67577>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7f973fe-2151-4ee9-845e-4db5eb7dfb5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7f973fe-2151-4ee9-845e-4db5eb7dfb5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7f973fe-2151-4ee9-845e-4db5eb7dfb5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4d8c40f-65bf-4c13-b87d-f64639accae0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4d8c40f-65bf-4c13-b87d-f64639accae0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4d8c40f-65bf-4c13-b87d-f64639accae0>.
+    
+<http://data.lblod.info/id/remote-data-objects/514daed2-6b12-426c-b559-978f80bd4745> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "514daed2-6b12-426c-b559-978f80bd4745";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/514daed2-6b12-426c-b559-978f80bd4745>.
+    
+<http://data.lblod.info/id/remote-data-objects/577e9e17-8b4f-4f99-a622-8580c61badef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "577e9e17-8b4f-4f99-a622-8580c61badef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/577e9e17-8b4f-4f99-a622-8580c61badef>.
+    
+<http://data.lblod.info/id/remote-data-objects/0519e0cb-902a-4354-a4d3-3c0120f11b05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0519e0cb-902a-4354-a4d3-3c0120f11b05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0519e0cb-902a-4354-a4d3-3c0120f11b05>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a0d521f-b248-40a4-ab87-9a62ef52c5ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a0d521f-b248-40a4-ab87-9a62ef52c5ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_26-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a0d521f-b248-40a4-ab87-9a62ef52c5ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d87c584-f731-4a34-8f37-82b227f7a42b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d87c584-f731-4a34-8f37-82b227f7a42b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d87c584-f731-4a34-8f37-82b227f7a42b>.
+    
+<http://data.lblod.info/id/remote-data-objects/60612203-2f7d-40b2-8fe8-35ddd4043ead> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60612203-2f7d-40b2-8fe8-35ddd4043ead";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60612203-2f7d-40b2-8fe8-35ddd4043ead>.
+    
+<http://data.lblod.info/id/remote-data-objects/378b97d0-9ad4-42a0-a976-646749fc63f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "378b97d0-9ad4-42a0-a976-646749fc63f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/378b97d0-9ad4-42a0-a976-646749fc63f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecf4dfac-f9d3-44be-bd6b-a14f032f14ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecf4dfac-f9d3-44be-bd6b-a14f032f14ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/544f169d-5f2f-40b7-aff4-2934a6d08d8f/GetPublication?filename=BesluitenLijst_Vast%20Bureau_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecf4dfac-f9d3-44be-bd6b-a14f032f14ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/71962f1d-7811-4bce-bd75-b094994775eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71962f1d-7811-4bce-bd75-b094994775eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71962f1d-7811-4bce-bd75-b094994775eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/220c90dd-da25-46b7-8aeb-467147d772d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "220c90dd-da25-46b7-8aeb-467147d772d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/220c90dd-da25-46b7-8aeb-467147d772d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c055836-d8f4-436e-84a7-c2651dc02fd4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c055836-d8f4-436e-84a7-c2651dc02fd4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c055836-d8f4-436e-84a7-c2651dc02fd4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7ad735c-99e2-4b26-b414-5029a3a8ec77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7ad735c-99e2-4b26-b414-5029a3a8ec77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7ad735c-99e2-4b26-b414-5029a3a8ec77>.
+    
+<http://data.lblod.info/id/remote-data-objects/8449a74f-0d26-45f6-87ae-6dcdcdaa6567> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8449a74f-0d26-45f6-87ae-6dcdcdaa6567";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8449a74f-0d26-45f6-87ae-6dcdcdaa6567>.
+    
+<http://data.lblod.info/id/remote-data-objects/c513325c-87a2-4407-a930-fff105021012> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c513325c-87a2-4407-a930-fff105021012";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c513325c-87a2-4407-a930-fff105021012>.
+    
+<http://data.lblod.info/id/remote-data-objects/23e7d69c-f311-4196-a6b7-b9e1cb459397> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23e7d69c-f311-4196-a6b7-b9e1cb459397";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23e7d69c-f311-4196-a6b7-b9e1cb459397>.
+    
+<http://data.lblod.info/id/remote-data-objects/0885b260-91d2-4a6b-967c-c65315a6dcb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0885b260-91d2-4a6b-967c-c65315a6dcb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0885b260-91d2-4a6b-967c-c65315a6dcb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2e86339-e0c7-4725-b55c-3736de8a9435> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2e86339-e0c7-4725-b55c-3736de8a9435";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2e86339-e0c7-4725-b55c-3736de8a9435>.
+    
+<http://data.lblod.info/id/remote-data-objects/970070cf-afa8-4600-847c-7882502187b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "970070cf-afa8-4600-847c-7882502187b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/970070cf-afa8-4600-847c-7882502187b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/63282662-2fd9-4184-93ec-288986d5e918> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63282662-2fd9-4184-93ec-288986d5e918";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63282662-2fd9-4184-93ec-288986d5e918>.
+    
+<http://data.lblod.info/id/remote-data-objects/cec1792d-c6fa-4cdc-ac70-e7d292a96a28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cec1792d-c6fa-4cdc-ac70-e7d292a96a28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cec1792d-c6fa-4cdc-ac70-e7d292a96a28>.
+    
+<http://data.lblod.info/id/remote-data-objects/92c71d08-28a0-44b5-bfb2-f4124c51c81b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92c71d08-28a0-44b5-bfb2-f4124c51c81b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92c71d08-28a0-44b5-bfb2-f4124c51c81b>.
+    
+<http://data.lblod.info/id/remote-data-objects/36ee5a99-7b74-480f-b321-33af7828fab1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36ee5a99-7b74-480f-b321-33af7828fab1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36ee5a99-7b74-480f-b321-33af7828fab1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1355a84-8db4-4a09-81de-045042bded4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1355a84-8db4-4a09-81de-045042bded4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1355a84-8db4-4a09-81de-045042bded4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/41a11f56-a102-4fb4-aaad-447bb2130544> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41a11f56-a102-4fb4-aaad-447bb2130544";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41a11f56-a102-4fb4-aaad-447bb2130544>.
+    
+<http://data.lblod.info/id/remote-data-objects/751c91ed-4e46-4ad3-b3e3-764fa7bd5310> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "751c91ed-4e46-4ad3-b3e3-764fa7bd5310";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/751c91ed-4e46-4ad3-b3e3-764fa7bd5310>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a5f0111-9d80-49f2-8254-209ad464b86e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a5f0111-9d80-49f2-8254-209ad464b86e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a5f0111-9d80-49f2-8254-209ad464b86e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b5e32d4-2387-422e-ab99-b34a4fc66ab5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b5e32d4-2387-422e-ab99-b34a4fc66ab5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b5e32d4-2387-422e-ab99-b34a4fc66ab5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3e1b514-b204-45f4-ae3b-b69d785e15ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3e1b514-b204-45f4-ae3b-b69d785e15ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/29027139-d76a-4b37-84db-a932d1c2004e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3e1b514-b204-45f4-ae3b-b69d785e15ee>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201608-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201608-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201608-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201608-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/992beeb0-c5e3-4aca-baca-0dde0359e07a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "992beeb0-c5e3-4aca-baca-0dde0359e07a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "514d667d-051f-4092-9b54-79703d104721";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/3f0e3393-c04f-4217-81db-fee04bc2a959> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3f0e3393-c04f-4217-81db-fee04bc2a959";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721>.
+
+  <http://redpencil.data.gift/id/task/7da56ab1-97c4-4177-991a-8be94b3819b2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7da56ab1-97c4-4177-991a-8be94b3819b2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/992beeb0-c5e3-4aca-baca-0dde0359e07a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/3f0e3393-c04f-4217-81db-fee04bc2a959>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/81afe3a1-804e-483d-9158-7222af638c1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81afe3a1-804e-483d-9158-7222af638c1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81afe3a1-804e-483d-9158-7222af638c1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/879f687a-4ec7-4f2d-aa5c-dee2d083acc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "879f687a-4ec7-4f2d-aa5c-dee2d083acc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Uittreksels_16-12-2021_41304.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/879f687a-4ec7-4f2d-aa5c-dee2d083acc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/425eb638-adfa-4797-b98b-af5b5ff4f4c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "425eb638-adfa-4797-b98b-af5b5ff4f4c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Uittreksels_19-05-2022_44541.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/425eb638-adfa-4797-b98b-af5b5ff4f4c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ad28486-9d46-4531-a970-efa47ee3f3de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ad28486-9d46-4531-a970-efa47ee3f3de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Uittreksels_23-06-2022_44338.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ad28486-9d46-4531-a970-efa47ee3f3de>.
+    
+<http://data.lblod.info/id/remote-data-objects/aca7a645-8986-4f78-ab4b-1b0012b5f94f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aca7a645-8986-4f78-ab4b-1b0012b5f94f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Uittreksels_23-06-2022_45094.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aca7a645-8986-4f78-ab4b-1b0012b5f94f>.
+    
+<http://data.lblod.info/id/remote-data-objects/08d1820c-aa46-4b5c-834c-a62a98ce44a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08d1820c-aa46-4b5c-834c-a62a98ce44a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/917d02620269b69223bb26c23bc34b20bcd7c3b94bdd54b048c164ad29bdf3c7/GetPublication?filename=Uittreksels_28-04-2022_43449.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08d1820c-aa46-4b5c-834c-a62a98ce44a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/40f42675-b91b-47c1-b0a6-21bed4f9fe57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40f42675-b91b-47c1-b0a6-21bed4f9fe57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40f42675-b91b-47c1-b0a6-21bed4f9fe57>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2687143-5e7f-430e-b122-a3e7e51248ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2687143-5e7f-430e-b122-a3e7e51248ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2687143-5e7f-430e-b122-a3e7e51248ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f80714a-8b4d-45cc-877d-d97c105461e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f80714a-8b4d-45cc-877d-d97c105461e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f80714a-8b4d-45cc-877d-d97c105461e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf5ec356-06f2-42d5-a6d9-b2d01a51b18a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf5ec356-06f2-42d5-a6d9-b2d01a51b18a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_01-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf5ec356-06f2-42d5-a6d9-b2d01a51b18a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b75a0fb-4015-4432-95b0-c91d6cbc77f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b75a0fb-4015-4432-95b0-c91d6cbc77f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b75a0fb-4015-4432-95b0-c91d6cbc77f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c704d53-fdc7-4ac9-b61c-1972d606fcde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c704d53-fdc7-4ac9-b61c-1972d606fcde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c704d53-fdc7-4ac9-b61c-1972d606fcde>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ea0b306-deab-4bc4-8667-5692357f2c39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ea0b306-deab-4bc4-8667-5692357f2c39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ea0b306-deab-4bc4-8667-5692357f2c39>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd98e7fd-f5f8-49be-a697-b285b08d0b17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd98e7fd-f5f8-49be-a697-b285b08d0b17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_03-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd98e7fd-f5f8-49be-a697-b285b08d0b17>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3521c75-e859-43fd-9843-f6e22fc1aad5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3521c75-e859-43fd-9843-f6e22fc1aad5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3521c75-e859-43fd-9843-f6e22fc1aad5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c432d18f-be0e-4731-8848-6709a3a318d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c432d18f-be0e-4731-8848-6709a3a318d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_04-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c432d18f-be0e-4731-8848-6709a3a318d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4b74d8d-1f40-435b-a997-69fa691e445b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4b74d8d-1f40-435b-a997-69fa691e445b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4b74d8d-1f40-435b-a997-69fa691e445b>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdf3868d-410f-4294-b4ba-67e12669f8a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdf3868d-410f-4294-b4ba-67e12669f8a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdf3868d-410f-4294-b4ba-67e12669f8a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/834123c5-73a9-4c05-ae6e-3c81fac06e22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "834123c5-73a9-4c05-ae6e-3c81fac06e22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/834123c5-73a9-4c05-ae6e-3c81fac06e22>.
+    
+<http://data.lblod.info/id/remote-data-objects/c241afc8-8707-41b1-a0e2-8d6b3eaf2a23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c241afc8-8707-41b1-a0e2-8d6b3eaf2a23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c241afc8-8707-41b1-a0e2-8d6b3eaf2a23>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8fd2f12-f2ba-4fd4-bc92-d76e97cb7d80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8fd2f12-f2ba-4fd4-bc92-d76e97cb7d80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8fd2f12-f2ba-4fd4-bc92-d76e97cb7d80>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0291d3f-e965-44c8-b1b6-7078bd074d4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0291d3f-e965-44c8-b1b6-7078bd074d4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_07-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0291d3f-e965-44c8-b1b6-7078bd074d4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d24926a9-f0e8-4147-a508-30436c87fb6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d24926a9-f0e8-4147-a508-30436c87fb6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d24926a9-f0e8-4147-a508-30436c87fb6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/210cfc76-7348-409c-9512-a8443ad07318> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "210cfc76-7348-409c-9512-a8443ad07318";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/210cfc76-7348-409c-9512-a8443ad07318>.
+    
+<http://data.lblod.info/id/remote-data-objects/0abb9fb0-f4ff-4516-b6b5-71aed69449c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0abb9fb0-f4ff-4516-b6b5-71aed69449c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0abb9fb0-f4ff-4516-b6b5-71aed69449c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a335d17-42c2-42ce-9201-0d52eb38a2bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a335d17-42c2-42ce-9201-0d52eb38a2bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a335d17-42c2-42ce-9201-0d52eb38a2bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/35b5f5d8-a850-49f9-b9d4-8e62afded1bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35b5f5d8-a850-49f9-b9d4-8e62afded1bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35b5f5d8-a850-49f9-b9d4-8e62afded1bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa412afe-a8fb-4e5d-88fc-27f3ce56f172> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa412afe-a8fb-4e5d-88fc-27f3ce56f172";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_08-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa412afe-a8fb-4e5d-88fc-27f3ce56f172>.
+    
+<http://data.lblod.info/id/remote-data-objects/376aa175-abcd-45fa-abd0-6613e1dfc567> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "376aa175-abcd-45fa-abd0-6613e1dfc567";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/376aa175-abcd-45fa-abd0-6613e1dfc567>.
+    
+<http://data.lblod.info/id/remote-data-objects/c777c2a6-2879-4670-b646-ae4c7ba86676> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c777c2a6-2879-4670-b646-ae4c7ba86676";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c777c2a6-2879-4670-b646-ae4c7ba86676>.
+    
+<http://data.lblod.info/id/remote-data-objects/022d289b-1032-4b89-af9b-47326629fb96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "022d289b-1032-4b89-af9b-47326629fb96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_10-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/022d289b-1032-4b89-af9b-47326629fb96>.
+    
+<http://data.lblod.info/id/remote-data-objects/a08a1833-b821-4c5d-ac00-20a3e1fb1b5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a08a1833-b821-4c5d-ac00-20a3e1fb1b5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_10-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a08a1833-b821-4c5d-ac00-20a3e1fb1b5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f683b9ec-f980-4a7c-b4d7-16d11a6b6046> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f683b9ec-f980-4a7c-b4d7-16d11a6b6046";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f683b9ec-f980-4a7c-b4d7-16d11a6b6046>.
+    
+<http://data.lblod.info/id/remote-data-objects/85140703-b7fe-4675-b396-0daebdd2f70d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85140703-b7fe-4675-b396-0daebdd2f70d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_11-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85140703-b7fe-4675-b396-0daebdd2f70d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd10e9eb-893e-46c0-b7a9-7a992af7ac30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd10e9eb-893e-46c0-b7a9-7a992af7ac30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_11-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd10e9eb-893e-46c0-b7a9-7a992af7ac30>.
+    
+<http://data.lblod.info/id/remote-data-objects/b41a9092-0aee-4788-be77-553e2ffbb47e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b41a9092-0aee-4788-be77-553e2ffbb47e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b41a9092-0aee-4788-be77-553e2ffbb47e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b54df52e-cd09-4195-93a4-10b65e98b05b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b54df52e-cd09-4195-93a4-10b65e98b05b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b54df52e-cd09-4195-93a4-10b65e98b05b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f47bcb32-7895-4c0f-a4ac-c431103e1708> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f47bcb32-7895-4c0f-a4ac-c431103e1708";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f47bcb32-7895-4c0f-a4ac-c431103e1708>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d3dea2d-d497-4d6f-88b9-4566ae0a163e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d3dea2d-d497-4d6f-88b9-4566ae0a163e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_12-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d3dea2d-d497-4d6f-88b9-4566ae0a163e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ef6243b-ab40-4e4e-8c23-6ca67fbf9922> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ef6243b-ab40-4e4e-8c23-6ca67fbf9922";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ef6243b-ab40-4e4e-8c23-6ca67fbf9922>.
+    
+<http://data.lblod.info/id/remote-data-objects/161fd065-e767-4330-a6b1-2fb46e600160> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "161fd065-e767-4330-a6b1-2fb46e600160";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_14-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/161fd065-e767-4330-a6b1-2fb46e600160>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d6352aa-c71e-47df-9233-905510ab9cd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d6352aa-c71e-47df-9233-905510ab9cd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d6352aa-c71e-47df-9233-905510ab9cd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/2400fea0-f017-4a5a-8634-b83000784330> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2400fea0-f017-4a5a-8634-b83000784330";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2400fea0-f017-4a5a-8634-b83000784330>.
+    
+<http://data.lblod.info/id/remote-data-objects/31b9c6fe-fa72-4f3f-9863-d88d549440b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31b9c6fe-fa72-4f3f-9863-d88d549440b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31b9c6fe-fa72-4f3f-9863-d88d549440b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6dda0aa-d7d3-452e-9fdb-38d8ac597e73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6dda0aa-d7d3-452e-9fdb-38d8ac597e73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6dda0aa-d7d3-452e-9fdb-38d8ac597e73>.
+    
+<http://data.lblod.info/id/remote-data-objects/e65c291a-2003-45f4-8347-f2fef51a8189> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e65c291a-2003-45f4-8347-f2fef51a8189";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_15-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e65c291a-2003-45f4-8347-f2fef51a8189>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b81d284-9808-4ad1-bdec-f4f4b7a6fa99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b81d284-9808-4ad1-bdec-f4f4b7a6fa99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b81d284-9808-4ad1-bdec-f4f4b7a6fa99>.
+    
+<http://data.lblod.info/id/remote-data-objects/913cd20d-c1a3-4577-8658-5b6d0cfc3023> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "913cd20d-c1a3-4577-8658-5b6d0cfc3023";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/913cd20d-c1a3-4577-8658-5b6d0cfc3023>.
+    
+<http://data.lblod.info/id/remote-data-objects/80e76a0c-2d23-4efb-b283-1a8b32156dc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80e76a0c-2d23-4efb-b283-1a8b32156dc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80e76a0c-2d23-4efb-b283-1a8b32156dc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/572f0748-ea5d-44cb-82d1-08861eff3e60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "572f0748-ea5d-44cb-82d1-08861eff3e60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/514d667d-051f-4092-9b54-79703d104721> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/572f0748-ea5d-44cb-82d1-08861eff3e60>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201609-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201609-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201609-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201609-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a1bac4a9-4486-4178-a3b1-70ced6f1033f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a1bac4a9-4486-4178-a3b1-70ced6f1033f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "753a9fce-c957-4537-8726-94056a5f832b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9bbe6c9d-5c3e-4b76-a98a-5890d2e8dee6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9bbe6c9d-5c3e-4b76-a98a-5890d2e8dee6";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b>.
+
+  <http://redpencil.data.gift/id/task/a6952a24-716a-474b-b4b2-261d006d0b2a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a6952a24-716a-474b-b4b2-261d006d0b2a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a1bac4a9-4486-4178-a3b1-70ced6f1033f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9bbe6c9d-5c3e-4b76-a98a-5890d2e8dee6>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/67dffe2d-54c4-4b39-8a21-8ade61cfc098> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67dffe2d-54c4-4b39-8a21-8ade61cfc098";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_17-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67dffe2d-54c4-4b39-8a21-8ade61cfc098>.
+    
+<http://data.lblod.info/id/remote-data-objects/052f0539-416d-48e7-8eab-f37a369acfff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "052f0539-416d-48e7-8eab-f37a369acfff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_17-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/052f0539-416d-48e7-8eab-f37a369acfff>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcbe0503-9162-4cc1-9a6a-9f96bcaea7ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcbe0503-9162-4cc1-9a6a-9f96bcaea7ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcbe0503-9162-4cc1-9a6a-9f96bcaea7ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe25926c-b7b4-4a1b-a86c-1be650d3c961> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe25926c-b7b4-4a1b-a86c-1be650d3c961";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe25926c-b7b4-4a1b-a86c-1be650d3c961>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e359dfa-b6dd-4aa0-b2e4-b1d6d6934792> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e359dfa-b6dd-4aa0-b2e4-b1d6d6934792";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_18-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e359dfa-b6dd-4aa0-b2e4-b1d6d6934792>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2ca7552-70e8-4178-931d-f057b5805881> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2ca7552-70e8-4178-931d-f057b5805881";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2ca7552-70e8-4178-931d-f057b5805881>.
+    
+<http://data.lblod.info/id/remote-data-objects/34270598-a41d-4309-b6e3-4a14173cb9b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34270598-a41d-4309-b6e3-4a14173cb9b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_19-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34270598-a41d-4309-b6e3-4a14173cb9b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c92c7d62-5cad-4798-bdb9-a6cce38c224f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c92c7d62-5cad-4798-bdb9-a6cce38c224f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c92c7d62-5cad-4798-bdb9-a6cce38c224f>.
+    
+<http://data.lblod.info/id/remote-data-objects/852086ce-020a-44a6-b507-8fb35661bcb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "852086ce-020a-44a6-b507-8fb35661bcb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/852086ce-020a-44a6-b507-8fb35661bcb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/00d91527-12c1-4849-8990-b41f26f174be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00d91527-12c1-4849-8990-b41f26f174be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00d91527-12c1-4849-8990-b41f26f174be>.
+    
+<http://data.lblod.info/id/remote-data-objects/740a4440-16fd-4288-9934-d8d6977714e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "740a4440-16fd-4288-9934-d8d6977714e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/740a4440-16fd-4288-9934-d8d6977714e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/782cbbfa-a222-4e79-8839-287af85b6294> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "782cbbfa-a222-4e79-8839-287af85b6294";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/782cbbfa-a222-4e79-8839-287af85b6294>.
+    
+<http://data.lblod.info/id/remote-data-objects/40d92df7-e2cd-469e-ac8b-ab166d3d22c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40d92df7-e2cd-469e-ac8b-ab166d3d22c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_20-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40d92df7-e2cd-469e-ac8b-ab166d3d22c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d88a307-fe24-480d-957a-5cc81084bb96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d88a307-fe24-480d-957a-5cc81084bb96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_21-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d88a307-fe24-480d-957a-5cc81084bb96>.
+    
+<http://data.lblod.info/id/remote-data-objects/5184b1f5-f3b9-4981-ace8-a386ba2cd273> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5184b1f5-f3b9-4981-ace8-a386ba2cd273";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5184b1f5-f3b9-4981-ace8-a386ba2cd273>.
+    
+<http://data.lblod.info/id/remote-data-objects/d35cbb50-f38e-4b2b-a977-7741044398c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d35cbb50-f38e-4b2b-a977-7741044398c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d35cbb50-f38e-4b2b-a977-7741044398c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b5a518b-b7d6-4e3a-8517-b4650a6f6ead> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b5a518b-b7d6-4e3a-8517-b4650a6f6ead";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b5a518b-b7d6-4e3a-8517-b4650a6f6ead>.
+    
+<http://data.lblod.info/id/remote-data-objects/31a93afd-1de4-4cdd-9ca3-fc80d20da06f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31a93afd-1de4-4cdd-9ca3-fc80d20da06f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31a93afd-1de4-4cdd-9ca3-fc80d20da06f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b385f7cf-c789-430a-a9f1-f38ab9ec1f40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b385f7cf-c789-430a-a9f1-f38ab9ec1f40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_22-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b385f7cf-c789-430a-a9f1-f38ab9ec1f40>.
+    
+<http://data.lblod.info/id/remote-data-objects/e25a8d4b-f5b2-45c4-8076-e31e0996bb6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e25a8d4b-f5b2-45c4-8076-e31e0996bb6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_22-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e25a8d4b-f5b2-45c4-8076-e31e0996bb6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e266bd94-47bf-40f4-8dff-32f0ae595818> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e266bd94-47bf-40f4-8dff-32f0ae595818";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_22-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e266bd94-47bf-40f4-8dff-32f0ae595818>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdfb92c3-be6d-49df-89a2-d3dde6f32219> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdfb92c3-be6d-49df-89a2-d3dde6f32219";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdfb92c3-be6d-49df-89a2-d3dde6f32219>.
+    
+<http://data.lblod.info/id/remote-data-objects/41511868-f5ad-4f50-aa9c-1a2026d38454> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41511868-f5ad-4f50-aa9c-1a2026d38454";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41511868-f5ad-4f50-aa9c-1a2026d38454>.
+    
+<http://data.lblod.info/id/remote-data-objects/f072fb0e-eb8d-44f8-9ec3-51a89cc17bcb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f072fb0e-eb8d-44f8-9ec3-51a89cc17bcb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f072fb0e-eb8d-44f8-9ec3-51a89cc17bcb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3bf24d2-30d8-46de-8940-f86fb6e4549d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3bf24d2-30d8-46de-8940-f86fb6e4549d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3bf24d2-30d8-46de-8940-f86fb6e4549d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a87e6eff-07f2-47db-ad54-e316e41ba917> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a87e6eff-07f2-47db-ad54-e316e41ba917";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a87e6eff-07f2-47db-ad54-e316e41ba917>.
+    
+<http://data.lblod.info/id/remote-data-objects/50228d46-11a9-4e05-90a0-d831e35c427c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50228d46-11a9-4e05-90a0-d831e35c427c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_24-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50228d46-11a9-4e05-90a0-d831e35c427c>.
+    
+<http://data.lblod.info/id/remote-data-objects/60875f10-7b12-4829-b398-7c6a881f6202> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60875f10-7b12-4829-b398-7c6a881f6202";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60875f10-7b12-4829-b398-7c6a881f6202>.
+    
+<http://data.lblod.info/id/remote-data-objects/208a0e8c-bbb9-4a5c-ae6e-901d6a843d79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "208a0e8c-bbb9-4a5c-ae6e-901d6a843d79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_25-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/208a0e8c-bbb9-4a5c-ae6e-901d6a843d79>.
+    
+<http://data.lblod.info/id/remote-data-objects/b115cc15-a1cc-488d-9196-fa6a24094690> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b115cc15-a1cc-488d-9196-fa6a24094690";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_25-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b115cc15-a1cc-488d-9196-fa6a24094690>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbeeb2d1-eb74-4fed-9b54-42c6ede65912> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbeeb2d1-eb74-4fed-9b54-42c6ede65912";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbeeb2d1-eb74-4fed-9b54-42c6ede65912>.
+    
+<http://data.lblod.info/id/remote-data-objects/977284ed-c8fd-46f1-95e2-b5af2b638317> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "977284ed-c8fd-46f1-95e2-b5af2b638317";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/977284ed-c8fd-46f1-95e2-b5af2b638317>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1451967-d162-46b7-8eff-22af97be2b4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1451967-d162-46b7-8eff-22af97be2b4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_26-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1451967-d162-46b7-8eff-22af97be2b4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e234641-f7c7-46a6-96a0-74b109e1a309> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e234641-f7c7-46a6-96a0-74b109e1a309";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_27-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e234641-f7c7-46a6-96a0-74b109e1a309>.
+    
+<http://data.lblod.info/id/remote-data-objects/28c54018-a937-49d1-afae-bdd51f0970a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28c54018-a937-49d1-afae-bdd51f0970a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_27-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28c54018-a937-49d1-afae-bdd51f0970a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d26ec3af-d9ce-4265-b8ac-45104c5775be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d26ec3af-d9ce-4265-b8ac-45104c5775be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d26ec3af-d9ce-4265-b8ac-45104c5775be>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a1405fc-65e6-41a7-bf8b-7090139a7321> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a1405fc-65e6-41a7-bf8b-7090139a7321";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a1405fc-65e6-41a7-bf8b-7090139a7321>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a9f51d9-4a2f-47f2-a71f-bbd56ccaa65c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a9f51d9-4a2f-47f2-a71f-bbd56ccaa65c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a9f51d9-4a2f-47f2-a71f-bbd56ccaa65c>.
+    
+<http://data.lblod.info/id/remote-data-objects/72a9070e-0fd9-442e-aa3b-fbb4d08cf29a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72a9070e-0fd9-442e-aa3b-fbb4d08cf29a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72a9070e-0fd9-442e-aa3b-fbb4d08cf29a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a63e92be-3fa6-41e0-803f-149a0fea4812> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a63e92be-3fa6-41e0-803f-149a0fea4812";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_29-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a63e92be-3fa6-41e0-803f-149a0fea4812>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d45add0-d7c1-4efe-9ec1-3ba26a7d13b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d45add0-d7c1-4efe-9ec1-3ba26a7d13b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d45add0-d7c1-4efe-9ec1-3ba26a7d13b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c70384b6-3be9-4d34-9795-285a83edcf2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c70384b6-3be9-4d34-9795-285a83edcf2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c70384b6-3be9-4d34-9795-285a83edcf2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/616031cd-b3c8-462e-8be3-af4f73b8c089> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "616031cd-b3c8-462e-8be3-af4f73b8c089";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=BesluitenLijst_Burgemeester_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/616031cd-b3c8-462e-8be3-af4f73b8c089>.
+    
+<http://data.lblod.info/id/remote-data-objects/84d84a85-f558-4835-a05d-952400712e5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84d84a85-f558-4835-a05d-952400712e5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=Uittreksels_18-05-2022_44906.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84d84a85-f558-4835-a05d-952400712e5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e62fe9c-2bd9-4a2e-a0d2-aa0ce9c30c0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e62fe9c-2bd9-4a2e-a0d2-aa0ce9c30c0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=Uittreksels_19-01-2022_42381.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e62fe9c-2bd9-4a2e-a0d2-aa0ce9c30c0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bb1d42f-7533-47e3-95f5-1e73aa8a4dde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bb1d42f-7533-47e3-95f5-1e73aa8a4dde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=Uittreksels_24-11-2021_41330.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bb1d42f-7533-47e3-95f5-1e73aa8a4dde>.
+    
+<http://data.lblod.info/id/remote-data-objects/f217029c-6921-408f-b4a6-319166d2b7cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f217029c-6921-408f-b4a6-319166d2b7cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93947cba566a08a29c8123aba8dc7513f21f9f747d2456b5b826f9276fb39761/GetPublication?filename=Uittreksels_27-07-2022_46219.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f217029c-6921-408f-b4a6-319166d2b7cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/166c20f5-5f69-4921-bcdf-b182e5d45355> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "166c20f5-5f69-4921-bcdf-b182e5d45355";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Agenda_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/166c20f5-5f69-4921-bcdf-b182e5d45355>.
+    
+<http://data.lblod.info/id/remote-data-objects/0acb36ee-1b54-4e4d-b4de-3dd20c3a3215> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0acb36ee-1b54-4e4d-b4de-3dd20c3a3215";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Agenda_Gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0acb36ee-1b54-4e4d-b4de-3dd20c3a3215>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a7836ec-f872-4887-a762-bba7874974fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a7836ec-f872-4887-a762-bba7874974fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Agenda_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/753a9fce-c957-4537-8726-94056a5f832b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a7836ec-f872-4887-a762-bba7874974fe>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201610-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201610-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201610-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201610-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a6d8f7dd-0d5b-4a53-a033-ecf55b09b929> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a6d8f7dd-0d5b-4a53-a033-ecf55b09b929";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "022976bc-8858-401a-8c4a-349684528d84";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/93fdb8d6-4e32-4e6a-bd31-73f02dc542c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "93fdb8d6-4e32-4e6a-bd31-73f02dc542c9";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84>.
+
+  <http://redpencil.data.gift/id/task/7e9c8366-1175-467d-9dc4-886c4ed5eca5> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7e9c8366-1175-467d-9dc4-886c4ed5eca5";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a6d8f7dd-0d5b-4a53-a033-ecf55b09b929>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/93fdb8d6-4e32-4e6a-bd31-73f02dc542c9>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/ffa275d3-595e-4079-bcec-682207c5b446> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffa275d3-595e-4079-bcec-682207c5b446";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Agenda_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffa275d3-595e-4079-bcec-682207c5b446>.
+    
+<http://data.lblod.info/id/remote-data-objects/e445ade3-ad31-4ded-a861-237bd58bdb90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e445ade3-ad31-4ded-a861-237bd58bdb90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Agenda_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e445ade3-ad31-4ded-a861-237bd58bdb90>.
+    
+<http://data.lblod.info/id/remote-data-objects/277b4491-894a-450c-a4bb-db07b2201a7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "277b4491-894a-450c-a4bb-db07b2201a7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Agenda_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/277b4491-894a-450c-a4bb-db07b2201a7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bca93a95-3464-4b63-84f9-49ee0f502ce3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bca93a95-3464-4b63-84f9-49ee0f502ce3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Agenda_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bca93a95-3464-4b63-84f9-49ee0f502ce3>.
+    
+<http://data.lblod.info/id/remote-data-objects/27b3d245-8110-4d4a-96c7-131a5ebc2025> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27b3d245-8110-4d4a-96c7-131a5ebc2025";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Agenda_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27b3d245-8110-4d4a-96c7-131a5ebc2025>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfa2940d-2158-454b-9d03-7d4c3fc4e72f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfa2940d-2158-454b-9d03-7d4c3fc4e72f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Agenda_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfa2940d-2158-454b-9d03-7d4c3fc4e72f>.
+    
+<http://data.lblod.info/id/remote-data-objects/915c7342-2d26-461d-a0b4-fe15257349d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "915c7342-2d26-461d-a0b4-fe15257349d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=BesluitenLijst_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/915c7342-2d26-461d-a0b4-fe15257349d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6386b39-fb11-4b98-bd82-90aa74db125d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6386b39-fb11-4b98-bd82-90aa74db125d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=BesluitenLijst_Gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6386b39-fb11-4b98-bd82-90aa74db125d>.
+    
+<http://data.lblod.info/id/remote-data-objects/269d082a-e630-446a-8ade-7289a6e919ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "269d082a-e630-446a-8ade-7289a6e919ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/269d082a-e630-446a-8ade-7289a6e919ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/a47d35cf-2fad-4564-8335-a56f2ef052ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a47d35cf-2fad-4564-8335-a56f2ef052ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a47d35cf-2fad-4564-8335-a56f2ef052ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8fba45c-8311-46bc-afa3-aac4ec388d2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8fba45c-8311-46bc-afa3-aac4ec388d2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8fba45c-8311-46bc-afa3-aac4ec388d2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8011a6b6-15c0-448e-a434-f79909c7d322> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8011a6b6-15c0-448e-a434-f79909c7d322";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8011a6b6-15c0-448e-a434-f79909c7d322>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d88c8f0-4dd5-4538-a7af-771df5d7af5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d88c8f0-4dd5-4538-a7af-771df5d7af5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d88c8f0-4dd5-4538-a7af-771df5d7af5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a1449be-3cc3-4602-ba2f-7896b1a7c750> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a1449be-3cc3-4602-ba2f-7896b1a7c750";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a1449be-3cc3-4602-ba2f-7896b1a7c750>.
+    
+<http://data.lblod.info/id/remote-data-objects/212c1fce-f947-4605-a0d5-bef54d90befd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "212c1fce-f947-4605-a0d5-bef54d90befd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/212c1fce-f947-4605-a0d5-bef54d90befd>.
+    
+<http://data.lblod.info/id/remote-data-objects/305fb9d1-7c54-4ef2-8bd8-00f3d1e79590> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "305fb9d1-7c54-4ef2-8bd8-00f3d1e79590";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Notulen_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/305fb9d1-7c54-4ef2-8bd8-00f3d1e79590>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec03e81f-b287-4598-856e-80724757272a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec03e81f-b287-4598-856e-80724757272a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Notulen_Gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec03e81f-b287-4598-856e-80724757272a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b5e22c2-e137-41a8-8590-cd0a45c2d9b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b5e22c2-e137-41a8-8590-cd0a45c2d9b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Notulen_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b5e22c2-e137-41a8-8590-cd0a45c2d9b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f39a093-1aca-42c3-ad17-dea623109b25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f39a093-1aca-42c3-ad17-dea623109b25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Notulen_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f39a093-1aca-42c3-ad17-dea623109b25>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0e64087-6d79-4e34-af5d-fed1c78c377f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0e64087-6d79-4e34-af5d-fed1c78c377f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Notulen_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0e64087-6d79-4e34-af5d-fed1c78c377f>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb789f5d-e93f-480a-8fea-0360d5cd1006> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb789f5d-e93f-480a-8fea-0360d5cd1006";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Notulen_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb789f5d-e93f-480a-8fea-0360d5cd1006>.
+    
+<http://data.lblod.info/id/remote-data-objects/b307e079-d066-4988-859b-93b6e81f12c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b307e079-d066-4988-859b-93b6e81f12c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Notulen_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b307e079-d066-4988-859b-93b6e81f12c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f64af41-0242-4e07-a994-7356df1d7bfc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f64af41-0242-4e07-a994-7356df1d7bfc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Notulen_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f64af41-0242-4e07-a994-7356df1d7bfc>.
+    
+<http://data.lblod.info/id/remote-data-objects/5952ed1c-ffc3-4c01-a45e-95b86e5e8112> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5952ed1c-ffc3-4c01-a45e-95b86e5e8112";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Notulen_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5952ed1c-ffc3-4c01-a45e-95b86e5e8112>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8040e05-f642-4a24-85a2-357c8ba14c18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8040e05-f642-4a24-85a2-357c8ba14c18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_16-12-2021_41264.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8040e05-f642-4a24-85a2-357c8ba14c18>.
+    
+<http://data.lblod.info/id/remote-data-objects/de56e1f1-5ae9-4227-a6d7-2cd1b9caef31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de56e1f1-5ae9-4227-a6d7-2cd1b9caef31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_16-12-2021_41268.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de56e1f1-5ae9-4227-a6d7-2cd1b9caef31>.
+    
+<http://data.lblod.info/id/remote-data-objects/98c1b2fe-c93d-400a-b21e-79d8ccc95075> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98c1b2fe-c93d-400a-b21e-79d8ccc95075";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_16-12-2021_41281.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98c1b2fe-c93d-400a-b21e-79d8ccc95075>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb9c9977-4572-4d83-aa9c-0a4db205f30a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb9c9977-4572-4d83-aa9c-0a4db205f30a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_16-12-2021_41286.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb9c9977-4572-4d83-aa9c-0a4db205f30a>.
+    
+<http://data.lblod.info/id/remote-data-objects/51217e5c-65bb-4049-8264-87eb4f2fbe84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51217e5c-65bb-4049-8264-87eb4f2fbe84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_16-12-2021_41300.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51217e5c-65bb-4049-8264-87eb4f2fbe84>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5dee429-973b-4bd2-903f-54348735dc19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5dee429-973b-4bd2-903f-54348735dc19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_16-12-2021_41301.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5dee429-973b-4bd2-903f-54348735dc19>.
+    
+<http://data.lblod.info/id/remote-data-objects/557c54e3-5c2b-4ac8-aeb1-71fc866feea9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "557c54e3-5c2b-4ac8-aeb1-71fc866feea9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_16-12-2021_41302.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/557c54e3-5c2b-4ac8-aeb1-71fc866feea9>.
+    
+<http://data.lblod.info/id/remote-data-objects/44764ce4-0469-4173-99dc-4937ed7f86f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44764ce4-0469-4173-99dc-4937ed7f86f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_16-12-2021_41303.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44764ce4-0469-4173-99dc-4937ed7f86f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b5fd62e-e34c-4806-a393-4892881f91b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b5fd62e-e34c-4806-a393-4892881f91b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_16-12-2021_41551.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b5fd62e-e34c-4806-a393-4892881f91b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/39b77ece-1298-4596-b3ac-384840c2a541> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39b77ece-1298-4596-b3ac-384840c2a541";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_16-12-2021_41587.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39b77ece-1298-4596-b3ac-384840c2a541>.
+    
+<http://data.lblod.info/id/remote-data-objects/63df0ded-61ee-47ec-be95-b53507d190cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63df0ded-61ee-47ec-be95-b53507d190cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_23-06-2022_44334.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63df0ded-61ee-47ec-be95-b53507d190cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e976d1f-48af-4b1b-a676-087857496044> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e976d1f-48af-4b1b-a676-087857496044";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_23-06-2022_44336.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e976d1f-48af-4b1b-a676-087857496044>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bbd4948-8850-4100-a531-e437254051d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bbd4948-8850-4100-a531-e437254051d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_23-06-2022_45086.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bbd4948-8850-4100-a531-e437254051d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2e291b4-6525-40ad-adee-867be4516baa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2e291b4-6525-40ad-adee-867be4516baa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_23-06-2022_45149.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2e291b4-6525-40ad-adee-867be4516baa>.
+    
+<http://data.lblod.info/id/remote-data-objects/55ccae8e-c586-46a4-a174-f1d00bad43ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55ccae8e-c586-46a4-a174-f1d00bad43ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_23-06-2022_45314.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55ccae8e-c586-46a4-a174-f1d00bad43ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/98469188-e2f2-4b3f-a1e7-b5d07e9c287f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98469188-e2f2-4b3f-a1e7-b5d07e9c287f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_24-02-2022_42711.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98469188-e2f2-4b3f-a1e7-b5d07e9c287f>.
+    
+<http://data.lblod.info/id/remote-data-objects/33630826-468c-4dfc-ab51-0899c95da10e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33630826-468c-4dfc-ab51-0899c95da10e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_24-02-2022_42736.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33630826-468c-4dfc-ab51-0899c95da10e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f54cd277-8061-4592-980c-38108cba55c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f54cd277-8061-4592-980c-38108cba55c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_24-02-2022_42822.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f54cd277-8061-4592-980c-38108cba55c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4800df1d-c8d2-4dc5-8578-b22722e1de2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4800df1d-c8d2-4dc5-8578-b22722e1de2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_24-02-2022_42834.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4800df1d-c8d2-4dc5-8578-b22722e1de2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b674834d-8f49-46ea-9800-885c7edabc79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b674834d-8f49-46ea-9800-885c7edabc79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_24-03-2022_43314.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b674834d-8f49-46ea-9800-885c7edabc79>.
+    
+<http://data.lblod.info/id/remote-data-objects/82cfd8e3-c698-4e00-ba15-98360cd875a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82cfd8e3-c698-4e00-ba15-98360cd875a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_24-03-2022_43378.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82cfd8e3-c698-4e00-ba15-98360cd875a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/40ab88c8-b63a-4938-9342-65ec4ddfc1bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40ab88c8-b63a-4938-9342-65ec4ddfc1bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_24-03-2022_43466.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40ab88c8-b63a-4938-9342-65ec4ddfc1bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7201214-d3dc-4eda-8020-284e2f09380a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7201214-d3dc-4eda-8020-284e2f09380a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40639.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7201214-d3dc-4eda-8020-284e2f09380a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9303eed2-962d-4018-b3d8-7b8b99328740> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9303eed2-962d-4018-b3d8-7b8b99328740";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40640.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9303eed2-962d-4018-b3d8-7b8b99328740>.
+    
+<http://data.lblod.info/id/remote-data-objects/696e95ce-8494-4bd6-ba0b-247e29d67309> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "696e95ce-8494-4bd6-ba0b-247e29d67309";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40862.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/696e95ce-8494-4bd6-ba0b-247e29d67309>.
+    
+<http://data.lblod.info/id/remote-data-objects/35d7c8aa-67f5-47c8-ba4c-fa8896b48c3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35d7c8aa-67f5-47c8-ba4c-fa8896b48c3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40863.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/022976bc-8858-401a-8c4a-349684528d84> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35d7c8aa-67f5-47c8-ba4c-fa8896b48c3c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201612-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201612-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201612-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201612-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/8d3205b1-5b9b-4544-a08e-4e21c8be2750> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8d3205b1-5b9b-4544-a08e-4e21c8be2750";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dc756330-f648-42c8-9227-e834baa3e608";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/71de7353-9c6e-4f83-984b-56ed95beca8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "71de7353-9c6e-4f83-984b-56ed95beca8b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608>.
+
+  <http://redpencil.data.gift/id/task/ebc5e489-af40-4677-aec1-7809d7f4c296> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ebc5e489-af40-4677-aec1-7809d7f4c296";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/8d3205b1-5b9b-4544-a08e-4e21c8be2750>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/71de7353-9c6e-4f83-984b-56ed95beca8b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/39ee4f49-7a00-40a4-85fe-177602bff38f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39ee4f49-7a00-40a4-85fe-177602bff38f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40864.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39ee4f49-7a00-40a4-85fe-177602bff38f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6d3167e-3ba6-4d70-8910-2036b0ae35aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6d3167e-3ba6-4d70-8910-2036b0ae35aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40865.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6d3167e-3ba6-4d70-8910-2036b0ae35aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/2873e317-157f-4960-b569-420da711ed48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2873e317-157f-4960-b569-420da711ed48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40866.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2873e317-157f-4960-b569-420da711ed48>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d502350-8e07-4c85-9b90-3d91052361b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d502350-8e07-4c85-9b90-3d91052361b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40869.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d502350-8e07-4c85-9b90-3d91052361b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2b6c932-b77f-42fc-b8e6-29ba77b49530> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2b6c932-b77f-42fc-b8e6-29ba77b49530";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40879.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2b6c932-b77f-42fc-b8e6-29ba77b49530>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c090ed3-2454-4eaa-ab82-8d9aa0d69326> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c090ed3-2454-4eaa-ab82-8d9aa0d69326";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40898.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c090ed3-2454-4eaa-ab82-8d9aa0d69326>.
+    
+<http://data.lblod.info/id/remote-data-objects/f676547c-a490-44ac-8f92-b1921a3ab193> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f676547c-a490-44ac-8f92-b1921a3ab193";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40906.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f676547c-a490-44ac-8f92-b1921a3ab193>.
+    
+<http://data.lblod.info/id/remote-data-objects/08333d9d-1d30-4666-bc7e-39cfc4df8af3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08333d9d-1d30-4666-bc7e-39cfc4df8af3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40914.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08333d9d-1d30-4666-bc7e-39cfc4df8af3>.
+    
+<http://data.lblod.info/id/remote-data-objects/4666b364-6ef1-4f3f-8f2f-90767b710a1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4666b364-6ef1-4f3f-8f2f-90767b710a1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40917.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4666b364-6ef1-4f3f-8f2f-90767b710a1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9463172-19af-497e-882e-c7e5912623a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9463172-19af-497e-882e-c7e5912623a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40924.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9463172-19af-497e-882e-c7e5912623a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/948bcef7-7ab8-4654-a48e-6c4719c7c676> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "948bcef7-7ab8-4654-a48e-6c4719c7c676";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40979.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/948bcef7-7ab8-4654-a48e-6c4719c7c676>.
+    
+<http://data.lblod.info/id/remote-data-objects/bab44d35-9988-4bc4-a901-d987939d7767> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bab44d35-9988-4bc4-a901-d987939d7767";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40980.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bab44d35-9988-4bc4-a901-d987939d7767>.
+    
+<http://data.lblod.info/id/remote-data-objects/28e3748b-de99-4e64-9e1e-63c0a3de88ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28e3748b-de99-4e64-9e1e-63c0a3de88ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40982.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28e3748b-de99-4e64-9e1e-63c0a3de88ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/4eb67ffe-5826-4152-8e20-596c84e1308a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4eb67ffe-5826-4152-8e20-596c84e1308a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_40983.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4eb67ffe-5826-4152-8e20-596c84e1308a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6af44dfc-60db-46f3-8199-3cdad47bb3da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6af44dfc-60db-46f3-8199-3cdad47bb3da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_41117.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6af44dfc-60db-46f3-8199-3cdad47bb3da>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd19e84f-fc18-4a9c-99ee-4a42904656ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd19e84f-fc18-4a9c-99ee-4a42904656ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_41119.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd19e84f-fc18-4a9c-99ee-4a42904656ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1e10bf5-c792-4098-8d5c-470c1625ab86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1e10bf5-c792-4098-8d5c-470c1625ab86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_25-11-2021_41148.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1e10bf5-c792-4098-8d5c-470c1625ab86>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c1a4bf3-f174-401f-a3ec-8194dca807ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c1a4bf3-f174-401f-a3ec-8194dca807ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_27-01-2022_42264.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c1a4bf3-f174-401f-a3ec-8194dca807ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/132c8303-cdf8-42c2-b1b9-c19e2c9693f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "132c8303-cdf8-42c2-b1b9-c19e2c9693f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_28-10-2021_40212.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/132c8303-cdf8-42c2-b1b9-c19e2c9693f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/dba3335f-813a-4448-8bf8-707bb5e832f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dba3335f-813a-4448-8bf8-707bb5e832f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_28-10-2021_40486.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dba3335f-813a-4448-8bf8-707bb5e832f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f4f964a-6ada-4adf-b08c-2ad67eee049c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f4f964a-6ada-4adf-b08c-2ad67eee049c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_28-10-2021_40488.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f4f964a-6ada-4adf-b08c-2ad67eee049c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d302622a-5082-4585-a836-f1f73f200359> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d302622a-5082-4585-a836-f1f73f200359";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_28-10-2021_40490.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d302622a-5082-4585-a836-f1f73f200359>.
+    
+<http://data.lblod.info/id/remote-data-objects/2126b588-a009-4ffc-a638-11abfa1f4a4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2126b588-a009-4ffc-a638-11abfa1f4a4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_28-10-2021_40492.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2126b588-a009-4ffc-a638-11abfa1f4a4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/84f51f27-7d27-42dd-92e7-f16d7cf32cc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84f51f27-7d27-42dd-92e7-f16d7cf32cc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_28-10-2021_40494.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84f51f27-7d27-42dd-92e7-f16d7cf32cc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3509ac6-7d16-4bb7-8c89-f8237adec656> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3509ac6-7d16-4bb7-8c89-f8237adec656";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_28-10-2021_40495.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3509ac6-7d16-4bb7-8c89-f8237adec656>.
+    
+<http://data.lblod.info/id/remote-data-objects/55947356-9f5d-41b2-ad64-c777d06f7b61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55947356-9f5d-41b2-ad64-c777d06f7b61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_28-10-2021_40496.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55947356-9f5d-41b2-ad64-c777d06f7b61>.
+    
+<http://data.lblod.info/id/remote-data-objects/68bcf7b3-8adc-4719-ab78-fb92dcef865d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68bcf7b3-8adc-4719-ab78-fb92dcef865d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_28-10-2021_40499.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68bcf7b3-8adc-4719-ab78-fb92dcef865d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d98df4b8-005d-45f1-b81c-4759f193d18a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d98df4b8-005d-45f1-b81c-4759f193d18a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_28-10-2021_40500.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d98df4b8-005d-45f1-b81c-4759f193d18a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3f4449d-b9c8-4dbc-b4dd-12a110338eb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3f4449d-b9c8-4dbc-b4dd-12a110338eb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_28-10-2021_40501.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3f4449d-b9c8-4dbc-b4dd-12a110338eb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6d36490-3f5e-43ef-a316-0e9f5af44955> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6d36490-3f5e-43ef-a316-0e9f5af44955";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_28-10-2021_40503.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6d36490-3f5e-43ef-a316-0e9f5af44955>.
+    
+<http://data.lblod.info/id/remote-data-objects/a92cba80-ed44-4f13-9145-578d0dfca820> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a92cba80-ed44-4f13-9145-578d0dfca820";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_28-10-2021_40506.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a92cba80-ed44-4f13-9145-578d0dfca820>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb0d4ac2-f6c8-4bf8-bb31-06998d675fbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb0d4ac2-f6c8-4bf8-bb31-06998d675fbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_28-10-2021_40593.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb0d4ac2-f6c8-4bf8-bb31-06998d675fbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f14e0b05-3fd8-4174-be3b-f0c22f3b0982> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f14e0b05-3fd8-4174-be3b-f0c22f3b0982";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/93e0e85187b0b47966c96e7c06fa36822867a78fb6f56c61cb0f5ea7b3a54fad/GetPublication?filename=Uittreksels_28-10-2021_40635.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f14e0b05-3fd8-4174-be3b-f0c22f3b0982>.
+    
+<http://data.lblod.info/id/remote-data-objects/106e7766-1593-4ede-bccb-96cce25a96dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "106e7766-1593-4ede-bccb-96cce25a96dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/106e7766-1593-4ede-bccb-96cce25a96dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/73ff6907-8623-413d-b2d1-cc3fd78ad7ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73ff6907-8623-413d-b2d1-cc3fd78ad7ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73ff6907-8623-413d-b2d1-cc3fd78ad7ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ccf15c6-7e5f-483a-9aad-ff86f02dd2e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ccf15c6-7e5f-483a-9aad-ff86f02dd2e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ccf15c6-7e5f-483a-9aad-ff86f02dd2e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7342c8dc-1bb5-44ad-a2b4-38d9b40c1ac4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7342c8dc-1bb5-44ad-a2b4-38d9b40c1ac4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7342c8dc-1bb5-44ad-a2b4-38d9b40c1ac4>.
+    
+<http://data.lblod.info/id/remote-data-objects/79b827ca-195f-452a-adb7-c675139957f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79b827ca-195f-452a-adb7-c675139957f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79b827ca-195f-452a-adb7-c675139957f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/420abed7-bdb2-4725-8766-bad77dfc02ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "420abed7-bdb2-4725-8766-bad77dfc02ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/420abed7-bdb2-4725-8766-bad77dfc02ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/60668571-2aab-433c-a595-c94ef9c05ee6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60668571-2aab-433c-a595-c94ef9c05ee6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60668571-2aab-433c-a595-c94ef9c05ee6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0387a803-433b-48b9-aa42-4f0384c06984> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0387a803-433b-48b9-aa42-4f0384c06984";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0387a803-433b-48b9-aa42-4f0384c06984>.
+    
+<http://data.lblod.info/id/remote-data-objects/38ca0e62-a658-45a9-a7d5-47f68d90c420> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38ca0e62-a658-45a9-a7d5-47f68d90c420";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38ca0e62-a658-45a9-a7d5-47f68d90c420>.
+    
+<http://data.lblod.info/id/remote-data-objects/16ccffe9-9500-46d1-90d6-4bf7d5262d61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16ccffe9-9500-46d1-90d6-4bf7d5262d61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16ccffe9-9500-46d1-90d6-4bf7d5262d61>.
+    
+<http://data.lblod.info/id/remote-data-objects/535c5cde-91c4-43ac-95de-b986f0b1ac78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "535c5cde-91c4-43ac-95de-b986f0b1ac78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/535c5cde-91c4-43ac-95de-b986f0b1ac78>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3e0202a-67b8-4a91-a753-20c190f65550> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3e0202a-67b8-4a91-a753-20c190f65550";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3e0202a-67b8-4a91-a753-20c190f65550>.
+    
+<http://data.lblod.info/id/remote-data-objects/765254b5-f138-4d4b-8a5e-3898bcb7df23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "765254b5-f138-4d4b-8a5e-3898bcb7df23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/765254b5-f138-4d4b-8a5e-3898bcb7df23>.
+    
+<http://data.lblod.info/id/remote-data-objects/06e9994d-4753-4d2d-9317-ca25eb23d49c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06e9994d-4753-4d2d-9317-ca25eb23d49c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06e9994d-4753-4d2d-9317-ca25eb23d49c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3f054bc-d20c-4438-90b4-eb0657b15782> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3f054bc-d20c-4438-90b4-eb0657b15782";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3f054bc-d20c-4438-90b4-eb0657b15782>.
+    
+<http://data.lblod.info/id/remote-data-objects/df654d3e-1114-4088-b86d-4fbcfaeaa114> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df654d3e-1114-4088-b86d-4fbcfaeaa114";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df654d3e-1114-4088-b86d-4fbcfaeaa114>.
+    
+<http://data.lblod.info/id/remote-data-objects/700a1329-66cf-4dfd-b8ad-abe30e8a3794> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "700a1329-66cf-4dfd-b8ad-abe30e8a3794";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dc756330-f648-42c8-9227-e834baa3e608> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/700a1329-66cf-4dfd-b8ad-abe30e8a3794>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201613-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201613-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201613-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201613-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e2d1c4ae-97f2-4e4b-9bb5-befb74b45073> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e2d1c4ae-97f2-4e4b-9bb5-befb74b45073";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f9b94751-1675-4819-9472-c1eb5671188b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/5440baef-5116-4f36-b4dd-83bc42b2ce02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5440baef-5116-4f36-b4dd-83bc42b2ce02";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b>.
+
+  <http://redpencil.data.gift/id/task/7a6c45f5-94e8-478f-844e-b6456582fbb4> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7a6c45f5-94e8-478f-844e-b6456582fbb4";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e2d1c4ae-97f2-4e4b-9bb5-befb74b45073>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/5440baef-5116-4f36-b4dd-83bc42b2ce02>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5cc89a8c-ac97-4798-bdb0-8429c9fcf1ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cc89a8c-ac97-4798-bdb0-8429c9fcf1ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cc89a8c-ac97-4798-bdb0-8429c9fcf1ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dfb6160-4333-41e2-9700-e0d9526f4121> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dfb6160-4333-41e2-9700-e0d9526f4121";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dfb6160-4333-41e2-9700-e0d9526f4121>.
+    
+<http://data.lblod.info/id/remote-data-objects/993b48f6-0261-4877-945c-630e0495fc5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "993b48f6-0261-4877-945c-630e0495fc5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/993b48f6-0261-4877-945c-630e0495fc5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd66e3eb-67e0-4b05-adf3-3f00bd1f4c6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd66e3eb-67e0-4b05-adf3-3f00bd1f4c6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd66e3eb-67e0-4b05-adf3-3f00bd1f4c6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/01a2c961-c3be-450c-813c-b5cd344e8f35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01a2c961-c3be-450c-813c-b5cd344e8f35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01a2c961-c3be-450c-813c-b5cd344e8f35>.
+    
+<http://data.lblod.info/id/remote-data-objects/11c71b39-4c90-4839-8e8c-010462a86056> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11c71b39-4c90-4839-8e8c-010462a86056";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11c71b39-4c90-4839-8e8c-010462a86056>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b60758b-a050-40f8-bdca-9af4b6e04d71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b60758b-a050-40f8-bdca-9af4b6e04d71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b60758b-a050-40f8-bdca-9af4b6e04d71>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8c08b13-eced-49d3-a705-a946cf457c58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8c08b13-eced-49d3-a705-a946cf457c58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8c08b13-eced-49d3-a705-a946cf457c58>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffab53a9-088f-4086-b3a4-eca27feea149> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffab53a9-088f-4086-b3a4-eca27feea149";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffab53a9-088f-4086-b3a4-eca27feea149>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d6b011e-2b64-4648-b8da-c28777183969> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d6b011e-2b64-4648-b8da-c28777183969";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d6b011e-2b64-4648-b8da-c28777183969>.
+    
+<http://data.lblod.info/id/remote-data-objects/e470bebd-4f7c-48a3-9608-1c330557f272> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e470bebd-4f7c-48a3-9608-1c330557f272";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e470bebd-4f7c-48a3-9608-1c330557f272>.
+    
+<http://data.lblod.info/id/remote-data-objects/954e685b-6187-440f-a768-f979591a9827> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "954e685b-6187-440f-a768-f979591a9827";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/954e685b-6187-440f-a768-f979591a9827>.
+    
+<http://data.lblod.info/id/remote-data-objects/c71c7288-50ed-463a-a197-3b17d2c6e3c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c71c7288-50ed-463a-a197-3b17d2c6e3c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c71c7288-50ed-463a-a197-3b17d2c6e3c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/19c14752-643f-4116-944f-f345d532e6fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19c14752-643f-4116-944f-f345d532e6fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_26-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19c14752-643f-4116-944f-f345d532e6fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/334671c2-8db9-4df1-a475-1fb9b3219834> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "334671c2-8db9-4df1-a475-1fb9b3219834";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/334671c2-8db9-4df1-a475-1fb9b3219834>.
+    
+<http://data.lblod.info/id/remote-data-objects/77ddfed1-e357-4ee9-86c1-94b3edaf3412> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77ddfed1-e357-4ee9-86c1-94b3edaf3412";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77ddfed1-e357-4ee9-86c1-94b3edaf3412>.
+    
+<http://data.lblod.info/id/remote-data-objects/55f5b1ab-7037-4226-8f3f-0ae075de3942> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55f5b1ab-7037-4226-8f3f-0ae075de3942";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55f5b1ab-7037-4226-8f3f-0ae075de3942>.
+    
+<http://data.lblod.info/id/remote-data-objects/007594c2-9692-47d6-8eed-40472dbc9c2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "007594c2-9692-47d6-8eed-40472dbc9c2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/007594c2-9692-47d6-8eed-40472dbc9c2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/865d8626-0262-436a-ba68-cceb914f56fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "865d8626-0262-436a-ba68-cceb914f56fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/865d8626-0262-436a-ba68-cceb914f56fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/8da46874-5506-42b7-bfba-89fb7687e748> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8da46874-5506-42b7-bfba-89fb7687e748";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8da46874-5506-42b7-bfba-89fb7687e748>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b646f2f-04b8-4c4f-a5e0-ea208ab8d3d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b646f2f-04b8-4c4f-a5e0-ea208ab8d3d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_01-02-2022_42469.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b646f2f-04b8-4c4f-a5e0-ea208ab8d3d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/96b06ca4-afe1-48f5-90b5-ae0263fe34db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96b06ca4-afe1-48f5-90b5-ae0263fe34db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_03-05-2022_44430.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96b06ca4-afe1-48f5-90b5-ae0263fe34db>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a935a3f-35de-438d-83d9-cbb7d4075bdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a935a3f-35de-438d-83d9-cbb7d4075bdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_05-10-2021_40313.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a935a3f-35de-438d-83d9-cbb7d4075bdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/44ae8178-f436-4a4b-ba62-a107970fe1a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44ae8178-f436-4a4b-ba62-a107970fe1a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_07-06-2022_45219.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44ae8178-f436-4a4b-ba62-a107970fe1a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb9c5d12-3de3-4e53-ac3e-0d091c16c0ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb9c5d12-3de3-4e53-ac3e-0d091c16c0ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_08-02-2022_42617.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb9c5d12-3de3-4e53-ac3e-0d091c16c0ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd87f747-3f53-4c3b-b45d-a635df2690d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd87f747-3f53-4c3b-b45d-a635df2690d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_08-02-2022_42687.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd87f747-3f53-4c3b-b45d-a635df2690d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/003bd1b4-dd1e-4016-a02b-7d3b6b5e15ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "003bd1b4-dd1e-4016-a02b-7d3b6b5e15ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_08-03-2022_43018.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/003bd1b4-dd1e-4016-a02b-7d3b6b5e15ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/dea2c942-c883-413d-a7a4-3e5858c2d332> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dea2c942-c883-413d-a7a4-3e5858c2d332";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_08-03-2022_43224.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dea2c942-c883-413d-a7a4-3e5858c2d332>.
+    
+<http://data.lblod.info/id/remote-data-objects/3db35616-c226-4728-a71a-9555cfbbe51b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3db35616-c226-4728-a71a-9555cfbbe51b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_08-03-2022_43261.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3db35616-c226-4728-a71a-9555cfbbe51b>.
+    
+<http://data.lblod.info/id/remote-data-objects/050a1f74-5269-4fbc-9935-63ea6d687e39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "050a1f74-5269-4fbc-9935-63ea6d687e39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_09-11-2021_40985.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/050a1f74-5269-4fbc-9935-63ea6d687e39>.
+    
+<http://data.lblod.info/id/remote-data-objects/84434aac-711d-471a-ad6e-bb4f17f8faf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84434aac-711d-471a-ad6e-bb4f17f8faf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_10-05-2022_44548.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84434aac-711d-471a-ad6e-bb4f17f8faf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/11626a8b-886c-4168-b2c7-809c14c8894c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11626a8b-886c-4168-b2c7-809c14c8894c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_10-05-2022_44549.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11626a8b-886c-4168-b2c7-809c14c8894c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1401e94f-ed0a-49e0-b8be-5552508e4e73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1401e94f-ed0a-49e0-b8be-5552508e4e73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_10-05-2022_44550.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1401e94f-ed0a-49e0-b8be-5552508e4e73>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1f7fb29-59b3-4b09-8c53-01f8c2156fe2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1f7fb29-59b3-4b09-8c53-01f8c2156fe2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_10-05-2022_44567.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1f7fb29-59b3-4b09-8c53-01f8c2156fe2>.
+    
+<http://data.lblod.info/id/remote-data-objects/26a7a66e-ff35-4e9e-acbb-58e5732e006c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26a7a66e-ff35-4e9e-acbb-58e5732e006c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_11-01-2022_42078.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26a7a66e-ff35-4e9e-acbb-58e5732e006c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8e78101-df70-48be-9167-7cb5192346c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8e78101-df70-48be-9167-7cb5192346c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_12-04-2022_43925.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8e78101-df70-48be-9167-7cb5192346c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e8acf9e-f174-4d71-8e10-0e37e151c356> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e8acf9e-f174-4d71-8e10-0e37e151c356";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_12-04-2022_43981.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e8acf9e-f174-4d71-8e10-0e37e151c356>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1eb7768-9ab9-4f35-bf87-af0e68dddd12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1eb7768-9ab9-4f35-bf87-af0e68dddd12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_12-04-2022_44018.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1eb7768-9ab9-4f35-bf87-af0e68dddd12>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad36e958-22a3-4f29-b9cf-959b3bdd2c6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad36e958-22a3-4f29-b9cf-959b3bdd2c6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_12-04-2022_44022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad36e958-22a3-4f29-b9cf-959b3bdd2c6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6307893e-0253-48d2-a139-d626c701f452> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6307893e-0253-48d2-a139-d626c701f452";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_12-04-2022_44046.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6307893e-0253-48d2-a139-d626c701f452>.
+    
+<http://data.lblod.info/id/remote-data-objects/484bd52a-05ed-4755-99a0-dc531f165e7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "484bd52a-05ed-4755-99a0-dc531f165e7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_12-04-2022_44047.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/484bd52a-05ed-4755-99a0-dc531f165e7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/56d68536-1b28-47ad-b5e6-d7450be5850c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56d68536-1b28-47ad-b5e6-d7450be5850c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_12-04-2022_44069.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56d68536-1b28-47ad-b5e6-d7450be5850c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a30ee168-ba2f-4309-8114-6b5830f7e87e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a30ee168-ba2f-4309-8114-6b5830f7e87e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_12-07-2022_45795.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a30ee168-ba2f-4309-8114-6b5830f7e87e>.
+    
+<http://data.lblod.info/id/remote-data-objects/07d4d997-3651-439d-b557-3b2a8ea7d279> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07d4d997-3651-439d-b557-3b2a8ea7d279";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_12-07-2022_45808.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07d4d997-3651-439d-b557-3b2a8ea7d279>.
+    
+<http://data.lblod.info/id/remote-data-objects/581835ed-26f0-44f8-aebf-efbde2828055> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "581835ed-26f0-44f8-aebf-efbde2828055";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_12-07-2022_45848.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/581835ed-26f0-44f8-aebf-efbde2828055>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e09b0e1-8f9a-4977-8153-d424702368e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e09b0e1-8f9a-4977-8153-d424702368e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_12-07-2022_45885.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e09b0e1-8f9a-4977-8153-d424702368e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0855060c-4958-4252-896f-0ba004cf4c6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0855060c-4958-4252-896f-0ba004cf4c6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_12-10-2021_40445.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0855060c-4958-4252-896f-0ba004cf4c6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c69a104a-187b-4112-9758-e60ab6e9bca4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c69a104a-187b-4112-9758-e60ab6e9bca4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_14-06-2022_45245.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c69a104a-187b-4112-9758-e60ab6e9bca4>.
+    
+<http://data.lblod.info/id/remote-data-objects/206e6619-86b8-427d-9b9a-706509d83930> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "206e6619-86b8-427d-9b9a-706509d83930";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_14-06-2022_45326.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/206e6619-86b8-427d-9b9a-706509d83930>.
+    
+<http://data.lblod.info/id/remote-data-objects/bec04e0e-a8e0-40ef-b397-f96ddadc1731> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bec04e0e-a8e0-40ef-b397-f96ddadc1731";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_14-06-2022_45328.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9b94751-1675-4819-9472-c1eb5671188b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bec04e0e-a8e0-40ef-b397-f96ddadc1731>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201614-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201614-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201614-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201614-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/ccc29cae-20b5-4797-ab4f-6412bcea1943> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ccc29cae-20b5-4797-ab4f-6412bcea1943";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1c8dbb12-651e-4b03-b399-166db3c2a6cb";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b07ad946-a2b6-46ae-9fb2-2d3a213d912a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b07ad946-a2b6-46ae-9fb2-2d3a213d912a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb>.
+
+  <http://redpencil.data.gift/id/task/61ed454f-c32b-41c4-9f27-ced265c1fc97> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "61ed454f-c32b-41c4-9f27-ced265c1fc97";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/ccc29cae-20b5-4797-ab4f-6412bcea1943>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b07ad946-a2b6-46ae-9fb2-2d3a213d912a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b3d88062-c349-4892-9587-a7e924b23aec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3d88062-c349-4892-9587-a7e924b23aec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_14-06-2022_45329.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3d88062-c349-4892-9587-a7e924b23aec>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7ed9f02-f4e9-4e67-8b59-6e2557fffb45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7ed9f02-f4e9-4e67-8b59-6e2557fffb45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_14-06-2022_45330.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7ed9f02-f4e9-4e67-8b59-6e2557fffb45>.
+    
+<http://data.lblod.info/id/remote-data-objects/687f91e6-41af-4599-bcc4-f3678d31f738> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "687f91e6-41af-4599-bcc4-f3678d31f738";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_14-06-2022_45341.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/687f91e6-41af-4599-bcc4-f3678d31f738>.
+    
+<http://data.lblod.info/id/remote-data-objects/753f2593-2c17-49a8-8e14-166c02246b2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "753f2593-2c17-49a8-8e14-166c02246b2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_14-06-2022_45343.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/753f2593-2c17-49a8-8e14-166c02246b2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f15d1822-bae8-4fc3-9f12-960921d83ee9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f15d1822-bae8-4fc3-9f12-960921d83ee9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_14-12-2021_41701.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f15d1822-bae8-4fc3-9f12-960921d83ee9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5d973b3-37c5-4fc2-ad73-3a83f9d31b5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5d973b3-37c5-4fc2-ad73-3a83f9d31b5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_15-02-2022_42721.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5d973b3-37c5-4fc2-ad73-3a83f9d31b5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/07cc64aa-6e7c-4ecd-ad8f-40374b1737f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07cc64aa-6e7c-4ecd-ad8f-40374b1737f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_15-02-2022_42725.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07cc64aa-6e7c-4ecd-ad8f-40374b1737f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce105532-16e6-4ad0-a110-97dbac10da71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce105532-16e6-4ad0-a110-97dbac10da71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_15-03-2022_43328.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce105532-16e6-4ad0-a110-97dbac10da71>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d354ce2-60ff-4ab4-bc61-43e2448dd5dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d354ce2-60ff-4ab4-bc61-43e2448dd5dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_15-03-2022_43329.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d354ce2-60ff-4ab4-bc61-43e2448dd5dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/15d28e59-7310-4e45-8ae6-b4fcbacfbf7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15d28e59-7310-4e45-8ae6-b4fcbacfbf7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_15-03-2022_43441.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15d28e59-7310-4e45-8ae6-b4fcbacfbf7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4959579d-5ea9-41e0-a25e-a550d5dbbd7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4959579d-5ea9-41e0-a25e-a550d5dbbd7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_16-11-2021_41088.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4959579d-5ea9-41e0-a25e-a550d5dbbd7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e28e810f-f2b2-490c-bc9f-ed3cb295c1e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e28e810f-f2b2-490c-bc9f-ed3cb295c1e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_17-05-2022_44788.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e28e810f-f2b2-490c-bc9f-ed3cb295c1e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8691133-be8f-409e-8843-35e2d2789d6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8691133-be8f-409e-8843-35e2d2789d6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_19-04-2022_44202.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8691133-be8f-409e-8843-35e2d2789d6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b306af9a-9c1c-4627-8d5a-0e12a1cd1a0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b306af9a-9c1c-4627-8d5a-0e12a1cd1a0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_19-04-2022_44210.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b306af9a-9c1c-4627-8d5a-0e12a1cd1a0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/493e5168-9800-47a2-b63f-200ab8eedd82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "493e5168-9800-47a2-b63f-200ab8eedd82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_19-04-2022_44214.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/493e5168-9800-47a2-b63f-200ab8eedd82>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e8c7ddc-1f7f-4195-b885-728aab9532fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e8c7ddc-1f7f-4195-b885-728aab9532fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_19-10-2021_40557.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e8c7ddc-1f7f-4195-b885-728aab9532fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/19bbb95c-cd04-4e16-9ddd-aed3c4df9668> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19bbb95c-cd04-4e16-9ddd-aed3c4df9668";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_19-10-2021_40560.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19bbb95c-cd04-4e16-9ddd-aed3c4df9668>.
+    
+<http://data.lblod.info/id/remote-data-objects/e35e6acd-6c10-4a04-984e-883b1326e335> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e35e6acd-6c10-4a04-984e-883b1326e335";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_19-10-2021_40607.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e35e6acd-6c10-4a04-984e-883b1326e335>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f6253ab-7ae3-49bf-ab8a-b7daa5ece913> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f6253ab-7ae3-49bf-ab8a-b7daa5ece913";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_21-06-2022_45384.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f6253ab-7ae3-49bf-ab8a-b7daa5ece913>.
+    
+<http://data.lblod.info/id/remote-data-objects/f23d10c9-c616-4d94-a383-5035f67d06aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f23d10c9-c616-4d94-a383-5035f67d06aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_22-02-2022_42970.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f23d10c9-c616-4d94-a383-5035f67d06aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fc0c1d0-b4c0-4bd5-8740-1d6ad1df5c5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fc0c1d0-b4c0-4bd5-8740-1d6ad1df5c5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_22-03-2022_43468.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fc0c1d0-b4c0-4bd5-8740-1d6ad1df5c5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e6e6a9f-e4bf-42e8-906e-b57e4d21e979> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e6e6a9f-e4bf-42e8-906e-b57e4d21e979";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_22-03-2022_43497.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e6e6a9f-e4bf-42e8-906e-b57e4d21e979>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d6d4e8b-c563-41d8-9aed-987cec7bb687> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d6d4e8b-c563-41d8-9aed-987cec7bb687";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_22-03-2022_43567.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d6d4e8b-c563-41d8-9aed-987cec7bb687>.
+    
+<http://data.lblod.info/id/remote-data-objects/08be06d4-013e-4717-b475-4e4f70a288e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08be06d4-013e-4717-b475-4e4f70a288e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_22-03-2022_43570.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08be06d4-013e-4717-b475-4e4f70a288e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8ad5a8c-4949-4f51-ac0c-b876c8ec7c61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8ad5a8c-4949-4f51-ac0c-b876c8ec7c61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_22-03-2022_43591.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8ad5a8c-4949-4f51-ac0c-b876c8ec7c61>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9b66ff7-07d0-49a5-865b-d7c66eb08706> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9b66ff7-07d0-49a5-865b-d7c66eb08706";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_22-03-2022_43596.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9b66ff7-07d0-49a5-865b-d7c66eb08706>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8b7370f-b580-490c-acf0-e6658db8af45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8b7370f-b580-490c-acf0-e6658db8af45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_22-03-2022_43598.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8b7370f-b580-490c-acf0-e6658db8af45>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a2415e6-f097-479c-a8c3-2646dbe5326c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a2415e6-f097-479c-a8c3-2646dbe5326c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_22-03-2022_43600.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a2415e6-f097-479c-a8c3-2646dbe5326c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7e7457a-02ee-4fa5-8c62-4615a9f9ea99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7e7457a-02ee-4fa5-8c62-4615a9f9ea99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_24-05-2022_44827.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7e7457a-02ee-4fa5-8c62-4615a9f9ea99>.
+    
+<http://data.lblod.info/id/remote-data-objects/85b84659-e595-4840-9eab-f7fd88c277ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85b84659-e595-4840-9eab-f7fd88c277ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_24-05-2022_44828.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85b84659-e595-4840-9eab-f7fd88c277ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbcc25ad-da2c-41d5-bc96-7e9b5f7d1af6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbcc25ad-da2c-41d5-bc96-7e9b5f7d1af6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_24-05-2022_44939.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbcc25ad-da2c-41d5-bc96-7e9b5f7d1af6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1b82c83-49c3-4647-bb81-65c6fb461a1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1b82c83-49c3-4647-bb81-65c6fb461a1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_26-04-2022_44283.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1b82c83-49c3-4647-bb81-65c6fb461a1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f5ba587-6802-4b31-bc82-cc697812d70c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f5ba587-6802-4b31-bc82-cc697812d70c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_26-07-2022_46054.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f5ba587-6802-4b31-bc82-cc697812d70c>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf12f679-1b4e-4e67-9e02-3b43ee0f4eaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf12f679-1b4e-4e67-9e02-3b43ee0f4eaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_26-07-2022_46055.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf12f679-1b4e-4e67-9e02-3b43ee0f4eaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d978d3f-b058-484a-8d7c-fef89b388cca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d978d3f-b058-484a-8d7c-fef89b388cca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_26-07-2022_46057.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d978d3f-b058-484a-8d7c-fef89b388cca>.
+    
+<http://data.lblod.info/id/remote-data-objects/58d13665-8a56-4d1e-89be-c40ad845385a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58d13665-8a56-4d1e-89be-c40ad845385a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_26-07-2022_46107.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58d13665-8a56-4d1e-89be-c40ad845385a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba5a8da4-83b2-4883-b886-b919156e9fd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba5a8da4-83b2-4883-b886-b919156e9fd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_26-07-2022_46122.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba5a8da4-83b2-4883-b886-b919156e9fd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ade07351-0492-400d-9e85-e02cd4c0c9d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ade07351-0492-400d-9e85-e02cd4c0c9d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_26-07-2022_46131.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ade07351-0492-400d-9e85-e02cd4c0c9d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bdbe522-2099-4b71-b545-6e54ffe52019> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bdbe522-2099-4b71-b545-6e54ffe52019";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_26-10-2021_40712.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bdbe522-2099-4b71-b545-6e54ffe52019>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7be3b3c-71d7-41f5-9279-ce233e79c132> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7be3b3c-71d7-41f5-9279-ce233e79c132";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_28-06-2022_45522.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7be3b3c-71d7-41f5-9279-ce233e79c132>.
+    
+<http://data.lblod.info/id/remote-data-objects/93dbfad8-6806-4277-9ada-8b6d8fae2591> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93dbfad8-6806-4277-9ada-8b6d8fae2591";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_28-06-2022_45582.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93dbfad8-6806-4277-9ada-8b6d8fae2591>.
+    
+<http://data.lblod.info/id/remote-data-objects/4869d20f-1007-4ffa-832d-693ba691bba1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4869d20f-1007-4ffa-832d-693ba691bba1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_28-06-2022_45583.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4869d20f-1007-4ffa-832d-693ba691bba1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9389c3e-5f2e-4749-b549-8278d92d6407> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9389c3e-5f2e-4749-b549-8278d92d6407";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_28-06-2022_45585.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9389c3e-5f2e-4749-b549-8278d92d6407>.
+    
+<http://data.lblod.info/id/remote-data-objects/12b602ac-e4f5-4244-b631-39fe2442c9dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12b602ac-e4f5-4244-b631-39fe2442c9dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_28-06-2022_45586.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12b602ac-e4f5-4244-b631-39fe2442c9dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d85912a9-92b9-42b5-9675-70e543229fb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d85912a9-92b9-42b5-9675-70e543229fb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_28-06-2022_45595.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d85912a9-92b9-42b5-9675-70e543229fb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ee166ce-3aeb-4a5f-9788-fa9ec214067e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ee166ce-3aeb-4a5f-9788-fa9ec214067e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_29-03-2022_43686.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ee166ce-3aeb-4a5f-9788-fa9ec214067e>.
+    
+<http://data.lblod.info/id/remote-data-objects/16afaab2-7597-4ba9-af5e-f650edce4f9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16afaab2-7597-4ba9-af5e-f650edce4f9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_30-11-2021_41331.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16afaab2-7597-4ba9-af5e-f650edce4f9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/104da850-1229-49d8-88df-6ca17567016a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "104da850-1229-49d8-88df-6ca17567016a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_30-11-2021_41333.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/104da850-1229-49d8-88df-6ca17567016a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cf9e1b0-1d59-4490-8883-e449418860f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cf9e1b0-1d59-4490-8883-e449418860f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_30-11-2021_41389.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cf9e1b0-1d59-4490-8883-e449418860f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/4398302a-8903-4920-b8b2-7163fe27f815> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4398302a-8903-4920-b8b2-7163fe27f815";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_30-11-2021_41390.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1c8dbb12-651e-4b03-b399-166db3c2a6cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4398302a-8903-4920-b8b2-7163fe27f815>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201615-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201615-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201615-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201615-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2a45b955-b3db-4a26-94bc-830a96aec20d> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2a45b955-b3db-4a26-94bc-830a96aec20d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7ba46c2d-a861-43ac-b552-812e22e9e32f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/22b35340-0cfe-4154-a49b-219669837eb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "22b35340-0cfe-4154-a49b-219669837eb0";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f>.
+
+  <http://redpencil.data.gift/id/task/805ac881-e94a-40cd-808b-355a2eddfc1d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "805ac881-e94a-40cd-808b-355a2eddfc1d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2a45b955-b3db-4a26-94bc-830a96aec20d>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/22b35340-0cfe-4154-a49b-219669837eb0>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4ba9b72d-2bdd-4849-aa48-0d1a9977de02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ba9b72d-2bdd-4849-aa48-0d1a9977de02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_31-05-2022_44995.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ba9b72d-2bdd-4849-aa48-0d1a9977de02>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b95574a-e9c1-41de-9521-4e4487968869> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b95574a-e9c1-41de-9521-4e4487968869";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_31-05-2022_45055.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b95574a-e9c1-41de-9521-4e4487968869>.
+    
+<http://data.lblod.info/id/remote-data-objects/0716555d-f9e8-4c17-84e3-0d7b16ed7dd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0716555d-f9e8-4c17-84e3-0d7b16ed7dd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.nieuwpoort.be/LBLODWeb/Home/Overzicht/c7704bdc26f9fcbf524e715aa1523e46a196b1af40ba1edc322df56d1758eb0f/GetPublication?filename=Uittreksels_31-05-2022_45067.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0716555d-f9e8-4c17-84e3-0d7b16ed7dd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/d027303f-5626-4e47-a88d-f26323641a12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d027303f-5626-4e47-a88d-f26323641a12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d027303f-5626-4e47-a88d-f26323641a12>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf704cad-87ff-4e71-b780-3f1e35ef7f69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf704cad-87ff-4e71-b780-3f1e35ef7f69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf704cad-87ff-4e71-b780-3f1e35ef7f69>.
+    
+<http://data.lblod.info/id/remote-data-objects/51e985ee-c0a5-4bd6-a190-11303bfd0b95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51e985ee-c0a5-4bd6-a190-11303bfd0b95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51e985ee-c0a5-4bd6-a190-11303bfd0b95>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bc61d2f-e584-4f1a-bb5e-2b394e379f0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bc61d2f-e584-4f1a-bb5e-2b394e379f0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bc61d2f-e584-4f1a-bb5e-2b394e379f0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a338ca9b-e9ab-4baf-a8ef-45eb3ed24743> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a338ca9b-e9ab-4baf-a8ef-45eb3ed24743";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a338ca9b-e9ab-4baf-a8ef-45eb3ed24743>.
+    
+<http://data.lblod.info/id/remote-data-objects/378b6b81-31cf-4deb-ab97-d687a88a8e96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "378b6b81-31cf-4deb-ab97-d687a88a8e96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/378b6b81-31cf-4deb-ab97-d687a88a8e96>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0978eca-6dcc-45dc-b865-e15559e82b78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0978eca-6dcc-45dc-b865-e15559e82b78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0978eca-6dcc-45dc-b865-e15559e82b78>.
+    
+<http://data.lblod.info/id/remote-data-objects/4daf03ac-50d0-419b-a0c9-37e8966cf5df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4daf03ac-50d0-419b-a0c9-37e8966cf5df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4daf03ac-50d0-419b-a0c9-37e8966cf5df>.
+    
+<http://data.lblod.info/id/remote-data-objects/3014f5d7-f2ab-45d8-85f1-b052b2a221f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3014f5d7-f2ab-45d8-85f1-b052b2a221f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3014f5d7-f2ab-45d8-85f1-b052b2a221f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a077a5c-9a34-41e1-b91d-2c280a844580> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a077a5c-9a34-41e1-b91d-2c280a844580";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a077a5c-9a34-41e1-b91d-2c280a844580>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7081e28-bd09-40fd-88f0-9d528217ffb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7081e28-bd09-40fd-88f0-9d528217ffb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7081e28-bd09-40fd-88f0-9d528217ffb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b4b50d6-72db-4d56-bba0-604931900d1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b4b50d6-72db-4d56-bba0-604931900d1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b4b50d6-72db-4d56-bba0-604931900d1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ec339b5-f49d-4b08-83ad-d5d335f28f19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ec339b5-f49d-4b08-83ad-d5d335f28f19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ec339b5-f49d-4b08-83ad-d5d335f28f19>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2ec1f84-590c-40f5-81fa-b2f5ad52521d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2ec1f84-590c-40f5-81fa-b2f5ad52521d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2ec1f84-590c-40f5-81fa-b2f5ad52521d>.
+    
+<http://data.lblod.info/id/remote-data-objects/10b252f8-fa07-4096-b92c-fbb4a9cbdb08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10b252f8-fa07-4096-b92c-fbb4a9cbdb08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10b252f8-fa07-4096-b92c-fbb4a9cbdb08>.
+    
+<http://data.lblod.info/id/remote-data-objects/228f4306-a256-4995-8fee-f1674d1ec77b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "228f4306-a256-4995-8fee-f1674d1ec77b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/228f4306-a256-4995-8fee-f1674d1ec77b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ab4c6e3-7a36-4cfd-b791-d8d7a825cbd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ab4c6e3-7a36-4cfd-b791-d8d7a825cbd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ab4c6e3-7a36-4cfd-b791-d8d7a825cbd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/96b13993-d590-4602-a365-efa3b74d41dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96b13993-d590-4602-a365-efa3b74d41dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96b13993-d590-4602-a365-efa3b74d41dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4b3e38a-6d08-4330-901e-6f7e1cd7cd91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4b3e38a-6d08-4330-901e-6f7e1cd7cd91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4b3e38a-6d08-4330-901e-6f7e1cd7cd91>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0fd57f7-ab38-49c8-9cde-3bc1bda9ebb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0fd57f7-ab38-49c8-9cde-3bc1bda9ebb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0fd57f7-ab38-49c8-9cde-3bc1bda9ebb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3489c97b-2a4b-4fcc-9f99-20123ecd006f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3489c97b-2a4b-4fcc-9f99-20123ecd006f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3489c97b-2a4b-4fcc-9f99-20123ecd006f>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb072374-f4e4-4c66-884e-551e59975cfc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb072374-f4e4-4c66-884e-551e59975cfc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb072374-f4e4-4c66-884e-551e59975cfc>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa3c7c08-16cb-4c81-ba99-990ebfe8093a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa3c7c08-16cb-4c81-ba99-990ebfe8093a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa3c7c08-16cb-4c81-ba99-990ebfe8093a>.
+    
+<http://data.lblod.info/id/remote-data-objects/021de564-9266-46b0-bc0e-5bad6b8fa44b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "021de564-9266-46b0-bc0e-5bad6b8fa44b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/021de564-9266-46b0-bc0e-5bad6b8fa44b>.
+    
+<http://data.lblod.info/id/remote-data-objects/302dccac-0762-4587-8074-1f8be092b42c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "302dccac-0762-4587-8074-1f8be092b42c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/1fc1e70ea537e823e78e4d7edf4e8236548cc62bf56bb7be947bb563fcb11c59/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/302dccac-0762-4587-8074-1f8be092b42c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a67a148f-6070-4bf3-8871-6e56d3514e6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a67a148f-6070-4bf3-8871-6e56d3514e6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a67a148f-6070-4bf3-8871-6e56d3514e6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee783c20-45f0-403b-9253-e8a0336d46e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee783c20-45f0-403b-9253-e8a0336d46e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee783c20-45f0-403b-9253-e8a0336d46e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/f87bdda6-d7dd-4eab-998b-ac93f64e3e22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f87bdda6-d7dd-4eab-998b-ac93f64e3e22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f87bdda6-d7dd-4eab-998b-ac93f64e3e22>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0154543-b9c7-4922-ae2b-293a01c96426> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0154543-b9c7-4922-ae2b-293a01c96426";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0154543-b9c7-4922-ae2b-293a01c96426>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2ed16e9-f7aa-41fa-93d9-2e9d65ffe481> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2ed16e9-f7aa-41fa-93d9-2e9d65ffe481";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2ed16e9-f7aa-41fa-93d9-2e9d65ffe481>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad0a005e-48bd-4ac3-b216-bdb6f1866f44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad0a005e-48bd-4ac3-b216-bdb6f1866f44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad0a005e-48bd-4ac3-b216-bdb6f1866f44>.
+    
+<http://data.lblod.info/id/remote-data-objects/068a8f5a-f93c-4eec-81bd-0394e49fcf92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "068a8f5a-f93c-4eec-81bd-0394e49fcf92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/068a8f5a-f93c-4eec-81bd-0394e49fcf92>.
+    
+<http://data.lblod.info/id/remote-data-objects/00099c6c-8925-44ee-84a1-462a88572e67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00099c6c-8925-44ee-84a1-462a88572e67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00099c6c-8925-44ee-84a1-462a88572e67>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea4ebb76-7545-4ef6-b52e-103055c3b9d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea4ebb76-7545-4ef6-b52e-103055c3b9d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea4ebb76-7545-4ef6-b52e-103055c3b9d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8346828b-f68d-4439-bf4a-cf64cd6939cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8346828b-f68d-4439-bf4a-cf64cd6939cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8346828b-f68d-4439-bf4a-cf64cd6939cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f5fa2a6-2987-4121-9187-0cdd60658557> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f5fa2a6-2987-4121-9187-0cdd60658557";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f5fa2a6-2987-4121-9187-0cdd60658557>.
+    
+<http://data.lblod.info/id/remote-data-objects/f18a40d7-3838-4dc5-8597-787ca2794957> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f18a40d7-3838-4dc5-8597-787ca2794957";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f18a40d7-3838-4dc5-8597-787ca2794957>.
+    
+<http://data.lblod.info/id/remote-data-objects/e182125e-3290-47a9-a259-e65e34e66e50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e182125e-3290-47a9-a259-e65e34e66e50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e182125e-3290-47a9-a259-e65e34e66e50>.
+    
+<http://data.lblod.info/id/remote-data-objects/c872e3cd-1307-4fcc-ab7c-7d04d423cf3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c872e3cd-1307-4fcc-ab7c-7d04d423cf3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c872e3cd-1307-4fcc-ab7c-7d04d423cf3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/837ba1bb-fc91-4fe0-8e03-5fbec29b6851> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "837ba1bb-fc91-4fe0-8e03-5fbec29b6851";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/837ba1bb-fc91-4fe0-8e03-5fbec29b6851>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cfd1570-d51c-44e6-b2fa-762b7eb1830d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cfd1570-d51c-44e6-b2fa-762b7eb1830d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cfd1570-d51c-44e6-b2fa-762b7eb1830d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b8eeade-3f62-41c3-8b10-0f7e68953062> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b8eeade-3f62-41c3-8b10-0f7e68953062";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b8eeade-3f62-41c3-8b10-0f7e68953062>.
+    
+<http://data.lblod.info/id/remote-data-objects/8002680c-8191-4df2-8635-c7b48a166257> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8002680c-8191-4df2-8635-c7b48a166257";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8002680c-8191-4df2-8635-c7b48a166257>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc2f4d8e-0a27-4bae-a5f9-804b5cebe8dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc2f4d8e-0a27-4bae-a5f9-804b5cebe8dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc2f4d8e-0a27-4bae-a5f9-804b5cebe8dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4663402-433f-40ab-a1e6-8e2b0d58eef7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4663402-433f-40ab-a1e6-8e2b0d58eef7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4663402-433f-40ab-a1e6-8e2b0d58eef7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d605db4d-b2fb-4677-95f4-d856a9bd0d41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d605db4d-b2fb-4677-95f4-d856a9bd0d41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d605db4d-b2fb-4677-95f4-d856a9bd0d41>.
+    
+<http://data.lblod.info/id/remote-data-objects/62149c3f-27a4-4d8b-968f-d3ec8d0c7fca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62149c3f-27a4-4d8b-968f-d3ec8d0c7fca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7ba46c2d-a861-43ac-b552-812e22e9e32f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62149c3f-27a4-4d8b-968f-d3ec8d0c7fca>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201617-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201617-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201617-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201617-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/5c0accd6-8c08-4734-bda1-00696a569140> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5c0accd6-8c08-4734-bda1-00696a569140";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2d091eb8-6945-4dd5-bfa9-ad520e613af6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ffb487be-3854-4491-9842-363a8a1a94db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ffb487be-3854-4491-9842-363a8a1a94db";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6>.
+
+  <http://redpencil.data.gift/id/task/5275b544-e0e5-4c52-b9fe-40958f3742b5> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5275b544-e0e5-4c52-b9fe-40958f3742b5";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/5c0accd6-8c08-4734-bda1-00696a569140>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ffb487be-3854-4491-9842-363a8a1a94db>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c66aeccb-cf58-4abf-a0cd-eecc22a6eeb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c66aeccb-cf58-4abf-a0cd-eecc22a6eeb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c66aeccb-cf58-4abf-a0cd-eecc22a6eeb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2617896-efaa-49ef-af9f-f49e1b3bfbeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2617896-efaa-49ef-af9f-f49e1b3bfbeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2617896-efaa-49ef-af9f-f49e1b3bfbeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/928b35ca-957b-45ee-8bdc-3a9e07d44d3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "928b35ca-957b-45ee-8bdc-3a9e07d44d3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/928b35ca-957b-45ee-8bdc-3a9e07d44d3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/841ec490-b996-4acc-a500-9b9b1832ef71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "841ec490-b996-4acc-a500-9b9b1832ef71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/841ec490-b996-4acc-a500-9b9b1832ef71>.
+    
+<http://data.lblod.info/id/remote-data-objects/a08b9322-3dab-411a-9441-86a941719239> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a08b9322-3dab-411a-9441-86a941719239";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a08b9322-3dab-411a-9441-86a941719239>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ce811c4-7c01-4aa8-8e12-9d12758f1c3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ce811c4-7c01-4aa8-8e12-9d12758f1c3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ce811c4-7c01-4aa8-8e12-9d12758f1c3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8e28aea-dffe-4e28-96ff-538edcf17fd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8e28aea-dffe-4e28-96ff-538edcf17fd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8e28aea-dffe-4e28-96ff-538edcf17fd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/d45bc386-fcac-423b-ab7d-053ca0ff9574> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d45bc386-fcac-423b-ab7d-053ca0ff9574";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d45bc386-fcac-423b-ab7d-053ca0ff9574>.
+    
+<http://data.lblod.info/id/remote-data-objects/2dcb414f-88d0-4664-9121-d87bacdf727a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2dcb414f-88d0-4664-9121-d87bacdf727a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2dcb414f-88d0-4664-9121-d87bacdf727a>.
+    
+<http://data.lblod.info/id/remote-data-objects/12979599-a2f6-4753-88b7-63c579662ea2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12979599-a2f6-4753-88b7-63c579662ea2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12979599-a2f6-4753-88b7-63c579662ea2>.
+    
+<http://data.lblod.info/id/remote-data-objects/41683c62-7e4e-422b-83c4-54e71fb2b609> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41683c62-7e4e-422b-83c4-54e71fb2b609";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41683c62-7e4e-422b-83c4-54e71fb2b609>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d94c9db-ba51-4a52-aa67-a27f26da88de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d94c9db-ba51-4a52-aa67-a27f26da88de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d94c9db-ba51-4a52-aa67-a27f26da88de>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf924237-0b60-4bba-848f-d2b76a015671> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf924237-0b60-4bba-848f-d2b76a015671";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/22ddeec4c9b92aa26d580592d2e16b4ef9966d581c441926862e64ba77c72ec9/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf924237-0b60-4bba-848f-d2b76a015671>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f752223-c977-449e-91f1-e7807fc74882> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f752223-c977-449e-91f1-e7807fc74882";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Agenda_Gemeenteraad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f752223-c977-449e-91f1-e7807fc74882>.
+    
+<http://data.lblod.info/id/remote-data-objects/5807189c-07b0-4dcd-9893-a9cd62703485> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5807189c-07b0-4dcd-9893-a9cd62703485";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Agenda_Gemeenteraad_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5807189c-07b0-4dcd-9893-a9cd62703485>.
+    
+<http://data.lblod.info/id/remote-data-objects/815e0a7e-8818-40ee-88cd-3b34b5d18d10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "815e0a7e-8818-40ee-88cd-3b34b5d18d10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Agenda_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/815e0a7e-8818-40ee-88cd-3b34b5d18d10>.
+    
+<http://data.lblod.info/id/remote-data-objects/6043b37f-f696-4c67-b64b-a094f7516322> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6043b37f-f696-4c67-b64b-a094f7516322";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Agenda_Gemeenteraad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6043b37f-f696-4c67-b64b-a094f7516322>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cf75f94-c01f-4aa9-a4a8-d80abd0fcc4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cf75f94-c01f-4aa9-a4a8-d80abd0fcc4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Agenda_Gemeenteraad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cf75f94-c01f-4aa9-a4a8-d80abd0fcc4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ce9f9eb-ae9e-46d7-9370-b2f582520519> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ce9f9eb-ae9e-46d7-9370-b2f582520519";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Agenda_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ce9f9eb-ae9e-46d7-9370-b2f582520519>.
+    
+<http://data.lblod.info/id/remote-data-objects/b621b9f3-1ccb-42a0-b226-b936f895b709> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b621b9f3-1ccb-42a0-b226-b936f895b709";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Agenda_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b621b9f3-1ccb-42a0-b226-b936f895b709>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6d3bb05-b2d0-4b9a-b4ec-c8e6eec7c898> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6d3bb05-b2d0-4b9a-b4ec-c8e6eec7c898";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Agenda_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6d3bb05-b2d0-4b9a-b4ec-c8e6eec7c898>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3ef8cde-b7f6-4dbf-86fd-25ef6b7180ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3ef8cde-b7f6-4dbf-86fd-25ef6b7180ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Agenda_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3ef8cde-b7f6-4dbf-86fd-25ef6b7180ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/d32bd441-10f4-40bb-98b6-32a9ab9e7bfe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d32bd441-10f4-40bb-98b6-32a9ab9e7bfe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Agenda_Gemeenteraad_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d32bd441-10f4-40bb-98b6-32a9ab9e7bfe>.
+    
+<http://data.lblod.info/id/remote-data-objects/61e6f04d-aae2-4ff3-8718-0d79de314a6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61e6f04d-aae2-4ff3-8718-0d79de314a6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijst_Gemeenteraad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61e6f04d-aae2-4ff3-8718-0d79de314a6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab7132e1-172d-415c-b349-ad1ad2615bca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab7132e1-172d-415c-b349-ad1ad2615bca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijst_Gemeenteraad_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab7132e1-172d-415c-b349-ad1ad2615bca>.
+    
+<http://data.lblod.info/id/remote-data-objects/006c08f2-7c89-46fc-b9e7-fae8e13866d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "006c08f2-7c89-46fc-b9e7-fae8e13866d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/006c08f2-7c89-46fc-b9e7-fae8e13866d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b490360-b3d0-41eb-8c1b-056922d20c1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b490360-b3d0-41eb-8c1b-056922d20c1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b490360-b3d0-41eb-8c1b-056922d20c1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/73bd307c-5854-4052-88bc-c60cf7e9fff6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73bd307c-5854-4052-88bc-c60cf7e9fff6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijst_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73bd307c-5854-4052-88bc-c60cf7e9fff6>.
+    
+<http://data.lblod.info/id/remote-data-objects/17a3210f-994b-4b5f-b790-4b2b9fbcaeda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17a3210f-994b-4b5f-b790-4b2b9fbcaeda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijst_Gemeenteraad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17a3210f-994b-4b5f-b790-4b2b9fbcaeda>.
+    
+<http://data.lblod.info/id/remote-data-objects/54ed85d0-28c2-4ce6-a57a-6d2ea4f499e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54ed85d0-28c2-4ce6-a57a-6d2ea4f499e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54ed85d0-28c2-4ce6-a57a-6d2ea4f499e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/318efad3-842f-4ca2-901f-d40cedd36f56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "318efad3-842f-4ca2-901f-d40cedd36f56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/318efad3-842f-4ca2-901f-d40cedd36f56>.
+    
+<http://data.lblod.info/id/remote-data-objects/1af9897e-a5ba-4f28-afd9-fcd5a90fce81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1af9897e-a5ba-4f28-afd9-fcd5a90fce81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1af9897e-a5ba-4f28-afd9-fcd5a90fce81>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab427486-a5f3-444e-97da-86eca1da0ec4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab427486-a5f3-444e-97da-86eca1da0ec4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab427486-a5f3-444e-97da-86eca1da0ec4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6131d5c3-494b-491c-8352-19dc1df040d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6131d5c3-494b-491c-8352-19dc1df040d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6131d5c3-494b-491c-8352-19dc1df040d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/899ff651-41ba-4bb1-b922-15982a9ce155> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "899ff651-41ba-4bb1-b922-15982a9ce155";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/899ff651-41ba-4bb1-b922-15982a9ce155>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab899f6b-e16f-4c3b-9f0e-af16226ef4e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab899f6b-e16f-4c3b-9f0e-af16226ef4e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab899f6b-e16f-4c3b-9f0e-af16226ef4e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/caa7042d-799a-45f5-974f-fdc220efc0b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "caa7042d-799a-45f5-974f-fdc220efc0b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/caa7042d-799a-45f5-974f-fdc220efc0b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/695ce0e9-c9e7-416e-93ed-c5f3410625ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "695ce0e9-c9e7-416e-93ed-c5f3410625ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/695ce0e9-c9e7-416e-93ed-c5f3410625ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a0e7886-f617-4ba1-8642-1c7bf45cece1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a0e7886-f617-4ba1-8642-1c7bf45cece1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a0e7886-f617-4ba1-8642-1c7bf45cece1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c744eac-d4ea-43a8-83bc-c47738e82d05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c744eac-d4ea-43a8-83bc-c47738e82d05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c744eac-d4ea-43a8-83bc-c47738e82d05>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccd8f5fb-0b3f-407a-b0c7-8f306957e362> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccd8f5fb-0b3f-407a-b0c7-8f306957e362";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccd8f5fb-0b3f-407a-b0c7-8f306957e362>.
+    
+<http://data.lblod.info/id/remote-data-objects/f86b0e21-657c-4c92-b08a-68fa0632d8db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f86b0e21-657c-4c92-b08a-68fa0632d8db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Notulen_Gemeenteraad_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f86b0e21-657c-4c92-b08a-68fa0632d8db>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7d7aa80-455e-4862-a36f-f4d7bf86c1a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7d7aa80-455e-4862-a36f-f4d7bf86c1a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Notulen_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7d7aa80-455e-4862-a36f-f4d7bf86c1a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/178e2365-1afb-48c2-9e47-1368f1b8d2f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "178e2365-1afb-48c2-9e47-1368f1b8d2f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Notulen_Gemeenteraad_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/178e2365-1afb-48c2-9e47-1368f1b8d2f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f81db25f-1058-4fa2-96ef-26cee4b69251> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f81db25f-1058-4fa2-96ef-26cee4b69251";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Notulen_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f81db25f-1058-4fa2-96ef-26cee4b69251>.
+    
+<http://data.lblod.info/id/remote-data-objects/92d8e914-07ab-4632-ade9-27e2a68ee390> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92d8e914-07ab-4632-ade9-27e2a68ee390";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Notulen_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92d8e914-07ab-4632-ade9-27e2a68ee390>.
+    
+<http://data.lblod.info/id/remote-data-objects/5842d55c-bdbf-440d-99c7-5fde6a22f823> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5842d55c-bdbf-440d-99c7-5fde6a22f823";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Notulen_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5842d55c-bdbf-440d-99c7-5fde6a22f823>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b99885d-fa8a-4831-bf6c-9c1d0c31ceb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b99885d-fa8a-4831-bf6c-9c1d0c31ceb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Notulen_Gemeenteraad_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b99885d-fa8a-4831-bf6c-9c1d0c31ceb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/175ce47d-b35b-435f-aa7e-0fe6da20cbcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "175ce47d-b35b-435f-aa7e-0fe6da20cbcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Uittreksels_13-12-2021_103690.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/175ce47d-b35b-435f-aa7e-0fe6da20cbcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/63488ea3-9cbf-4346-a985-53b69c08d67d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63488ea3-9cbf-4346-a985-53b69c08d67d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Uittreksels_13-12-2021_103691.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d091eb8-6945-4dd5-bfa9-ad520e613af6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63488ea3-9cbf-4346-a985-53b69c08d67d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201618-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201618-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201618-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201618-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f4bcb929-48a4-4bb4-bd20-b04e337442d7> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f4bcb929-48a4-4bb4-bd20-b04e337442d7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "48d9731e-5c19-4f61-a19d-2381313908b4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/639c9905-4e00-437f-bce3-58ff31ad2a63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "639c9905-4e00-437f-bce3-58ff31ad2a63";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4>.
+
+  <http://redpencil.data.gift/id/task/26d32f18-de4b-4350-bca5-6e22504cf907> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "26d32f18-de4b-4350-bca5-6e22504cf907";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f4bcb929-48a4-4bb4-bd20-b04e337442d7>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/639c9905-4e00-437f-bce3-58ff31ad2a63>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/f9734b90-f4be-474e-bba6-6912427293d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9734b90-f4be-474e-bba6-6912427293d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Uittreksels_13-12-2021_103700.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9734b90-f4be-474e-bba6-6912427293d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/dacfd210-4cf5-468e-97db-1deefbcaecf3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dacfd210-4cf5-468e-97db-1deefbcaecf3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Uittreksels_21-03-2022_106996.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dacfd210-4cf5-468e-97db-1deefbcaecf3>.
+    
+<http://data.lblod.info/id/remote-data-objects/fff62eea-a453-45a1-9e31-ee23d0014206> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fff62eea-a453-45a1-9e31-ee23d0014206";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Uittreksels_22-11-2021_102820.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fff62eea-a453-45a1-9e31-ee23d0014206>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab677eb6-4b84-4190-beee-3eb016d72472> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab677eb6-4b84-4190-beee-3eb016d72472";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Uittreksels_25-04-2022_108099.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab677eb6-4b84-4190-beee-3eb016d72472>.
+    
+<http://data.lblod.info/id/remote-data-objects/97c16cc7-8060-43e2-a559-e176f0c1c6bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97c16cc7-8060-43e2-a559-e176f0c1c6bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/54f62c2852996f718e3cdb711baf0735365fec955e31e52e245b3fd21a78bf5a/GetPublication?filename=Uittreksels_25-04-2022_108100.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97c16cc7-8060-43e2-a559-e176f0c1c6bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/51427597-c800-4cd4-bf18-267f147a87ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51427597-c800-4cd4-bf18-267f147a87ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51427597-c800-4cd4-bf18-267f147a87ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2de2c90-cfa2-46e9-b2d6-fcb0aa4f90b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2de2c90-cfa2-46e9-b2d6-fcb0aa4f90b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_01-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2de2c90-cfa2-46e9-b2d6-fcb0aa4f90b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/537dffc4-f31c-4548-9940-3b8785b485ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "537dffc4-f31c-4548-9940-3b8785b485ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_02-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/537dffc4-f31c-4548-9940-3b8785b485ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/834b250c-753c-4987-a211-cf3787db73b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "834b250c-753c-4987-a211-cf3787db73b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_02-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/834b250c-753c-4987-a211-cf3787db73b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f531f213-6fca-450f-9fa4-628aee91a6e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f531f213-6fca-450f-9fa4-628aee91a6e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f531f213-6fca-450f-9fa4-628aee91a6e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5495142-6b00-4630-a3b7-804337babad8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5495142-6b00-4630-a3b7-804337babad8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5495142-6b00-4630-a3b7-804337babad8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2091176-8872-4b04-9d96-66595f3a130e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2091176-8872-4b04-9d96-66595f3a130e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2091176-8872-4b04-9d96-66595f3a130e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f97d6e0b-40ef-466e-83ab-6e56bbaf12e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f97d6e0b-40ef-466e-83ab-6e56bbaf12e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f97d6e0b-40ef-466e-83ab-6e56bbaf12e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d59cb7a-fb4d-4ad7-af20-230fb5f51a28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d59cb7a-fb4d-4ad7-af20-230fb5f51a28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d59cb7a-fb4d-4ad7-af20-230fb5f51a28>.
+    
+<http://data.lblod.info/id/remote-data-objects/94ab79c8-842b-4ece-8b20-4a3652d8f32d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94ab79c8-842b-4ece-8b20-4a3652d8f32d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_06-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94ab79c8-842b-4ece-8b20-4a3652d8f32d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5aef7c06-4dd5-4ccd-86e8-788d57a16b6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5aef7c06-4dd5-4ccd-86e8-788d57a16b6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5aef7c06-4dd5-4ccd-86e8-788d57a16b6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/878bef07-8100-45dd-9879-2713d5f58f5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "878bef07-8100-45dd-9879-2713d5f58f5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/878bef07-8100-45dd-9879-2713d5f58f5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b3ea37e-af52-4a00-ae24-b7d843ff9a68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b3ea37e-af52-4a00-ae24-b7d843ff9a68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b3ea37e-af52-4a00-ae24-b7d843ff9a68>.
+    
+<http://data.lblod.info/id/remote-data-objects/e21088c3-3284-4e86-92ba-249e339720ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e21088c3-3284-4e86-92ba-249e339720ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_12-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e21088c3-3284-4e86-92ba-249e339720ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/d11c132c-c1ed-4392-ab1b-019793214def> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d11c132c-c1ed-4392-ab1b-019793214def";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d11c132c-c1ed-4392-ab1b-019793214def>.
+    
+<http://data.lblod.info/id/remote-data-objects/92226640-ba35-4090-a099-d2780b288976> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92226640-ba35-4090-a099-d2780b288976";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92226640-ba35-4090-a099-d2780b288976>.
+    
+<http://data.lblod.info/id/remote-data-objects/83df9df2-aeea-41a8-8203-fe62b8581399> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83df9df2-aeea-41a8-8203-fe62b8581399";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83df9df2-aeea-41a8-8203-fe62b8581399>.
+    
+<http://data.lblod.info/id/remote-data-objects/38be4c8d-1463-4d9e-9629-c5de694487d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38be4c8d-1463-4d9e-9629-c5de694487d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38be4c8d-1463-4d9e-9629-c5de694487d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4017300-2e41-4365-87b1-812fb929da3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4017300-2e41-4365-87b1-812fb929da3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_16-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4017300-2e41-4365-87b1-812fb929da3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4045f560-e4d8-49d3-9c21-8298a920b983> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4045f560-e4d8-49d3-9c21-8298a920b983";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4045f560-e4d8-49d3-9c21-8298a920b983>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4c7fe3c-7ec9-484d-935f-928aa8950e30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4c7fe3c-7ec9-484d-935f-928aa8950e30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4c7fe3c-7ec9-484d-935f-928aa8950e30>.
+    
+<http://data.lblod.info/id/remote-data-objects/e06ec6b4-2077-43b8-85ce-b5563c65a420> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e06ec6b4-2077-43b8-85ce-b5563c65a420";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_19-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e06ec6b4-2077-43b8-85ce-b5563c65a420>.
+    
+<http://data.lblod.info/id/remote-data-objects/27e9887f-6910-4b23-9236-276eaed43a1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27e9887f-6910-4b23-9236-276eaed43a1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27e9887f-6910-4b23-9236-276eaed43a1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d8919be-3b32-45be-8b2d-fc1ff968afbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d8919be-3b32-45be-8b2d-fc1ff968afbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_20-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d8919be-3b32-45be-8b2d-fc1ff968afbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e6741e5-d91f-4032-bc64-8b6c66f9222a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e6741e5-d91f-4032-bc64-8b6c66f9222a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_20-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e6741e5-d91f-4032-bc64-8b6c66f9222a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5db35b17-2f80-4d63-b248-a875e74771e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5db35b17-2f80-4d63-b248-a875e74771e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5db35b17-2f80-4d63-b248-a875e74771e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdd9d633-6b24-41eb-b182-3431aedfcdef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdd9d633-6b24-41eb-b182-3431aedfcdef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdd9d633-6b24-41eb-b182-3431aedfcdef>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffd6344a-2871-4bb9-a8d6-da17e1f6c6ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffd6344a-2871-4bb9-a8d6-da17e1f6c6ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffd6344a-2871-4bb9-a8d6-da17e1f6c6ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/0de3b92e-7505-4969-9687-a1b2691012c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0de3b92e-7505-4969-9687-a1b2691012c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0de3b92e-7505-4969-9687-a1b2691012c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1406c4f-a5ae-450d-8589-22548c22b1d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1406c4f-a5ae-450d-8589-22548c22b1d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1406c4f-a5ae-450d-8589-22548c22b1d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c47e786-42f5-4ae3-9896-4dc7dc89155e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c47e786-42f5-4ae3-9896-4dc7dc89155e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c47e786-42f5-4ae3-9896-4dc7dc89155e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9107812-27d8-4184-94a9-75d6fe572c28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9107812-27d8-4184-94a9-75d6fe572c28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9107812-27d8-4184-94a9-75d6fe572c28>.
+    
+<http://data.lblod.info/id/remote-data-objects/e07e9bb7-1147-4b6b-bf56-ee3882a8aebe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e07e9bb7-1147-4b6b-bf56-ee3882a8aebe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e07e9bb7-1147-4b6b-bf56-ee3882a8aebe>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ef96a6f-fe7d-4d2b-8ce2-0461036f8d94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ef96a6f-fe7d-4d2b-8ce2-0461036f8d94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_27-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ef96a6f-fe7d-4d2b-8ce2-0461036f8d94>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f357acf-c187-48cd-87bd-54ad129b9938> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f357acf-c187-48cd-87bd-54ad129b9938";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f357acf-c187-48cd-87bd-54ad129b9938>.
+    
+<http://data.lblod.info/id/remote-data-objects/712ff531-c5fd-4410-9b34-5fb73d79eb13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "712ff531-c5fd-4410-9b34-5fb73d79eb13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_29-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/712ff531-c5fd-4410-9b34-5fb73d79eb13>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdc0d123-f169-481a-8b92-eb4600921d47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdc0d123-f169-481a-8b92-eb4600921d47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5592dcdda5c9408ceac7739ea5af6fd1ef701bd00f83a73f11ec6dce3d1d91d5/GetPublication?filename=BesluitenLijst_Besluiten%20van%20de%20burgemeester_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdc0d123-f169-481a-8b92-eb4600921d47>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bb3ce1e-9b12-4334-8c2e-c390f27be063> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bb3ce1e-9b12-4334-8c2e-c390f27be063";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bb3ce1e-9b12-4334-8c2e-c390f27be063>.
+    
+<http://data.lblod.info/id/remote-data-objects/5643e7ac-525c-4cb8-8193-fb8502f21500> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5643e7ac-525c-4cb8-8193-fb8502f21500";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5643e7ac-525c-4cb8-8193-fb8502f21500>.
+    
+<http://data.lblod.info/id/remote-data-objects/8572abab-42bd-4093-86f9-d86cbb1b2764> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8572abab-42bd-4093-86f9-d86cbb1b2764";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8572abab-42bd-4093-86f9-d86cbb1b2764>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b904753-71b6-439c-92b1-178b3cbaf1f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b904753-71b6-439c-92b1-178b3cbaf1f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b904753-71b6-439c-92b1-178b3cbaf1f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c55af7d5-448a-402d-833f-2ed20bba7884> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c55af7d5-448a-402d-833f-2ed20bba7884";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c55af7d5-448a-402d-833f-2ed20bba7884>.
+    
+<http://data.lblod.info/id/remote-data-objects/5651c27e-b7bc-407a-a907-0cf175c8f792> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5651c27e-b7bc-407a-a907-0cf175c8f792";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5651c27e-b7bc-407a-a907-0cf175c8f792>.
+    
+<http://data.lblod.info/id/remote-data-objects/13002df5-bfe8-4be6-801e-846151a995dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13002df5-bfe8-4be6-801e-846151a995dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13002df5-bfe8-4be6-801e-846151a995dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/24513ec6-1649-4869-9844-e78e9ca4bb35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24513ec6-1649-4869-9844-e78e9ca4bb35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/48d9731e-5c19-4f61-a19d-2381313908b4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24513ec6-1649-4869-9844-e78e9ca4bb35>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201619-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201619-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201619-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201619-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/fd6f379e-9800-46a8-afe5-0ed316a21a9f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fd6f379e-9800-46a8-afe5-0ed316a21a9f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "86ce70d3-cb79-4dfb-bdf4-f1d2886980e7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/edf80644-63fd-4c45-9b6a-a75fc687e111> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "edf80644-63fd-4c45-9b6a-a75fc687e111";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7>.
+
+  <http://redpencil.data.gift/id/task/c49722d5-b45a-4856-9079-e6cee0e00430> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c49722d5-b45a-4856-9079-e6cee0e00430";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/fd6f379e-9800-46a8-afe5-0ed316a21a9f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/edf80644-63fd-4c45-9b6a-a75fc687e111>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/70bc1a20-eca7-4bfa-b8b3-1b25f9b98066> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70bc1a20-eca7-4bfa-b8b3-1b25f9b98066";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70bc1a20-eca7-4bfa-b8b3-1b25f9b98066>.
+    
+<http://data.lblod.info/id/remote-data-objects/15713604-4b99-4422-a872-1dc500fa20d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15713604-4b99-4422-a872-1dc500fa20d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15713604-4b99-4422-a872-1dc500fa20d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f5c2523-9a00-429b-b2be-c350ceefcbfb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f5c2523-9a00-429b-b2be-c350ceefcbfb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f5c2523-9a00-429b-b2be-c350ceefcbfb>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c442572-af57-45f7-a4fc-36bc72b8600e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c442572-af57-45f7-a4fc-36bc72b8600e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c442572-af57-45f7-a4fc-36bc72b8600e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a2e1bbc-746d-45bb-a681-7d99cff8bc3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a2e1bbc-746d-45bb-a681-7d99cff8bc3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a2e1bbc-746d-45bb-a681-7d99cff8bc3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a2f18fd-7868-457a-9912-0762a32fc7db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a2f18fd-7868-457a-9912-0762a32fc7db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a2f18fd-7868-457a-9912-0762a32fc7db>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee0de4e1-af4c-4ba3-911a-88fba78efe78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee0de4e1-af4c-4ba3-911a-88fba78efe78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee0de4e1-af4c-4ba3-911a-88fba78efe78>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ffccee7-0951-4a80-995d-ea88b23b0176> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ffccee7-0951-4a80-995d-ea88b23b0176";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ffccee7-0951-4a80-995d-ea88b23b0176>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5518b15-4e5a-41f1-8b61-6c869bb3f320> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5518b15-4e5a-41f1-8b61-6c869bb3f320";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5518b15-4e5a-41f1-8b61-6c869bb3f320>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3fec153-b742-4f72-86ad-b44bc1f0a7c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3fec153-b742-4f72-86ad-b44bc1f0a7c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3fec153-b742-4f72-86ad-b44bc1f0a7c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c945dc40-59f5-494c-aef6-cb896447f57a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c945dc40-59f5-494c-aef6-cb896447f57a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c945dc40-59f5-494c-aef6-cb896447f57a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d628433a-70a5-49fc-a5cb-0768d00fd72c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d628433a-70a5-49fc-a5cb-0768d00fd72c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d628433a-70a5-49fc-a5cb-0768d00fd72c>.
+    
+<http://data.lblod.info/id/remote-data-objects/21562e5e-7fd8-4ad6-a54b-334b0695b30f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21562e5e-7fd8-4ad6-a54b-334b0695b30f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21562e5e-7fd8-4ad6-a54b-334b0695b30f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b188e666-724d-4b39-a842-308cef24663f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b188e666-724d-4b39-a842-308cef24663f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b188e666-724d-4b39-a842-308cef24663f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d64f34b5-efb5-4a37-a73b-08e9158d1cad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d64f34b5-efb5-4a37-a73b-08e9158d1cad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d64f34b5-efb5-4a37-a73b-08e9158d1cad>.
+    
+<http://data.lblod.info/id/remote-data-objects/b002bf9b-1383-4d6d-8c80-84454be5fbf4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b002bf9b-1383-4d6d-8c80-84454be5fbf4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b002bf9b-1383-4d6d-8c80-84454be5fbf4>.
+    
+<http://data.lblod.info/id/remote-data-objects/07d7f597-fe69-4adf-acbe-90df67d67fc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07d7f597-fe69-4adf-acbe-90df67d67fc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07d7f597-fe69-4adf-acbe-90df67d67fc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/f24d4264-9f4c-4d46-900c-ca180c601db4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f24d4264-9f4c-4d46-900c-ca180c601db4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f24d4264-9f4c-4d46-900c-ca180c601db4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8840be6d-6348-48c7-80cb-3ccc42ba5408> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8840be6d-6348-48c7-80cb-3ccc42ba5408";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8840be6d-6348-48c7-80cb-3ccc42ba5408>.
+    
+<http://data.lblod.info/id/remote-data-objects/5852447f-c170-4b49-9335-c8a52789dfab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5852447f-c170-4b49-9335-c8a52789dfab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5852447f-c170-4b49-9335-c8a52789dfab>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5c22bb8-358e-4a41-8dc3-338a6d59359e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5c22bb8-358e-4a41-8dc3-338a6d59359e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5c22bb8-358e-4a41-8dc3-338a6d59359e>.
+    
+<http://data.lblod.info/id/remote-data-objects/97c7ccf6-89f0-49ca-9e45-5f9bbb36982d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97c7ccf6-89f0-49ca-9e45-5f9bbb36982d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97c7ccf6-89f0-49ca-9e45-5f9bbb36982d>.
+    
+<http://data.lblod.info/id/remote-data-objects/86fc2cee-4a4c-4b10-bb8f-379586822e14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86fc2cee-4a4c-4b10-bb8f-379586822e14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86fc2cee-4a4c-4b10-bb8f-379586822e14>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5b7ae47-98a9-4683-9651-0df2c58c0fcf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5b7ae47-98a9-4683-9651-0df2c58c0fcf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5b7ae47-98a9-4683-9651-0df2c58c0fcf>.
+    
+<http://data.lblod.info/id/remote-data-objects/16a938ad-6b8a-4686-9f22-a6e868ecc719> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16a938ad-6b8a-4686-9f22-a6e868ecc719";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16a938ad-6b8a-4686-9f22-a6e868ecc719>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d65efb9-433e-45d9-94f1-37ef93be91a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d65efb9-433e-45d9-94f1-37ef93be91a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d65efb9-433e-45d9-94f1-37ef93be91a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/6424a190-0b64-40ff-8f76-3fd47ffa23c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6424a190-0b64-40ff-8f76-3fd47ffa23c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6424a190-0b64-40ff-8f76-3fd47ffa23c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/529a73cd-1519-46c6-bb8a-8347427f509b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "529a73cd-1519-46c6-bb8a-8347427f509b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/529a73cd-1519-46c6-bb8a-8347427f509b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0292e151-2b11-4db6-8bde-1bdf419c5933> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0292e151-2b11-4db6-8bde-1bdf419c5933";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0292e151-2b11-4db6-8bde-1bdf419c5933>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cf29eca-6e21-4162-9f56-2d1ab72e7f1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cf29eca-6e21-4162-9f56-2d1ab72e7f1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cf29eca-6e21-4162-9f56-2d1ab72e7f1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca2e06d7-38c5-4b6a-a2db-18b1c895a47d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca2e06d7-38c5-4b6a-a2db-18b1c895a47d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca2e06d7-38c5-4b6a-a2db-18b1c895a47d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0fbd552-8012-4135-8170-d46048392638> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0fbd552-8012-4135-8170-d46048392638";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_26-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0fbd552-8012-4135-8170-d46048392638>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d9c9395-a307-4b7d-a862-17a5bc151f4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d9c9395-a307-4b7d-a862-17a5bc151f4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d9c9395-a307-4b7d-a862-17a5bc151f4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/477c3516-5c05-4fe3-8399-51cbf73fc938> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "477c3516-5c05-4fe3-8399-51cbf73fc938";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/477c3516-5c05-4fe3-8399-51cbf73fc938>.
+    
+<http://data.lblod.info/id/remote-data-objects/78ed0f47-cee3-4d56-a983-68d08badde9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78ed0f47-cee3-4d56-a983-68d08badde9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78ed0f47-cee3-4d56-a983-68d08badde9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2ff56b0-6b9b-43c4-b30e-adc05166f7d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2ff56b0-6b9b-43c4-b30e-adc05166f7d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.ninove.be/LBLODWeb/Home/Overzicht/5f391089604f493ab22c8129654e2c9cdc947f45d5ffaedce631ab137f275146/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2ff56b0-6b9b-43c4-b30e-adc05166f7d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b08a7521-1e96-412d-805f-5ab0441cd684> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b08a7521-1e96-412d-805f-5ab0441cd684";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/ad97d27853f95e31592a29262a396b2ae7e4c834108ce97256441a75b89c7e21/GetPublication?filename=BesluitenLijst_OCMW%20raad_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b08a7521-1e96-412d-805f-5ab0441cd684>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a445450-600e-4992-8258-a72829e5dbad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a445450-600e-4992-8258-a72829e5dbad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/ad97d27853f95e31592a29262a396b2ae7e4c834108ce97256441a75b89c7e21/GetPublication?filename=BesluitenLijst_OCMW%20raad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a445450-600e-4992-8258-a72829e5dbad>.
+    
+<http://data.lblod.info/id/remote-data-objects/311462b1-62db-4dd9-8e76-c8b6965d77a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "311462b1-62db-4dd9-8e76-c8b6965d77a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/ad97d27853f95e31592a29262a396b2ae7e4c834108ce97256441a75b89c7e21/GetPublication?filename=BesluitenLijst_OCMW%20raad_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/311462b1-62db-4dd9-8e76-c8b6965d77a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/28cb9dd6-eecf-4ee8-a72f-faa9f31d207d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28cb9dd6-eecf-4ee8-a72f-faa9f31d207d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/ad97d27853f95e31592a29262a396b2ae7e4c834108ce97256441a75b89c7e21/GetPublication?filename=BesluitenLijst_OCMW%20raad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28cb9dd6-eecf-4ee8-a72f-faa9f31d207d>.
+    
+<http://data.lblod.info/id/remote-data-objects/dafd7c21-a308-4df9-83b6-9e394c5d374a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dafd7c21-a308-4df9-83b6-9e394c5d374a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/ad97d27853f95e31592a29262a396b2ae7e4c834108ce97256441a75b89c7e21/GetPublication?filename=BesluitenLijst_OCMW%20raad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dafd7c21-a308-4df9-83b6-9e394c5d374a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff3036d4-20ff-4cb5-846f-fbe6fc102cfd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff3036d4-20ff-4cb5-846f-fbe6fc102cfd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/ad97d27853f95e31592a29262a396b2ae7e4c834108ce97256441a75b89c7e21/GetPublication?filename=BesluitenLijst_OCMW%20raad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff3036d4-20ff-4cb5-846f-fbe6fc102cfd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7769815-1be2-41b2-9a9d-274466c636b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7769815-1be2-41b2-9a9d-274466c636b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/ad97d27853f95e31592a29262a396b2ae7e4c834108ce97256441a75b89c7e21/GetPublication?filename=BesluitenLijst_OCMW%20raad_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7769815-1be2-41b2-9a9d-274466c636b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9284da8-58ef-47dc-96c6-83d94bbbc8b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9284da8-58ef-47dc-96c6-83d94bbbc8b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/ad97d27853f95e31592a29262a396b2ae7e4c834108ce97256441a75b89c7e21/GetPublication?filename=BesluitenLijst_OCMW%20raad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9284da8-58ef-47dc-96c6-83d94bbbc8b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/83227ee2-cba0-4ff1-98cb-36aedcdd4f96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83227ee2-cba0-4ff1-98cb-36aedcdd4f96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/ad97d27853f95e31592a29262a396b2ae7e4c834108ce97256441a75b89c7e21/GetPublication?filename=Notulen_OCMW%20raad_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83227ee2-cba0-4ff1-98cb-36aedcdd4f96>.
+    
+<http://data.lblod.info/id/remote-data-objects/70467134-b172-4456-994f-35a5a3641932> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70467134-b172-4456-994f-35a5a3641932";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/ad97d27853f95e31592a29262a396b2ae7e4c834108ce97256441a75b89c7e21/GetPublication?filename=Uittreksels_21-06-2022_44908.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70467134-b172-4456-994f-35a5a3641932>.
+    
+<http://data.lblod.info/id/remote-data-objects/e062d8cb-8693-45f1-b6c3-fd8b470dfadb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e062d8cb-8693-45f1-b6c3-fd8b470dfadb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/ad97d27853f95e31592a29262a396b2ae7e4c834108ce97256441a75b89c7e21/GetPublication?filename=Uittreksels_26-04-2022_44399.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e062d8cb-8693-45f1-b6c3-fd8b470dfadb>.
+    
+<http://data.lblod.info/id/remote-data-objects/2aa48932-b615-49c2-8c44-21e0d626b874> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2aa48932-b615-49c2-8c44-21e0d626b874";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/ad97d27853f95e31592a29262a396b2ae7e4c834108ce97256441a75b89c7e21/GetPublication?filename=Uittreksels_28-10-2021_42244.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2aa48932-b615-49c2-8c44-21e0d626b874>.
+    
+<http://data.lblod.info/id/remote-data-objects/c47b39c8-0d1b-4d8d-8675-e8ffd24711fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c47b39c8-0d1b-4d8d-8675-e8ffd24711fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/ad97d27853f95e31592a29262a396b2ae7e4c834108ce97256441a75b89c7e21/GetPublication?filename=Uittreksels_28-10-2021_42684.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c47b39c8-0d1b-4d8d-8675-e8ffd24711fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d268b12-625e-41f1-9dc9-ce2d4090605c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d268b12-625e-41f1-9dc9-ce2d4090605c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/ad97d27853f95e31592a29262a396b2ae7e4c834108ce97256441a75b89c7e21/GetPublication?filename=Uittreksels_28-10-2021_42685.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/86ce70d3-cb79-4dfb-bdf4-f1d2886980e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d268b12-625e-41f1-9dc9-ce2d4090605c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201620-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201620-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201620-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201620-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/10ee57e9-196e-4e96-90db-cc12e814f32d> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "10ee57e9-196e-4e96-90db-cc12e814f32d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "527ff797-1b0e-4d74-b037-cad996610daf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/af9eda0c-8219-4073-9f66-23e7762e881b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "af9eda0c-8219-4073-9f66-23e7762e881b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf>.
+
+  <http://redpencil.data.gift/id/task/b9edf9bc-2cd9-4873-8f5f-cd0f11d255aa> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b9edf9bc-2cd9-4873-8f5f-cd0f11d255aa";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/10ee57e9-196e-4e96-90db-cc12e814f32d>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/af9eda0c-8219-4073-9f66-23e7762e881b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e3d1acf1-34e2-442d-adef-ffde8ec8df4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3d1acf1-34e2-442d-adef-ffde8ec8df4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=BesluitenLijst_Gemeenteraad_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3d1acf1-34e2-442d-adef-ffde8ec8df4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9201ffaa-230b-4271-81af-0ee3bb941bee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9201ffaa-230b-4271-81af-0ee3bb941bee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9201ffaa-230b-4271-81af-0ee3bb941bee>.
+    
+<http://data.lblod.info/id/remote-data-objects/56450529-e0c3-4f5b-9ae6-67356f063c17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56450529-e0c3-4f5b-9ae6-67356f063c17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56450529-e0c3-4f5b-9ae6-67356f063c17>.
+    
+<http://data.lblod.info/id/remote-data-objects/863825f2-fbdd-48c5-b435-baade5b31cf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "863825f2-fbdd-48c5-b435-baade5b31cf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=BesluitenLijst_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/863825f2-fbdd-48c5-b435-baade5b31cf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8d06263-6145-459a-912a-91ed4a113e52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8d06263-6145-459a-912a-91ed4a113e52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8d06263-6145-459a-912a-91ed4a113e52>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfdc8150-986a-4578-a491-0b7880631b71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfdc8150-986a-4578-a491-0b7880631b71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfdc8150-986a-4578-a491-0b7880631b71>.
+    
+<http://data.lblod.info/id/remote-data-objects/b255e0d6-4a61-4681-b33c-9eea24c58621> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b255e0d6-4a61-4681-b33c-9eea24c58621";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=BesluitenLijst_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b255e0d6-4a61-4681-b33c-9eea24c58621>.
+    
+<http://data.lblod.info/id/remote-data-objects/741c41dd-18e7-4f01-841d-3eec6a392c9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "741c41dd-18e7-4f01-841d-3eec6a392c9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/741c41dd-18e7-4f01-841d-3eec6a392c9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b26e391-470c-40d6-ae0c-83ee95fbe4de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b26e391-470c-40d6-ae0c-83ee95fbe4de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=BesluitenLijst_Gemeenteraad_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b26e391-470c-40d6-ae0c-83ee95fbe4de>.
+    
+<http://data.lblod.info/id/remote-data-objects/1afbeb62-424d-4ae2-acbf-ce256d70ab5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1afbeb62-424d-4ae2-acbf-ce256d70ab5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=BesluitenLijst_Gemeenteraad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1afbeb62-424d-4ae2-acbf-ce256d70ab5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/efa4a740-5c15-433f-b619-f273583fe6ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efa4a740-5c15-433f-b619-f273583fe6ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Notulen_Gemeenteraad_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efa4a740-5c15-433f-b619-f273583fe6ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/905855a0-b2a8-4fb1-a008-645db560b2d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "905855a0-b2a8-4fb1-a008-645db560b2d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Notulen_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/905855a0-b2a8-4fb1-a008-645db560b2d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/345cd2d5-8552-475d-802e-6b115f2efe21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "345cd2d5-8552-475d-802e-6b115f2efe21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_21-06-2022_44848.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/345cd2d5-8552-475d-802e-6b115f2efe21>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dd2b5ba-113e-468c-a235-ddfcecc0b881> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dd2b5ba-113e-468c-a235-ddfcecc0b881";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_21-06-2022_44897.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dd2b5ba-113e-468c-a235-ddfcecc0b881>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a124a97-b350-4fcb-9029-af0b5208f4e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a124a97-b350-4fcb-9029-af0b5208f4e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_21-06-2022_44898.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a124a97-b350-4fcb-9029-af0b5208f4e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed031d6c-4a65-4b36-a513-5d737415d180> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed031d6c-4a65-4b36-a513-5d737415d180";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_21-06-2022_44903.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed031d6c-4a65-4b36-a513-5d737415d180>.
+    
+<http://data.lblod.info/id/remote-data-objects/779c55b7-319e-4670-b6b4-84e6f7ef4e1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "779c55b7-319e-4670-b6b4-84e6f7ef4e1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_21-06-2022_44904.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/779c55b7-319e-4670-b6b4-84e6f7ef4e1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/85774c48-d0df-434e-8d30-d19dded58ecc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85774c48-d0df-434e-8d30-d19dded58ecc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_21-06-2022_44956.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85774c48-d0df-434e-8d30-d19dded58ecc>.
+    
+<http://data.lblod.info/id/remote-data-objects/0125b6ba-666e-408a-a647-fc969dd55634> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0125b6ba-666e-408a-a647-fc969dd55634";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_21-06-2022_44959.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0125b6ba-666e-408a-a647-fc969dd55634>.
+    
+<http://data.lblod.info/id/remote-data-objects/08d6b3da-82a4-4967-bd6e-fdbbe6cedb01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08d6b3da-82a4-4967-bd6e-fdbbe6cedb01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_21-06-2022_44961.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08d6b3da-82a4-4967-bd6e-fdbbe6cedb01>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc52aeb9-cc55-43c3-952d-9b66d0aa7cd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc52aeb9-cc55-43c3-952d-9b66d0aa7cd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_21-06-2022_44964.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc52aeb9-cc55-43c3-952d-9b66d0aa7cd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/4891313d-05ca-4214-bd48-7ab3e4530749> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4891313d-05ca-4214-bd48-7ab3e4530749";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_21-06-2022_44972.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4891313d-05ca-4214-bd48-7ab3e4530749>.
+    
+<http://data.lblod.info/id/remote-data-objects/02359141-641e-47ee-90f6-5f957eb0f7c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02359141-641e-47ee-90f6-5f957eb0f7c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_21-12-2021_43012.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02359141-641e-47ee-90f6-5f957eb0f7c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a76b8a1c-1001-43cc-86a8-9b966a6d1567> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a76b8a1c-1001-43cc-86a8-9b966a6d1567";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_23-11-2021_42814.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a76b8a1c-1001-43cc-86a8-9b966a6d1567>.
+    
+<http://data.lblod.info/id/remote-data-objects/b22457cc-33d5-4022-ae78-50ed3d40c2d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b22457cc-33d5-4022-ae78-50ed3d40c2d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_23-11-2021_42815.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b22457cc-33d5-4022-ae78-50ed3d40c2d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a98f1c7-ad4f-40d5-a927-b4f71853c81c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a98f1c7-ad4f-40d5-a927-b4f71853c81c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_26-04-2022_41181.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a98f1c7-ad4f-40d5-a927-b4f71853c81c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba670bca-7f00-4b6f-9369-0059506dfa73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba670bca-7f00-4b6f-9369-0059506dfa73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_26-04-2022_43340.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba670bca-7f00-4b6f-9369-0059506dfa73>.
+    
+<http://data.lblod.info/id/remote-data-objects/76403438-81c3-44ba-aec8-3f270bef932b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76403438-81c3-44ba-aec8-3f270bef932b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_26-04-2022_44234.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76403438-81c3-44ba-aec8-3f270bef932b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed1454b7-40e4-4ed1-9a0f-f41f54686394> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed1454b7-40e4-4ed1-9a0f-f41f54686394";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_28-10-2021_42243.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed1454b7-40e4-4ed1-9a0f-f41f54686394>.
+    
+<http://data.lblod.info/id/remote-data-objects/73c391c1-b073-41c7-ab8a-2d379308b987> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73c391c1-b073-41c7-ab8a-2d379308b987";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_28-10-2021_42474.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73c391c1-b073-41c7-ab8a-2d379308b987>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ebb860c-9db1-4bb0-91cd-4ae16f793b93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ebb860c-9db1-4bb0-91cd-4ae16f793b93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_28-10-2021_42475.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ebb860c-9db1-4bb0-91cd-4ae16f793b93>.
+    
+<http://data.lblod.info/id/remote-data-objects/4af57d7c-3fa9-4743-909c-4fba6561f243> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4af57d7c-3fa9-4743-909c-4fba6561f243";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_28-10-2021_42476.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4af57d7c-3fa9-4743-909c-4fba6561f243>.
+    
+<http://data.lblod.info/id/remote-data-objects/b39458c8-f424-4b9e-b0c4-1d13be09b566> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b39458c8-f424-4b9e-b0c4-1d13be09b566";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_28-10-2021_42480.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b39458c8-f424-4b9e-b0c4-1d13be09b566>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dcc2e95-93a6-45a9-887a-db58279705c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dcc2e95-93a6-45a9-887a-db58279705c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_28-10-2021_42528.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dcc2e95-93a6-45a9-887a-db58279705c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ee0ea5a-32bf-4ae7-a7a9-8b75a42c40a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ee0ea5a-32bf-4ae7-a7a9-8b75a42c40a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_28-10-2021_42604.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ee0ea5a-32bf-4ae7-a7a9-8b75a42c40a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/73787fe5-9160-41f8-bc19-c5b17049cfd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73787fe5-9160-41f8-bc19-c5b17049cfd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_28-10-2021_42627.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73787fe5-9160-41f8-bc19-c5b17049cfd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/9386498e-b58f-4d9a-82ba-6d9083c207bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9386498e-b58f-4d9a-82ba-6d9083c207bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_28-10-2021_42628.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9386498e-b58f-4d9a-82ba-6d9083c207bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d03aa249-2580-4d60-b25f-48d29ea96b54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d03aa249-2580-4d60-b25f-48d29ea96b54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_29-03-2022_43735.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d03aa249-2580-4d60-b25f-48d29ea96b54>.
+    
+<http://data.lblod.info/id/remote-data-objects/218e4497-c454-4efa-bacf-32911aa463c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "218e4497-c454-4efa-bacf-32911aa463c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_29-03-2022_44232.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/218e4497-c454-4efa-bacf-32911aa463c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a6fef1d-3aa2-488c-a79f-485c84e2428d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a6fef1d-3aa2-488c-a79f-485c84e2428d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_31-05-2022_44414.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a6fef1d-3aa2-488c-a79f-485c84e2428d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b6b352c-0d94-4183-9193-24c64b7f9062> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b6b352c-0d94-4183-9193-24c64b7f9062";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_31-05-2022_44507.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b6b352c-0d94-4183-9193-24c64b7f9062>.
+    
+<http://data.lblod.info/id/remote-data-objects/6252e316-991e-4e93-8f8e-bf6ed3166455> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6252e316-991e-4e93-8f8e-bf6ed3166455";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oosterzele.be/LBLODWeb/Home/Overzicht/d7492d27f36b7652a1e2510304b50bbcf2d9aa0be6d3c6dcc16bb77234b233a7/GetPublication?filename=Uittreksels_31-05-2022_44615.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6252e316-991e-4e93-8f8e-bf6ed3166455>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1bac652-c910-4a13-8ce1-cd491259e6ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1bac652-c910-4a13-8ce1-cd491259e6ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1bac652-c910-4a13-8ce1-cd491259e6ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/2375cfb9-69cd-4122-b8ab-3f69f4e0c1a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2375cfb9-69cd-4122-b8ab-3f69f4e0c1a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2375cfb9-69cd-4122-b8ab-3f69f4e0c1a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/822f78c4-d924-4d3f-8403-f5c0bf6bcbe6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "822f78c4-d924-4d3f-8403-f5c0bf6bcbe6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/822f78c4-d924-4d3f-8403-f5c0bf6bcbe6>.
+    
+<http://data.lblod.info/id/remote-data-objects/081f4b2d-92e1-4e82-ad86-f0d1e095f517> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "081f4b2d-92e1-4e82-ad86-f0d1e095f517";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/081f4b2d-92e1-4e82-ad86-f0d1e095f517>.
+    
+<http://data.lblod.info/id/remote-data-objects/47c9828d-6f13-4dcc-843f-11648e0e8e21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47c9828d-6f13-4dcc-843f-11648e0e8e21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47c9828d-6f13-4dcc-843f-11648e0e8e21>.
+    
+<http://data.lblod.info/id/remote-data-objects/fec106bf-1a0a-4c58-9cae-c24076548209> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fec106bf-1a0a-4c58-9cae-c24076548209";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fec106bf-1a0a-4c58-9cae-c24076548209>.
+    
+<http://data.lblod.info/id/remote-data-objects/30e82def-d5d1-4230-b353-e25ed61908ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30e82def-d5d1-4230-b353-e25ed61908ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30e82def-d5d1-4230-b353-e25ed61908ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/02b6354f-cc7c-44c4-a555-3449ee24341b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02b6354f-cc7c-44c4-a555-3449ee24341b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/527ff797-1b0e-4d74-b037-cad996610daf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02b6354f-cc7c-44c4-a555-3449ee24341b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201621-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201621-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201621-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201621-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/242d0be1-a8b1-4bb2-aefd-7b06e98187cf> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "242d0be1-a8b1-4bb2-aefd-7b06e98187cf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4354adf9-bf97-424e-814c-cce527f753a3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/37bcde7b-5b1d-40c2-939c-bb9ba7b3b2ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "37bcde7b-5b1d-40c2-939c-bb9ba7b3b2ed";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3>.
+
+  <http://redpencil.data.gift/id/task/c5e657fc-af2e-4c1c-ae71-5a823744f94b> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c5e657fc-af2e-4c1c-ae71-5a823744f94b";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/242d0be1-a8b1-4bb2-aefd-7b06e98187cf>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/37bcde7b-5b1d-40c2-939c-bb9ba7b3b2ed>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/fb5a8fd3-989a-43b9-9e26-447f7cd88e4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb5a8fd3-989a-43b9-9e26-447f7cd88e4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb5a8fd3-989a-43b9-9e26-447f7cd88e4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5da4d751-6ce8-4c52-8ac5-a2d64f63dd12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5da4d751-6ce8-4c52-8ac5-a2d64f63dd12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5da4d751-6ce8-4c52-8ac5-a2d64f63dd12>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0d54a4f-45be-48d7-97d2-84f0c3ff96f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0d54a4f-45be-48d7-97d2-84f0c3ff96f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0d54a4f-45be-48d7-97d2-84f0c3ff96f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/eeff71d5-64f7-4433-a775-180ce2195d72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eeff71d5-64f7-4433-a775-180ce2195d72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eeff71d5-64f7-4433-a775-180ce2195d72>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd993611-7626-4dc7-a19d-39acc7005822> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd993611-7626-4dc7-a19d-39acc7005822";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd993611-7626-4dc7-a19d-39acc7005822>.
+    
+<http://data.lblod.info/id/remote-data-objects/8839f056-2646-4664-ac53-6205b03ed9f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8839f056-2646-4664-ac53-6205b03ed9f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8839f056-2646-4664-ac53-6205b03ed9f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d80ed41-4d45-4a2a-8d2f-a2367dfd6fa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d80ed41-4d45-4a2a-8d2f-a2367dfd6fa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d80ed41-4d45-4a2a-8d2f-a2367dfd6fa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d3b78e7-3974-45a8-9b09-a0163d5f88ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d3b78e7-3974-45a8-9b09-a0163d5f88ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d3b78e7-3974-45a8-9b09-a0163d5f88ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/382c663a-69f0-4d8c-885d-ac0595b76a84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "382c663a-69f0-4d8c-885d-ac0595b76a84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/382c663a-69f0-4d8c-885d-ac0595b76a84>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a5a12e4-09d6-4ae6-bbe9-6f5d667d1c58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a5a12e4-09d6-4ae6-bbe9-6f5d667d1c58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a5a12e4-09d6-4ae6-bbe9-6f5d667d1c58>.
+    
+<http://data.lblod.info/id/remote-data-objects/4076e6cc-b296-4642-a943-a4adbd9fb25d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4076e6cc-b296-4642-a943-a4adbd9fb25d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4076e6cc-b296-4642-a943-a4adbd9fb25d>.
+    
+<http://data.lblod.info/id/remote-data-objects/132aea89-a6e3-4bbe-b471-25380fad8ecd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "132aea89-a6e3-4bbe-b471-25380fad8ecd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/132aea89-a6e3-4bbe-b471-25380fad8ecd>.
+    
+<http://data.lblod.info/id/remote-data-objects/7469b534-130b-4629-afb2-d732bdaee8f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7469b534-130b-4629-afb2-d732bdaee8f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7469b534-130b-4629-afb2-d732bdaee8f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/aad499c5-d128-43cf-be74-eee989bee1d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aad499c5-d128-43cf-be74-eee989bee1d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aad499c5-d128-43cf-be74-eee989bee1d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a66986b5-ca7c-465a-ae5a-5ac54203710c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a66986b5-ca7c-465a-ae5a-5ac54203710c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a66986b5-ca7c-465a-ae5a-5ac54203710c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c7cf43b-f4cd-4f0d-816d-4ddd2a7f6338> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c7cf43b-f4cd-4f0d-816d-4ddd2a7f6338";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c7cf43b-f4cd-4f0d-816d-4ddd2a7f6338>.
+    
+<http://data.lblod.info/id/remote-data-objects/365a0c75-d75b-480c-b856-440aa227c939> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "365a0c75-d75b-480c-b856-440aa227c939";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/365a0c75-d75b-480c-b856-440aa227c939>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf9b6665-7955-433a-a9cf-2fd273a60e5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf9b6665-7955-433a-a9cf-2fd273a60e5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/654fc9b687568acdbe68025d3ebdc222520470a959c20fa2c9fc6d8316c1040e/GetPublication?filename=BesluitenLijst_Schepencollege_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf9b6665-7955-433a-a9cf-2fd273a60e5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1118e4be-4c17-4c0e-86a6-18707fb4fd99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1118e4be-4c17-4c0e-86a6-18707fb4fd99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=Agenda_OCMW-raad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1118e4be-4c17-4c0e-86a6-18707fb4fd99>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5204a56-2c17-4058-a0a0-c422744a4e6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5204a56-2c17-4058-a0a0-c422744a4e6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=Agenda_OCMW-raad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5204a56-2c17-4058-a0a0-c422744a4e6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9284fae7-a7a3-47a2-9325-4b19b69fb6a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9284fae7-a7a3-47a2-9325-4b19b69fb6a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=Agenda_OCMW-raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9284fae7-a7a3-47a2-9325-4b19b69fb6a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e72af269-feee-4d12-b494-3babb0ff4ad9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e72af269-feee-4d12-b494-3babb0ff4ad9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=Agenda_OCMW-raad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e72af269-feee-4d12-b494-3babb0ff4ad9>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc522d34-714f-44d8-93b0-588b5cd92950> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc522d34-714f-44d8-93b0-588b5cd92950";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=Agenda_OCMW-raad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc522d34-714f-44d8-93b0-588b5cd92950>.
+    
+<http://data.lblod.info/id/remote-data-objects/243faea1-b1c4-4383-8a84-091d49a6142a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "243faea1-b1c4-4383-8a84-091d49a6142a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=Agenda_OCMW-raad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/243faea1-b1c4-4383-8a84-091d49a6142a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d47c993-fb71-4fbc-95b2-09c9c01e4a2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d47c993-fb71-4fbc-95b2-09c9c01e4a2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=BesluitenLijst_OCMW-raad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d47c993-fb71-4fbc-95b2-09c9c01e4a2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/50f19c1f-a2ac-4cbe-a3df-02e31194b099> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50f19c1f-a2ac-4cbe-a3df-02e31194b099";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=BesluitenLijst_OCMW-raad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50f19c1f-a2ac-4cbe-a3df-02e31194b099>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fd2bee9-85ed-46e9-a58c-60e073eeb3e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fd2bee9-85ed-46e9-a58c-60e073eeb3e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=BesluitenLijst_OCMW-raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fd2bee9-85ed-46e9-a58c-60e073eeb3e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1323502b-f8bd-4508-ba2b-deb97c92ec6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1323502b-f8bd-4508-ba2b-deb97c92ec6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=BesluitenLijst_OCMW-raad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1323502b-f8bd-4508-ba2b-deb97c92ec6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/71d52acb-5eea-4e67-80c3-e47e7304cc34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71d52acb-5eea-4e67-80c3-e47e7304cc34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=BesluitenLijst_OCMW-raad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71d52acb-5eea-4e67-80c3-e47e7304cc34>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b4a9399-e5bd-43f9-ae1d-a3deddf423e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b4a9399-e5bd-43f9-ae1d-a3deddf423e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=BesluitenLijst_OCMW-raad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b4a9399-e5bd-43f9-ae1d-a3deddf423e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/afe8c650-5126-4af4-a082-72e1de9586a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afe8c650-5126-4af4-a082-72e1de9586a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=Notulen_OCMW-raad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afe8c650-5126-4af4-a082-72e1de9586a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ee0d3f2-c3d5-4baf-922b-156da7d91762> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ee0d3f2-c3d5-4baf-922b-156da7d91762";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=Notulen_OCMW-raad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ee0d3f2-c3d5-4baf-922b-156da7d91762>.
+    
+<http://data.lblod.info/id/remote-data-objects/84d0ba58-d9e4-4b83-8141-ce0b8f78d3fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84d0ba58-d9e4-4b83-8141-ce0b8f78d3fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=Notulen_OCMW-raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84d0ba58-d9e4-4b83-8141-ce0b8f78d3fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/bab79e36-51d0-4206-b610-131661d2cb10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bab79e36-51d0-4206-b610-131661d2cb10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=Notulen_OCMW-raad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bab79e36-51d0-4206-b610-131661d2cb10>.
+    
+<http://data.lblod.info/id/remote-data-objects/c498c420-9a8b-45e9-988f-ed3e529fe552> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c498c420-9a8b-45e9-988f-ed3e529fe552";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/87dce252ea3cdc981002def9f7654a931f30553af76e8827d853fa70f6853d5e/GetPublication?filename=Notulen_OCMW-raad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c498c420-9a8b-45e9-988f-ed3e529fe552>.
+    
+<http://data.lblod.info/id/remote-data-objects/b874e8ad-552f-4bf0-831a-d7db3f33fa68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b874e8ad-552f-4bf0-831a-d7db3f33fa68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=Agenda_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b874e8ad-552f-4bf0-831a-d7db3f33fa68>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5d83f58-7e09-4533-8383-aad9bce3e801> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5d83f58-7e09-4533-8383-aad9bce3e801";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=Agenda_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5d83f58-7e09-4533-8383-aad9bce3e801>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ed0db5e-4828-4185-9abf-994e7c395c8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ed0db5e-4828-4185-9abf-994e7c395c8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=Agenda_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ed0db5e-4828-4185-9abf-994e7c395c8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/373d437f-c1c5-45d6-8059-d53751955fee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "373d437f-c1c5-45d6-8059-d53751955fee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=Agenda_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/373d437f-c1c5-45d6-8059-d53751955fee>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a99ca7b-8837-4200-bdde-9e72f62f0353> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a99ca7b-8837-4200-bdde-9e72f62f0353";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=Agenda_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a99ca7b-8837-4200-bdde-9e72f62f0353>.
+    
+<http://data.lblod.info/id/remote-data-objects/df9a945d-bb39-4144-abeb-578c68205d78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df9a945d-bb39-4144-abeb-578c68205d78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=Agenda_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df9a945d-bb39-4144-abeb-578c68205d78>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fa13e05-fec9-4f12-93ae-faf5785e5d11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fa13e05-fec9-4f12-93ae-faf5785e5d11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fa13e05-fec9-4f12-93ae-faf5785e5d11>.
+    
+<http://data.lblod.info/id/remote-data-objects/76e2d0d6-23e9-487e-b80d-f8b6a9eaccc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76e2d0d6-23e9-487e-b80d-f8b6a9eaccc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76e2d0d6-23e9-487e-b80d-f8b6a9eaccc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e38fc5d1-a998-493d-8184-936dae9eca94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e38fc5d1-a998-493d-8184-936dae9eca94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e38fc5d1-a998-493d-8184-936dae9eca94>.
+    
+<http://data.lblod.info/id/remote-data-objects/01f4add7-8c53-4d73-b09d-d695632b5826> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01f4add7-8c53-4d73-b09d-d695632b5826";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01f4add7-8c53-4d73-b09d-d695632b5826>.
+    
+<http://data.lblod.info/id/remote-data-objects/80e5164c-14b8-42ca-b541-9a2a38a84c8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80e5164c-14b8-42ca-b541-9a2a38a84c8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80e5164c-14b8-42ca-b541-9a2a38a84c8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/017e064c-8f5b-44d5-8858-25d7363714f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "017e064c-8f5b-44d5-8858-25d7363714f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=BesluitenLijst_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/017e064c-8f5b-44d5-8858-25d7363714f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d17957a7-d0ee-4623-a1ae-3ce52653b765> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d17957a7-d0ee-4623-a1ae-3ce52653b765";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=Notulen_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d17957a7-d0ee-4623-a1ae-3ce52653b765>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee18e952-e7f8-402f-9869-b167e184be58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee18e952-e7f8-402f-9869-b167e184be58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=Notulen_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee18e952-e7f8-402f-9869-b167e184be58>.
+    
+<http://data.lblod.info/id/remote-data-objects/25b09368-ca21-4fb2-8a26-68b78af197d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25b09368-ca21-4fb2-8a26-68b78af197d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=Notulen_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4354adf9-bf97-424e-814c-cce527f753a3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25b09368-ca21-4fb2-8a26-68b78af197d0>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201623-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201623-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201623-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201623-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/017bac23-da57-4579-a79e-d95bda9bae31> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "017bac23-da57-4579-a79e-d95bda9bae31";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "99b34c05-49c3-4ac9-98b1-34333694b302";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/fff1314f-4f44-45ae-a317-b74b9d58f191> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fff1314f-4f44-45ae-a317-b74b9d58f191";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302>.
+
+  <http://redpencil.data.gift/id/task/217ee3ab-dd9f-4ddb-b0bb-6eccd4773c55> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "217ee3ab-dd9f-4ddb-b0bb-6eccd4773c55";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/017bac23-da57-4579-a79e-d95bda9bae31>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/fff1314f-4f44-45ae-a317-b74b9d58f191>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/949eeeee-a314-4c6d-939d-516808a8509f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "949eeeee-a314-4c6d-939d-516808a8509f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=Notulen_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/949eeeee-a314-4c6d-939d-516808a8509f>.
+    
+<http://data.lblod.info/id/remote-data-objects/82efe8d3-4180-42d3-b5bf-f07de9cd9323> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82efe8d3-4180-42d3-b5bf-f07de9cd9323";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/e9e9065c49c1a32d4c543c9c18ddecc66ba5d4d03816c7d1d07fbe734d4456e8/GetPublication?filename=Notulen_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82efe8d3-4180-42d3-b5bf-f07de9cd9323>.
+    
+<http://data.lblod.info/id/remote-data-objects/3afc781d-ad1a-495b-a4bf-11a00c17514f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3afc781d-ad1a-495b-a4bf-11a00c17514f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3afc781d-ad1a-495b-a4bf-11a00c17514f>.
+    
+<http://data.lblod.info/id/remote-data-objects/216086e3-fdfa-4160-ada6-0425f0e17dc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "216086e3-fdfa-4160-ada6-0425f0e17dc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/216086e3-fdfa-4160-ada6-0425f0e17dc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/723f89d9-065f-4526-a161-6534e7a57ba7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "723f89d9-065f-4526-a161-6534e7a57ba7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/723f89d9-065f-4526-a161-6534e7a57ba7>.
+    
+<http://data.lblod.info/id/remote-data-objects/693caa3c-e8a4-4748-a352-3176bc2d8562> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "693caa3c-e8a4-4748-a352-3176bc2d8562";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/693caa3c-e8a4-4748-a352-3176bc2d8562>.
+    
+<http://data.lblod.info/id/remote-data-objects/03309596-990f-4c74-9e1b-c45dc34a89ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03309596-990f-4c74-9e1b-c45dc34a89ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03309596-990f-4c74-9e1b-c45dc34a89ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/4025b16c-406f-4c72-b945-bdeaea11e2cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4025b16c-406f-4c72-b945-bdeaea11e2cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4025b16c-406f-4c72-b945-bdeaea11e2cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/38e2207b-2390-4314-8c93-002611ec6a03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38e2207b-2390-4314-8c93-002611ec6a03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38e2207b-2390-4314-8c93-002611ec6a03>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cc09d7c-e2bd-4632-9144-93ad15fdbfb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cc09d7c-e2bd-4632-9144-93ad15fdbfb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cc09d7c-e2bd-4632-9144-93ad15fdbfb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/14fc98d3-27bb-4fe3-9574-3c05a5de7dd4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14fc98d3-27bb-4fe3-9574-3c05a5de7dd4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14fc98d3-27bb-4fe3-9574-3c05a5de7dd4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d8c7b35-cac3-464e-b6d6-01889694ee30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d8c7b35-cac3-464e-b6d6-01889694ee30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d8c7b35-cac3-464e-b6d6-01889694ee30>.
+    
+<http://data.lblod.info/id/remote-data-objects/367f3f46-ab3a-47c4-8d39-d0608ac496ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "367f3f46-ab3a-47c4-8d39-d0608ac496ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/367f3f46-ab3a-47c4-8d39-d0608ac496ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/be62ad00-72a3-4edb-ac54-5df5e27bf19b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be62ad00-72a3-4edb-ac54-5df5e27bf19b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be62ad00-72a3-4edb-ac54-5df5e27bf19b>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc4de2ed-618d-47e2-aaf3-968cea55ecfd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc4de2ed-618d-47e2-aaf3-968cea55ecfd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc4de2ed-618d-47e2-aaf3-968cea55ecfd>.
+    
+<http://data.lblod.info/id/remote-data-objects/18bb47d2-ed9b-4ae6-91f5-71cdf1f2df6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18bb47d2-ed9b-4ae6-91f5-71cdf1f2df6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18bb47d2-ed9b-4ae6-91f5-71cdf1f2df6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7892e6b5-68dd-4284-91ce-4ab31eb5170e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7892e6b5-68dd-4284-91ce-4ab31eb5170e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7892e6b5-68dd-4284-91ce-4ab31eb5170e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b53afa2-efc7-4510-b889-3ecf8791f21b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b53afa2-efc7-4510-b889-3ecf8791f21b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b53afa2-efc7-4510-b889-3ecf8791f21b>.
+    
+<http://data.lblod.info/id/remote-data-objects/81587450-df2d-48e2-bcfa-77a0115f056d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81587450-df2d-48e2-bcfa-77a0115f056d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81587450-df2d-48e2-bcfa-77a0115f056d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b02c69d5-aafe-4bc6-a4c1-7022aee0b8c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b02c69d5-aafe-4bc6-a4c1-7022aee0b8c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b02c69d5-aafe-4bc6-a4c1-7022aee0b8c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/899c3ea5-c591-46f3-8f2d-9b57b045be1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "899c3ea5-c591-46f3-8f2d-9b57b045be1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/899c3ea5-c591-46f3-8f2d-9b57b045be1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/399083aa-075d-4e46-afc0-4dac2f2816de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "399083aa-075d-4e46-afc0-4dac2f2816de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/399083aa-075d-4e46-afc0-4dac2f2816de>.
+    
+<http://data.lblod.info/id/remote-data-objects/aeeb6db5-c069-4fa7-b053-9671532ffa31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aeeb6db5-c069-4fa7-b053-9671532ffa31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aeeb6db5-c069-4fa7-b053-9671532ffa31>.
+    
+<http://data.lblod.info/id/remote-data-objects/235f0236-47a1-4035-97f3-162f9a4d8dd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "235f0236-47a1-4035-97f3-162f9a4d8dd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/235f0236-47a1-4035-97f3-162f9a4d8dd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd29a549-54e0-479a-817e-9581178730e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd29a549-54e0-479a-817e-9581178730e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd29a549-54e0-479a-817e-9581178730e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/163d1729-3d53-48fc-8956-ad50f1f1c8aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "163d1729-3d53-48fc-8956-ad50f1f1c8aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/163d1729-3d53-48fc-8956-ad50f1f1c8aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/48b6ac82-37aa-428d-884f-45507dd56a03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48b6ac82-37aa-428d-884f-45507dd56a03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48b6ac82-37aa-428d-884f-45507dd56a03>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbf30c11-3d47-4dee-9f1c-c8ac0d1aa7c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbf30c11-3d47-4dee-9f1c-c8ac0d1aa7c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.oudenaarde.be/LBLODWeb/Home/Overzicht/f4e27d2b-5fc2-48b2-8756-b01636e43304/GetPublication?filename=BesluitenLijst_Vast%20Bureau%20OCMW_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbf30c11-3d47-4dee-9f1c-c8ac0d1aa7c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e2efbcb-967d-4898-8dba-60a0cca5234b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e2efbcb-967d-4898-8dba-60a0cca5234b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e2efbcb-967d-4898-8dba-60a0cca5234b>.
+    
+<http://data.lblod.info/id/remote-data-objects/06998fb6-4b04-40fe-9d56-879b363f2110> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06998fb6-4b04-40fe-9d56-879b363f2110";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06998fb6-4b04-40fe-9d56-879b363f2110>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f5efe22-e8b6-4041-879f-54d423d64817> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f5efe22-e8b6-4041-879f-54d423d64817";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f5efe22-e8b6-4041-879f-54d423d64817>.
+    
+<http://data.lblod.info/id/remote-data-objects/58567a2d-e64f-42cc-8819-a96c146f8cae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58567a2d-e64f-42cc-8819-a96c146f8cae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58567a2d-e64f-42cc-8819-a96c146f8cae>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cb5fbe6-2dad-4e90-9898-df4385e1f643> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cb5fbe6-2dad-4e90-9898-df4385e1f643";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cb5fbe6-2dad-4e90-9898-df4385e1f643>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa68d0f7-4a0f-4bc9-ac31-89b416707797> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa68d0f7-4a0f-4bc9-ac31-89b416707797";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa68d0f7-4a0f-4bc9-ac31-89b416707797>.
+    
+<http://data.lblod.info/id/remote-data-objects/e60e32c7-eeca-401a-a378-011b7c4619ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e60e32c7-eeca-401a-a378-011b7c4619ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e60e32c7-eeca-401a-a378-011b7c4619ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c2a2a77-fd74-4544-9403-c587a05a7434> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c2a2a77-fd74-4544-9403-c587a05a7434";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c2a2a77-fd74-4544-9403-c587a05a7434>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c50c79d-7314-48ec-9716-b9ad4a6a36c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c50c79d-7314-48ec-9716-b9ad4a6a36c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c50c79d-7314-48ec-9716-b9ad4a6a36c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9added1-91a8-459c-b7cd-231f3a8f97cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9added1-91a8-459c-b7cd-231f3a8f97cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9added1-91a8-459c-b7cd-231f3a8f97cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0612c1c-14a9-4859-9958-4836f401e077> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0612c1c-14a9-4859-9958-4836f401e077";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0612c1c-14a9-4859-9958-4836f401e077>.
+    
+<http://data.lblod.info/id/remote-data-objects/4375263a-9bc9-436c-9294-90bcc79e0499> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4375263a-9bc9-436c-9294-90bcc79e0499";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4375263a-9bc9-436c-9294-90bcc79e0499>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ec9c991-f566-45ed-bbf8-29f027c4acf7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ec9c991-f566-45ed-bbf8-29f027c4acf7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ec9c991-f566-45ed-bbf8-29f027c4acf7>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e813a5d-2915-42ae-a069-5f0e76492d54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e813a5d-2915-42ae-a069-5f0e76492d54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e813a5d-2915-42ae-a069-5f0e76492d54>.
+    
+<http://data.lblod.info/id/remote-data-objects/95141c1b-117b-4014-a303-5e233065fc74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95141c1b-117b-4014-a303-5e233065fc74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95141c1b-117b-4014-a303-5e233065fc74>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5c628cf-d4bb-4bd4-81d3-db7b67b30939> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5c628cf-d4bb-4bd4-81d3-db7b67b30939";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5c628cf-d4bb-4bd4-81d3-db7b67b30939>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3250fd9-61a6-4f6a-a305-85a262f4f356> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3250fd9-61a6-4f6a-a305-85a262f4f356";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3250fd9-61a6-4f6a-a305-85a262f4f356>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfddd7f8-b08e-4b97-9aa6-011a58b3ec0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfddd7f8-b08e-4b97-9aa6-011a58b3ec0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfddd7f8-b08e-4b97-9aa6-011a58b3ec0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/de3dd2d1-55a5-4e58-9899-4570a2835ef0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de3dd2d1-55a5-4e58-9899-4570a2835ef0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de3dd2d1-55a5-4e58-9899-4570a2835ef0>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfdf4d97-9a04-43af-a104-56a655f1a85f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfdf4d97-9a04-43af-a104-56a655f1a85f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfdf4d97-9a04-43af-a104-56a655f1a85f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b5fdff8-7e91-41fc-b071-a96170dbde26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b5fdff8-7e91-41fc-b071-a96170dbde26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b5fdff8-7e91-41fc-b071-a96170dbde26>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e9818dd-83a3-430e-a1b6-d5617bf1086d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e9818dd-83a3-430e-a1b6-d5617bf1086d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/99b34c05-49c3-4ac9-98b1-34333694b302> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e9818dd-83a3-430e-a1b6-d5617bf1086d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201624-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201624-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201624-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201624-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/acf5a0d3-5a91-4a4e-b342-6eb6a709b9d5> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "acf5a0d3-5a91-4a4e-b342-6eb6a709b9d5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4cb46c68-6184-4c44-b41f-1df20089fc5f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/1469146a-b406-4fe8-b2db-8afe58199788> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1469146a-b406-4fe8-b2db-8afe58199788";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f>.
+
+  <http://redpencil.data.gift/id/task/f116f7d5-0d50-4707-a5cb-fd3f14e81644> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f116f7d5-0d50-4707-a5cb-fd3f14e81644";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/acf5a0d3-5a91-4a4e-b342-6eb6a709b9d5>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/1469146a-b406-4fe8-b2db-8afe58199788>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/122f4b61-2443-4836-adb7-d4e16c1eb65d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "122f4b61-2443-4836-adb7-d4e16c1eb65d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/122f4b61-2443-4836-adb7-d4e16c1eb65d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6522998-0b8e-4dba-910b-7120961c105b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6522998-0b8e-4dba-910b-7120961c105b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6522998-0b8e-4dba-910b-7120961c105b>.
+    
+<http://data.lblod.info/id/remote-data-objects/47df346b-1efb-4f73-9500-92b3bcdd41ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47df346b-1efb-4f73-9500-92b3bcdd41ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47df346b-1efb-4f73-9500-92b3bcdd41ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4c24d10-e678-4900-b0dc-af12e3c485fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4c24d10-e678-4900-b0dc-af12e3c485fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4c24d10-e678-4900-b0dc-af12e3c485fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/035e9c8f-b598-48d3-90d9-b3c585b87342> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "035e9c8f-b598-48d3-90d9-b3c585b87342";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/035e9c8f-b598-48d3-90d9-b3c585b87342>.
+    
+<http://data.lblod.info/id/remote-data-objects/d653235a-f1da-4fe2-b653-dda51fa6a09f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d653235a-f1da-4fe2-b653-dda51fa6a09f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d653235a-f1da-4fe2-b653-dda51fa6a09f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c94cb7dd-8f77-4c92-a450-e22f67302ccb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c94cb7dd-8f77-4c92-a450-e22f67302ccb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c94cb7dd-8f77-4c92-a450-e22f67302ccb>.
+    
+<http://data.lblod.info/id/remote-data-objects/f38c6d69-5692-4972-8245-5e18de0d41aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f38c6d69-5692-4972-8245-5e18de0d41aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f38c6d69-5692-4972-8245-5e18de0d41aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/43fd863b-3d3f-42ff-baf5-fe11893dad75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43fd863b-3d3f-42ff-baf5-fe11893dad75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43fd863b-3d3f-42ff-baf5-fe11893dad75>.
+    
+<http://data.lblod.info/id/remote-data-objects/32e47970-ccc3-4097-b0be-b01179a9d210> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32e47970-ccc3-4097-b0be-b01179a9d210";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32e47970-ccc3-4097-b0be-b01179a9d210>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f0ec8bf-7390-4ea1-b6ac-e1e4301a7c3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f0ec8bf-7390-4ea1-b6ac-e1e4301a7c3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f0ec8bf-7390-4ea1-b6ac-e1e4301a7c3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d3eb197-dba6-4c11-9a45-3c6e2f4912e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d3eb197-dba6-4c11-9a45-3c6e2f4912e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d3eb197-dba6-4c11-9a45-3c6e2f4912e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d86b4af5-173c-4a26-8c04-f4e9baa7616f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d86b4af5-173c-4a26-8c04-f4e9baa7616f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d86b4af5-173c-4a26-8c04-f4e9baa7616f>.
+    
+<http://data.lblod.info/id/remote-data-objects/77eade94-647e-4e58-a19f-d33f3cb8de54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77eade94-647e-4e58-a19f-d33f3cb8de54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77eade94-647e-4e58-a19f-d33f3cb8de54>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed77a5bc-a7e3-4f48-b32e-a7f5bae9b8b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed77a5bc-a7e3-4f48-b32e-a7f5bae9b8b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed77a5bc-a7e3-4f48-b32e-a7f5bae9b8b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b5105e1-a924-481a-8643-6537f66888fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b5105e1-a924-481a-8643-6537f66888fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b5105e1-a924-481a-8643-6537f66888fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff8643f1-56b6-44d2-85a8-5f847f906d49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff8643f1-56b6-44d2-85a8-5f847f906d49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/49e039a5-acef-46fe-88fa-e91d438ac903/GetPublication?filename=BesluitenLijst_Vast%20Bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff8643f1-56b6-44d2-85a8-5f847f906d49>.
+    
+<http://data.lblod.info/id/remote-data-objects/2472e90e-b52d-4a54-89af-e976cb7ff5c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2472e90e-b52d-4a54-89af-e976cb7ff5c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2472e90e-b52d-4a54-89af-e976cb7ff5c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8774981-60a3-4ced-99e9-1eda79b026c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8774981-60a3-4ced-99e9-1eda79b026c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8774981-60a3-4ced-99e9-1eda79b026c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/feb63554-15ec-4e72-8e19-b9370ec629de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "feb63554-15ec-4e72-8e19-b9370ec629de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/feb63554-15ec-4e72-8e19-b9370ec629de>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0aef044-2285-4543-8931-c243e6fb246f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0aef044-2285-4543-8931-c243e6fb246f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0aef044-2285-4543-8931-c243e6fb246f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b304fc77-73de-4ecb-9c52-348577620f2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b304fc77-73de-4ecb-9c52-348577620f2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b304fc77-73de-4ecb-9c52-348577620f2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/69998a62-38fe-4025-8032-5c1d578a8074> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69998a62-38fe-4025-8032-5c1d578a8074";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69998a62-38fe-4025-8032-5c1d578a8074>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b72e14e-3228-49fe-a34d-93cc38eaf422> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b72e14e-3228-49fe-a34d-93cc38eaf422";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b72e14e-3228-49fe-a34d-93cc38eaf422>.
+    
+<http://data.lblod.info/id/remote-data-objects/97435506-cc0a-47e7-b438-78ef904ec0cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97435506-cc0a-47e7-b438-78ef904ec0cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97435506-cc0a-47e7-b438-78ef904ec0cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b326904-1a92-4e97-b5b9-0fb4fede08f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b326904-1a92-4e97-b5b9-0fb4fede08f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b326904-1a92-4e97-b5b9-0fb4fede08f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c2be288-ff08-4d13-a684-bb5cf5fb32a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c2be288-ff08-4d13-a684-bb5cf5fb32a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c2be288-ff08-4d13-a684-bb5cf5fb32a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b632d055-10ec-4108-8c27-2255637cda68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b632d055-10ec-4108-8c27-2255637cda68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b632d055-10ec-4108-8c27-2255637cda68>.
+    
+<http://data.lblod.info/id/remote-data-objects/2603ec0b-d5a9-48ef-a04d-a64fb32d89b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2603ec0b-d5a9-48ef-a04d-a64fb32d89b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2603ec0b-d5a9-48ef-a04d-a64fb32d89b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a76c8f2-012a-4a0b-b233-5fc75582169c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a76c8f2-012a-4a0b-b233-5fc75582169c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a76c8f2-012a-4a0b-b233-5fc75582169c>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdbc0859-8021-4319-92b8-4bd598553163> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdbc0859-8021-4319-92b8-4bd598553163";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdbc0859-8021-4319-92b8-4bd598553163>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7ad8782-8edd-43b9-b2a1-4cd5f9c0825d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7ad8782-8edd-43b9-b2a1-4cd5f9c0825d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7ad8782-8edd-43b9-b2a1-4cd5f9c0825d>.
+    
+<http://data.lblod.info/id/remote-data-objects/28f4fd68-afcb-4b16-8356-646094c258f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28f4fd68-afcb-4b16-8356-646094c258f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28f4fd68-afcb-4b16-8356-646094c258f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/550162d5-c07f-4de3-82a2-c8bb9ac7be59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "550162d5-c07f-4de3-82a2-c8bb9ac7be59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/550162d5-c07f-4de3-82a2-c8bb9ac7be59>.
+    
+<http://data.lblod.info/id/remote-data-objects/976899fc-986f-4415-b8b4-2962918e0d76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "976899fc-986f-4415-b8b4-2962918e0d76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/976899fc-986f-4415-b8b4-2962918e0d76>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1b07da9-d58d-4d3d-acc6-2e205aef88ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1b07da9-d58d-4d3d-acc6-2e205aef88ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1b07da9-d58d-4d3d-acc6-2e205aef88ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4edb57d-31c6-40d9-93ba-201812e8493f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4edb57d-31c6-40d9-93ba-201812e8493f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4edb57d-31c6-40d9-93ba-201812e8493f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1dcc5c5c-a438-44e9-80dd-8bec21e1448b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1dcc5c5c-a438-44e9-80dd-8bec21e1448b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1dcc5c5c-a438-44e9-80dd-8bec21e1448b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff2ebe73-8c78-436e-869d-3f1fcfefdd92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff2ebe73-8c78-436e-869d-3f1fcfefdd92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff2ebe73-8c78-436e-869d-3f1fcfefdd92>.
+    
+<http://data.lblod.info/id/remote-data-objects/9231b807-73bd-4816-bc95-fd7b5602bde3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9231b807-73bd-4816-bc95-fd7b5602bde3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9231b807-73bd-4816-bc95-fd7b5602bde3>.
+    
+<http://data.lblod.info/id/remote-data-objects/0760c029-c577-4ae7-9ba3-ea1592bc3c67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0760c029-c577-4ae7-9ba3-ea1592bc3c67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0760c029-c577-4ae7-9ba3-ea1592bc3c67>.
+    
+<http://data.lblod.info/id/remote-data-objects/87fa266b-f0e0-4483-ae76-773ca476308c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87fa266b-f0e0-4483-ae76-773ca476308c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87fa266b-f0e0-4483-ae76-773ca476308c>.
+    
+<http://data.lblod.info/id/remote-data-objects/07cd9fb1-36ec-45a7-baad-3972866bcf5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07cd9fb1-36ec-45a7-baad-3972866bcf5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07cd9fb1-36ec-45a7-baad-3972866bcf5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/711ecb75-190e-4d9c-ba71-18f4929d99b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "711ecb75-190e-4d9c-ba71-18f4929d99b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_22-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/711ecb75-190e-4d9c-ba71-18f4929d99b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0020d4dc-b63e-4446-83f3-8326ed8134c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0020d4dc-b63e-4446-83f3-8326ed8134c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0020d4dc-b63e-4446-83f3-8326ed8134c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/922f6069-c961-469a-9893-0b559ba96c61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "922f6069-c961-469a-9893-0b559ba96c61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/922f6069-c961-469a-9893-0b559ba96c61>.
+    
+<http://data.lblod.info/id/remote-data-objects/cde51214-e1f1-4f29-84d3-84788f95d6ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cde51214-e1f1-4f29-84d3-84788f95d6ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cde51214-e1f1-4f29-84d3-84788f95d6ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/00574d83-224f-4b30-85d9-42be013b9f1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00574d83-224f-4b30-85d9-42be013b9f1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00574d83-224f-4b30-85d9-42be013b9f1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0ee90a6-9b15-4412-b2f2-42e409785ed0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0ee90a6-9b15-4412-b2f2-42e409785ed0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0ee90a6-9b15-4412-b2f2-42e409785ed0>.
+    
+<http://data.lblod.info/id/remote-data-objects/95588356-7d68-4165-9864-7430e82cfb72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95588356-7d68-4165-9864-7430e82cfb72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4cb46c68-6184-4c44-b41f-1df20089fc5f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95588356-7d68-4165-9864-7430e82cfb72>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201625-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201625-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201625-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201625-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/6966c50a-4d0e-40c9-83d7-23e8cf2f278e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6966c50a-4d0e-40c9-83d7-23e8cf2f278e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "da8bea22-b14a-4e79-b9d1-a00257f3143d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/5e410473-8161-4058-8c57-4f6e8cad3a9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5e410473-8161-4058-8c57-4f6e8cad3a9b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d>.
+
+  <http://redpencil.data.gift/id/task/6046dea2-eabe-412c-b403-49c619c73d1a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6046dea2-eabe-412c-b403-49c619c73d1a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/6966c50a-4d0e-40c9-83d7-23e8cf2f278e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/5e410473-8161-4058-8c57-4f6e8cad3a9b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/f6c7cd65-37cd-432a-b1bc-c665c19183bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6c7cd65-37cd-432a-b1bc-c665c19183bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6c7cd65-37cd-432a-b1bc-c665c19183bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/26e489bc-4810-4be4-8987-f7090e739c95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26e489bc-4810-4be4-8987-f7090e739c95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26e489bc-4810-4be4-8987-f7090e739c95>.
+    
+<http://data.lblod.info/id/remote-data-objects/bffba971-edbd-4d15-bc40-936e7f476016> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bffba971-edbd-4d15-bc40-936e7f476016";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bffba971-edbd-4d15-bc40-936e7f476016>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e5aa1c5-5c86-49ba-a761-e4003cda0088> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e5aa1c5-5c86-49ba-a761-e4003cda0088";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e5aa1c5-5c86-49ba-a761-e4003cda0088>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea124bb6-96a9-4ed9-8838-dac841f6e8e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea124bb6-96a9-4ed9-8838-dac841f6e8e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea124bb6-96a9-4ed9-8838-dac841f6e8e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc0dbebc-f2b2-48c6-b10b-795b63f3339d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc0dbebc-f2b2-48c6-b10b-795b63f3339d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc0dbebc-f2b2-48c6-b10b-795b63f3339d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b2034a4-577e-4858-8d68-792af3bb2e3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b2034a4-577e-4858-8d68-792af3bb2e3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b2034a4-577e-4858-8d68-792af3bb2e3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebf31438-3613-46d0-84bb-4d4dcdfcaf03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebf31438-3613-46d0-84bb-4d4dcdfcaf03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_02-05-2022_45669.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebf31438-3613-46d0-84bb-4d4dcdfcaf03>.
+    
+<http://data.lblod.info/id/remote-data-objects/870a8480-0d3f-462a-bc7b-377edbcfb324> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "870a8480-0d3f-462a-bc7b-377edbcfb324";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_02-05-2022_48579.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/870a8480-0d3f-462a-bc7b-377edbcfb324>.
+    
+<http://data.lblod.info/id/remote-data-objects/37da1132-329c-45ab-8688-85ad4fe988b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37da1132-329c-45ab-8688-85ad4fe988b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_02-05-2022_48630.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37da1132-329c-45ab-8688-85ad4fe988b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f6e6c71-8d0a-4f7a-91fa-2c2fcce8da20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f6e6c71-8d0a-4f7a-91fa-2c2fcce8da20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_02-05-2022_48990.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f6e6c71-8d0a-4f7a-91fa-2c2fcce8da20>.
+    
+<http://data.lblod.info/id/remote-data-objects/410452a7-cf5d-4350-9b4f-7cc434243983> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "410452a7-cf5d-4350-9b4f-7cc434243983";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_03-01-2022_43174.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/410452a7-cf5d-4350-9b4f-7cc434243983>.
+    
+<http://data.lblod.info/id/remote-data-objects/167ff7e1-ce32-4b11-b7c5-d7bf4f94b2af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "167ff7e1-ce32-4b11-b7c5-d7bf4f94b2af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-04-2022_46820.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/167ff7e1-ce32-4b11-b7c5-d7bf4f94b2af>.
+    
+<http://data.lblod.info/id/remote-data-objects/ded821b8-769a-4cb3-9f69-bfce84cae59f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ded821b8-769a-4cb3-9f69-bfce84cae59f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-04-2022_46910.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ded821b8-769a-4cb3-9f69-bfce84cae59f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d1f9deb-82ec-4033-9f72-a6d6f652dc2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d1f9deb-82ec-4033-9f72-a6d6f652dc2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-04-2022_46983.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d1f9deb-82ec-4033-9f72-a6d6f652dc2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a6eeb56-acbe-4063-b7e9-4f08e355218d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a6eeb56-acbe-4063-b7e9-4f08e355218d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-04-2022_47240.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a6eeb56-acbe-4063-b7e9-4f08e355218d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0335f3a-9d6e-48af-afe4-5cdafef4c786> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0335f3a-9d6e-48af-afe4-5cdafef4c786";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-04-2022_47255.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0335f3a-9d6e-48af-afe4-5cdafef4c786>.
+    
+<http://data.lblod.info/id/remote-data-objects/43b23d34-a777-4282-b52d-56bf81157a4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43b23d34-a777-4282-b52d-56bf81157a4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-04-2022_47267.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43b23d34-a777-4282-b52d-56bf81157a4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3733866a-6bd1-46cd-bdb3-8a16a24a99f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3733866a-6bd1-46cd-bdb3-8a16a24a99f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-04-2022_48475.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3733866a-6bd1-46cd-bdb3-8a16a24a99f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/2956b884-10d9-4742-bff8-9f2471a0b529> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2956b884-10d9-4742-bff8-9f2471a0b529";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-04-2022_48477.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2956b884-10d9-4742-bff8-9f2471a0b529>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff7d5cb4-6a84-489a-9fdb-1503176f2a79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff7d5cb4-6a84-489a-9fdb-1503176f2a79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-04-2022_48551.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff7d5cb4-6a84-489a-9fdb-1503176f2a79>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5706cc7-e0c8-42f8-bc63-b3ea9ef6f300> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5706cc7-e0c8-42f8-bc63-b3ea9ef6f300";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-04-2022_48552.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5706cc7-e0c8-42f8-bc63-b3ea9ef6f300>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a484a98-9be5-4f8a-bb92-77e003b0dc5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a484a98-9be5-4f8a-bb92-77e003b0dc5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-04-2022_48554.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a484a98-9be5-4f8a-bb92-77e003b0dc5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/efc60154-a87a-43f6-bf82-6a020be75b15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efc60154-a87a-43f6-bf82-6a020be75b15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-07-2022_47265.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efc60154-a87a-43f6-bf82-6a020be75b15>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f5f4b99-954a-4fd9-8d60-a40d48280a1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f5f4b99-954a-4fd9-8d60-a40d48280a1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-07-2022_49008.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f5f4b99-954a-4fd9-8d60-a40d48280a1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/83eac0eb-ec36-418e-a601-2a2c4f61f677> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83eac0eb-ec36-418e-a601-2a2c4f61f677";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-07-2022_49040.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83eac0eb-ec36-418e-a601-2a2c4f61f677>.
+    
+<http://data.lblod.info/id/remote-data-objects/58d33dab-c5d1-4980-9b37-0836a74080f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58d33dab-c5d1-4980-9b37-0836a74080f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-07-2022_49142.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58d33dab-c5d1-4980-9b37-0836a74080f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a3815f8-995d-4878-8009-d3cb39898473> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a3815f8-995d-4878-8009-d3cb39898473";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-07-2022_49143.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a3815f8-995d-4878-8009-d3cb39898473>.
+    
+<http://data.lblod.info/id/remote-data-objects/83d2ba99-53e9-4b51-ad57-c26365e5c756> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83d2ba99-53e9-4b51-ad57-c26365e5c756";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-07-2022_49252.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83d2ba99-53e9-4b51-ad57-c26365e5c756>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d748460-de8f-413c-affa-18386fe7aef3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d748460-de8f-413c-affa-18386fe7aef3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-07-2022_49253.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d748460-de8f-413c-affa-18386fe7aef3>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbf16ec2-05c7-48c1-8602-ebf0e1e4ffb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbf16ec2-05c7-48c1-8602-ebf0e1e4ffb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-07-2022_49254.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbf16ec2-05c7-48c1-8602-ebf0e1e4ffb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/832cfca1-75dd-4cf1-87eb-96d4547eb9f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "832cfca1-75dd-4cf1-87eb-96d4547eb9f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-07-2022_49529.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/832cfca1-75dd-4cf1-87eb-96d4547eb9f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b679483-843d-48d8-82b3-e8fb9c61eff8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b679483-843d-48d8-82b3-e8fb9c61eff8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-07-2022_49663.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b679483-843d-48d8-82b3-e8fb9c61eff8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2e335a8-0936-409c-8481-5b26a97ee757> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2e335a8-0936-409c-8481-5b26a97ee757";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-07-2022_50135.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2e335a8-0936-409c-8481-5b26a97ee757>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf1dd3ea-b650-48ae-b5af-b8afb6a99292> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf1dd3ea-b650-48ae-b5af-b8afb6a99292";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_04-10-2021_40561.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf1dd3ea-b650-48ae-b5af-b8afb6a99292>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb3a6b3b-9bc9-4959-98e7-9eb1e051940f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb3a6b3b-9bc9-4959-98e7-9eb1e051940f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_06-12-2021_40584.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb3a6b3b-9bc9-4959-98e7-9eb1e051940f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6348af2f-49bc-414e-8be0-476b73eaebd6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6348af2f-49bc-414e-8be0-476b73eaebd6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_06-12-2021_41502.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6348af2f-49bc-414e-8be0-476b73eaebd6>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ddaad79-bb31-4b3a-a224-3864cbdd07ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ddaad79-bb31-4b3a-a224-3864cbdd07ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_07-03-2022_46792.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ddaad79-bb31-4b3a-a224-3864cbdd07ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/13411326-1170-4922-94fe-80981a0acc9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13411326-1170-4922-94fe-80981a0acc9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_07-03-2022_47188.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13411326-1170-4922-94fe-80981a0acc9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/378c8e74-458d-428e-a9d5-843cfad99abc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "378c8e74-458d-428e-a9d5-843cfad99abc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_08-07-2022_50218.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/378c8e74-458d-428e-a9d5-843cfad99abc>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c7cbd3c-b32c-44c5-8004-89dcff231211> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c7cbd3c-b32c-44c5-8004-89dcff231211";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_08-11-2021_40722.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c7cbd3c-b32c-44c5-8004-89dcff231211>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b12d6bd-73c6-4246-afc6-b8599cf2ff27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b12d6bd-73c6-4246-afc6-b8599cf2ff27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_08-11-2021_40728.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b12d6bd-73c6-4246-afc6-b8599cf2ff27>.
+    
+<http://data.lblod.info/id/remote-data-objects/56162486-6f3f-4368-b148-30261bf3d41e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56162486-6f3f-4368-b148-30261bf3d41e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_08-11-2021_41186.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56162486-6f3f-4368-b148-30261bf3d41e>.
+    
+<http://data.lblod.info/id/remote-data-objects/66314b3b-26b0-4d1d-966a-41fd522e4f8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66314b3b-26b0-4d1d-966a-41fd522e4f8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_08-11-2021_41238.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66314b3b-26b0-4d1d-966a-41fd522e4f8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c715790a-4b91-4fdf-b465-4ff0fb0ec22a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c715790a-4b91-4fdf-b465-4ff0fb0ec22a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_09-05-2022_47064.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c715790a-4b91-4fdf-b465-4ff0fb0ec22a>.
+    
+<http://data.lblod.info/id/remote-data-objects/65552aa1-3435-4df7-bad7-fe343aa604f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65552aa1-3435-4df7-bad7-fe343aa604f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_09-05-2022_47097.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65552aa1-3435-4df7-bad7-fe343aa604f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/69e13139-3be5-4539-bfa4-eb0dd4a2eddd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69e13139-3be5-4539-bfa4-eb0dd4a2eddd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_09-05-2022_48478.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69e13139-3be5-4539-bfa4-eb0dd4a2eddd>.
+    
+<http://data.lblod.info/id/remote-data-objects/82f28e69-5faf-4e2b-83bb-104c6c632406> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82f28e69-5faf-4e2b-83bb-104c6c632406";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_09-05-2022_48566.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82f28e69-5faf-4e2b-83bb-104c6c632406>.
+    
+<http://data.lblod.info/id/remote-data-objects/c44078f0-8a15-40b1-b775-cfd39f157cfd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c44078f0-8a15-40b1-b775-cfd39f157cfd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_09-05-2022_48628.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c44078f0-8a15-40b1-b775-cfd39f157cfd>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c15e1fe-a2f7-4597-8478-b0abb247cc16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c15e1fe-a2f7-4597-8478-b0abb247cc16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_09-05-2022_48898.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/da8bea22-b14a-4e79-b9d1-a00257f3143d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c15e1fe-a2f7-4597-8478-b0abb247cc16>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201626-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201626-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201626-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201626-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/30d7ac13-bd73-496c-aaab-05355b4da0e6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "30d7ac13-bd73-496c-aaab-05355b4da0e6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "06a17e28-2223-4c72-b39a-e6d3e4eab77b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f28fe076-0456-4a8b-8678-6138e93dfb1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f28fe076-0456-4a8b-8678-6138e93dfb1f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b>.
+
+  <http://redpencil.data.gift/id/task/b3eb8eb0-aa99-4053-a38d-abca641499da> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b3eb8eb0-aa99-4053-a38d-abca641499da";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/30d7ac13-bd73-496c-aaab-05355b4da0e6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f28fe076-0456-4a8b-8678-6138e93dfb1f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/1f41abf9-a74c-435e-b3be-209a5a136840> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f41abf9-a74c-435e-b3be-209a5a136840";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_09-05-2022_49053.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f41abf9-a74c-435e-b3be-209a5a136840>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d58c658-0b89-4d54-a104-b0a64208551f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d58c658-0b89-4d54-a104-b0a64208551f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_09-05-2022_49102.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d58c658-0b89-4d54-a104-b0a64208551f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a942423f-4482-4628-a390-81af5aad2b59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a942423f-4482-4628-a390-81af5aad2b59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_09-05-2022_49181.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a942423f-4482-4628-a390-81af5aad2b59>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6eea66a-af5d-4413-bf67-f87d70b53387> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6eea66a-af5d-4413-bf67-f87d70b53387";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_11-04-2022_46902.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6eea66a-af5d-4413-bf67-f87d70b53387>.
+    
+<http://data.lblod.info/id/remote-data-objects/827dba85-8f07-4d3b-aa63-304f0f5ccc6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "827dba85-8f07-4d3b-aa63-304f0f5ccc6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_11-04-2022_47112.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/827dba85-8f07-4d3b-aa63-304f0f5ccc6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e073944-184c-4546-807b-d78d77e05d59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e073944-184c-4546-807b-d78d77e05d59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_11-04-2022_48373.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e073944-184c-4546-807b-d78d77e05d59>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cb77c2f-e6df-42ce-93ce-3b193d4e52f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cb77c2f-e6df-42ce-93ce-3b193d4e52f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_11-04-2022_48719.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cb77c2f-e6df-42ce-93ce-3b193d4e52f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d613414-5668-4d10-b2ca-120e3d4b2985> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d613414-5668-4d10-b2ca-120e3d4b2985";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_11-10-2021_40613.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d613414-5668-4d10-b2ca-120e3d4b2985>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc53e443-99a5-49b7-a614-36a405a21b45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc53e443-99a5-49b7-a614-36a405a21b45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_11-10-2021_40706.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc53e443-99a5-49b7-a614-36a405a21b45>.
+    
+<http://data.lblod.info/id/remote-data-objects/81f6c312-9eb7-4b8d-b00a-ca4646b42a26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81f6c312-9eb7-4b8d-b00a-ca4646b42a26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_11-10-2021_40743.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81f6c312-9eb7-4b8d-b00a-ca4646b42a26>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ab0ef78-7866-438d-9dab-1243c9a15ab9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ab0ef78-7866-438d-9dab-1243c9a15ab9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_13-06-2022_46950.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ab0ef78-7866-438d-9dab-1243c9a15ab9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b4541ad-17ba-4948-9ac5-cc6c94a35262> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b4541ad-17ba-4948-9ac5-cc6c94a35262";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_13-06-2022_48555.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b4541ad-17ba-4948-9ac5-cc6c94a35262>.
+    
+<http://data.lblod.info/id/remote-data-objects/60352dce-5da1-4804-bf7c-74bf3996639f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60352dce-5da1-4804-bf7c-74bf3996639f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_13-06-2022_48733.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60352dce-5da1-4804-bf7c-74bf3996639f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb009507-c1c2-43be-bac5-9f9e0e824c01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb009507-c1c2-43be-bac5-9f9e0e824c01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_13-06-2022_49591.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb009507-c1c2-43be-bac5-9f9e0e824c01>.
+    
+<http://data.lblod.info/id/remote-data-objects/430a3014-ef19-4799-9826-0cc430709b1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "430a3014-ef19-4799-9826-0cc430709b1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_13-06-2022_49639.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/430a3014-ef19-4799-9826-0cc430709b1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b61dfe6e-f63d-451f-9181-07aaf9d38892> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b61dfe6e-f63d-451f-9181-07aaf9d38892";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_13-06-2022_49643.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b61dfe6e-f63d-451f-9181-07aaf9d38892>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee0a157e-b0b8-4914-8002-71ffb8145099> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee0a157e-b0b8-4914-8002-71ffb8145099";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_13-12-2021_40903.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee0a157e-b0b8-4914-8002-71ffb8145099>.
+    
+<http://data.lblod.info/id/remote-data-objects/4881d5ef-efa3-442f-a96b-10cf828b4486> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4881d5ef-efa3-442f-a96b-10cf828b4486";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_13-12-2021_41908.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4881d5ef-efa3-442f-a96b-10cf828b4486>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2eae138-4e4c-4921-ab36-e52da7cfdd48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2eae138-4e4c-4921-ab36-e52da7cfdd48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_13-12-2021_41983.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2eae138-4e4c-4921-ab36-e52da7cfdd48>.
+    
+<http://data.lblod.info/id/remote-data-objects/f98e1a30-a9ca-4926-be09-0cfae31176e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f98e1a30-a9ca-4926-be09-0cfae31176e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_14-03-2022_46814.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f98e1a30-a9ca-4926-be09-0cfae31176e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/db673d31-929a-4c9e-873c-75ac38ad9ac1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db673d31-929a-4c9e-873c-75ac38ad9ac1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_14-03-2022_46843.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db673d31-929a-4c9e-873c-75ac38ad9ac1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3ad1fd0-7976-4c95-b876-018df5f8d7d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3ad1fd0-7976-4c95-b876-018df5f8d7d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_14-03-2022_47086.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3ad1fd0-7976-4c95-b876-018df5f8d7d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/adcedf75-24b9-4232-bd4b-c3bf2e366b11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "adcedf75-24b9-4232-bd4b-c3bf2e366b11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_14-03-2022_47096.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/adcedf75-24b9-4232-bd4b-c3bf2e366b11>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce56f7cd-6bba-44e6-ab38-e4cc2099249e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce56f7cd-6bba-44e6-ab38-e4cc2099249e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_14-03-2022_47109.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce56f7cd-6bba-44e6-ab38-e4cc2099249e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7081ead7-3b55-4626-a01f-881b4bb3968c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7081ead7-3b55-4626-a01f-881b4bb3968c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_14-03-2022_48317.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7081ead7-3b55-4626-a01f-881b4bb3968c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a2b1ab9-dbeb-4a99-bff0-1a80b676cc26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a2b1ab9-dbeb-4a99-bff0-1a80b676cc26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_16-05-2022_48941.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a2b1ab9-dbeb-4a99-bff0-1a80b676cc26>.
+    
+<http://data.lblod.info/id/remote-data-objects/d418ff6d-6ff9-44bf-b5ef-d7b5d8205719> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d418ff6d-6ff9-44bf-b5ef-d7b5d8205719";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_18-10-2021_40725.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d418ff6d-6ff9-44bf-b5ef-d7b5d8205719>.
+    
+<http://data.lblod.info/id/remote-data-objects/3196fc32-a299-43cd-ab06-5cd1e443915d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3196fc32-a299-43cd-ab06-5cd1e443915d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_18-10-2021_40942.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3196fc32-a299-43cd-ab06-5cd1e443915d>.
+    
+<http://data.lblod.info/id/remote-data-objects/2535d42b-ac8b-4a87-b1e1-17b398eae431> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2535d42b-ac8b-4a87-b1e1-17b398eae431";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_20-06-2022_48377.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2535d42b-ac8b-4a87-b1e1-17b398eae431>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d3f5ad0-ff06-4bbb-8c1b-a2e883469e94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d3f5ad0-ff06-4bbb-8c1b-a2e883469e94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_20-06-2022_48565.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d3f5ad0-ff06-4bbb-8c1b-a2e883469e94>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe29e5c2-68d6-4d94-8166-fc559a31a9ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe29e5c2-68d6-4d94-8166-fc559a31a9ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_20-06-2022_48697.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe29e5c2-68d6-4d94-8166-fc559a31a9ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/73a723a6-85e1-4953-9826-d78bb4b84d44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73a723a6-85e1-4953-9826-d78bb4b84d44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_20-06-2022_48698.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73a723a6-85e1-4953-9826-d78bb4b84d44>.
+    
+<http://data.lblod.info/id/remote-data-objects/81406651-cd8b-4fd3-bd8d-dbffd94bbb68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81406651-cd8b-4fd3-bd8d-dbffd94bbb68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_20-06-2022_49082.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81406651-cd8b-4fd3-bd8d-dbffd94bbb68>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fe31fe3-8df1-4425-a876-bf380ced4714> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fe31fe3-8df1-4425-a876-bf380ced4714";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_20-06-2022_49166.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fe31fe3-8df1-4425-a876-bf380ced4714>.
+    
+<http://data.lblod.info/id/remote-data-objects/03916d39-aeea-4547-9456-35970ab870d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03916d39-aeea-4547-9456-35970ab870d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_20-06-2022_49662.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03916d39-aeea-4547-9456-35970ab870d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/bec438fe-246c-468b-86dd-80d2c9548c58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bec438fe-246c-468b-86dd-80d2c9548c58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_20-06-2022_49720.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bec438fe-246c-468b-86dd-80d2c9548c58>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1dc1a88-a473-4ae8-85ef-1e62c77b5ff8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1dc1a88-a473-4ae8-85ef-1e62c77b5ff8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_20-06-2022_49881.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1dc1a88-a473-4ae8-85ef-1e62c77b5ff8>.
+    
+<http://data.lblod.info/id/remote-data-objects/72243e82-47c9-4408-acda-4bcfc5955bd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72243e82-47c9-4408-acda-4bcfc5955bd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_20-06-2022_49883.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72243e82-47c9-4408-acda-4bcfc5955bd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/85f1470b-753e-4967-af43-ef6a7c2f5b1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85f1470b-753e-4967-af43-ef6a7c2f5b1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_20-06-2022_49903.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85f1470b-753e-4967-af43-ef6a7c2f5b1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4762a0c7-00a1-4cea-a442-3836c36ba16b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4762a0c7-00a1-4cea-a442-3836c36ba16b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_20-12-2021_41174.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4762a0c7-00a1-4cea-a442-3836c36ba16b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fb8b0d6-cd19-4dc8-9b57-ef39c6261a58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fb8b0d6-cd19-4dc8-9b57-ef39c6261a58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_21-03-2022_48422.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fb8b0d6-cd19-4dc8-9b57-ef39c6261a58>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3d0ea29-219c-455b-8afb-4227f228bea9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3d0ea29-219c-455b-8afb-4227f228bea9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_22-11-2021_41245.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3d0ea29-219c-455b-8afb-4227f228bea9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e14b9668-0bba-440e-9d09-8d6781fdc95d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e14b9668-0bba-440e-9d09-8d6781fdc95d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_23-05-2022_43458.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e14b9668-0bba-440e-9d09-8d6781fdc95d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef886fe4-82e4-48c0-80df-8a315b9450a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef886fe4-82e4-48c0-80df-8a315b9450a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_23-05-2022_46908.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef886fe4-82e4-48c0-80df-8a315b9450a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/21d90947-b8da-461e-9c6a-d1bd820d1e5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21d90947-b8da-461e-9c6a-d1bd820d1e5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_23-05-2022_46977.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21d90947-b8da-461e-9c6a-d1bd820d1e5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/19ead10f-da82-4283-ab72-e8ba21ee99cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19ead10f-da82-4283-ab72-e8ba21ee99cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_23-05-2022_48295.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19ead10f-da82-4283-ab72-e8ba21ee99cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/c582c115-aee1-4d4c-86ab-af7d6258e7f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c582c115-aee1-4d4c-86ab-af7d6258e7f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_23-05-2022_48466.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c582c115-aee1-4d4c-86ab-af7d6258e7f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/27ce640c-d853-4c76-be3e-408013ace1d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27ce640c-d853-4c76-be3e-408013ace1d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_23-05-2022_48741.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27ce640c-d853-4c76-be3e-408013ace1d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a193188b-da92-4337-9beb-e0fcb1a9ad96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a193188b-da92-4337-9beb-e0fcb1a9ad96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_23-05-2022_48994.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a193188b-da92-4337-9beb-e0fcb1a9ad96>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f567be7-d97b-4cc7-9033-53daa0f0773e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f567be7-d97b-4cc7-9033-53daa0f0773e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_23-05-2022_49141.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/06a17e28-2223-4c72-b39a-e6d3e4eab77b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f567be7-d97b-4cc7-9033-53daa0f0773e>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201628-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201628-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201628-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201628-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f4902fc1-fcde-432c-8fdb-fe21db8f7b97> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f4902fc1-fcde-432c-8fdb-fe21db8f7b97";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6adbb73d-2364-4093-853c-b46766b40cb2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f7381b56-5f4d-42af-87e9-098e77cc3723> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f7381b56-5f4d-42af-87e9-098e77cc3723";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2>.
+
+  <http://redpencil.data.gift/id/task/2ed4aad6-4507-45d4-9349-6c79753a756f> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2ed4aad6-4507-45d4-9349-6c79753a756f";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f4902fc1-fcde-432c-8fdb-fe21db8f7b97>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f7381b56-5f4d-42af-87e9-098e77cc3723>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/eff2ae45-475c-46c8-a175-ad752ea40df4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eff2ae45-475c-46c8-a175-ad752ea40df4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_23-05-2022_49297.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eff2ae45-475c-46c8-a175-ad752ea40df4>.
+    
+<http://data.lblod.info/id/remote-data-objects/48188dc5-6cdf-4a83-b2c8-ecff0fd844a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48188dc5-6cdf-4a83-b2c8-ecff0fd844a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_23-05-2022_49343.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48188dc5-6cdf-4a83-b2c8-ecff0fd844a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/b57984f6-2ee1-4df1-88ed-a918c4f3330d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b57984f6-2ee1-4df1-88ed-a918c4f3330d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-04-2022_48659.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b57984f6-2ee1-4df1-88ed-a918c4f3330d>.
+    
+<http://data.lblod.info/id/remote-data-objects/627abbef-2c50-42c5-8c0e-6e4c63f2f6b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "627abbef-2c50-42c5-8c0e-6e4c63f2f6b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-04-2022_48885.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/627abbef-2c50-42c5-8c0e-6e4c63f2f6b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0890535-2da7-4195-9736-1344ead4823a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0890535-2da7-4195-9736-1344ead4823a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-07-2022_47266.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0890535-2da7-4195-9736-1344ead4823a>.
+    
+<http://data.lblod.info/id/remote-data-objects/01a22061-4e30-44e0-b72f-c321292d8c91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01a22061-4e30-44e0-b72f-c321292d8c91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-07-2022_48368.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01a22061-4e30-44e0-b72f-c321292d8c91>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9d9919b-3439-4d4e-8f0d-68dc421182ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9d9919b-3439-4d4e-8f0d-68dc421182ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-07-2022_48986.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9d9919b-3439-4d4e-8f0d-68dc421182ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/92b0ed06-23f8-4088-ac04-e17cd992d5d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92b0ed06-23f8-4088-ac04-e17cd992d5d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-07-2022_49317.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92b0ed06-23f8-4088-ac04-e17cd992d5d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6fc528e-a7ec-4a10-858c-b6a4da177161> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6fc528e-a7ec-4a10-858c-b6a4da177161";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-07-2022_49418.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6fc528e-a7ec-4a10-858c-b6a4da177161>.
+    
+<http://data.lblod.info/id/remote-data-objects/0129ff0c-4a84-4a73-bffc-564f0874a015> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0129ff0c-4a84-4a73-bffc-564f0874a015";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-07-2022_49658.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0129ff0c-4a84-4a73-bffc-564f0874a015>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e644359-64be-4c12-90e2-40cb3e3ad5f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e644359-64be-4c12-90e2-40cb3e3ad5f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-07-2022_49666.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e644359-64be-4c12-90e2-40cb3e3ad5f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/517200ee-90a1-470c-a4e0-f831a3d02711> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "517200ee-90a1-470c-a4e0-f831a3d02711";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-07-2022_49844.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/517200ee-90a1-470c-a4e0-f831a3d02711>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bc4d6d5-2b60-47c3-b4dd-8cdf4051a3a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bc4d6d5-2b60-47c3-b4dd-8cdf4051a3a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-07-2022_49846.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bc4d6d5-2b60-47c3-b4dd-8cdf4051a3a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c318c271-dfd2-4718-abf2-c30069bc8ab2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c318c271-dfd2-4718-abf2-c30069bc8ab2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-07-2022_50257.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c318c271-dfd2-4718-abf2-c30069bc8ab2>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bcb6fc7-e3f1-4313-9430-fbf8910b600b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bcb6fc7-e3f1-4313-9430-fbf8910b600b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-07-2022_51398.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bcb6fc7-e3f1-4313-9430-fbf8910b600b>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd1f6b09-0f3f-4da7-ae10-f4e92a63797d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd1f6b09-0f3f-4da7-ae10-f4e92a63797d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-10-2021_40741.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd1f6b09-0f3f-4da7-ae10-f4e92a63797d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5e9496b-aaa5-4713-87b6-bc370610ec27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5e9496b-aaa5-4713-87b6-bc370610ec27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-10-2021_40745.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5e9496b-aaa5-4713-87b6-bc370610ec27>.
+    
+<http://data.lblod.info/id/remote-data-objects/34e87706-7844-448e-be04-2702316888b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34e87706-7844-448e-be04-2702316888b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-10-2021_41013.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34e87706-7844-448e-be04-2702316888b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4eb69ec5-f3e8-49e4-80fd-cf416b927c9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4eb69ec5-f3e8-49e4-80fd-cf416b927c9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_25-10-2021_41025.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4eb69ec5-f3e8-49e4-80fd-cf416b927c9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab309efb-4c2a-40fa-b4c2-ac7dde96c7a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab309efb-4c2a-40fa-b4c2-ac7dde96c7a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_27-06-2022_49198.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab309efb-4c2a-40fa-b4c2-ac7dde96c7a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf52753b-f225-46b1-a9b2-9abb83585196> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf52753b-f225-46b1-a9b2-9abb83585196";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_27-06-2022_49273.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf52753b-f225-46b1-a9b2-9abb83585196>.
+    
+<http://data.lblod.info/id/remote-data-objects/c92b3a20-ff0a-413a-824d-08efb667c498> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c92b3a20-ff0a-413a-824d-08efb667c498";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_27-06-2022_49405.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c92b3a20-ff0a-413a-824d-08efb667c498>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed07afb4-7406-4551-be21-bb0594a6330f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed07afb4-7406-4551-be21-bb0594a6330f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_27-06-2022_49570.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed07afb4-7406-4551-be21-bb0594a6330f>.
+    
+<http://data.lblod.info/id/remote-data-objects/658a8c5d-258a-414d-8269-c592bba17d57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "658a8c5d-258a-414d-8269-c592bba17d57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_27-06-2022_49664.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/658a8c5d-258a-414d-8269-c592bba17d57>.
+    
+<http://data.lblod.info/id/remote-data-objects/07eca6ea-3faf-4eac-a152-ef9e312a7c4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07eca6ea-3faf-4eac-a152-ef9e312a7c4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_27-06-2022_49665.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07eca6ea-3faf-4eac-a152-ef9e312a7c4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cf87042-7125-45ba-a87d-81ac3677fcf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cf87042-7125-45ba-a87d-81ac3677fcf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_27-06-2022_49708.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cf87042-7125-45ba-a87d-81ac3677fcf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a456e3b5-1a87-40ca-8cd1-acf9f925956e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a456e3b5-1a87-40ca-8cd1-acf9f925956e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_27-06-2022_49863.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a456e3b5-1a87-40ca-8cd1-acf9f925956e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f63c5149-a31d-40c2-92d9-e8bc12572cc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f63c5149-a31d-40c2-92d9-e8bc12572cc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_27-06-2022_49930.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f63c5149-a31d-40c2-92d9-e8bc12572cc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/932803d0-d882-495d-9600-7c06416e4ef0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "932803d0-d882-495d-9600-7c06416e4ef0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_27-06-2022_50076.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/932803d0-d882-495d-9600-7c06416e4ef0>.
+    
+<http://data.lblod.info/id/remote-data-objects/125adf27-589b-4c61-9022-f73c45a623c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "125adf27-589b-4c61-9022-f73c45a623c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_28-02-2022_41842.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/125adf27-589b-4c61-9022-f73c45a623c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/23598549-2cf8-458e-b98d-015c03b99fc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23598549-2cf8-458e-b98d-015c03b99fc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_28-02-2022_41964.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23598549-2cf8-458e-b98d-015c03b99fc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/37985fb4-28ae-43a1-8bc4-7023f2051cfe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37985fb4-28ae-43a1-8bc4-7023f2051cfe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_28-02-2022_43461.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37985fb4-28ae-43a1-8bc4-7023f2051cfe>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad8da27f-88d5-4cc1-8a9f-f47e1515ebcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad8da27f-88d5-4cc1-8a9f-f47e1515ebcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_28-03-2022_43191.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad8da27f-88d5-4cc1-8a9f-f47e1515ebcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/50b3ca82-25c0-4096-b4c4-2bf43c16c8a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50b3ca82-25c0-4096-b4c4-2bf43c16c8a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_28-03-2022_48334.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50b3ca82-25c0-4096-b4c4-2bf43c16c8a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/38bb9abd-94a6-48d5-b484-79169442787a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38bb9abd-94a6-48d5-b484-79169442787a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_28-03-2022_48335.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38bb9abd-94a6-48d5-b484-79169442787a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c7a7e99-6115-4514-89ac-33a4b63a0e08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c7a7e99-6115-4514-89ac-33a4b63a0e08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_28-03-2022_48336.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c7a7e99-6115-4514-89ac-33a4b63a0e08>.
+    
+<http://data.lblod.info/id/remote-data-objects/abcc03b7-ab93-4956-b011-2f4a5e33cfb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abcc03b7-ab93-4956-b011-2f4a5e33cfb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_28-03-2022_48465.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abcc03b7-ab93-4956-b011-2f4a5e33cfb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a768eb1b-3ec9-41bd-bac3-66b060f00c6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a768eb1b-3ec9-41bd-bac3-66b060f00c6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_28-03-2022_48483.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a768eb1b-3ec9-41bd-bac3-66b060f00c6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ffb249b-84ea-4531-a943-ad243ba0bdda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ffb249b-84ea-4531-a943-ad243ba0bdda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_29-11-2021_40905.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ffb249b-84ea-4531-a943-ad243ba0bdda>.
+    
+<http://data.lblod.info/id/remote-data-objects/6aebf3e6-bdb9-4b9c-a085-c4501dd19a24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6aebf3e6-bdb9-4b9c-a085-c4501dd19a24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_29-11-2021_41242.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6aebf3e6-bdb9-4b9c-a085-c4501dd19a24>.
+    
+<http://data.lblod.info/id/remote-data-objects/49a47292-4b08-4a4d-b28a-755a394bb5a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49a47292-4b08-4a4d-b28a-755a394bb5a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_29-11-2021_41246.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49a47292-4b08-4a4d-b28a-755a394bb5a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6abbc24-8a7c-4eab-a952-900d05e5237c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6abbc24-8a7c-4eab-a952-900d05e5237c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_29-11-2021_41707.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6abbc24-8a7c-4eab-a952-900d05e5237c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4cfc88e-1f8c-4235-ab82-af6c9b5fdf13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4cfc88e-1f8c-4235-ab82-af6c9b5fdf13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_30-05-2022_48631.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4cfc88e-1f8c-4235-ab82-af6c9b5fdf13>.
+    
+<http://data.lblod.info/id/remote-data-objects/39b76861-f1f4-4817-b1c1-7d4e3fabc979> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39b76861-f1f4-4817-b1c1-7d4e3fabc979";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_30-05-2022_48632.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39b76861-f1f4-4817-b1c1-7d4e3fabc979>.
+    
+<http://data.lblod.info/id/remote-data-objects/348d0ae3-6f58-47bb-afc9-8adae594563e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "348d0ae3-6f58-47bb-afc9-8adae594563e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_30-05-2022_49083.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/348d0ae3-6f58-47bb-afc9-8adae594563e>.
+    
+<http://data.lblod.info/id/remote-data-objects/30456e73-ef67-4041-817a-ced8445d74b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30456e73-ef67-4041-817a-ced8445d74b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_30-05-2022_49084.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30456e73-ef67-4041-817a-ced8445d74b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/307c6dbd-6aa3-4aef-ac2e-9f37ee827aae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "307c6dbd-6aa3-4aef-ac2e-9f37ee827aae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_30-05-2022_49124.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/307c6dbd-6aa3-4aef-ac2e-9f37ee827aae>.
+    
+<http://data.lblod.info/id/remote-data-objects/d82f7c89-25ec-45a1-a91d-511498633fa9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d82f7c89-25ec-45a1-a91d-511498633fa9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_30-05-2022_49186.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d82f7c89-25ec-45a1-a91d-511498633fa9>.
+    
+<http://data.lblod.info/id/remote-data-objects/64dd28b3-f01b-4b69-9032-e6f50d6e96bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64dd28b3-f01b-4b69-9032-e6f50d6e96bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_30-05-2022_49331.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64dd28b3-f01b-4b69-9032-e6f50d6e96bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/166d4e34-e79a-43c3-86a0-a432f38fcb76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "166d4e34-e79a-43c3-86a0-a432f38fcb76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_30-05-2022_49502.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6adbb73d-2364-4093-853c-b46766b40cb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/166d4e34-e79a-43c3-86a0-a432f38fcb76>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201629-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201629-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201629-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201629-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b23acf40-6345-4bbc-af5b-64aec0afdcb8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b23acf40-6345-4bbc-af5b-64aec0afdcb8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "88336c82-f6d2-4d29-ba7c-2fc3723723e2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6653204e-0e58-4498-94b7-0bfa71885d53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6653204e-0e58-4498-94b7-0bfa71885d53";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2>.
+
+  <http://redpencil.data.gift/id/task/08a31cbb-33c2-4b8c-8715-f0024c74f4ed> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "08a31cbb-33c2-4b8c-8715-f0024c74f4ed";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b23acf40-6345-4bbc-af5b-64aec0afdcb8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6653204e-0e58-4498-94b7-0bfa71885d53>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/0e2b7632-60e0-412d-9bfd-cf67cb458a76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e2b7632-60e0-412d-9bfd-cf67cb458a76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/5cb84f63b31bbc150e01f4b2453ee23b2b4bf366194c66e64c71f664fd5640b9/GetPublication?filename=Uittreksels_31-01-2022_43474.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e2b7632-60e0-412d-9bfd-cf67cb458a76>.
+    
+<http://data.lblod.info/id/remote-data-objects/08833a97-e824-4914-a440-7b4ba41b4ed4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08833a97-e824-4914-a440-7b4ba41b4ed4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/80bf150fbc7f6a117753ee07a13f70313f144cd8e203e5dddfba38a3548ca697/GetPublication?filename=BesluitenLijst_Besluit%20burgemeester_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08833a97-e824-4914-a440-7b4ba41b4ed4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cac66ed-73f6-4a57-b0ba-339815bf27b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cac66ed-73f6-4a57-b0ba-339815bf27b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/80bf150fbc7f6a117753ee07a13f70313f144cd8e203e5dddfba38a3548ca697/GetPublication?filename=BesluitenLijst_Besluit%20burgemeester_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cac66ed-73f6-4a57-b0ba-339815bf27b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/814209f8-6b9f-497e-8738-8065ab32fede> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "814209f8-6b9f-497e-8738-8065ab32fede";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/80bf150fbc7f6a117753ee07a13f70313f144cd8e203e5dddfba38a3548ca697/GetPublication?filename=BesluitenLijst_Besluit%20burgemeester_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/814209f8-6b9f-497e-8738-8065ab32fede>.
+    
+<http://data.lblod.info/id/remote-data-objects/888a8430-e46f-44e0-b21a-c39af508b225> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "888a8430-e46f-44e0-b21a-c39af508b225";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/80bf150fbc7f6a117753ee07a13f70313f144cd8e203e5dddfba38a3548ca697/GetPublication?filename=BesluitenLijst_Besluit%20burgemeester_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/888a8430-e46f-44e0-b21a-c39af508b225>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c1b5e99-ac8b-437e-95ba-70155ac5dba1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c1b5e99-ac8b-437e-95ba-70155ac5dba1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/80bf150fbc7f6a117753ee07a13f70313f144cd8e203e5dddfba38a3548ca697/GetPublication?filename=BesluitenLijst_Besluit%20burgemeester_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c1b5e99-ac8b-437e-95ba-70155ac5dba1>.
+    
+<http://data.lblod.info/id/remote-data-objects/0327695d-f92a-4aa2-9e9f-fe54068cfbe6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0327695d-f92a-4aa2-9e9f-fe54068cfbe6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/80bf150fbc7f6a117753ee07a13f70313f144cd8e203e5dddfba38a3548ca697/GetPublication?filename=BesluitenLijst_Besluit%20burgemeester_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0327695d-f92a-4aa2-9e9f-fe54068cfbe6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a39cd607-96b9-47b5-870b-d46d2a59f60e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a39cd607-96b9-47b5-870b-d46d2a59f60e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/80bf150fbc7f6a117753ee07a13f70313f144cd8e203e5dddfba38a3548ca697/GetPublication?filename=BesluitenLijst_Besluit%20burgemeester_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a39cd607-96b9-47b5-870b-d46d2a59f60e>.
+    
+<http://data.lblod.info/id/remote-data-objects/750009e8-b69e-4e33-b5e2-407dc7decf59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "750009e8-b69e-4e33-b5e2-407dc7decf59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/80bf150fbc7f6a117753ee07a13f70313f144cd8e203e5dddfba38a3548ca697/GetPublication?filename=Uittreksels_25-10-2021_41179.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/750009e8-b69e-4e33-b5e2-407dc7decf59>.
+    
+<http://data.lblod.info/id/remote-data-objects/0830795a-aaa1-4a62-9278-0f10b8dc19a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0830795a-aaa1-4a62-9278-0f10b8dc19a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/80bf150fbc7f6a117753ee07a13f70313f144cd8e203e5dddfba38a3548ca697/GetPublication?filename=Uittreksels_30-06-2022_50118.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0830795a-aaa1-4a62-9278-0f10b8dc19a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/607515d0-73a5-4365-8c9c-aced3de6fa34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "607515d0-73a5-4365-8c9c-aced3de6fa34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=BesluitenLijst_Gemeenteraad_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/607515d0-73a5-4365-8c9c-aced3de6fa34>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf9cb69c-1213-4cb9-b4ed-5402256053f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf9cb69c-1213-4cb9-b4ed-5402256053f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=BesluitenLijst_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf9cb69c-1213-4cb9-b4ed-5402256053f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae84340a-c248-4371-bf47-bc048427cf03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae84340a-c248-4371-bf47-bc048427cf03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae84340a-c248-4371-bf47-bc048427cf03>.
+    
+<http://data.lblod.info/id/remote-data-objects/85c2e9f8-2a46-41f2-8b34-528e64d93bbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85c2e9f8-2a46-41f2-8b34-528e64d93bbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85c2e9f8-2a46-41f2-8b34-528e64d93bbb>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce48a013-cc19-4eb8-b7b9-31c813b35dfb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce48a013-cc19-4eb8-b7b9-31c813b35dfb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce48a013-cc19-4eb8-b7b9-31c813b35dfb>.
+    
+<http://data.lblod.info/id/remote-data-objects/128ec720-1ca2-4226-8cf2-969db3585c08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "128ec720-1ca2-4226-8cf2-969db3585c08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/128ec720-1ca2-4226-8cf2-969db3585c08>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5a5ada5-2150-48a7-b938-357107c7f159> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5a5ada5-2150-48a7-b938-357107c7f159";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=BesluitenLijst_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5a5ada5-2150-48a7-b938-357107c7f159>.
+    
+<http://data.lblod.info/id/remote-data-objects/993c654a-dd81-4c00-b09d-862a97cb7889> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "993c654a-dd81-4c00-b09d-862a97cb7889";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=BesluitenLijst_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/993c654a-dd81-4c00-b09d-862a97cb7889>.
+    
+<http://data.lblod.info/id/remote-data-objects/27a283bc-55e5-437b-8613-0460bd0a019f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27a283bc-55e5-437b-8613-0460bd0a019f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=BesluitenLijst_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27a283bc-55e5-437b-8613-0460bd0a019f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca9c5467-c848-4876-8a8f-a46de47d67ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca9c5467-c848-4876-8a8f-a46de47d67ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Notulen_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca9c5467-c848-4876-8a8f-a46de47d67ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0bb0450-45fc-4751-b80c-91de9b84b5e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0bb0450-45fc-4751-b80c-91de9b84b5e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Notulen_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0bb0450-45fc-4751-b80c-91de9b84b5e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b78161cc-96a7-4336-a29f-36c2a64e9dd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b78161cc-96a7-4336-a29f-36c2a64e9dd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Notulen_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b78161cc-96a7-4336-a29f-36c2a64e9dd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ade13fb-2ee1-47f7-b201-25a7574ac63c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ade13fb-2ee1-47f7-b201-25a7574ac63c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Notulen_Gemeenteraad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ade13fb-2ee1-47f7-b201-25a7574ac63c>.
+    
+<http://data.lblod.info/id/remote-data-objects/da8513d6-5f60-42f5-97d6-166503540dca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da8513d6-5f60-42f5-97d6-166503540dca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Notulen_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da8513d6-5f60-42f5-97d6-166503540dca>.
+    
+<http://data.lblod.info/id/remote-data-objects/a380f7da-1b5d-43f7-88db-a135c4268f89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a380f7da-1b5d-43f7-88db-a135c4268f89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Notulen_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a380f7da-1b5d-43f7-88db-a135c4268f89>.
+    
+<http://data.lblod.info/id/remote-data-objects/e60f72af-3012-463f-8ba2-9f73b9aebd76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e60f72af-3012-463f-8ba2-9f73b9aebd76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Notulen_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e60f72af-3012-463f-8ba2-9f73b9aebd76>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8167851-d577-4aec-98d5-fb166f6687b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8167851-d577-4aec-98d5-fb166f6687b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Notulen_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8167851-d577-4aec-98d5-fb166f6687b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/5482f03e-f051-49d0-8a55-6ea4df14e6c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5482f03e-f051-49d0-8a55-6ea4df14e6c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49051.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5482f03e-f051-49d0-8a55-6ea4df14e6c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/998f92f3-5347-489a-93c6-e0024ffc6f18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "998f92f3-5347-489a-93c6-e0024ffc6f18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49224.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/998f92f3-5347-489a-93c6-e0024ffc6f18>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9165f88-9145-46cd-ac1c-5db0a5f6a5fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9165f88-9145-46cd-ac1c-5db0a5f6a5fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49225.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9165f88-9145-46cd-ac1c-5db0a5f6a5fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc83bc77-631f-4e98-aca2-460ba7f7a6de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc83bc77-631f-4e98-aca2-460ba7f7a6de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49227.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc83bc77-631f-4e98-aca2-460ba7f7a6de>.
+    
+<http://data.lblod.info/id/remote-data-objects/b25b256f-ea53-4124-9b82-b2b86d3caef1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b25b256f-ea53-4124-9b82-b2b86d3caef1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49228.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b25b256f-ea53-4124-9b82-b2b86d3caef1>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f966a9d-3ff9-432a-832b-1be6baa653dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f966a9d-3ff9-432a-832b-1be6baa653dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49229.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f966a9d-3ff9-432a-832b-1be6baa653dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/39cf8c51-3683-4a8b-a0be-dadf303bbdf3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39cf8c51-3683-4a8b-a0be-dadf303bbdf3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49230.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39cf8c51-3683-4a8b-a0be-dadf303bbdf3>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a92693c-c737-44dc-a6e1-236866ecf91e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a92693c-c737-44dc-a6e1-236866ecf91e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49231.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a92693c-c737-44dc-a6e1-236866ecf91e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e3f6807-1052-428a-9f3f-b974ea86f5f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e3f6807-1052-428a-9f3f-b974ea86f5f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49232.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e3f6807-1052-428a-9f3f-b974ea86f5f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1270b525-8af8-4983-ab44-92822f9c3023> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1270b525-8af8-4983-ab44-92822f9c3023";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49234.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1270b525-8af8-4983-ab44-92822f9c3023>.
+    
+<http://data.lblod.info/id/remote-data-objects/348f837d-c959-461b-96a3-6cb3c750d549> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "348f837d-c959-461b-96a3-6cb3c750d549";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49235.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/348f837d-c959-461b-96a3-6cb3c750d549>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dcfcd9f-dbc5-4ca7-9239-f7e99b8ae3ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dcfcd9f-dbc5-4ca7-9239-f7e99b8ae3ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49251.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dcfcd9f-dbc5-4ca7-9239-f7e99b8ae3ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/c37d0a86-fe26-4f06-87bd-8ccbc2bc6973> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c37d0a86-fe26-4f06-87bd-8ccbc2bc6973";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49287.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c37d0a86-fe26-4f06-87bd-8ccbc2bc6973>.
+    
+<http://data.lblod.info/id/remote-data-objects/88e49bd7-50e6-4edd-a63d-df0159466c50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88e49bd7-50e6-4edd-a63d-df0159466c50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49705.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88e49bd7-50e6-4edd-a63d-df0159466c50>.
+    
+<http://data.lblod.info/id/remote-data-objects/672ff085-55f8-4324-b037-3f86331e8661> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "672ff085-55f8-4324-b037-3f86331e8661";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49761.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/672ff085-55f8-4324-b037-3f86331e8661>.
+    
+<http://data.lblod.info/id/remote-data-objects/afa2f662-8fc6-4dd1-8ce7-c59fc558deb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afa2f662-8fc6-4dd1-8ce7-c59fc558deb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49762.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afa2f662-8fc6-4dd1-8ce7-c59fc558deb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b0bdfb0-cb2b-48cf-9771-fcb952db4a46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b0bdfb0-cb2b-48cf-9771-fcb952db4a46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49764.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b0bdfb0-cb2b-48cf-9771-fcb952db4a46>.
+    
+<http://data.lblod.info/id/remote-data-objects/c72c4a55-4848-4be3-8cbf-820ab67b0064> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c72c4a55-4848-4be3-8cbf-820ab67b0064";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49765.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c72c4a55-4848-4be3-8cbf-820ab67b0064>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce895ab9-4e96-43e9-b032-6a63e5cca23e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce895ab9-4e96-43e9-b032-6a63e5cca23e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49766.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce895ab9-4e96-43e9-b032-6a63e5cca23e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d4fde48-ed06-435d-8421-8ee29632cdcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d4fde48-ed06-435d-8421-8ee29632cdcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49767.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d4fde48-ed06-435d-8421-8ee29632cdcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ee6c9ee-2d36-4cc3-80f3-0da107af86ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ee6c9ee-2d36-4cc3-80f3-0da107af86ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_49884.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ee6c9ee-2d36-4cc3-80f3-0da107af86ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/c384b22b-a088-40f8-aa73-c228cb2ef21f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c384b22b-a088-40f8-aa73-c228cb2ef21f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_04-07-2022_50182.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c384b22b-a088-40f8-aa73-c228cb2ef21f>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfe0cc37-47e1-4835-9e4f-792f826e84fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfe0cc37-47e1-4835-9e4f-792f826e84fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_20-12-2021_41679.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88336c82-f6d2-4d29-ba7c-2fc3723723e2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfe0cc37-47e1-4835-9e4f-792f826e84fe>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201630-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201630-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201630-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201630-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a4886343-3638-4452-9d47-985c50ea55a1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a4886343-3638-4452-9d47-985c50ea55a1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6573cb60-b787-4579-952c-8796c43fa4e6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/dbac3ea0-67a0-4c62-b3e0-7a64c8f2ec47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dbac3ea0-67a0-4c62-b3e0-7a64c8f2ec47";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6>.
+
+  <http://redpencil.data.gift/id/task/04876ebf-fcc7-4a7d-8477-3b927dbeb381> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "04876ebf-fcc7-4a7d-8477-3b927dbeb381";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a4886343-3638-4452-9d47-985c50ea55a1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/dbac3ea0-67a0-4c62-b3e0-7a64c8f2ec47>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7afb0fdd-a69f-42ca-a300-fb0e3e5bdb86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7afb0fdd-a69f-42ca-a300-fb0e3e5bdb86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_20-12-2021_41732.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7afb0fdd-a69f-42ca-a300-fb0e3e5bdb86>.
+    
+<http://data.lblod.info/id/remote-data-objects/c23a0e63-3352-43c3-8a61-beb33eb524c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c23a0e63-3352-43c3-8a61-beb33eb524c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_20-12-2021_41743.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c23a0e63-3352-43c3-8a61-beb33eb524c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f8be29b-6c17-4642-a5e5-2e905b78104d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f8be29b-6c17-4642-a5e5-2e905b78104d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_20-12-2021_41753.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f8be29b-6c17-4642-a5e5-2e905b78104d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8c9ac54-84fa-41e9-b6e3-2aef699a0ae1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8c9ac54-84fa-41e9-b6e3-2aef699a0ae1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_20-12-2021_41754.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8c9ac54-84fa-41e9-b6e3-2aef699a0ae1>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd483135-08b8-47e3-b325-36c438609972> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd483135-08b8-47e3-b325-36c438609972";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_20-12-2021_41755.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd483135-08b8-47e3-b325-36c438609972>.
+    
+<http://data.lblod.info/id/remote-data-objects/0033e113-70d2-47aa-9389-42bcab309532> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0033e113-70d2-47aa-9389-42bcab309532";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_20-12-2021_41757.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0033e113-70d2-47aa-9389-42bcab309532>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2be394a-dc34-4bb7-b6f5-ca4a5f4f5bbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2be394a-dc34-4bb7-b6f5-ca4a5f4f5bbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_25-04-2022_48607.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2be394a-dc34-4bb7-b6f5-ca4a5f4f5bbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fb5d6b8-1619-413f-92b8-1ea088ecb1cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fb5d6b8-1619-413f-92b8-1ea088ecb1cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_25-10-2021_38260.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fb5d6b8-1619-413f-92b8-1ea088ecb1cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/39a5ab59-fd68-42b0-8152-59caf8f54c6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39a5ab59-fd68-42b0-8152-59caf8f54c6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_25-10-2021_38803.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39a5ab59-fd68-42b0-8152-59caf8f54c6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e67aab5-6956-4d74-8fe6-e8f5f9cfa8d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e67aab5-6956-4d74-8fe6-e8f5f9cfa8d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_25-10-2021_40765.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e67aab5-6956-4d74-8fe6-e8f5f9cfa8d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/82a36fcb-eaa3-4d04-baf7-46626aafbbe0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82a36fcb-eaa3-4d04-baf7-46626aafbbe0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_25-10-2021_40779.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82a36fcb-eaa3-4d04-baf7-46626aafbbe0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a182fb9-ec40-4b89-a59c-941752569959> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a182fb9-ec40-4b89-a59c-941752569959";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_28-02-2022_43222.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a182fb9-ec40-4b89-a59c-941752569959>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dcab6b6-679a-46e3-830d-02e4c902ea9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dcab6b6-679a-46e3-830d-02e4c902ea9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_28-02-2022_43499.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dcab6b6-679a-46e3-830d-02e4c902ea9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/478ddf8c-3dd6-4fd6-8fff-2fae777a9df6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "478ddf8c-3dd6-4fd6-8fff-2fae777a9df6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_28-02-2022_46795.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/478ddf8c-3dd6-4fd6-8fff-2fae777a9df6>.
+    
+<http://data.lblod.info/id/remote-data-objects/423ba409-8590-4c3d-ae30-84981d017941> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "423ba409-8590-4c3d-ae30-84981d017941";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_28-03-2022_47257.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/423ba409-8590-4c3d-ae30-84981d017941>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac1bb082-f572-4e63-845b-7f1af56a6cae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac1bb082-f572-4e63-845b-7f1af56a6cae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_28-03-2022_48333.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac1bb082-f572-4e63-845b-7f1af56a6cae>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c382f6f-b00c-4a31-b520-abc8ee5e6b13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c382f6f-b00c-4a31-b520-abc8ee5e6b13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_29-11-2021_38804.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c382f6f-b00c-4a31-b520-abc8ee5e6b13>.
+    
+<http://data.lblod.info/id/remote-data-objects/1dd903a0-4958-497e-b008-d67ce8d3a3a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1dd903a0-4958-497e-b008-d67ce8d3a3a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_29-11-2021_39889.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1dd903a0-4958-497e-b008-d67ce8d3a3a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/480263cf-93bd-437e-b62b-d0836d8e94e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "480263cf-93bd-437e-b62b-d0836d8e94e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_29-11-2021_41303.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/480263cf-93bd-437e-b62b-d0836d8e94e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c5304d9-046b-40c8-a7f9-7396e8ea695f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c5304d9-046b-40c8-a7f9-7396e8ea695f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_29-11-2021_41504.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c5304d9-046b-40c8-a7f9-7396e8ea695f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1acde9c1-25e2-46ec-bbdc-b21c8ebf990a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1acde9c1-25e2-46ec-bbdc-b21c8ebf990a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_30-05-2022_48653.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1acde9c1-25e2-46ec-bbdc-b21c8ebf990a>.
+    
+<http://data.lblod.info/id/remote-data-objects/160bf1ce-e27c-42b5-8d5b-47deec1d4d88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "160bf1ce-e27c-42b5-8d5b-47deec1d4d88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_30-05-2022_49050.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/160bf1ce-e27c-42b5-8d5b-47deec1d4d88>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0253015-d72c-43c1-b0ca-0870044e2af5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0253015-d72c-43c1-b0ca-0870044e2af5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_30-05-2022_49195.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0253015-d72c-43c1-b0ca-0870044e2af5>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ef20492-5610-47e3-9b17-402b80af0ed7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ef20492-5610-47e3-9b17-402b80af0ed7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_30-05-2022_49272.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ef20492-5610-47e3-9b17-402b80af0ed7>.
+    
+<http://data.lblod.info/id/remote-data-objects/92801138-4a34-4d99-a9c1-dde033919d9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92801138-4a34-4d99-a9c1-dde033919d9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_30-05-2022_49320.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92801138-4a34-4d99-a9c1-dde033919d9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/bff4cd11-dddf-4de8-ba02-da42db063669> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bff4cd11-dddf-4de8-ba02-da42db063669";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/91e62aaa9be11d6ce1357efc99da93a802aa37f1b67cbf36becd4c30867fca1c/GetPublication?filename=Uittreksels_31-01-2022_43233.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bff4cd11-dddf-4de8-ba02-da42db063669>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b4fcecc-08d7-4e51-98ac-2cde311c2564> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b4fcecc-08d7-4e51-98ac-2cde311c2564";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b4fcecc-08d7-4e51-98ac-2cde311c2564>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc9b4689-5346-44d3-b91b-462fcc005fb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc9b4689-5346-44d3-b91b-462fcc005fb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc9b4689-5346-44d3-b91b-462fcc005fb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4791af7-2ca7-4549-8c8b-1eaf99388072> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4791af7-2ca7-4549-8c8b-1eaf99388072";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4791af7-2ca7-4549-8c8b-1eaf99388072>.
+    
+<http://data.lblod.info/id/remote-data-objects/6824792e-7683-4bef-b108-0276c873c0cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6824792e-7683-4bef-b108-0276c873c0cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6824792e-7683-4bef-b108-0276c873c0cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/aff84017-2fdc-4c7c-a636-fbd0d1e1eb6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aff84017-2fdc-4c7c-a636-fbd0d1e1eb6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aff84017-2fdc-4c7c-a636-fbd0d1e1eb6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd5c4d2d-5ae8-4228-bd86-abcab88718d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd5c4d2d-5ae8-4228-bd86-abcab88718d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd5c4d2d-5ae8-4228-bd86-abcab88718d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2b6e633-7e79-4b01-bb71-a48c158984c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2b6e633-7e79-4b01-bb71-a48c158984c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2b6e633-7e79-4b01-bb71-a48c158984c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/128d2924-91e4-4d99-8532-285ded809355> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "128d2924-91e4-4d99-8532-285ded809355";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/128d2924-91e4-4d99-8532-285ded809355>.
+    
+<http://data.lblod.info/id/remote-data-objects/90f32f54-20f9-4dc4-af0c-ebdb8b613414> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90f32f54-20f9-4dc4-af0c-ebdb8b613414";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90f32f54-20f9-4dc4-af0c-ebdb8b613414>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5e3cde1-d6a6-4114-9730-99f60e958310> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5e3cde1-d6a6-4114-9730-99f60e958310";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5e3cde1-d6a6-4114-9730-99f60e958310>.
+    
+<http://data.lblod.info/id/remote-data-objects/89f79f0b-6458-4141-b8b8-c886db92c4b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89f79f0b-6458-4141-b8b8-c886db92c4b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89f79f0b-6458-4141-b8b8-c886db92c4b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e9d8ff4-2b6c-447b-a4f9-d05773d37772> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e9d8ff4-2b6c-447b-a4f9-d05773d37772";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e9d8ff4-2b6c-447b-a4f9-d05773d37772>.
+    
+<http://data.lblod.info/id/remote-data-objects/74da4ed0-efaa-4684-a193-c8f5ed58fac1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74da4ed0-efaa-4684-a193-c8f5ed58fac1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74da4ed0-efaa-4684-a193-c8f5ed58fac1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f23dd95-3dde-4db6-8e4b-50f8af93690d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f23dd95-3dde-4db6-8e4b-50f8af93690d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f23dd95-3dde-4db6-8e4b-50f8af93690d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d477048d-b8ea-4414-a32c-fe5b787d8a5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d477048d-b8ea-4414-a32c-fe5b787d8a5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d477048d-b8ea-4414-a32c-fe5b787d8a5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bde0d534-1645-4cd6-af8f-aac98a75c778> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bde0d534-1645-4cd6-af8f-aac98a75c778";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bde0d534-1645-4cd6-af8f-aac98a75c778>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a93869f-23b5-4184-8baa-20edc296735b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a93869f-23b5-4184-8baa-20edc296735b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a93869f-23b5-4184-8baa-20edc296735b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0810e1d4-ba7d-4fcf-b108-856282d535e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0810e1d4-ba7d-4fcf-b108-856282d535e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=Uittreksels_04-07-2022_49415.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0810e1d4-ba7d-4fcf-b108-856282d535e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/39218d00-4102-42ae-938a-b924cd44cbc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39218d00-4102-42ae-938a-b924cd44cbc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=Uittreksels_04-07-2022_49770.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39218d00-4102-42ae-938a-b924cd44cbc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/056f5a8d-a5e9-4837-a098-4653cf370836> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "056f5a8d-a5e9-4837-a098-4653cf370836";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=Uittreksels_04-07-2022_49771.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/056f5a8d-a5e9-4837-a098-4653cf370836>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b98cd94-91be-479b-bfa8-0a947ca8f27f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b98cd94-91be-479b-bfa8-0a947ca8f27f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=Uittreksels_04-07-2022_49807.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b98cd94-91be-479b-bfa8-0a947ca8f27f>.
+    
+<http://data.lblod.info/id/remote-data-objects/53309c4b-beea-40fa-b7af-2f7d4817f57b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53309c4b-beea-40fa-b7af-2f7d4817f57b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=Uittreksels_20-12-2021_41773.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53309c4b-beea-40fa-b7af-2f7d4817f57b>.
+    
+<http://data.lblod.info/id/remote-data-objects/452570f8-4331-472f-89f4-bc240a9ee68a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "452570f8-4331-472f-89f4-bc240a9ee68a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=Uittreksels_29-11-2021_41511.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/452570f8-4331-472f-89f4-bc240a9ee68a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ef0eea2-ad08-4413-8104-39b56bbfabcf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ef0eea2-ad08-4413-8104-39b56bbfabcf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.poperinge.be/LBLODWeb/Home/Overzicht/f0f2bdaec6186f87d8f4ff65edeb4acd996bd2ed7ac9aea63e33c0d2cf54b900/GetPublication?filename=Uittreksels_30-05-2022_49324.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6573cb60-b787-4579-952c-8796c43fa4e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ef0eea2-ad08-4413-8104-39b56bbfabcf>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201631-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201631-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201631-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201631-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/47f34b28-88fc-41ff-b8c5-5ce8dbf8e07d> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "47f34b28-88fc-41ff-b8c5-5ce8dbf8e07d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "853ddf7f-d00a-4561-ae80-c2d99bebac5b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4b9b2758-8de8-460d-8e4d-bb36d8109cec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4b9b2758-8de8-460d-8e4d-bb36d8109cec";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b>.
+
+  <http://redpencil.data.gift/id/task/fdf15aaa-dd9a-40e9-9353-5ef96c12fe69> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fdf15aaa-dd9a-40e9-9353-5ef96c12fe69";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/47f34b28-88fc-41ff-b8c5-5ce8dbf8e07d>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4b9b2758-8de8-460d-8e4d-bb36d8109cec>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/cdf1318e-c6e0-4ff4-801c-fbbe1aae2a6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdf1318e-c6e0-4ff4-801c-fbbe1aae2a6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdf1318e-c6e0-4ff4-801c-fbbe1aae2a6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee38b4ff-e707-4282-8ab2-fd0a1d05e444> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee38b4ff-e707-4282-8ab2-fd0a1d05e444";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee38b4ff-e707-4282-8ab2-fd0a1d05e444>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d57bfad-0bc6-4aa6-940b-ad5b3192aed2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d57bfad-0bc6-4aa6-940b-ad5b3192aed2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d57bfad-0bc6-4aa6-940b-ad5b3192aed2>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebb7ccc9-7574-482f-9697-0a52cdfc659e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebb7ccc9-7574-482f-9697-0a52cdfc659e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebb7ccc9-7574-482f-9697-0a52cdfc659e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbffe92f-7517-49bb-a251-b216caff3f0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbffe92f-7517-49bb-a251-b216caff3f0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbffe92f-7517-49bb-a251-b216caff3f0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/52acaa58-6ba2-41bd-bf95-4ed6445fd392> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52acaa58-6ba2-41bd-bf95-4ed6445fd392";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52acaa58-6ba2-41bd-bf95-4ed6445fd392>.
+    
+<http://data.lblod.info/id/remote-data-objects/27a0b24d-d6cf-45f9-9a52-92b6b08135a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27a0b24d-d6cf-45f9-9a52-92b6b08135a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27a0b24d-d6cf-45f9-9a52-92b6b08135a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bd673f5-120d-44f2-8c55-205cce043551> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bd673f5-120d-44f2-8c55-205cce043551";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bd673f5-120d-44f2-8c55-205cce043551>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8d854ab-a557-4187-9f99-1acd1ff7e7ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8d854ab-a557-4187-9f99-1acd1ff7e7ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8d854ab-a557-4187-9f99-1acd1ff7e7ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfb4dd5f-16c9-49dd-8362-5a0cd9cbe9b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfb4dd5f-16c9-49dd-8362-5a0cd9cbe9b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfb4dd5f-16c9-49dd-8362-5a0cd9cbe9b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae104e5d-6e9b-45cc-9594-3b2d2e5427a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae104e5d-6e9b-45cc-9594-3b2d2e5427a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae104e5d-6e9b-45cc-9594-3b2d2e5427a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a78d0e8e-198b-423b-9bf6-945e1d9d00ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a78d0e8e-198b-423b-9bf6-945e1d9d00ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a78d0e8e-198b-423b-9bf6-945e1d9d00ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/790d4354-74bd-4d88-a035-dcd1e9ffefe1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "790d4354-74bd-4d88-a035-dcd1e9ffefe1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/790d4354-74bd-4d88-a035-dcd1e9ffefe1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c0fb78a-2654-429d-8435-0c1fec6ec495> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c0fb78a-2654-429d-8435-0c1fec6ec495";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_16-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c0fb78a-2654-429d-8435-0c1fec6ec495>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea101e2f-d592-402a-a075-a9cf44ca2bf0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea101e2f-d592-402a-a075-a9cf44ca2bf0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea101e2f-d592-402a-a075-a9cf44ca2bf0>.
+    
+<http://data.lblod.info/id/remote-data-objects/98f177f3-a61f-43d9-b999-90e097bd7f04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98f177f3-a61f-43d9-b999-90e097bd7f04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98f177f3-a61f-43d9-b999-90e097bd7f04>.
+    
+<http://data.lblod.info/id/remote-data-objects/1489ca58-1c72-43ad-9148-dadc24b045d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1489ca58-1c72-43ad-9148-dadc24b045d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1489ca58-1c72-43ad-9148-dadc24b045d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ea38bf6-5201-4c73-979c-6b21bee12229> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ea38bf6-5201-4c73-979c-6b21bee12229";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ea38bf6-5201-4c73-979c-6b21bee12229>.
+    
+<http://data.lblod.info/id/remote-data-objects/845d57d7-7816-4a61-bc1b-d5ced54f93e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "845d57d7-7816-4a61-bc1b-d5ced54f93e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/845d57d7-7816-4a61-bc1b-d5ced54f93e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b04553a0-27a0-4498-9b2b-a848e544a678> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b04553a0-27a0-4498-9b2b-a848e544a678";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b04553a0-27a0-4498-9b2b-a848e544a678>.
+    
+<http://data.lblod.info/id/remote-data-objects/671493d6-8fa1-41c6-8fd7-fe18a732125b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "671493d6-8fa1-41c6-8fd7-fe18a732125b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/671493d6-8fa1-41c6-8fd7-fe18a732125b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7491f4d1-c0d4-42f1-b2e4-099d5324289d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7491f4d1-c0d4-42f1-b2e4-099d5324289d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7491f4d1-c0d4-42f1-b2e4-099d5324289d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7f0bde8-e371-4bfb-92f8-c478c6a77dc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7f0bde8-e371-4bfb-92f8-c478c6a77dc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7f0bde8-e371-4bfb-92f8-c478c6a77dc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec5c116e-34bd-4603-9d5d-0a9daf3a3119> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec5c116e-34bd-4603-9d5d-0a9daf3a3119";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec5c116e-34bd-4603-9d5d-0a9daf3a3119>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4864937-2f52-4430-bb72-c5b2c7a3166b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4864937-2f52-4430-bb72-c5b2c7a3166b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4864937-2f52-4430-bb72-c5b2c7a3166b>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb3bf7a3-97f2-411d-8ecb-60901e9a40c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb3bf7a3-97f2-411d-8ecb-60901e9a40c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=Uittreksels_09-12-2021_53652.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb3bf7a3-97f2-411d-8ecb-60901e9a40c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/da762af1-5e1a-4ac8-a50b-b572355aeb65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da762af1-5e1a-4ac8-a50b-b572355aeb65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=Uittreksels_09-12-2021_53666.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da762af1-5e1a-4ac8-a50b-b572355aeb65>.
+    
+<http://data.lblod.info/id/remote-data-objects/422bf8f7-205e-41a9-8a19-c4bd9e02e69a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "422bf8f7-205e-41a9-8a19-c4bd9e02e69a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=Uittreksels_15-06-2022_56890.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/422bf8f7-205e-41a9-8a19-c4bd9e02e69a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9301faf-0585-4235-8395-e3dc65b0bda8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9301faf-0585-4235-8395-e3dc65b0bda8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=Uittreksels_16-02-2022_55288.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9301faf-0585-4235-8395-e3dc65b0bda8>.
+    
+<http://data.lblod.info/id/remote-data-objects/23b5da4b-9679-4d4c-8c05-f8069d8b5bf0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23b5da4b-9679-4d4c-8c05-f8069d8b5bf0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=Uittreksels_17-11-2021_53338.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23b5da4b-9679-4d4c-8c05-f8069d8b5bf0>.
+    
+<http://data.lblod.info/id/remote-data-objects/76ec0e47-9cdd-48a2-ac43-0f787e71db42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76ec0e47-9cdd-48a2-ac43-0f787e71db42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=Uittreksels_18-07-2022_58265.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76ec0e47-9cdd-48a2-ac43-0f787e71db42>.
+    
+<http://data.lblod.info/id/remote-data-objects/90488543-7314-46a3-9eb5-1e7d0fc0c44e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90488543-7314-46a3-9eb5-1e7d0fc0c44e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=Uittreksels_23-11-2021_53404.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90488543-7314-46a3-9eb5-1e7d0fc0c44e>.
+    
+<http://data.lblod.info/id/remote-data-objects/72df36eb-bd29-458b-8e88-58b5b90e6402> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72df36eb-bd29-458b-8e88-58b5b90e6402";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=Uittreksels_24-11-2021_53437.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72df36eb-bd29-458b-8e88-58b5b90e6402>.
+    
+<http://data.lblod.info/id/remote-data-objects/823842aa-17a5-488c-9c56-f6732ee4e0bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "823842aa-17a5-488c-9c56-f6732ee4e0bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=Uittreksels_25-01-2022_54780.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/823842aa-17a5-488c-9c56-f6732ee4e0bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5f02a27-18c6-44cb-b6df-4b295172d7c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5f02a27-18c6-44cb-b6df-4b295172d7c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=Uittreksels_25-04-2022_56139.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5f02a27-18c6-44cb-b6df-4b295172d7c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0a52e00-8595-49ff-8721-1dcaa8d0a0a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0a52e00-8595-49ff-8721-1dcaa8d0a0a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=Uittreksels_25-04-2022_56141.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0a52e00-8595-49ff-8721-1dcaa8d0a0a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/aae2b675-7a15-4001-87d0-5e13a9fcc58c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aae2b675-7a15-4001-87d0-5e13a9fcc58c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=Uittreksels_28-10-2021_53059.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aae2b675-7a15-4001-87d0-5e13a9fcc58c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6781e2f6-b613-4974-bd20-3cea160f8eac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6781e2f6-b613-4974-bd20-3cea160f8eac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/1344ada217d2f9d45fc40afe99e4f93debd7a0f57f216dd2b73b189faaf55065/GetPublication?filename=Uittreksels_28-10-2021_53072.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6781e2f6-b613-4974-bd20-3cea160f8eac>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bbbda70-d808-44d0-bd80-da2b04ba5db3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bbbda70-d808-44d0-bd80-da2b04ba5db3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Agenda_Gemeenteraad_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bbbda70-d808-44d0-bd80-da2b04ba5db3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d9e14f1-f46a-41d3-90bb-12826a05fa6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d9e14f1-f46a-41d3-90bb-12826a05fa6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Agenda_Gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d9e14f1-f46a-41d3-90bb-12826a05fa6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/70b24905-89cb-474a-a085-6e88c0d63977> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70b24905-89cb-474a-a085-6e88c0d63977";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Agenda_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70b24905-89cb-474a-a085-6e88c0d63977>.
+    
+<http://data.lblod.info/id/remote-data-objects/603baa83-343b-4ce4-9cfb-296b07addce0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "603baa83-343b-4ce4-9cfb-296b07addce0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Agenda_Gemeenteraad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/603baa83-343b-4ce4-9cfb-296b07addce0>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ddfdbac-c5e8-47d8-87de-40e1ae6bd660> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ddfdbac-c5e8-47d8-87de-40e1ae6bd660";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Agenda_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ddfdbac-c5e8-47d8-87de-40e1ae6bd660>.
+    
+<http://data.lblod.info/id/remote-data-objects/66b307e5-6868-49d4-aa38-e3ba109a8163> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66b307e5-6868-49d4-aa38-e3ba109a8163";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Agenda_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66b307e5-6868-49d4-aa38-e3ba109a8163>.
+    
+<http://data.lblod.info/id/remote-data-objects/c215ac9b-b54b-4674-ac19-d37439cf5ccc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c215ac9b-b54b-4674-ac19-d37439cf5ccc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Agenda_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c215ac9b-b54b-4674-ac19-d37439cf5ccc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c876e05-5110-428d-ae61-63b623683778> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c876e05-5110-428d-ae61-63b623683778";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Agenda_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c876e05-5110-428d-ae61-63b623683778>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b211652-254b-4d49-9daf-8eaf53b9a5c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b211652-254b-4d49-9daf-8eaf53b9a5c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=BesluitenLijst_Gemeenteraad_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b211652-254b-4d49-9daf-8eaf53b9a5c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9537b6b4-821a-4b7f-a3b3-5540264461e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9537b6b4-821a-4b7f-a3b3-5540264461e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=BesluitenLijst_Gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9537b6b4-821a-4b7f-a3b3-5540264461e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/08748194-74e8-4824-b0a1-853d965346d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08748194-74e8-4824-b0a1-853d965346d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08748194-74e8-4824-b0a1-853d965346d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e92c1231-783a-4d22-b85f-32ca4808a1c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e92c1231-783a-4d22-b85f-32ca4808a1c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/853ddf7f-d00a-4561-ae80-c2d99bebac5b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e92c1231-783a-4d22-b85f-32ca4808a1c9>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201633-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201633-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201633-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201633-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3c5afffb-b299-493c-82f7-0c8ed6ae2cf8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3c5afffb-b299-493c-82f7-0c8ed6ae2cf8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f1694cba-53c1-4e64-b4d5-b381a9cf7c94";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/03723a11-5f6e-476d-8d96-87077687a354> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "03723a11-5f6e-476d-8d96-87077687a354";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94>.
+
+  <http://redpencil.data.gift/id/task/1a47bc21-fd03-4e0f-bbba-3fcc8004e234> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1a47bc21-fd03-4e0f-bbba-3fcc8004e234";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3c5afffb-b299-493c-82f7-0c8ed6ae2cf8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/03723a11-5f6e-476d-8d96-87077687a354>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e74aa95d-cb54-4525-af81-108fd94c1ff8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e74aa95d-cb54-4525-af81-108fd94c1ff8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e74aa95d-cb54-4525-af81-108fd94c1ff8>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa94d466-629c-4c2f-9945-91c2e31ab320> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa94d466-629c-4c2f-9945-91c2e31ab320";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa94d466-629c-4c2f-9945-91c2e31ab320>.
+    
+<http://data.lblod.info/id/remote-data-objects/30a52437-107a-4893-ab32-af04267d7597> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30a52437-107a-4893-ab32-af04267d7597";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30a52437-107a-4893-ab32-af04267d7597>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c061da6-6827-41ab-a228-873228cc1d1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c061da6-6827-41ab-a228-873228cc1d1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c061da6-6827-41ab-a228-873228cc1d1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e369962-6d49-484c-8b1d-b8d61a1da465> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e369962-6d49-484c-8b1d-b8d61a1da465";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Notulen_Gemeenteraad_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e369962-6d49-484c-8b1d-b8d61a1da465>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6bb766d-0483-4355-81af-b9efe2cdab69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6bb766d-0483-4355-81af-b9efe2cdab69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Notulen_Gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6bb766d-0483-4355-81af-b9efe2cdab69>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0884f5e-dc1b-4096-a4bd-249a7b65e17b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0884f5e-dc1b-4096-a4bd-249a7b65e17b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Notulen_Gemeenteraad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0884f5e-dc1b-4096-a4bd-249a7b65e17b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7c61141-e927-4274-8973-48086480dec4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7c61141-e927-4274-8973-48086480dec4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Notulen_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7c61141-e927-4274-8973-48086480dec4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b89b324-e3a1-4f38-9343-b2dddfad8d89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b89b324-e3a1-4f38-9343-b2dddfad8d89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Notulen_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b89b324-e3a1-4f38-9343-b2dddfad8d89>.
+    
+<http://data.lblod.info/id/remote-data-objects/835bb761-3157-451d-b5a2-de33354baad9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "835bb761-3157-451d-b5a2-de33354baad9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Notulen_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/835bb761-3157-451d-b5a2-de33354baad9>.
+    
+<http://data.lblod.info/id/remote-data-objects/dae5456d-b10e-472b-9ae7-36e5968ab6f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dae5456d-b10e-472b-9ae7-36e5968ab6f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dae5456d-b10e-472b-9ae7-36e5968ab6f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/85de3a53-8d2d-4357-bc78-cfa17edf04b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85de3a53-8d2d-4357-bc78-cfa17edf04b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_10-02-2022_54855.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85de3a53-8d2d-4357-bc78-cfa17edf04b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1e7228e-9675-490f-bb33-26a2f60ad114> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1e7228e-9675-490f-bb33-26a2f60ad114";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_19-05-2022_56291.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1e7228e-9675-490f-bb33-26a2f60ad114>.
+    
+<http://data.lblod.info/id/remote-data-objects/93349720-55d7-4cb0-9d8e-7ece295d66e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93349720-55d7-4cb0-9d8e-7ece295d66e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_19-05-2022_56292.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93349720-55d7-4cb0-9d8e-7ece295d66e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7430d83e-008b-4d27-9f15-d75b75515d3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7430d83e-008b-4d27-9f15-d75b75515d3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-06-2022_56669.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7430d83e-008b-4d27-9f15-d75b75515d3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a767e18-d893-4ebf-9d4c-adac0b5f45d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a767e18-d893-4ebf-9d4c-adac0b5f45d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-06-2022_56670.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a767e18-d893-4ebf-9d4c-adac0b5f45d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1306901-822c-4e93-a51b-e9f97d827ee5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1306901-822c-4e93-a51b-e9f97d827ee5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-06-2022_56705.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1306901-822c-4e93-a51b-e9f97d827ee5>.
+    
+<http://data.lblod.info/id/remote-data-objects/b868a62e-b2b1-43f3-a919-1592883bb613> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b868a62e-b2b1-43f3-a919-1592883bb613";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-06-2022_56706.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b868a62e-b2b1-43f3-a919-1592883bb613>.
+    
+<http://data.lblod.info/id/remote-data-objects/c12ef02c-5fd5-4ae5-bc30-d30903657508> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c12ef02c-5fd5-4ae5-bc30-d30903657508";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-06-2022_56707.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c12ef02c-5fd5-4ae5-bc30-d30903657508>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb6ae667-dea4-4cab-bfef-eee00f60dc9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb6ae667-dea4-4cab-bfef-eee00f60dc9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-06-2022_56708.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb6ae667-dea4-4cab-bfef-eee00f60dc9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfb2d97f-637b-41de-a855-834a11e5bc3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfb2d97f-637b-41de-a855-834a11e5bc3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-06-2022_56709.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfb2d97f-637b-41de-a855-834a11e5bc3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/19794a71-d97e-4703-a651-7c771757963c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19794a71-d97e-4703-a651-7c771757963c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-06-2022_56710.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19794a71-d97e-4703-a651-7c771757963c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d896dbef-11d1-4abf-9bf9-f541089191a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d896dbef-11d1-4abf-9bf9-f541089191a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-06-2022_56779.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d896dbef-11d1-4abf-9bf9-f541089191a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/61b340ee-a1a3-49b1-9c5f-c9b9ee95d670> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61b340ee-a1a3-49b1-9c5f-c9b9ee95d670";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53268.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61b340ee-a1a3-49b1-9c5f-c9b9ee95d670>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee6dd2db-f2b9-4864-bab7-3db414c92bf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee6dd2db-f2b9-4864-bab7-3db414c92bf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53269.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee6dd2db-f2b9-4864-bab7-3db414c92bf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b67fef8d-368b-4f38-aa10-de4121ccb29e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b67fef8d-368b-4f38-aa10-de4121ccb29e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53575.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b67fef8d-368b-4f38-aa10-de4121ccb29e>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa33cf76-8927-447c-be79-886c0b5303cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa33cf76-8927-447c-be79-886c0b5303cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53650.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa33cf76-8927-447c-be79-886c0b5303cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d862c8bd-a8d4-425f-8778-c230010a879c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d862c8bd-a8d4-425f-8778-c230010a879c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53655.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d862c8bd-a8d4-425f-8778-c230010a879c>.
+    
+<http://data.lblod.info/id/remote-data-objects/612df98b-4621-45ce-89bf-319b4f3af346> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "612df98b-4621-45ce-89bf-319b4f3af346";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53697.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/612df98b-4621-45ce-89bf-319b4f3af346>.
+    
+<http://data.lblod.info/id/remote-data-objects/43f2d1c7-85f2-45ec-a807-1a89d3f484aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43f2d1c7-85f2-45ec-a807-1a89d3f484aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53698.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43f2d1c7-85f2-45ec-a807-1a89d3f484aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/704a84aa-b0c2-4faf-becd-46600c80f99c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "704a84aa-b0c2-4faf-becd-46600c80f99c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53700.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/704a84aa-b0c2-4faf-becd-46600c80f99c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e141e037-a04c-47d5-b57a-04ac6f64ab1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e141e037-a04c-47d5-b57a-04ac6f64ab1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53701.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e141e037-a04c-47d5-b57a-04ac6f64ab1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc950765-a985-41f9-a544-56e2a5b3cc19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc950765-a985-41f9-a544-56e2a5b3cc19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53703.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc950765-a985-41f9-a544-56e2a5b3cc19>.
+    
+<http://data.lblod.info/id/remote-data-objects/d83abf7c-3f58-40e4-8cfd-d3121522912c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d83abf7c-3f58-40e4-8cfd-d3121522912c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53704.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d83abf7c-3f58-40e4-8cfd-d3121522912c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1734f787-bb53-484f-9868-e758ac0c7e04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1734f787-bb53-484f-9868-e758ac0c7e04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53705.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1734f787-bb53-484f-9868-e758ac0c7e04>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1f29d92-4528-4d59-b521-511fc7f1a97d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1f29d92-4528-4d59-b521-511fc7f1a97d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53706.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1f29d92-4528-4d59-b521-511fc7f1a97d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d92792c7-7603-4531-96c9-2a3b6c3d9525> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d92792c7-7603-4531-96c9-2a3b6c3d9525";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53707.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d92792c7-7603-4531-96c9-2a3b6c3d9525>.
+    
+<http://data.lblod.info/id/remote-data-objects/aaa2554e-9910-4476-914d-887f261f837f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aaa2554e-9910-4476-914d-887f261f837f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53708.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aaa2554e-9910-4476-914d-887f261f837f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a8b7491-6f63-4ea5-a675-ee59e45599bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a8b7491-6f63-4ea5-a675-ee59e45599bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53709.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a8b7491-6f63-4ea5-a675-ee59e45599bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1d0e578-a2e4-4d90-9d0f-dd57e4e12f45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1d0e578-a2e4-4d90-9d0f-dd57e4e12f45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53710.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1d0e578-a2e4-4d90-9d0f-dd57e4e12f45>.
+    
+<http://data.lblod.info/id/remote-data-objects/57aae99c-617c-47aa-86f2-d21ea3a931a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57aae99c-617c-47aa-86f2-d21ea3a931a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53713.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57aae99c-617c-47aa-86f2-d21ea3a931a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a0ba49b-70fc-42f2-940e-da581dce8bed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a0ba49b-70fc-42f2-940e-da581dce8bed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53719.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a0ba49b-70fc-42f2-940e-da581dce8bed>.
+    
+<http://data.lblod.info/id/remote-data-objects/c95ab734-4b5e-4827-86ba-f232ab90c7d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c95ab734-4b5e-4827-86ba-f232ab90c7d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53724.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c95ab734-4b5e-4827-86ba-f232ab90c7d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/91429824-cb00-4747-8d0d-8f85882b2a94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91429824-cb00-4747-8d0d-8f85882b2a94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53725.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91429824-cb00-4747-8d0d-8f85882b2a94>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1fd3573-e8fb-411a-8b0c-18cad76854e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1fd3573-e8fb-411a-8b0c-18cad76854e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_23-12-2021_53727.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1fd3573-e8fb-411a-8b0c-18cad76854e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/78e45e22-e1db-4ac0-a653-7f47f6afdae4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78e45e22-e1db-4ac0-a653-7f47f6afdae4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_24-03-2022_55244.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78e45e22-e1db-4ac0-a653-7f47f6afdae4>.
+    
+<http://data.lblod.info/id/remote-data-objects/43543e00-ce57-4513-8b79-a71c9c47b389> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43543e00-ce57-4513-8b79-a71c9c47b389";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_24-03-2022_55504.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43543e00-ce57-4513-8b79-a71c9c47b389>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c71f230-7d31-4d0d-a4f4-0fd1b97771e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c71f230-7d31-4d0d-a4f4-0fd1b97771e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_24-03-2022_55513.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c71f230-7d31-4d0d-a4f4-0fd1b97771e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e84d9dea-d14f-4129-b0ab-39c2afecbcd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e84d9dea-d14f-4129-b0ab-39c2afecbcd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_25-11-2021_53192.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e84d9dea-d14f-4129-b0ab-39c2afecbcd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/566e7046-c1c8-4e4d-9838-bbd789311d1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "566e7046-c1c8-4e4d-9838-bbd789311d1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_25-11-2021_53272.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f1694cba-53c1-4e64-b4d5-b381a9cf7c94> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/566e7046-c1c8-4e4d-9838-bbd789311d1e>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201634-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201634-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201634-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201634-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/fc3696bd-9e59-446c-aea2-7ebbf6d61f2a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fc3696bd-9e59-446c-aea2-7ebbf6d61f2a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/421c834c-f586-46dd-adef-f70414b081bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "421c834c-f586-46dd-adef-f70414b081bb";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8>.
+
+  <http://redpencil.data.gift/id/task/6d6eb318-6ffa-4be1-a0d9-6e4c311de673> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6d6eb318-6ffa-4be1-a0d9-6e4c311de673";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/fc3696bd-9e59-446c-aea2-7ebbf6d61f2a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/421c834c-f586-46dd-adef-f70414b081bb>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/1b56c978-1315-4648-a584-a79a71e65b3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b56c978-1315-4648-a584-a79a71e65b3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_28-04-2022_54850.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b56c978-1315-4648-a584-a79a71e65b3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cee001a-fe60-4416-8e00-381db9776ac3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cee001a-fe60-4416-8e00-381db9776ac3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_28-04-2022_54851.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cee001a-fe60-4416-8e00-381db9776ac3>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8a6b511-69d0-4829-b848-addb25f6fee8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8a6b511-69d0-4829-b848-addb25f6fee8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_28-04-2022_55902.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8a6b511-69d0-4829-b848-addb25f6fee8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a12fe4f9-e115-481c-9862-45253188aebd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a12fe4f9-e115-481c-9862-45253188aebd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_28-04-2022_55904.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a12fe4f9-e115-481c-9862-45253188aebd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d26c7892-458e-41bc-bb44-26ecd65179cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d26c7892-458e-41bc-bb44-26ecd65179cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_28-10-2021_52605.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d26c7892-458e-41bc-bb44-26ecd65179cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/81877dce-07db-4427-9688-a5943ba65525> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81877dce-07db-4427-9688-a5943ba65525";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/44d83f242a9e71b1411fd9f736e5fd1d56fcf86019fb26b88ad7e727ab48bdb9/GetPublication?filename=Uittreksels_28-10-2021_52902.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81877dce-07db-4427-9688-a5943ba65525>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7c9628c-e6e6-459d-9a26-0e8d8413a334> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7c9628c-e6e6-459d-9a26-0e8d8413a334";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7c9628c-e6e6-459d-9a26-0e8d8413a334>.
+    
+<http://data.lblod.info/id/remote-data-objects/616f735b-412b-4106-98f7-5d6efb260a36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "616f735b-412b-4106-98f7-5d6efb260a36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/616f735b-412b-4106-98f7-5d6efb260a36>.
+    
+<http://data.lblod.info/id/remote-data-objects/4355d287-3fbd-49d2-9091-3d842e3f96b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4355d287-3fbd-49d2-9091-3d842e3f96b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4355d287-3fbd-49d2-9091-3d842e3f96b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fe7baff-244d-4e76-9243-f0fcb00bac3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fe7baff-244d-4e76-9243-f0fcb00bac3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fe7baff-244d-4e76-9243-f0fcb00bac3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f194450a-7c25-4967-a46e-7af21aee9721> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f194450a-7c25-4967-a46e-7af21aee9721";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f194450a-7c25-4967-a46e-7af21aee9721>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e53d264-0d2b-4ba0-a432-7fbdbae9da82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e53d264-0d2b-4ba0-a432-7fbdbae9da82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e53d264-0d2b-4ba0-a432-7fbdbae9da82>.
+    
+<http://data.lblod.info/id/remote-data-objects/59b14d3a-3fcf-4b69-9507-93b92aa43536> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59b14d3a-3fcf-4b69-9507-93b92aa43536";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59b14d3a-3fcf-4b69-9507-93b92aa43536>.
+    
+<http://data.lblod.info/id/remote-data-objects/f22df5ce-282d-4fd7-9560-8c5035c3edae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f22df5ce-282d-4fd7-9560-8c5035c3edae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f22df5ce-282d-4fd7-9560-8c5035c3edae>.
+    
+<http://data.lblod.info/id/remote-data-objects/057b0fa2-9229-482c-a855-496c1fff8c4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "057b0fa2-9229-482c-a855-496c1fff8c4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/057b0fa2-9229-482c-a855-496c1fff8c4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab0dd3aa-09fe-4221-899f-696db73d4319> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab0dd3aa-09fe-4221-899f-696db73d4319";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab0dd3aa-09fe-4221-899f-696db73d4319>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6eb3a2e-d53f-4dee-ada5-9c95403ba31a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6eb3a2e-d53f-4dee-ada5-9c95403ba31a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6eb3a2e-d53f-4dee-ada5-9c95403ba31a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b56938e-2cf3-44b3-a325-fa6a8c4d5b0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b56938e-2cf3-44b3-a325-fa6a8c4d5b0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b56938e-2cf3-44b3-a325-fa6a8c4d5b0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2a0a61d-cfb2-492f-b67d-7c55420f75dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2a0a61d-cfb2-492f-b67d-7c55420f75dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2a0a61d-cfb2-492f-b67d-7c55420f75dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/291dc6e6-b268-494f-9a3b-bf689d38d734> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "291dc6e6-b268-494f-9a3b-bf689d38d734";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/291dc6e6-b268-494f-9a3b-bf689d38d734>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e9cecf1-93ce-4de0-97c8-21897234eb78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e9cecf1-93ce-4de0-97c8-21897234eb78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e9cecf1-93ce-4de0-97c8-21897234eb78>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb729e00-878c-48e3-8223-f14a105b65d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb729e00-878c-48e3-8223-f14a105b65d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb729e00-878c-48e3-8223-f14a105b65d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a441aadb-0c22-46de-909c-41a0ae512cf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a441aadb-0c22-46de-909c-41a0ae512cf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a441aadb-0c22-46de-909c-41a0ae512cf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/18afebd3-0d32-47c4-bf16-74d28f3d10b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18afebd3-0d32-47c4-bf16-74d28f3d10b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18afebd3-0d32-47c4-bf16-74d28f3d10b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fa49b51-ce15-48e7-ab6f-623b77804293> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fa49b51-ce15-48e7-ab6f-623b77804293";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fa49b51-ce15-48e7-ab6f-623b77804293>.
+    
+<http://data.lblod.info/id/remote-data-objects/82549a03-ff5d-46d8-813b-8d91cb71418d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82549a03-ff5d-46d8-813b-8d91cb71418d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82549a03-ff5d-46d8-813b-8d91cb71418d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fba4eb66-ad95-4a7c-93bd-7bed916b0461> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fba4eb66-ad95-4a7c-93bd-7bed916b0461";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fba4eb66-ad95-4a7c-93bd-7bed916b0461>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3c51463-f3eb-4890-a7a5-422db96fb8cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3c51463-f3eb-4890-a7a5-422db96fb8cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3c51463-f3eb-4890-a7a5-422db96fb8cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d299b3d0-fe0b-4f10-8fbd-264795b61f62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d299b3d0-fe0b-4f10-8fbd-264795b61f62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d299b3d0-fe0b-4f10-8fbd-264795b61f62>.
+    
+<http://data.lblod.info/id/remote-data-objects/68485447-eb1c-4f44-97c5-76f758222e77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68485447-eb1c-4f44-97c5-76f758222e77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68485447-eb1c-4f44-97c5-76f758222e77>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ffb5b5f-ad2f-4025-8de0-2a5647f4c0f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ffb5b5f-ad2f-4025-8de0-2a5647f4c0f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ffb5b5f-ad2f-4025-8de0-2a5647f4c0f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f7813ac-e378-4188-a5dd-477a9cd25aac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f7813ac-e378-4188-a5dd-477a9cd25aac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f7813ac-e378-4188-a5dd-477a9cd25aac>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ccb3563-c8cd-4e6f-ae03-7294dc7b83fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ccb3563-c8cd-4e6f-ae03-7294dc7b83fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ccb3563-c8cd-4e6f-ae03-7294dc7b83fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/74eaed1c-d03b-479c-8b7e-1335319ed63a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74eaed1c-d03b-479c-8b7e-1335319ed63a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74eaed1c-d03b-479c-8b7e-1335319ed63a>.
+    
+<http://data.lblod.info/id/remote-data-objects/860124f7-c091-4400-af5a-15959e9c273d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "860124f7-c091-4400-af5a-15959e9c273d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/860124f7-c091-4400-af5a-15959e9c273d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d281b16-2434-412b-9406-baffcec9509f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d281b16-2434-412b-9406-baffcec9509f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d281b16-2434-412b-9406-baffcec9509f>.
+    
+<http://data.lblod.info/id/remote-data-objects/937ac811-7d78-40e2-8296-581c9aadc3a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "937ac811-7d78-40e2-8296-581c9aadc3a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/937ac811-7d78-40e2-8296-581c9aadc3a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ff11f56-1c4f-46df-9d92-fbb80a4fe524> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ff11f56-1c4f-46df-9d92-fbb80a4fe524";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ff11f56-1c4f-46df-9d92-fbb80a4fe524>.
+    
+<http://data.lblod.info/id/remote-data-objects/0046ce58-bca0-40f0-bcde-042d69eedbcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0046ce58-bca0-40f0-bcde-042d69eedbcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0046ce58-bca0-40f0-bcde-042d69eedbcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/83c99b36-3840-416b-bdfa-aa5bea5354c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83c99b36-3840-416b-bdfa-aa5bea5354c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83c99b36-3840-416b-bdfa-aa5bea5354c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa13ae96-e251-4d48-9d11-e86b76bd51ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa13ae96-e251-4d48-9d11-e86b76bd51ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa13ae96-e251-4d48-9d11-e86b76bd51ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/afe4dc0a-157e-4ddf-a872-4abad3191d63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afe4dc0a-157e-4ddf-a872-4abad3191d63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afe4dc0a-157e-4ddf-a872-4abad3191d63>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ceb8780-053f-4069-97b2-2055d18f21c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ceb8780-053f-4069-97b2-2055d18f21c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ceb8780-053f-4069-97b2-2055d18f21c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/da264af2-386e-4e0e-a1aa-b4e84ccad044> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da264af2-386e-4e0e-a1aa-b4e84ccad044";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da264af2-386e-4e0e-a1aa-b4e84ccad044>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e8cc94e-00fd-4947-9f34-8310b8c8f03a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e8cc94e-00fd-4947-9f34-8310b8c8f03a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e8cc94e-00fd-4947-9f34-8310b8c8f03a>.
+    
+<http://data.lblod.info/id/remote-data-objects/72be279c-38a8-4e1b-8bbd-4091af09084d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72be279c-38a8-4e1b-8bbd-4091af09084d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/615bbe86d482ba474256634ad071b89f045666192fb3572abedb847013bb3d9e/GetPublication?filename=BesluitenLijst_Vast%20bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72be279c-38a8-4e1b-8bbd-4091af09084d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab60b501-47c6-432f-adb2-6939e4af7b13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab60b501-47c6-432f-adb2-6939e4af7b13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab60b501-47c6-432f-adb2-6939e4af7b13>.
+    
+<http://data.lblod.info/id/remote-data-objects/6365d804-8ed5-4721-bc51-a0b10908ceef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6365d804-8ed5-4721-bc51-a0b10908ceef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6365d804-8ed5-4721-bc51-a0b10908ceef>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d05b567-3db9-40cc-aa34-6923c0a8a4f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d05b567-3db9-40cc-aa34-6923c0a8a4f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d05b567-3db9-40cc-aa34-6923c0a8a4f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/9946f8e7-9601-4282-90e6-a1aed823e342> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9946f8e7-9601-4282-90e6-a1aed823e342";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ccbd2b2-5efd-4a83-b618-9ec0e5a04ba8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9946f8e7-9601-4282-90e6-a1aed823e342>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201635-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201635-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201635-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201635-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/88821931-1d11-44dd-8b6c-39617a174790> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "88821931-1d11-44dd-8b6c-39617a174790";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "90c301d9-ab0c-4cb9-9de6-4938400737ce";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/1ab5b676-2184-4aee-bd05-7710caee4bfd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1ab5b676-2184-4aee-bd05-7710caee4bfd";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce>.
+
+  <http://redpencil.data.gift/id/task/a1fb699b-0607-42bd-9f3d-45d5d17fb553> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a1fb699b-0607-42bd-9f3d-45d5d17fb553";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/88821931-1d11-44dd-8b6c-39617a174790>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/1ab5b676-2184-4aee-bd05-7710caee4bfd>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d82684b8-3fef-45ff-83e2-4ada8a54ef95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d82684b8-3fef-45ff-83e2-4ada8a54ef95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d82684b8-3fef-45ff-83e2-4ada8a54ef95>.
+    
+<http://data.lblod.info/id/remote-data-objects/aded0abb-1fb3-4b80-8cc2-5860c9fa7e2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aded0abb-1fb3-4b80-8cc2-5860c9fa7e2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aded0abb-1fb3-4b80-8cc2-5860c9fa7e2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/38fe8094-c261-4518-b283-00e8d6dc0c5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38fe8094-c261-4518-b283-00e8d6dc0c5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38fe8094-c261-4518-b283-00e8d6dc0c5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/15883c2a-e32b-478c-b01c-c91e274db1b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15883c2a-e32b-478c-b01c-c91e274db1b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15883c2a-e32b-478c-b01c-c91e274db1b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fb95634-b3f9-42c4-a413-cae9229fbc00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fb95634-b3f9-42c4-a413-cae9229fbc00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fb95634-b3f9-42c4-a413-cae9229fbc00>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc5c73f4-43d3-4762-a2da-28d311f82450> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc5c73f4-43d3-4762-a2da-28d311f82450";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc5c73f4-43d3-4762-a2da-28d311f82450>.
+    
+<http://data.lblod.info/id/remote-data-objects/25dadf2b-6dd7-4e93-92bb-40411ff0d772> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25dadf2b-6dd7-4e93-92bb-40411ff0d772";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25dadf2b-6dd7-4e93-92bb-40411ff0d772>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a727684-5601-41c4-81aa-6e8c0f83aee3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a727684-5601-41c4-81aa-6e8c0f83aee3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a727684-5601-41c4-81aa-6e8c0f83aee3>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2a63cfd-1f49-4a3e-bb1f-f307a37c6928> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2a63cfd-1f49-4a3e-bb1f-f307a37c6928";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2a63cfd-1f49-4a3e-bb1f-f307a37c6928>.
+    
+<http://data.lblod.info/id/remote-data-objects/d15f5e59-5073-42ec-9858-1b1dc3841124> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d15f5e59-5073-42ec-9858-1b1dc3841124";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d15f5e59-5073-42ec-9858-1b1dc3841124>.
+    
+<http://data.lblod.info/id/remote-data-objects/a930047b-9ec9-4b53-8aca-201d9cadd7d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a930047b-9ec9-4b53-8aca-201d9cadd7d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a930047b-9ec9-4b53-8aca-201d9cadd7d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/496539a4-53df-4b73-b64e-4e5058f6af32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "496539a4-53df-4b73-b64e-4e5058f6af32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/496539a4-53df-4b73-b64e-4e5058f6af32>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f8723b9-022d-4605-bb7b-645f379e12f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f8723b9-022d-4605-bb7b-645f379e12f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f8723b9-022d-4605-bb7b-645f379e12f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/55be6c76-5e58-4043-84de-990633730cdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55be6c76-5e58-4043-84de-990633730cdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55be6c76-5e58-4043-84de-990633730cdf>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a893d83-196b-487c-8b18-a45a92f2839b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a893d83-196b-487c-8b18-a45a92f2839b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a893d83-196b-487c-8b18-a45a92f2839b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f51dcf44-4499-4778-a9dd-a2d284283881> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f51dcf44-4499-4778-a9dd-a2d284283881";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f51dcf44-4499-4778-a9dd-a2d284283881>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ac8e590-a01b-4d35-8c09-d62c90b3b976> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ac8e590-a01b-4d35-8c09-d62c90b3b976";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ac8e590-a01b-4d35-8c09-d62c90b3b976>.
+    
+<http://data.lblod.info/id/remote-data-objects/193b172d-4f07-46cc-91e9-f75a41fab76a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "193b172d-4f07-46cc-91e9-f75a41fab76a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/193b172d-4f07-46cc-91e9-f75a41fab76a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3044da65-7351-444a-9195-5f9e05128902> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3044da65-7351-444a-9195-5f9e05128902";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3044da65-7351-444a-9195-5f9e05128902>.
+    
+<http://data.lblod.info/id/remote-data-objects/63dce9d0-f6ca-4f79-9b3f-e4bde1ac01ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63dce9d0-f6ca-4f79-9b3f-e4bde1ac01ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Uittreksels_23-12-2021_53596.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63dce9d0-f6ca-4f79-9b3f-e4bde1ac01ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/5369168c-5633-46d9-bfa9-c1ff32f0f21e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5369168c-5633-46d9-bfa9-c1ff32f0f21e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Uittreksels_23-12-2021_53720.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5369168c-5633-46d9-bfa9-c1ff32f0f21e>.
+    
+<http://data.lblod.info/id/remote-data-objects/807c0604-4558-42d4-ae87-d16451ff6ee6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "807c0604-4558-42d4-ae87-d16451ff6ee6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Uittreksels_24-03-2022_55386.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/807c0604-4558-42d4-ae87-d16451ff6ee6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a18d6582-51ae-4530-9bd9-50c41eb3bcfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a18d6582-51ae-4530-9bd9-50c41eb3bcfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Uittreksels_24-03-2022_55387.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a18d6582-51ae-4530-9bd9-50c41eb3bcfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/3aa05c59-bbf7-4bbd-ac14-e8cd46b928bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3aa05c59-bbf7-4bbd-ac14-e8cd46b928bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/ac85a084b2d9fade222f7b4792648c3068fc24d08b124483171e78efffd375ce/GetPublication?filename=Uittreksels_28-04-2022_55905.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3aa05c59-bbf7-4bbd-ac14-e8cd46b928bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b935314-0a26-452c-b211-305a9e6c7b08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b935314-0a26-452c-b211-305a9e6c7b08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b935314-0a26-452c-b211-305a9e6c7b08>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ca0cfa9-3d33-4084-b7ef-aab19f19f438> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ca0cfa9-3d33-4084-b7ef-aab19f19f438";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ca0cfa9-3d33-4084-b7ef-aab19f19f438>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e8e506c-2356-46f6-b5ff-c895e2e5e55e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e8e506c-2356-46f6-b5ff-c895e2e5e55e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e8e506c-2356-46f6-b5ff-c895e2e5e55e>.
+    
+<http://data.lblod.info/id/remote-data-objects/85e8bdd7-562c-4bfc-b93f-8232302ebd2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85e8bdd7-562c-4bfc-b93f-8232302ebd2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85e8bdd7-562c-4bfc-b93f-8232302ebd2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffe669b7-c501-4a42-9e50-b901c48d8a06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffe669b7-c501-4a42-9e50-b901c48d8a06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffe669b7-c501-4a42-9e50-b901c48d8a06>.
+    
+<http://data.lblod.info/id/remote-data-objects/381be1fe-9bf4-46c5-952c-0e90ba82cc52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "381be1fe-9bf4-46c5-952c-0e90ba82cc52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/381be1fe-9bf4-46c5-952c-0e90ba82cc52>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8e0ebde-1639-4f51-9303-62136db4c3c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8e0ebde-1639-4f51-9303-62136db4c3c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8e0ebde-1639-4f51-9303-62136db4c3c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e5982cf-7ea3-4f4c-9ccf-46c69f043039> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e5982cf-7ea3-4f4c-9ccf-46c69f043039";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e5982cf-7ea3-4f4c-9ccf-46c69f043039>.
+    
+<http://data.lblod.info/id/remote-data-objects/53954ff0-70b9-4ecb-ae55-59fedefbbdb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53954ff0-70b9-4ecb-ae55-59fedefbbdb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53954ff0-70b9-4ecb-ae55-59fedefbbdb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2659bf4-f6a0-409c-983f-4d8ac81e4adc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2659bf4-f6a0-409c-983f-4d8ac81e4adc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2659bf4-f6a0-409c-983f-4d8ac81e4adc>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c2bdec1-57cd-4cd8-9d6f-a0986d690831> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c2bdec1-57cd-4cd8-9d6f-a0986d690831";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c2bdec1-57cd-4cd8-9d6f-a0986d690831>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed30f63c-188c-4b0e-aae9-9feda4fa3bd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed30f63c-188c-4b0e-aae9-9feda4fa3bd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed30f63c-188c-4b0e-aae9-9feda4fa3bd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/4958fc7d-4e59-4f25-ac16-5b060cc49aa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4958fc7d-4e59-4f25-ac16-5b060cc49aa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4958fc7d-4e59-4f25-ac16-5b060cc49aa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5f7cd29-fb5a-44c6-99ca-3747fc654cd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5f7cd29-fb5a-44c6-99ca-3747fc654cd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5f7cd29-fb5a-44c6-99ca-3747fc654cd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac3006c0-ce5a-4e8d-a7ad-8e196fb333ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac3006c0-ce5a-4e8d-a7ad-8e196fb333ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac3006c0-ce5a-4e8d-a7ad-8e196fb333ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/af47d21b-8e80-4cf5-97a5-9fefc1aed908> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af47d21b-8e80-4cf5-97a5-9fefc1aed908";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af47d21b-8e80-4cf5-97a5-9fefc1aed908>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f819253-4148-4d5b-b647-fb90fcd56fb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f819253-4148-4d5b-b647-fb90fcd56fb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f819253-4148-4d5b-b647-fb90fcd56fb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e56f26da-bcfb-4753-8a3e-cc4203b33a26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e56f26da-bcfb-4753-8a3e-cc4203b33a26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e56f26da-bcfb-4753-8a3e-cc4203b33a26>.
+    
+<http://data.lblod.info/id/remote-data-objects/f52227ef-7ac2-438d-90b9-cad5e86b0eac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f52227ef-7ac2-438d-90b9-cad5e86b0eac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f52227ef-7ac2-438d-90b9-cad5e86b0eac>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b538115-6c1f-4238-bdec-b3d97091bddd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b538115-6c1f-4238-bdec-b3d97091bddd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b538115-6c1f-4238-bdec-b3d97091bddd>.
+    
+<http://data.lblod.info/id/remote-data-objects/f38b500d-172f-4441-a9e1-a742c2cb6408> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f38b500d-172f-4441-a9e1-a742c2cb6408";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f38b500d-172f-4441-a9e1-a742c2cb6408>.
+    
+<http://data.lblod.info/id/remote-data-objects/585b9252-c61f-4fc8-a1f5-dc9570f2942d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "585b9252-c61f-4fc8-a1f5-dc9570f2942d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/585b9252-c61f-4fc8-a1f5-dc9570f2942d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1be9e92-7f23-440c-8145-a601dae3d598> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1be9e92-7f23-440c-8145-a601dae3d598";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_17-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1be9e92-7f23-440c-8145-a601dae3d598>.
+    
+<http://data.lblod.info/id/remote-data-objects/51464a6f-5a67-48dd-8a12-5cdd9a2f829f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51464a6f-5a67-48dd-8a12-5cdd9a2f829f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51464a6f-5a67-48dd-8a12-5cdd9a2f829f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3acbbf5d-3613-487e-b670-9a9a52cfe176> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3acbbf5d-3613-487e-b670-9a9a52cfe176";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3acbbf5d-3613-487e-b670-9a9a52cfe176>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2822d3d-455e-4f37-bc88-078b95c4d529> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2822d3d-455e-4f37-bc88-078b95c4d529";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/90c301d9-ab0c-4cb9-9de6-4938400737ce> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2822d3d-455e-4f37-bc88-078b95c4d529>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201636-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201636-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201636-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201636-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f7ad4696-3d0b-41b4-9170-6c157f681858> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f7ad4696-3d0b-41b4-9170-6c157f681858";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c1c40bf3-33d7-4bca-8473-5979d557bc28";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ab0a3493-fd6a-4b15-9157-8196dcb06f0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ab0a3493-fd6a-4b15-9157-8196dcb06f0f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28>.
+
+  <http://redpencil.data.gift/id/task/6df86617-fc72-4ac4-b6ec-e9dd7a4eb269> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6df86617-fc72-4ac4-b6ec-e9dd7a4eb269";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f7ad4696-3d0b-41b4-9170-6c157f681858>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ab0a3493-fd6a-4b15-9157-8196dcb06f0f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/22cd00a1-c01d-42d0-9d4a-c0040b59896b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22cd00a1-c01d-42d0-9d4a-c0040b59896b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22cd00a1-c01d-42d0-9d4a-c0040b59896b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9e2543c-fc95-4674-bf0f-d6c3d6163cc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9e2543c-fc95-4674-bf0f-d6c3d6163cc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9e2543c-fc95-4674-bf0f-d6c3d6163cc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/41cfd928-a026-4b6c-a7ea-d35005d7227c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41cfd928-a026-4b6c-a7ea-d35005d7227c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41cfd928-a026-4b6c-a7ea-d35005d7227c>.
+    
+<http://data.lblod.info/id/remote-data-objects/424e8f32-d3ab-42fd-ae8c-12406f5e4277> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "424e8f32-d3ab-42fd-ae8c-12406f5e4277";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/424e8f32-d3ab-42fd-ae8c-12406f5e4277>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b352b69-b9e2-49b8-a15e-1094c491c668> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b352b69-b9e2-49b8-a15e-1094c491c668";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b352b69-b9e2-49b8-a15e-1094c491c668>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e3dc58b-9815-4ecc-9ee7-73575182bab3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e3dc58b-9815-4ecc-9ee7-73575182bab3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e3dc58b-9815-4ecc-9ee7-73575182bab3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a110c56-80fb-4e27-8073-65e22425000f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a110c56-80fb-4e27-8073-65e22425000f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a110c56-80fb-4e27-8073-65e22425000f>.
+    
+<http://data.lblod.info/id/remote-data-objects/07f0acd9-a12a-4491-8bf6-71844d9e99ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07f0acd9-a12a-4491-8bf6-71844d9e99ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07f0acd9-a12a-4491-8bf6-71844d9e99ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6a79a56-1071-423e-bff9-5a06e46d3003> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6a79a56-1071-423e-bff9-5a06e46d3003";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6a79a56-1071-423e-bff9-5a06e46d3003>.
+    
+<http://data.lblod.info/id/remote-data-objects/50801230-02b0-4f61-bb26-2370e13fbaab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50801230-02b0-4f61-bb26-2370e13fbaab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50801230-02b0-4f61-bb26-2370e13fbaab>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6fb9c87-643f-4597-a1bd-915fdd25ca25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6fb9c87-643f-4597-a1bd-915fdd25ca25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6fb9c87-643f-4597-a1bd-915fdd25ca25>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd546376-4e78-4dcd-ba41-28de46fe8f62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd546376-4e78-4dcd-ba41-28de46fe8f62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd546376-4e78-4dcd-ba41-28de46fe8f62>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcf1d5ad-72e7-46cb-a1f8-4adeec93a793> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcf1d5ad-72e7-46cb-a1f8-4adeec93a793";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcf1d5ad-72e7-46cb-a1f8-4adeec93a793>.
+    
+<http://data.lblod.info/id/remote-data-objects/75b11c93-d93e-4735-8478-77e7f255e504> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75b11c93-d93e-4735-8478-77e7f255e504";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75b11c93-d93e-4735-8478-77e7f255e504>.
+    
+<http://data.lblod.info/id/remote-data-objects/8429f05a-f640-4288-8931-1af327da8755> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8429f05a-f640-4288-8931-1af327da8755";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8429f05a-f640-4288-8931-1af327da8755>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec454d80-7cd6-4e0e-babb-bc9fb0748468> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec454d80-7cd6-4e0e-babb-bc9fb0748468";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_29-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec454d80-7cd6-4e0e-babb-bc9fb0748468>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd28211f-f5bf-4573-be66-0b0c09938d16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd28211f-f5bf-4573-be66-0b0c09938d16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd28211f-f5bf-4573-be66-0b0c09938d16>.
+    
+<http://data.lblod.info/id/remote-data-objects/9810f1c7-9e8a-4358-9b32-910d8a5b8795> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9810f1c7-9e8a-4358-9b32-910d8a5b8795";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9810f1c7-9e8a-4358-9b32-910d8a5b8795>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa0b27d4-f9fa-47e7-8db2-6417a3d63c07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa0b27d4-f9fa-47e7-8db2-6417a3d63c07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_02-05-2022_56131.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa0b27d4-f9fa-47e7-8db2-6417a3d63c07>.
+    
+<http://data.lblod.info/id/remote-data-objects/95531260-78c1-429c-99b0-c58f67e28310> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95531260-78c1-429c-99b0-c58f67e28310";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_02-05-2022_56137.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95531260-78c1-429c-99b0-c58f67e28310>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec945336-2383-43b5-b631-4257e6d0ec2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec945336-2383-43b5-b631-4257e6d0ec2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_02-05-2022_56183.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec945336-2383-43b5-b631-4257e6d0ec2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fed8f21-9cc9-4963-9f2f-ab193c792cf0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fed8f21-9cc9-4963-9f2f-ab193c792cf0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_02-05-2022_56220.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fed8f21-9cc9-4963-9f2f-ab193c792cf0>.
+    
+<http://data.lblod.info/id/remote-data-objects/71556fb8-7694-4d20-993c-6938f6fe95dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71556fb8-7694-4d20-993c-6938f6fe95dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_04-07-2022_57049.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71556fb8-7694-4d20-993c-6938f6fe95dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/87ac9e47-b638-4827-8d37-b930c817b66d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87ac9e47-b638-4827-8d37-b930c817b66d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_07-02-2022_54886.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87ac9e47-b638-4827-8d37-b930c817b66d>.
+    
+<http://data.lblod.info/id/remote-data-objects/35326c53-9b5e-4d93-b172-76f00a197ae7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35326c53-9b5e-4d93-b172-76f00a197ae7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_07-06-2022_56542.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35326c53-9b5e-4d93-b172-76f00a197ae7>.
+    
+<http://data.lblod.info/id/remote-data-objects/aea409eb-e5ca-4cb5-866a-34fdd3858ac5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aea409eb-e5ca-4cb5-866a-34fdd3858ac5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_07-06-2022_56613.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aea409eb-e5ca-4cb5-866a-34fdd3858ac5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f7bdfae-a65c-4d96-8fcc-89a464ab7755> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f7bdfae-a65c-4d96-8fcc-89a464ab7755";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_07-06-2022_56617.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f7bdfae-a65c-4d96-8fcc-89a464ab7755>.
+    
+<http://data.lblod.info/id/remote-data-objects/e383edee-944a-4cfa-9b59-752a59b34361> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e383edee-944a-4cfa-9b59-752a59b34361";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_08-11-2021_53015.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e383edee-944a-4cfa-9b59-752a59b34361>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cdd1acb-526e-4f86-abf6-762e3124bfca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cdd1acb-526e-4f86-abf6-762e3124bfca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_09-05-2022_56273.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cdd1acb-526e-4f86-abf6-762e3124bfca>.
+    
+<http://data.lblod.info/id/remote-data-objects/3485340b-ca82-44a4-9d47-c99f3e13fad9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3485340b-ca82-44a4-9d47-c99f3e13fad9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_11-10-2021_52781.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3485340b-ca82-44a4-9d47-c99f3e13fad9>.
+    
+<http://data.lblod.info/id/remote-data-objects/530c9945-1067-42e5-88fc-4d1a6372a0fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "530c9945-1067-42e5-88fc-4d1a6372a0fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_12-07-2022_56855.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/530c9945-1067-42e5-88fc-4d1a6372a0fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/71cb708f-57c4-47e7-9b69-3fbdad83fc52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71cb708f-57c4-47e7-9b69-3fbdad83fc52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_12-07-2022_58099.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71cb708f-57c4-47e7-9b69-3fbdad83fc52>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fecd4d3-5f2e-41c7-b407-b2d76b223729> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fecd4d3-5f2e-41c7-b407-b2d76b223729";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_12-07-2022_58102.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fecd4d3-5f2e-41c7-b407-b2d76b223729>.
+    
+<http://data.lblod.info/id/remote-data-objects/7eba3926-d6e9-40f8-93c5-6b09e450b611> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7eba3926-d6e9-40f8-93c5-6b09e450b611";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_12-07-2022_58112.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7eba3926-d6e9-40f8-93c5-6b09e450b611>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5247098-42e9-45ce-95dc-9889f6ba45e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5247098-42e9-45ce-95dc-9889f6ba45e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_12-07-2022_58129.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5247098-42e9-45ce-95dc-9889f6ba45e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5f44573-1011-4476-a95e-3adfa230cb8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5f44573-1011-4476-a95e-3adfa230cb8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_12-07-2022_58140.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5f44573-1011-4476-a95e-3adfa230cb8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/213ca86b-198f-457a-9ef5-3de3a9b4db59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "213ca86b-198f-457a-9ef5-3de3a9b4db59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_13-06-2022_56619.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/213ca86b-198f-457a-9ef5-3de3a9b4db59>.
+    
+<http://data.lblod.info/id/remote-data-objects/91688642-7ac8-43e9-9935-2164b9c7bcc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91688642-7ac8-43e9-9935-2164b9c7bcc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_13-06-2022_56741.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91688642-7ac8-43e9-9935-2164b9c7bcc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9616b1e-290a-4388-b5b1-bc464861404e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9616b1e-290a-4388-b5b1-bc464861404e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_13-06-2022_56742.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9616b1e-290a-4388-b5b1-bc464861404e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c629b4d2-ceae-4d53-ba7e-a5cf4897af68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c629b4d2-ceae-4d53-ba7e-a5cf4897af68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_13-06-2022_56743.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c629b4d2-ceae-4d53-ba7e-a5cf4897af68>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7e23fb1-5451-45e7-a6a7-053f23e8a4eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7e23fb1-5451-45e7-a6a7-053f23e8a4eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_14-02-2022_55221.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7e23fb1-5451-45e7-a6a7-053f23e8a4eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/785bc256-9909-41a6-9ba5-2afd9a65f298> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "785bc256-9909-41a6-9ba5-2afd9a65f298";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_14-03-2022_55494.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/785bc256-9909-41a6-9ba5-2afd9a65f298>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f142292-1c94-493b-b5c3-3692bc890f42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f142292-1c94-493b-b5c3-3692bc890f42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_14-03-2022_55546.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f142292-1c94-493b-b5c3-3692bc890f42>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6bbfee3-d831-4f05-84cb-f712647e3138> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6bbfee3-d831-4f05-84cb-f712647e3138";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_16-05-2022_56360.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6bbfee3-d831-4f05-84cb-f712647e3138>.
+    
+<http://data.lblod.info/id/remote-data-objects/94d294b8-a8f5-46e0-9aec-471fc33b6c4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94d294b8-a8f5-46e0-9aec-471fc33b6c4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_16-05-2022_56361.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94d294b8-a8f5-46e0-9aec-471fc33b6c4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/77b2c288-c057-473f-a42e-1afa0cb85fe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77b2c288-c057-473f-a42e-1afa0cb85fe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_18-10-2021_52834.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77b2c288-c057-473f-a42e-1afa0cb85fe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f0b2635-009f-4f1a-bae5-52d08499919c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f0b2635-009f-4f1a-bae5-52d08499919c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_18-10-2021_52835.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f0b2635-009f-4f1a-bae5-52d08499919c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f4f797f-1561-420c-a372-0ebba55cc79b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f4f797f-1561-420c-a372-0ebba55cc79b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_19-04-2022_55960.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f4f797f-1561-420c-a372-0ebba55cc79b>.
+    
+<http://data.lblod.info/id/remote-data-objects/58b613b0-8b6c-4d4d-b03e-12cd6ce79b24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58b613b0-8b6c-4d4d-b03e-12cd6ce79b24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_19-04-2022_55978.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58b613b0-8b6c-4d4d-b03e-12cd6ce79b24>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5fa8f94-071b-44a8-ae78-40f6d09dbb19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5fa8f94-071b-44a8-ae78-40f6d09dbb19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_19-04-2022_56010.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c1c40bf3-33d7-4bca-8473-5979d557bc28> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5fa8f94-071b-44a8-ae78-40f6d09dbb19>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201637-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201637-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201637-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201637-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/9151f278-0626-4ffd-929d-d347e8f6de9e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9151f278-0626-4ffd-929d-d347e8f6de9e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b1af9c93-1b35-46bb-99f5-4702d95d6566";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d6970e1e-defa-4fd1-aa36-22fecc300764> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d6970e1e-defa-4fd1-aa36-22fecc300764";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566>.
+
+  <http://redpencil.data.gift/id/task/638b2348-74d3-4b74-a165-00db4a97aa65> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "638b2348-74d3-4b74-a165-00db4a97aa65";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/9151f278-0626-4ffd-929d-d347e8f6de9e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d6970e1e-defa-4fd1-aa36-22fecc300764>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/f7456513-cb33-48ac-8c7d-529b0b1e2cc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7456513-cb33-48ac-8c7d-529b0b1e2cc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_19-04-2022_56015.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7456513-cb33-48ac-8c7d-529b0b1e2cc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bd0e245-080f-4544-b031-f1d9a65cd1d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bd0e245-080f-4544-b031-f1d9a65cd1d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_20-06-2022_56839.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bd0e245-080f-4544-b031-f1d9a65cd1d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9232c2e0-ac41-45f7-a279-a50a8caac6be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9232c2e0-ac41-45f7-a279-a50a8caac6be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_20-06-2022_56927.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9232c2e0-ac41-45f7-a279-a50a8caac6be>.
+    
+<http://data.lblod.info/id/remote-data-objects/999aa056-2ef0-486b-b1ff-6d2f6279ba72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "999aa056-2ef0-486b-b1ff-6d2f6279ba72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_20-12-2021_53865.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/999aa056-2ef0-486b-b1ff-6d2f6279ba72>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c1f4299-95ac-482b-9b65-3aaa8207cdd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c1f4299-95ac-482b-9b65-3aaa8207cdd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_20-12-2021_53867.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c1f4299-95ac-482b-9b65-3aaa8207cdd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d9c47ee-c898-4177-bdcd-8fa0ef235591> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d9c47ee-c898-4177-bdcd-8fa0ef235591";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_21-02-2022_55241.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d9c47ee-c898-4177-bdcd-8fa0ef235591>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ce5df86-0189-4dcb-8b35-74a0db101dae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ce5df86-0189-4dcb-8b35-74a0db101dae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_21-03-2022_55617.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ce5df86-0189-4dcb-8b35-74a0db101dae>.
+    
+<http://data.lblod.info/id/remote-data-objects/03060aa9-18a5-468c-9502-a75ede17e992> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03060aa9-18a5-468c-9502-a75ede17e992";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_21-03-2022_55668.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03060aa9-18a5-468c-9502-a75ede17e992>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc713768-a82f-4f29-bb22-0be27f523433> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc713768-a82f-4f29-bb22-0be27f523433";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_22-11-2021_53306.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc713768-a82f-4f29-bb22-0be27f523433>.
+    
+<http://data.lblod.info/id/remote-data-objects/61fb3ed3-cafb-4745-a1cf-6124e2eb3cda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61fb3ed3-cafb-4745-a1cf-6124e2eb3cda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_22-11-2021_53309.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61fb3ed3-cafb-4745-a1cf-6124e2eb3cda>.
+    
+<http://data.lblod.info/id/remote-data-objects/aabdd1d5-e9de-4b8f-b9b0-781cd49dd1ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aabdd1d5-e9de-4b8f-b9b0-781cd49dd1ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_22-11-2021_53310.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aabdd1d5-e9de-4b8f-b9b0-781cd49dd1ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/5517663f-81c5-41f7-85f9-64495759a15f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5517663f-81c5-41f7-85f9-64495759a15f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_23-05-2022_56226.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5517663f-81c5-41f7-85f9-64495759a15f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5adffef3-d1d8-4c13-8997-002ca7c864f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5adffef3-d1d8-4c13-8997-002ca7c864f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_23-05-2022_56377.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5adffef3-d1d8-4c13-8997-002ca7c864f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9f92b00-dde4-49f8-b51a-23025d53bc37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9f92b00-dde4-49f8-b51a-23025d53bc37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_23-05-2022_56448.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9f92b00-dde4-49f8-b51a-23025d53bc37>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d1e6fa8-7a16-416a-beb0-3a20e3850f1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d1e6fa8-7a16-416a-beb0-3a20e3850f1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_25-07-2022_58219.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d1e6fa8-7a16-416a-beb0-3a20e3850f1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/41024ccd-99c2-454c-806b-c1d560fd4964> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41024ccd-99c2-454c-806b-c1d560fd4964";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_25-07-2022_58233.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41024ccd-99c2-454c-806b-c1d560fd4964>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a476886-ee01-49df-91f5-07be87473c59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a476886-ee01-49df-91f5-07be87473c59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_25-07-2022_58237.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a476886-ee01-49df-91f5-07be87473c59>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe809a6e-41dd-4a79-b198-5a1964f64881> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe809a6e-41dd-4a79-b198-5a1964f64881";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_25-07-2022_58274.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe809a6e-41dd-4a79-b198-5a1964f64881>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c427f54-7e57-4a92-aad4-fb7f7afa859a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c427f54-7e57-4a92-aad4-fb7f7afa859a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_25-07-2022_58277.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c427f54-7e57-4a92-aad4-fb7f7afa859a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f9fe683-d44f-4276-9124-8d9960966c43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f9fe683-d44f-4276-9124-8d9960966c43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_25-07-2022_58280.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f9fe683-d44f-4276-9124-8d9960966c43>.
+    
+<http://data.lblod.info/id/remote-data-objects/6faa2c75-7c86-457d-b031-da2b719de98c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6faa2c75-7c86-457d-b031-da2b719de98c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_25-07-2022_58332.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6faa2c75-7c86-457d-b031-da2b719de98c>.
+    
+<http://data.lblod.info/id/remote-data-objects/96657e38-ea97-4ba6-a8fe-35c83a80d19c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96657e38-ea97-4ba6-a8fe-35c83a80d19c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_25-07-2022_58373.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96657e38-ea97-4ba6-a8fe-35c83a80d19c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d549380-088b-4d78-ba66-fb4c731bde91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d549380-088b-4d78-ba66-fb4c731bde91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_25-10-2021_52977.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d549380-088b-4d78-ba66-fb4c731bde91>.
+    
+<http://data.lblod.info/id/remote-data-objects/835d3aa2-3a2a-4c9f-8a3e-a0038af39794> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "835d3aa2-3a2a-4c9f-8a3e-a0038af39794";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_27-06-2022_56841.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/835d3aa2-3a2a-4c9f-8a3e-a0038af39794>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcd08ad2-09c6-4b0b-9ec9-c2b366e0d69a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcd08ad2-09c6-4b0b-9ec9-c2b366e0d69a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_27-06-2022_56945.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcd08ad2-09c6-4b0b-9ec9-c2b366e0d69a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1864e8a0-93a6-49bf-b794-e306f30551af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1864e8a0-93a6-49bf-b794-e306f30551af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_27-06-2022_56948.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1864e8a0-93a6-49bf-b794-e306f30551af>.
+    
+<http://data.lblod.info/id/remote-data-objects/268a19db-9026-4275-9035-1e03d5272d38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "268a19db-9026-4275-9035-1e03d5272d38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_28-03-2022_55751.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/268a19db-9026-4275-9035-1e03d5272d38>.
+    
+<http://data.lblod.info/id/remote-data-objects/66ec0465-a689-454a-80ae-9f719995d236> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66ec0465-a689-454a-80ae-9f719995d236";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_29-11-2021_53455.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66ec0465-a689-454a-80ae-9f719995d236>.
+    
+<http://data.lblod.info/id/remote-data-objects/b72f5ccf-138a-4baa-bde3-6d4f0637f83c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b72f5ccf-138a-4baa-bde3-6d4f0637f83c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_55275.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b72f5ccf-138a-4baa-bde3-6d4f0637f83c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e736c75-216c-4433-ba9e-934f8b491826> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e736c75-216c-4433-ba9e-934f8b491826";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_55980.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e736c75-216c-4433-ba9e-934f8b491826>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2049f05-f1c2-454b-a72e-811841839afa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2049f05-f1c2-454b-a72e-811841839afa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_56235.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2049f05-f1c2-454b-a72e-811841839afa>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e03b3f4-1b17-49b8-80c2-368a4e73a617> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e03b3f4-1b17-49b8-80c2-368a4e73a617";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_56238.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e03b3f4-1b17-49b8-80c2-368a4e73a617>.
+    
+<http://data.lblod.info/id/remote-data-objects/9130f6ca-bf04-4c69-a255-4b8f54f8a5fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9130f6ca-bf04-4c69-a255-4b8f54f8a5fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_56240.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9130f6ca-bf04-4c69-a255-4b8f54f8a5fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/6efcd095-5e82-4b48-b154-29e0294e85ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6efcd095-5e82-4b48-b154-29e0294e85ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_56541.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6efcd095-5e82-4b48-b154-29e0294e85ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/f323200f-c79a-425e-b757-18c64e93ca1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f323200f-c79a-425e-b757-18c64e93ca1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_56543.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f323200f-c79a-425e-b757-18c64e93ca1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/def42df6-5cac-44de-a589-47e07c977003> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "def42df6-5cac-44de-a589-47e07c977003";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_56544.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/def42df6-5cac-44de-a589-47e07c977003>.
+    
+<http://data.lblod.info/id/remote-data-objects/5eed6e7d-dbe4-4b9f-9af7-e52292b3db0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5eed6e7d-dbe4-4b9f-9af7-e52292b3db0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_56553.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5eed6e7d-dbe4-4b9f-9af7-e52292b3db0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/68574e1b-cc5b-4bee-8c13-d8417b15629a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68574e1b-cc5b-4bee-8c13-d8417b15629a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_56554.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68574e1b-cc5b-4bee-8c13-d8417b15629a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcaa341c-eaa6-47ce-abb8-1bfdeee84fa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcaa341c-eaa6-47ce-abb8-1bfdeee84fa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_56555.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcaa341c-eaa6-47ce-abb8-1bfdeee84fa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b1fd0cc-27f9-493f-8f29-a99205069993> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b1fd0cc-27f9-493f-8f29-a99205069993";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_56561.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b1fd0cc-27f9-493f-8f29-a99205069993>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a58e612-ec09-4362-bbb3-001914ad0faa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a58e612-ec09-4362-bbb3-001914ad0faa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_56565.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a58e612-ec09-4362-bbb3-001914ad0faa>.
+    
+<http://data.lblod.info/id/remote-data-objects/c34e431e-7795-4767-ba56-ac9d82901edc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c34e431e-7795-4767-ba56-ac9d82901edc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_56575.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c34e431e-7795-4767-ba56-ac9d82901edc>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdb52dd7-be06-45f4-9bcd-e093600e1577> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdb52dd7-be06-45f4-9bcd-e093600e1577";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_56582.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdb52dd7-be06-45f4-9bcd-e093600e1577>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb39ce4d-2f60-464e-8a49-e96ee6cb7348> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb39ce4d-2f60-464e-8a49-e96ee6cb7348";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_56587.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb39ce4d-2f60-464e-8a49-e96ee6cb7348>.
+    
+<http://data.lblod.info/id/remote-data-objects/92aa108a-fc5a-41ac-9346-f178169f2355> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92aa108a-fc5a-41ac-9346-f178169f2355";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_30-05-2022_56588.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92aa108a-fc5a-41ac-9346-f178169f2355>.
+    
+<http://data.lblod.info/id/remote-data-objects/508b135a-53bf-4e54-84e0-1b68ee25148f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "508b135a-53bf-4e54-84e0-1b68ee25148f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.scherpenheuvel-zichem.be/LBLODWeb/Home/Overzicht/bc8f9e4167fe0c6877bacc1be3b9e1e863f1f2310910d06e64c1045325c0a684/GetPublication?filename=Uittreksels_31-01-2022_54657.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/508b135a-53bf-4e54-84e0-1b68ee25148f>.
+    
+<http://data.lblod.info/id/remote-data-objects/53990549-5c29-441f-a380-f1a65bd54523> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53990549-5c29-441f-a380-f1a65bd54523";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53990549-5c29-441f-a380-f1a65bd54523>.
+    
+<http://data.lblod.info/id/remote-data-objects/42b23afa-e36c-4fb3-bd84-5c7f5e2898ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42b23afa-e36c-4fb3-bd84-5c7f5e2898ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42b23afa-e36c-4fb3-bd84-5c7f5e2898ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/de40bafc-86ad-46db-b97c-020fa93fde41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de40bafc-86ad-46db-b97c-020fa93fde41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de40bafc-86ad-46db-b97c-020fa93fde41>.
+    
+<http://data.lblod.info/id/remote-data-objects/917743ba-ec10-4909-86e2-3acc5e29c149> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "917743ba-ec10-4909-86e2-3acc5e29c149";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b1af9c93-1b35-46bb-99f5-4702d95d6566> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/917743ba-ec10-4909-86e2-3acc5e29c149>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201639-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201639-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201639-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201639-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/bc05388e-ef3c-410b-8fdd-58027137aa78> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bc05388e-ef3c-410b-8fdd-58027137aa78";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d597d0bc-6d3e-4f5b-b38b-7aca11ba2103";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/003342ea-6b52-4013-9bfa-ba50157fa08a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "003342ea-6b52-4013-9bfa-ba50157fa08a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103>.
+
+  <http://redpencil.data.gift/id/task/87fffa80-e554-4a66-8c01-c870a5d97eb9> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "87fffa80-e554-4a66-8c01-c870a5d97eb9";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/bc05388e-ef3c-410b-8fdd-58027137aa78>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/003342ea-6b52-4013-9bfa-ba50157fa08a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/3a0cec31-b3de-44cd-9e99-2f144a795ed6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a0cec31-b3de-44cd-9e99-2f144a795ed6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a0cec31-b3de-44cd-9e99-2f144a795ed6>.
+    
+<http://data.lblod.info/id/remote-data-objects/84f4c05e-1c1b-4308-a171-0f8c47bfa360> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84f4c05e-1c1b-4308-a171-0f8c47bfa360";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84f4c05e-1c1b-4308-a171-0f8c47bfa360>.
+    
+<http://data.lblod.info/id/remote-data-objects/42ffd4fb-76fe-4982-839d-1c7933e74f7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42ffd4fb-76fe-4982-839d-1c7933e74f7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42ffd4fb-76fe-4982-839d-1c7933e74f7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bbfe80d-0451-40a3-a10f-0258490b1ca3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bbfe80d-0451-40a3-a10f-0258490b1ca3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_08-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bbfe80d-0451-40a3-a10f-0258490b1ca3>.
+    
+<http://data.lblod.info/id/remote-data-objects/80f81806-80c0-4466-ab8d-88684589bf24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80f81806-80c0-4466-ab8d-88684589bf24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80f81806-80c0-4466-ab8d-88684589bf24>.
+    
+<http://data.lblod.info/id/remote-data-objects/c37eea6d-23a1-49e6-8ba0-19d7db614421> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c37eea6d-23a1-49e6-8ba0-19d7db614421";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_09-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c37eea6d-23a1-49e6-8ba0-19d7db614421>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2cd4750-4f99-4c68-8d84-d6e09401b613> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2cd4750-4f99-4c68-8d84-d6e09401b613";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2cd4750-4f99-4c68-8d84-d6e09401b613>.
+    
+<http://data.lblod.info/id/remote-data-objects/f695638c-e1c1-40f9-9376-91b918d6b63d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f695638c-e1c1-40f9-9376-91b918d6b63d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f695638c-e1c1-40f9-9376-91b918d6b63d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb3ba898-5eef-40d8-91b1-4b5d2ebb5bd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb3ba898-5eef-40d8-91b1-4b5d2ebb5bd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb3ba898-5eef-40d8-91b1-4b5d2ebb5bd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/c93019dd-f8f6-46c8-b6ff-0e02ced36f69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c93019dd-f8f6-46c8-b6ff-0e02ced36f69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c93019dd-f8f6-46c8-b6ff-0e02ced36f69>.
+    
+<http://data.lblod.info/id/remote-data-objects/48984c64-6688-4e25-ad7c-8c9dd39e20cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48984c64-6688-4e25-ad7c-8c9dd39e20cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48984c64-6688-4e25-ad7c-8c9dd39e20cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c27dd75f-3bc7-49c1-8a80-4e2528b083b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c27dd75f-3bc7-49c1-8a80-4e2528b083b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c27dd75f-3bc7-49c1-8a80-4e2528b083b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc2adf81-53af-4478-9e60-0cfe2a901865> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc2adf81-53af-4478-9e60-0cfe2a901865";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc2adf81-53af-4478-9e60-0cfe2a901865>.
+    
+<http://data.lblod.info/id/remote-data-objects/a06f9822-ff67-48d5-9c2a-23a4c90d3e2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a06f9822-ff67-48d5-9c2a-23a4c90d3e2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a06f9822-ff67-48d5-9c2a-23a4c90d3e2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dd3ac7f-8d47-4d99-9b98-3effbeef78aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dd3ac7f-8d47-4d99-9b98-3effbeef78aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dd3ac7f-8d47-4d99-9b98-3effbeef78aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/592908c6-32d8-4fda-ae13-f68f6fe2cd10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "592908c6-32d8-4fda-ae13-f68f6fe2cd10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/592908c6-32d8-4fda-ae13-f68f6fe2cd10>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ea2e9c8-a6e3-40fe-9095-3690077289e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ea2e9c8-a6e3-40fe-9095-3690077289e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ea2e9c8-a6e3-40fe-9095-3690077289e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e33e4ac-d8d6-41d1-a41c-6265911956f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e33e4ac-d8d6-41d1-a41c-6265911956f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e33e4ac-d8d6-41d1-a41c-6265911956f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbff4c0a-1568-40e4-b5f9-8a4980cce765> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbff4c0a-1568-40e4-b5f9-8a4980cce765";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbff4c0a-1568-40e4-b5f9-8a4980cce765>.
+    
+<http://data.lblod.info/id/remote-data-objects/141b3a39-9370-4565-ac25-19f0eca74d14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "141b3a39-9370-4565-ac25-19f0eca74d14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/141b3a39-9370-4565-ac25-19f0eca74d14>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fadd95a-24ab-40dd-9269-047b36ba9027> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fadd95a-24ab-40dd-9269-047b36ba9027";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fadd95a-24ab-40dd-9269-047b36ba9027>.
+    
+<http://data.lblod.info/id/remote-data-objects/93a1d6ae-9472-486b-b276-e05fb6c48072> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93a1d6ae-9472-486b-b276-e05fb6c48072";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93a1d6ae-9472-486b-b276-e05fb6c48072>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e064014-65cb-4dba-b81c-47b1b10b3c70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e064014-65cb-4dba-b81c-47b1b10b3c70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e064014-65cb-4dba-b81c-47b1b10b3c70>.
+    
+<http://data.lblod.info/id/remote-data-objects/d948f241-ffd9-49e3-8c18-b81a06b3a42f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d948f241-ffd9-49e3-8c18-b81a06b3a42f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d948f241-ffd9-49e3-8c18-b81a06b3a42f>.
+    
+<http://data.lblod.info/id/remote-data-objects/996ce812-a9ae-4e0b-9f5f-1d36426910e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "996ce812-a9ae-4e0b-9f5f-1d36426910e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/996ce812-a9ae-4e0b-9f5f-1d36426910e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3bd74e9-2059-4270-bdf1-392855785728> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3bd74e9-2059-4270-bdf1-392855785728";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3bd74e9-2059-4270-bdf1-392855785728>.
+    
+<http://data.lblod.info/id/remote-data-objects/13e188aa-0942-4b4c-b8a8-98b507669f63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13e188aa-0942-4b4c-b8a8-98b507669f63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13e188aa-0942-4b4c-b8a8-98b507669f63>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4e15a73-d48d-47ff-9ce8-8e8279dc175f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4e15a73-d48d-47ff-9ce8-8e8279dc175f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4e15a73-d48d-47ff-9ce8-8e8279dc175f>.
+    
+<http://data.lblod.info/id/remote-data-objects/63df4f9f-b598-4c3a-9ab3-2a3c05e555ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63df4f9f-b598-4c3a-9ab3-2a3c05e555ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63df4f9f-b598-4c3a-9ab3-2a3c05e555ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/8aa0e65a-944a-4993-bde2-edae422db0db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8aa0e65a-944a-4993-bde2-edae422db0db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8aa0e65a-944a-4993-bde2-edae422db0db>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e1f6d92-d4af-454b-8a6d-a26ee6812c6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e1f6d92-d4af-454b-8a6d-a26ee6812c6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_28-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e1f6d92-d4af-454b-8a6d-a26ee6812c6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/39176f6b-2157-4255-969f-b163db8356f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39176f6b-2157-4255-969f-b163db8356f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39176f6b-2157-4255-969f-b163db8356f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/999acc46-a58b-4c34-ae75-69f08ab7714c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "999acc46-a58b-4c34-ae75-69f08ab7714c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/999acc46-a58b-4c34-ae75-69f08ab7714c>.
+    
+<http://data.lblod.info/id/remote-data-objects/68a7c050-42e8-469d-8c31-6f83ed24e512> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68a7c050-42e8-469d-8c31-6f83ed24e512";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68a7c050-42e8-469d-8c31-6f83ed24e512>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8fa2f7a-8c08-42c0-9368-e6cd030a69bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8fa2f7a-8c08-42c0-9368-e6cd030a69bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/0c87f27e59a4c55c64b956928e10f2e1d85cfbfd796c5ba1da92821663b408a3/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8fa2f7a-8c08-42c0-9368-e6cd030a69bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/97bba8f8-985e-4552-91b9-d73ea81f274b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97bba8f8-985e-4552-91b9-d73ea81f274b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97bba8f8-985e-4552-91b9-d73ea81f274b>.
+    
+<http://data.lblod.info/id/remote-data-objects/df555057-7720-4cac-acd2-59f7276e19ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df555057-7720-4cac-acd2-59f7276e19ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df555057-7720-4cac-acd2-59f7276e19ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/10d9a549-2e1f-4e4e-9ed4-1ba7210b0a55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10d9a549-2e1f-4e4e-9ed4-1ba7210b0a55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_04-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10d9a549-2e1f-4e4e-9ed4-1ba7210b0a55>.
+    
+<http://data.lblod.info/id/remote-data-objects/f67c5dd3-adee-4d64-99db-b2a89e9e3582> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f67c5dd3-adee-4d64-99db-b2a89e9e3582";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f67c5dd3-adee-4d64-99db-b2a89e9e3582>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b76605b-46ab-421b-8cbc-ed82c44c1a6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b76605b-46ab-421b-8cbc-ed82c44c1a6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_06-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b76605b-46ab-421b-8cbc-ed82c44c1a6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f6ff1b5-1f01-4638-a927-f9837cdbf96a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f6ff1b5-1f01-4638-a927-f9837cdbf96a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_07-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f6ff1b5-1f01-4638-a927-f9837cdbf96a>.
+    
+<http://data.lblod.info/id/remote-data-objects/364ba4cf-138c-4740-8284-34d284556241> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "364ba4cf-138c-4740-8284-34d284556241";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/364ba4cf-138c-4740-8284-34d284556241>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b117fc8-2f05-41e9-aa29-96d39ba8dac3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b117fc8-2f05-41e9-aa29-96d39ba8dac3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b117fc8-2f05-41e9-aa29-96d39ba8dac3>.
+    
+<http://data.lblod.info/id/remote-data-objects/6794f291-8ad2-4355-adf1-a92ff701aef2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6794f291-8ad2-4355-adf1-a92ff701aef2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_09-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6794f291-8ad2-4355-adf1-a92ff701aef2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d585a784-cebc-482f-bd49-5968ca983b1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d585a784-cebc-482f-bd49-5968ca983b1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d585a784-cebc-482f-bd49-5968ca983b1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fb5a01c-ca47-4f39-a413-198553d7af27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fb5a01c-ca47-4f39-a413-198553d7af27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fb5a01c-ca47-4f39-a413-198553d7af27>.
+    
+<http://data.lblod.info/id/remote-data-objects/cadcdddf-f851-4825-92a1-7ddb236d412a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cadcdddf-f851-4825-92a1-7ddb236d412a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cadcdddf-f851-4825-92a1-7ddb236d412a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0781c7c-cb30-4f9f-8af3-84d33088ce11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0781c7c-cb30-4f9f-8af3-84d33088ce11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0781c7c-cb30-4f9f-8af3-84d33088ce11>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b654271-4b1d-4999-a4f7-6e32fda73f03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b654271-4b1d-4999-a4f7-6e32fda73f03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b654271-4b1d-4999-a4f7-6e32fda73f03>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc5e7734-a5b1-4e60-8c9a-c3790da0d270> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc5e7734-a5b1-4e60-8c9a-c3790da0d270";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d597d0bc-6d3e-4f5b-b38b-7aca11ba2103> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc5e7734-a5b1-4e60-8c9a-c3790da0d270>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201640-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201640-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201640-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201640-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/84d3709d-252a-4554-acff-3e7e7edda38f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "84d3709d-252a-4554-acff-3e7e7edda38f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a9839d0b-911b-4059-9b23-abe0488341e6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e0fb3479-12c3-4b5f-bcf4-1d555458f685> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e0fb3479-12c3-4b5f-bcf4-1d555458f685";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6>.
+
+  <http://redpencil.data.gift/id/task/46050ea6-0a59-4965-b96c-c2ee7878aee6> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "46050ea6-0a59-4965-b96c-c2ee7878aee6";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/84d3709d-252a-4554-acff-3e7e7edda38f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e0fb3479-12c3-4b5f-bcf4-1d555458f685>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/47d1809a-cd9b-4328-b1b0-4ecfbb01cb06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47d1809a-cd9b-4328-b1b0-4ecfbb01cb06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47d1809a-cd9b-4328-b1b0-4ecfbb01cb06>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d821cbe-49ae-4c52-8633-33df6bc8dfa4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d821cbe-49ae-4c52-8633-33df6bc8dfa4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d821cbe-49ae-4c52-8633-33df6bc8dfa4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e7115b8-299c-4442-b677-5a9c940d0cca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e7115b8-299c-4442-b677-5a9c940d0cca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e7115b8-299c-4442-b677-5a9c940d0cca>.
+    
+<http://data.lblod.info/id/remote-data-objects/55feb4a8-552d-40c2-880a-24458d691f8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55feb4a8-552d-40c2-880a-24458d691f8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55feb4a8-552d-40c2-880a-24458d691f8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/082c5e0b-c041-47db-8a5b-cb362e3d1085> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "082c5e0b-c041-47db-8a5b-cb362e3d1085";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/082c5e0b-c041-47db-8a5b-cb362e3d1085>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea82a317-d06d-4aff-9731-5fa081e002e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea82a317-d06d-4aff-9731-5fa081e002e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea82a317-d06d-4aff-9731-5fa081e002e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd134cdc-47de-4301-a814-6c6deaef3d3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd134cdc-47de-4301-a814-6c6deaef3d3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd134cdc-47de-4301-a814-6c6deaef3d3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce828703-f16a-45fe-ac5c-4ff4f8665d90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce828703-f16a-45fe-ac5c-4ff4f8665d90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce828703-f16a-45fe-ac5c-4ff4f8665d90>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c9a3089-d130-40ef-ab73-e9556cee6504> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c9a3089-d130-40ef-ab73-e9556cee6504";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c9a3089-d130-40ef-ab73-e9556cee6504>.
+    
+<http://data.lblod.info/id/remote-data-objects/88a71116-b1e6-4af0-9450-d24ae9a50212> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88a71116-b1e6-4af0-9450-d24ae9a50212";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88a71116-b1e6-4af0-9450-d24ae9a50212>.
+    
+<http://data.lblod.info/id/remote-data-objects/2404ac0b-27db-4025-82fd-09b29e9d7be0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2404ac0b-27db-4025-82fd-09b29e9d7be0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2404ac0b-27db-4025-82fd-09b29e9d7be0>.
+    
+<http://data.lblod.info/id/remote-data-objects/16341eb7-cf97-4d75-b14d-7e2e30afb67c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16341eb7-cf97-4d75-b14d-7e2e30afb67c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16341eb7-cf97-4d75-b14d-7e2e30afb67c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b53f28c-d23a-45f6-8b37-a8236b5bdeb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b53f28c-d23a-45f6-8b37-a8236b5bdeb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b53f28c-d23a-45f6-8b37-a8236b5bdeb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f3f8627-1a05-4b3d-85b1-70317b4e3a61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f3f8627-1a05-4b3d-85b1-70317b4e3a61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f3f8627-1a05-4b3d-85b1-70317b4e3a61>.
+    
+<http://data.lblod.info/id/remote-data-objects/abd9f6cc-f268-4186-bd55-e907fc6dc0bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abd9f6cc-f268-4186-bd55-e907fc6dc0bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abd9f6cc-f268-4186-bd55-e907fc6dc0bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b04b32f-299d-4f23-b20f-094785a7cd69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b04b32f-299d-4f23-b20f-094785a7cd69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b04b32f-299d-4f23-b20f-094785a7cd69>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0c2255a-5635-404c-919c-a126cb335f76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0c2255a-5635-404c-919c-a126cb335f76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0c2255a-5635-404c-919c-a126cb335f76>.
+    
+<http://data.lblod.info/id/remote-data-objects/478d0c62-9f85-469e-a777-5292c7eadfdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "478d0c62-9f85-469e-a777-5292c7eadfdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/478d0c62-9f85-469e-a777-5292c7eadfdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/75110dc4-0c00-4e1e-b1b0-7157f91eccf0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75110dc4-0c00-4e1e-b1b0-7157f91eccf0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_24-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75110dc4-0c00-4e1e-b1b0-7157f91eccf0>.
+    
+<http://data.lblod.info/id/remote-data-objects/436c982f-800d-441b-b0af-2961a5a3a412> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "436c982f-800d-441b-b0af-2961a5a3a412";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/436c982f-800d-441b-b0af-2961a5a3a412>.
+    
+<http://data.lblod.info/id/remote-data-objects/b73acb89-0256-467f-a33f-c5e782c1a276> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b73acb89-0256-467f-a33f-c5e782c1a276";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b73acb89-0256-467f-a33f-c5e782c1a276>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cf74364-e7d1-4a85-a7a5-809af8af0869> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cf74364-e7d1-4a85-a7a5-809af8af0869";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cf74364-e7d1-4a85-a7a5-809af8af0869>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb67f883-a043-4e2f-8772-dc6f6981f16e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb67f883-a043-4e2f-8772-dc6f6981f16e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_28-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb67f883-a043-4e2f-8772-dc6f6981f16e>.
+    
+<http://data.lblod.info/id/remote-data-objects/af45ba03-2885-4adc-8f27-157d9908b531> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af45ba03-2885-4adc-8f27-157d9908b531";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af45ba03-2885-4adc-8f27-157d9908b531>.
+    
+<http://data.lblod.info/id/remote-data-objects/00a8657d-a9a9-411d-a630-7f76a01141fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00a8657d-a9a9-411d-a630-7f76a01141fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00a8657d-a9a9-411d-a630-7f76a01141fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/6348da82-58c9-41fd-8000-83bb35a3f5e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6348da82-58c9-41fd-8000-83bb35a3f5e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=BesluitenLijstUitspraak_Burgemeester%20beslissing_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6348da82-58c9-41fd-8000-83bb35a3f5e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/46164018-a2ca-4a65-a968-01857654353b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46164018-a2ca-4a65-a968-01857654353b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=Uittreksels_19-11-2021_61105.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46164018-a2ca-4a65-a968-01857654353b>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfaf6f35-2248-49a4-87b8-2ee47ed8b8bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfaf6f35-2248-49a4-87b8-2ee47ed8b8bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/94100445cadc31a40935e34aac44e07e35efdf667c47699ee97b6afff9fe714d/GetPublication?filename=Uittreksels_27-10-2021_59873.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfaf6f35-2248-49a4-87b8-2ee47ed8b8bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b6456c0-0210-46a5-9408-f5e5c12b98de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b6456c0-0210-46a5-9408-f5e5c12b98de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b6456c0-0210-46a5-9408-f5e5c12b98de>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1bd1542-f58d-46ff-816b-c0f8db27166e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1bd1542-f58d-46ff-816b-c0f8db27166e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1bd1542-f58d-46ff-816b-c0f8db27166e>.
+    
+<http://data.lblod.info/id/remote-data-objects/486f36fa-b861-44c3-8f66-d7dbcf599995> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "486f36fa-b861-44c3-8f66-d7dbcf599995";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/486f36fa-b861-44c3-8f66-d7dbcf599995>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce9ce7fd-163a-423a-8645-caf6698413b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce9ce7fd-163a-423a-8645-caf6698413b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce9ce7fd-163a-423a-8645-caf6698413b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd8e7ba0-5229-4115-bc0d-85d5bc521576> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd8e7ba0-5229-4115-bc0d-85d5bc521576";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_04-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd8e7ba0-5229-4115-bc0d-85d5bc521576>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd6b1d2e-54b4-4fff-b7d8-f1aef3b23630> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd6b1d2e-54b4-4fff-b7d8-f1aef3b23630";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd6b1d2e-54b4-4fff-b7d8-f1aef3b23630>.
+    
+<http://data.lblod.info/id/remote-data-objects/eea8b9db-f899-41fb-afbb-a03d7ea3f300> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eea8b9db-f899-41fb-afbb-a03d7ea3f300";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eea8b9db-f899-41fb-afbb-a03d7ea3f300>.
+    
+<http://data.lblod.info/id/remote-data-objects/09786748-156f-4607-bbed-b629ee799f61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09786748-156f-4607-bbed-b629ee799f61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09786748-156f-4607-bbed-b629ee799f61>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac03ce2d-33e0-43a2-b937-63772d979e90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac03ce2d-33e0-43a2-b937-63772d979e90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_08-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac03ce2d-33e0-43a2-b937-63772d979e90>.
+    
+<http://data.lblod.info/id/remote-data-objects/f18dee5a-e63f-4e3c-a5f1-28697ba148c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f18dee5a-e63f-4e3c-a5f1-28697ba148c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f18dee5a-e63f-4e3c-a5f1-28697ba148c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a4efc69-4266-473d-9310-72131f268599> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a4efc69-4266-473d-9310-72131f268599";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_09-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a4efc69-4266-473d-9310-72131f268599>.
+    
+<http://data.lblod.info/id/remote-data-objects/50c108d7-814a-4d87-9498-b676becb5027> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50c108d7-814a-4d87-9498-b676becb5027";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50c108d7-814a-4d87-9498-b676becb5027>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbd0f524-2c29-471e-aafd-bda72ef15cf7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbd0f524-2c29-471e-aafd-bda72ef15cf7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbd0f524-2c29-471e-aafd-bda72ef15cf7>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ba9e738-12e5-4d8e-b18c-28bb58ab3a91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ba9e738-12e5-4d8e-b18c-28bb58ab3a91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ba9e738-12e5-4d8e-b18c-28bb58ab3a91>.
+    
+<http://data.lblod.info/id/remote-data-objects/89f9287e-654e-4142-b451-e5934486d066> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89f9287e-654e-4142-b451-e5934486d066";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89f9287e-654e-4142-b451-e5934486d066>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a4e298d-6bda-4403-8c4f-0e16f13c6cd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a4e298d-6bda-4403-8c4f-0e16f13c6cd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a4e298d-6bda-4403-8c4f-0e16f13c6cd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3362545-443f-4482-8140-f4705e88d619> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3362545-443f-4482-8140-f4705e88d619";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3362545-443f-4482-8140-f4705e88d619>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbe3cfe0-198a-4058-9ccc-e2717d890c2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbe3cfe0-198a-4058-9ccc-e2717d890c2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbe3cfe0-198a-4058-9ccc-e2717d890c2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1014e5a-2b68-42a7-91ca-63d0d814a959> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1014e5a-2b68-42a7-91ca-63d0d814a959";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1014e5a-2b68-42a7-91ca-63d0d814a959>.
+    
+<http://data.lblod.info/id/remote-data-objects/98c80036-ab6b-423c-bfb6-a93841e161a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98c80036-ab6b-423c-bfb6-a93841e161a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98c80036-ab6b-423c-bfb6-a93841e161a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d94d53b-5853-4e1b-b223-5ab0203fd46c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d94d53b-5853-4e1b-b223-5ab0203fd46c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d94d53b-5853-4e1b-b223-5ab0203fd46c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f2eb48e-284a-4c58-a981-40e3673ca099> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f2eb48e-284a-4c58-a981-40e3673ca099";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a9839d0b-911b-4059-9b23-abe0488341e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f2eb48e-284a-4c58-a981-40e3673ca099>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201641-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201641-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201641-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201641-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f217bc19-9e31-419e-93a7-6d1208fe4806> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f217bc19-9e31-419e-93a7-6d1208fe4806";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b68807bd-f6c2-460b-ae31-c47cc5bf7833";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/3b5efbee-d930-415a-afb8-1459af70f5f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3b5efbee-d930-415a-afb8-1459af70f5f0";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833>.
+
+  <http://redpencil.data.gift/id/task/61d6c178-e86d-4bff-be36-b79b3ef15906> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "61d6c178-e86d-4bff-be36-b79b3ef15906";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f217bc19-9e31-419e-93a7-6d1208fe4806>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/3b5efbee-d930-415a-afb8-1459af70f5f0>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/819dd111-645f-4daf-950c-bd190a3459cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "819dd111-645f-4daf-950c-bd190a3459cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/819dd111-645f-4daf-950c-bd190a3459cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/51668772-ecb8-4753-943b-87bd5a21c18e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51668772-ecb8-4753-943b-87bd5a21c18e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51668772-ecb8-4753-943b-87bd5a21c18e>.
+    
+<http://data.lblod.info/id/remote-data-objects/530b34ef-a9d0-459e-986f-d82a681a7c63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "530b34ef-a9d0-459e-986f-d82a681a7c63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/530b34ef-a9d0-459e-986f-d82a681a7c63>.
+    
+<http://data.lblod.info/id/remote-data-objects/af716849-ff9a-44ab-a646-f9ae4f6c0818> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af716849-ff9a-44ab-a646-f9ae4f6c0818";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af716849-ff9a-44ab-a646-f9ae4f6c0818>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2912c0d-a65f-4f6d-b72a-296ed94af807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2912c0d-a65f-4f6d-b72a-296ed94af807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2912c0d-a65f-4f6d-b72a-296ed94af807>.
+    
+<http://data.lblod.info/id/remote-data-objects/de0d7e55-d72a-4a3a-98f7-e1633e1a1e22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de0d7e55-d72a-4a3a-98f7-e1633e1a1e22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de0d7e55-d72a-4a3a-98f7-e1633e1a1e22>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe86dc94-522d-459f-88ee-61ec11ab15bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe86dc94-522d-459f-88ee-61ec11ab15bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe86dc94-522d-459f-88ee-61ec11ab15bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/43c44ad0-13a5-4781-82cc-bf7002c38164> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43c44ad0-13a5-4781-82cc-bf7002c38164";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43c44ad0-13a5-4781-82cc-bf7002c38164>.
+    
+<http://data.lblod.info/id/remote-data-objects/2360cf73-1b94-4543-a41c-08fb317ddfd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2360cf73-1b94-4543-a41c-08fb317ddfd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2360cf73-1b94-4543-a41c-08fb317ddfd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/075e5e78-7e74-4b63-9d5f-469a32986e80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "075e5e78-7e74-4b63-9d5f-469a32986e80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/075e5e78-7e74-4b63-9d5f-469a32986e80>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6261bf1-69f9-4f16-a624-ad0841481f5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6261bf1-69f9-4f16-a624-ad0841481f5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6261bf1-69f9-4f16-a624-ad0841481f5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6e241ff-a6fd-43c9-9156-e1f8bc22e337> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6e241ff-a6fd-43c9-9156-e1f8bc22e337";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6e241ff-a6fd-43c9-9156-e1f8bc22e337>.
+    
+<http://data.lblod.info/id/remote-data-objects/61f9562f-4b5b-4fc2-9331-c5cf5d834314> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61f9562f-4b5b-4fc2-9331-c5cf5d834314";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61f9562f-4b5b-4fc2-9331-c5cf5d834314>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fe5fd15-b7a8-45af-895c-33d581b8f38a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fe5fd15-b7a8-45af-895c-33d581b8f38a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_28-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fe5fd15-b7a8-45af-895c-33d581b8f38a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5447b81b-db81-41ad-aec8-5c5d57e43035> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5447b81b-db81-41ad-aec8-5c5d57e43035";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5447b81b-db81-41ad-aec8-5c5d57e43035>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ac147bc-41c8-49aa-9d5f-c35da4a98255> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ac147bc-41c8-49aa-9d5f-c35da4a98255";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ac147bc-41c8-49aa-9d5f-c35da4a98255>.
+    
+<http://data.lblod.info/id/remote-data-objects/74f75091-8a5f-4711-93fe-8f3872713601> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74f75091-8a5f-4711-93fe-8f3872713601";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74f75091-8a5f-4711-93fe-8f3872713601>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c6bbe9b-97ce-4353-b588-abc669c13ded> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c6bbe9b-97ce-4353-b588-abc669c13ded";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/a690212a8d78be38f70b83c18a6bd5701e414bb60ed9fdb29acb31d40803ac8a/GetPublication?filename=BesluitenLijstUitspraak_schepencollege_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c6bbe9b-97ce-4353-b588-abc669c13ded>.
+    
+<http://data.lblod.info/id/remote-data-objects/83c2cf6f-fb11-496b-9a5c-10933fcba703> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83c2cf6f-fb11-496b-9a5c-10933fcba703";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Agenda_OCMW-raad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83c2cf6f-fb11-496b-9a5c-10933fcba703>.
+    
+<http://data.lblod.info/id/remote-data-objects/49af779c-2d07-48b4-9e04-ad42fc3b0bd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49af779c-2d07-48b4-9e04-ad42fc3b0bd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Agenda_OCMW-raad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49af779c-2d07-48b4-9e04-ad42fc3b0bd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a59527d-c7f5-4e82-a8fb-e42db4dd06c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a59527d-c7f5-4e82-a8fb-e42db4dd06c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Agenda_OCMW-raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a59527d-c7f5-4e82-a8fb-e42db4dd06c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/265cb9b5-7a27-4bac-b9bd-3bdbfcd54f9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "265cb9b5-7a27-4bac-b9bd-3bdbfcd54f9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Agenda_OCMW-raad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/265cb9b5-7a27-4bac-b9bd-3bdbfcd54f9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/916aa16e-3f18-42f6-ad25-c8f24d5c281c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "916aa16e-3f18-42f6-ad25-c8f24d5c281c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Agenda_OCMW-raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/916aa16e-3f18-42f6-ad25-c8f24d5c281c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b07ce13-9fcb-48e3-b5c4-93645b0afc51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b07ce13-9fcb-48e3-b5c4-93645b0afc51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Agenda_OCMW-raad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b07ce13-9fcb-48e3-b5c4-93645b0afc51>.
+    
+<http://data.lblod.info/id/remote-data-objects/84a0b1e0-f628-474d-b5fb-c37909b1fd1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84a0b1e0-f628-474d-b5fb-c37909b1fd1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Agenda_OCMW-raad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84a0b1e0-f628-474d-b5fb-c37909b1fd1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/82a27330-8263-49e8-bc81-1cd8895dcda5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82a27330-8263-49e8-bc81-1cd8895dcda5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Agenda_OCMW-raad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82a27330-8263-49e8-bc81-1cd8895dcda5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d07bfed-9b66-4a77-b45c-47313d3cdfeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d07bfed-9b66-4a77-b45c-47313d3cdfeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d07bfed-9b66-4a77-b45c-47313d3cdfeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/7393885b-d5fb-4904-9330-219438139341> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7393885b-d5fb-4904-9330-219438139341";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7393885b-d5fb-4904-9330-219438139341>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cdd42b4-6216-4f64-ad4d-f87e5802ae71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cdd42b4-6216-4f64-ad4d-f87e5802ae71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cdd42b4-6216-4f64-ad4d-f87e5802ae71>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8b229d1-9ea3-4b76-957f-1cb1b2528b55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8b229d1-9ea3-4b76-957f-1cb1b2528b55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8b229d1-9ea3-4b76-957f-1cb1b2528b55>.
+    
+<http://data.lblod.info/id/remote-data-objects/76d22041-7255-413f-a638-9d153badfd00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76d22041-7255-413f-a638-9d153badfd00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76d22041-7255-413f-a638-9d153badfd00>.
+    
+<http://data.lblod.info/id/remote-data-objects/2563bcca-78a0-42ba-80f4-3d637147ec5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2563bcca-78a0-42ba-80f4-3d637147ec5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2563bcca-78a0-42ba-80f4-3d637147ec5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9bc3954f-935a-4110-9b26-9bdb325de359> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9bc3954f-935a-4110-9b26-9bdb325de359";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9bc3954f-935a-4110-9b26-9bdb325de359>.
+    
+<http://data.lblod.info/id/remote-data-objects/caa1854a-5929-48b1-af76-b76d8438107d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "caa1854a-5929-48b1-af76-b76d8438107d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/caa1854a-5929-48b1-af76-b76d8438107d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1a5812b-fa45-47f6-bd26-5ca9dff0d9e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1a5812b-fa45-47f6-bd26-5ca9dff0d9e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Notulen_OCMW-raad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1a5812b-fa45-47f6-bd26-5ca9dff0d9e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/95d44a80-abef-408f-ba4e-63ad6503eb1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95d44a80-abef-408f-ba4e-63ad6503eb1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Notulen_OCMW-raad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95d44a80-abef-408f-ba4e-63ad6503eb1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0032457-d4a0-4172-bfc2-f822b226eed0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0032457-d4a0-4172-bfc2-f822b226eed0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Notulen_OCMW-raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0032457-d4a0-4172-bfc2-f822b226eed0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecc4dbbe-f115-4562-ba51-900159aec39e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecc4dbbe-f115-4562-ba51-900159aec39e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Notulen_OCMW-raad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecc4dbbe-f115-4562-ba51-900159aec39e>.
+    
+<http://data.lblod.info/id/remote-data-objects/83a35c31-f271-4895-8890-d642215a7655> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83a35c31-f271-4895-8890-d642215a7655";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Notulen_OCMW-raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83a35c31-f271-4895-8890-d642215a7655>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea55c9e1-da3f-4108-b8d1-19beae8c9812> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea55c9e1-da3f-4108-b8d1-19beae8c9812";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Notulen_OCMW-raad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea55c9e1-da3f-4108-b8d1-19beae8c9812>.
+    
+<http://data.lblod.info/id/remote-data-objects/505b19db-1312-4596-bd1b-410de85a325a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "505b19db-1312-4596-bd1b-410de85a325a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Notulen_OCMW-raad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/505b19db-1312-4596-bd1b-410de85a325a>.
+    
+<http://data.lblod.info/id/remote-data-objects/90fba71c-db04-46fd-9277-6abb107bfca3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90fba71c-db04-46fd-9277-6abb107bfca3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Uittreksels_16-12-2021_61276.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90fba71c-db04-46fd-9277-6abb107bfca3>.
+    
+<http://data.lblod.info/id/remote-data-objects/65a25cf0-84e3-4ac7-b4b1-af0e66d4fcd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65a25cf0-84e3-4ac7-b4b1-af0e66d4fcd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Uittreksels_19-05-2022_64441.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65a25cf0-84e3-4ac7-b4b1-af0e66d4fcd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/321a0d4b-b9fb-48da-9ea3-a866ae9751ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "321a0d4b-b9fb-48da-9ea3-a866ae9751ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/ba24c826f29d125e92cd99fbde6624910d22baf775f2c716ec5506597a877667/GetPublication?filename=Uittreksels_30-06-2022_65117.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/321a0d4b-b9fb-48da-9ea3-a866ae9751ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/db00971d-7c92-4be2-acf9-f4c50f993376> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db00971d-7c92-4be2-acf9-f4c50f993376";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Agenda_gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db00971d-7c92-4be2-acf9-f4c50f993376>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e7ae499-0118-4737-8996-fa1ba1529f45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e7ae499-0118-4737-8996-fa1ba1529f45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Agenda_gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e7ae499-0118-4737-8996-fa1ba1529f45>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d2acc9a-bbe1-4490-837a-5a77e56c51bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d2acc9a-bbe1-4490-837a-5a77e56c51bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Agenda_gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d2acc9a-bbe1-4490-837a-5a77e56c51bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3fa912c-d60a-42be-802f-2d2af7b7ac17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3fa912c-d60a-42be-802f-2d2af7b7ac17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Agenda_gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3fa912c-d60a-42be-802f-2d2af7b7ac17>.
+    
+<http://data.lblod.info/id/remote-data-objects/72857390-70e0-4cf6-b55c-df7e245e4e25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72857390-70e0-4cf6-b55c-df7e245e4e25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Agenda_gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72857390-70e0-4cf6-b55c-df7e245e4e25>.
+    
+<http://data.lblod.info/id/remote-data-objects/11be23ca-649d-4a35-95a3-a5d1682bf691> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11be23ca-649d-4a35-95a3-a5d1682bf691";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Agenda_gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b68807bd-f6c2-460b-ae31-c47cc5bf7833> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11be23ca-649d-4a35-95a3-a5d1682bf691>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201642-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201642-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201642-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201642-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7ea4803e-e28f-41fa-96ca-bfa6519c854b> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7ea4803e-e28f-41fa-96ca-bfa6519c854b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f467ee4b-c9dd-4822-92cf-5c2a3d7554e6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/cf80ae05-2d2b-4cef-a22f-7b142cf1cfc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cf80ae05-2d2b-4cef-a22f-7b142cf1cfc0";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6>.
+
+  <http://redpencil.data.gift/id/task/1dcfaac0-fc30-43e2-8610-16ffe8e0fe51> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1dcfaac0-fc30-43e2-8610-16ffe8e0fe51";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7ea4803e-e28f-41fa-96ca-bfa6519c854b>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/cf80ae05-2d2b-4cef-a22f-7b142cf1cfc0>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/960a6a2d-fd95-48ab-be72-71fb30abeb13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "960a6a2d-fd95-48ab-be72-71fb30abeb13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Agenda_gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/960a6a2d-fd95-48ab-be72-71fb30abeb13>.
+    
+<http://data.lblod.info/id/remote-data-objects/b51f132a-c66f-49c6-bba0-44015c6046a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b51f132a-c66f-49c6-bba0-44015c6046a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Agenda_gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b51f132a-c66f-49c6-bba0-44015c6046a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/11630cdb-a74a-4207-b85a-00373f75d418> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11630cdb-a74a-4207-b85a-00373f75d418";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Agenda_gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11630cdb-a74a-4207-b85a-00373f75d418>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3279c10-1f8a-46d8-aa51-200558f0c56e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3279c10-1f8a-46d8-aa51-200558f0c56e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3279c10-1f8a-46d8-aa51-200558f0c56e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9f10ee3-f896-41a9-b027-1d56295f6aca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9f10ee3-f896-41a9-b027-1d56295f6aca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9f10ee3-f896-41a9-b027-1d56295f6aca>.
+    
+<http://data.lblod.info/id/remote-data-objects/46913c63-2012-4aae-ba56-6795995cc67c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46913c63-2012-4aae-ba56-6795995cc67c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46913c63-2012-4aae-ba56-6795995cc67c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bfddcab-fd9a-47a6-bc74-57a640752905> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bfddcab-fd9a-47a6-bc74-57a640752905";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bfddcab-fd9a-47a6-bc74-57a640752905>.
+    
+<http://data.lblod.info/id/remote-data-objects/44ed7e79-0f0b-43d5-add9-6350a99ae4f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44ed7e79-0f0b-43d5-add9-6350a99ae4f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44ed7e79-0f0b-43d5-add9-6350a99ae4f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/07f152a0-e2e1-4467-ab4b-a89d855dc31f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07f152a0-e2e1-4467-ab4b-a89d855dc31f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07f152a0-e2e1-4467-ab4b-a89d855dc31f>.
+    
+<http://data.lblod.info/id/remote-data-objects/68288b51-f887-4fde-b35a-1cde74014665> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68288b51-f887-4fde-b35a-1cde74014665";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68288b51-f887-4fde-b35a-1cde74014665>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7efe616-31c5-4f80-9ac6-eedb5ffa60af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7efe616-31c5-4f80-9ac6-eedb5ffa60af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7efe616-31c5-4f80-9ac6-eedb5ffa60af>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e2abc47-9971-4bd4-9140-42c8835ce3c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e2abc47-9971-4bd4-9140-42c8835ce3c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e2abc47-9971-4bd4-9140-42c8835ce3c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ae23246-21be-4d33-963b-3d850132fefa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ae23246-21be-4d33-963b-3d850132fefa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Notulen_gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ae23246-21be-4d33-963b-3d850132fefa>.
+    
+<http://data.lblod.info/id/remote-data-objects/204da6c9-afd3-475b-a021-e718a526a8f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "204da6c9-afd3-475b-a021-e718a526a8f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Notulen_gemeenteraad_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/204da6c9-afd3-475b-a021-e718a526a8f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a524bc06-cf9e-4b2a-ae96-dd73eefa56e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a524bc06-cf9e-4b2a-ae96-dd73eefa56e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Notulen_gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a524bc06-cf9e-4b2a-ae96-dd73eefa56e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed6ea5a1-9f7d-456a-bd2e-f6e4d6dfd06f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed6ea5a1-9f7d-456a-bd2e-f6e4d6dfd06f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Notulen_gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed6ea5a1-9f7d-456a-bd2e-f6e4d6dfd06f>.
+    
+<http://data.lblod.info/id/remote-data-objects/70c4426d-a9e4-48e2-8bba-8ab4f29b49a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70c4426d-a9e4-48e2-8bba-8ab4f29b49a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Notulen_gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70c4426d-a9e4-48e2-8bba-8ab4f29b49a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/01c89f2a-716f-4a40-8f37-9f00ba64b0b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01c89f2a-716f-4a40-8f37-9f00ba64b0b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Notulen_gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01c89f2a-716f-4a40-8f37-9f00ba64b0b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/56a2340e-7fc3-4c23-a352-55da92c72eb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56a2340e-7fc3-4c23-a352-55da92c72eb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Notulen_gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56a2340e-7fc3-4c23-a352-55da92c72eb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/558df1c5-7bb8-4183-a59d-c2b5c76a38eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "558df1c5-7bb8-4183-a59d-c2b5c76a38eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Notulen_gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/558df1c5-7bb8-4183-a59d-c2b5c76a38eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/79be10ef-a45e-4082-8f07-13cab2f41714> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79be10ef-a45e-4082-8f07-13cab2f41714";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_16-12-2021_61294.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79be10ef-a45e-4082-8f07-13cab2f41714>.
+    
+<http://data.lblod.info/id/remote-data-objects/035455c9-8a4d-4cf8-8dd2-7b6116f85d92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "035455c9-8a4d-4cf8-8dd2-7b6116f85d92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_16-12-2021_61297.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/035455c9-8a4d-4cf8-8dd2-7b6116f85d92>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f109000-0af3-4378-b101-c7462dc7446a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f109000-0af3-4378-b101-c7462dc7446a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_16-12-2021_61302.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f109000-0af3-4378-b101-c7462dc7446a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d5ed829-6445-417d-a666-4e3e6e3947e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d5ed829-6445-417d-a666-4e3e6e3947e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_16-12-2021_61303.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d5ed829-6445-417d-a666-4e3e6e3947e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/87a60055-9ac9-4ab7-8e9f-85b0c705cfb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87a60055-9ac9-4ab7-8e9f-85b0c705cfb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_19-05-2022_64416.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87a60055-9ac9-4ab7-8e9f-85b0c705cfb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/620d9bcf-6676-4ba2-ba83-a1e0d2a99b6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "620d9bcf-6676-4ba2-ba83-a1e0d2a99b6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61020.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/620d9bcf-6676-4ba2-ba83-a1e0d2a99b6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6067f3a-4e8b-47f5-aebd-c4ada72b4cb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6067f3a-4e8b-47f5-aebd-c4ada72b4cb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6067f3a-4e8b-47f5-aebd-c4ada72b4cb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7afa6760-5af3-497d-9440-6273e5f0ecf7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7afa6760-5af3-497d-9440-6273e5f0ecf7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7afa6760-5af3-497d-9440-6273e5f0ecf7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b82c56a7-b050-4fcd-acda-90e450b6034e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b82c56a7-b050-4fcd-acda-90e450b6034e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61023.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b82c56a7-b050-4fcd-acda-90e450b6034e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d040a29-5157-4272-8185-858b6fc88e9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d040a29-5157-4272-8185-858b6fc88e9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61024.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d040a29-5157-4272-8185-858b6fc88e9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8ab753e-74f2-429c-aa63-214fdb366f73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8ab753e-74f2-429c-aa63-214fdb366f73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61025.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8ab753e-74f2-429c-aa63-214fdb366f73>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f16f377-519f-44d5-b9fc-3f38e96b710d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f16f377-519f-44d5-b9fc-3f38e96b710d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61026.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f16f377-519f-44d5-b9fc-3f38e96b710d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b599fa6-fdb6-48de-b3b5-6d5d2b4c9889> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b599fa6-fdb6-48de-b3b5-6d5d2b4c9889";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61027.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b599fa6-fdb6-48de-b3b5-6d5d2b4c9889>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e0eecb9-b865-4d28-a152-3e9fe2792a9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e0eecb9-b865-4d28-a152-3e9fe2792a9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61028.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e0eecb9-b865-4d28-a152-3e9fe2792a9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6c2a396-a695-485c-b5d7-02e42c385f1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6c2a396-a695-485c-b5d7-02e42c385f1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61029.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6c2a396-a695-485c-b5d7-02e42c385f1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c93d678-6779-450b-aaaf-8989a0332841> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c93d678-6779-450b-aaaf-8989a0332841";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61030.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c93d678-6779-450b-aaaf-8989a0332841>.
+    
+<http://data.lblod.info/id/remote-data-objects/8de9db54-351b-4445-8416-0da38988c571> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8de9db54-351b-4445-8416-0da38988c571";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61031.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8de9db54-351b-4445-8416-0da38988c571>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddd2421f-3b88-415b-9489-318c766c4b1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddd2421f-3b88-415b-9489-318c766c4b1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61032.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddd2421f-3b88-415b-9489-318c766c4b1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4dc1f5e-e06e-4d66-aa6a-a36afdeef78d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4dc1f5e-e06e-4d66-aa6a-a36afdeef78d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61033.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4dc1f5e-e06e-4d66-aa6a-a36afdeef78d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4131837f-cd39-4a40-9e91-9635e83bf89a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4131837f-cd39-4a40-9e91-9635e83bf89a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61034.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4131837f-cd39-4a40-9e91-9635e83bf89a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c9ec178-8c18-4696-91fe-30efcfa5919c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c9ec178-8c18-4696-91fe-30efcfa5919c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61035.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c9ec178-8c18-4696-91fe-30efcfa5919c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2a0f8db-55fc-4908-a0fc-2654f97004b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2a0f8db-55fc-4908-a0fc-2654f97004b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61036.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2a0f8db-55fc-4908-a0fc-2654f97004b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d8c64f2-caa9-4b46-a52f-515b31cfc812> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d8c64f2-caa9-4b46-a52f-515b31cfc812";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61037.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d8c64f2-caa9-4b46-a52f-515b31cfc812>.
+    
+<http://data.lblod.info/id/remote-data-objects/d077a117-2e5c-456e-9546-d420173b25c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d077a117-2e5c-456e-9546-d420173b25c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61038.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d077a117-2e5c-456e-9546-d420173b25c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/28c2cc9c-4a1b-4d2c-bbec-378d9d796fd4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28c2cc9c-4a1b-4d2c-bbec-378d9d796fd4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61039.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28c2cc9c-4a1b-4d2c-bbec-378d9d796fd4>.
+    
+<http://data.lblod.info/id/remote-data-objects/f751e819-6444-4e41-94c1-41cc3938fb60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f751e819-6444-4e41-94c1-41cc3938fb60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61040.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f751e819-6444-4e41-94c1-41cc3938fb60>.
+    
+<http://data.lblod.info/id/remote-data-objects/27342526-0d11-4f08-b39d-c192731a8dec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27342526-0d11-4f08-b39d-c192731a8dec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61041.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27342526-0d11-4f08-b39d-c192731a8dec>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f0de916-57d0-4077-ae2d-0a58d46f0cc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f0de916-57d0-4077-ae2d-0a58d46f0cc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61042.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f0de916-57d0-4077-ae2d-0a58d46f0cc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4438d834-4e18-4823-ab85-31d3b8523510> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4438d834-4e18-4823-ab85-31d3b8523510";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61043.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4438d834-4e18-4823-ab85-31d3b8523510>.
+    
+<http://data.lblod.info/id/remote-data-objects/2259a919-2d75-4d75-96ce-9f0b1d338c3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2259a919-2d75-4d75-96ce-9f0b1d338c3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61044.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f467ee4b-c9dd-4822-92cf-5c2a3d7554e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2259a919-2d75-4d75-96ce-9f0b1d338c3f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201644-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201644-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201644-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201644-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/628a8902-7715-446d-acef-07c30e0494a0> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "628a8902-7715-446d-acef-07c30e0494a0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4243e6b3-ea3b-40ef-a0c6-86dc6fa3457e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4243e6b3-ea3b-40ef-a0c6-86dc6fa3457e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31>.
+
+  <http://redpencil.data.gift/id/task/b607344f-672d-47c2-8e38-0e38218e5cf9> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b607344f-672d-47c2-8e38-0e38218e5cf9";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/628a8902-7715-446d-acef-07c30e0494a0>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4243e6b3-ea3b-40ef-a0c6-86dc6fa3457e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/75b50701-1971-44c4-9278-f4edaf86df6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75b50701-1971-44c4-9278-f4edaf86df6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61045.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75b50701-1971-44c4-9278-f4edaf86df6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/846c6b54-ee81-4b40-b682-e2f37ff3aba3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "846c6b54-ee81-4b40-b682-e2f37ff3aba3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61046.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/846c6b54-ee81-4b40-b682-e2f37ff3aba3>.
+    
+<http://data.lblod.info/id/remote-data-objects/aaea80b6-c36e-400d-9ce2-054c52ea2456> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aaea80b6-c36e-400d-9ce2-054c52ea2456";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61047.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aaea80b6-c36e-400d-9ce2-054c52ea2456>.
+    
+<http://data.lblod.info/id/remote-data-objects/7856a0fc-b571-4bb4-ba1a-a77d58a8d697> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7856a0fc-b571-4bb4-ba1a-a77d58a8d697";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61048.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7856a0fc-b571-4bb4-ba1a-a77d58a8d697>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1a87602-b0eb-44ea-80d8-76699af59037> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1a87602-b0eb-44ea-80d8-76699af59037";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_25-11-2021_61114.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1a87602-b0eb-44ea-80d8-76699af59037>.
+    
+<http://data.lblod.info/id/remote-data-objects/a92881af-e654-442b-aafa-16f066021c50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a92881af-e654-442b-aafa-16f066021c50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_27-01-2022_61984.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a92881af-e654-442b-aafa-16f066021c50>.
+    
+<http://data.lblod.info/id/remote-data-objects/df12130b-0888-4329-aa87-c6daa4ed6319> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df12130b-0888-4329-aa87-c6daa4ed6319";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_28-10-2021_59879.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df12130b-0888-4329-aa87-c6daa4ed6319>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc4e0072-7bae-4637-b152-6b60cc35d1b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc4e0072-7bae-4637-b152-6b60cc35d1b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_30-06-2022_65007.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc4e0072-7bae-4637-b152-6b60cc35d1b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2b5df8c-ff11-488d-a8cd-533aecccd18d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2b5df8c-ff11-488d-a8cd-533aecccd18d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_30-06-2022_65008.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2b5df8c-ff11-488d-a8cd-533aecccd18d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e563d95c-0e9e-4dfa-8e2d-361364efcf4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e563d95c-0e9e-4dfa-8e2d-361364efcf4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_30-06-2022_65010.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e563d95c-0e9e-4dfa-8e2d-361364efcf4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/79ddbab8-71ff-4036-a11c-7443101f8c61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79ddbab8-71ff-4036-a11c-7443101f8c61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_30-06-2022_65011.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79ddbab8-71ff-4036-a11c-7443101f8c61>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d37d3e2-04f4-4d6f-8a2d-80880446c3d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d37d3e2-04f4-4d6f-8a2d-80880446c3d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_30-06-2022_65022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d37d3e2-04f4-4d6f-8a2d-80880446c3d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/94ecf024-937d-4f9d-9be0-74bec254914a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94ecf024-937d-4f9d-9be0-74bec254914a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_30-06-2022_65026.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94ecf024-937d-4f9d-9be0-74bec254914a>.
+    
+<http://data.lblod.info/id/remote-data-objects/81173444-939f-43ff-94f9-1e41e142d677> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81173444-939f-43ff-94f9-1e41e142d677";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_30-06-2022_65027.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81173444-939f-43ff-94f9-1e41e142d677>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8c36e50-f88f-4f89-8380-eb3bf55f3809> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8c36e50-f88f-4f89-8380-eb3bf55f3809";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_31-03-2022_62851.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8c36e50-f88f-4f89-8380-eb3bf55f3809>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ed7add5-cb3c-499d-bd00-1d1be480002d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ed7add5-cb3c-499d-bd00-1d1be480002d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-gillis-waas.be/LBLODWeb/Home/Overzicht/d7c440513b4aa84aebfa467f61cdfca4fd1092517d68fad387623f380ae70fba/GetPublication?filename=Uittreksels_31-03-2022_62856.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ed7add5-cb3c-499d-bd00-1d1be480002d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d13d5252-139d-4d2f-9e3d-a05adbd83ca1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d13d5252-139d-4d2f-9e3d-a05adbd83ca1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d13d5252-139d-4d2f-9e3d-a05adbd83ca1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1bc74be-8c6b-4ac2-aaeb-894a4539435a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1bc74be-8c6b-4ac2-aaeb-894a4539435a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_01-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1bc74be-8c6b-4ac2-aaeb-894a4539435a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9e1e799-02b9-4af9-8773-aa02663416e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9e1e799-02b9-4af9-8773-aa02663416e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9e1e799-02b9-4af9-8773-aa02663416e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9640295c-9bb1-4719-be70-0fbd83ff2299> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9640295c-9bb1-4719-be70-0fbd83ff2299";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9640295c-9bb1-4719-be70-0fbd83ff2299>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ff9f89b-c0d0-49bc-9aa1-13246efa26c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ff9f89b-c0d0-49bc-9aa1-13246efa26c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_04-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ff9f89b-c0d0-49bc-9aa1-13246efa26c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cb0fbd1-286f-4f32-b5eb-0e8d19236a3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cb0fbd1-286f-4f32-b5eb-0e8d19236a3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_05-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cb0fbd1-286f-4f32-b5eb-0e8d19236a3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed18cf9b-12e0-4162-a354-ce4e94993da7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed18cf9b-12e0-4162-a354-ce4e94993da7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed18cf9b-12e0-4162-a354-ce4e94993da7>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa63c838-2e2f-4ecb-abe6-ae6904de858f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa63c838-2e2f-4ecb-abe6-ae6904de858f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_07-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa63c838-2e2f-4ecb-abe6-ae6904de858f>.
+    
+<http://data.lblod.info/id/remote-data-objects/650cd85f-c1c1-4eb4-95f6-6d0e625d6d1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "650cd85f-c1c1-4eb4-95f6-6d0e625d6d1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_08-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/650cd85f-c1c1-4eb4-95f6-6d0e625d6d1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4796f6b6-13e5-4cdf-a5b8-eafd63fa185a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4796f6b6-13e5-4cdf-a5b8-eafd63fa185a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4796f6b6-13e5-4cdf-a5b8-eafd63fa185a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9393f9ed-4d3f-44b5-a77b-e9a61f3fbbce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9393f9ed-4d3f-44b5-a77b-e9a61f3fbbce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_10-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9393f9ed-4d3f-44b5-a77b-e9a61f3fbbce>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8e51661-05b8-4258-9791-aa9456220812> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8e51661-05b8-4258-9791-aa9456220812";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_11-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8e51661-05b8-4258-9791-aa9456220812>.
+    
+<http://data.lblod.info/id/remote-data-objects/32bcfe1f-7e47-4656-8265-72a8b4c4bb50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32bcfe1f-7e47-4656-8265-72a8b4c4bb50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32bcfe1f-7e47-4656-8265-72a8b4c4bb50>.
+    
+<http://data.lblod.info/id/remote-data-objects/feba6c1f-5706-4453-b2c6-fd4bc5876506> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "feba6c1f-5706-4453-b2c6-fd4bc5876506";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/feba6c1f-5706-4453-b2c6-fd4bc5876506>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7aeb4df-c271-44d6-b987-e19142dd7e5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7aeb4df-c271-44d6-b987-e19142dd7e5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_14-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7aeb4df-c271-44d6-b987-e19142dd7e5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2df40021-8dc3-4c76-ad51-f53776e03809> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2df40021-8dc3-4c76-ad51-f53776e03809";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2df40021-8dc3-4c76-ad51-f53776e03809>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6f6c45b-ed01-4426-ac63-34a506b039d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6f6c45b-ed01-4426-ac63-34a506b039d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6f6c45b-ed01-4426-ac63-34a506b039d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b833a20b-840d-477f-b12a-0fcd250d8882> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b833a20b-840d-477f-b12a-0fcd250d8882";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_17-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b833a20b-840d-477f-b12a-0fcd250d8882>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a4c559a-e567-4053-8dfd-53c5f6d76702> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a4c559a-e567-4053-8dfd-53c5f6d76702";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a4c559a-e567-4053-8dfd-53c5f6d76702>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e3fbae4-698c-4dbb-b9fa-f3b894ec5aa2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e3fbae4-698c-4dbb-b9fa-f3b894ec5aa2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_18-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e3fbae4-698c-4dbb-b9fa-f3b894ec5aa2>.
+    
+<http://data.lblod.info/id/remote-data-objects/41208a5d-5d90-4dad-bcde-043ea4cb4eb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41208a5d-5d90-4dad-bcde-043ea4cb4eb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41208a5d-5d90-4dad-bcde-043ea4cb4eb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/16776808-d321-4094-bdd0-811c194b5770> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16776808-d321-4094-bdd0-811c194b5770";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16776808-d321-4094-bdd0-811c194b5770>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2bf7754-16db-4c61-b4c9-10f26c809036> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2bf7754-16db-4c61-b4c9-10f26c809036";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_22-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2bf7754-16db-4c61-b4c9-10f26c809036>.
+    
+<http://data.lblod.info/id/remote-data-objects/5355f5fc-7f2b-4dad-8fab-c59788b2cd76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5355f5fc-7f2b-4dad-8fab-c59788b2cd76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5355f5fc-7f2b-4dad-8fab-c59788b2cd76>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a66bb27-33f5-4a95-a326-c42c94212218> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a66bb27-33f5-4a95-a326-c42c94212218";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_25-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a66bb27-33f5-4a95-a326-c42c94212218>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb59c008-a10b-494b-9ad4-a457b33f75b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb59c008-a10b-494b-9ad4-a457b33f75b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_25-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb59c008-a10b-494b-9ad4-a457b33f75b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/93e22db9-5db7-4992-bb07-c0fa9457ddf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93e22db9-5db7-4992-bb07-c0fa9457ddf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93e22db9-5db7-4992-bb07-c0fa9457ddf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/dad66898-d995-4100-a9ab-2298bee8a3cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dad66898-d995-4100-a9ab-2298bee8a3cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_26-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dad66898-d995-4100-a9ab-2298bee8a3cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e87d453-00ac-4508-bd96-04c27ba33067> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e87d453-00ac-4508-bd96-04c27ba33067";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_27-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e87d453-00ac-4508-bd96-04c27ba33067>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8582644-43ab-4168-a82b-269bb40d5429> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8582644-43ab-4168-a82b-269bb40d5429";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8582644-43ab-4168-a82b-269bb40d5429>.
+    
+<http://data.lblod.info/id/remote-data-objects/221a32d3-ce7a-4564-8c53-9bed0ae2702b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "221a32d3-ce7a-4564-8c53-9bed0ae2702b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/221a32d3-ce7a-4564-8c53-9bed0ae2702b>.
+    
+<http://data.lblod.info/id/remote-data-objects/bedf208f-696f-4948-b461-db53fe7d9286> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bedf208f-696f-4948-b461-db53fe7d9286";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_29-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bedf208f-696f-4948-b461-db53fe7d9286>.
+    
+<http://data.lblod.info/id/remote-data-objects/9efca5cb-77d9-4e21-bd63-32513e8445ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9efca5cb-77d9-4e21-bd63-32513e8445ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/8be95d506cdae36b7d7b04bf81d1c8518a18e8d7792dae57f5d26cac3836970b/GetPublication?filename=BesluitenLijst_Burgemeester_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9efca5cb-77d9-4e21-bd63-32513e8445ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/01ff290c-1705-46a7-a8a3-d717a37106ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01ff290c-1705-46a7-a8a3-d717a37106ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e0c04ed5-b6ce-4a06-90c3-b4aa445f6b31> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01ff290c-1705-46a7-a8a3-d717a37106ae>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201645-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201645-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201645-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201645-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/364422bc-ab66-45e7-a77b-8d7c7dc1804a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "364422bc-ab66-45e7-a77b-8d7c7dc1804a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2370b9ba-e9b7-4a98-bed1-2191d32780e6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/79b6518f-c18d-40a7-9c57-fe5432c0e4f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "79b6518f-c18d-40a7-9c57-fe5432c0e4f2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6>.
+
+  <http://redpencil.data.gift/id/task/bd56c6cf-f192-4835-ab0d-0486a328ac7c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bd56c6cf-f192-4835-ab0d-0486a328ac7c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/364422bc-ab66-45e7-a77b-8d7c7dc1804a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/79b6518f-c18d-40a7-9c57-fe5432c0e4f2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c8c7218c-4930-4c6b-bec4-791bdcc4afcb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8c7218c-4930-4c6b-bec4-791bdcc4afcb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8c7218c-4930-4c6b-bec4-791bdcc4afcb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d016a5d3-a5e8-4248-bc9b-39c62c9acf5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d016a5d3-a5e8-4248-bc9b-39c62c9acf5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d016a5d3-a5e8-4248-bc9b-39c62c9acf5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/87580fcb-945c-4c93-84f2-587cfeead561> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87580fcb-945c-4c93-84f2-587cfeead561";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87580fcb-945c-4c93-84f2-587cfeead561>.
+    
+<http://data.lblod.info/id/remote-data-objects/d11f65d8-4af9-4fbb-bc4f-041a0d777638> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d11f65d8-4af9-4fbb-bc4f-041a0d777638";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_04-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d11f65d8-4af9-4fbb-bc4f-041a0d777638>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d229951-ca3d-46b3-872c-cf48862b16f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d229951-ca3d-46b3-872c-cf48862b16f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d229951-ca3d-46b3-872c-cf48862b16f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/81a52726-073a-4feb-9466-281c3a9b4429> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81a52726-073a-4feb-9466-281c3a9b4429";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81a52726-073a-4feb-9466-281c3a9b4429>.
+    
+<http://data.lblod.info/id/remote-data-objects/796c8db6-08b1-4dc6-a2ac-89634ac8aaf4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "796c8db6-08b1-4dc6-a2ac-89634ac8aaf4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_07-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/796c8db6-08b1-4dc6-a2ac-89634ac8aaf4>.
+    
+<http://data.lblod.info/id/remote-data-objects/2851a069-4617-4999-9c5e-3ff3a32a4f6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2851a069-4617-4999-9c5e-3ff3a32a4f6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2851a069-4617-4999-9c5e-3ff3a32a4f6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a34c4ed-784b-4f92-b561-bd070f0b4357> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a34c4ed-784b-4f92-b561-bd070f0b4357";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a34c4ed-784b-4f92-b561-bd070f0b4357>.
+    
+<http://data.lblod.info/id/remote-data-objects/f43ac3aa-1dac-4adb-9594-f2b4041b942b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f43ac3aa-1dac-4adb-9594-f2b4041b942b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_09-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f43ac3aa-1dac-4adb-9594-f2b4041b942b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2773b0cd-c58f-40fd-a0aa-fc3722545092> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2773b0cd-c58f-40fd-a0aa-fc3722545092";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2773b0cd-c58f-40fd-a0aa-fc3722545092>.
+    
+<http://data.lblod.info/id/remote-data-objects/6af186ba-8e78-4748-b4b0-863cc564d23f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6af186ba-8e78-4748-b4b0-863cc564d23f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6af186ba-8e78-4748-b4b0-863cc564d23f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d30d2509-ef6d-4712-bc42-3a530f10cf2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d30d2509-ef6d-4712-bc42-3a530f10cf2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d30d2509-ef6d-4712-bc42-3a530f10cf2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b5ffeea-2b7e-423a-9f28-fdbbd33fb90a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b5ffeea-2b7e-423a-9f28-fdbbd33fb90a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b5ffeea-2b7e-423a-9f28-fdbbd33fb90a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f02bb5d-cf80-483a-b2ff-cfdffe95aa2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f02bb5d-cf80-483a-b2ff-cfdffe95aa2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f02bb5d-cf80-483a-b2ff-cfdffe95aa2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/97e473d9-a2f2-4270-8239-32fd1332a1f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97e473d9-a2f2-4270-8239-32fd1332a1f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97e473d9-a2f2-4270-8239-32fd1332a1f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/df75ad5c-7e9d-445d-b113-b9ba7233d67f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df75ad5c-7e9d-445d-b113-b9ba7233d67f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df75ad5c-7e9d-445d-b113-b9ba7233d67f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e77b3e5-d14f-472c-bbde-4027dadb5154> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e77b3e5-d14f-472c-bbde-4027dadb5154";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e77b3e5-d14f-472c-bbde-4027dadb5154>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e4e5b93-e15e-4756-a130-655c8a3e4a2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e4e5b93-e15e-4756-a130-655c8a3e4a2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e4e5b93-e15e-4756-a130-655c8a3e4a2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bc6098a-935e-4415-9c61-9aed143f3584> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bc6098a-935e-4415-9c61-9aed143f3584";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bc6098a-935e-4415-9c61-9aed143f3584>.
+    
+<http://data.lblod.info/id/remote-data-objects/b356d404-1831-4fab-b62d-753c51724673> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b356d404-1831-4fab-b62d-753c51724673";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b356d404-1831-4fab-b62d-753c51724673>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e2f3268-b1d8-4ab4-afbb-d78c8ff54703> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e2f3268-b1d8-4ab4-afbb-d78c8ff54703";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e2f3268-b1d8-4ab4-afbb-d78c8ff54703>.
+    
+<http://data.lblod.info/id/remote-data-objects/0db29601-8c67-4eee-a8c4-3f98f902f495> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0db29601-8c67-4eee-a8c4-3f98f902f495";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0db29601-8c67-4eee-a8c4-3f98f902f495>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b0c28e5-9546-47bf-a89e-7f5a8e2f0a88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b0c28e5-9546-47bf-a89e-7f5a8e2f0a88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b0c28e5-9546-47bf-a89e-7f5a8e2f0a88>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cbe4084-55a1-485f-83b9-26a2ce1f4e3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cbe4084-55a1-485f-83b9-26a2ce1f4e3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cbe4084-55a1-485f-83b9-26a2ce1f4e3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4d889bd-b0d6-4611-aded-eea2f64998dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4d889bd-b0d6-4611-aded-eea2f64998dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4d889bd-b0d6-4611-aded-eea2f64998dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8e21048-b91e-44a8-9779-e3cd79042481> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8e21048-b91e-44a8-9779-e3cd79042481";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8e21048-b91e-44a8-9779-e3cd79042481>.
+    
+<http://data.lblod.info/id/remote-data-objects/27b6d906-8500-4cb4-927b-9b5465e27629> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27b6d906-8500-4cb4-927b-9b5465e27629";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27b6d906-8500-4cb4-927b-9b5465e27629>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ddec682-0219-4e32-b118-e33fc1cd1479> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ddec682-0219-4e32-b118-e33fc1cd1479";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ddec682-0219-4e32-b118-e33fc1cd1479>.
+    
+<http://data.lblod.info/id/remote-data-objects/28da9bb0-6443-4639-a9bc-642dcb7685ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28da9bb0-6443-4639-a9bc-642dcb7685ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28da9bb0-6443-4639-a9bc-642dcb7685ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/37c5552e-1b08-4f28-87af-a59635329ad0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37c5552e-1b08-4f28-87af-a59635329ad0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37c5552e-1b08-4f28-87af-a59635329ad0>.
+    
+<http://data.lblod.info/id/remote-data-objects/612a2401-c85d-4c2a-a2a9-154f4530fe02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "612a2401-c85d-4c2a-a2a9-154f4530fe02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/612a2401-c85d-4c2a-a2a9-154f4530fe02>.
+    
+<http://data.lblod.info/id/remote-data-objects/3619107f-3d33-4922-bdef-97853188370d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3619107f-3d33-4922-bdef-97853188370d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3619107f-3d33-4922-bdef-97853188370d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3ace415-33fa-4ae1-9d32-610373da9a7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3ace415-33fa-4ae1-9d32-610373da9a7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3ace415-33fa-4ae1-9d32-610373da9a7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0eed1aad-79a4-47ac-88e7-4a2897666820> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0eed1aad-79a4-47ac-88e7-4a2897666820";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0eed1aad-79a4-47ac-88e7-4a2897666820>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cccf9de-0151-440c-9e89-e795f5955453> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cccf9de-0151-440c-9e89-e795f5955453";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cccf9de-0151-440c-9e89-e795f5955453>.
+    
+<http://data.lblod.info/id/remote-data-objects/6450a249-cbf5-48e0-b1ef-2dd5fe74fdd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6450a249-cbf5-48e0-b1ef-2dd5fe74fdd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_28-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6450a249-cbf5-48e0-b1ef-2dd5fe74fdd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9195587-8638-447a-b454-7926b771adcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9195587-8638-447a-b454-7926b771adcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9195587-8638-447a-b454-7926b771adcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/48e9a1ed-1437-4ee8-a12d-4cb80cee0d3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48e9a1ed-1437-4ee8-a12d-4cb80cee0d3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48e9a1ed-1437-4ee8-a12d-4cb80cee0d3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9670357b-caf2-4941-8795-cd7d92652af9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9670357b-caf2-4941-8795-cd7d92652af9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9670357b-caf2-4941-8795-cd7d92652af9>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c28d72e-4c7b-4937-8ec1-369a9c4efa4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c28d72e-4c7b-4937-8ec1-369a9c4efa4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=BesluitenLijst_College_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c28d72e-4c7b-4937-8ec1-369a9c4efa4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5527d42-2697-4adf-982a-89586f6b0f75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5527d42-2697-4adf-982a-89586f6b0f75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/9522f42bdd7b46b3d5341b3cf196c9b6c981703022796b7af6e29746193bbf52/GetPublication?filename=Uittreksels_02-12-2021_33390.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5527d42-2697-4adf-982a-89586f6b0f75>.
+    
+<http://data.lblod.info/id/remote-data-objects/15c9993d-aea6-4ef4-8b6b-7e11ef832192> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15c9993d-aea6-4ef4-8b6b-7e11ef832192";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Agenda_OCMW-raad_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15c9993d-aea6-4ef4-8b6b-7e11ef832192>.
+    
+<http://data.lblod.info/id/remote-data-objects/663dc158-8d4f-4fcf-b3be-e9ab5f22c2a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "663dc158-8d4f-4fcf-b3be-e9ab5f22c2a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Agenda_OCMW-raad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/663dc158-8d4f-4fcf-b3be-e9ab5f22c2a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/aaabe585-86a7-48c8-b527-6aaaf3c608ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aaabe585-86a7-48c8-b527-6aaaf3c608ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Agenda_OCMW-raad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aaabe585-86a7-48c8-b527-6aaaf3c608ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/e19aab07-e917-433d-b31e-ddf11d18dbdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e19aab07-e917-433d-b31e-ddf11d18dbdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Agenda_OCMW-raad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e19aab07-e917-433d-b31e-ddf11d18dbdf>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cee5f75-db66-4977-bc2c-a1ee4be66141> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cee5f75-db66-4977-bc2c-a1ee4be66141";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Agenda_OCMW-raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cee5f75-db66-4977-bc2c-a1ee4be66141>.
+    
+<http://data.lblod.info/id/remote-data-objects/839cf3f7-e779-445e-9b97-6a83c32adcb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "839cf3f7-e779-445e-9b97-6a83c32adcb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Agenda_OCMW-raad_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/839cf3f7-e779-445e-9b97-6a83c32adcb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9cf20af-fa69-49f3-840f-44716f75b6a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9cf20af-fa69-49f3-840f-44716f75b6a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Agenda_OCMW-raad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9cf20af-fa69-49f3-840f-44716f75b6a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1c1af4c-f13b-4b12-b7ea-57093b92dd76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1c1af4c-f13b-4b12-b7ea-57093b92dd76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=BesluitenLijst_OCMW-raad_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2370b9ba-e9b7-4a98-bed1-2191d32780e6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1c1af4c-f13b-4b12-b7ea-57093b92dd76>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201646-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201646-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201646-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201646-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/fd3f5a36-4f25-4c1d-8e1c-ca63e851081c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fd3f5a36-4f25-4c1d-8e1c-ca63e851081c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "68f20550-0b49-404b-9978-d0945daff063";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/78e8434b-cafa-4286-88eb-c8daee216469> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "78e8434b-cafa-4286-88eb-c8daee216469";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063>.
+
+  <http://redpencil.data.gift/id/task/b1565580-23ef-42cc-ad53-975682c552c9> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b1565580-23ef-42cc-ad53-975682c552c9";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/fd3f5a36-4f25-4c1d-8e1c-ca63e851081c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/78e8434b-cafa-4286-88eb-c8daee216469>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/134fa36a-bddf-4b81-a3a0-a4954b6ac100> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "134fa36a-bddf-4b81-a3a0-a4954b6ac100";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=BesluitenLijst_OCMW-raad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/134fa36a-bddf-4b81-a3a0-a4954b6ac100>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce42a8d9-3576-44ca-8abf-e41f02aa86c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce42a8d9-3576-44ca-8abf-e41f02aa86c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=BesluitenLijst_OCMW-raad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce42a8d9-3576-44ca-8abf-e41f02aa86c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/93011d24-8fd7-455c-aa57-c4e053a26944> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93011d24-8fd7-455c-aa57-c4e053a26944";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=BesluitenLijst_OCMW-raad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93011d24-8fd7-455c-aa57-c4e053a26944>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3ce91cf-a088-43f4-a8b7-0176067a67a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3ce91cf-a088-43f4-a8b7-0176067a67a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=BesluitenLijst_OCMW-raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3ce91cf-a088-43f4-a8b7-0176067a67a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/0976e903-ad26-49c1-99fa-cdccf35c8bdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0976e903-ad26-49c1-99fa-cdccf35c8bdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=BesluitenLijst_OCMW-raad_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0976e903-ad26-49c1-99fa-cdccf35c8bdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f04d89e-d909-49b1-848e-a753089ef5d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f04d89e-d909-49b1-848e-a753089ef5d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=BesluitenLijst_OCMW-raad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f04d89e-d909-49b1-848e-a753089ef5d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c5d3814-c639-4c8a-a897-4c14ff9756d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c5d3814-c639-4c8a-a897-4c14ff9756d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Notulen_OCMW-raad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c5d3814-c639-4c8a-a897-4c14ff9756d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fe16aed-1e1c-48af-92cf-13288d321103> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fe16aed-1e1c-48af-92cf-13288d321103";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Notulen_OCMW-raad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fe16aed-1e1c-48af-92cf-13288d321103>.
+    
+<http://data.lblod.info/id/remote-data-objects/77821804-a1f5-4543-9b00-150f8abae373> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77821804-a1f5-4543-9b00-150f8abae373";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Notulen_OCMW-raad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77821804-a1f5-4543-9b00-150f8abae373>.
+    
+<http://data.lblod.info/id/remote-data-objects/af534b8d-deb8-4244-babb-3c2da7254f0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af534b8d-deb8-4244-babb-3c2da7254f0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Notulen_OCMW-raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af534b8d-deb8-4244-babb-3c2da7254f0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/444c9668-5c6e-4f2a-b238-ee4b674c5e88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "444c9668-5c6e-4f2a-b238-ee4b674c5e88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Notulen_OCMW-raad_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/444c9668-5c6e-4f2a-b238-ee4b674c5e88>.
+    
+<http://data.lblod.info/id/remote-data-objects/2742a4d4-cb5c-42b2-8828-531a587c77f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2742a4d4-cb5c-42b2-8828-531a587c77f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Notulen_OCMW-raad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2742a4d4-cb5c-42b2-8828-531a587c77f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6c3697e-e6db-4988-b3d6-f9a5e15711e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6c3697e-e6db-4988-b3d6-f9a5e15711e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Uittreksels_05-07-2022_35893.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6c3697e-e6db-4988-b3d6-f9a5e15711e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0be1691f-648f-4bcc-83be-e94178fc0926> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0be1691f-648f-4bcc-83be-e94178fc0926";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Uittreksels_22-12-2021_33397.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0be1691f-648f-4bcc-83be-e94178fc0926>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f474e07-1422-42c1-a069-f7204cdbd131> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f474e07-1422-42c1-a069-f7204cdbd131";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Uittreksels_22-12-2021_33523.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f474e07-1422-42c1-a069-f7204cdbd131>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e2fced5-bafe-47b6-98f5-dbbacfd267eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e2fced5-bafe-47b6-98f5-dbbacfd267eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Uittreksels_25-01-2022_33796.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e2fced5-bafe-47b6-98f5-dbbacfd267eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b9fb48b-134a-4f39-ab31-f19f00333992> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b9fb48b-134a-4f39-ab31-f19f00333992";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Uittreksels_25-01-2022_33797.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b9fb48b-134a-4f39-ab31-f19f00333992>.
+    
+<http://data.lblod.info/id/remote-data-objects/df0d72b5-380b-4a61-be47-90d7fe1cecf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df0d72b5-380b-4a61-be47-90d7fe1cecf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Uittreksels_25-01-2022_33798.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df0d72b5-380b-4a61-be47-90d7fe1cecf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/6de2feb3-7a11-47e7-b876-61b3c08310d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6de2feb3-7a11-47e7-b876-61b3c08310d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Uittreksels_25-01-2022_33821.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6de2feb3-7a11-47e7-b876-61b3c08310d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7c1f5f2-fdab-4a59-a49e-0b32d4a693cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7c1f5f2-fdab-4a59-a49e-0b32d4a693cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/b3859b9714acc1f6fe093b5b54262daebd150f8c1bfcf75d0f7d4418ee517111/GetPublication?filename=Uittreksels_31-05-2022_35041.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7c1f5f2-fdab-4a59-a49e-0b32d4a693cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc593000-a849-42a6-9ba1-ecc86eb142bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc593000-a849-42a6-9ba1-ecc86eb142bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Agenda_Gemeenteraad_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc593000-a849-42a6-9ba1-ecc86eb142bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3d0ddcb-215e-426f-8811-d4695ad7de20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3d0ddcb-215e-426f-8811-d4695ad7de20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Agenda_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3d0ddcb-215e-426f-8811-d4695ad7de20>.
+    
+<http://data.lblod.info/id/remote-data-objects/d453a12e-f3ce-418f-bafd-9c7503b8a6c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d453a12e-f3ce-418f-bafd-9c7503b8a6c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Agenda_Gemeenteraad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d453a12e-f3ce-418f-bafd-9c7503b8a6c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cf391ec-9822-4ee3-8df6-8087c3b9c6a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cf391ec-9822-4ee3-8df6-8087c3b9c6a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Agenda_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cf391ec-9822-4ee3-8df6-8087c3b9c6a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a73eed85-e42c-4247-8454-411d148c626c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a73eed85-e42c-4247-8454-411d148c626c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Agenda_Gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a73eed85-e42c-4247-8454-411d148c626c>.
+    
+<http://data.lblod.info/id/remote-data-objects/68776ec5-983b-4c83-8580-5836cf750ec3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68776ec5-983b-4c83-8580-5836cf750ec3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Agenda_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68776ec5-983b-4c83-8580-5836cf750ec3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7797a7d3-4ffd-4a07-a8cb-fd39178ff87e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7797a7d3-4ffd-4a07-a8cb-fd39178ff87e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Agenda_Gemeenteraad_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7797a7d3-4ffd-4a07-a8cb-fd39178ff87e>.
+    
+<http://data.lblod.info/id/remote-data-objects/abb5b5ea-8615-4e1b-a771-e74e66884707> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abb5b5ea-8615-4e1b-a771-e74e66884707";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Agenda_Gemeenteraad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abb5b5ea-8615-4e1b-a771-e74e66884707>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e8dd5bc-0fb7-4805-aedc-b0f5e45b34bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e8dd5bc-0fb7-4805-aedc-b0f5e45b34bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=BesluitenLijst_Gemeenteraad_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e8dd5bc-0fb7-4805-aedc-b0f5e45b34bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/bca2a365-9f64-489a-bd11-98e5fbff0f10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bca2a365-9f64-489a-bd11-98e5fbff0f10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=BesluitenLijst_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bca2a365-9f64-489a-bd11-98e5fbff0f10>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a3b6ca4-83e9-41d6-96a3-c5c4d15486c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a3b6ca4-83e9-41d6-96a3-c5c4d15486c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=BesluitenLijst_Gemeenteraad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a3b6ca4-83e9-41d6-96a3-c5c4d15486c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/90b84434-864e-4a11-ba24-391ed6559015> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90b84434-864e-4a11-ba24-391ed6559015";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90b84434-864e-4a11-ba24-391ed6559015>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7799cc6-ad51-4caf-98d9-ab981edf6ba2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7799cc6-ad51-4caf-98d9-ab981edf6ba2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=BesluitenLijst_Gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7799cc6-ad51-4caf-98d9-ab981edf6ba2>.
+    
+<http://data.lblod.info/id/remote-data-objects/59e694c5-c08a-4b8e-a878-448123395bef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59e694c5-c08a-4b8e-a878-448123395bef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59e694c5-c08a-4b8e-a878-448123395bef>.
+    
+<http://data.lblod.info/id/remote-data-objects/c03f71ae-6f8a-49a3-a36f-1596c02a49d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c03f71ae-6f8a-49a3-a36f-1596c02a49d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=BesluitenLijst_Gemeenteraad_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c03f71ae-6f8a-49a3-a36f-1596c02a49d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/218ebf34-d715-4e60-8a1a-70eaf3d09750> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "218ebf34-d715-4e60-8a1a-70eaf3d09750";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=BesluitenLijst_Gemeenteraad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/218ebf34-d715-4e60-8a1a-70eaf3d09750>.
+    
+<http://data.lblod.info/id/remote-data-objects/a377dddf-a619-4f49-b011-ba307175ee2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a377dddf-a619-4f49-b011-ba307175ee2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Notulen_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a377dddf-a619-4f49-b011-ba307175ee2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ebb0d33-7b4b-4dd5-b3e2-6ae20843defe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ebb0d33-7b4b-4dd5-b3e2-6ae20843defe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Notulen_Gemeenteraad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ebb0d33-7b4b-4dd5-b3e2-6ae20843defe>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4aaeeef-16d2-4c27-a44d-fbe6d695e12e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4aaeeef-16d2-4c27-a44d-fbe6d695e12e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Notulen_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4aaeeef-16d2-4c27-a44d-fbe6d695e12e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ac403a0-e641-43e3-8b01-0cfad3cc4487> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ac403a0-e641-43e3-8b01-0cfad3cc4487";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Notulen_Gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ac403a0-e641-43e3-8b01-0cfad3cc4487>.
+    
+<http://data.lblod.info/id/remote-data-objects/7217d34e-816f-4e52-973f-b220bdf30cd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7217d34e-816f-4e52-973f-b220bdf30cd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Notulen_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7217d34e-816f-4e52-973f-b220bdf30cd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5ff7456-ab13-4547-b009-967135f49ab4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5ff7456-ab13-4547-b009-967135f49ab4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Notulen_Gemeenteraad_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5ff7456-ab13-4547-b009-967135f49ab4>.
+    
+<http://data.lblod.info/id/remote-data-objects/fee9bad5-f1cf-4cee-93a2-eeee660260e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fee9bad5-f1cf-4cee-93a2-eeee660260e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Notulen_Gemeenteraad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fee9bad5-f1cf-4cee-93a2-eeee660260e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7618155-48bd-4df4-be3f-2196f90125e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7618155-48bd-4df4-be3f-2196f90125e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_05-07-2022_35381.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7618155-48bd-4df4-be3f-2196f90125e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c84baff-9694-4c7a-ac67-172c511c0743> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c84baff-9694-4c7a-ac67-172c511c0743";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_05-07-2022_35887.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c84baff-9694-4c7a-ac67-172c511c0743>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2f415cf-5d2d-4274-b09f-9f6630c4a08b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2f415cf-5d2d-4274-b09f-9f6630c4a08b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_05-07-2022_35888.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2f415cf-5d2d-4274-b09f-9f6630c4a08b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d62bfde-2e29-4c0d-a828-47432d79d1b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d62bfde-2e29-4c0d-a828-47432d79d1b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_05-07-2022_35983.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d62bfde-2e29-4c0d-a828-47432d79d1b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d969d6b-2459-4315-aaf6-f00d1545b976> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d969d6b-2459-4315-aaf6-f00d1545b976";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_05-07-2022_36076.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d969d6b-2459-4315-aaf6-f00d1545b976>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad240573-2769-431f-bcda-49863fd6e0f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad240573-2769-431f-bcda-49863fd6e0f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_22-02-2022_34360.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad240573-2769-431f-bcda-49863fd6e0f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5277aec2-3619-465b-b27e-d326aba492b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5277aec2-3619-465b-b27e-d326aba492b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_22-12-2021_33121.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/68f20550-0b49-404b-9978-d0945daff063> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5277aec2-3619-465b-b27e-d326aba492b0>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201647-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201647-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201647-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201647-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b5e842f2-bc9c-4851-8448-9b2b5797f608> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b5e842f2-bc9c-4851-8448-9b2b5797f608";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b91d480f-bd31-4209-b57c-8295c3d9def3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d5f1c116-5595-464d-b26b-42e15f567ed8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d5f1c116-5595-464d-b26b-42e15f567ed8";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3>.
+
+  <http://redpencil.data.gift/id/task/b6e2e5f0-5f2f-498b-8573-8bbbc19d72a4> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b6e2e5f0-5f2f-498b-8573-8bbbc19d72a4";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b5e842f2-bc9c-4851-8448-9b2b5797f608>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d5f1c116-5595-464d-b26b-42e15f567ed8>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/97c53aab-f628-4100-8d4c-7f60aacbd1d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97c53aab-f628-4100-8d4c-7f60aacbd1d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_22-12-2021_33232.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97c53aab-f628-4100-8d4c-7f60aacbd1d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/49df7f2f-d025-40a1-bdc6-8f887a762c2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49df7f2f-d025-40a1-bdc6-8f887a762c2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_22-12-2021_33394.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49df7f2f-d025-40a1-bdc6-8f887a762c2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7ab5e20-c3e2-49eb-abb2-52ee0d4fd5c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7ab5e20-c3e2-49eb-abb2-52ee0d4fd5c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_22-12-2021_33395.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7ab5e20-c3e2-49eb-abb2-52ee0d4fd5c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4226de5a-7ffa-4a82-bc63-fecdd2ab4838> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4226de5a-7ffa-4a82-bc63-fecdd2ab4838";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_22-12-2021_33455.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4226de5a-7ffa-4a82-bc63-fecdd2ab4838>.
+    
+<http://data.lblod.info/id/remote-data-objects/5afd9522-e60d-431e-b0a3-392f47a4362b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5afd9522-e60d-431e-b0a3-392f47a4362b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_22-12-2021_33467.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5afd9522-e60d-431e-b0a3-392f47a4362b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7123fdbd-221e-414d-bca9-70b791579cc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7123fdbd-221e-414d-bca9-70b791579cc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_22-12-2021_33522.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7123fdbd-221e-414d-bca9-70b791579cc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/71c6483a-39bf-40d9-9ec9-d7ded56bf4a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71c6483a-39bf-40d9-9ec9-d7ded56bf4a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_25-01-2022_33762.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71c6483a-39bf-40d9-9ec9-d7ded56bf4a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1f3b6a2-7b19-4bee-964d-5c7a8d35f0da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1f3b6a2-7b19-4bee-964d-5c7a8d35f0da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_25-01-2022_33763.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1f3b6a2-7b19-4bee-964d-5c7a8d35f0da>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4422669-eb22-401e-b092-32b6a4ced60d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4422669-eb22-401e-b092-32b6a4ced60d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_25-01-2022_33793.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4422669-eb22-401e-b092-32b6a4ced60d>.
+    
+<http://data.lblod.info/id/remote-data-objects/865ffdc5-f4c9-46a2-8304-152a9ed368e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "865ffdc5-f4c9-46a2-8304-152a9ed368e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_26-10-2021_32683.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/865ffdc5-f4c9-46a2-8304-152a9ed368e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a0d200a-8f6a-4aa1-9b6d-70b220129dd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a0d200a-8f6a-4aa1-9b6d-70b220129dd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_26-10-2021_32782.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a0d200a-8f6a-4aa1-9b6d-70b220129dd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/80e55a42-5587-4f86-a763-cb6fa463c017> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80e55a42-5587-4f86-a763-cb6fa463c017";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_26-10-2021_32788.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80e55a42-5587-4f86-a763-cb6fa463c017>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8ae6e88-b632-40fb-977d-7716d823e36d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8ae6e88-b632-40fb-977d-7716d823e36d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_28-04-2022_34821.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8ae6e88-b632-40fb-977d-7716d823e36d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8052a4f-4db3-4da7-8522-ce356a835b13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8052a4f-4db3-4da7-8522-ce356a835b13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_28-04-2022_34961.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8052a4f-4db3-4da7-8522-ce356a835b13>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d94678f-335d-400a-86f1-951886bed6c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d94678f-335d-400a-86f1-951886bed6c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_28-04-2022_35068.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d94678f-335d-400a-86f1-951886bed6c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9d32835-9548-4c9b-8f6f-52306e0bae4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9d32835-9548-4c9b-8f6f-52306e0bae4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_30-03-2022_34377.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9d32835-9548-4c9b-8f6f-52306e0bae4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef71bf92-f533-41c1-a913-0cfeb21e844b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef71bf92-f533-41c1-a913-0cfeb21e844b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_30-03-2022_34540.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef71bf92-f533-41c1-a913-0cfeb21e844b>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd57a52a-6039-41e1-9c67-631009a37b7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd57a52a-6039-41e1-9c67-631009a37b7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_30-03-2022_34889.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd57a52a-6039-41e1-9c67-631009a37b7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/27108be8-60ba-4e31-8ef9-cf449f1cafd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27108be8-60ba-4e31-8ef9-cf449f1cafd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_31-05-2022_35039.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27108be8-60ba-4e31-8ef9-cf449f1cafd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/691da7ed-9ad4-45bf-966b-0d1e3541f89a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "691da7ed-9ad4-45bf-966b-0d1e3541f89a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_31-05-2022_35040.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/691da7ed-9ad4-45bf-966b-0d1e3541f89a>.
+    
+<http://data.lblod.info/id/remote-data-objects/009d5567-63c4-4551-9455-ef5a5fdf7bed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "009d5567-63c4-4551-9455-ef5a5fdf7bed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_31-05-2022_35377.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/009d5567-63c4-4551-9455-ef5a5fdf7bed>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf607c30-7a83-49b3-8963-d453cde178a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf607c30-7a83-49b3-8963-d453cde178a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_31-05-2022_35378.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf607c30-7a83-49b3-8963-d453cde178a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/eafc7afd-3d37-4801-a1fe-38893d89b937> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eafc7afd-3d37-4801-a1fe-38893d89b937";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_31-05-2022_35379.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eafc7afd-3d37-4801-a1fe-38893d89b937>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe9843ff-fd50-4b7f-a9e4-d103bd9256fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe9843ff-fd50-4b7f-a9e4-d103bd9256fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_31-05-2022_35380.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe9843ff-fd50-4b7f-a9e4-d103bd9256fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b504fba-6b88-4a26-9fdd-91ebe495abc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b504fba-6b88-4a26-9fdd-91ebe495abc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_31-05-2022_35385.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b504fba-6b88-4a26-9fdd-91ebe495abc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c3d5521-6219-4b56-af58-86a4ad044d2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c3d5521-6219-4b56-af58-86a4ad044d2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15657e33d38762d25b1b084322f53e6bad535fbaf2e431c91e92316cbe8ae79/GetPublication?filename=Uittreksels_31-05-2022_35500.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c3d5521-6219-4b56-af58-86a4ad044d2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4232af44-b023-4aa9-82a9-7e9db7b8a387> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4232af44-b023-4aa9-82a9-7e9db7b8a387";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4232af44-b023-4aa9-82a9-7e9db7b8a387>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac1f25d2-87b4-4ebf-a85b-141e66ba4ede> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac1f25d2-87b4-4ebf-a85b-141e66ba4ede";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac1f25d2-87b4-4ebf-a85b-141e66ba4ede>.
+    
+<http://data.lblod.info/id/remote-data-objects/71e7ec94-ecc0-4dab-9db0-2d03979e998c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71e7ec94-ecc0-4dab-9db0-2d03979e998c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71e7ec94-ecc0-4dab-9db0-2d03979e998c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4514c77-08a2-4cb0-921d-0d33e894b850> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4514c77-08a2-4cb0-921d-0d33e894b850";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4514c77-08a2-4cb0-921d-0d33e894b850>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7294683-3a96-43d3-9fb1-8011679e661b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7294683-3a96-43d3-9fb1-8011679e661b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7294683-3a96-43d3-9fb1-8011679e661b>.
+    
+<http://data.lblod.info/id/remote-data-objects/695f454b-f2f1-407e-aa60-c0a1f526d139> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "695f454b-f2f1-407e-aa60-c0a1f526d139";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/695f454b-f2f1-407e-aa60-c0a1f526d139>.
+    
+<http://data.lblod.info/id/remote-data-objects/26144807-f28f-4f70-9074-c31edb3a5a08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26144807-f28f-4f70-9074-c31edb3a5a08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26144807-f28f-4f70-9074-c31edb3a5a08>.
+    
+<http://data.lblod.info/id/remote-data-objects/bca73efc-f73a-44af-82ea-282a2e181fa6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bca73efc-f73a-44af-82ea-282a2e181fa6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bca73efc-f73a-44af-82ea-282a2e181fa6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7ef890f-6690-457e-9c93-6f152e7b7c83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7ef890f-6690-457e-9c93-6f152e7b7c83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7ef890f-6690-457e-9c93-6f152e7b7c83>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bd2bc9f-4fb5-48b7-948c-61a0c3472c74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bd2bc9f-4fb5-48b7-948c-61a0c3472c74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bd2bc9f-4fb5-48b7-948c-61a0c3472c74>.
+    
+<http://data.lblod.info/id/remote-data-objects/44d0bf66-efc6-4ef8-b362-b67f6fe9b2d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44d0bf66-efc6-4ef8-b362-b67f6fe9b2d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44d0bf66-efc6-4ef8-b362-b67f6fe9b2d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c77a0bf-4db5-4656-975a-37d1dc17c9c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c77a0bf-4db5-4656-975a-37d1dc17c9c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c77a0bf-4db5-4656-975a-37d1dc17c9c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/68ca7826-39cb-4859-aa3f-2c32ad0281b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68ca7826-39cb-4859-aa3f-2c32ad0281b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68ca7826-39cb-4859-aa3f-2c32ad0281b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/281681d7-860e-4f7c-95cb-10af8af2e5c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "281681d7-860e-4f7c-95cb-10af8af2e5c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/281681d7-860e-4f7c-95cb-10af8af2e5c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/64476189-e31a-4655-be1a-ee218ea9ddeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64476189-e31a-4655-be1a-ee218ea9ddeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64476189-e31a-4655-be1a-ee218ea9ddeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/8be18211-ffb1-41e7-83c3-f3586b00fe3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8be18211-ffb1-41e7-83c3-f3586b00fe3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8be18211-ffb1-41e7-83c3-f3586b00fe3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a93b5c11-99ae-485a-88cf-2bac48c36402> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a93b5c11-99ae-485a-88cf-2bac48c36402";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a93b5c11-99ae-485a-88cf-2bac48c36402>.
+    
+<http://data.lblod.info/id/remote-data-objects/e995e5e6-5728-4e93-9b7e-c7b54dbede09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e995e5e6-5728-4e93-9b7e-c7b54dbede09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e995e5e6-5728-4e93-9b7e-c7b54dbede09>.
+    
+<http://data.lblod.info/id/remote-data-objects/dca9ec29-22e6-440c-b848-d436f1f4a8d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dca9ec29-22e6-440c-b848-d436f1f4a8d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dca9ec29-22e6-440c-b848-d436f1f4a8d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/564f2ec0-da65-4060-994c-476c0b398892> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "564f2ec0-da65-4060-994c-476c0b398892";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/564f2ec0-da65-4060-994c-476c0b398892>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0464747-5d90-48ae-9d72-8caa1d782335> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0464747-5d90-48ae-9d72-8caa1d782335";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0464747-5d90-48ae-9d72-8caa1d782335>.
+    
+<http://data.lblod.info/id/remote-data-objects/14394ffb-6199-4fe9-b3c4-82a9890ea2c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14394ffb-6199-4fe9-b3c4-82a9890ea2c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14394ffb-6199-4fe9-b3c4-82a9890ea2c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb6cec1f-bc61-4651-9e2e-9fefd22c886c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb6cec1f-bc61-4651-9e2e-9fefd22c886c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb6cec1f-bc61-4651-9e2e-9fefd22c886c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6b42b0c-4b94-4083-9329-0b86a2a60602> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6b42b0c-4b94-4083-9329-0b86a2a60602";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b91d480f-bd31-4209-b57c-8295c3d9def3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6b42b0c-4b94-4083-9329-0b86a2a60602>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201649-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201649-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201649-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201649-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e3c5ae21-835f-42f4-99c1-d6818840e903> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e3c5ae21-835f-42f4-99c1-d6818840e903";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c92f660c-da19-469e-9c62-692d481ae990";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d01c2629-c823-4a12-84ca-eb42398045f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d01c2629-c823-4a12-84ca-eb42398045f8";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990>.
+
+  <http://redpencil.data.gift/id/task/0290d170-e482-4fe1-94aa-ea3fffa2cf3b> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0290d170-e482-4fe1-94aa-ea3fffa2cf3b";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e3c5ae21-835f-42f4-99c1-d6818840e903>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d01c2629-c823-4a12-84ca-eb42398045f8>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/0a8c4c10-d8f7-4a42-9a56-4badfc679689> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a8c4c10-d8f7-4a42-9a56-4badfc679689";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a8c4c10-d8f7-4a42-9a56-4badfc679689>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c45eac7-1ea5-4cee-930c-519d915251b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c45eac7-1ea5-4cee-930c-519d915251b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c45eac7-1ea5-4cee-930c-519d915251b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/17153da7-4558-45bf-8f50-2abf9dbf11f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17153da7-4558-45bf-8f50-2abf9dbf11f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17153da7-4558-45bf-8f50-2abf9dbf11f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd5f4bc0-b23f-4048-a8f6-cf0ec8bf3a32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd5f4bc0-b23f-4048-a8f6-cf0ec8bf3a32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd5f4bc0-b23f-4048-a8f6-cf0ec8bf3a32>.
+    
+<http://data.lblod.info/id/remote-data-objects/8716a001-73c9-4247-a157-d49b805f9993> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8716a001-73c9-4247-a157-d49b805f9993";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8716a001-73c9-4247-a157-d49b805f9993>.
+    
+<http://data.lblod.info/id/remote-data-objects/35fc5c1e-df81-461f-8797-03b40007a3df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35fc5c1e-df81-461f-8797-03b40007a3df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35fc5c1e-df81-461f-8797-03b40007a3df>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad7843c6-f1b1-4c61-9e1e-cd0a9d8e72d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad7843c6-f1b1-4c61-9e1e-cd0a9d8e72d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad7843c6-f1b1-4c61-9e1e-cd0a9d8e72d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6811878e-a5eb-4967-977d-82622fde19ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6811878e-a5eb-4967-977d-82622fde19ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6811878e-a5eb-4967-977d-82622fde19ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6c774d2-ae5e-4de0-8d66-6431e3aa1a99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6c774d2-ae5e-4de0-8d66-6431e3aa1a99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6c774d2-ae5e-4de0-8d66-6431e3aa1a99>.
+    
+<http://data.lblod.info/id/remote-data-objects/d44a1a39-6a4b-47b3-a5a4-8d7159f580b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d44a1a39-6a4b-47b3-a5a4-8d7159f580b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d44a1a39-6a4b-47b3-a5a4-8d7159f580b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ea7b624-2811-418b-8ef1-3d37953ade8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ea7b624-2811-418b-8ef1-3d37953ade8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ea7b624-2811-418b-8ef1-3d37953ade8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/18a44501-f8d4-4c4d-83c8-b1bbab0b1a9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18a44501-f8d4-4c4d-83c8-b1bbab0b1a9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18a44501-f8d4-4c4d-83c8-b1bbab0b1a9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2417ef0-d523-4cc2-8bce-c2dd14d2d131> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2417ef0-d523-4cc2-8bce-c2dd14d2d131";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2417ef0-d523-4cc2-8bce-c2dd14d2d131>.
+    
+<http://data.lblod.info/id/remote-data-objects/37c5b3ef-10ec-452d-bda6-4a78b15fd768> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37c5b3ef-10ec-452d-bda6-4a78b15fd768";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37c5b3ef-10ec-452d-bda6-4a78b15fd768>.
+    
+<http://data.lblod.info/id/remote-data-objects/3496efb7-0de9-4908-837e-229738bd2d84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3496efb7-0de9-4908-837e-229738bd2d84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3496efb7-0de9-4908-837e-229738bd2d84>.
+    
+<http://data.lblod.info/id/remote-data-objects/87b828f7-6f22-43cb-b834-0aa9d68e88ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87b828f7-6f22-43cb-b834-0aa9d68e88ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87b828f7-6f22-43cb-b834-0aa9d68e88ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/34b26ccd-5dad-4183-88c1-843d84f1c9df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34b26ccd-5dad-4183-88c1-843d84f1c9df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.sint-lievens-houtem.be/LBLODWeb/Home/Overzicht/c15cde9e-fbf0-48ff-86bf-a90740f8f575/GetPublication?filename=BesluitenLijst_Vast%20Bureau_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34b26ccd-5dad-4183-88c1-843d84f1c9df>.
+    
+<http://data.lblod.info/id/remote-data-objects/68571499-c0e5-44af-878d-c3faa99b4f7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68571499-c0e5-44af-878d-c3faa99b4f7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68571499-c0e5-44af-878d-c3faa99b4f7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5a8a9e8-ceb5-47ae-9c2b-34f0f1045cbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5a8a9e8-ceb5-47ae-9c2b-34f0f1045cbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5a8a9e8-ceb5-47ae-9c2b-34f0f1045cbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5eca1d7-fe82-44a4-a82a-070512052918> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5eca1d7-fe82-44a4-a82a-070512052918";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5eca1d7-fe82-44a4-a82a-070512052918>.
+    
+<http://data.lblod.info/id/remote-data-objects/0190082a-1171-4416-a739-63f929260288> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0190082a-1171-4416-a739-63f929260288";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0190082a-1171-4416-a739-63f929260288>.
+    
+<http://data.lblod.info/id/remote-data-objects/44f720c6-7d10-4ecc-9071-be7773c9c14c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44f720c6-7d10-4ecc-9071-be7773c9c14c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44f720c6-7d10-4ecc-9071-be7773c9c14c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f44430c8-9955-476c-b545-da14092a9b7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f44430c8-9955-476c-b545-da14092a9b7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f44430c8-9955-476c-b545-da14092a9b7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/acfb5508-8cbe-4b9b-8e3b-261193561fc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acfb5508-8cbe-4b9b-8e3b-261193561fc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acfb5508-8cbe-4b9b-8e3b-261193561fc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/126d19fe-d88d-46a8-a69c-03838c0f0c8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "126d19fe-d88d-46a8-a69c-03838c0f0c8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_14-12-2021_65263.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/126d19fe-d88d-46a8-a69c-03838c0f0c8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/942f8ace-f38e-4530-83a6-08794c61d2e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "942f8ace-f38e-4530-83a6-08794c61d2e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_14-12-2021_66482.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/942f8ace-f38e-4530-83a6-08794c61d2e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/04f0fabd-8769-4fbc-8c0b-1c8b84c5e359> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04f0fabd-8769-4fbc-8c0b-1c8b84c5e359";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_14-12-2021_66484.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04f0fabd-8769-4fbc-8c0b-1c8b84c5e359>.
+    
+<http://data.lblod.info/id/remote-data-objects/431b2f86-3f00-4315-ab4a-20b523bab8c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "431b2f86-3f00-4315-ab4a-20b523bab8c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_14-12-2021_66553.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/431b2f86-3f00-4315-ab4a-20b523bab8c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/dba98b43-ded5-4af3-ba35-18ab192148ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dba98b43-ded5-4af3-ba35-18ab192148ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_14-12-2021_66625.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dba98b43-ded5-4af3-ba35-18ab192148ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/88080aa1-5433-4c8d-a095-118b8a8c589c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88080aa1-5433-4c8d-a095-118b8a8c589c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_22-02-2022_69344.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88080aa1-5433-4c8d-a095-118b8a8c589c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e0e3f02-62cd-4d64-b74b-4d1e5ab28ce0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e0e3f02-62cd-4d64-b74b-4d1e5ab28ce0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_22-02-2022_69479.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e0e3f02-62cd-4d64-b74b-4d1e5ab28ce0>.
+    
+<http://data.lblod.info/id/remote-data-objects/60a04e3f-7347-490f-b6ed-9ca9e95f7e59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60a04e3f-7347-490f-b6ed-9ca9e95f7e59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_22-02-2022_69497.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60a04e3f-7347-490f-b6ed-9ca9e95f7e59>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cd8b6b3-0f1e-4cd5-9f60-602d467ea42c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cd8b6b3-0f1e-4cd5-9f60-602d467ea42c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_22-02-2022_69504.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cd8b6b3-0f1e-4cd5-9f60-602d467ea42c>.
+    
+<http://data.lblod.info/id/remote-data-objects/eba98048-56de-488f-996b-13a9b59cea1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eba98048-56de-488f-996b-13a9b59cea1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_22-02-2022_69506.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eba98048-56de-488f-996b-13a9b59cea1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbf5c602-b37c-451c-b169-8c240de34cd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbf5c602-b37c-451c-b169-8c240de34cd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_22-02-2022_69527.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbf5c602-b37c-451c-b169-8c240de34cd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/96cd0cc2-d8a8-4ecf-ba31-e7eda2a49b05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96cd0cc2-d8a8-4ecf-ba31-e7eda2a49b05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_22-02-2022_69536.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96cd0cc2-d8a8-4ecf-ba31-e7eda2a49b05>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a6e11af-c1db-41e0-8bba-7bdbe34ca449> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a6e11af-c1db-41e0-8bba-7bdbe34ca449";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_22-02-2022_69593.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a6e11af-c1db-41e0-8bba-7bdbe34ca449>.
+    
+<http://data.lblod.info/id/remote-data-objects/13a10413-57df-484d-b12c-e02cddc45c7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13a10413-57df-484d-b12c-e02cddc45c7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_22-03-2022_69304.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13a10413-57df-484d-b12c-e02cddc45c7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/aab72489-f095-49ee-9738-c644c954a601> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aab72489-f095-49ee-9738-c644c954a601";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_22-03-2022_69968.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aab72489-f095-49ee-9738-c644c954a601>.
+    
+<http://data.lblod.info/id/remote-data-objects/b40a6a2e-c90f-48ea-ae6e-380266cb5964> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b40a6a2e-c90f-48ea-ae6e-380266cb5964";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_22-03-2022_70172.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b40a6a2e-c90f-48ea-ae6e-380266cb5964>.
+    
+<http://data.lblod.info/id/remote-data-objects/e694c06e-492f-45e5-a9e0-1bcfb5237c9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e694c06e-492f-45e5-a9e0-1bcfb5237c9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_23-11-2021_63886.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e694c06e-492f-45e5-a9e0-1bcfb5237c9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/87222e81-da08-48ba-a5df-d9cedfaa87ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87222e81-da08-48ba-a5df-d9cedfaa87ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_23-11-2021_63888.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87222e81-da08-48ba-a5df-d9cedfaa87ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a723dca-d258-4cb1-aea6-16d9420e2ae7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a723dca-d258-4cb1-aea6-16d9420e2ae7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_23-11-2021_63889.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a723dca-d258-4cb1-aea6-16d9420e2ae7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7118a2e-c6ef-4719-b5ea-c33dbe4af520> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7118a2e-c6ef-4719-b5ea-c33dbe4af520";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_23-11-2021_63890.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7118a2e-c6ef-4719-b5ea-c33dbe4af520>.
+    
+<http://data.lblod.info/id/remote-data-objects/bff2878e-db99-4657-b60c-25df2f383827> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bff2878e-db99-4657-b60c-25df2f383827";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_23-11-2021_64036.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bff2878e-db99-4657-b60c-25df2f383827>.
+    
+<http://data.lblod.info/id/remote-data-objects/5dbf07e4-60b0-4cd4-bb20-2cac73f7861d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5dbf07e4-60b0-4cd4-bb20-2cac73f7861d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_23-11-2021_64158.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5dbf07e4-60b0-4cd4-bb20-2cac73f7861d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fa657da-2ecf-4cfd-94b1-ffbc677c3636> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fa657da-2ecf-4cfd-94b1-ffbc677c3636";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_23-11-2021_66454.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fa657da-2ecf-4cfd-94b1-ffbc677c3636>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc7e6a98-a87b-4698-87c1-1ce528c4e82d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc7e6a98-a87b-4698-87c1-1ce528c4e82d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_24-05-2022_70712.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc7e6a98-a87b-4698-87c1-1ce528c4e82d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f5e4057-2c12-43a0-8023-a6c30c80b216> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f5e4057-2c12-43a0-8023-a6c30c80b216";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_24-05-2022_70713.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f5e4057-2c12-43a0-8023-a6c30c80b216>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2b0e57d-1b92-40cf-a6be-6915032e7460> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2b0e57d-1b92-40cf-a6be-6915032e7460";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_24-05-2022_70714.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c92f660c-da19-469e-9c62-692d481ae990> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2b0e57d-1b92-40cf-a6be-6915032e7460>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201650-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201650-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201650-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201650-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e56e9787-1acb-4155-8ab1-0f0368a44ebe> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e56e9787-1acb-4155-8ab1-0f0368a44ebe";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "33f17133-6d67-4b18-a571-eed9ec4d023c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d4f8565b-0c37-4a24-8990-bc0ba93bf354> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d4f8565b-0c37-4a24-8990-bc0ba93bf354";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c>.
+
+  <http://redpencil.data.gift/id/task/4f8e34d5-20f4-4ae1-81d8-7620318ac490> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4f8e34d5-20f4-4ae1-81d8-7620318ac490";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e56e9787-1acb-4155-8ab1-0f0368a44ebe>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d4f8565b-0c37-4a24-8990-bc0ba93bf354>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/6c990fd1-b2e3-4520-8908-92d459a3d9d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c990fd1-b2e3-4520-8908-92d459a3d9d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_24-05-2022_70715.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c990fd1-b2e3-4520-8908-92d459a3d9d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/733c2538-4db0-48cd-bdc9-8e15cccc795c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "733c2538-4db0-48cd-bdc9-8e15cccc795c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_24-05-2022_71031.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/733c2538-4db0-48cd-bdc9-8e15cccc795c>.
+    
+<http://data.lblod.info/id/remote-data-objects/035b2281-a698-4c4a-8bc4-88a8ab2d113a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "035b2281-a698-4c4a-8bc4-88a8ab2d113a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_25-01-2022_62635.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/035b2281-a698-4c4a-8bc4-88a8ab2d113a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d5cdbb2-f7a7-4f14-83d0-ab81aa2535b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d5cdbb2-f7a7-4f14-83d0-ab81aa2535b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_25-01-2022_66434.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d5cdbb2-f7a7-4f14-83d0-ab81aa2535b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ad6e5a6-d19c-4e4e-a39d-52248353ff5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ad6e5a6-d19c-4e4e-a39d-52248353ff5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_25-01-2022_67786.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ad6e5a6-d19c-4e4e-a39d-52248353ff5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb7d4e3e-d27d-4391-a24c-81d6d17a89f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb7d4e3e-d27d-4391-a24c-81d6d17a89f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_25-01-2022_69030.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb7d4e3e-d27d-4391-a24c-81d6d17a89f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bc14b34-afb3-4bf4-8afd-92ef8b722444> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bc14b34-afb3-4bf4-8afd-92ef8b722444";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_25-01-2022_69083.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bc14b34-afb3-4bf4-8afd-92ef8b722444>.
+    
+<http://data.lblod.info/id/remote-data-objects/f844aa4d-3c33-4dd7-b785-9ffe0713fa5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f844aa4d-3c33-4dd7-b785-9ffe0713fa5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_25-01-2022_69087.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f844aa4d-3c33-4dd7-b785-9ffe0713fa5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/790b1fa4-4615-45f0-a775-6184b01bae93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "790b1fa4-4615-45f0-a775-6184b01bae93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_25-01-2022_69144.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/790b1fa4-4615-45f0-a775-6184b01bae93>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fce7cc0-873f-4723-9b68-02ad87728a5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fce7cc0-873f-4723-9b68-02ad87728a5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/07ec953037e26be2c7fb27c4fea131e7835b7c2dfef809f5875931745d2bf879/GetPublication?filename=Uittreksels_26-04-2022_70587.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fce7cc0-873f-4723-9b68-02ad87728a5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/229b7904-bab4-4a37-bf99-d7e10c35fac0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "229b7904-bab4-4a37-bf99-d7e10c35fac0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/0d3942b49594387952a9a63138a5d2afe32640f5479cc6a777acf89761b5355e/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/229b7904-bab4-4a37-bf99-d7e10c35fac0>.
+    
+<http://data.lblod.info/id/remote-data-objects/6960b0ce-477e-43bd-98d8-74691a0028ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6960b0ce-477e-43bd-98d8-74691a0028ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/0d3942b49594387952a9a63138a5d2afe32640f5479cc6a777acf89761b5355e/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6960b0ce-477e-43bd-98d8-74691a0028ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/f20ffee1-5dc3-40a7-9112-b0e3f13efe70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f20ffee1-5dc3-40a7-9112-b0e3f13efe70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/0d3942b49594387952a9a63138a5d2afe32640f5479cc6a777acf89761b5355e/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f20ffee1-5dc3-40a7-9112-b0e3f13efe70>.
+    
+<http://data.lblod.info/id/remote-data-objects/d29ce1fa-6e38-4342-b2ea-3b1bc78950d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d29ce1fa-6e38-4342-b2ea-3b1bc78950d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/0d3942b49594387952a9a63138a5d2afe32640f5479cc6a777acf89761b5355e/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d29ce1fa-6e38-4342-b2ea-3b1bc78950d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d840e59c-571c-4448-84b3-2d5d09488fac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d840e59c-571c-4448-84b3-2d5d09488fac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/0d3942b49594387952a9a63138a5d2afe32640f5479cc6a777acf89761b5355e/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d840e59c-571c-4448-84b3-2d5d09488fac>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5078557-c2af-41f5-8f66-3b3551b280cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5078557-c2af-41f5-8f66-3b3551b280cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/0d3942b49594387952a9a63138a5d2afe32640f5479cc6a777acf89761b5355e/GetPublication?filename=Uittreksels_14-12-2021_66483.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5078557-c2af-41f5-8f66-3b3551b280cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d6c94fd-5b18-4fe4-a028-ee0f2c0920ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d6c94fd-5b18-4fe4-a028-ee0f2c0920ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/0d3942b49594387952a9a63138a5d2afe32640f5479cc6a777acf89761b5355e/GetPublication?filename=Uittreksels_14-12-2021_66629.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d6c94fd-5b18-4fe4-a028-ee0f2c0920ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/06fbe3a9-249c-47cc-96a1-cf9d5526d7cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06fbe3a9-249c-47cc-96a1-cf9d5526d7cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/0d3942b49594387952a9a63138a5d2afe32640f5479cc6a777acf89761b5355e/GetPublication?filename=Uittreksels_22-02-2022_69535.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06fbe3a9-249c-47cc-96a1-cf9d5526d7cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4640ad6-5945-4705-98f6-b604f3157794> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4640ad6-5945-4705-98f6-b604f3157794";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/0d3942b49594387952a9a63138a5d2afe32640f5479cc6a777acf89761b5355e/GetPublication?filename=Uittreksels_23-11-2021_64085.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4640ad6-5945-4705-98f6-b604f3157794>.
+    
+<http://data.lblod.info/id/remote-data-objects/3720f6ea-ae57-472e-9375-83ebc63df259> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3720f6ea-ae57-472e-9375-83ebc63df259";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/0d3942b49594387952a9a63138a5d2afe32640f5479cc6a777acf89761b5355e/GetPublication?filename=Uittreksels_23-11-2021_65204.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3720f6ea-ae57-472e-9375-83ebc63df259>.
+    
+<http://data.lblod.info/id/remote-data-objects/48b14ea0-0d43-45f6-b3aa-6ed69919734c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48b14ea0-0d43-45f6-b3aa-6ed69919734c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/0d3942b49594387952a9a63138a5d2afe32640f5479cc6a777acf89761b5355e/GetPublication?filename=Uittreksels_23-11-2021_66550.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48b14ea0-0d43-45f6-b3aa-6ed69919734c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc8b8ee1-5ee3-4ef1-8c13-7e9a3ec1b7ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc8b8ee1-5ee3-4ef1-8c13-7e9a3ec1b7ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/0d3942b49594387952a9a63138a5d2afe32640f5479cc6a777acf89761b5355e/GetPublication?filename=Uittreksels_25-01-2022_69147.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc8b8ee1-5ee3-4ef1-8c13-7e9a3ec1b7ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2cfaa0d-9b93-4b9b-ad4f-4f7732301b95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2cfaa0d-9b93-4b9b-ad4f-4f7732301b95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2cfaa0d-9b93-4b9b-ad4f-4f7732301b95>.
+    
+<http://data.lblod.info/id/remote-data-objects/7032ba37-4539-4a3d-aac6-a3ea9f14a772> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7032ba37-4539-4a3d-aac6-a3ea9f14a772";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7032ba37-4539-4a3d-aac6-a3ea9f14a772>.
+    
+<http://data.lblod.info/id/remote-data-objects/60540de6-9b68-424e-82aa-49b1d9dde37d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60540de6-9b68-424e-82aa-49b1d9dde37d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60540de6-9b68-424e-82aa-49b1d9dde37d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ae14f61-1616-4654-a0dd-becd240c0ad8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ae14f61-1616-4654-a0dd-becd240c0ad8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ae14f61-1616-4654-a0dd-becd240c0ad8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7034341-ceff-4bce-b4b7-86a21f9347d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7034341-ceff-4bce-b4b7-86a21f9347d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7034341-ceff-4bce-b4b7-86a21f9347d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/baf28a80-9719-4aa7-8342-0a56f585bc85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "baf28a80-9719-4aa7-8342-0a56f585bc85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_06-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/baf28a80-9719-4aa7-8342-0a56f585bc85>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c1862fd-f120-42d0-aff5-3250f3b99d29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c1862fd-f120-42d0-aff5-3250f3b99d29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c1862fd-f120-42d0-aff5-3250f3b99d29>.
+    
+<http://data.lblod.info/id/remote-data-objects/c374558c-785d-4393-af69-e02eaf1ecf1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c374558c-785d-4393-af69-e02eaf1ecf1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c374558c-785d-4393-af69-e02eaf1ecf1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/50def706-7006-4691-86ae-4ca620c64f3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50def706-7006-4691-86ae-4ca620c64f3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50def706-7006-4691-86ae-4ca620c64f3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b873a61-52ae-4cac-b359-3e4d9f3bd602> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b873a61-52ae-4cac-b359-3e4d9f3bd602";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b873a61-52ae-4cac-b359-3e4d9f3bd602>.
+    
+<http://data.lblod.info/id/remote-data-objects/22c0aa44-15fc-4ec5-8b62-414eccb53f01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22c0aa44-15fc-4ec5-8b62-414eccb53f01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22c0aa44-15fc-4ec5-8b62-414eccb53f01>.
+    
+<http://data.lblod.info/id/remote-data-objects/099422cc-8ad8-48db-ab28-587176bce52b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "099422cc-8ad8-48db-ab28-587176bce52b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/099422cc-8ad8-48db-ab28-587176bce52b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebf5f4d8-00bd-4181-9212-4699c8ea96c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebf5f4d8-00bd-4181-9212-4699c8ea96c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebf5f4d8-00bd-4181-9212-4699c8ea96c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a7439d7-3616-4e77-b57d-004977051a37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a7439d7-3616-4e77-b57d-004977051a37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_11-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a7439d7-3616-4e77-b57d-004977051a37>.
+    
+<http://data.lblod.info/id/remote-data-objects/14e819ab-b41a-43f6-9eb8-c5174b90ab21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14e819ab-b41a-43f6-9eb8-c5174b90ab21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14e819ab-b41a-43f6-9eb8-c5174b90ab21>.
+    
+<http://data.lblod.info/id/remote-data-objects/c56a31d0-1538-47fe-aece-b78fc4c02eb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c56a31d0-1538-47fe-aece-b78fc4c02eb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c56a31d0-1538-47fe-aece-b78fc4c02eb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4f62008-bc1f-4579-afbc-bcb56b512864> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4f62008-bc1f-4579-afbc-bcb56b512864";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4f62008-bc1f-4579-afbc-bcb56b512864>.
+    
+<http://data.lblod.info/id/remote-data-objects/c886f3a8-d73c-492c-953f-0be5724989a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c886f3a8-d73c-492c-953f-0be5724989a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c886f3a8-d73c-492c-953f-0be5724989a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a3cf86c-a410-4b7a-bab0-12cba656a653> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a3cf86c-a410-4b7a-bab0-12cba656a653";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a3cf86c-a410-4b7a-bab0-12cba656a653>.
+    
+<http://data.lblod.info/id/remote-data-objects/db09472f-74d8-42e5-9fee-017691cd5b3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db09472f-74d8-42e5-9fee-017691cd5b3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db09472f-74d8-42e5-9fee-017691cd5b3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/806ccd32-8553-408a-bb97-9b39c373fcff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "806ccd32-8553-408a-bb97-9b39c373fcff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/806ccd32-8553-408a-bb97-9b39c373fcff>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb1097c1-f99b-47a9-bc38-ec6b9c381a95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb1097c1-f99b-47a9-bc38-ec6b9c381a95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb1097c1-f99b-47a9-bc38-ec6b9c381a95>.
+    
+<http://data.lblod.info/id/remote-data-objects/23d5d32e-4e75-4d2b-9288-a51a4940abed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23d5d32e-4e75-4d2b-9288-a51a4940abed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_18-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23d5d32e-4e75-4d2b-9288-a51a4940abed>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5326f56-fa44-40e7-bcd2-db769dcddb68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5326f56-fa44-40e7-bcd2-db769dcddb68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5326f56-fa44-40e7-bcd2-db769dcddb68>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6da92e2-6ecc-483a-ae61-e0b13d444cf7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6da92e2-6ecc-483a-ae61-e0b13d444cf7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6da92e2-6ecc-483a-ae61-e0b13d444cf7>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b1e2661-a4aa-4749-b36b-a4bcbd3aa597> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b1e2661-a4aa-4749-b36b-a4bcbd3aa597";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b1e2661-a4aa-4749-b36b-a4bcbd3aa597>.
+    
+<http://data.lblod.info/id/remote-data-objects/da04307d-75dc-4658-968a-353948e73922> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da04307d-75dc-4658-968a-353948e73922";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da04307d-75dc-4658-968a-353948e73922>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd012a13-aa89-4722-9f5a-ed1b28e9523e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd012a13-aa89-4722-9f5a-ed1b28e9523e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/33f17133-6d67-4b18-a571-eed9ec4d023c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd012a13-aa89-4722-9f5a-ed1b28e9523e>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201651-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201651-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201651-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201651-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/1641917d-5d39-4dae-b996-0759b68fc866> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1641917d-5d39-4dae-b996-0759b68fc866";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6b1c98ae-c849-408e-8d08-779fe5090919";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/89212e8a-49e6-40cb-95e3-195b4afe017c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "89212e8a-49e6-40cb-95e3-195b4afe017c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919>.
+
+  <http://redpencil.data.gift/id/task/d6935a9e-eb48-430e-8716-614c1c311032> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d6935a9e-eb48-430e-8716-614c1c311032";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/1641917d-5d39-4dae-b996-0759b68fc866>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/89212e8a-49e6-40cb-95e3-195b4afe017c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4991ca22-c1b3-467c-8572-11ca89381794> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4991ca22-c1b3-467c-8572-11ca89381794";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4991ca22-c1b3-467c-8572-11ca89381794>.
+    
+<http://data.lblod.info/id/remote-data-objects/babb0a21-3b11-41df-b185-4a85c3a28c55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "babb0a21-3b11-41df-b185-4a85c3a28c55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/babb0a21-3b11-41df-b185-4a85c3a28c55>.
+    
+<http://data.lblod.info/id/remote-data-objects/026fcc17-888d-4e27-9055-84de70e438bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "026fcc17-888d-4e27-9055-84de70e438bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/026fcc17-888d-4e27-9055-84de70e438bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bc6ce7e-18bf-4e52-82e7-e4891aa195a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bc6ce7e-18bf-4e52-82e7-e4891aa195a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bc6ce7e-18bf-4e52-82e7-e4891aa195a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/11bcd724-e939-4424-a40b-06cd056c866c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11bcd724-e939-4424-a40b-06cd056c866c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11bcd724-e939-4424-a40b-06cd056c866c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f298fbf1-833d-4f61-b6b4-62c090f46ebe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f298fbf1-833d-4f61-b6b4-62c090f46ebe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f298fbf1-833d-4f61-b6b4-62c090f46ebe>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa4218e3-19f8-4fd9-ba91-86eec04b7ba8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa4218e3-19f8-4fd9-ba91-86eec04b7ba8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa4218e3-19f8-4fd9-ba91-86eec04b7ba8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0315fecd-0059-4eae-934a-ecc7bd9e217c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0315fecd-0059-4eae-934a-ecc7bd9e217c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0315fecd-0059-4eae-934a-ecc7bd9e217c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad57d539-aa49-4fae-b109-373905b7b220> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad57d539-aa49-4fae-b109-373905b7b220";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad57d539-aa49-4fae-b109-373905b7b220>.
+    
+<http://data.lblod.info/id/remote-data-objects/103ba581-1899-4a92-8fa3-0b3960f51c19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "103ba581-1899-4a92-8fa3-0b3960f51c19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/103ba581-1899-4a92-8fa3-0b3960f51c19>.
+    
+<http://data.lblod.info/id/remote-data-objects/83af186f-05c8-4d27-9749-7cca7a65ba96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83af186f-05c8-4d27-9749-7cca7a65ba96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83af186f-05c8-4d27-9749-7cca7a65ba96>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4c30946-c9cb-4e5d-8124-5eec74941e06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4c30946-c9cb-4e5d-8124-5eec74941e06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4c30946-c9cb-4e5d-8124-5eec74941e06>.
+    
+<http://data.lblod.info/id/remote-data-objects/e405b1f5-ecf7-471f-ada1-d44d4b3d0510> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e405b1f5-ecf7-471f-ada1-d44d4b3d0510";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/16817c7f325c4f299f6eac94a60ac169f73b451126847a5c0a170e4481bf7f8b/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e405b1f5-ecf7-471f-ada1-d44d4b3d0510>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a8cfe04-3344-4484-96b9-74f5f2b3a913> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a8cfe04-3344-4484-96b9-74f5f2b3a913";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a8cfe04-3344-4484-96b9-74f5f2b3a913>.
+    
+<http://data.lblod.info/id/remote-data-objects/13628769-5356-4572-aaa0-19eab505d960> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13628769-5356-4572-aaa0-19eab505d960";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13628769-5356-4572-aaa0-19eab505d960>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d731f0c-97ac-4590-979b-22324b4311f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d731f0c-97ac-4590-979b-22324b4311f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d731f0c-97ac-4590-979b-22324b4311f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/34685918-be04-4049-8e57-a883a06f631f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34685918-be04-4049-8e57-a883a06f631f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34685918-be04-4049-8e57-a883a06f631f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c863b59-53f4-49a2-860f-f15250dbfdbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c863b59-53f4-49a2-860f-f15250dbfdbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c863b59-53f4-49a2-860f-f15250dbfdbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b8f5bee-816f-4ad6-bf94-a4af88d0a095> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b8f5bee-816f-4ad6-bf94-a4af88d0a095";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b8f5bee-816f-4ad6-bf94-a4af88d0a095>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ab1ea14-d12b-4350-b1b0-18d5e464ab43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ab1ea14-d12b-4350-b1b0-18d5e464ab43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ab1ea14-d12b-4350-b1b0-18d5e464ab43>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d2003b9-95a4-466f-88a1-56b23a2f1b44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d2003b9-95a4-466f-88a1-56b23a2f1b44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d2003b9-95a4-466f-88a1-56b23a2f1b44>.
+    
+<http://data.lblod.info/id/remote-data-objects/e860709f-45d2-4b3f-bce8-a03c2be6e774> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e860709f-45d2-4b3f-bce8-a03c2be6e774";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e860709f-45d2-4b3f-bce8-a03c2be6e774>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba88de78-89e3-4a4a-85a2-e0c65117a586> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba88de78-89e3-4a4a-85a2-e0c65117a586";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba88de78-89e3-4a4a-85a2-e0c65117a586>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcbef4ba-b051-424d-b0d3-6ef957f49522> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcbef4ba-b051-424d-b0d3-6ef957f49522";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcbef4ba-b051-424d-b0d3-6ef957f49522>.
+    
+<http://data.lblod.info/id/remote-data-objects/33758917-fad5-42c0-8dee-9ab1c593c36e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33758917-fad5-42c0-8dee-9ab1c593c36e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33758917-fad5-42c0-8dee-9ab1c593c36e>.
+    
+<http://data.lblod.info/id/remote-data-objects/521544cf-5ea2-43bb-a5b1-6916f3bb68ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "521544cf-5ea2-43bb-a5b1-6916f3bb68ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/521544cf-5ea2-43bb-a5b1-6916f3bb68ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/febf57f6-0c53-4425-a663-9cdceb9445d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "febf57f6-0c53-4425-a663-9cdceb9445d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/febf57f6-0c53-4425-a663-9cdceb9445d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/eabd48a4-0f34-452c-a819-2f8778c0ec82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eabd48a4-0f34-452c-a819-2f8778c0ec82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eabd48a4-0f34-452c-a819-2f8778c0ec82>.
+    
+<http://data.lblod.info/id/remote-data-objects/b60b318d-2f92-4603-8573-ae9b5855c2c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b60b318d-2f92-4603-8573-ae9b5855c2c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b60b318d-2f92-4603-8573-ae9b5855c2c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dbe1804-6b88-4ad9-8c1c-35a8346b8032> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dbe1804-6b88-4ad9-8c1c-35a8346b8032";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dbe1804-6b88-4ad9-8c1c-35a8346b8032>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e4ba69b-d28a-4197-8e94-16e1675ec788> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e4ba69b-d28a-4197-8e94-16e1675ec788";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e4ba69b-d28a-4197-8e94-16e1675ec788>.
+    
+<http://data.lblod.info/id/remote-data-objects/773d7bbc-27d6-4229-809a-854c4645f865> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "773d7bbc-27d6-4229-809a-854c4645f865";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/773d7bbc-27d6-4229-809a-854c4645f865>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe048945-0ed2-49b5-8fe5-d2b4a17b8bed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe048945-0ed2-49b5-8fe5-d2b4a17b8bed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe048945-0ed2-49b5-8fe5-d2b4a17b8bed>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3c9641a-a32c-4ac8-a0f8-9b2d782f37f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3c9641a-a32c-4ac8-a0f8-9b2d782f37f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3c9641a-a32c-4ac8-a0f8-9b2d782f37f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cec2d9d-38f3-4f0e-8da8-6f9ad7998f71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cec2d9d-38f3-4f0e-8da8-6f9ad7998f71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cec2d9d-38f3-4f0e-8da8-6f9ad7998f71>.
+    
+<http://data.lblod.info/id/remote-data-objects/61308412-bbb4-4da3-a34d-2e74c1b5dd0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61308412-bbb4-4da3-a34d-2e74c1b5dd0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61308412-bbb4-4da3-a34d-2e74c1b5dd0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/24033773-7e35-400a-90d9-4c58dc49036f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24033773-7e35-400a-90d9-4c58dc49036f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24033773-7e35-400a-90d9-4c58dc49036f>.
+    
+<http://data.lblod.info/id/remote-data-objects/816bafc9-a51b-4334-bdbc-f6e7a43bbe63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "816bafc9-a51b-4334-bdbc-f6e7a43bbe63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/816bafc9-a51b-4334-bdbc-f6e7a43bbe63>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe68932d-20be-4fd7-8ada-307d570c5237> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe68932d-20be-4fd7-8ada-307d570c5237";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe68932d-20be-4fd7-8ada-307d570c5237>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ba6e4e8-5c08-4806-8a3b-7b16a93894f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ba6e4e8-5c08-4806-8a3b-7b16a93894f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ba6e4e8-5c08-4806-8a3b-7b16a93894f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc5650e2-3334-4745-9513-3c66e0ef8336> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc5650e2-3334-4745-9513-3c66e0ef8336";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/7e983a077a22d08cb874274e73d1e9762e88ce5064bae9b34d415edb81f1be9d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc5650e2-3334-4745-9513-3c66e0ef8336>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ffa195a-47d4-41a3-9d9e-2e83d8fd4ce4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ffa195a-47d4-41a3-9d9e-2e83d8fd4ce4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ffa195a-47d4-41a3-9d9e-2e83d8fd4ce4>.
+    
+<http://data.lblod.info/id/remote-data-objects/059b4f35-27e2-4f8a-9f24-8c37113732cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "059b4f35-27e2-4f8a-9f24-8c37113732cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/059b4f35-27e2-4f8a-9f24-8c37113732cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ecc64af-7919-4066-adf2-015fdd11e5dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ecc64af-7919-4066-adf2-015fdd11e5dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ecc64af-7919-4066-adf2-015fdd11e5dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f4dc834-3a34-4812-9888-e245aa4602a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f4dc834-3a34-4812-9888-e245aa4602a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f4dc834-3a34-4812-9888-e245aa4602a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc1cc602-3563-482b-ac1a-4184d5cccbbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc1cc602-3563-482b-ac1a-4184d5cccbbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc1cc602-3563-482b-ac1a-4184d5cccbbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/2698f9e6-db21-476c-ab29-b509134c3e0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2698f9e6-db21-476c-ab29-b509134c3e0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2698f9e6-db21-476c-ab29-b509134c3e0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/58cea43b-5e70-40bd-83a9-b994ca6c45a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58cea43b-5e70-40bd-83a9-b994ca6c45a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58cea43b-5e70-40bd-83a9-b994ca6c45a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/61b97092-6478-40e0-9828-b0e69e4862f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61b97092-6478-40e0-9828-b0e69e4862f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61b97092-6478-40e0-9828-b0e69e4862f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/53d05381-f659-43a8-aab0-effe3f3647d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53d05381-f659-43a8-aab0-effe3f3647d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6b1c98ae-c849-408e-8d08-779fe5090919> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53d05381-f659-43a8-aab0-effe3f3647d4>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201652-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201652-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201652-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201652-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/810a61fc-be66-48a5-ac1d-880e827397a2> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "810a61fc-be66-48a5-ac1d-880e827397a2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dbe6cb8d-9bca-4ded-8523-807869a3ca59";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9fce6d93-2051-4430-a6c3-95a165c4b483> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9fce6d93-2051-4430-a6c3-95a165c4b483";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59>.
+
+  <http://redpencil.data.gift/id/task/9ef81edf-6cde-4f60-a212-c172d0ad4c00> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9ef81edf-6cde-4f60-a212-c172d0ad4c00";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/810a61fc-be66-48a5-ac1d-880e827397a2>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9fce6d93-2051-4430-a6c3-95a165c4b483>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b15592af-fcc5-4b59-9f4d-80d24cd29e74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b15592af-fcc5-4b59-9f4d-80d24cd29e74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b15592af-fcc5-4b59-9f4d-80d24cd29e74>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e7a2380-d485-4586-9311-179cba92a5a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e7a2380-d485-4586-9311-179cba92a5a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e7a2380-d485-4586-9311-179cba92a5a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/662f4841-f74e-4622-935c-b5d4a0f5ac80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "662f4841-f74e-4622-935c-b5d4a0f5ac80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/662f4841-f74e-4622-935c-b5d4a0f5ac80>.
+    
+<http://data.lblod.info/id/remote-data-objects/8268fd5f-107c-4ea0-b766-269e5f3421cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8268fd5f-107c-4ea0-b766-269e5f3421cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8268fd5f-107c-4ea0-b766-269e5f3421cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/6279201f-e6e1-4180-9caf-f6e84f82caea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6279201f-e6e1-4180-9caf-f6e84f82caea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6279201f-e6e1-4180-9caf-f6e84f82caea>.
+    
+<http://data.lblod.info/id/remote-data-objects/d73690bb-029d-4c2b-a1d7-2aa46ba747a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d73690bb-029d-4c2b-a1d7-2aa46ba747a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d73690bb-029d-4c2b-a1d7-2aa46ba747a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/97c33cba-e656-42ff-97ef-ceca96bc6e40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97c33cba-e656-42ff-97ef-ceca96bc6e40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97c33cba-e656-42ff-97ef-ceca96bc6e40>.
+    
+<http://data.lblod.info/id/remote-data-objects/13ec0b36-bc82-4658-be22-ffa974bf406d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13ec0b36-bc82-4658-be22-ffa974bf406d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13ec0b36-bc82-4658-be22-ffa974bf406d>.
+    
+<http://data.lblod.info/id/remote-data-objects/678075b7-ea89-414b-8205-8467da2ae8b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "678075b7-ea89-414b-8205-8467da2ae8b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/678075b7-ea89-414b-8205-8467da2ae8b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cf6bb4e-160f-4710-ac32-10d77508b680> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cf6bb4e-160f-4710-ac32-10d77508b680";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cf6bb4e-160f-4710-ac32-10d77508b680>.
+    
+<http://data.lblod.info/id/remote-data-objects/58e5bd9e-d315-4ecd-bff0-9dadb09fbf95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58e5bd9e-d315-4ecd-bff0-9dadb09fbf95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58e5bd9e-d315-4ecd-bff0-9dadb09fbf95>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed216b7c-1253-4dce-9885-efecc8e3d15f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed216b7c-1253-4dce-9885-efecc8e3d15f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed216b7c-1253-4dce-9885-efecc8e3d15f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e68619c0-4937-406d-afdf-f5d054eab72a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e68619c0-4937-406d-afdf-f5d054eab72a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e68619c0-4937-406d-afdf-f5d054eab72a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2925b0d8-1892-4712-8f91-e74b68d10187> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2925b0d8-1892-4712-8f91-e74b68d10187";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2925b0d8-1892-4712-8f91-e74b68d10187>.
+    
+<http://data.lblod.info/id/remote-data-objects/7edfdc77-86b4-41a3-9f17-b0f1c342f9f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7edfdc77-86b4-41a3-9f17-b0f1c342f9f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7edfdc77-86b4-41a3-9f17-b0f1c342f9f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/85d4ac09-4069-4a7d-ba74-a7066935ba51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85d4ac09-4069-4a7d-ba74-a7066935ba51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85d4ac09-4069-4a7d-ba74-a7066935ba51>.
+    
+<http://data.lblod.info/id/remote-data-objects/d42068d9-ebb8-453e-95f5-a7752845abc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d42068d9-ebb8-453e-95f5-a7752845abc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d42068d9-ebb8-453e-95f5-a7752845abc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c185c8c5-7c8f-490e-9ce3-3ac7945c0e18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c185c8c5-7c8f-490e-9ce3-3ac7945c0e18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c185c8c5-7c8f-490e-9ce3-3ac7945c0e18>.
+    
+<http://data.lblod.info/id/remote-data-objects/495dbd42-e325-47d1-a9c6-9c70200f5a35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "495dbd42-e325-47d1-a9c6-9c70200f5a35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/495dbd42-e325-47d1-a9c6-9c70200f5a35>.
+    
+<http://data.lblod.info/id/remote-data-objects/39db5713-ab56-44f9-9351-fc529846fe59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39db5713-ab56-44f9-9351-fc529846fe59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.stekene.be/LBLODWeb/Home/Overzicht/a42ce8da113854c4eb0a7af76f46fe92751b64267a050ccfcf478d04563ccaeb/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39db5713-ab56-44f9-9351-fc529846fe59>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3243264-e5ac-4394-b34b-24e147ae6f27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3243264-e5ac-4394-b34b-24e147ae6f27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3243264-e5ac-4394-b34b-24e147ae6f27>.
+    
+<http://data.lblod.info/id/remote-data-objects/22692ff6-971d-4fc3-8b56-823a053a6a44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22692ff6-971d-4fc3-8b56-823a053a6a44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22692ff6-971d-4fc3-8b56-823a053a6a44>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5db2bef-4904-4c2e-a328-84ac0a929158> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5db2bef-4904-4c2e-a328-84ac0a929158";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5db2bef-4904-4c2e-a328-84ac0a929158>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd18ee4a-9f2f-4f51-ab61-f8625a1b2598> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd18ee4a-9f2f-4f51-ab61-f8625a1b2598";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd18ee4a-9f2f-4f51-ab61-f8625a1b2598>.
+    
+<http://data.lblod.info/id/remote-data-objects/31f8706d-73eb-47f3-9aa7-5cb73f1d4027> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31f8706d-73eb-47f3-9aa7-5cb73f1d4027";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31f8706d-73eb-47f3-9aa7-5cb73f1d4027>.
+    
+<http://data.lblod.info/id/remote-data-objects/dde0eaf2-1dbf-4f3d-b9b8-1e6c7879e8ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dde0eaf2-1dbf-4f3d-b9b8-1e6c7879e8ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dde0eaf2-1dbf-4f3d-b9b8-1e6c7879e8ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/014dc616-e52d-452c-b0f2-b5d01c6012dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "014dc616-e52d-452c-b0f2-b5d01c6012dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/014dc616-e52d-452c-b0f2-b5d01c6012dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/e75b4e2c-a528-4d21-af13-a8639dce4c1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e75b4e2c-a528-4d21-af13-a8639dce4c1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e75b4e2c-a528-4d21-af13-a8639dce4c1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/56497383-2c92-4cfb-9416-15a252e2ab3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56497383-2c92-4cfb-9416-15a252e2ab3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56497383-2c92-4cfb-9416-15a252e2ab3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/001e00d3-464c-4378-a294-3950ea835467> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "001e00d3-464c-4378-a294-3950ea835467";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/001e00d3-464c-4378-a294-3950ea835467>.
+    
+<http://data.lblod.info/id/remote-data-objects/98eb899a-082e-4009-a87b-55470552852e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98eb899a-082e-4009-a87b-55470552852e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98eb899a-082e-4009-a87b-55470552852e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5392571-e92d-4150-a4a2-0bb89af6a0c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5392571-e92d-4150-a4a2-0bb89af6a0c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5392571-e92d-4150-a4a2-0bb89af6a0c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe3c46e7-7b56-46ff-b0ae-7a49611e484b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe3c46e7-7b56-46ff-b0ae-7a49611e484b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe3c46e7-7b56-46ff-b0ae-7a49611e484b>.
+    
+<http://data.lblod.info/id/remote-data-objects/75723724-afd4-4001-b9b5-e8442247a29a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75723724-afd4-4001-b9b5-e8442247a29a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75723724-afd4-4001-b9b5-e8442247a29a>.
+    
+<http://data.lblod.info/id/remote-data-objects/90a0d817-0db5-418e-a897-e545531a2733> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90a0d817-0db5-418e-a897-e545531a2733";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90a0d817-0db5-418e-a897-e545531a2733>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fad7fef-beae-495a-b1d1-62bc5b98eece> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fad7fef-beae-495a-b1d1-62bc5b98eece";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fad7fef-beae-495a-b1d1-62bc5b98eece>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b043d17-3773-4ef5-a8f3-341a452c701b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b043d17-3773-4ef5-a8f3-341a452c701b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b043d17-3773-4ef5-a8f3-341a452c701b>.
+    
+<http://data.lblod.info/id/remote-data-objects/30625c64-e35d-4649-b966-9b29921137a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30625c64-e35d-4649-b966-9b29921137a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30625c64-e35d-4649-b966-9b29921137a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/618a5328-1ac5-4e94-bc44-d7b787666994> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "618a5328-1ac5-4e94-bc44-d7b787666994";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/618a5328-1ac5-4e94-bc44-d7b787666994>.
+    
+<http://data.lblod.info/id/remote-data-objects/a33a78a3-0cd3-4cdf-9801-df5fc42232a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a33a78a3-0cd3-4cdf-9801-df5fc42232a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a33a78a3-0cd3-4cdf-9801-df5fc42232a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/011790d5-e04f-4117-91f3-08b9f046c23e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "011790d5-e04f-4117-91f3-08b9f046c23e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/011790d5-e04f-4117-91f3-08b9f046c23e>.
+    
+<http://data.lblod.info/id/remote-data-objects/89b56c15-8f6a-430d-b1ce-0ef9396f99b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89b56c15-8f6a-430d-b1ce-0ef9396f99b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89b56c15-8f6a-430d-b1ce-0ef9396f99b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a9833d3-de54-4324-861c-fa0f41f9b029> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a9833d3-de54-4324-861c-fa0f41f9b029";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a9833d3-de54-4324-861c-fa0f41f9b029>.
+    
+<http://data.lblod.info/id/remote-data-objects/984e2403-6b8a-440f-9f3e-028d35f254d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "984e2403-6b8a-440f-9f3e-028d35f254d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/984e2403-6b8a-440f-9f3e-028d35f254d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c73ab2f-75c3-42c6-a6f4-e5c873e84710> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c73ab2f-75c3-42c6-a6f4-e5c873e84710";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c73ab2f-75c3-42c6-a6f4-e5c873e84710>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0092a3b-4a99-4df6-8d17-b03fbbfc73c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0092a3b-4a99-4df6-8d17-b03fbbfc73c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0092a3b-4a99-4df6-8d17-b03fbbfc73c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cf4a25c-47bc-455f-b48e-81ca643cc379> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cf4a25c-47bc-455f-b48e-81ca643cc379";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cf4a25c-47bc-455f-b48e-81ca643cc379>.
+    
+<http://data.lblod.info/id/remote-data-objects/513e3e6e-dabe-44bb-a2eb-cc6073fdcd49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "513e3e6e-dabe-44bb-a2eb-cc6073fdcd49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/513e3e6e-dabe-44bb-a2eb-cc6073fdcd49>.
+    
+<http://data.lblod.info/id/remote-data-objects/62d1759b-7f48-4f1e-bc86-e0ce4281e183> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62d1759b-7f48-4f1e-bc86-e0ce4281e183";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62d1759b-7f48-4f1e-bc86-e0ce4281e183>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed8d48e6-d3d6-46c6-accb-e21b4c3548c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed8d48e6-d3d6-46c6-accb-e21b4c3548c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbe6cb8d-9bca-4ded-8523-807869a3ca59> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed8d48e6-d3d6-46c6-accb-e21b4c3548c7>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201653-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201653-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201653-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201653-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/67404535-cc0d-4fc8-a1d4-a4b751c84a7b> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "67404535-cc0d-4fc8-a1d4-a4b751c84a7b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7d16ae8a-8b1a-42fe-9f7f-874739ba86b1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/04c676a0-63c7-4cf8-9189-d0c536260d1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "04c676a0-63c7-4cf8-9189-d0c536260d1d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1>.
+
+  <http://redpencil.data.gift/id/task/34271096-9f5a-4cd7-826e-08d3a3b3315a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "34271096-9f5a-4cd7-826e-08d3a3b3315a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/67404535-cc0d-4fc8-a1d4-a4b751c84a7b>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/04c676a0-63c7-4cf8-9189-d0c536260d1d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/9dad0000-2a66-4db4-bc28-d6360f661e28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dad0000-2a66-4db4-bc28-d6360f661e28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dad0000-2a66-4db4-bc28-d6360f661e28>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bf2530d-d187-4abc-aeb0-36c0960df9f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bf2530d-d187-4abc-aeb0-36c0960df9f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bf2530d-d187-4abc-aeb0-36c0960df9f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b76b0a7-253c-4d9d-b195-0aaf122cd416> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b76b0a7-253c-4d9d-b195-0aaf122cd416";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b76b0a7-253c-4d9d-b195-0aaf122cd416>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e0240db-54a3-4450-97a7-5d2c493bfdd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e0240db-54a3-4450-97a7-5d2c493bfdd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e0240db-54a3-4450-97a7-5d2c493bfdd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3d648e4-bf5c-4aad-a497-be68d4539cfe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3d648e4-bf5c-4aad-a497-be68d4539cfe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3d648e4-bf5c-4aad-a497-be68d4539cfe>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef9c3c8b-2cf1-4a33-bf30-577443439966> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef9c3c8b-2cf1-4a33-bf30-577443439966";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef9c3c8b-2cf1-4a33-bf30-577443439966>.
+    
+<http://data.lblod.info/id/remote-data-objects/076753b2-bb4f-47f1-a110-973fa1844837> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "076753b2-bb4f-47f1-a110-973fa1844837";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/076753b2-bb4f-47f1-a110-973fa1844837>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7bf84ab-d3a9-4b30-a8a5-24123cca4cea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7bf84ab-d3a9-4b30-a8a5-24123cca4cea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7bf84ab-d3a9-4b30-a8a5-24123cca4cea>.
+    
+<http://data.lblod.info/id/remote-data-objects/097704e7-6d99-491b-bba4-aec13f5e7105> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "097704e7-6d99-491b-bba4-aec13f5e7105";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/097704e7-6d99-491b-bba4-aec13f5e7105>.
+    
+<http://data.lblod.info/id/remote-data-objects/32afc780-6f89-4da9-b4ce-9831cb748fbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32afc780-6f89-4da9-b4ce-9831cb748fbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32afc780-6f89-4da9-b4ce-9831cb748fbb>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ca75f8d-cf9d-4594-b8ca-685421b83685> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ca75f8d-cf9d-4594-b8ca-685421b83685";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ca75f8d-cf9d-4594-b8ca-685421b83685>.
+    
+<http://data.lblod.info/id/remote-data-objects/9bdbc70f-6867-4b02-a70c-15b47627d745> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9bdbc70f-6867-4b02-a70c-15b47627d745";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9bdbc70f-6867-4b02-a70c-15b47627d745>.
+    
+<http://data.lblod.info/id/remote-data-objects/70ec5324-b8fc-4309-8872-3bf2252ac1ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70ec5324-b8fc-4309-8872-3bf2252ac1ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_31-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70ec5324-b8fc-4309-8872-3bf2252ac1ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/57b602d5-ac89-424d-97f7-c2fc2dd4ebcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57b602d5-ac89-424d-97f7-c2fc2dd4ebcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_02-05-2022_42700.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57b602d5-ac89-424d-97f7-c2fc2dd4ebcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/34bf2c04-3b75-4fb2-a6e8-22c10a88c167> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34bf2c04-3b75-4fb2-a6e8-22c10a88c167";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_04-04-2022_42092.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34bf2c04-3b75-4fb2-a6e8-22c10a88c167>.
+    
+<http://data.lblod.info/id/remote-data-objects/72f4286d-31e8-492d-b0d4-8803cd3d54ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72f4286d-31e8-492d-b0d4-8803cd3d54ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_04-07-2022_44400.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72f4286d-31e8-492d-b0d4-8803cd3d54ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/a14ff0c9-450f-4af6-8eff-dca1b5180236> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a14ff0c9-450f-4af6-8eff-dca1b5180236";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_04-07-2022_44409.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a14ff0c9-450f-4af6-8eff-dca1b5180236>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fbeb13d-f069-4a62-bd7a-906d508a2adf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fbeb13d-f069-4a62-bd7a-906d508a2adf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_07-03-2022_41279.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fbeb13d-f069-4a62-bd7a-906d508a2adf>.
+    
+<http://data.lblod.info/id/remote-data-objects/89a73c15-c05e-4b1b-96b4-5b4e5f0197c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89a73c15-c05e-4b1b-96b4-5b4e5f0197c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_09-05-2022_42753.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89a73c15-c05e-4b1b-96b4-5b4e5f0197c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/0702bd6e-13df-47fa-a9fa-66e0a1deebe3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0702bd6e-13df-47fa-a9fa-66e0a1deebe3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_11-10-2021_37515.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0702bd6e-13df-47fa-a9fa-66e0a1deebe3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed4289e8-7550-476c-bb06-9c5645aae8db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed4289e8-7550-476c-bb06-9c5645aae8db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_12-07-2022_44703.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed4289e8-7550-476c-bb06-9c5645aae8db>.
+    
+<http://data.lblod.info/id/remote-data-objects/294e8a4c-ea79-4f2c-8c84-35a238051081> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "294e8a4c-ea79-4f2c-8c84-35a238051081";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_13-12-2021_39265.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/294e8a4c-ea79-4f2c-8c84-35a238051081>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1acb4c7-dc90-40a3-a043-fbc936e55dbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1acb4c7-dc90-40a3-a043-fbc936e55dbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_14-03-2022_41424.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1acb4c7-dc90-40a3-a043-fbc936e55dbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/1355e5fd-cf22-41e7-af5b-8c87e9db1ec9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1355e5fd-cf22-41e7-af5b-8c87e9db1ec9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_17-01-2022_40082.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1355e5fd-cf22-41e7-af5b-8c87e9db1ec9>.
+    
+<http://data.lblod.info/id/remote-data-objects/483e56cf-1b2c-4c0f-8ce6-eab8ee664162> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "483e56cf-1b2c-4c0f-8ce6-eab8ee664162";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_18-10-2021_37691.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/483e56cf-1b2c-4c0f-8ce6-eab8ee664162>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb63a7cf-65d1-4695-a6e7-2437ca4cf323> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb63a7cf-65d1-4695-a6e7-2437ca4cf323";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_19-04-2022_42365.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb63a7cf-65d1-4695-a6e7-2437ca4cf323>.
+    
+<http://data.lblod.info/id/remote-data-objects/142d3252-3e0b-4598-9925-6f030e2f2b55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "142d3252-3e0b-4598-9925-6f030e2f2b55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_20-12-2021_39500.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/142d3252-3e0b-4598-9925-6f030e2f2b55>.
+    
+<http://data.lblod.info/id/remote-data-objects/1be06126-2670-4b49-a799-4c1e2a6bd276> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1be06126-2670-4b49-a799-4c1e2a6bd276";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_21-02-2022_41015.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1be06126-2670-4b49-a799-4c1e2a6bd276>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fae4a06-7269-40d2-b119-490f5ebab250> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fae4a06-7269-40d2-b119-490f5ebab250";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_21-03-2022_41722.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fae4a06-7269-40d2-b119-490f5ebab250>.
+    
+<http://data.lblod.info/id/remote-data-objects/836be7d1-5f66-4622-bbb2-4559e7ccad4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "836be7d1-5f66-4622-bbb2-4559e7ccad4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_22-11-2021_38622.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/836be7d1-5f66-4622-bbb2-4559e7ccad4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f2e95d1-f4ee-43a3-bfab-ff7efbdd0e97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f2e95d1-f4ee-43a3-bfab-ff7efbdd0e97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_25-04-2022_42509.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f2e95d1-f4ee-43a3-bfab-ff7efbdd0e97>.
+    
+<http://data.lblod.info/id/remote-data-objects/f23c577b-a3d3-4d2d-a514-f11eef9042cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f23c577b-a3d3-4d2d-a514-f11eef9042cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/11adc16f687c1f7c24ff9bfe3407508fb9b7ea14eaf6e10750ea4c8d6e938f47/GetPublication?filename=Uittreksels_28-03-2022_41812.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f23c577b-a3d3-4d2d-a514-f11eef9042cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cb1fa91-2b6e-4514-a970-50a047c4d919> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cb1fa91-2b6e-4514-a970-50a047c4d919";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cb1fa91-2b6e-4514-a970-50a047c4d919>.
+    
+<http://data.lblod.info/id/remote-data-objects/d40c04c8-1123-4bcb-9195-f8ee05b0cb00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d40c04c8-1123-4bcb-9195-f8ee05b0cb00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d40c04c8-1123-4bcb-9195-f8ee05b0cb00>.
+    
+<http://data.lblod.info/id/remote-data-objects/846ab435-62c2-4bf5-8186-dd9f8793b97a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "846ab435-62c2-4bf5-8186-dd9f8793b97a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/846ab435-62c2-4bf5-8186-dd9f8793b97a>.
+    
+<http://data.lblod.info/id/remote-data-objects/86d0e028-959f-4a1f-a49a-947b45afc49a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86d0e028-959f-4a1f-a49a-947b45afc49a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86d0e028-959f-4a1f-a49a-947b45afc49a>.
+    
+<http://data.lblod.info/id/remote-data-objects/619c76a1-48df-4824-ba3e-ffb6768ff1fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "619c76a1-48df-4824-ba3e-ffb6768ff1fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/619c76a1-48df-4824-ba3e-ffb6768ff1fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/63c6f5d6-6c4f-4e5a-b925-9f56a13ffc01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63c6f5d6-6c4f-4e5a-b925-9f56a13ffc01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63c6f5d6-6c4f-4e5a-b925-9f56a13ffc01>.
+    
+<http://data.lblod.info/id/remote-data-objects/c077a18b-d60c-4deb-af87-7f392f17178a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c077a18b-d60c-4deb-af87-7f392f17178a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c077a18b-d60c-4deb-af87-7f392f17178a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e53aa652-9c23-4fab-9673-3168c5fda675> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e53aa652-9c23-4fab-9673-3168c5fda675";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e53aa652-9c23-4fab-9673-3168c5fda675>.
+    
+<http://data.lblod.info/id/remote-data-objects/eddf68b1-4774-4b0a-bbde-4f7f35a8fe26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eddf68b1-4774-4b0a-bbde-4f7f35a8fe26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eddf68b1-4774-4b0a-bbde-4f7f35a8fe26>.
+    
+<http://data.lblod.info/id/remote-data-objects/58804164-af98-48d5-b09a-cfb0b311ee01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58804164-af98-48d5-b09a-cfb0b311ee01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58804164-af98-48d5-b09a-cfb0b311ee01>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6d00535-1340-418c-8fd4-e88ccbafb07e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6d00535-1340-418c-8fd4-e88ccbafb07e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6d00535-1340-418c-8fd4-e88ccbafb07e>.
+    
+<http://data.lblod.info/id/remote-data-objects/83848365-5613-420a-949f-7b3af022dd85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83848365-5613-420a-949f-7b3af022dd85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83848365-5613-420a-949f-7b3af022dd85>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff482f0e-5928-4026-9bc2-864eb5aa7806> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff482f0e-5928-4026-9bc2-864eb5aa7806";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff482f0e-5928-4026-9bc2-864eb5aa7806>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab08c153-bee1-4ea0-b6ad-60dd316890ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab08c153-bee1-4ea0-b6ad-60dd316890ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab08c153-bee1-4ea0-b6ad-60dd316890ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fed576a-2fa0-4f61-864e-7e6869e06c32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fed576a-2fa0-4f61-864e-7e6869e06c32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fed576a-2fa0-4f61-864e-7e6869e06c32>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9fe3c18-c825-4eb8-95e6-f9f621e45d45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9fe3c18-c825-4eb8-95e6-f9f621e45d45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9fe3c18-c825-4eb8-95e6-f9f621e45d45>.
+    
+<http://data.lblod.info/id/remote-data-objects/138432bf-9e0d-4828-b936-b94c83ea07eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "138432bf-9e0d-4828-b936-b94c83ea07eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/138432bf-9e0d-4828-b936-b94c83ea07eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/dee54aa8-18d5-46e2-bfc4-0a0dc73fbacf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dee54aa8-18d5-46e2-bfc4-0a0dc73fbacf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7d16ae8a-8b1a-42fe-9f7f-874739ba86b1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dee54aa8-18d5-46e2-bfc4-0a0dc73fbacf>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201655-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201655-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201655-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201655-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/1d8ee4bd-64ad-45e2-bf0b-aa6b040f465e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1d8ee4bd-64ad-45e2-bf0b-aa6b040f465e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "09390eca-fb14-4b94-ab44-2468dc230742";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f4847879-ee74-42b4-9ffa-938d6cdc7921> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f4847879-ee74-42b4-9ffa-938d6cdc7921";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742>.
+
+  <http://redpencil.data.gift/id/task/4184b7e3-8e38-4236-8bfd-c07900743b27> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4184b7e3-8e38-4236-8bfd-c07900743b27";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/1d8ee4bd-64ad-45e2-bf0b-aa6b040f465e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f4847879-ee74-42b4-9ffa-938d6cdc7921>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/6fc8837b-ce31-46a5-8883-351ced732b7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fc8837b-ce31-46a5-8883-351ced732b7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fc8837b-ce31-46a5-8883-351ced732b7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f32a98ab-0dc1-4a74-8b6f-2e58ff0497fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f32a98ab-0dc1-4a74-8b6f-2e58ff0497fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f32a98ab-0dc1-4a74-8b6f-2e58ff0497fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/94907a49-f27b-401e-a1e2-30db6e7e871b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94907a49-f27b-401e-a1e2-30db6e7e871b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94907a49-f27b-401e-a1e2-30db6e7e871b>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa13096d-1615-44ec-a793-874e63fbf78f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa13096d-1615-44ec-a793-874e63fbf78f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa13096d-1615-44ec-a793-874e63fbf78f>.
+    
+<http://data.lblod.info/id/remote-data-objects/27810f40-ce45-47fd-9882-479ee9bea2f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27810f40-ce45-47fd-9882-479ee9bea2f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27810f40-ce45-47fd-9882-479ee9bea2f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b87535e-d2ae-49d0-90af-44102fb9ce88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b87535e-d2ae-49d0-90af-44102fb9ce88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b87535e-d2ae-49d0-90af-44102fb9ce88>.
+    
+<http://data.lblod.info/id/remote-data-objects/55b08e99-dd58-49cc-b0b5-ad1dc37ddc77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55b08e99-dd58-49cc-b0b5-ad1dc37ddc77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55b08e99-dd58-49cc-b0b5-ad1dc37ddc77>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f3f84f0-53c9-47eb-acd3-0d43fe6580f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f3f84f0-53c9-47eb-acd3-0d43fe6580f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Uittreksels_25-04-2022_41914.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f3f84f0-53c9-47eb-acd3-0d43fe6580f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cc69cb5-5e55-4ed5-8c5e-ea3543ee411c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cc69cb5-5e55-4ed5-8c5e-ea3543ee411c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Uittreksels_28-02-2022_38283.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cc69cb5-5e55-4ed5-8c5e-ea3543ee411c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9bb8848b-279b-4828-a486-c1d5088733b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9bb8848b-279b-4828-a486-c1d5088733b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Uittreksels_28-02-2022_40021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9bb8848b-279b-4828-a486-c1d5088733b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e3da312-6180-4d1a-9dae-b9416763b812> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e3da312-6180-4d1a-9dae-b9416763b812";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Uittreksels_28-02-2022_40871.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e3da312-6180-4d1a-9dae-b9416763b812>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a74e3c0-84e3-45f8-8d2c-943235f76cfd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a74e3c0-84e3-45f8-8d2c-943235f76cfd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/457e5024005a4bcf9b068df5d0981ade35a33d1f77033e547c5067de603a213e/GetPublication?filename=Uittreksels_28-03-2022_41419.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a74e3c0-84e3-45f8-8d2c-943235f76cfd>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f8b9442-1c2f-4ace-9f13-f89829802708> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f8b9442-1c2f-4ace-9f13-f89829802708";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Agenda_gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f8b9442-1c2f-4ace-9f13-f89829802708>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef576752-013b-4a32-ae86-8d772addee0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef576752-013b-4a32-ae86-8d772addee0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Agenda_gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef576752-013b-4a32-ae86-8d772addee0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/839f4376-a78c-40b4-aa10-1612568ad0ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "839f4376-a78c-40b4-aa10-1612568ad0ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Agenda_gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/839f4376-a78c-40b4-aa10-1612568ad0ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/db3b8ba4-3fde-4be2-a623-71c6409f2938> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db3b8ba4-3fde-4be2-a623-71c6409f2938";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Agenda_gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db3b8ba4-3fde-4be2-a623-71c6409f2938>.
+    
+<http://data.lblod.info/id/remote-data-objects/1254a366-4996-483d-bc10-e285029eb151> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1254a366-4996-483d-bc10-e285029eb151";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Agenda_gemeenteraad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1254a366-4996-483d-bc10-e285029eb151>.
+    
+<http://data.lblod.info/id/remote-data-objects/10b4a029-01ad-4dfb-a1fa-d16237649f49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10b4a029-01ad-4dfb-a1fa-d16237649f49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Agenda_gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10b4a029-01ad-4dfb-a1fa-d16237649f49>.
+    
+<http://data.lblod.info/id/remote-data-objects/e082bf29-7db8-40d3-a40b-7bc7b31502da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e082bf29-7db8-40d3-a40b-7bc7b31502da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Agenda_gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e082bf29-7db8-40d3-a40b-7bc7b31502da>.
+    
+<http://data.lblod.info/id/remote-data-objects/37e5db34-b500-48c3-a75e-7d74438bb986> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37e5db34-b500-48c3-a75e-7d74438bb986";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Agenda_gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37e5db34-b500-48c3-a75e-7d74438bb986>.
+    
+<http://data.lblod.info/id/remote-data-objects/c041eb7e-e6c0-4ffb-8a90-1ca403915cda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c041eb7e-e6c0-4ffb-8a90-1ca403915cda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Agenda_gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c041eb7e-e6c0-4ffb-8a90-1ca403915cda>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d130b8d-1a0b-468d-8816-51147830e332> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d130b8d-1a0b-468d-8816-51147830e332";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d130b8d-1a0b-468d-8816-51147830e332>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a326a94-48e4-44b1-b49d-02c393279c23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a326a94-48e4-44b1-b49d-02c393279c23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a326a94-48e4-44b1-b49d-02c393279c23>.
+    
+<http://data.lblod.info/id/remote-data-objects/64f37bf8-0151-42d4-9348-e2afa4934216> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64f37bf8-0151-42d4-9348-e2afa4934216";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64f37bf8-0151-42d4-9348-e2afa4934216>.
+    
+<http://data.lblod.info/id/remote-data-objects/26cd0647-1048-45cb-95e5-8fec7de09639> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26cd0647-1048-45cb-95e5-8fec7de09639";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26cd0647-1048-45cb-95e5-8fec7de09639>.
+    
+<http://data.lblod.info/id/remote-data-objects/c08de006-391c-45da-8b93-02bcd3af7341> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c08de006-391c-45da-8b93-02bcd3af7341";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c08de006-391c-45da-8b93-02bcd3af7341>.
+    
+<http://data.lblod.info/id/remote-data-objects/79f11731-1a41-4b21-b7b4-950e2aa89780> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79f11731-1a41-4b21-b7b4-950e2aa89780";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79f11731-1a41-4b21-b7b4-950e2aa89780>.
+    
+<http://data.lblod.info/id/remote-data-objects/53230746-ad71-48a1-963b-cf3831744c96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53230746-ad71-48a1-963b-cf3831744c96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53230746-ad71-48a1-963b-cf3831744c96>.
+    
+<http://data.lblod.info/id/remote-data-objects/13c6aa65-4833-4d2e-9cbc-7037c87bf63c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13c6aa65-4833-4d2e-9cbc-7037c87bf63c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13c6aa65-4833-4d2e-9cbc-7037c87bf63c>.
+    
+<http://data.lblod.info/id/remote-data-objects/12481cea-2ae8-4f8a-9da3-8318de019276> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12481cea-2ae8-4f8a-9da3-8318de019276";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12481cea-2ae8-4f8a-9da3-8318de019276>.
+    
+<http://data.lblod.info/id/remote-data-objects/513aed98-76f3-43b9-a0d9-86ad22f7e942> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "513aed98-76f3-43b9-a0d9-86ad22f7e942";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Notulen_gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/513aed98-76f3-43b9-a0d9-86ad22f7e942>.
+    
+<http://data.lblod.info/id/remote-data-objects/7910e8ce-232a-4f08-9e59-81256d6176e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7910e8ce-232a-4f08-9e59-81256d6176e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Notulen_gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7910e8ce-232a-4f08-9e59-81256d6176e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd769829-67ae-41a6-ab36-690493e50c1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd769829-67ae-41a6-ab36-690493e50c1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Notulen_gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd769829-67ae-41a6-ab36-690493e50c1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4e2c013-b3ab-4e7a-9f05-f1d8749e4aef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4e2c013-b3ab-4e7a-9f05-f1d8749e4aef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Notulen_gemeenteraad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4e2c013-b3ab-4e7a-9f05-f1d8749e4aef>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c39c650-c433-4ace-906e-9762df6bc0a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c39c650-c433-4ace-906e-9762df6bc0a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Notulen_gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c39c650-c433-4ace-906e-9762df6bc0a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/71adf421-9b5e-4d58-a282-eca9eb367bab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71adf421-9b5e-4d58-a282-eca9eb367bab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Notulen_gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71adf421-9b5e-4d58-a282-eca9eb367bab>.
+    
+<http://data.lblod.info/id/remote-data-objects/997ac74b-6317-40bf-b7e8-dde6565b29b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "997ac74b-6317-40bf-b7e8-dde6565b29b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Notulen_gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/997ac74b-6317-40bf-b7e8-dde6565b29b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdaf3ca2-c6cd-43c8-98bb-2ff3064573f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdaf3ca2-c6cd-43c8-98bb-2ff3064573f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_20-12-2021_37893.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdaf3ca2-c6cd-43c8-98bb-2ff3064573f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a7e60ac-9629-494c-924e-849b47903e93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a7e60ac-9629-494c-924e-849b47903e93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_20-12-2021_37915.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a7e60ac-9629-494c-924e-849b47903e93>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbc53f9e-20c2-47d3-9b53-dc7f8d1c4c98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbc53f9e-20c2-47d3-9b53-dc7f8d1c4c98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_20-12-2021_38838.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbc53f9e-20c2-47d3-9b53-dc7f8d1c4c98>.
+    
+<http://data.lblod.info/id/remote-data-objects/28f0be6f-ed3f-4fa4-bd1b-65c8dfe7d606> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28f0be6f-ed3f-4fa4-bd1b-65c8dfe7d606";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_20-12-2021_39053.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28f0be6f-ed3f-4fa4-bd1b-65c8dfe7d606>.
+    
+<http://data.lblod.info/id/remote-data-objects/543b04e0-e172-4af5-a577-f19f76a75745> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "543b04e0-e172-4af5-a577-f19f76a75745";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_20-12-2021_39084.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/543b04e0-e172-4af5-a577-f19f76a75745>.
+    
+<http://data.lblod.info/id/remote-data-objects/687f3214-c3ea-4f79-832d-84c56ec18f07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "687f3214-c3ea-4f79-832d-84c56ec18f07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_25-04-2022_41913.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/687f3214-c3ea-4f79-832d-84c56ec18f07>.
+    
+<http://data.lblod.info/id/remote-data-objects/c840814b-906f-4106-9ef4-e88bb6546d52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c840814b-906f-4106-9ef4-e88bb6546d52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_25-04-2022_42385.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c840814b-906f-4106-9ef4-e88bb6546d52>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f266bf7-5660-4b64-a7c9-9e4498e77b89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f266bf7-5660-4b64-a7c9-9e4498e77b89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_25-10-2021_37529.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f266bf7-5660-4b64-a7c9-9e4498e77b89>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d8828c0-2ec8-4f32-82f0-24cd05b36195> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d8828c0-2ec8-4f32-82f0-24cd05b36195";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_28-02-2022_37720.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d8828c0-2ec8-4f32-82f0-24cd05b36195>.
+    
+<http://data.lblod.info/id/remote-data-objects/356a57ed-2f87-4621-95f0-ca6b4c4390f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "356a57ed-2f87-4621-95f0-ca6b4c4390f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_28-02-2022_39505.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/356a57ed-2f87-4621-95f0-ca6b4c4390f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/962b7280-ca25-47a3-93b7-cc28fe5a19b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "962b7280-ca25-47a3-93b7-cc28fe5a19b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_28-02-2022_39737.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/962b7280-ca25-47a3-93b7-cc28fe5a19b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/f12ff105-c596-4523-9391-4a9bdb5e8151> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f12ff105-c596-4523-9391-4a9bdb5e8151";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_28-02-2022_40696.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f12ff105-c596-4523-9391-4a9bdb5e8151>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f2ccac3-e6bd-4ffe-93d2-ddd2ca715d40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f2ccac3-e6bd-4ffe-93d2-ddd2ca715d40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_28-02-2022_40869.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/09390eca-fb14-4b94-ab44-2468dc230742> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f2ccac3-e6bd-4ffe-93d2-ddd2ca715d40>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201656-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201656-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201656-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201656-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/deeb59cc-aef0-4028-bdb3-26747794704d> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "deeb59cc-aef0-4028-bdb3-26747794704d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cbc10912-b823-4a52-8fdb-599ec55ec119";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/545bca56-7d63-4c47-8cd3-fbb29f688f4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "545bca56-7d63-4c47-8cd3-fbb29f688f4e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119>.
+
+  <http://redpencil.data.gift/id/task/63bf510e-44f5-482f-8063-9230d28b4212> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "63bf510e-44f5-482f-8063-9230d28b4212";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/deeb59cc-aef0-4028-bdb3-26747794704d>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/545bca56-7d63-4c47-8cd3-fbb29f688f4e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/9ecf5b92-0974-4555-a737-6f1089106ccb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ecf5b92-0974-4555-a737-6f1089106ccb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_28-02-2022_40870.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ecf5b92-0974-4555-a737-6f1089106ccb>.
+    
+<http://data.lblod.info/id/remote-data-objects/46c11f1e-a117-4358-8f3e-5c4513e39a7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46c11f1e-a117-4358-8f3e-5c4513e39a7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_28-03-2022_41418.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46c11f1e-a117-4358-8f3e-5c4513e39a7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0c89ff7-dd08-4465-9f7f-afea387b1ae1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0c89ff7-dd08-4465-9f7f-afea387b1ae1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_28-03-2022_41460.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0c89ff7-dd08-4465-9f7f-afea387b1ae1>.
+    
+<http://data.lblod.info/id/remote-data-objects/51ba081b-1134-485e-b476-dc6a8586d4bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51ba081b-1134-485e-b476-dc6a8586d4bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/62ad6c67f3c78adf663f6ea1a8aa3b1b88f8fa7521454ff814dfa5b8380c26d4/GetPublication?filename=Uittreksels_30-05-2022_42925.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51ba081b-1134-485e-b476-dc6a8586d4bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6725415-ddf8-4a6c-ae42-814ce728b580> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6725415-ddf8-4a6c-ae42-814ce728b580";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/9a277808624f35bbed455196a2d2035b75a7a8fb6ac7336ad558389128837f8e/GetPublication?filename=BesluitenLijstUitspraak_besluiten%20burgemeester_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6725415-ddf8-4a6c-ae42-814ce728b580>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9bda95b-9fd6-4997-b856-04eadd72a8f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9bda95b-9fd6-4997-b856-04eadd72a8f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/9a277808624f35bbed455196a2d2035b75a7a8fb6ac7336ad558389128837f8e/GetPublication?filename=BesluitenLijstUitspraak_besluiten%20burgemeester_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9bda95b-9fd6-4997-b856-04eadd72a8f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b733d36-a620-46da-8172-39372cfcd894> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b733d36-a620-46da-8172-39372cfcd894";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/9a277808624f35bbed455196a2d2035b75a7a8fb6ac7336ad558389128837f8e/GetPublication?filename=BesluitenLijstUitspraak_besluiten%20burgemeester_08-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b733d36-a620-46da-8172-39372cfcd894>.
+    
+<http://data.lblod.info/id/remote-data-objects/05925a75-5db2-4f6a-8aff-f8618f964fec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05925a75-5db2-4f6a-8aff-f8618f964fec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/9a277808624f35bbed455196a2d2035b75a7a8fb6ac7336ad558389128837f8e/GetPublication?filename=BesluitenLijstUitspraak_besluiten%20burgemeester_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05925a75-5db2-4f6a-8aff-f8618f964fec>.
+    
+<http://data.lblod.info/id/remote-data-objects/39137bef-5335-4754-b2be-cd50f0cb0900> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39137bef-5335-4754-b2be-cd50f0cb0900";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/9a277808624f35bbed455196a2d2035b75a7a8fb6ac7336ad558389128837f8e/GetPublication?filename=BesluitenLijstUitspraak_besluiten%20burgemeester_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39137bef-5335-4754-b2be-cd50f0cb0900>.
+    
+<http://data.lblod.info/id/remote-data-objects/84df1a01-4709-401b-ba41-0c25fdaf93c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84df1a01-4709-401b-ba41-0c25fdaf93c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/9a277808624f35bbed455196a2d2035b75a7a8fb6ac7336ad558389128837f8e/GetPublication?filename=BesluitenLijstUitspraak_besluiten%20burgemeester_18-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84df1a01-4709-401b-ba41-0c25fdaf93c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddb2f4e0-4e77-4cd0-96d9-a2e016573ea7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddb2f4e0-4e77-4cd0-96d9-a2e016573ea7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/9a277808624f35bbed455196a2d2035b75a7a8fb6ac7336ad558389128837f8e/GetPublication?filename=BesluitenLijstUitspraak_besluiten%20burgemeester_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddb2f4e0-4e77-4cd0-96d9-a2e016573ea7>.
+    
+<http://data.lblod.info/id/remote-data-objects/983b0bf8-37a3-4414-b954-f8f37c206bbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "983b0bf8-37a3-4414-b954-f8f37c206bbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/9a277808624f35bbed455196a2d2035b75a7a8fb6ac7336ad558389128837f8e/GetPublication?filename=Uittreksels_17-02-2022_41050.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/983b0bf8-37a3-4414-b954-f8f37c206bbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee03cc8f-7b70-4173-b408-295a2fe55af7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee03cc8f-7b70-4173-b408-295a2fe55af7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/9a277808624f35bbed455196a2d2035b75a7a8fb6ac7336ad558389128837f8e/GetPublication?filename=Uittreksels_19-11-2021_38734.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee03cc8f-7b70-4173-b408-295a2fe55af7>.
+    
+<http://data.lblod.info/id/remote-data-objects/64007069-268a-41df-9f32-63fbe4a27629> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64007069-268a-41df-9f32-63fbe4a27629";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64007069-268a-41df-9f32-63fbe4a27629>.
+    
+<http://data.lblod.info/id/remote-data-objects/df8c9091-f410-42bd-9779-265487623be4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df8c9091-f410-42bd-9779-265487623be4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df8c9091-f410-42bd-9779-265487623be4>.
+    
+<http://data.lblod.info/id/remote-data-objects/fda4b6c3-58f0-4ef2-9adf-604431e7a2c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fda4b6c3-58f0-4ef2-9adf-604431e7a2c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fda4b6c3-58f0-4ef2-9adf-604431e7a2c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/786aa59c-a570-45e7-ac0b-c34218e12d09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "786aa59c-a570-45e7-ac0b-c34218e12d09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/786aa59c-a570-45e7-ac0b-c34218e12d09>.
+    
+<http://data.lblod.info/id/remote-data-objects/37002bde-1669-4320-bf86-2f04c15ee9a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37002bde-1669-4320-bf86-2f04c15ee9a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37002bde-1669-4320-bf86-2f04c15ee9a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b4c2d3d-5c5f-4b6a-8a05-d42b8ea98992> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b4c2d3d-5c5f-4b6a-8a05-d42b8ea98992";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b4c2d3d-5c5f-4b6a-8a05-d42b8ea98992>.
+    
+<http://data.lblod.info/id/remote-data-objects/8429ea00-a4c2-4bc1-8751-c3219f788903> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8429ea00-a4c2-4bc1-8751-c3219f788903";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8429ea00-a4c2-4bc1-8751-c3219f788903>.
+    
+<http://data.lblod.info/id/remote-data-objects/44c35d19-b3ea-482a-a43a-916634d67334> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44c35d19-b3ea-482a-a43a-916634d67334";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44c35d19-b3ea-482a-a43a-916634d67334>.
+    
+<http://data.lblod.info/id/remote-data-objects/845de2ce-37e7-4ae6-b7e5-61808e137098> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "845de2ce-37e7-4ae6-b7e5-61808e137098";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/845de2ce-37e7-4ae6-b7e5-61808e137098>.
+    
+<http://data.lblod.info/id/remote-data-objects/8341bb36-c3b4-4de8-a81a-b297c2adc9cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8341bb36-c3b4-4de8-a81a-b297c2adc9cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8341bb36-c3b4-4de8-a81a-b297c2adc9cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/73c11548-d71f-4fca-8746-2f73184e65bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73c11548-d71f-4fca-8746-2f73184e65bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73c11548-d71f-4fca-8746-2f73184e65bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7cdf22a-5b46-4974-becf-146bbda932e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7cdf22a-5b46-4974-becf-146bbda932e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7cdf22a-5b46-4974-becf-146bbda932e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/f864a619-b5ad-447f-bcd1-57f8e7da4200> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f864a619-b5ad-447f-bcd1-57f8e7da4200";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f864a619-b5ad-447f-bcd1-57f8e7da4200>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b672280-6fc1-478b-a23b-c6f5f7e42d35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b672280-6fc1-478b-a23b-c6f5f7e42d35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b672280-6fc1-478b-a23b-c6f5f7e42d35>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f89cee8-0a77-4846-936c-b364ece4c5f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f89cee8-0a77-4846-936c-b364ece4c5f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f89cee8-0a77-4846-936c-b364ece4c5f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4cd0955-565d-4efc-a518-2c64429af07a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4cd0955-565d-4efc-a518-2c64429af07a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4cd0955-565d-4efc-a518-2c64429af07a>.
+    
+<http://data.lblod.info/id/remote-data-objects/aea8828b-b788-4c1b-9144-43af655ea2e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aea8828b-b788-4c1b-9144-43af655ea2e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aea8828b-b788-4c1b-9144-43af655ea2e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/9408a94c-7d07-4876-a24c-9e8f4177ea25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9408a94c-7d07-4876-a24c-9e8f4177ea25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9408a94c-7d07-4876-a24c-9e8f4177ea25>.
+    
+<http://data.lblod.info/id/remote-data-objects/09ea4ec8-266c-40fc-9359-595357bba50f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09ea4ec8-266c-40fc-9359-595357bba50f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09ea4ec8-266c-40fc-9359-595357bba50f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e521c064-36ff-43f5-b778-ebd4002b4e56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e521c064-36ff-43f5-b778-ebd4002b4e56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e521c064-36ff-43f5-b778-ebd4002b4e56>.
+    
+<http://data.lblod.info/id/remote-data-objects/1286e02a-6817-411b-a799-c31b060640ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1286e02a-6817-411b-a799-c31b060640ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1286e02a-6817-411b-a799-c31b060640ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ce827f2-936b-414a-84d2-f0a70e2c86e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ce827f2-936b-414a-84d2-f0a70e2c86e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ce827f2-936b-414a-84d2-f0a70e2c86e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/46ada436-3cc5-4849-bd49-dfafb85547ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46ada436-3cc5-4849-bd49-dfafb85547ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46ada436-3cc5-4849-bd49-dfafb85547ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/60b51c6e-7721-4844-896a-a2c1eca05e97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60b51c6e-7721-4844-896a-a2c1eca05e97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60b51c6e-7721-4844-896a-a2c1eca05e97>.
+    
+<http://data.lblod.info/id/remote-data-objects/646e66cf-623e-47ef-8a86-0422d35a7a84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "646e66cf-623e-47ef-8a86-0422d35a7a84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/646e66cf-623e-47ef-8a86-0422d35a7a84>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc837a95-91b4-43d2-a1d4-5598c073f71d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc837a95-91b4-43d2-a1d4-5598c073f71d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc837a95-91b4-43d2-a1d4-5598c073f71d>.
+    
+<http://data.lblod.info/id/remote-data-objects/042c9b3e-3438-4fc5-801a-936e8f31172d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "042c9b3e-3438-4fc5-801a-936e8f31172d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/042c9b3e-3438-4fc5-801a-936e8f31172d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f215eac8-26e5-4df1-bce7-b3fb4255f8a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f215eac8-26e5-4df1-bce7-b3fb4255f8a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f215eac8-26e5-4df1-bce7-b3fb4255f8a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9b7ce53-c665-4ea1-b492-fb56e1350672> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9b7ce53-c665-4ea1-b492-fb56e1350672";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9b7ce53-c665-4ea1-b492-fb56e1350672>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f7aff9c-ea99-4e95-a1a2-6fd99a26c6ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f7aff9c-ea99-4e95-a1a2-6fd99a26c6ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f7aff9c-ea99-4e95-a1a2-6fd99a26c6ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f825cb5-7a3b-4ff1-a425-8277314a1bed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f825cb5-7a3b-4ff1-a425-8277314a1bed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f825cb5-7a3b-4ff1-a425-8277314a1bed>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b749cc1-f1e0-4157-890c-6db2b3d4ce8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b749cc1-f1e0-4157-890c-6db2b3d4ce8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b749cc1-f1e0-4157-890c-6db2b3d4ce8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d760f7f-9a76-459a-a1e4-b88754bf27ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d760f7f-9a76-459a-a1e4-b88754bf27ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d760f7f-9a76-459a-a1e4-b88754bf27ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9ef6d3c-107d-48dc-a3d3-44cf930751dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9ef6d3c-107d-48dc-a3d3-44cf930751dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9ef6d3c-107d-48dc-a3d3-44cf930751dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/29e488a5-d077-4dfc-bbf7-74cfdddb200e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29e488a5-d077-4dfc-bbf7-74cfdddb200e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29e488a5-d077-4dfc-bbf7-74cfdddb200e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbcb5dff-f708-40a4-beca-07ab74c9138b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbcb5dff-f708-40a4-beca-07ab74c9138b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbcb5dff-f708-40a4-beca-07ab74c9138b>.
+    
+<http://data.lblod.info/id/remote-data-objects/91a6b9b2-0a87-4422-b4b4-7c507596d2ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91a6b9b2-0a87-4422-b4b4-7c507596d2ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.temse.be/LBLODWeb/Home/Overzicht/d86dbc47db801af8b38d544fc73e3cfd1a7c8b2e5a6d399f4b163d671faaa94f/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cbc10912-b823-4a52-8fdb-599ec55ec119> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91a6b9b2-0a87-4422-b4b4-7c507596d2ab>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201657-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201657-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201657-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201657-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/9cc8e6ab-ab88-471f-b647-2810d0229c54> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9cc8e6ab-ab88-471f-b647-2810d0229c54";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0b8576f0-814e-497e-ae65-f58aa8b1f0bc";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/619196f0-0f37-4cf4-a225-7c75d653927e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "619196f0-0f37-4cf4-a225-7c75d653927e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc>.
+
+  <http://redpencil.data.gift/id/task/2a6618bf-5ddc-4ebb-9c3d-fdb1f7bfd226> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2a6618bf-5ddc-4ebb-9c3d-fdb1f7bfd226";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/9cc8e6ab-ab88-471f-b647-2810d0229c54>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/619196f0-0f37-4cf4-a225-7c75d653927e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/9dc06232-3818-44a0-91dc-105c6352caf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dc06232-3818-44a0-91dc-105c6352caf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Agenda_OCMW-raad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dc06232-3818-44a0-91dc-105c6352caf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fcbdc56-86b3-40b1-9794-16729caa50e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fcbdc56-86b3-40b1-9794-16729caa50e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Agenda_OCMW-raad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fcbdc56-86b3-40b1-9794-16729caa50e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/228bf9ff-3358-4394-9ca0-0c1066fd5ae3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "228bf9ff-3358-4394-9ca0-0c1066fd5ae3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Agenda_OCMW-raad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/228bf9ff-3358-4394-9ca0-0c1066fd5ae3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f23f5f4-ded7-48ad-aea2-a4ae9c8b58a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f23f5f4-ded7-48ad-aea2-a4ae9c8b58a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Agenda_OCMW-raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f23f5f4-ded7-48ad-aea2-a4ae9c8b58a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c27640d8-0536-4de8-856b-eba6b0303982> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c27640d8-0536-4de8-856b-eba6b0303982";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Agenda_OCMW-raad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c27640d8-0536-4de8-856b-eba6b0303982>.
+    
+<http://data.lblod.info/id/remote-data-objects/25e31b7c-2801-4112-9fec-cba15ef9201e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25e31b7c-2801-4112-9fec-cba15ef9201e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Agenda_OCMW-raad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25e31b7c-2801-4112-9fec-cba15ef9201e>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd944d26-3a3d-415c-8e32-5ee16f39f500> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd944d26-3a3d-415c-8e32-5ee16f39f500";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Agenda_OCMW-raad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd944d26-3a3d-415c-8e32-5ee16f39f500>.
+    
+<http://data.lblod.info/id/remote-data-objects/d13dcf9c-6713-4ca0-ab4c-7a5c6b4730b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d13dcf9c-6713-4ca0-ab4c-7a5c6b4730b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Agenda_OCMW-raad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d13dcf9c-6713-4ca0-ab4c-7a5c6b4730b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a6cab98-83a3-4803-a6a3-d025f0f97a84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a6cab98-83a3-4803-a6a3-d025f0f97a84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Agenda_OCMW-raad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a6cab98-83a3-4803-a6a3-d025f0f97a84>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ed398cd-c847-44d5-9fd2-9d63ed7c40df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ed398cd-c847-44d5-9fd2-9d63ed7c40df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=BesluitenLijst_OCMW-raad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ed398cd-c847-44d5-9fd2-9d63ed7c40df>.
+    
+<http://data.lblod.info/id/remote-data-objects/29e2c45e-444a-4cfd-9d83-0099e0935f2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29e2c45e-444a-4cfd-9d83-0099e0935f2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=BesluitenLijst_OCMW-raad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29e2c45e-444a-4cfd-9d83-0099e0935f2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b01b0b1-e2b0-4347-a475-77925f192b64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b01b0b1-e2b0-4347-a475-77925f192b64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=BesluitenLijst_OCMW-raad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b01b0b1-e2b0-4347-a475-77925f192b64>.
+    
+<http://data.lblod.info/id/remote-data-objects/d043fa84-240e-420c-a9cb-f1e3832c53ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d043fa84-240e-420c-a9cb-f1e3832c53ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=BesluitenLijst_OCMW-raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d043fa84-240e-420c-a9cb-f1e3832c53ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ffe0e1b-eb92-4d3c-a6a9-783b294d7a36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ffe0e1b-eb92-4d3c-a6a9-783b294d7a36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=BesluitenLijst_OCMW-raad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ffe0e1b-eb92-4d3c-a6a9-783b294d7a36>.
+    
+<http://data.lblod.info/id/remote-data-objects/a22fad91-381b-44eb-adc7-95200d694f9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a22fad91-381b-44eb-adc7-95200d694f9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=BesluitenLijst_OCMW-raad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a22fad91-381b-44eb-adc7-95200d694f9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bedf1b2-67e7-489b-9a4e-1a92aef71720> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bedf1b2-67e7-489b-9a4e-1a92aef71720";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=BesluitenLijst_OCMW-raad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bedf1b2-67e7-489b-9a4e-1a92aef71720>.
+    
+<http://data.lblod.info/id/remote-data-objects/54f33374-fa52-403e-ba8d-e852c16e6459> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54f33374-fa52-403e-ba8d-e852c16e6459";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=BesluitenLijst_OCMW-raad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54f33374-fa52-403e-ba8d-e852c16e6459>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5507c8f-7b15-485c-8dbd-66c71b93b980> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5507c8f-7b15-485c-8dbd-66c71b93b980";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=BesluitenLijst_OCMW-raad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5507c8f-7b15-485c-8dbd-66c71b93b980>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ab13d1e-f331-4cfc-9ca3-4b1a5250809e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ab13d1e-f331-4cfc-9ca3-4b1a5250809e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Notulen_OCMW-raad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ab13d1e-f331-4cfc-9ca3-4b1a5250809e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f16d6a69-bfd3-4a36-83e7-6e5211ee0914> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f16d6a69-bfd3-4a36-83e7-6e5211ee0914";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Notulen_OCMW-raad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f16d6a69-bfd3-4a36-83e7-6e5211ee0914>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cc9f11c-124d-4436-ab67-5cede8321894> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cc9f11c-124d-4436-ab67-5cede8321894";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Notulen_OCMW-raad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cc9f11c-124d-4436-ab67-5cede8321894>.
+    
+<http://data.lblod.info/id/remote-data-objects/0030d974-7ff0-4b6a-ae1a-bb5ebccf6646> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0030d974-7ff0-4b6a-ae1a-bb5ebccf6646";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Notulen_OCMW-raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0030d974-7ff0-4b6a-ae1a-bb5ebccf6646>.
+    
+<http://data.lblod.info/id/remote-data-objects/990ecb41-585c-431e-91a9-83e0abe88b0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "990ecb41-585c-431e-91a9-83e0abe88b0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Notulen_OCMW-raad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/990ecb41-585c-431e-91a9-83e0abe88b0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb4375f9-a267-4b75-ad0d-0a84fb3621c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb4375f9-a267-4b75-ad0d-0a84fb3621c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Notulen_OCMW-raad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb4375f9-a267-4b75-ad0d-0a84fb3621c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1bf3a53-286b-46ac-8f91-32c5524942a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1bf3a53-286b-46ac-8f91-32c5524942a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Notulen_OCMW-raad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1bf3a53-286b-46ac-8f91-32c5524942a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d17f265e-0433-4a45-9b3f-f99175b3675a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d17f265e-0433-4a45-9b3f-f99175b3675a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Notulen_OCMW-raad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d17f265e-0433-4a45-9b3f-f99175b3675a>.
+    
+<http://data.lblod.info/id/remote-data-objects/37adb650-f433-4684-afa6-38592b69cd77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37adb650-f433-4684-afa6-38592b69cd77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Uittreksels_27-06-2022_28625.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37adb650-f433-4684-afa6-38592b69cd77>.
+    
+<http://data.lblod.info/id/remote-data-objects/46bc9085-9612-4cdd-a3f6-944251555470> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46bc9085-9612-4cdd-a3f6-944251555470";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Uittreksels_28-03-2022_26439.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46bc9085-9612-4cdd-a3f6-944251555470>.
+    
+<http://data.lblod.info/id/remote-data-objects/0342fb16-8ee8-407d-ba07-796982e728a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0342fb16-8ee8-407d-ba07-796982e728a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Uittreksels_28-03-2022_26862.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0342fb16-8ee8-407d-ba07-796982e728a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0900575-3ee1-4cec-9da5-acf401f188a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0900575-3ee1-4cec-9da5-acf401f188a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Uittreksels_29-11-2021_26017.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0900575-3ee1-4cec-9da5-acf401f188a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/519dcbaf-7645-4f2e-88c1-73b398bc2118> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "519dcbaf-7645-4f2e-88c1-73b398bc2118";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/07f833558dbb27902863f375811059b8098c26158cfabf3f6814a7ade4462db6/GetPublication?filename=Uittreksels_29-11-2021_26122.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/519dcbaf-7645-4f2e-88c1-73b398bc2118>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea194c62-fc7a-432d-abda-f97c7ba40243> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea194c62-fc7a-432d-abda-f97c7ba40243";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/4a062aba747e07436c789cf5bbf3363b39878e8f27a8f882befea4260d6749b8/GetPublication?filename=BesluitenLijst_besluiten%20burgemeester_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea194c62-fc7a-432d-abda-f97c7ba40243>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecd3e7e9-4b08-4d98-abe8-ae65a3ee6b5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecd3e7e9-4b08-4d98-abe8-ae65a3ee6b5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/4a062aba747e07436c789cf5bbf3363b39878e8f27a8f882befea4260d6749b8/GetPublication?filename=BesluitenLijst_besluiten%20burgemeester_30-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecd3e7e9-4b08-4d98-abe8-ae65a3ee6b5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfab1fb4-7914-4243-a363-2bd40ec74eee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfab1fb4-7914-4243-a363-2bd40ec74eee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/4a062aba747e07436c789cf5bbf3363b39878e8f27a8f882befea4260d6749b8/GetPublication?filename=BesluitenLijst_besluiten%20burgemeester_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfab1fb4-7914-4243-a363-2bd40ec74eee>.
+    
+<http://data.lblod.info/id/remote-data-objects/75ebba47-6565-451f-b2ab-0fa64f49e2c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75ebba47-6565-451f-b2ab-0fa64f49e2c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/4a062aba747e07436c789cf5bbf3363b39878e8f27a8f882befea4260d6749b8/GetPublication?filename=BesluitenLijst_besluiten%20burgemeester_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75ebba47-6565-451f-b2ab-0fa64f49e2c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/cefff846-649a-4d4d-8f8f-a34f8352b83b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cefff846-649a-4d4d-8f8f-a34f8352b83b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/4a062aba747e07436c789cf5bbf3363b39878e8f27a8f882befea4260d6749b8/GetPublication?filename=BesluitenLijst_besluiten%20burgemeester_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cefff846-649a-4d4d-8f8f-a34f8352b83b>.
+    
+<http://data.lblod.info/id/remote-data-objects/09794cc6-42e8-4057-8949-d48baa7e7309> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09794cc6-42e8-4057-8949-d48baa7e7309";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/4a062aba747e07436c789cf5bbf3363b39878e8f27a8f882befea4260d6749b8/GetPublication?filename=BesluitenLijst_besluiten%20burgemeester_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09794cc6-42e8-4057-8949-d48baa7e7309>.
+    
+<http://data.lblod.info/id/remote-data-objects/2264ffb8-a2b0-4395-8ca2-b2471f0c7dd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2264ffb8-a2b0-4395-8ca2-b2471f0c7dd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/4a062aba747e07436c789cf5bbf3363b39878e8f27a8f882befea4260d6749b8/GetPublication?filename=BesluitenLijst_besluiten%20burgemeester_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2264ffb8-a2b0-4395-8ca2-b2471f0c7dd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e7ee194-5264-4a22-86e0-53c2526858a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e7ee194-5264-4a22-86e0-53c2526858a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/4a062aba747e07436c789cf5bbf3363b39878e8f27a8f882befea4260d6749b8/GetPublication?filename=BesluitenLijst_besluiten%20burgemeester_31-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e7ee194-5264-4a22-86e0-53c2526858a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9535466-9b9d-43ef-92d0-f587558da838> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9535466-9b9d-43ef-92d0-f587558da838";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/4a062aba747e07436c789cf5bbf3363b39878e8f27a8f882befea4260d6749b8/GetPublication?filename=BesluitenLijst_besluiten%20burgemeester_31-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9535466-9b9d-43ef-92d0-f587558da838>.
+    
+<http://data.lblod.info/id/remote-data-objects/7096a9f1-5399-4e70-9ffe-d0b409217b56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7096a9f1-5399-4e70-9ffe-d0b409217b56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/4a062aba747e07436c789cf5bbf3363b39878e8f27a8f882befea4260d6749b8/GetPublication?filename=BesluitenLijst_besluiten%20burgemeester_31-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7096a9f1-5399-4e70-9ffe-d0b409217b56>.
+    
+<http://data.lblod.info/id/remote-data-objects/89d677d9-cb7f-4c2d-a739-0b7033e2c7f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89d677d9-cb7f-4c2d-a739-0b7033e2c7f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/4a062aba747e07436c789cf5bbf3363b39878e8f27a8f882befea4260d6749b8/GetPublication?filename=Uittreksels_30-04-2022_28015.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89d677d9-cb7f-4c2d-a739-0b7033e2c7f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e34e6593-9960-4b3d-b5af-d4bca84d569a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e34e6593-9960-4b3d-b5af-d4bca84d569a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/4a062aba747e07436c789cf5bbf3363b39878e8f27a8f882befea4260d6749b8/GetPublication?filename=Uittreksels_30-11-2021_26119.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e34e6593-9960-4b3d-b5af-d4bca84d569a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd550899-af4d-41b7-b9dd-698298d07d6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd550899-af4d-41b7-b9dd-698298d07d6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Agenda_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd550899-af4d-41b7-b9dd-698298d07d6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b812e9be-caca-4ec8-a93c-b70967741f39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b812e9be-caca-4ec8-a93c-b70967741f39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Agenda_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b812e9be-caca-4ec8-a93c-b70967741f39>.
+    
+<http://data.lblod.info/id/remote-data-objects/768700bc-1694-4d16-a8de-3c1489673790> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "768700bc-1694-4d16-a8de-3c1489673790";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Agenda_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/768700bc-1694-4d16-a8de-3c1489673790>.
+    
+<http://data.lblod.info/id/remote-data-objects/78360cd8-ad22-4fd0-be07-a7642cf777ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78360cd8-ad22-4fd0-be07-a7642cf777ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Agenda_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78360cd8-ad22-4fd0-be07-a7642cf777ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/de47f6d9-6271-4828-ae94-822fe88fa0f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de47f6d9-6271-4828-ae94-822fe88fa0f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Agenda_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de47f6d9-6271-4828-ae94-822fe88fa0f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5587e81b-1aa2-4076-bcb4-7b0d633cf8e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5587e81b-1aa2-4076-bcb4-7b0d633cf8e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Agenda_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5587e81b-1aa2-4076-bcb4-7b0d633cf8e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/17a170c1-c674-4c9d-bc51-bf59093b9a5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17a170c1-c674-4c9d-bc51-bf59093b9a5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Agenda_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0b8576f0-814e-497e-ae65-f58aa8b1f0bc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17a170c1-c674-4c9d-bc51-bf59093b9a5f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201658-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201658-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201658-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201658-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3bbede5b-bc67-4c81-8946-9025b5c28e6e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3bbede5b-bc67-4c81-8946-9025b5c28e6e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "89e74959-e627-4f83-89e5-8bc27b1f4a62";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4baffd86-57d9-40e5-a905-126032d45610> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4baffd86-57d9-40e5-a905-126032d45610";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62>.
+
+  <http://redpencil.data.gift/id/task/21df68e2-3a48-467a-aa81-d78ab3dd66cb> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "21df68e2-3a48-467a-aa81-d78ab3dd66cb";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3bbede5b-bc67-4c81-8946-9025b5c28e6e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4baffd86-57d9-40e5-a905-126032d45610>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/36646720-5fc4-42db-acac-8e8208d6f226> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36646720-5fc4-42db-acac-8e8208d6f226";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Agenda_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36646720-5fc4-42db-acac-8e8208d6f226>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6815023-f59a-4d09-8c50-c1a178cf41dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6815023-f59a-4d09-8c50-c1a178cf41dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Agenda_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6815023-f59a-4d09-8c50-c1a178cf41dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/8afb2db2-1af5-4180-89c0-22275bb27b4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8afb2db2-1af5-4180-89c0-22275bb27b4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=BesluitenLijst_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8afb2db2-1af5-4180-89c0-22275bb27b4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/434ccfd5-fdb6-42f3-8bb6-65ded6777abd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "434ccfd5-fdb6-42f3-8bb6-65ded6777abd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/434ccfd5-fdb6-42f3-8bb6-65ded6777abd>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa1822c5-7b6d-4930-bba2-3af524319b71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa1822c5-7b6d-4930-bba2-3af524319b71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa1822c5-7b6d-4930-bba2-3af524319b71>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fd65381-fa2e-4717-a210-f08cbdccda5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fd65381-fa2e-4717-a210-f08cbdccda5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fd65381-fa2e-4717-a210-f08cbdccda5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/50d994b3-1787-4e04-b82c-cee42e718283> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50d994b3-1787-4e04-b82c-cee42e718283";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50d994b3-1787-4e04-b82c-cee42e718283>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b8832d1-8734-4d6b-8b4e-dbacc26ce0b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b8832d1-8734-4d6b-8b4e-dbacc26ce0b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b8832d1-8734-4d6b-8b4e-dbacc26ce0b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff664051-17e3-4ce6-889e-bb8809377812> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff664051-17e3-4ce6-889e-bb8809377812";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff664051-17e3-4ce6-889e-bb8809377812>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcd8c1f6-1e15-477b-856a-12e100b725aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcd8c1f6-1e15-477b-856a-12e100b725aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=BesluitenLijst_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcd8c1f6-1e15-477b-856a-12e100b725aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd370616-e710-430c-8767-871a0bb5dcfc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd370616-e710-430c-8767-871a0bb5dcfc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=BesluitenLijst_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd370616-e710-430c-8767-871a0bb5dcfc>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c37a503-9327-4c29-831f-54578c228dd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c37a503-9327-4c29-831f-54578c228dd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Notulen_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c37a503-9327-4c29-831f-54578c228dd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/362fde4c-4003-4e2b-9f01-7f7f4cadbc00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "362fde4c-4003-4e2b-9f01-7f7f4cadbc00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Notulen_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/362fde4c-4003-4e2b-9f01-7f7f4cadbc00>.
+    
+<http://data.lblod.info/id/remote-data-objects/624f64de-94f4-4820-9ad6-d9a12ae166e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "624f64de-94f4-4820-9ad6-d9a12ae166e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Notulen_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/624f64de-94f4-4820-9ad6-d9a12ae166e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/98a96156-097f-4fc4-a7cb-7a42571b8cc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98a96156-097f-4fc4-a7cb-7a42571b8cc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Notulen_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98a96156-097f-4fc4-a7cb-7a42571b8cc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/29db2dcb-b50d-4d4f-baff-5f33da2f4ace> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29db2dcb-b50d-4d4f-baff-5f33da2f4ace";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Notulen_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29db2dcb-b50d-4d4f-baff-5f33da2f4ace>.
+    
+<http://data.lblod.info/id/remote-data-objects/39393f51-8d8c-4656-93c1-a11eb8064b15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39393f51-8d8c-4656-93c1-a11eb8064b15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Notulen_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39393f51-8d8c-4656-93c1-a11eb8064b15>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d8637b4-1d65-4051-bb35-831a5f5b6262> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d8637b4-1d65-4051-bb35-831a5f5b6262";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Notulen_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d8637b4-1d65-4051-bb35-831a5f5b6262>.
+    
+<http://data.lblod.info/id/remote-data-objects/73f2a379-7d72-468e-b71e-cd7c45bf3b0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73f2a379-7d72-468e-b71e-cd7c45bf3b0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Notulen_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73f2a379-7d72-468e-b71e-cd7c45bf3b0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3615b3f4-a158-4752-91a8-608378c95e90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3615b3f4-a158-4752-91a8-608378c95e90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_20-12-2021_26172.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3615b3f4-a158-4752-91a8-608378c95e90>.
+    
+<http://data.lblod.info/id/remote-data-objects/35e04a3f-9119-4f85-8d8b-aa90142cfbea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35e04a3f-9119-4f85-8d8b-aa90142cfbea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_20-12-2021_26173.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35e04a3f-9119-4f85-8d8b-aa90142cfbea>.
+    
+<http://data.lblod.info/id/remote-data-objects/114b48c1-3ce2-45e2-a90d-cc469ef95855> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "114b48c1-3ce2-45e2-a90d-cc469ef95855";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_20-12-2021_26176.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/114b48c1-3ce2-45e2-a90d-cc469ef95855>.
+    
+<http://data.lblod.info/id/remote-data-objects/651cad05-2c93-433c-ba99-0a60c156cb6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "651cad05-2c93-433c-ba99-0a60c156cb6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_20-12-2021_26180.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/651cad05-2c93-433c-ba99-0a60c156cb6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/73548008-4e64-46b4-bc49-f7c41a621b1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73548008-4e64-46b4-bc49-f7c41a621b1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_20-12-2021_26181.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73548008-4e64-46b4-bc49-f7c41a621b1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/25efd1b6-3aa2-452b-b4ff-c9fc265de665> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25efd1b6-3aa2-452b-b4ff-c9fc265de665";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_20-12-2021_26185.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25efd1b6-3aa2-452b-b4ff-c9fc265de665>.
+    
+<http://data.lblod.info/id/remote-data-objects/504c6914-c774-4481-b110-d1cccf0c4af0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "504c6914-c774-4481-b110-d1cccf0c4af0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_20-12-2021_26204.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/504c6914-c774-4481-b110-d1cccf0c4af0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d08ba891-eda1-40ed-bf48-b7e69aa57f21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d08ba891-eda1-40ed-bf48-b7e69aa57f21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_20-12-2021_26205.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d08ba891-eda1-40ed-bf48-b7e69aa57f21>.
+    
+<http://data.lblod.info/id/remote-data-objects/b360b870-db65-44be-a030-369d6f9410e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b360b870-db65-44be-a030-369d6f9410e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_20-12-2021_26212.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b360b870-db65-44be-a030-369d6f9410e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3594d3e-e972-4be6-a806-b737ff7b8fd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3594d3e-e972-4be6-a806-b737ff7b8fd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_24-01-2022_26373.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3594d3e-e972-4be6-a806-b737ff7b8fd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/82c7bb33-658e-4a7b-8a11-6d2a4d9b9abd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82c7bb33-658e-4a7b-8a11-6d2a4d9b9abd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_24-01-2022_26501.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82c7bb33-658e-4a7b-8a11-6d2a4d9b9abd>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8bfd959-3554-47a5-9cea-d087a12c5ec3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8bfd959-3554-47a5-9cea-d087a12c5ec3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_24-01-2022_26618.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8bfd959-3554-47a5-9cea-d087a12c5ec3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6adbeba-a47d-4b3a-b683-dd2c397992dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6adbeba-a47d-4b3a-b683-dd2c397992dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_24-01-2022_26634.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6adbeba-a47d-4b3a-b683-dd2c397992dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/695fd45c-6e65-4ebb-857b-93cb5b84d30e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "695fd45c-6e65-4ebb-857b-93cb5b84d30e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_24-01-2022_26635.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/695fd45c-6e65-4ebb-857b-93cb5b84d30e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1686daf3-f34c-4639-9bb9-9b3ea57a6f02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1686daf3-f34c-4639-9bb9-9b3ea57a6f02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_25-04-2022_27736.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1686daf3-f34c-4639-9bb9-9b3ea57a6f02>.
+    
+<http://data.lblod.info/id/remote-data-objects/88f0821a-4578-42ca-b580-29dbc433e4bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88f0821a-4578-42ca-b580-29dbc433e4bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_25-04-2022_27822.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88f0821a-4578-42ca-b580-29dbc433e4bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/33f8e86d-a9f2-48aa-902d-af01b4e44b46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33f8e86d-a9f2-48aa-902d-af01b4e44b46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_25-10-2021_24965.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33f8e86d-a9f2-48aa-902d-af01b4e44b46>.
+    
+<http://data.lblod.info/id/remote-data-objects/432ff5c7-7a43-4141-9ff6-f17d401f5d72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "432ff5c7-7a43-4141-9ff6-f17d401f5d72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_25-10-2021_24967.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/432ff5c7-7a43-4141-9ff6-f17d401f5d72>.
+    
+<http://data.lblod.info/id/remote-data-objects/0856a4cf-812c-4571-9de9-1cdfa882cc2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0856a4cf-812c-4571-9de9-1cdfa882cc2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_25-10-2021_24968.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0856a4cf-812c-4571-9de9-1cdfa882cc2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ed9ea20-42f8-4f5a-807f-803449a23865> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ed9ea20-42f8-4f5a-807f-803449a23865";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_25-10-2021_24970.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ed9ea20-42f8-4f5a-807f-803449a23865>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c1ad26a-00da-4331-85ac-e66f680c85fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c1ad26a-00da-4331-85ac-e66f680c85fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_27-06-2022_27670.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c1ad26a-00da-4331-85ac-e66f680c85fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/d475d8c5-fa5d-4263-87d4-192d320393c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d475d8c5-fa5d-4263-87d4-192d320393c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_27-06-2022_28298.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d475d8c5-fa5d-4263-87d4-192d320393c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/8322360d-30df-41d3-bd28-817ada73a561> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8322360d-30df-41d3-bd28-817ada73a561";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_27-06-2022_28365.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8322360d-30df-41d3-bd28-817ada73a561>.
+    
+<http://data.lblod.info/id/remote-data-objects/947b72ac-30f1-4734-a054-eb7c3fa3fbd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "947b72ac-30f1-4734-a054-eb7c3fa3fbd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_27-06-2022_28547.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/947b72ac-30f1-4734-a054-eb7c3fa3fbd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/b22eef94-aba6-4827-bc41-0d924c0f893b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b22eef94-aba6-4827-bc41-0d924c0f893b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_27-06-2022_28566.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b22eef94-aba6-4827-bc41-0d924c0f893b>.
+    
+<http://data.lblod.info/id/remote-data-objects/17ecaf4c-eeea-4fd3-8158-a7941cc4fe85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17ecaf4c-eeea-4fd3-8158-a7941cc4fe85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_27-06-2022_28595.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17ecaf4c-eeea-4fd3-8158-a7941cc4fe85>.
+    
+<http://data.lblod.info/id/remote-data-objects/887b6158-c786-4478-b051-e69b27881779> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "887b6158-c786-4478-b051-e69b27881779";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_27-06-2022_28623.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/887b6158-c786-4478-b051-e69b27881779>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a4cce81-a5c1-467e-a9ac-bbfc9df29033> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a4cce81-a5c1-467e-a9ac-bbfc9df29033";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_27-06-2022_28624.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a4cce81-a5c1-467e-a9ac-bbfc9df29033>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e897819-5f1a-4e08-ab85-00dd2b209666> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e897819-5f1a-4e08-ab85-00dd2b209666";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_27-06-2022_28653.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e897819-5f1a-4e08-ab85-00dd2b209666>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fbdcf4f-eba9-4631-b41f-39927f7c1953> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fbdcf4f-eba9-4631-b41f-39927f7c1953";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_28-03-2022_27275.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fbdcf4f-eba9-4631-b41f-39927f7c1953>.
+    
+<http://data.lblod.info/id/remote-data-objects/5be26ed2-6608-4427-877b-38b2fa4b2c56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5be26ed2-6608-4427-877b-38b2fa4b2c56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_28-03-2022_27276.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:16:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/89e74959-e627-4f83-89e5-8bc27b1f4a62> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5be26ed2-6608-4427-877b-38b2fa4b2c56>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201700-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201700-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201700-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201700-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/53cca684-cb7b-4fd2-b8c6-b4c650eef683> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "53cca684-cb7b-4fd2-b8c6-b4c650eef683";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/36537dc3-18d4-42da-a335-59b8ab1ec181> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "36537dc3-18d4-42da-a335-59b8ab1ec181";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8>.
+
+  <http://redpencil.data.gift/id/task/4304f89a-a440-4c38-9a15-837c0afd00b2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4304f89a-a440-4c38-9a15-837c0afd00b2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/53cca684-cb7b-4fd2-b8c6-b4c650eef683>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/36537dc3-18d4-42da-a335-59b8ab1ec181>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/f6741b5f-efe9-472f-8d30-a6effbcec4da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6741b5f-efe9-472f-8d30-a6effbcec4da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_29-11-2021_25778.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6741b5f-efe9-472f-8d30-a6effbcec4da>.
+    
+<http://data.lblod.info/id/remote-data-objects/60570430-3ba0-45aa-b031-38b8751862c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60570430-3ba0-45aa-b031-38b8751862c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_29-11-2021_25965.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60570430-3ba0-45aa-b031-38b8751862c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/214ea080-2bd1-42c9-b24f-0ef5bfabc83d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "214ea080-2bd1-42c9-b24f-0ef5bfabc83d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_29-11-2021_25966.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/214ea080-2bd1-42c9-b24f-0ef5bfabc83d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6446f3f-9a4d-4c0d-a934-79f9b1e75273> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6446f3f-9a4d-4c0d-a934-79f9b1e75273";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_29-11-2021_26015.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6446f3f-9a4d-4c0d-a934-79f9b1e75273>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3874d45-19fd-4b01-8a0b-96e69e594219> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3874d45-19fd-4b01-8a0b-96e69e594219";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_29-11-2021_26016.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3874d45-19fd-4b01-8a0b-96e69e594219>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a39358b-1d56-49c4-8613-4e7e381478a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a39358b-1d56-49c4-8613-4e7e381478a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_29-11-2021_26121.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a39358b-1d56-49c4-8613-4e7e381478a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ee7550e-0e65-49c6-a6c8-fd926f460d61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ee7550e-0e65-49c6-a6c8-fd926f460d61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_30-05-2022_27947.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ee7550e-0e65-49c6-a6c8-fd926f460d61>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b5e98eb-34e3-48aa-a373-c79895b6dcae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b5e98eb-34e3-48aa-a373-c79895b6dcae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_30-05-2022_28018.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b5e98eb-34e3-48aa-a373-c79895b6dcae>.
+    
+<http://data.lblod.info/id/remote-data-objects/08e3eef9-5c01-40cc-b9c6-94e6c01a0989> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08e3eef9-5c01-40cc-b9c6-94e6c01a0989";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_30-05-2022_28185.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08e3eef9-5c01-40cc-b9c6-94e6c01a0989>.
+    
+<http://data.lblod.info/id/remote-data-objects/f27755b1-6691-476e-bdb0-b20ae27ce66f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f27755b1-6691-476e-bdb0-b20ae27ce66f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_30-05-2022_28204.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f27755b1-6691-476e-bdb0-b20ae27ce66f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c8f082d-88ef-4af9-8a95-7836c06cfbd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c8f082d-88ef-4af9-8a95-7836c06cfbd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_30-05-2022_28205.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c8f082d-88ef-4af9-8a95-7836c06cfbd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/95616b99-0af6-405e-92c2-76f8c21ad64c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95616b99-0af6-405e-92c2-76f8c21ad64c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/6a7f6ed7610fc6a04422513f7210e5a450455f9b2450dd171f3c87827e9a4d63/GetPublication?filename=Uittreksels_30-05-2022_28297.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95616b99-0af6-405e-92c2-76f8c21ad64c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9e5d66b-2f69-43ab-9208-63bb486577ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9e5d66b-2f69-43ab-9208-63bb486577ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9e5d66b-2f69-43ab-9208-63bb486577ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/d45a6beb-713c-4b84-a3a4-56df991a97cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d45a6beb-713c-4b84-a3a4-56df991a97cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d45a6beb-713c-4b84-a3a4-56df991a97cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8f8090c-e28c-43d0-af9c-8e8cafac140f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8f8090c-e28c-43d0-af9c-8e8cafac140f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8f8090c-e28c-43d0-af9c-8e8cafac140f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ea7382c-7112-4c4d-8f55-8f52eef9a653> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ea7382c-7112-4c4d-8f55-8f52eef9a653";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ea7382c-7112-4c4d-8f55-8f52eef9a653>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d90915e-e85c-44aa-81c9-42ca7b1eb8f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d90915e-e85c-44aa-81c9-42ca7b1eb8f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d90915e-e85c-44aa-81c9-42ca7b1eb8f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc4980df-124e-474e-ad50-f64705c49239> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc4980df-124e-474e-ad50-f64705c49239";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc4980df-124e-474e-ad50-f64705c49239>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a9b61a0-7f4e-4c7b-b5f5-be08a31f5c8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a9b61a0-7f4e-4c7b-b5f5-be08a31f5c8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_06-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a9b61a0-7f4e-4c7b-b5f5-be08a31f5c8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c01bb2d-17b5-49af-992b-f61c934a089c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c01bb2d-17b5-49af-992b-f61c934a089c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c01bb2d-17b5-49af-992b-f61c934a089c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d32b1fda-5a7a-472a-9f76-25ab1ed06dcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d32b1fda-5a7a-472a-9f76-25ab1ed06dcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_09-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d32b1fda-5a7a-472a-9f76-25ab1ed06dcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f453ae2-0b8d-47c5-a86a-0364a88ad045> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f453ae2-0b8d-47c5-a86a-0364a88ad045";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f453ae2-0b8d-47c5-a86a-0364a88ad045>.
+    
+<http://data.lblod.info/id/remote-data-objects/1120553f-04d8-47a1-8247-ca2bd51ef476> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1120553f-04d8-47a1-8247-ca2bd51ef476";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1120553f-04d8-47a1-8247-ca2bd51ef476>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e6a85e8-79fd-418b-a4dd-1e9c25754d11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e6a85e8-79fd-418b-a4dd-1e9c25754d11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e6a85e8-79fd-418b-a4dd-1e9c25754d11>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3a86491-87de-49c4-b72b-aa5d7a6b05db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3a86491-87de-49c4-b72b-aa5d7a6b05db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3a86491-87de-49c4-b72b-aa5d7a6b05db>.
+    
+<http://data.lblod.info/id/remote-data-objects/26407d55-5c51-4c9b-8f73-9fae6746c781> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26407d55-5c51-4c9b-8f73-9fae6746c781";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26407d55-5c51-4c9b-8f73-9fae6746c781>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bc3d71a-7e63-4226-8d7a-95ee1c4210c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bc3d71a-7e63-4226-8d7a-95ee1c4210c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bc3d71a-7e63-4226-8d7a-95ee1c4210c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c676f3b0-6244-4e68-8a71-9110b9aa8372> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c676f3b0-6244-4e68-8a71-9110b9aa8372";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c676f3b0-6244-4e68-8a71-9110b9aa8372>.
+    
+<http://data.lblod.info/id/remote-data-objects/21393380-4f77-4d90-bd37-db5a60d36130> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21393380-4f77-4d90-bd37-db5a60d36130";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21393380-4f77-4d90-bd37-db5a60d36130>.
+    
+<http://data.lblod.info/id/remote-data-objects/09526f4a-341c-4ec1-801f-03a8975cf26d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09526f4a-341c-4ec1-801f-03a8975cf26d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09526f4a-341c-4ec1-801f-03a8975cf26d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a29c238-f2c2-4dbc-a427-538897798384> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a29c238-f2c2-4dbc-a427-538897798384";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a29c238-f2c2-4dbc-a427-538897798384>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d7ff55d-3cee-4d68-8a56-86ce32b5bcbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d7ff55d-3cee-4d68-8a56-86ce32b5bcbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d7ff55d-3cee-4d68-8a56-86ce32b5bcbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/3048c399-b8b6-4b77-b4bb-0c0af133acd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3048c399-b8b6-4b77-b4bb-0c0af133acd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3048c399-b8b6-4b77-b4bb-0c0af133acd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f16fd286-e0f3-430d-a5bc-ef239de10079> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f16fd286-e0f3-430d-a5bc-ef239de10079";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f16fd286-e0f3-430d-a5bc-ef239de10079>.
+    
+<http://data.lblod.info/id/remote-data-objects/8754955e-e79d-4576-bdd4-134536a42ec5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8754955e-e79d-4576-bdd4-134536a42ec5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8754955e-e79d-4576-bdd4-134536a42ec5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2762c7d-1e5c-4cea-bb59-65504d2ea0c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2762c7d-1e5c-4cea-bb59-65504d2ea0c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2762c7d-1e5c-4cea-bb59-65504d2ea0c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb46deaf-f7fb-4c6d-bdfe-2327d2a1c99e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb46deaf-f7fb-4c6d-bdfe-2327d2a1c99e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb46deaf-f7fb-4c6d-bdfe-2327d2a1c99e>.
+    
+<http://data.lblod.info/id/remote-data-objects/204d7561-b369-44c1-92e4-8f12cf7a142c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "204d7561-b369-44c1-92e4-8f12cf7a142c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/204d7561-b369-44c1-92e4-8f12cf7a142c>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbb8298a-6903-407d-b2b6-287c64e7836b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbb8298a-6903-407d-b2b6-287c64e7836b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbb8298a-6903-407d-b2b6-287c64e7836b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9283398b-06a4-434c-bb08-22714f0e51e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9283398b-06a4-434c-bb08-22714f0e51e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9283398b-06a4-434c-bb08-22714f0e51e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/98a72c93-0a87-4b44-ab9a-4f1a12073d24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98a72c93-0a87-4b44-ab9a-4f1a12073d24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98a72c93-0a87-4b44-ab9a-4f1a12073d24>.
+    
+<http://data.lblod.info/id/remote-data-objects/605bfb04-ef57-42e2-922c-d31157770ccd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "605bfb04-ef57-42e2-922c-d31157770ccd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/605bfb04-ef57-42e2-922c-d31157770ccd>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fbe78ec-b6bb-4ef4-81cc-8c94bf04d166> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fbe78ec-b6bb-4ef4-81cc-8c94bf04d166";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fbe78ec-b6bb-4ef4-81cc-8c94bf04d166>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c69add9-cbe0-497d-91a3-82fcf6715e71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c69add9-cbe0-497d-91a3-82fcf6715e71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c69add9-cbe0-497d-91a3-82fcf6715e71>.
+    
+<http://data.lblod.info/id/remote-data-objects/a02ab3b6-4dcd-426d-bf7e-e6a66c853fec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a02ab3b6-4dcd-426d-bf7e-e6a66c853fec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a02ab3b6-4dcd-426d-bf7e-e6a66c853fec>.
+    
+<http://data.lblod.info/id/remote-data-objects/864ab139-9a2d-4684-aa49-81a96392e266> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "864ab139-9a2d-4684-aa49-81a96392e266";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/864ab139-9a2d-4684-aa49-81a96392e266>.
+    
+<http://data.lblod.info/id/remote-data-objects/99503b92-4c19-4fc2-b1c5-0663ba0d6883> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99503b92-4c19-4fc2-b1c5-0663ba0d6883";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99503b92-4c19-4fc2-b1c5-0663ba0d6883>.
+    
+<http://data.lblod.info/id/remote-data-objects/b685d454-4fb9-477f-9fe9-a675159e7325> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b685d454-4fb9-477f-9fe9-a675159e7325";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b685d454-4fb9-477f-9fe9-a675159e7325>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4aa92a1-9cc0-437c-a076-e4dfc8ef65af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4aa92a1-9cc0-437c-a076-e4dfc8ef65af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/ad5806a9-5bf7-4c04-99d8-19974c0a4ece/GetPublication?filename=BesluitenLijst_Vast%20bureau_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4aa92a1-9cc0-437c-a076-e4dfc8ef65af>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9a01e2c-012a-4dea-bb3f-3a1f44c93e66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9a01e2c-012a-4dea-bb3f-3a1f44c93e66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c09ca94-7a3f-49b1-bc4e-fb5f5594d4b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9a01e2c-012a-4dea-bb3f-3a1f44c93e66>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201701-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201701-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201701-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201701-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e0ccf1f1-9c5f-4366-9bf4-6acdd4a9a0e4> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e0ccf1f1-9c5f-4366-9bf4-6acdd4a9a0e4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "150f214e-c58e-417e-9f36-31d2903c6062";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a63fd94d-526e-4be1-b22c-114c5908284c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a63fd94d-526e-4be1-b22c-114c5908284c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062>.
+
+  <http://redpencil.data.gift/id/task/4b94363b-2af0-424b-afb7-dedb3a34aa96> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4b94363b-2af0-424b-afb7-dedb3a34aa96";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e0ccf1f1-9c5f-4366-9bf4-6acdd4a9a0e4>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a63fd94d-526e-4be1-b22c-114c5908284c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7ff526d0-6aaf-47f0-a72c-fe2f792886ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ff526d0-6aaf-47f0-a72c-fe2f792886ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ff526d0-6aaf-47f0-a72c-fe2f792886ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/449ec261-4410-4bad-a128-38e33f86e511> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "449ec261-4410-4bad-a128-38e33f86e511";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/449ec261-4410-4bad-a128-38e33f86e511>.
+    
+<http://data.lblod.info/id/remote-data-objects/f473c273-d1b9-433e-baa8-2fc8618c039e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f473c273-d1b9-433e-baa8-2fc8618c039e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f473c273-d1b9-433e-baa8-2fc8618c039e>.
+    
+<http://data.lblod.info/id/remote-data-objects/61b19e71-abf1-4f13-930d-6da1f0d4e936> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61b19e71-abf1-4f13-930d-6da1f0d4e936";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61b19e71-abf1-4f13-930d-6da1f0d4e936>.
+    
+<http://data.lblod.info/id/remote-data-objects/b81cc36f-2891-4585-a04a-7fb21b019b67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b81cc36f-2891-4585-a04a-7fb21b019b67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b81cc36f-2891-4585-a04a-7fb21b019b67>.
+    
+<http://data.lblod.info/id/remote-data-objects/b77d81bd-d68b-4a9e-835a-65b7f0513b65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b77d81bd-d68b-4a9e-835a-65b7f0513b65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_06-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b77d81bd-d68b-4a9e-835a-65b7f0513b65>.
+    
+<http://data.lblod.info/id/remote-data-objects/70a768d1-0b3b-4e2e-89fe-0d47f5455ced> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70a768d1-0b3b-4e2e-89fe-0d47f5455ced";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70a768d1-0b3b-4e2e-89fe-0d47f5455ced>.
+    
+<http://data.lblod.info/id/remote-data-objects/62bea5d7-93a3-4a48-a730-09426185f9d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62bea5d7-93a3-4a48-a730-09426185f9d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_09-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62bea5d7-93a3-4a48-a730-09426185f9d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c1fc8be-4243-455e-913c-e9f11ec75d60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c1fc8be-4243-455e-913c-e9f11ec75d60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c1fc8be-4243-455e-913c-e9f11ec75d60>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b5a6159-144b-4636-8220-49ee2974f365> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b5a6159-144b-4636-8220-49ee2974f365";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b5a6159-144b-4636-8220-49ee2974f365>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a5931f1-f843-4c89-925e-9b840b6f8920> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a5931f1-f843-4c89-925e-9b840b6f8920";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a5931f1-f843-4c89-925e-9b840b6f8920>.
+    
+<http://data.lblod.info/id/remote-data-objects/a018aa46-afbb-4196-babc-962899695414> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a018aa46-afbb-4196-babc-962899695414";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a018aa46-afbb-4196-babc-962899695414>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cbb1db8-d229-4b78-ad4d-953c05c5c438> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cbb1db8-d229-4b78-ad4d-953c05c5c438";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cbb1db8-d229-4b78-ad4d-953c05c5c438>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4267d1b-8db9-42fc-a6c6-6b2845196ca9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4267d1b-8db9-42fc-a6c6-6b2845196ca9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4267d1b-8db9-42fc-a6c6-6b2845196ca9>.
+    
+<http://data.lblod.info/id/remote-data-objects/747b2f28-771e-4228-9a64-7f03ecbaf560> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "747b2f28-771e-4228-9a64-7f03ecbaf560";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/747b2f28-771e-4228-9a64-7f03ecbaf560>.
+    
+<http://data.lblod.info/id/remote-data-objects/970d2679-e00b-4948-99fd-8f5ee229a335> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "970d2679-e00b-4948-99fd-8f5ee229a335";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/970d2679-e00b-4948-99fd-8f5ee229a335>.
+    
+<http://data.lblod.info/id/remote-data-objects/15f38c82-46f1-418d-aa57-22fbce6abf7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15f38c82-46f1-418d-aa57-22fbce6abf7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15f38c82-46f1-418d-aa57-22fbce6abf7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/76fcfa77-e089-48e1-b076-9eb403b70a05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76fcfa77-e089-48e1-b076-9eb403b70a05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76fcfa77-e089-48e1-b076-9eb403b70a05>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa21ede4-6b97-45a7-9f61-977810b4b862> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa21ede4-6b97-45a7-9f61-977810b4b862";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa21ede4-6b97-45a7-9f61-977810b4b862>.
+    
+<http://data.lblod.info/id/remote-data-objects/6efc8caa-7ea2-447a-a4dc-e8f4e3b711d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6efc8caa-7ea2-447a-a4dc-e8f4e3b711d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6efc8caa-7ea2-447a-a4dc-e8f4e3b711d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0eba456b-72f9-481f-b31f-8f1cc274fc98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0eba456b-72f9-481f-b31f-8f1cc274fc98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0eba456b-72f9-481f-b31f-8f1cc274fc98>.
+    
+<http://data.lblod.info/id/remote-data-objects/17c2d843-24de-46ac-af52-1d2dce7300e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17c2d843-24de-46ac-af52-1d2dce7300e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17c2d843-24de-46ac-af52-1d2dce7300e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0844e57-0169-4d33-a2af-b2907131d83d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0844e57-0169-4d33-a2af-b2907131d83d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0844e57-0169-4d33-a2af-b2907131d83d>.
+    
+<http://data.lblod.info/id/remote-data-objects/824f8180-5fb0-4076-af3e-9519a6f927d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "824f8180-5fb0-4076-af3e-9519a6f927d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/824f8180-5fb0-4076-af3e-9519a6f927d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8938970a-e969-4154-ac17-7d1293cdb3e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8938970a-e969-4154-ac17-7d1293cdb3e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8938970a-e969-4154-ac17-7d1293cdb3e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/059ad858-73e3-499f-ba9d-6e832dd13b2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "059ad858-73e3-499f-ba9d-6e832dd13b2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/059ad858-73e3-499f-ba9d-6e832dd13b2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e46a7855-95b8-43e4-96a6-2827018ba769> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e46a7855-95b8-43e4-96a6-2827018ba769";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e46a7855-95b8-43e4-96a6-2827018ba769>.
+    
+<http://data.lblod.info/id/remote-data-objects/a888736b-57d7-4a61-9a2e-e343be933ca6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a888736b-57d7-4a61-9a2e-e343be933ca6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a888736b-57d7-4a61-9a2e-e343be933ca6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8560854-7f12-432a-b194-46b738cab545> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8560854-7f12-432a-b194-46b738cab545";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8560854-7f12-432a-b194-46b738cab545>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5dc4e64-5bc0-4f6c-af80-81e0f4b200b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5dc4e64-5bc0-4f6c-af80-81e0f4b200b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5dc4e64-5bc0-4f6c-af80-81e0f4b200b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/31d13f66-15c7-4e70-a172-4719c44d9807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31d13f66-15c7-4e70-a172-4719c44d9807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31d13f66-15c7-4e70-a172-4719c44d9807>.
+    
+<http://data.lblod.info/id/remote-data-objects/04252a6c-df55-4002-a2b7-e2747fdc1288> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04252a6c-df55-4002-a2b7-e2747fdc1288";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04252a6c-df55-4002-a2b7-e2747fdc1288>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9a48eb0-eae2-4956-8697-47beab59bd3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9a48eb0-eae2-4956-8697-47beab59bd3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9a48eb0-eae2-4956-8697-47beab59bd3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/61143b39-0241-46e3-b4c9-53ca1c7840ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61143b39-0241-46e3-b4c9-53ca1c7840ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_28-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61143b39-0241-46e3-b4c9-53ca1c7840ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b2874f7-277f-47bf-96d3-656c09e545c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b2874f7-277f-47bf-96d3-656c09e545c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b2874f7-277f-47bf-96d3-656c09e545c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0de7dbfa-84d8-464c-b32b-ecc5bff7f17a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0de7dbfa-84d8-464c-b32b-ecc5bff7f17a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0de7dbfa-84d8-464c-b32b-ecc5bff7f17a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e3b712d-a7fb-4d11-9eda-f5f24c9f3afd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e3b712d-a7fb-4d11-9eda-f5f24c9f3afd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=BesluitenLijst_Schepencollege_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e3b712d-a7fb-4d11-9eda-f5f24c9f3afd>.
+    
+<http://data.lblod.info/id/remote-data-objects/c745b17e-1956-4b63-995e-b939ad5b1637> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c745b17e-1956-4b63-995e-b939ad5b1637";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_02-06-2022_28469.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c745b17e-1956-4b63-995e-b939ad5b1637>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5eb0244-eeb3-4456-a931-885388a035dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5eb0244-eeb3-4456-a931-885388a035dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_02-06-2022_28472.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5eb0244-eeb3-4456-a931-885388a035dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7478c64c-814f-43ff-a038-813ef30bc2af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7478c64c-814f-43ff-a038-813ef30bc2af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_03-02-2022_26822.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7478c64c-814f-43ff-a038-813ef30bc2af>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d725598-7927-4ab4-9cf9-14873c3551f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d725598-7927-4ab4-9cf9-14873c3551f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_05-05-2022_27754.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d725598-7927-4ab4-9cf9-14873c3551f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3172cc4-3fc7-4a4d-8a4e-0a9a7fb109d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3172cc4-3fc7-4a4d-8a4e-0a9a7fb109d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_05-05-2022_27951.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3172cc4-3fc7-4a4d-8a4e-0a9a7fb109d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff1ede1b-18c6-42f9-9ffa-a98d2e301e84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff1ede1b-18c6-42f9-9ffa-a98d2e301e84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_05-05-2022_27998.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff1ede1b-18c6-42f9-9ffa-a98d2e301e84>.
+    
+<http://data.lblod.info/id/remote-data-objects/baf4e855-0941-4dd5-82b1-5bc3bd1806e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "baf4e855-0941-4dd5-82b1-5bc3bd1806e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_05-05-2022_28017.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/baf4e855-0941-4dd5-82b1-5bc3bd1806e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e55a95fc-07a6-4446-96c0-5c7546c9af4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e55a95fc-07a6-4446-96c0-5c7546c9af4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_05-05-2022_28098.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e55a95fc-07a6-4446-96c0-5c7546c9af4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1f78917-6b10-4065-9a6d-ef6a9d30e9b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1f78917-6b10-4065-9a6d-ef6a9d30e9b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_07-07-2022_28786.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1f78917-6b10-4065-9a6d-ef6a9d30e9b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddf0ba7a-af40-46eb-9f8b-1970c8e6944c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddf0ba7a-af40-46eb-9f8b-1970c8e6944c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_07-07-2022_28864.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddf0ba7a-af40-46eb-9f8b-1970c8e6944c>.
+    
+<http://data.lblod.info/id/remote-data-objects/454fc92a-6a37-4019-8ffa-d7f63c65b1a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "454fc92a-6a37-4019-8ffa-d7f63c65b1a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_07-07-2022_28870.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/454fc92a-6a37-4019-8ffa-d7f63c65b1a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/163cdf01-effa-43c8-8d3d-00bb421c7d55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "163cdf01-effa-43c8-8d3d-00bb421c7d55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_09-06-2022_28473.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/163cdf01-effa-43c8-8d3d-00bb421c7d55>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc3589d4-5f2b-40de-b131-f41665f662fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc3589d4-5f2b-40de-b131-f41665f662fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_09-06-2022_28475.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/150f214e-c58e-417e-9f36-31d2903c6062> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc3589d4-5f2b-40de-b131-f41665f662fd>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201702-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201702-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201702-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201702-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/10bc311c-4fc2-4091-88c0-4fb5b0bba1db> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "10bc311c-4fc2-4091-88c0-4fb5b0bba1db";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a04da985-c483-4685-97ac-de2a445c0e98";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9dfb8cb0-97ac-48ab-8066-e49739eaa760> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9dfb8cb0-97ac-48ab-8066-e49739eaa760";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98>.
+
+  <http://redpencil.data.gift/id/task/a7be8d4a-38fb-4a1b-a157-a0f8422bb4aa> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a7be8d4a-38fb-4a1b-a157-a0f8422bb4aa";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/10bc311c-4fc2-4091-88c0-4fb5b0bba1db>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9dfb8cb0-97ac-48ab-8066-e49739eaa760>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/34ad9bb4-ca72-403b-82eb-9dc09ca4900e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34ad9bb4-ca72-403b-82eb-9dc09ca4900e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_09-06-2022_28497.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34ad9bb4-ca72-403b-82eb-9dc09ca4900e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a1beb2d-a43a-4684-af49-519d6cee3b7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a1beb2d-a43a-4684-af49-519d6cee3b7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_09-06-2022_28575.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a1beb2d-a43a-4684-af49-519d6cee3b7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b77aed47-77b1-4c38-a4d4-215347f47a34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b77aed47-77b1-4c38-a4d4-215347f47a34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_09-06-2022_28576.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b77aed47-77b1-4c38-a4d4-215347f47a34>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2cb5d27-2edd-4e51-bc03-9938fc79c5fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2cb5d27-2edd-4e51-bc03-9938fc79c5fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_09-06-2022_28603.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2cb5d27-2edd-4e51-bc03-9938fc79c5fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/6013df59-e79f-47bb-adef-41bc3322316f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6013df59-e79f-47bb-adef-41bc3322316f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_10-03-2022_27235.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6013df59-e79f-47bb-adef-41bc3322316f>.
+    
+<http://data.lblod.info/id/remote-data-objects/60e1b5ab-3afc-4308-a130-e728e691ac04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60e1b5ab-3afc-4308-a130-e728e691ac04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_10-03-2022_27343.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60e1b5ab-3afc-4308-a130-e728e691ac04>.
+    
+<http://data.lblod.info/id/remote-data-objects/16a8a809-5f33-4790-a046-cbf4ec372ed8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16a8a809-5f33-4790-a046-cbf4ec372ed8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_10-03-2022_27366.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16a8a809-5f33-4790-a046-cbf4ec372ed8>.
+    
+<http://data.lblod.info/id/remote-data-objects/087a8e0f-ffe1-4038-9184-361d0f06c71e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "087a8e0f-ffe1-4038-9184-361d0f06c71e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_14-04-2022_27665.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/087a8e0f-ffe1-4038-9184-361d0f06c71e>.
+    
+<http://data.lblod.info/id/remote-data-objects/876ba5f2-d7bd-4df2-908d-3cec5f80cc55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "876ba5f2-d7bd-4df2-908d-3cec5f80cc55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_14-04-2022_27687.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/876ba5f2-d7bd-4df2-908d-3cec5f80cc55>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5a1b0d8-c3d3-4a2c-9257-37813e7fcff5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5a1b0d8-c3d3-4a2c-9257-37813e7fcff5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_14-04-2022_27737.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5a1b0d8-c3d3-4a2c-9257-37813e7fcff5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ede13f8-dc60-40fa-ab5c-f5b090f6801e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ede13f8-dc60-40fa-ab5c-f5b090f6801e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_14-04-2022_27739.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ede13f8-dc60-40fa-ab5c-f5b090f6801e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f47c731c-d851-4622-9867-5270d1bab0db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f47c731c-d851-4622-9867-5270d1bab0db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_14-10-2021_25526.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f47c731c-d851-4622-9867-5270d1bab0db>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe9a7722-80e0-47dd-9673-cf778fd59894> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe9a7722-80e0-47dd-9673-cf778fd59894";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_14-10-2021_25700.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe9a7722-80e0-47dd-9673-cf778fd59894>.
+    
+<http://data.lblod.info/id/remote-data-objects/f55f7d57-e6c0-4453-acf6-7528aa76e810> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f55f7d57-e6c0-4453-acf6-7528aa76e810";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_14-10-2021_25703.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f55f7d57-e6c0-4453-acf6-7528aa76e810>.
+    
+<http://data.lblod.info/id/remote-data-objects/94b1bfa5-302f-4b18-9b09-b1adf2c0724b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94b1bfa5-302f-4b18-9b09-b1adf2c0724b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_16-06-2022_28577.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94b1bfa5-302f-4b18-9b09-b1adf2c0724b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c9a71b2-aa5a-459f-81ed-f47ee876a279> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c9a71b2-aa5a-459f-81ed-f47ee876a279";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_16-06-2022_28597.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c9a71b2-aa5a-459f-81ed-f47ee876a279>.
+    
+<http://data.lblod.info/id/remote-data-objects/9636d882-0b06-43ce-99ef-52490fa24aed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9636d882-0b06-43ce-99ef-52490fa24aed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_16-06-2022_28685.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9636d882-0b06-43ce-99ef-52490fa24aed>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cfe5877-cc65-4480-b14e-522bef382179> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cfe5877-cc65-4480-b14e-522bef382179";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_16-06-2022_28686.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cfe5877-cc65-4480-b14e-522bef382179>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d4865ca-9974-4ce4-97a1-67f771467c5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d4865ca-9974-4ce4-97a1-67f771467c5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_17-02-2022_27052.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d4865ca-9974-4ce4-97a1-67f771467c5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c281ca8-6a28-4c3c-a67f-54a9a0103c65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c281ca8-6a28-4c3c-a67f-54a9a0103c65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_17-02-2022_27078.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c281ca8-6a28-4c3c-a67f-54a9a0103c65>.
+    
+<http://data.lblod.info/id/remote-data-objects/294f3c8b-a7f1-4fd8-acbe-c9d99f92c70f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "294f3c8b-a7f1-4fd8-acbe-c9d99f92c70f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_17-03-2022_27374.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/294f3c8b-a7f1-4fd8-acbe-c9d99f92c70f>.
+    
+<http://data.lblod.info/id/remote-data-objects/98ac4d3c-4ffc-44a6-97a8-3bf0517e1183> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98ac4d3c-4ffc-44a6-97a8-3bf0517e1183";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_17-03-2022_27473.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98ac4d3c-4ffc-44a6-97a8-3bf0517e1183>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcac398a-058d-4262-8533-0059eb980409> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcac398a-058d-4262-8533-0059eb980409";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_17-03-2022_27475.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcac398a-058d-4262-8533-0059eb980409>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ffafbc6-2a28-4fbb-88e2-29c86ac0496c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ffafbc6-2a28-4fbb-88e2-29c86ac0496c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_18-11-2021_26073.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ffafbc6-2a28-4fbb-88e2-29c86ac0496c>.
+    
+<http://data.lblod.info/id/remote-data-objects/73f45935-46da-46db-afa2-c755c7e294b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73f45935-46da-46db-afa2-c755c7e294b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_19-05-2022_28245.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73f45935-46da-46db-afa2-c755c7e294b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/5697f1fa-b612-4f24-904e-a2948b329c8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5697f1fa-b612-4f24-904e-a2948b329c8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_19-05-2022_28374.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5697f1fa-b612-4f24-904e-a2948b329c8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a6bb16b-9c2e-4fde-bc7f-f1adc98b2897> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a6bb16b-9c2e-4fde-bc7f-f1adc98b2897";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_19-05-2022_28434.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a6bb16b-9c2e-4fde-bc7f-f1adc98b2897>.
+    
+<http://data.lblod.info/id/remote-data-objects/f93b1ec4-8891-4d0f-a2d4-f8fbf0d35db5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f93b1ec4-8891-4d0f-a2d4-f8fbf0d35db5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_19-05-2022_28436.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f93b1ec4-8891-4d0f-a2d4-f8fbf0d35db5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ed3f5e2-4d8e-46b5-aeeb-68db720923f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ed3f5e2-4d8e-46b5-aeeb-68db720923f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_21-04-2022_27778.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ed3f5e2-4d8e-46b5-aeeb-68db720923f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee275a01-144a-489f-96d0-25aa1f36f820> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee275a01-144a-489f-96d0-25aa1f36f820";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_21-10-2021_25702.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee275a01-144a-489f-96d0-25aa1f36f820>.
+    
+<http://data.lblod.info/id/remote-data-objects/f99fa5d5-f143-44ff-a06c-d91e57c597c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f99fa5d5-f143-44ff-a06c-d91e57c597c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_21-10-2021_25787.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f99fa5d5-f143-44ff-a06c-d91e57c597c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2f1dc1a-2d26-464b-a357-04a36a12be9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2f1dc1a-2d26-464b-a357-04a36a12be9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_21-10-2021_25788.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2f1dc1a-2d26-464b-a357-04a36a12be9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb035940-d569-4a63-9e6d-53df6258779f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb035940-d569-4a63-9e6d-53df6258779f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_21-10-2021_25793.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb035940-d569-4a63-9e6d-53df6258779f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d6ec9b2-1981-48f2-be60-76cdd49871c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d6ec9b2-1981-48f2-be60-76cdd49871c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_23-06-2022_28754.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d6ec9b2-1981-48f2-be60-76cdd49871c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8f7c7ab-e1fa-4129-9bb1-fbfdbb2bed64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8f7c7ab-e1fa-4129-9bb1-fbfdbb2bed64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_23-06-2022_28770.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8f7c7ab-e1fa-4129-9bb1-fbfdbb2bed64>.
+    
+<http://data.lblod.info/id/remote-data-objects/93fd11e8-b564-41fa-aaee-71745e658a02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93fd11e8-b564-41fa-aaee-71745e658a02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_23-06-2022_28778.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93fd11e8-b564-41fa-aaee-71745e658a02>.
+    
+<http://data.lblod.info/id/remote-data-objects/20931a0d-1fd4-413e-813a-5073e3544276> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20931a0d-1fd4-413e-813a-5073e3544276";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_24-02-2022_27105.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20931a0d-1fd4-413e-813a-5073e3544276>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc447c6b-52aa-45fa-8ffa-a78a495571e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc447c6b-52aa-45fa-8ffa-a78a495571e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_24-02-2022_27128.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc447c6b-52aa-45fa-8ffa-a78a495571e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/124944d6-62ab-4c1c-ab85-dff292af47aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "124944d6-62ab-4c1c-ab85-dff292af47aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_24-02-2022_27132.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/124944d6-62ab-4c1c-ab85-dff292af47aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee3f8c1e-9176-4adf-8a50-1a1868c1af50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee3f8c1e-9176-4adf-8a50-1a1868c1af50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_24-03-2022_27483.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee3f8c1e-9176-4adf-8a50-1a1868c1af50>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc279f57-40a9-45de-af0d-515e6791372d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc279f57-40a9-45de-af0d-515e6791372d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_24-03-2022_27510.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc279f57-40a9-45de-af0d-515e6791372d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3880d810-2f88-4aab-956a-a79d345a4f52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3880d810-2f88-4aab-956a-a79d345a4f52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_24-03-2022_27530.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3880d810-2f88-4aab-956a-a79d345a4f52>.
+    
+<http://data.lblod.info/id/remote-data-objects/de02ccf9-67cb-452b-9bb1-5e2d5c78f42f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de02ccf9-67cb-452b-9bb1-5e2d5c78f42f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_24-03-2022_27573.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de02ccf9-67cb-452b-9bb1-5e2d5c78f42f>.
+    
+<http://data.lblod.info/id/remote-data-objects/78ff9a1f-1d48-4ab9-9f3e-fc35cf2b7a42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78ff9a1f-1d48-4ab9-9f3e-fc35cf2b7a42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_25-11-2021_26107.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78ff9a1f-1d48-4ab9-9f3e-fc35cf2b7a42>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d722078-7286-4f7f-bef9-2ec525406d15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d722078-7286-4f7f-bef9-2ec525406d15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_27-04-2022_27981.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d722078-7286-4f7f-bef9-2ec525406d15>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bddd3eb-f56e-4718-b182-8a812d8fb76a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bddd3eb-f56e-4718-b182-8a812d8fb76a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_27-04-2022_27990.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bddd3eb-f56e-4718-b182-8a812d8fb76a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e17ae6d-d6e3-4f8f-9ab7-c971c608eb25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e17ae6d-d6e3-4f8f-9ab7-c971c608eb25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_28-07-2022_29112.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e17ae6d-d6e3-4f8f-9ab7-c971c608eb25>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7d9bce3-9067-4231-9dcd-b76d3d5e7620> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7d9bce3-9067-4231-9dcd-b76d3d5e7620";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_28-07-2022_29113.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7d9bce3-9067-4231-9dcd-b76d3d5e7620>.
+    
+<http://data.lblod.info/id/remote-data-objects/68e2c238-d667-487c-884d-f7c4a5cb4425> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68e2c238-d667-487c-884d-f7c4a5cb4425";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_28-07-2022_29115.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68e2c238-d667-487c-884d-f7c4a5cb4425>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec1f53e0-e123-4eb0-b7d9-0a56b8a74075> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec1f53e0-e123-4eb0-b7d9-0a56b8a74075";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_28-10-2021_25868.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a04da985-c483-4685-97ac-de2a445c0e98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec1f53e0-e123-4eb0-b7d9-0a56b8a74075>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201703-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201703-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201703-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201703-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/ff5e2e9c-3250-443e-8bc4-18b6df27cf73> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ff5e2e9c-3250-443e-8bc4-18b6df27cf73";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/fef10e97-23cd-488f-b035-af6b7d5d19d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fef10e97-23cd-488f-b035-af6b7d5d19d6";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3>.
+
+  <http://redpencil.data.gift/id/task/ecd28e44-0723-4be5-b75e-a75921dea5c0> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ecd28e44-0723-4be5-b75e-a75921dea5c0";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/ff5e2e9c-3250-443e-8bc4-18b6df27cf73>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/fef10e97-23cd-488f-b035-af6b7d5d19d6>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/99961de6-1324-4098-a5d4-7ad23dd86818> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99961de6-1324-4098-a5d4-7ad23dd86818";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_28-10-2021_25882.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99961de6-1324-4098-a5d4-7ad23dd86818>.
+    
+<http://data.lblod.info/id/remote-data-objects/cac8e308-5b4d-411d-86d1-5a75809ce3e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cac8e308-5b4d-411d-86d1-5a75809ce3e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_30-06-2022_28868.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cac8e308-5b4d-411d-86d1-5a75809ce3e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cf92202-f6ea-4ec1-8392-164a83054863> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cf92202-f6ea-4ec1-8392-164a83054863";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.torhout.be/LBLODWeb/Home/Overzicht/db718ed085bc5b38ccbd197c0fb0564b3e97627d5ac778994ed80c12064e7fb7/GetPublication?filename=Uittreksels_31-03-2022_27584.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cf92202-f6ea-4ec1-8392-164a83054863>.
+    
+<http://data.lblod.info/id/remote-data-objects/da1c4e51-1f31-4e0b-bc20-cd56db27d67d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da1c4e51-1f31-4e0b-bc20-cd56db27d67d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da1c4e51-1f31-4e0b-bc20-cd56db27d67d>.
+    
+<http://data.lblod.info/id/remote-data-objects/22eb27ab-0bfc-485c-b09f-0a723f326982> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22eb27ab-0bfc-485c-b09f-0a723f326982";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22eb27ab-0bfc-485c-b09f-0a723f326982>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7273a36-6a23-44dd-84e5-e54587614b0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7273a36-6a23-44dd-84e5-e54587614b0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7273a36-6a23-44dd-84e5-e54587614b0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8da5eb64-5643-44e1-8a33-d60ed465529d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8da5eb64-5643-44e1-8a33-d60ed465529d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8da5eb64-5643-44e1-8a33-d60ed465529d>.
+    
+<http://data.lblod.info/id/remote-data-objects/dadf2785-b743-49bf-b7f4-7386292309a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dadf2785-b743-49bf-b7f4-7386292309a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dadf2785-b743-49bf-b7f4-7386292309a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/cde1d9b0-9d59-4078-88b9-c0534e284085> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cde1d9b0-9d59-4078-88b9-c0534e284085";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cde1d9b0-9d59-4078-88b9-c0534e284085>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5d443f6-756f-4c7d-8e06-c8105579ee85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5d443f6-756f-4c7d-8e06-c8105579ee85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5d443f6-756f-4c7d-8e06-c8105579ee85>.
+    
+<http://data.lblod.info/id/remote-data-objects/e02b94ef-b31f-4ecd-84ef-44df63418e6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e02b94ef-b31f-4ecd-84ef-44df63418e6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e02b94ef-b31f-4ecd-84ef-44df63418e6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/77f1b448-eb96-40a5-9cc1-bc477f4623df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77f1b448-eb96-40a5-9cc1-bc477f4623df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77f1b448-eb96-40a5-9cc1-bc477f4623df>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cab4608-a7c6-4a64-9e77-7ebb9e3c70dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cab4608-a7c6-4a64-9e77-7ebb9e3c70dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cab4608-a7c6-4a64-9e77-7ebb9e3c70dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4c7c2dc-e558-4520-8b5e-e768e4b95a26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4c7c2dc-e558-4520-8b5e-e768e4b95a26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4c7c2dc-e558-4520-8b5e-e768e4b95a26>.
+    
+<http://data.lblod.info/id/remote-data-objects/78bc62d4-fdd9-46d6-9302-5978049590f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78bc62d4-fdd9-46d6-9302-5978049590f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78bc62d4-fdd9-46d6-9302-5978049590f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d666d9d9-5bd8-426a-892f-e6d0e385ae54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d666d9d9-5bd8-426a-892f-e6d0e385ae54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d666d9d9-5bd8-426a-892f-e6d0e385ae54>.
+    
+<http://data.lblod.info/id/remote-data-objects/d91ea40f-967a-4ea6-b0c1-b7bf46b67794> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d91ea40f-967a-4ea6-b0c1-b7bf46b67794";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d91ea40f-967a-4ea6-b0c1-b7bf46b67794>.
+    
+<http://data.lblod.info/id/remote-data-objects/1520ed3e-ad82-4a93-8293-d266209ac106> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1520ed3e-ad82-4a93-8293-d266209ac106";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1520ed3e-ad82-4a93-8293-d266209ac106>.
+    
+<http://data.lblod.info/id/remote-data-objects/51e0783e-cd8c-4227-88a7-17b9761d7b35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51e0783e-cd8c-4227-88a7-17b9761d7b35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51e0783e-cd8c-4227-88a7-17b9761d7b35>.
+    
+<http://data.lblod.info/id/remote-data-objects/88b12122-d2ba-4d71-9563-b996f0efa6e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88b12122-d2ba-4d71-9563-b996f0efa6e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88b12122-d2ba-4d71-9563-b996f0efa6e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e15bbd16-9f64-4f04-9dbb-8f8a1e70820f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e15bbd16-9f64-4f04-9dbb-8f8a1e70820f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e15bbd16-9f64-4f04-9dbb-8f8a1e70820f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bfb9a79-f0e0-46b9-b683-887b66069274> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bfb9a79-f0e0-46b9-b683-887b66069274";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bfb9a79-f0e0-46b9-b683-887b66069274>.
+    
+<http://data.lblod.info/id/remote-data-objects/f61dc2c3-6545-4fac-bd2a-acf35f83f810> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f61dc2c3-6545-4fac-bd2a-acf35f83f810";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f61dc2c3-6545-4fac-bd2a-acf35f83f810>.
+    
+<http://data.lblod.info/id/remote-data-objects/9481c6c3-7b43-4d7a-916e-68a10952fb1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9481c6c3-7b43-4d7a-916e-68a10952fb1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9481c6c3-7b43-4d7a-916e-68a10952fb1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d6246d1-bc4a-47ae-a934-614634e2dd45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d6246d1-bc4a-47ae-a934-614634e2dd45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d6246d1-bc4a-47ae-a934-614634e2dd45>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0e530b0-076e-4018-a9ce-95f321dfb199> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0e530b0-076e-4018-a9ce-95f321dfb199";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0e530b0-076e-4018-a9ce-95f321dfb199>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebe113f8-6909-40b1-9239-a964c2830775> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebe113f8-6909-40b1-9239-a964c2830775";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebe113f8-6909-40b1-9239-a964c2830775>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9073882-4600-4676-9619-83d52a91dd78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9073882-4600-4676-9619-83d52a91dd78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9073882-4600-4676-9619-83d52a91dd78>.
+    
+<http://data.lblod.info/id/remote-data-objects/26b2b06b-0026-4e72-b43f-71d39c96b91a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26b2b06b-0026-4e72-b43f-71d39c96b91a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26b2b06b-0026-4e72-b43f-71d39c96b91a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7922e7c-6932-4a9b-89f6-76834464a936> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7922e7c-6932-4a9b-89f6-76834464a936";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7922e7c-6932-4a9b-89f6-76834464a936>.
+    
+<http://data.lblod.info/id/remote-data-objects/481449c2-0645-48bf-bbc0-f22afb353ba5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "481449c2-0645-48bf-bbc0-f22afb353ba5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/481449c2-0645-48bf-bbc0-f22afb353ba5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0459563b-7df9-4155-9a3b-272ae88dbb73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0459563b-7df9-4155-9a3b-272ae88dbb73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0459563b-7df9-4155-9a3b-272ae88dbb73>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f1f93cc-7574-4635-8bad-ffd80402d169> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f1f93cc-7574-4635-8bad-ffd80402d169";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f1f93cc-7574-4635-8bad-ffd80402d169>.
+    
+<http://data.lblod.info/id/remote-data-objects/25f57189-4376-4dc6-bd77-16a9a211a6b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25f57189-4376-4dc6-bd77-16a9a211a6b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25f57189-4376-4dc6-bd77-16a9a211a6b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7ba40a4-a2e2-4266-8834-0b4b37bff435> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7ba40a4-a2e2-4266-8834-0b4b37bff435";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7ba40a4-a2e2-4266-8834-0b4b37bff435>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6e8d85f-fd2c-4c5b-a602-6a74425e38a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6e8d85f-fd2c-4c5b-a602-6a74425e38a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6e8d85f-fd2c-4c5b-a602-6a74425e38a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f426381-6c92-445d-a3f5-0c6f13d15384> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f426381-6c92-445d-a3f5-0c6f13d15384";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f426381-6c92-445d-a3f5-0c6f13d15384>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a975f33-dbbf-4b0a-9a7d-36fe3236f7b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a975f33-dbbf-4b0a-9a7d-36fe3236f7b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a975f33-dbbf-4b0a-9a7d-36fe3236f7b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2925e4a7-1e01-4a60-b454-08e140471e42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2925e4a7-1e01-4a60-b454-08e140471e42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2925e4a7-1e01-4a60-b454-08e140471e42>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd7cbb02-e523-4faf-9c17-62ecee2c41ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd7cbb02-e523-4faf-9c17-62ecee2c41ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd7cbb02-e523-4faf-9c17-62ecee2c41ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/7690df01-6432-4a10-ad4a-caa305e9431c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7690df01-6432-4a10-ad4a-caa305e9431c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7690df01-6432-4a10-ad4a-caa305e9431c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9bfb7243-2f34-408f-b77f-3971449046c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9bfb7243-2f34-408f-b77f-3971449046c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/48d94283f3826785f73eddda2f9cef0a8683c92430c6b2c6335f72f73f050509/GetPublication?filename=BesluitenLijst_Vast%20Bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9bfb7243-2f34-408f-b77f-3971449046c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/9beb16e2-34d1-4702-abab-5d5ae1751209> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9beb16e2-34d1-4702-abab-5d5ae1751209";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9beb16e2-34d1-4702-abab-5d5ae1751209>.
+    
+<http://data.lblod.info/id/remote-data-objects/230c59ba-147b-46da-81a8-4abb5ec3109b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "230c59ba-147b-46da-81a8-4abb5ec3109b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/230c59ba-147b-46da-81a8-4abb5ec3109b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c9043b4-1266-4623-b943-0b5728a05820> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c9043b4-1266-4623-b943-0b5728a05820";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c9043b4-1266-4623-b943-0b5728a05820>.
+    
+<http://data.lblod.info/id/remote-data-objects/6375adce-f72f-4d45-a50d-84b7b4acecc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6375adce-f72f-4d45-a50d-84b7b4acecc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6375adce-f72f-4d45-a50d-84b7b4acecc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dda1bbc-924d-488e-8ca1-73ca6256207a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dda1bbc-924d-488e-8ca1-73ca6256207a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dda1bbc-924d-488e-8ca1-73ca6256207a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c044d73e-5a4a-44a1-9dc5-bba4126cf24b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c044d73e-5a4a-44a1-9dc5-bba4126cf24b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c044d73e-5a4a-44a1-9dc5-bba4126cf24b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c800bc6-ee41-490c-a717-6b935bc5b449> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c800bc6-ee41-490c-a717-6b935bc5b449";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c800bc6-ee41-490c-a717-6b935bc5b449>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf126a31-2e55-4230-a865-6e2a2b2404fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf126a31-2e55-4230-a865-6e2a2b2404fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c7c7811c-7f9b-40b9-9a0c-ed1cac0264d3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf126a31-2e55-4230-a865-6e2a2b2404fb>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201705-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201705-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201705-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201705-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3ee33c8c-2ade-4304-aa27-47712c5c752d> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3ee33c8c-2ade-4304-aa27-47712c5c752d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0e5e29f1-b92b-4e29-b117-979bdfaba7cb";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/74f5b4b4-7763-4da7-8396-2332e47616fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "74f5b4b4-7763-4da7-8396-2332e47616fb";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb>.
+
+  <http://redpencil.data.gift/id/task/66b82cc8-4cfe-42f5-8354-58ec6d3308b3> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "66b82cc8-4cfe-42f5-8354-58ec6d3308b3";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3ee33c8c-2ade-4304-aa27-47712c5c752d>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/74f5b4b4-7763-4da7-8396-2332e47616fb>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/96ecd904-5469-4d8e-9ed9-518d35662d84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96ecd904-5469-4d8e-9ed9-518d35662d84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96ecd904-5469-4d8e-9ed9-518d35662d84>.
+    
+<http://data.lblod.info/id/remote-data-objects/60fdead6-ede8-4791-8df1-a078fa31d31b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60fdead6-ede8-4791-8df1-a078fa31d31b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60fdead6-ede8-4791-8df1-a078fa31d31b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6ea46fe-2b29-4be7-8813-04eb0b8c57a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6ea46fe-2b29-4be7-8813-04eb0b8c57a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6ea46fe-2b29-4be7-8813-04eb0b8c57a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3a86aed-494a-47fd-8d53-c7b31615ff42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3a86aed-494a-47fd-8d53-c7b31615ff42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3a86aed-494a-47fd-8d53-c7b31615ff42>.
+    
+<http://data.lblod.info/id/remote-data-objects/2825a06b-616b-4a24-8dd2-460de093818a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2825a06b-616b-4a24-8dd2-460de093818a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2825a06b-616b-4a24-8dd2-460de093818a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6e3d3ab-f75d-4f8f-b6b7-b60d93406e9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6e3d3ab-f75d-4f8f-b6b7-b60d93406e9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6e3d3ab-f75d-4f8f-b6b7-b60d93406e9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c6061db-fe64-4b0d-8bda-ace612743bad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c6061db-fe64-4b0d-8bda-ace612743bad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c6061db-fe64-4b0d-8bda-ace612743bad>.
+    
+<http://data.lblod.info/id/remote-data-objects/86fd0d55-57c2-4721-8497-f6e7ae8a7a64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86fd0d55-57c2-4721-8497-f6e7ae8a7a64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86fd0d55-57c2-4721-8497-f6e7ae8a7a64>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4b44ed5-84a7-4ae8-9539-24948ea46af7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4b44ed5-84a7-4ae8-9539-24948ea46af7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4b44ed5-84a7-4ae8-9539-24948ea46af7>.
+    
+<http://data.lblod.info/id/remote-data-objects/983c60e9-88f8-4b98-bc7c-27eb39041444> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "983c60e9-88f8-4b98-bc7c-27eb39041444";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/983c60e9-88f8-4b98-bc7c-27eb39041444>.
+    
+<http://data.lblod.info/id/remote-data-objects/f42293bf-2ba0-4578-aaa9-7d957af50276> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f42293bf-2ba0-4578-aaa9-7d957af50276";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f42293bf-2ba0-4578-aaa9-7d957af50276>.
+    
+<http://data.lblod.info/id/remote-data-objects/69ad8bb3-5478-4201-8517-f7f5a2f43370> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69ad8bb3-5478-4201-8517-f7f5a2f43370";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69ad8bb3-5478-4201-8517-f7f5a2f43370>.
+    
+<http://data.lblod.info/id/remote-data-objects/03f78a79-f454-4bf6-a432-3f1a54ec77cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03f78a79-f454-4bf6-a432-3f1a54ec77cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03f78a79-f454-4bf6-a432-3f1a54ec77cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/119b18e4-a60d-4809-aec6-ab5e3f826ce5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "119b18e4-a60d-4809-aec6-ab5e3f826ce5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/119b18e4-a60d-4809-aec6-ab5e3f826ce5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e04d8c18-83b9-453a-92af-a8ef4193aee3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e04d8c18-83b9-453a-92af-a8ef4193aee3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e04d8c18-83b9-453a-92af-a8ef4193aee3>.
+    
+<http://data.lblod.info/id/remote-data-objects/42013985-66ee-49c9-a1d7-59a0fd947b18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42013985-66ee-49c9-a1d7-59a0fd947b18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42013985-66ee-49c9-a1d7-59a0fd947b18>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cf790e1-6439-4e94-a035-04ddb8306270> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cf790e1-6439-4e94-a035-04ddb8306270";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cf790e1-6439-4e94-a035-04ddb8306270>.
+    
+<http://data.lblod.info/id/remote-data-objects/04327245-6886-40e8-af98-40f4c82ebd04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04327245-6886-40e8-af98-40f4c82ebd04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04327245-6886-40e8-af98-40f4c82ebd04>.
+    
+<http://data.lblod.info/id/remote-data-objects/06f6ed35-3b88-4eb6-ac29-393869ace110> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06f6ed35-3b88-4eb6-ac29-393869ace110";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06f6ed35-3b88-4eb6-ac29-393869ace110>.
+    
+<http://data.lblod.info/id/remote-data-objects/5836f15f-71d0-4295-a531-d4bb02eb80dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5836f15f-71d0-4295-a531-d4bb02eb80dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5836f15f-71d0-4295-a531-d4bb02eb80dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/55dd42bb-27c4-44e1-8e4e-84dbedbc2531> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55dd42bb-27c4-44e1-8e4e-84dbedbc2531";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55dd42bb-27c4-44e1-8e4e-84dbedbc2531>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4d70cd7-1591-4548-9e59-c564c12e6990> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4d70cd7-1591-4548-9e59-c564c12e6990";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4d70cd7-1591-4548-9e59-c564c12e6990>.
+    
+<http://data.lblod.info/id/remote-data-objects/d347bde9-bfbb-43a8-932e-c430aed48677> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d347bde9-bfbb-43a8-932e-c430aed48677";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d347bde9-bfbb-43a8-932e-c430aed48677>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa7090b6-907f-4b2d-a37f-90e1a0eca8e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa7090b6-907f-4b2d-a37f-90e1a0eca8e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa7090b6-907f-4b2d-a37f-90e1a0eca8e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/297d5752-d549-4b97-a407-979b25261c41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "297d5752-d549-4b97-a407-979b25261c41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/297d5752-d549-4b97-a407-979b25261c41>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b145faa-75a6-495e-a9d7-66edfd5e7dbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b145faa-75a6-495e-a9d7-66edfd5e7dbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b145faa-75a6-495e-a9d7-66edfd5e7dbb>.
+    
+<http://data.lblod.info/id/remote-data-objects/f41c3ae3-fc55-4edf-96d1-c7cacf444aba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f41c3ae3-fc55-4edf-96d1-c7cacf444aba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f41c3ae3-fc55-4edf-96d1-c7cacf444aba>.
+    
+<http://data.lblod.info/id/remote-data-objects/7af3b3b1-8a6f-4272-b374-3ac2007af480> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7af3b3b1-8a6f-4272-b374-3ac2007af480";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7af3b3b1-8a6f-4272-b374-3ac2007af480>.
+    
+<http://data.lblod.info/id/remote-data-objects/18b1212b-1f9c-4492-8726-4e5c9b4f04a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18b1212b-1f9c-4492-8726-4e5c9b4f04a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18b1212b-1f9c-4492-8726-4e5c9b4f04a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/234d59cd-6acc-46c6-b187-7e61285c95f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "234d59cd-6acc-46c6-b187-7e61285c95f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/234d59cd-6acc-46c6-b187-7e61285c95f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b17964e-d4d1-4e94-abcc-8e686b9a9a98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b17964e-d4d1-4e94-abcc-8e686b9a9a98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b17964e-d4d1-4e94-abcc-8e686b9a9a98>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce31ae6c-a04e-4c40-a086-c86776a3d9a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce31ae6c-a04e-4c40-a086-c86776a3d9a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce31ae6c-a04e-4c40-a086-c86776a3d9a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e91e65da-6207-425a-9fb1-e9353f9b9823> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e91e65da-6207-425a-9fb1-e9353f9b9823";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=Uittreksels_13-06-2022_29622.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e91e65da-6207-425a-9fb1-e9353f9b9823>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7947b03-b9f9-4bbf-b73a-70f300faefc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7947b03-b9f9-4bbf-b73a-70f300faefc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/847711a39500f7ad8c6c4beb5cf37bc136df7e361370cc3fcd18b1844b1c368f/GetPublication?filename=Uittreksels_25-10-2021_25639.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7947b03-b9f9-4bbf-b73a-70f300faefc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a51c51ac-e266-4805-8882-2ac68ec198a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a51c51ac-e266-4805-8882-2ac68ec198a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Agenda_Gemeenteraad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a51c51ac-e266-4805-8882-2ac68ec198a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/41823608-bd1b-4ebd-a98e-23ee9a26661e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41823608-bd1b-4ebd-a98e-23ee9a26661e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Agenda_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41823608-bd1b-4ebd-a98e-23ee9a26661e>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd6d24eb-6490-4249-b431-047b5c225d36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd6d24eb-6490-4249-b431-047b5c225d36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Agenda_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd6d24eb-6490-4249-b431-047b5c225d36>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5f33c3e-8ac4-4f8a-9cf2-b11ca070940e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5f33c3e-8ac4-4f8a-9cf2-b11ca070940e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Agenda_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5f33c3e-8ac4-4f8a-9cf2-b11ca070940e>.
+    
+<http://data.lblod.info/id/remote-data-objects/457963d5-0d04-442c-bafb-536359e8d41b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "457963d5-0d04-442c-bafb-536359e8d41b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Agenda_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/457963d5-0d04-442c-bafb-536359e8d41b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8dabcc49-8026-429f-93fd-446a9b887d15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8dabcc49-8026-429f-93fd-446a9b887d15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Agenda_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8dabcc49-8026-429f-93fd-446a9b887d15>.
+    
+<http://data.lblod.info/id/remote-data-objects/08838eea-59b6-4bcb-8b67-a298d75d1769> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08838eea-59b6-4bcb-8b67-a298d75d1769";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Agenda_Gemeenteraad_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08838eea-59b6-4bcb-8b67-a298d75d1769>.
+    
+<http://data.lblod.info/id/remote-data-objects/77359af9-7637-41fb-beba-9c824d8f552d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77359af9-7637-41fb-beba-9c824d8f552d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Agenda_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77359af9-7637-41fb-beba-9c824d8f552d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddfe79fc-9256-4ee4-b109-73312ebde933> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddfe79fc-9256-4ee4-b109-73312ebde933";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Agenda_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddfe79fc-9256-4ee4-b109-73312ebde933>.
+    
+<http://data.lblod.info/id/remote-data-objects/649ef9e5-b8b5-47f3-a3cb-128e7db74bcb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "649ef9e5-b8b5-47f3-a3cb-128e7db74bcb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=BesluitenLijst_Gemeenteraad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/649ef9e5-b8b5-47f3-a3cb-128e7db74bcb>.
+    
+<http://data.lblod.info/id/remote-data-objects/03e2582b-4863-4d3d-b8af-180890d823a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03e2582b-4863-4d3d-b8af-180890d823a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03e2582b-4863-4d3d-b8af-180890d823a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c9ab77a-b4e8-4d07-8dbe-36a47ceb77a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c9ab77a-b4e8-4d07-8dbe-36a47ceb77a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c9ab77a-b4e8-4d07-8dbe-36a47ceb77a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/40c4d0a7-8266-48a8-ac11-eae870603a0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40c4d0a7-8266-48a8-ac11-eae870603a0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40c4d0a7-8266-48a8-ac11-eae870603a0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3769f6a4-8a8e-46f0-a608-d960bbab8bbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3769f6a4-8a8e-46f0-a608-d960bbab8bbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3769f6a4-8a8e-46f0-a608-d960bbab8bbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/46b1abfd-d155-4622-9d83-6db3c5b65058> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46b1abfd-d155-4622-9d83-6db3c5b65058";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46b1abfd-d155-4622-9d83-6db3c5b65058>.
+    
+<http://data.lblod.info/id/remote-data-objects/580a45ae-1a35-43fe-a14d-75eda57ad8f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "580a45ae-1a35-43fe-a14d-75eda57ad8f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0e5e29f1-b92b-4e29-b117-979bdfaba7cb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/580a45ae-1a35-43fe-a14d-75eda57ad8f5>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201706-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201706-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201706-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201706-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/49d3121b-eec4-418c-9efc-568e510d7633> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "49d3121b-eec4-418c-9efc-568e510d7633";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "627adcb7-cc55-4912-b4f9-75f093718fde";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ac1024b1-e710-412b-babf-166c4daeda3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ac1024b1-e710-412b-babf-166c4daeda3e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde>.
+
+  <http://redpencil.data.gift/id/task/db23f8f8-9143-473a-9722-62363984b9e6> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "db23f8f8-9143-473a-9722-62363984b9e6";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/49d3121b-eec4-418c-9efc-568e510d7633>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ac1024b1-e710-412b-babf-166c4daeda3e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/235622f2-8b16-4667-91ea-360f79888bde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "235622f2-8b16-4667-91ea-360f79888bde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/235622f2-8b16-4667-91ea-360f79888bde>.
+    
+<http://data.lblod.info/id/remote-data-objects/242163c1-1285-46a1-b901-dc900a671b87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "242163c1-1285-46a1-b901-dc900a671b87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=BesluitenLijst_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/242163c1-1285-46a1-b901-dc900a671b87>.
+    
+<http://data.lblod.info/id/remote-data-objects/96337b7d-6563-44d9-bca0-a3fbf473f027> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96337b7d-6563-44d9-bca0-a3fbf473f027";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Notulen_Gemeenteraad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96337b7d-6563-44d9-bca0-a3fbf473f027>.
+    
+<http://data.lblod.info/id/remote-data-objects/a37402ee-7700-47c5-91d7-4b5e43a81b29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a37402ee-7700-47c5-91d7-4b5e43a81b29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Notulen_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a37402ee-7700-47c5-91d7-4b5e43a81b29>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cf4b272-da8a-4df7-9db6-8432d47df3a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cf4b272-da8a-4df7-9db6-8432d47df3a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Notulen_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cf4b272-da8a-4df7-9db6-8432d47df3a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c176945f-25df-403b-b26d-5b6f5f9ff203> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c176945f-25df-403b-b26d-5b6f5f9ff203";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Notulen_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c176945f-25df-403b-b26d-5b6f5f9ff203>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb3f55d0-ad2a-47b1-a252-07fc3017849c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb3f55d0-ad2a-47b1-a252-07fc3017849c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Notulen_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb3f55d0-ad2a-47b1-a252-07fc3017849c>.
+    
+<http://data.lblod.info/id/remote-data-objects/97425c69-bb10-4ad5-8efe-a6aec0ce4040> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97425c69-bb10-4ad5-8efe-a6aec0ce4040";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Notulen_Gemeenteraad_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97425c69-bb10-4ad5-8efe-a6aec0ce4040>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff5ea222-86b8-4a3f-ab7e-077d5cabc83b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff5ea222-86b8-4a3f-ab7e-077d5cabc83b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Notulen_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff5ea222-86b8-4a3f-ab7e-077d5cabc83b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e17463e-9ea6-472f-a730-60cf706674e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e17463e-9ea6-472f-a730-60cf706674e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Notulen_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e17463e-9ea6-472f-a730-60cf706674e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d72161e6-b1a9-403d-8044-d443b749cc57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d72161e6-b1a9-403d-8044-d443b749cc57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_22314.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d72161e6-b1a9-403d-8044-d443b749cc57>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc060478-125d-415d-ab59-0d64ddfb0393> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc060478-125d-415d-ab59-0d64ddfb0393";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_22628.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc060478-125d-415d-ab59-0d64ddfb0393>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0114b56-baaa-470f-9816-62624a0fbbd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0114b56-baaa-470f-9816-62624a0fbbd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_25656.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0114b56-baaa-470f-9816-62624a0fbbd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9e37451-2903-413a-bb3e-2383423cd26c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9e37451-2903-413a-bb3e-2383423cd26c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_25685.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9e37451-2903-413a-bb3e-2383423cd26c>.
+    
+<http://data.lblod.info/id/remote-data-objects/70bb638f-7217-4828-8412-8cf925c59569> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70bb638f-7217-4828-8412-8cf925c59569";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_25686.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70bb638f-7217-4828-8412-8cf925c59569>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8fdbd78-c9e9-43cb-96df-1619fba8f9f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8fdbd78-c9e9-43cb-96df-1619fba8f9f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_25687.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8fdbd78-c9e9-43cb-96df-1619fba8f9f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d3b1ba9-c1ae-4198-8b2b-47f73d2532a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d3b1ba9-c1ae-4198-8b2b-47f73d2532a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_25689.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d3b1ba9-c1ae-4198-8b2b-47f73d2532a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/bec0945a-704b-4a3b-a332-5311641a3bef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bec0945a-704b-4a3b-a332-5311641a3bef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_25690.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bec0945a-704b-4a3b-a332-5311641a3bef>.
+    
+<http://data.lblod.info/id/remote-data-objects/76e73fc3-d32c-4843-b58e-0263903cec72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76e73fc3-d32c-4843-b58e-0263903cec72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_25691.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76e73fc3-d32c-4843-b58e-0263903cec72>.
+    
+<http://data.lblod.info/id/remote-data-objects/81d5fb6d-86c5-4c38-9d99-a4d80dc2a5b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81d5fb6d-86c5-4c38-9d99-a4d80dc2a5b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_25707.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81d5fb6d-86c5-4c38-9d99-a4d80dc2a5b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/81bd2785-dcc6-4a40-aea1-2a596d47605c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81bd2785-dcc6-4a40-aea1-2a596d47605c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_25874.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81bd2785-dcc6-4a40-aea1-2a596d47605c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a45498c-a7a2-45dd-a7f9-019d3ca273bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a45498c-a7a2-45dd-a7f9-019d3ca273bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_25895.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a45498c-a7a2-45dd-a7f9-019d3ca273bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/7baf5acd-42e4-4eaf-a49b-a93f74045749> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7baf5acd-42e4-4eaf-a49b-a93f74045749";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_25992.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7baf5acd-42e4-4eaf-a49b-a93f74045749>.
+    
+<http://data.lblod.info/id/remote-data-objects/0707b7e9-47c2-4808-8e64-8058b6308677> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0707b7e9-47c2-4808-8e64-8058b6308677";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_26147.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0707b7e9-47c2-4808-8e64-8058b6308677>.
+    
+<http://data.lblod.info/id/remote-data-objects/f30a7621-5af8-42cc-b140-e42f8ac498ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f30a7621-5af8-42cc-b140-e42f8ac498ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_26207.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f30a7621-5af8-42cc-b140-e42f8ac498ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c5f018f-5f79-48d0-b342-9ddcfbc8869e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c5f018f-5f79-48d0-b342-9ddcfbc8869e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_26354.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c5f018f-5f79-48d0-b342-9ddcfbc8869e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d526e0d-6d93-4881-ad16-1f2dcd7c9117> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d526e0d-6d93-4881-ad16-1f2dcd7c9117";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_26361.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d526e0d-6d93-4881-ad16-1f2dcd7c9117>.
+    
+<http://data.lblod.info/id/remote-data-objects/17ea61e6-a8df-4a08-9022-0a0dff309bb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17ea61e6-a8df-4a08-9022-0a0dff309bb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_26395.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17ea61e6-a8df-4a08-9022-0a0dff309bb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/439d8763-9d3f-499f-a2e8-4a14bd185ceb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "439d8763-9d3f-499f-a2e8-4a14bd185ceb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_13-12-2021_26432.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/439d8763-9d3f-499f-a2e8-4a14bd185ceb>.
+    
+<http://data.lblod.info/id/remote-data-objects/3390d3f4-5e13-4b05-841e-802c160f3a17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3390d3f4-5e13-4b05-841e-802c160f3a17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_21-02-2022_27400.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3390d3f4-5e13-4b05-841e-802c160f3a17>.
+    
+<http://data.lblod.info/id/remote-data-objects/78dcf664-0cd4-4095-b6f7-99d7536c7b7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78dcf664-0cd4-4095-b6f7-99d7536c7b7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_24-01-2022_26696.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78dcf664-0cd4-4095-b6f7-99d7536c7b7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8eccdd25-8ce8-40cc-bf9c-78cea0b877e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8eccdd25-8ce8-40cc-bf9c-78cea0b877e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_24-01-2022_26753.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8eccdd25-8ce8-40cc-bf9c-78cea0b877e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf693b6a-cffa-40a6-9d0f-d6134a1571ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf693b6a-cffa-40a6-9d0f-d6134a1571ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_24-01-2022_26951.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf693b6a-cffa-40a6-9d0f-d6134a1571ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7063d44-0223-4607-a69b-f49ad7019c36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7063d44-0223-4607-a69b-f49ad7019c36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_24-01-2022_26963.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7063d44-0223-4607-a69b-f49ad7019c36>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8847e81-8a9a-491b-856f-513ac1dc0c2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8847e81-8a9a-491b-856f-513ac1dc0c2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_24-01-2022_26980.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8847e81-8a9a-491b-856f-513ac1dc0c2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/010320ed-4f17-4140-9040-2e33a2b9d92a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "010320ed-4f17-4140-9040-2e33a2b9d92a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_25-04-2022_28276.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/010320ed-4f17-4140-9040-2e33a2b9d92a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e095ee28-d3e5-467a-be09-9d19c64fc872> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e095ee28-d3e5-467a-be09-9d19c64fc872";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_25-04-2022_28342.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e095ee28-d3e5-467a-be09-9d19c64fc872>.
+    
+<http://data.lblod.info/id/remote-data-objects/52ddcdd9-31d8-4c6e-b4e4-c270ccab57ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52ddcdd9-31d8-4c6e-b4e4-c270ccab57ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_25-04-2022_28494.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52ddcdd9-31d8-4c6e-b4e4-c270ccab57ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/eaa5f4c6-15bc-477f-bd2d-ed4da0525ecf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eaa5f4c6-15bc-477f-bd2d-ed4da0525ecf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_25-10-2021_25144.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eaa5f4c6-15bc-477f-bd2d-ed4da0525ecf>.
+    
+<http://data.lblod.info/id/remote-data-objects/0873acdb-6e00-4d88-ae39-e721fa11d47e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0873acdb-6e00-4d88-ae39-e721fa11d47e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_25-10-2021_25653.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0873acdb-6e00-4d88-ae39-e721fa11d47e>.
+    
+<http://data.lblod.info/id/remote-data-objects/06baea61-dd71-42e8-95d2-c170d421e91f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06baea61-dd71-42e8-95d2-c170d421e91f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_27-12-2021_26622.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06baea61-dd71-42e8-95d2-c170d421e91f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c320016-6cdd-4a6a-9081-5a82536cb056> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c320016-6cdd-4a6a-9081-5a82536cb056";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_28-03-2022_27742.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c320016-6cdd-4a6a-9081-5a82536cb056>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b99484d-0983-47c5-8109-e84ca1292ee4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b99484d-0983-47c5-8109-e84ca1292ee4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_28-03-2022_27751.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b99484d-0983-47c5-8109-e84ca1292ee4>.
+    
+<http://data.lblod.info/id/remote-data-objects/30faa3ea-cf64-475f-8977-0bb1b1aec8f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30faa3ea-cf64-475f-8977-0bb1b1aec8f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_28-03-2022_27839.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30faa3ea-cf64-475f-8977-0bb1b1aec8f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcd9e356-0b50-48be-a3af-e2f9af8cacf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcd9e356-0b50-48be-a3af-e2f9af8cacf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_28-03-2022_27840.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcd9e356-0b50-48be-a3af-e2f9af8cacf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8f7fb15-83cd-464c-9f79-03e394fedee1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8f7fb15-83cd-464c-9f79-03e394fedee1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_30-05-2022_28521.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8f7fb15-83cd-464c-9f79-03e394fedee1>.
+    
+<http://data.lblod.info/id/remote-data-objects/14ee8e77-d2c4-4dfc-b7e2-cb10308553af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14ee8e77-d2c4-4dfc-b7e2-cb10308553af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_30-05-2022_28522.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14ee8e77-d2c4-4dfc-b7e2-cb10308553af>.
+    
+<http://data.lblod.info/id/remote-data-objects/74244b58-c224-4f63-9c72-d2adeb217454> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74244b58-c224-4f63-9c72-d2adeb217454";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_30-05-2022_28523.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74244b58-c224-4f63-9c72-d2adeb217454>.
+    
+<http://data.lblod.info/id/remote-data-objects/889a932f-2d2a-4b4b-8be0-e6c3486191e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "889a932f-2d2a-4b4b-8be0-e6c3486191e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_30-05-2022_28559.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/889a932f-2d2a-4b4b-8be0-e6c3486191e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec2de83c-e341-483c-88fa-3e9cd64876ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec2de83c-e341-483c-88fa-3e9cd64876ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9877d55da079273a991a505e9af79aa8a564f40d864cedaba3306b4f3d51d40b/GetPublication?filename=Uittreksels_30-05-2022_29066.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/627adcb7-cc55-4912-b4f9-75f093718fde> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec2de83c-e341-483c-88fa-3e9cd64876ef>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201707-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201707-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201707-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201707-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/dc74bd73-85a3-478a-a0be-eb48f4d14273> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dc74bd73-85a3-478a-a0be-eb48f4d14273";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "355ec926-a488-4d03-92a8-4ec5b45b5e2a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/3cd4b249-9156-4bee-9fec-558ca3dc8c62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3cd4b249-9156-4bee-9fec-558ca3dc8c62";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a>.
+
+  <http://redpencil.data.gift/id/task/0ceba4ac-ef65-4e6a-b173-258ef6ed5166> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0ceba4ac-ef65-4e6a-b173-258ef6ed5166";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/dc74bd73-85a3-478a-a0be-eb48f4d14273>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/3cd4b249-9156-4bee-9fec-558ca3dc8c62>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b955eaff-3fd5-41b8-a619-44fd47797f45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b955eaff-3fd5-41b8-a619-44fd47797f45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9bc176566d4746db90ffd5f8ff9cd1c2bc13127487574704a2ac70a348910a4b/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b955eaff-3fd5-41b8-a619-44fd47797f45>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6fd90d6-a7b4-4c67-a6c5-40fd888bb0e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6fd90d6-a7b4-4c67-a6c5-40fd888bb0e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9bc176566d4746db90ffd5f8ff9cd1c2bc13127487574704a2ac70a348910a4b/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_30-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6fd90d6-a7b4-4c67-a6c5-40fd888bb0e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ab6be53-f52d-4bb2-8865-30fe484111bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ab6be53-f52d-4bb2-8865-30fe484111bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9bc176566d4746db90ffd5f8ff9cd1c2bc13127487574704a2ac70a348910a4b/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ab6be53-f52d-4bb2-8865-30fe484111bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c9411c8-a851-4ed3-b8c4-e42dea9818bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c9411c8-a851-4ed3-b8c4-e42dea9818bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9bc176566d4746db90ffd5f8ff9cd1c2bc13127487574704a2ac70a348910a4b/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c9411c8-a851-4ed3-b8c4-e42dea9818bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/01bdcd0c-9a14-4745-954e-4b34d154b44e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01bdcd0c-9a14-4745-954e-4b34d154b44e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9bc176566d4746db90ffd5f8ff9cd1c2bc13127487574704a2ac70a348910a4b/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01bdcd0c-9a14-4745-954e-4b34d154b44e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b9fbaea-705f-4261-9e8e-a02e58cbf82e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b9fbaea-705f-4261-9e8e-a02e58cbf82e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9bc176566d4746db90ffd5f8ff9cd1c2bc13127487574704a2ac70a348910a4b/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b9fbaea-705f-4261-9e8e-a02e58cbf82e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9153e75a-2ac8-4bbc-9722-c908acf1eb39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9153e75a-2ac8-4bbc-9722-c908acf1eb39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9bc176566d4746db90ffd5f8ff9cd1c2bc13127487574704a2ac70a348910a4b/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9153e75a-2ac8-4bbc-9722-c908acf1eb39>.
+    
+<http://data.lblod.info/id/remote-data-objects/d14f6de7-538b-4d99-b6be-7cc01881afe0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d14f6de7-538b-4d99-b6be-7cc01881afe0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9bc176566d4746db90ffd5f8ff9cd1c2bc13127487574704a2ac70a348910a4b/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_31-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d14f6de7-538b-4d99-b6be-7cc01881afe0>.
+    
+<http://data.lblod.info/id/remote-data-objects/af2cb458-443e-4c23-ac10-4f62455181dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af2cb458-443e-4c23-ac10-4f62455181dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9bc176566d4746db90ffd5f8ff9cd1c2bc13127487574704a2ac70a348910a4b/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_31-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af2cb458-443e-4c23-ac10-4f62455181dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/57869d17-cb7a-4647-8541-bee2b3f56c8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57869d17-cb7a-4647-8541-bee2b3f56c8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/9bc176566d4746db90ffd5f8ff9cd1c2bc13127487574704a2ac70a348910a4b/GetPublication?filename=BesluitenLijst_Besluiten%20Burgemeester_31-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57869d17-cb7a-4647-8541-bee2b3f56c8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7d1c372-fa6f-401c-8c11-043720803c9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7d1c372-fa6f-401c-8c11-043720803c9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7d1c372-fa6f-401c-8c11-043720803c9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ee9a676-e18d-4155-bc35-be4b0f58f61b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ee9a676-e18d-4155-bc35-be4b0f58f61b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ee9a676-e18d-4155-bc35-be4b0f58f61b>.
+    
+<http://data.lblod.info/id/remote-data-objects/44daae6f-802a-4c41-8d07-93a24d1c046c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44daae6f-802a-4c41-8d07-93a24d1c046c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44daae6f-802a-4c41-8d07-93a24d1c046c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce9d5385-e11c-4a60-bc5a-c4df1d294f52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce9d5385-e11c-4a60-bc5a-c4df1d294f52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce9d5385-e11c-4a60-bc5a-c4df1d294f52>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c55729d-e268-456f-b8b9-605365ca3eb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c55729d-e268-456f-b8b9-605365ca3eb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c55729d-e268-456f-b8b9-605365ca3eb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/dca8644d-2e9a-4895-9d95-a4a992c4541c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dca8644d-2e9a-4895-9d95-a4a992c4541c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dca8644d-2e9a-4895-9d95-a4a992c4541c>.
+    
+<http://data.lblod.info/id/remote-data-objects/88be39f3-d213-4625-88a4-f1faeb009df5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88be39f3-d213-4625-88a4-f1faeb009df5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88be39f3-d213-4625-88a4-f1faeb009df5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a0c4f5a-2ef5-4dfe-bdcc-5875a9edbaba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a0c4f5a-2ef5-4dfe-bdcc-5875a9edbaba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a0c4f5a-2ef5-4dfe-bdcc-5875a9edbaba>.
+    
+<http://data.lblod.info/id/remote-data-objects/b033428c-d55e-4184-8342-7856e7902f63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b033428c-d55e-4184-8342-7856e7902f63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b033428c-d55e-4184-8342-7856e7902f63>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bcc516a-9638-4975-96fe-ef6c46d5a834> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bcc516a-9638-4975-96fe-ef6c46d5a834";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bcc516a-9638-4975-96fe-ef6c46d5a834>.
+    
+<http://data.lblod.info/id/remote-data-objects/78c9f82d-962b-4154-bc30-14208c49edce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78c9f82d-962b-4154-bc30-14208c49edce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78c9f82d-962b-4154-bc30-14208c49edce>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7bfc99c-e303-4caf-bbe4-32432cebe510> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7bfc99c-e303-4caf-bbe4-32432cebe510";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7bfc99c-e303-4caf-bbe4-32432cebe510>.
+    
+<http://data.lblod.info/id/remote-data-objects/9aa7bb3a-f143-4d75-bc64-8937367aaee6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9aa7bb3a-f143-4d75-bc64-8937367aaee6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9aa7bb3a-f143-4d75-bc64-8937367aaee6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab9b41d1-66be-48e2-a953-ddad2bb1d30e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab9b41d1-66be-48e2-a953-ddad2bb1d30e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab9b41d1-66be-48e2-a953-ddad2bb1d30e>.
+    
+<http://data.lblod.info/id/remote-data-objects/349a39c5-d6d8-41ac-ac18-af73482c3aa8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "349a39c5-d6d8-41ac-ac18-af73482c3aa8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/349a39c5-d6d8-41ac-ac18-af73482c3aa8>.
+    
+<http://data.lblod.info/id/remote-data-objects/6784bd49-9dc2-4cc2-8e84-827d51e0e484> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6784bd49-9dc2-4cc2-8e84-827d51e0e484";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6784bd49-9dc2-4cc2-8e84-827d51e0e484>.
+    
+<http://data.lblod.info/id/remote-data-objects/263145ad-6b8f-47da-a983-d95373015873> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "263145ad-6b8f-47da-a983-d95373015873";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/263145ad-6b8f-47da-a983-d95373015873>.
+    
+<http://data.lblod.info/id/remote-data-objects/53d83215-9737-4e65-9cf4-6d9d10bf91e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53d83215-9737-4e65-9cf4-6d9d10bf91e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53d83215-9737-4e65-9cf4-6d9d10bf91e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5602226-e1f5-44f8-ba02-902060826d2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5602226-e1f5-44f8-ba02-902060826d2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5602226-e1f5-44f8-ba02-902060826d2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fd8c9fb-c521-47c3-90f0-47d1577bb09b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fd8c9fb-c521-47c3-90f0-47d1577bb09b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fd8c9fb-c521-47c3-90f0-47d1577bb09b>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcbe68e7-51ee-410f-bd3a-7fe801f0558f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcbe68e7-51ee-410f-bd3a-7fe801f0558f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcbe68e7-51ee-410f-bd3a-7fe801f0558f>.
+    
+<http://data.lblod.info/id/remote-data-objects/08346182-5792-4e1b-960e-fc4e2c6b7bc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08346182-5792-4e1b-960e-fc4e2c6b7bc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08346182-5792-4e1b-960e-fc4e2c6b7bc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a64c6a6e-2110-4fb2-ae9d-b7d982d05b94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a64c6a6e-2110-4fb2-ae9d-b7d982d05b94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a64c6a6e-2110-4fb2-ae9d-b7d982d05b94>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae5814ec-e58d-4d30-ad57-7c3c4ebaeacd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae5814ec-e58d-4d30-ad57-7c3c4ebaeacd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae5814ec-e58d-4d30-ad57-7c3c4ebaeacd>.
+    
+<http://data.lblod.info/id/remote-data-objects/888bd27e-beaf-4417-b070-0c66ddfe48a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "888bd27e-beaf-4417-b070-0c66ddfe48a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/888bd27e-beaf-4417-b070-0c66ddfe48a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a34768e7-dff9-4b62-9e95-70e3bf51f954> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a34768e7-dff9-4b62-9e95-70e3bf51f954";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a34768e7-dff9-4b62-9e95-70e3bf51f954>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ca7f374-8a17-4680-b5ef-c9f26e2aff13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ca7f374-8a17-4680-b5ef-c9f26e2aff13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Uittreksels_13-12-2021_25693.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ca7f374-8a17-4680-b5ef-c9f26e2aff13>.
+    
+<http://data.lblod.info/id/remote-data-objects/133970a2-7352-4b11-ba8e-a8a5ef2e4166> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "133970a2-7352-4b11-ba8e-a8a5ef2e4166";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Uittreksels_13-12-2021_25694.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/133970a2-7352-4b11-ba8e-a8a5ef2e4166>.
+    
+<http://data.lblod.info/id/remote-data-objects/76833e1c-bfd2-4d44-a33a-e5de6a7de0fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76833e1c-bfd2-4d44-a33a-e5de6a7de0fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Uittreksels_13-12-2021_25695.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76833e1c-bfd2-4d44-a33a-e5de6a7de0fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/874dbb72-b7d2-4584-96d4-46147907f3e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "874dbb72-b7d2-4584-96d4-46147907f3e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Uittreksels_21-02-2022_27296.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/874dbb72-b7d2-4584-96d4-46147907f3e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7798056-c03f-4ac0-bc1c-d20e298c394c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7798056-c03f-4ac0-bc1c-d20e298c394c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Uittreksels_30-05-2022_28519.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7798056-c03f-4ac0-bc1c-d20e298c394c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c29d551-7c4d-4bf7-bde5-6c1deee3d5f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c29d551-7c4d-4bf7-bde5-6c1deee3d5f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.veurne.be/LBLODWeb/Home/Overzicht/d99e6d4669d77f5dafc47c14f936bfaff31948f51fa7d4b2717b98f19511c211/GetPublication?filename=Uittreksels_30-05-2022_28997.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c29d551-7c4d-4bf7-bde5-6c1deee3d5f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/456137c2-232f-4963-b8e0-885adb7ce532> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "456137c2-232f-4963-b8e0-885adb7ce532";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=Agenda_Gemeenteraad_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/456137c2-232f-4963-b8e0-885adb7ce532>.
+    
+<http://data.lblod.info/id/remote-data-objects/33f7c844-1da4-425c-bd55-098e610ed9d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33f7c844-1da4-425c-bd55-098e610ed9d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=Agenda_Gemeenteraad_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33f7c844-1da4-425c-bd55-098e610ed9d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3125c6b4-6f07-4554-b86d-4043f62200f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3125c6b4-6f07-4554-b86d-4043f62200f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=Agenda_Gemeenteraad_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3125c6b4-6f07-4554-b86d-4043f62200f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/03a230ac-afcf-4bb2-ac1d-a7d04510988a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03a230ac-afcf-4bb2-ac1d-a7d04510988a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=Agenda_Gemeenteraad_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03a230ac-afcf-4bb2-ac1d-a7d04510988a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fc5a2bd-8e92-40d0-9d45-aa151bf54b9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fc5a2bd-8e92-40d0-9d45-aa151bf54b9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=Agenda_Gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fc5a2bd-8e92-40d0-9d45-aa151bf54b9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0778428d-6511-4484-8f72-68daf35d3f9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0778428d-6511-4484-8f72-68daf35d3f9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=BesluitenLijst_Gemeenteraad_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0778428d-6511-4484-8f72-68daf35d3f9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/769fc4a1-f16b-4390-893a-e9a92b69edb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "769fc4a1-f16b-4390-893a-e9a92b69edb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/769fc4a1-f16b-4390-893a-e9a92b69edb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/03ad9273-5781-4c1d-805d-bdc2245ac7b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03ad9273-5781-4c1d-805d-bdc2245ac7b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=BesluitenLijst_Gemeenteraad_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/355ec926-a488-4d03-92a8-4ec5b45b5e2a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03ad9273-5781-4c1d-805d-bdc2245ac7b9>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201708-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201708-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201708-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201708-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/391f65af-bf78-4ec2-ba2d-ee02451c513c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "391f65af-bf78-4ec2-ba2d-ee02451c513c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "61961720-3a17-4d47-be9d-1350b166bc58";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/531a1f14-6923-4347-bc6e-a3bf0ad85d5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "531a1f14-6923-4347-bc6e-a3bf0ad85d5f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58>.
+
+  <http://redpencil.data.gift/id/task/a21e1cbc-0a85-4cd6-aee9-79e9c097dd1e> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a21e1cbc-0a85-4cd6-aee9-79e9c097dd1e";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/391f65af-bf78-4ec2-ba2d-ee02451c513c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/531a1f14-6923-4347-bc6e-a3bf0ad85d5f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/2a6cb16d-6ead-4d8f-b8e4-e1a8b6cc7489> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a6cb16d-6ead-4d8f-b8e4-e1a8b6cc7489";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=BesluitenLijst_Gemeenteraad_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a6cb16d-6ead-4d8f-b8e4-e1a8b6cc7489>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a6522c8-6190-4555-b30f-627840254ad2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a6522c8-6190-4555-b30f-627840254ad2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=BesluitenLijst_Gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a6522c8-6190-4555-b30f-627840254ad2>.
+    
+<http://data.lblod.info/id/remote-data-objects/16a86f1c-0484-44be-be37-a7ab180ca43e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16a86f1c-0484-44be-be37-a7ab180ca43e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16a86f1c-0484-44be-be37-a7ab180ca43e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bb75609-7c0f-42ef-90d7-508baa1ff1a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bb75609-7c0f-42ef-90d7-508baa1ff1a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bb75609-7c0f-42ef-90d7-508baa1ff1a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c8799a5-753a-4fbd-9770-046f8b026110> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c8799a5-753a-4fbd-9770-046f8b026110";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=Notulen_Gemeenteraad_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c8799a5-753a-4fbd-9770-046f8b026110>.
+    
+<http://data.lblod.info/id/remote-data-objects/66d999f4-3e78-4054-b386-706bebc1bafe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66d999f4-3e78-4054-b386-706bebc1bafe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=Notulen_Gemeenteraad_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66d999f4-3e78-4054-b386-706bebc1bafe>.
+    
+<http://data.lblod.info/id/remote-data-objects/292713a7-99f0-40a7-b6d2-9d26e5e97cf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "292713a7-99f0-40a7-b6d2-9d26e5e97cf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=Notulen_Gemeenteraad_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/292713a7-99f0-40a7-b6d2-9d26e5e97cf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6561833-022a-42b5-8e0d-3065835cdf73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6561833-022a-42b5-8e0d-3065835cdf73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=Notulen_Gemeenteraad_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6561833-022a-42b5-8e0d-3065835cdf73>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2848604-35bb-4211-aad3-11b5094e1caa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2848604-35bb-4211-aad3-11b5094e1caa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/27c12eacd6d9d3e7f9c5c875f92bf465d18c10c5d253f06899f38f60d9a47c15/GetPublication?filename=Uittreksels_30-06-2022_10467.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2848604-35bb-4211-aad3-11b5094e1caa>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4ee4b0f-ab18-4054-a9f2-2472ee270770> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4ee4b0f-ab18-4054-a9f2-2472ee270770";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/670b922d16e6094a84cbadb5fb2f30c267ffed0ce77eb6de7924dd01676cc96a/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4ee4b0f-ab18-4054-a9f2-2472ee270770>.
+    
+<http://data.lblod.info/id/remote-data-objects/f02dfff1-4d79-484b-b7ea-c71c46b245c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f02dfff1-4d79-484b-b7ea-c71c46b245c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/670b922d16e6094a84cbadb5fb2f30c267ffed0ce77eb6de7924dd01676cc96a/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f02dfff1-4d79-484b-b7ea-c71c46b245c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bd3b79e-9235-4c11-b736-cfa488b9a688> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bd3b79e-9235-4c11-b736-cfa488b9a688";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/670b922d16e6094a84cbadb5fb2f30c267ffed0ce77eb6de7924dd01676cc96a/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bd3b79e-9235-4c11-b736-cfa488b9a688>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f625c0c-1072-467b-9f73-6415821ad3cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f625c0c-1072-467b-9f73-6415821ad3cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/670b922d16e6094a84cbadb5fb2f30c267ffed0ce77eb6de7924dd01676cc96a/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f625c0c-1072-467b-9f73-6415821ad3cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/de77f643-0150-4432-83db-3290948a8e1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de77f643-0150-4432-83db-3290948a8e1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/670b922d16e6094a84cbadb5fb2f30c267ffed0ce77eb6de7924dd01676cc96a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de77f643-0150-4432-83db-3290948a8e1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf068ee2-3252-4be6-8551-2916964f7a57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf068ee2-3252-4be6-8551-2916964f7a57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/670b922d16e6094a84cbadb5fb2f30c267ffed0ce77eb6de7924dd01676cc96a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf068ee2-3252-4be6-8551-2916964f7a57>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7677a38-7129-4115-8b86-b9549c8e238f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7677a38-7129-4115-8b86-b9549c8e238f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/670b922d16e6094a84cbadb5fb2f30c267ffed0ce77eb6de7924dd01676cc96a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7677a38-7129-4115-8b86-b9549c8e238f>.
+    
+<http://data.lblod.info/id/remote-data-objects/21cf60e4-0bb7-4ae3-946c-b7cb68b597f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21cf60e4-0bb7-4ae3-946c-b7cb68b597f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/670b922d16e6094a84cbadb5fb2f30c267ffed0ce77eb6de7924dd01676cc96a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21cf60e4-0bb7-4ae3-946c-b7cb68b597f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9a05e69-8148-4f0c-aba9-af411acef3cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9a05e69-8148-4f0c-aba9-af411acef3cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/670b922d16e6094a84cbadb5fb2f30c267ffed0ce77eb6de7924dd01676cc96a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9a05e69-8148-4f0c-aba9-af411acef3cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba5a9939-c430-4023-947d-f9013a7675f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba5a9939-c430-4023-947d-f9013a7675f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/670b922d16e6094a84cbadb5fb2f30c267ffed0ce77eb6de7924dd01676cc96a/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba5a9939-c430-4023-947d-f9013a7675f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/61f3a73c-c9be-42eb-b7ad-8f90134f99bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61f3a73c-c9be-42eb-b7ad-8f90134f99bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/670b922d16e6094a84cbadb5fb2f30c267ffed0ce77eb6de7924dd01676cc96a/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61f3a73c-c9be-42eb-b7ad-8f90134f99bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0e7f376-a3bb-4262-8e0f-3daeb789e676> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0e7f376-a3bb-4262-8e0f-3daeb789e676";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/670b922d16e6094a84cbadb5fb2f30c267ffed0ce77eb6de7924dd01676cc96a/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0e7f376-a3bb-4262-8e0f-3daeb789e676>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f4480ad-c2c0-465d-92b2-52e82d0e6d6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f4480ad-c2c0-465d-92b2-52e82d0e6d6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/670b922d16e6094a84cbadb5fb2f30c267ffed0ce77eb6de7924dd01676cc96a/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f4480ad-c2c0-465d-92b2-52e82d0e6d6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5cfb097-48f0-411c-a492-ef45f940eb64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5cfb097-48f0-411c-a492-ef45f940eb64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.vleteren.be/LBLODWeb/Home/Overzicht/670b922d16e6094a84cbadb5fb2f30c267ffed0ce77eb6de7924dd01676cc96a/GetPublication?filename=Uittreksels_30-06-2022_10477.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5cfb097-48f0-411c-a492-ef45f940eb64>.
+    
+<http://data.lblod.info/id/remote-data-objects/13f14d17-d15c-4f58-a16f-dbe4012388bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13f14d17-d15c-4f58-a16f-dbe4012388bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13f14d17-d15c-4f58-a16f-dbe4012388bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/09cdc0f5-2e9d-4d88-a6d0-ae3203f52709> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09cdc0f5-2e9d-4d88-a6d0-ae3203f52709";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09cdc0f5-2e9d-4d88-a6d0-ae3203f52709>.
+    
+<http://data.lblod.info/id/remote-data-objects/b25cea3b-4f27-44eb-9133-0b22ce303888> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b25cea3b-4f27-44eb-9133-0b22ce303888";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b25cea3b-4f27-44eb-9133-0b22ce303888>.
+    
+<http://data.lblod.info/id/remote-data-objects/18e2a8e7-87fa-4fd9-a534-38b949167784> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18e2a8e7-87fa-4fd9-a534-38b949167784";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18e2a8e7-87fa-4fd9-a534-38b949167784>.
+    
+<http://data.lblod.info/id/remote-data-objects/336fe201-3db8-4144-a5ac-ceb6fb7b494c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "336fe201-3db8-4144-a5ac-ceb6fb7b494c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/336fe201-3db8-4144-a5ac-ceb6fb7b494c>.
+    
+<http://data.lblod.info/id/remote-data-objects/830c6bb4-54a5-44a5-8589-004d208921b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "830c6bb4-54a5-44a5-8589-004d208921b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_05-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/830c6bb4-54a5-44a5-8589-004d208921b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd90e2d1-db85-46db-b95c-2180fa6f7a0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd90e2d1-db85-46db-b95c-2180fa6f7a0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd90e2d1-db85-46db-b95c-2180fa6f7a0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/448ba8dc-45a3-463c-8579-fa974f745d76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "448ba8dc-45a3-463c-8579-fa974f745d76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/448ba8dc-45a3-463c-8579-fa974f745d76>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa3eee0a-094a-408e-ab3e-26c872525cff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa3eee0a-094a-408e-ab3e-26c872525cff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa3eee0a-094a-408e-ab3e-26c872525cff>.
+    
+<http://data.lblod.info/id/remote-data-objects/376305fa-013e-4a86-b636-710e80314b39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "376305fa-013e-4a86-b636-710e80314b39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/376305fa-013e-4a86-b636-710e80314b39>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a4790b2-3a9e-41c7-a6b6-98990a59bf48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a4790b2-3a9e-41c7-a6b6-98990a59bf48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a4790b2-3a9e-41c7-a6b6-98990a59bf48>.
+    
+<http://data.lblod.info/id/remote-data-objects/3890e720-f2e9-400a-8a0d-398eaf42772b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3890e720-f2e9-400a-8a0d-398eaf42772b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3890e720-f2e9-400a-8a0d-398eaf42772b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dec78b2-f386-4488-a06c-f4a2d9229fa0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dec78b2-f386-4488-a06c-f4a2d9229fa0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dec78b2-f386-4488-a06c-f4a2d9229fa0>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cbee24b-a0bd-4d64-8279-736299244f67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cbee24b-a0bd-4d64-8279-736299244f67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cbee24b-a0bd-4d64-8279-736299244f67>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cc5c8ab-1504-4abd-b290-390effb45d81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cc5c8ab-1504-4abd-b290-390effb45d81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cc5c8ab-1504-4abd-b290-390effb45d81>.
+    
+<http://data.lblod.info/id/remote-data-objects/f51b2de2-b2f6-4034-96f4-8c444383ffb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f51b2de2-b2f6-4034-96f4-8c444383ffb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f51b2de2-b2f6-4034-96f4-8c444383ffb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dc38b6f-f79b-4c48-b92d-e50965d177e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dc38b6f-f79b-4c48-b92d-e50965d177e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dc38b6f-f79b-4c48-b92d-e50965d177e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfba0cb9-de11-448f-b36b-6a9727bf53a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfba0cb9-de11-448f-b36b-6a9727bf53a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfba0cb9-de11-448f-b36b-6a9727bf53a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/469d3119-6408-4a29-8c9d-dc40915bf44d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "469d3119-6408-4a29-8c9d-dc40915bf44d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/469d3119-6408-4a29-8c9d-dc40915bf44d>.
+    
+<http://data.lblod.info/id/remote-data-objects/089fa25a-7c08-42b9-8534-e8f25ad4cbc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "089fa25a-7c08-42b9-8534-e8f25ad4cbc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/089fa25a-7c08-42b9-8534-e8f25ad4cbc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a1d1b2b-744e-4db2-b58d-c6ca8dc51b22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a1d1b2b-744e-4db2-b58d-c6ca8dc51b22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a1d1b2b-744e-4db2-b58d-c6ca8dc51b22>.
+    
+<http://data.lblod.info/id/remote-data-objects/15525e73-fcf7-49b5-81d3-bca2ea2b5488> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15525e73-fcf7-49b5-81d3-bca2ea2b5488";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15525e73-fcf7-49b5-81d3-bca2ea2b5488>.
+    
+<http://data.lblod.info/id/remote-data-objects/29c68752-ae49-469c-81b6-f9b8bf31044b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29c68752-ae49-469c-81b6-f9b8bf31044b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29c68752-ae49-469c-81b6-f9b8bf31044b>.
+    
+<http://data.lblod.info/id/remote-data-objects/66e35a07-0434-465a-962e-d3b266db2b0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66e35a07-0434-465a-962e-d3b266db2b0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66e35a07-0434-465a-962e-d3b266db2b0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9224094b-9aa5-4b9f-8d56-5a14402dc9f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9224094b-9aa5-4b9f-8d56-5a14402dc9f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9224094b-9aa5-4b9f-8d56-5a14402dc9f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b46ecde9-ab63-415d-8737-2ef16fea04d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b46ecde9-ab63-415d-8737-2ef16fea04d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b46ecde9-ab63-415d-8737-2ef16fea04d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/43def0e4-a82f-4891-b178-a84bed336dce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43def0e4-a82f-4891-b178-a84bed336dce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/61961720-3a17-4d47-be9d-1350b166bc58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43def0e4-a82f-4891-b178-a84bed336dce>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201709-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201709-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201709-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201709-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/92abadc4-0b68-4ee1-af9d-feb11cb559a4> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "92abadc4-0b68-4ee1-af9d-feb11cb559a4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cb6821cb-1f2b-4d7b-9c50-63ce80e7d569";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b3f13078-e63c-4e19-8059-cb70b197e9e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b3f13078-e63c-4e19-8059-cb70b197e9e7";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569>.
+
+  <http://redpencil.data.gift/id/task/e8e039a0-2dc3-4632-8c63-07d44a388076> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e8e039a0-2dc3-4632-8c63-07d44a388076";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/92abadc4-0b68-4ee1-af9d-feb11cb559a4>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b3f13078-e63c-4e19-8059-cb70b197e9e7>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/faaf8fd1-1430-48c5-9623-e237f3d06d13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "faaf8fd1-1430-48c5-9623-e237f3d06d13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/faaf8fd1-1430-48c5-9623-e237f3d06d13>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbc91fbf-31aa-4f3c-8ead-abedc4d9f6cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbc91fbf-31aa-4f3c-8ead-abedc4d9f6cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbc91fbf-31aa-4f3c-8ead-abedc4d9f6cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fe6e34d-e263-4858-8c99-9d4cd2000e18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fe6e34d-e263-4858-8c99-9d4cd2000e18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fe6e34d-e263-4858-8c99-9d4cd2000e18>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab2e2f2a-cd1b-41a7-97ee-7060ad98ee77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab2e2f2a-cd1b-41a7-97ee-7060ad98ee77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab2e2f2a-cd1b-41a7-97ee-7060ad98ee77>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa7a200f-34d7-4227-91e3-8ef2df1f313d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa7a200f-34d7-4227-91e3-8ef2df1f313d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa7a200f-34d7-4227-91e3-8ef2df1f313d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fddc472c-b74b-42d5-b9f5-04fce359306a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fddc472c-b74b-42d5-b9f5-04fce359306a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fddc472c-b74b-42d5-b9f5-04fce359306a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4b0a619-11ec-48a3-a6bf-2426fe6104fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4b0a619-11ec-48a3-a6bf-2426fe6104fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4b0a619-11ec-48a3-a6bf-2426fe6104fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/821b3b00-1c74-447d-b687-77037b5eaf1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "821b3b00-1c74-447d-b687-77037b5eaf1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/821b3b00-1c74-447d-b687-77037b5eaf1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bf2ffd0-3d24-4f02-b1de-23d06f48ce3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bf2ffd0-3d24-4f02-b1de-23d06f48ce3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bf2ffd0-3d24-4f02-b1de-23d06f48ce3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/394abe0b-c50f-4108-b78a-e086a9dfe175> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "394abe0b-c50f-4108-b78a-e086a9dfe175";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/394abe0b-c50f-4108-b78a-e086a9dfe175>.
+    
+<http://data.lblod.info/id/remote-data-objects/b308da0d-4485-494a-9dff-7516e86817b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b308da0d-4485-494a-9dff-7516e86817b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b308da0d-4485-494a-9dff-7516e86817b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3a95cac-c31f-4ac1-a9f2-05bd9a095325> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3a95cac-c31f-4ac1-a9f2-05bd9a095325";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3a95cac-c31f-4ac1-a9f2-05bd9a095325>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcd0e2ba-1b55-437e-97be-131bbb96a6c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcd0e2ba-1b55-437e-97be-131bbb96a6c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcd0e2ba-1b55-437e-97be-131bbb96a6c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/bded2cd6-7c86-4869-9b65-8b4a537461d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bded2cd6-7c86-4869-9b65-8b4a537461d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_02-06-2022_17295.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bded2cd6-7c86-4869-9b65-8b4a537461d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f0b8975-faf8-4c2a-882f-0fb2c3bc2f37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f0b8975-faf8-4c2a-882f-0fb2c3bc2f37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_02-06-2022_17309.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f0b8975-faf8-4c2a-882f-0fb2c3bc2f37>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6fa2561-9897-48b4-aa64-8515fa03c6f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6fa2561-9897-48b4-aa64-8515fa03c6f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_02-06-2022_17313.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6fa2561-9897-48b4-aa64-8515fa03c6f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d2f1b8f-4398-4c15-bc08-8baebe43c4e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d2f1b8f-4398-4c15-bc08-8baebe43c4e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_02-06-2022_17318.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d2f1b8f-4398-4c15-bc08-8baebe43c4e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0827799-06b6-46ad-af2c-45d3de9de958> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0827799-06b6-46ad-af2c-45d3de9de958";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_02-12-2021_16208.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0827799-06b6-46ad-af2c-45d3de9de958>.
+    
+<http://data.lblod.info/id/remote-data-objects/18bddf3e-18ba-4ffe-8950-685edafe4819> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18bddf3e-18ba-4ffe-8950-685edafe4819";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_03-02-2022_16516.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18bddf3e-18ba-4ffe-8950-685edafe4819>.
+    
+<http://data.lblod.info/id/remote-data-objects/d76fdc7f-ec64-4a95-86c1-d912d9596bb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d76fdc7f-ec64-4a95-86c1-d912d9596bb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_03-03-2022_16694.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d76fdc7f-ec64-4a95-86c1-d912d9596bb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd38cfbb-58ce-4838-a05a-862a240c1ffa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd38cfbb-58ce-4838-a05a-862a240c1ffa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_03-03-2022_16695.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd38cfbb-58ce-4838-a05a-862a240c1ffa>.
+    
+<http://data.lblod.info/id/remote-data-objects/e92cec9a-5d07-4f19-821b-4ede88db8154> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e92cec9a-5d07-4f19-821b-4ede88db8154";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_03-03-2022_16697.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e92cec9a-5d07-4f19-821b-4ede88db8154>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5ca18d5-c05e-4273-881e-a9f89dfe3238> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5ca18d5-c05e-4273-881e-a9f89dfe3238";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_04-11-2021_16090.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5ca18d5-c05e-4273-881e-a9f89dfe3238>.
+    
+<http://data.lblod.info/id/remote-data-objects/43da9ad4-2e93-4f31-a05d-4b2b59b85982> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43da9ad4-2e93-4f31-a05d-4b2b59b85982";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_06-01-2022_16372.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43da9ad4-2e93-4f31-a05d-4b2b59b85982>.
+    
+<http://data.lblod.info/id/remote-data-objects/9834570a-727b-49d9-aa2d-2db0825c50a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9834570a-727b-49d9-aa2d-2db0825c50a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_06-01-2022_16373.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9834570a-727b-49d9-aa2d-2db0825c50a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/cca50a8f-d7b0-4b16-bd6b-3533811de586> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cca50a8f-d7b0-4b16-bd6b-3533811de586";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_06-01-2022_16375.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cca50a8f-d7b0-4b16-bd6b-3533811de586>.
+    
+<http://data.lblod.info/id/remote-data-objects/10794e7d-44d2-458b-8d19-d21e93abdfc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10794e7d-44d2-458b-8d19-d21e93abdfc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_07-04-2022_16890.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10794e7d-44d2-458b-8d19-d21e93abdfc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f6ade4f-9d03-497e-a425-0884c31891d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f6ade4f-9d03-497e-a425-0884c31891d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_07-10-2021_15939.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f6ade4f-9d03-497e-a425-0884c31891d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/819c68c2-88c3-4e77-902f-9e5fadf29b46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "819c68c2-88c3-4e77-902f-9e5fadf29b46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_09-06-2022_17327.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/819c68c2-88c3-4e77-902f-9e5fadf29b46>.
+    
+<http://data.lblod.info/id/remote-data-objects/528caed2-7b89-4fa7-beff-8413e7fb2371> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "528caed2-7b89-4fa7-beff-8413e7fb2371";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_09-06-2022_17344.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/528caed2-7b89-4fa7-beff-8413e7fb2371>.
+    
+<http://data.lblod.info/id/remote-data-objects/95c29436-73a9-4fda-a136-e227025a4bdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95c29436-73a9-4fda-a136-e227025a4bdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_09-06-2022_17345.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95c29436-73a9-4fda-a136-e227025a4bdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7fd63ee-7390-40c6-af7b-47b33677f566> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7fd63ee-7390-40c6-af7b-47b33677f566";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_09-12-2021_16243.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7fd63ee-7390-40c6-af7b-47b33677f566>.
+    
+<http://data.lblod.info/id/remote-data-objects/60d0dccc-aef1-47a2-8c49-c93ef00f8e05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60d0dccc-aef1-47a2-8c49-c93ef00f8e05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_10-03-2022_16699.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60d0dccc-aef1-47a2-8c49-c93ef00f8e05>.
+    
+<http://data.lblod.info/id/remote-data-objects/913fc34b-a9e1-4d03-8219-4335e749cfc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "913fc34b-a9e1-4d03-8219-4335e749cfc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_10-03-2022_16703.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/913fc34b-a9e1-4d03-8219-4335e749cfc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca6ba8c7-598b-47ec-bbdd-de4f7c65f25b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca6ba8c7-598b-47ec-bbdd-de4f7c65f25b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_10-03-2022_16743.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca6ba8c7-598b-47ec-bbdd-de4f7c65f25b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6028253b-bd46-4f42-afb6-5644200643ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6028253b-bd46-4f42-afb6-5644200643ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_10-03-2022_16744.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6028253b-bd46-4f42-afb6-5644200643ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/c148c29a-c2e2-4a66-8151-a3f85c316f9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c148c29a-c2e2-4a66-8151-a3f85c316f9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_10-03-2022_16749.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c148c29a-c2e2-4a66-8151-a3f85c316f9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fad309a-20e3-4b3f-852e-4268df3d7386> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fad309a-20e3-4b3f-852e-4268df3d7386";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_12-05-2022_17148.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fad309a-20e3-4b3f-852e-4268df3d7386>.
+    
+<http://data.lblod.info/id/remote-data-objects/97e0601c-29b7-42b3-8d77-d5abd6c5ee4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97e0601c-29b7-42b3-8d77-d5abd6c5ee4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_12-05-2022_17150.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97e0601c-29b7-42b3-8d77-d5abd6c5ee4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e3ed6a6-0c63-44c5-bf9c-142496d4806c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e3ed6a6-0c63-44c5-bf9c-142496d4806c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_13-01-2022_16384.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e3ed6a6-0c63-44c5-bf9c-142496d4806c>.
+    
+<http://data.lblod.info/id/remote-data-objects/565b715b-80e8-4cb8-9cbc-0b8bbfaa6e5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "565b715b-80e8-4cb8-9cbc-0b8bbfaa6e5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_13-01-2022_16395.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/565b715b-80e8-4cb8-9cbc-0b8bbfaa6e5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3e74297-b2c5-442c-ad93-7a06b3033aed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3e74297-b2c5-442c-ad93-7a06b3033aed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_13-01-2022_16398.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3e74297-b2c5-442c-ad93-7a06b3033aed>.
+    
+<http://data.lblod.info/id/remote-data-objects/96454502-7633-42b2-af7a-395a8684ebf0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96454502-7633-42b2-af7a-395a8684ebf0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_14-04-2022_16915.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96454502-7633-42b2-af7a-395a8684ebf0>.
+    
+<http://data.lblod.info/id/remote-data-objects/faea3bd3-08e9-489d-90ab-ae34154d81ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "faea3bd3-08e9-489d-90ab-ae34154d81ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_14-04-2022_16917.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/faea3bd3-08e9-489d-90ab-ae34154d81ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/25f4e3ef-f21c-4e62-a824-fc7f00a365a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25f4e3ef-f21c-4e62-a824-fc7f00a365a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_14-07-2022_17562.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25f4e3ef-f21c-4e62-a824-fc7f00a365a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/db115753-bfd1-46cf-ace6-8343bc6c3774> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db115753-bfd1-46cf-ace6-8343bc6c3774";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_14-07-2022_17611.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db115753-bfd1-46cf-ace6-8343bc6c3774>.
+    
+<http://data.lblod.info/id/remote-data-objects/2768f7b6-6235-4356-aed1-390fe0e032a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2768f7b6-6235-4356-aed1-390fe0e032a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_14-10-2021_15941.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2768f7b6-6235-4356-aed1-390fe0e032a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e56dadc4-3683-4efc-95e9-5a60b8302588> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e56dadc4-3683-4efc-95e9-5a60b8302588";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_14-10-2021_15943.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e56dadc4-3683-4efc-95e9-5a60b8302588>.
+    
+<http://data.lblod.info/id/remote-data-objects/90899a1b-278e-4e27-ab17-104c75aeef6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90899a1b-278e-4e27-ab17-104c75aeef6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_14-10-2021_15944.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90899a1b-278e-4e27-ab17-104c75aeef6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7c66ba4-d2c2-4c16-a582-77c50eda5f4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7c66ba4-d2c2-4c16-a582-77c50eda5f4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_16-06-2022_17353.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb6821cb-1f2b-4d7b-9c50-63ce80e7d569> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7c66ba4-d2c2-4c16-a582-77c50eda5f4d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201711-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201711-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201711-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201711-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/ccf94d78-c5f2-4249-9a9a-6629f143d0f1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ccf94d78-c5f2-4249-9a9a-6629f143d0f1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "71144e37-8227-4662-aa36-44d01bcbd27b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/8d618964-92b8-43c3-bf8b-3f14c56f8542> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8d618964-92b8-43c3-bf8b-3f14c56f8542";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b>.
+
+  <http://redpencil.data.gift/id/task/e5e38c0f-2372-4a1d-a631-738025a25c2f> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e5e38c0f-2372-4a1d-a631-738025a25c2f";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/ccf94d78-c5f2-4249-9a9a-6629f143d0f1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/8d618964-92b8-43c3-bf8b-3f14c56f8542>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/cc81c01c-086d-48c6-baf8-aa8c3372a9a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc81c01c-086d-48c6-baf8-aa8c3372a9a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_16-06-2022_17409.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc81c01c-086d-48c6-baf8-aa8c3372a9a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8612413d-3ee7-4f26-a0a2-6d4685179010> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8612413d-3ee7-4f26-a0a2-6d4685179010";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_16-12-2021_16292.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8612413d-3ee7-4f26-a0a2-6d4685179010>.
+    
+<http://data.lblod.info/id/remote-data-objects/68948d2b-15e6-485d-86f7-957a2892e9e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68948d2b-15e6-485d-86f7-957a2892e9e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_17-02-2022_16566.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68948d2b-15e6-485d-86f7-957a2892e9e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/858de4e8-9794-4c35-bb62-d68e3c22164c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "858de4e8-9794-4c35-bb62-d68e3c22164c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_17-02-2022_16617.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/858de4e8-9794-4c35-bb62-d68e3c22164c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bd2eba8-1397-4e50-a28d-577a536581d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bd2eba8-1397-4e50-a28d-577a536581d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_17-03-2022_16689.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bd2eba8-1397-4e50-a28d-577a536581d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/6aaa98d1-5973-4660-a819-763b5f64e137> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6aaa98d1-5973-4660-a819-763b5f64e137";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_17-03-2022_16690.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6aaa98d1-5973-4660-a819-763b5f64e137>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d06efd8-fc7b-4abb-accb-193024e84d46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d06efd8-fc7b-4abb-accb-193024e84d46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_17-03-2022_16691.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d06efd8-fc7b-4abb-accb-193024e84d46>.
+    
+<http://data.lblod.info/id/remote-data-objects/47564433-c082-4561-b8ca-220c4d9ba337> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47564433-c082-4561-b8ca-220c4d9ba337";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_19-05-2022_17206.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47564433-c082-4561-b8ca-220c4d9ba337>.
+    
+<http://data.lblod.info/id/remote-data-objects/015cb56c-335f-45c9-aada-d829847ae441> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "015cb56c-335f-45c9-aada-d829847ae441";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_19-05-2022_17207.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/015cb56c-335f-45c9-aada-d829847ae441>.
+    
+<http://data.lblod.info/id/remote-data-objects/c68a0d2e-ac4b-441a-a28f-9fdbd73453c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c68a0d2e-ac4b-441a-a28f-9fdbd73453c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_20-01-2022_16447.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c68a0d2e-ac4b-441a-a28f-9fdbd73453c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/04146517-b631-4872-a6a8-9ad1aa8bd75e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04146517-b631-4872-a6a8-9ad1aa8bd75e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_20-01-2022_16449.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04146517-b631-4872-a6a8-9ad1aa8bd75e>.
+    
+<http://data.lblod.info/id/remote-data-objects/601328d4-64a5-4992-9481-27f25c651fe1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "601328d4-64a5-4992-9481-27f25c651fe1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_20-01-2022_16452.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/601328d4-64a5-4992-9481-27f25c651fe1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ceff5d3-eea5-4a2f-8a6c-e5fa753f73bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ceff5d3-eea5-4a2f-8a6c-e5fa753f73bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_20-01-2022_16453.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ceff5d3-eea5-4a2f-8a6c-e5fa753f73bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/9042a1e8-3f45-4e00-96d9-e361683b36ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9042a1e8-3f45-4e00-96d9-e361683b36ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_21-10-2021_15983.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9042a1e8-3f45-4e00-96d9-e361683b36ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/3212d669-33dd-4992-bb3d-fb23e5e29ae3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3212d669-33dd-4992-bb3d-fb23e5e29ae3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_23-06-2022_17423.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3212d669-33dd-4992-bb3d-fb23e5e29ae3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1784260-f3ee-4047-ad74-a52e78563504> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1784260-f3ee-4047-ad74-a52e78563504";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_23-06-2022_17467.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1784260-f3ee-4047-ad74-a52e78563504>.
+    
+<http://data.lblod.info/id/remote-data-objects/be3418a9-039a-45ee-8ed6-8d3f13fcb15c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be3418a9-039a-45ee-8ed6-8d3f13fcb15c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_24-02-2022_16639.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be3418a9-039a-45ee-8ed6-8d3f13fcb15c>.
+    
+<http://data.lblod.info/id/remote-data-objects/60fe67f7-7237-4dcc-837d-462682847f0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60fe67f7-7237-4dcc-837d-462682847f0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_24-02-2022_16641.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60fe67f7-7237-4dcc-837d-462682847f0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb0c5370-4229-44cd-b40b-e3339aad38be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb0c5370-4229-44cd-b40b-e3339aad38be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_24-02-2022_16668.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb0c5370-4229-44cd-b40b-e3339aad38be>.
+    
+<http://data.lblod.info/id/remote-data-objects/60ff0459-2316-4d4b-91db-18212423b5cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60ff0459-2316-4d4b-91db-18212423b5cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_24-02-2022_16674.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60ff0459-2316-4d4b-91db-18212423b5cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdf287c1-78f0-488c-88cc-45f48ff89578> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdf287c1-78f0-488c-88cc-45f48ff89578";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_24-02-2022_16682.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdf287c1-78f0-488c-88cc-45f48ff89578>.
+    
+<http://data.lblod.info/id/remote-data-objects/5592451b-f65a-4f7b-a0a4-ec5dd9ad1b13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5592451b-f65a-4f7b-a0a4-ec5dd9ad1b13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_25-05-2022_17217.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5592451b-f65a-4f7b-a0a4-ec5dd9ad1b13>.
+    
+<http://data.lblod.info/id/remote-data-objects/265c7bfa-cba3-49db-9682-8f258b12c48e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "265c7bfa-cba3-49db-9682-8f258b12c48e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_27-01-2022_16474.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/265c7bfa-cba3-49db-9682-8f258b12c48e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3ad1d6a-60f6-4809-92a7-055c09796182> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3ad1d6a-60f6-4809-92a7-055c09796182";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_28-04-2022_17037.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3ad1d6a-60f6-4809-92a7-055c09796182>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f1db055-8a29-472e-9739-f2d76313886e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f1db055-8a29-472e-9739-f2d76313886e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_30-06-2022_17507.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f1db055-8a29-472e-9739-f2d76313886e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5a2aeef-6683-487a-99a3-e3ab404be945> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5a2aeef-6683-487a-99a3-e3ab404be945";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_31-03-2022_16562.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5a2aeef-6683-487a-99a3-e3ab404be945>.
+    
+<http://data.lblod.info/id/remote-data-objects/a895b114-af4c-4286-9a74-ebf156e76a4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a895b114-af4c-4286-9a74-ebf156e76a4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/884dbbe51608fb34d615349fd3b4813b2fdb6b0dbda77d03818bdb0f30660517/GetPublication?filename=Uittreksels_31-03-2022_16823.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a895b114-af4c-4286-9a74-ebf156e76a4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2775d80-d13d-4038-82a3-4b23ddace69f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2775d80-d13d-4038-82a3-4b23ddace69f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Agenda_OCMW-Raad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2775d80-d13d-4038-82a3-4b23ddace69f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9f466eb-4740-4cb0-ac6b-68452c625086> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9f466eb-4740-4cb0-ac6b-68452c625086";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Agenda_OCMW-Raad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9f466eb-4740-4cb0-ac6b-68452c625086>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cf9b07b-d0c8-4ce8-ba48-212745e4337f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cf9b07b-d0c8-4ce8-ba48-212745e4337f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Agenda_OCMW-Raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cf9b07b-d0c8-4ce8-ba48-212745e4337f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d38a5a45-f9a4-4284-b89c-32fedfc58ad4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d38a5a45-f9a4-4284-b89c-32fedfc58ad4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Agenda_OCMW-Raad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d38a5a45-f9a4-4284-b89c-32fedfc58ad4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6251043a-c1a1-4785-ac49-faad7e2bf1c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6251043a-c1a1-4785-ac49-faad7e2bf1c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Agenda_OCMW-Raad_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6251043a-c1a1-4785-ac49-faad7e2bf1c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/69b88e84-9f11-4738-88b7-81967d9cc39c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69b88e84-9f11-4738-88b7-81967d9cc39c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Agenda_OCMW-Raad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69b88e84-9f11-4738-88b7-81967d9cc39c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef0ea244-7c56-4b06-a3e7-4f8e711e19b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef0ea244-7c56-4b06-a3e7-4f8e711e19b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Agenda_OCMW-Raad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef0ea244-7c56-4b06-a3e7-4f8e711e19b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/38555b1d-4fae-432c-a5e9-9a739c4963a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38555b1d-4fae-432c-a5e9-9a739c4963a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Agenda_OCMW-Raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38555b1d-4fae-432c-a5e9-9a739c4963a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dd2eef9-2f67-4bbf-9dc9-41cacdaaed01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dd2eef9-2f67-4bbf-9dc9-41cacdaaed01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dd2eef9-2f67-4bbf-9dc9-41cacdaaed01>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa29b8d7-2130-49e7-a462-228a86fa709c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa29b8d7-2130-49e7-a462-228a86fa709c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa29b8d7-2130-49e7-a462-228a86fa709c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b481276b-d9a9-4f2e-bb94-7221bde501c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b481276b-d9a9-4f2e-bb94-7221bde501c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b481276b-d9a9-4f2e-bb94-7221bde501c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4a3eb01-7577-4a72-a772-e160ed7f3e13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4a3eb01-7577-4a72-a772-e160ed7f3e13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4a3eb01-7577-4a72-a772-e160ed7f3e13>.
+    
+<http://data.lblod.info/id/remote-data-objects/4475ed36-aac9-4050-9760-6dd20ba3b3a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4475ed36-aac9-4050-9760-6dd20ba3b3a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4475ed36-aac9-4050-9760-6dd20ba3b3a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/540dde35-dc71-4b1c-bed2-d59792bbbc9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "540dde35-dc71-4b1c-bed2-d59792bbbc9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/540dde35-dc71-4b1c-bed2-d59792bbbc9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9134559f-bc68-47b2-afcc-459f33c42b38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9134559f-bc68-47b2-afcc-459f33c42b38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9134559f-bc68-47b2-afcc-459f33c42b38>.
+    
+<http://data.lblod.info/id/remote-data-objects/1296666e-1014-420b-afd8-5221413883ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1296666e-1014-420b-afd8-5221413883ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=BesluitenLijstUitspraak_OCMW-Raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1296666e-1014-420b-afd8-5221413883ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/d83ed027-ae3f-4fc0-8258-3d88c7d9552e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d83ed027-ae3f-4fc0-8258-3d88c7d9552e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Notulen_OCMW-Raad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d83ed027-ae3f-4fc0-8258-3d88c7d9552e>.
+    
+<http://data.lblod.info/id/remote-data-objects/08e88d43-ef38-42c2-8156-11a2e8a6bebc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08e88d43-ef38-42c2-8156-11a2e8a6bebc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Notulen_OCMW-Raad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08e88d43-ef38-42c2-8156-11a2e8a6bebc>.
+    
+<http://data.lblod.info/id/remote-data-objects/07e406e0-1494-4e29-be31-d2c0cf115040> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07e406e0-1494-4e29-be31-d2c0cf115040";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Notulen_OCMW-Raad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07e406e0-1494-4e29-be31-d2c0cf115040>.
+    
+<http://data.lblod.info/id/remote-data-objects/955e3c0a-aaa8-46a1-8acb-327e2a1f2ff3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "955e3c0a-aaa8-46a1-8acb-327e2a1f2ff3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Notulen_OCMW-Raad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/955e3c0a-aaa8-46a1-8acb-327e2a1f2ff3>.
+    
+<http://data.lblod.info/id/remote-data-objects/810f6e1d-f043-4232-b6fd-243f43366e96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "810f6e1d-f043-4232-b6fd-243f43366e96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Notulen_OCMW-Raad_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/810f6e1d-f043-4232-b6fd-243f43366e96>.
+    
+<http://data.lblod.info/id/remote-data-objects/c00e04a4-38ca-4902-8804-41497ce23dff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c00e04a4-38ca-4902-8804-41497ce23dff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Notulen_OCMW-Raad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c00e04a4-38ca-4902-8804-41497ce23dff>.
+    
+<http://data.lblod.info/id/remote-data-objects/57c96613-8f8b-4455-a685-b3b60ef43354> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57c96613-8f8b-4455-a685-b3b60ef43354";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Notulen_OCMW-Raad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71144e37-8227-4662-aa36-44d01bcbd27b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57c96613-8f8b-4455-a685-b3b60ef43354>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201712-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201712-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201712-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201712-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/9ec29c0e-c0ca-45f9-a167-b36a98c6874b> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9ec29c0e-c0ca-45f9-a167-b36a98c6874b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "96842955-4776-4aa7-888e-a5f10fee4cbe";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/0d490c37-407b-474f-af29-5fe3dbe0bd1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0d490c37-407b-474f-af29-5fe3dbe0bd1c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe>.
+
+  <http://redpencil.data.gift/id/task/1f711fb6-d6e8-4d0e-9452-a63a1741a291> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1f711fb6-d6e8-4d0e-9452-a63a1741a291";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/9ec29c0e-c0ca-45f9-a167-b36a98c6874b>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/0d490c37-407b-474f-af29-5fe3dbe0bd1c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b9ca10c2-fb86-407c-94fa-4880329c8fea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9ca10c2-fb86-407c-94fa-4880329c8fea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Notulen_OCMW-Raad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9ca10c2-fb86-407c-94fa-4880329c8fea>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2c38fa2-ff67-4256-a30d-aab507b5462e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2c38fa2-ff67-4256-a30d-aab507b5462e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Uittreksels_23-06-2022_17307.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2c38fa2-ff67-4256-a30d-aab507b5462e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3021295c-c4b9-49f0-9c54-4657ce454dd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3021295c-c4b9-49f0-9c54-4657ce454dd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Uittreksels_23-12-2021_16242.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3021295c-c4b9-49f0-9c54-4657ce454dd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/40a80a51-def7-4ba0-9917-d3033f6cffb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40a80a51-def7-4ba0-9917-d3033f6cffb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Uittreksels_25-05-2022_17123.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40a80a51-def7-4ba0-9917-d3033f6cffb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/108fbf22-eb4e-47f3-aef6-4bcab639fc21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "108fbf22-eb4e-47f3-aef6-4bcab639fc21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Uittreksels_25-11-2021_16134.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/108fbf22-eb4e-47f3-aef6-4bcab639fc21>.
+    
+<http://data.lblod.info/id/remote-data-objects/f94dbc78-d3cf-4700-85c3-a6310c2fdda0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f94dbc78-d3cf-4700-85c3-a6310c2fdda0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/ad933a3247ab634eb1a8c7233e77d6ea8cd2b6e1950d302832d065dcb516bcf5/GetPublication?filename=Uittreksels_28-04-2022_16884.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f94dbc78-d3cf-4700-85c3-a6310c2fdda0>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e7ef276-d009-4c8a-a9db-3cca85bc24f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e7ef276-d009-4c8a-a9db-3cca85bc24f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Agenda_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e7ef276-d009-4c8a-a9db-3cca85bc24f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/92867a6a-ae5d-456e-a894-cb76b448c08f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92867a6a-ae5d-456e-a894-cb76b448c08f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Agenda_Gemeenteraad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92867a6a-ae5d-456e-a894-cb76b448c08f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a026c15-eb63-4407-be0b-0ac96b1539b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a026c15-eb63-4407-be0b-0ac96b1539b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Agenda_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a026c15-eb63-4407-be0b-0ac96b1539b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b54c884-ac55-4137-afa1-c5fd314f36e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b54c884-ac55-4137-afa1-c5fd314f36e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Agenda_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b54c884-ac55-4137-afa1-c5fd314f36e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/882eb128-7645-4fd7-a4cc-9b6525ee0c3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "882eb128-7645-4fd7-a4cc-9b6525ee0c3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Agenda_Gemeenteraad_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/882eb128-7645-4fd7-a4cc-9b6525ee0c3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b1def24-8df5-4af0-8fea-2a52a68804d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b1def24-8df5-4af0-8fea-2a52a68804d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Agenda_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b1def24-8df5-4af0-8fea-2a52a68804d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/155fd2e4-6a35-4468-9f97-bbb221667ff2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "155fd2e4-6a35-4468-9f97-bbb221667ff2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Agenda_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/155fd2e4-6a35-4468-9f97-bbb221667ff2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a3ec63a-2838-459a-943e-7e679b804d6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a3ec63a-2838-459a-943e-7e679b804d6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Agenda_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a3ec63a-2838-459a-943e-7e679b804d6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/da9fe24b-6841-4187-a92a-819fb6ca04f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da9fe24b-6841-4187-a92a-819fb6ca04f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Agenda_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da9fe24b-6841-4187-a92a-819fb6ca04f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1738962-5b0e-4cf1-b453-b8ff52100560> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1738962-5b0e-4cf1-b453-b8ff52100560";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1738962-5b0e-4cf1-b453-b8ff52100560>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f349af0-04d2-46de-85b6-24410f2116c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f349af0-04d2-46de-85b6-24410f2116c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f349af0-04d2-46de-85b6-24410f2116c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b19858b-92f0-4056-acb3-0fbf9657268d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b19858b-92f0-4056-acb3-0fbf9657268d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b19858b-92f0-4056-acb3-0fbf9657268d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e1be4cd-2d7d-4feb-92c7-24331ec154d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e1be4cd-2d7d-4feb-92c7-24331ec154d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e1be4cd-2d7d-4feb-92c7-24331ec154d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6f23bb2-2b08-4e6f-8114-852489a2cc16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6f23bb2-2b08-4e6f-8114-852489a2cc16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6f23bb2-2b08-4e6f-8114-852489a2cc16>.
+    
+<http://data.lblod.info/id/remote-data-objects/44745132-3b04-4c30-88e8-3deb44fd38a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44745132-3b04-4c30-88e8-3deb44fd38a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44745132-3b04-4c30-88e8-3deb44fd38a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c18bd379-2af4-4da1-a288-9f34d07bfe21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c18bd379-2af4-4da1-a288-9f34d07bfe21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c18bd379-2af4-4da1-a288-9f34d07bfe21>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d077108-a221-4138-8a28-8314a72dde0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d077108-a221-4138-8a28-8314a72dde0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d077108-a221-4138-8a28-8314a72dde0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/482a99fc-f3e0-467d-8ac3-cf8598e7fac3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "482a99fc-f3e0-467d-8ac3-cf8598e7fac3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/482a99fc-f3e0-467d-8ac3-cf8598e7fac3>.
+    
+<http://data.lblod.info/id/remote-data-objects/bea42737-253d-407c-9d2b-8a7880ee7c2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bea42737-253d-407c-9d2b-8a7880ee7c2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Notulen_Gemeenteraad_23-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bea42737-253d-407c-9d2b-8a7880ee7c2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea7a32e8-c16d-4b01-8de1-2a785b7c8d45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea7a32e8-c16d-4b01-8de1-2a785b7c8d45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Notulen_Gemeenteraad_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea7a32e8-c16d-4b01-8de1-2a785b7c8d45>.
+    
+<http://data.lblod.info/id/remote-data-objects/1215db6b-6d9c-45fe-9f7a-0e04915b5641> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1215db6b-6d9c-45fe-9f7a-0e04915b5641";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Notulen_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1215db6b-6d9c-45fe-9f7a-0e04915b5641>.
+    
+<http://data.lblod.info/id/remote-data-objects/23e031d2-a0dc-41d8-b169-8c220e1875dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23e031d2-a0dc-41d8-b169-8c220e1875dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Notulen_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23e031d2-a0dc-41d8-b169-8c220e1875dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfd4705e-a0db-4c9a-ae9d-8acf5b2e4be2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfd4705e-a0db-4c9a-ae9d-8acf5b2e4be2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Notulen_Gemeenteraad_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfd4705e-a0db-4c9a-ae9d-8acf5b2e4be2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c13d606a-3bfd-4a86-a2d7-4bdb2053abbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c13d606a-3bfd-4a86-a2d7-4bdb2053abbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Notulen_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c13d606a-3bfd-4a86-a2d7-4bdb2053abbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/15a6658d-3666-48b2-8c49-ef02796e4e10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15a6658d-3666-48b2-8c49-ef02796e4e10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Notulen_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15a6658d-3666-48b2-8c49-ef02796e4e10>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f1eefdd-b0e7-41f0-bf99-84d9011bd922> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f1eefdd-b0e7-41f0-bf99-84d9011bd922";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Notulen_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f1eefdd-b0e7-41f0-bf99-84d9011bd922>.
+    
+<http://data.lblod.info/id/remote-data-objects/48ab307b-3f31-43f7-ab1e-2d6638c92419> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48ab307b-3f31-43f7-ab1e-2d6638c92419";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Notulen_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48ab307b-3f31-43f7-ab1e-2d6638c92419>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ec53151-f23b-49ea-a71e-81042e6c2ad2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ec53151-f23b-49ea-a71e-81042e6c2ad2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ec53151-f23b-49ea-a71e-81042e6c2ad2>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b071de8-1a3a-4699-8aef-444efa9b9e63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b071de8-1a3a-4699-8aef-444efa9b9e63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b071de8-1a3a-4699-8aef-444efa9b9e63>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e3c7208-6a31-45f3-954a-acab0247df4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e3c7208-6a31-45f3-954a-acab0247df4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_23-06-2022_17305.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e3c7208-6a31-45f3-954a-acab0247df4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/49091ee2-a8f8-4d05-8044-4f1049372963> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49091ee2-a8f8-4d05-8044-4f1049372963";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_23-06-2022_17306.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49091ee2-a8f8-4d05-8044-4f1049372963>.
+    
+<http://data.lblod.info/id/remote-data-objects/20ed53a8-cdc2-4f38-bf53-0416147fe5d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20ed53a8-cdc2-4f38-bf53-0416147fe5d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_23-06-2022_17355.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20ed53a8-cdc2-4f38-bf53-0416147fe5d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/06c572de-8428-4d0b-a1ea-788ec06a385f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06c572de-8428-4d0b-a1ea-788ec06a385f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_23-06-2022_17368.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06c572de-8428-4d0b-a1ea-788ec06a385f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7877f308-a5e6-4c58-b461-894bf9091b93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7877f308-a5e6-4c58-b461-894bf9091b93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_23-12-2021_15985.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7877f308-a5e6-4c58-b461-894bf9091b93>.
+    
+<http://data.lblod.info/id/remote-data-objects/add028f9-097a-4c0b-907e-2d1d36c8ed84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "add028f9-097a-4c0b-907e-2d1d36c8ed84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_23-12-2021_15996.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/add028f9-097a-4c0b-907e-2d1d36c8ed84>.
+    
+<http://data.lblod.info/id/remote-data-objects/29cccfd3-7f05-4c62-aebd-537f4735549f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29cccfd3-7f05-4c62-aebd-537f4735549f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_23-12-2021_16173.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29cccfd3-7f05-4c62-aebd-537f4735549f>.
+    
+<http://data.lblod.info/id/remote-data-objects/917e188d-49fd-476c-aca5-0e0df76714fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "917e188d-49fd-476c-aca5-0e0df76714fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_24-02-2022_16473.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/917e188d-49fd-476c-aca5-0e0df76714fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1c4a790-bb26-4c58-826a-9f1afac73941> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1c4a790-bb26-4c58-826a-9f1afac73941";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_24-02-2022_16511.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1c4a790-bb26-4c58-826a-9f1afac73941>.
+    
+<http://data.lblod.info/id/remote-data-objects/eaff1b73-c42e-48a1-8868-48eabad0efe5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eaff1b73-c42e-48a1-8868-48eabad0efe5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_25-05-2022_17012.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eaff1b73-c42e-48a1-8868-48eabad0efe5>.
+    
+<http://data.lblod.info/id/remote-data-objects/93e01974-b523-4046-86b4-10c19e2d5654> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93e01974-b523-4046-86b4-10c19e2d5654";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_25-05-2022_17013.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93e01974-b523-4046-86b4-10c19e2d5654>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0958251-aaf1-4ef6-9f97-bf6bdd22faec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0958251-aaf1-4ef6-9f97-bf6bdd22faec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_25-05-2022_17014.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0958251-aaf1-4ef6-9f97-bf6bdd22faec>.
+    
+<http://data.lblod.info/id/remote-data-objects/94a72e0a-071b-4f99-811f-090ed053ccda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94a72e0a-071b-4f99-811f-090ed053ccda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_25-05-2022_17015.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94a72e0a-071b-4f99-811f-090ed053ccda>.
+    
+<http://data.lblod.info/id/remote-data-objects/10bc9f60-4ed6-4cdf-a099-7c7d8cfb8622> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10bc9f60-4ed6-4cdf-a099-7c7d8cfb8622";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_25-05-2022_17016.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10bc9f60-4ed6-4cdf-a099-7c7d8cfb8622>.
+    
+<http://data.lblod.info/id/remote-data-objects/34cd1fe2-5d3d-4435-ace1-4b0fd5e9e137> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34cd1fe2-5d3d-4435-ace1-4b0fd5e9e137";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_25-05-2022_17017.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/96842955-4776-4aa7-888e-a5f10fee4cbe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34cd1fe2-5d3d-4435-ace1-4b0fd5e9e137>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201713-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201713-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201713-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201713-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/80fb3290-23f3-493c-b634-d7b97c2f35fd> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "80fb3290-23f3-493c-b634-d7b97c2f35fd";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e3962c16-5ca8-419e-b491-44941152e4f8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4ea16324-c568-4b51-a943-fff891bd8139> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4ea16324-c568-4b51-a943-fff891bd8139";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8>.
+
+  <http://redpencil.data.gift/id/task/2f71bb6e-ffe7-4a6b-b970-58680957ce07> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2f71bb6e-ffe7-4a6b-b970-58680957ce07";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/80fb3290-23f3-493c-b634-d7b97c2f35fd>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4ea16324-c568-4b51-a943-fff891bd8139>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/aaa2ad83-1b17-4519-b37e-78ed88c4b16f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aaa2ad83-1b17-4519-b37e-78ed88c4b16f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_25-05-2022_17121.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aaa2ad83-1b17-4519-b37e-78ed88c4b16f>.
+    
+<http://data.lblod.info/id/remote-data-objects/faf5cae2-2eb2-4845-9c79-21b8660c7c67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "faf5cae2-2eb2-4845-9c79-21b8660c7c67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_25-05-2022_17122.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/faf5cae2-2eb2-4845-9c79-21b8660c7c67>.
+    
+<http://data.lblod.info/id/remote-data-objects/98558f01-82f0-4236-97c4-8878dc3c759a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98558f01-82f0-4236-97c4-8878dc3c759a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_25-05-2022_17195.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98558f01-82f0-4236-97c4-8878dc3c759a>.
+    
+<http://data.lblod.info/id/remote-data-objects/30112c89-ea38-4f8e-b50d-c0e73e8f9af4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30112c89-ea38-4f8e-b50d-c0e73e8f9af4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_25-05-2022_17199.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30112c89-ea38-4f8e-b50d-c0e73e8f9af4>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e434bb2-5eb4-4e91-8278-c0be9c2d3f03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e434bb2-5eb4-4e91-8278-c0be9c2d3f03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_25-11-2021_16118.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e434bb2-5eb4-4e91-8278-c0be9c2d3f03>.
+    
+<http://data.lblod.info/id/remote-data-objects/1267c2e5-49da-41c6-a36b-8e6cfc7c5756> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1267c2e5-49da-41c6-a36b-8e6cfc7c5756";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_25-11-2021_16135.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1267c2e5-49da-41c6-a36b-8e6cfc7c5756>.
+    
+<http://data.lblod.info/id/remote-data-objects/a68b58ad-47e5-484a-bd2e-89fab18f7d6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a68b58ad-47e5-484a-bd2e-89fab18f7d6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_25-11-2021_16136.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a68b58ad-47e5-484a-bd2e-89fab18f7d6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4e73925-9bb6-4808-97cd-71bd4b2f1a16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4e73925-9bb6-4808-97cd-71bd4b2f1a16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_25-11-2021_16137.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4e73925-9bb6-4808-97cd-71bd4b2f1a16>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fa9f38d-949e-41f8-87d2-dd66c142356c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fa9f38d-949e-41f8-87d2-dd66c142356c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_28-04-2022_16876.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fa9f38d-949e-41f8-87d2-dd66c142356c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed134950-ae80-4291-b854-fefc692a10b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed134950-ae80-4291-b854-fefc692a10b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_28-04-2022_16898.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed134950-ae80-4291-b854-fefc692a10b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c8e2fc0-1022-473f-9a97-41a116babf45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c8e2fc0-1022-473f-9a97-41a116babf45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_28-04-2022_16946.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c8e2fc0-1022-473f-9a97-41a116babf45>.
+    
+<http://data.lblod.info/id/remote-data-objects/7beb8294-0c16-4956-9641-2eda3e145785> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7beb8294-0c16-4956-9641-2eda3e145785";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.voeren.be/LBLODWeb/Home/Overzicht/c5007c39f1247f7e7c76f06a439302709b4e7856ec28baf72ef3a87cc21cd4fc/GetPublication?filename=Uittreksels_28-04-2022_16947.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7beb8294-0c16-4956-9641-2eda3e145785>.
+    
+<http://data.lblod.info/id/remote-data-objects/3afdee51-1d53-4380-90f5-ecfaec5faefe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3afdee51-1d53-4380-90f5-ecfaec5faefe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3afdee51-1d53-4380-90f5-ecfaec5faefe>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c07beb5-7eea-40a0-afc9-a497b9a0e080> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c07beb5-7eea-40a0-afc9-a497b9a0e080";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c07beb5-7eea-40a0-afc9-a497b9a0e080>.
+    
+<http://data.lblod.info/id/remote-data-objects/e12f57fe-b72f-448e-a0bb-789dc6a7c752> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e12f57fe-b72f-448e-a0bb-789dc6a7c752";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_02-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e12f57fe-b72f-448e-a0bb-789dc6a7c752>.
+    
+<http://data.lblod.info/id/remote-data-objects/c05ecfe7-b57e-484f-83bc-7b3721f93f6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c05ecfe7-b57e-484f-83bc-7b3721f93f6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_02-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c05ecfe7-b57e-484f-83bc-7b3721f93f6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f66ec9b1-faab-4cf7-b485-056a2254ba56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f66ec9b1-faab-4cf7-b485-056a2254ba56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f66ec9b1-faab-4cf7-b485-056a2254ba56>.
+    
+<http://data.lblod.info/id/remote-data-objects/75ffff9b-3844-437b-b541-62ad1e40261a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75ffff9b-3844-437b-b541-62ad1e40261a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75ffff9b-3844-437b-b541-62ad1e40261a>.
+    
+<http://data.lblod.info/id/remote-data-objects/27376423-d6ab-4f7f-a8aa-b20e7a5cff85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27376423-d6ab-4f7f-a8aa-b20e7a5cff85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27376423-d6ab-4f7f-a8aa-b20e7a5cff85>.
+    
+<http://data.lblod.info/id/remote-data-objects/76648de2-c323-4dcc-9a08-32042df49e4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76648de2-c323-4dcc-9a08-32042df49e4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76648de2-c323-4dcc-9a08-32042df49e4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a02d4084-6c75-4fc6-b300-2bd9b952e6ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a02d4084-6c75-4fc6-b300-2bd9b952e6ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a02d4084-6c75-4fc6-b300-2bd9b952e6ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/0811c250-2b36-4038-be1d-af28022c66ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0811c250-2b36-4038-be1d-af28022c66ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0811c250-2b36-4038-be1d-af28022c66ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/b424f217-863e-4f0c-bcec-9e82357618f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b424f217-863e-4f0c-bcec-9e82357618f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b424f217-863e-4f0c-bcec-9e82357618f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/aec9dd6f-991e-466c-b79a-3abd38f38c60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aec9dd6f-991e-466c-b79a-3abd38f38c60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aec9dd6f-991e-466c-b79a-3abd38f38c60>.
+    
+<http://data.lblod.info/id/remote-data-objects/633395f8-6495-414e-8fdb-72297e1cb7d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "633395f8-6495-414e-8fdb-72297e1cb7d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/633395f8-6495-414e-8fdb-72297e1cb7d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ab8f4da-b083-49f3-86c4-a1fd4a6e4882> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ab8f4da-b083-49f3-86c4-a1fd4a6e4882";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ab8f4da-b083-49f3-86c4-a1fd4a6e4882>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf365045-1935-4865-8ab8-2388a5062f72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf365045-1935-4865-8ab8-2388a5062f72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf365045-1935-4865-8ab8-2388a5062f72>.
+    
+<http://data.lblod.info/id/remote-data-objects/793d1e08-ac33-4515-a75c-8679b2291f8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "793d1e08-ac33-4515-a75c-8679b2291f8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/793d1e08-ac33-4515-a75c-8679b2291f8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b327ac1b-7d6a-464f-9d87-71a7dcbfe76e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b327ac1b-7d6a-464f-9d87-71a7dcbfe76e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b327ac1b-7d6a-464f-9d87-71a7dcbfe76e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a393d6ee-f78c-40ea-974f-9622783ab1ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a393d6ee-f78c-40ea-974f-9622783ab1ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a393d6ee-f78c-40ea-974f-9622783ab1ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/59e676d2-953c-461c-ad99-f493e2055cd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59e676d2-953c-461c-ad99-f493e2055cd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59e676d2-953c-461c-ad99-f493e2055cd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6379b1d-f974-43fe-a0b6-fd1a137cb622> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6379b1d-f974-43fe-a0b6-fd1a137cb622";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6379b1d-f974-43fe-a0b6-fd1a137cb622>.
+    
+<http://data.lblod.info/id/remote-data-objects/25edbfa0-311f-4a8c-a25e-6e3c2c15c18e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25edbfa0-311f-4a8c-a25e-6e3c2c15c18e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25edbfa0-311f-4a8c-a25e-6e3c2c15c18e>.
+    
+<http://data.lblod.info/id/remote-data-objects/24dfa3a4-1fc5-40b6-9d85-e47d8a3c4bda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24dfa3a4-1fc5-40b6-9d85-e47d8a3c4bda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24dfa3a4-1fc5-40b6-9d85-e47d8a3c4bda>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fe1f2d6-3b74-4917-879f-1633e734648b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fe1f2d6-3b74-4917-879f-1633e734648b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fe1f2d6-3b74-4917-879f-1633e734648b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f1da027-99f9-4bae-80f0-2a8516d405b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f1da027-99f9-4bae-80f0-2a8516d405b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f1da027-99f9-4bae-80f0-2a8516d405b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0df6478d-54ff-4fc2-93a4-c0d6a49c617f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0df6478d-54ff-4fc2-93a4-c0d6a49c617f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0df6478d-54ff-4fc2-93a4-c0d6a49c617f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fa80653-5542-4fba-aa53-9cb807512301> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fa80653-5542-4fba-aa53-9cb807512301";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fa80653-5542-4fba-aa53-9cb807512301>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0ef10cd-92ee-4f90-8ab5-f7e81f791f93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0ef10cd-92ee-4f90-8ab5-f7e81f791f93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_19-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0ef10cd-92ee-4f90-8ab5-f7e81f791f93>.
+    
+<http://data.lblod.info/id/remote-data-objects/660fd792-9de4-4f82-b486-4becb2f798b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "660fd792-9de4-4f82-b486-4becb2f798b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/660fd792-9de4-4f82-b486-4becb2f798b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/cca141ad-c7b3-41b9-b7d6-b0551a5c64a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cca141ad-c7b3-41b9-b7d6-b0551a5c64a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cca141ad-c7b3-41b9-b7d6-b0551a5c64a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/6706c5b3-d57b-4d7d-9f02-d9d0d814bb3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6706c5b3-d57b-4d7d-9f02-d9d0d814bb3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6706c5b3-d57b-4d7d-9f02-d9d0d814bb3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/92fba25b-1e44-4e3f-a8f7-0fca960ebc3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92fba25b-1e44-4e3f-a8f7-0fca960ebc3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92fba25b-1e44-4e3f-a8f7-0fca960ebc3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/edb99d3e-12d5-4890-b262-d50451f6f8aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edb99d3e-12d5-4890-b262-d50451f6f8aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edb99d3e-12d5-4890-b262-d50451f6f8aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9cd0aff-e31a-4ca4-b4ce-63c33f444371> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9cd0aff-e31a-4ca4-b4ce-63c33f444371";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9cd0aff-e31a-4ca4-b4ce-63c33f444371>.
+    
+<http://data.lblod.info/id/remote-data-objects/80fcec72-aa2b-44a0-a420-916542dd7246> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80fcec72-aa2b-44a0-a420-916542dd7246";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80fcec72-aa2b-44a0-a420-916542dd7246>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8cf0442-bef8-4b61-b0d7-19fe2c77c92a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8cf0442-bef8-4b61-b0d7-19fe2c77c92a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8cf0442-bef8-4b61-b0d7-19fe2c77c92a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbb41cc7-5b5a-4d95-ac29-578178baaa4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbb41cc7-5b5a-4d95-ac29-578178baaa4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbb41cc7-5b5a-4d95-ac29-578178baaa4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/faaecc52-4047-4473-a469-c920d0943d00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "faaecc52-4047-4473-a469-c920d0943d00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/faaecc52-4047-4473-a469-c920d0943d00>.
+    
+<http://data.lblod.info/id/remote-data-objects/14820832-7acf-43a5-9a2f-66171794b312> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14820832-7acf-43a5-9a2f-66171794b312";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e3962c16-5ca8-419e-b491-44941152e4f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14820832-7acf-43a5-9a2f-66171794b312>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201714-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201714-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201714-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201714-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f2c5e00e-aa81-499f-8e87-1ce586abeabf> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f2c5e00e-aa81-499f-8e87-1ce586abeabf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "acff72a2-4176-4bc8-a423-0f170c878124";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/268f4d0a-dd4e-4898-93de-c828d51c07bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "268f4d0a-dd4e-4898-93de-c828d51c07bb";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124>.
+
+  <http://redpencil.data.gift/id/task/06dd8627-331c-407e-9353-1cbae3bb59e9> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "06dd8627-331c-407e-9353-1cbae3bb59e9";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f2c5e00e-aa81-499f-8e87-1ce586abeabf>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/268f4d0a-dd4e-4898-93de-c828d51c07bb>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7d933859-3dc5-4f22-80f9-a38a45052f45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d933859-3dc5-4f22-80f9-a38a45052f45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d933859-3dc5-4f22-80f9-a38a45052f45>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f5d57af-2ab6-4e7d-a1bd-62544cc4a430> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f5d57af-2ab6-4e7d-a1bd-62544cc4a430";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f5d57af-2ab6-4e7d-a1bd-62544cc4a430>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfa8a02c-4667-438f-a3d9-5e21a2d8c50d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfa8a02c-4667-438f-a3d9-5e21a2d8c50d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfa8a02c-4667-438f-a3d9-5e21a2d8c50d>.
+    
+<http://data.lblod.info/id/remote-data-objects/94f4ccc4-d6f6-4ac6-9210-8c7f3de51999> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94f4ccc4-d6f6-4ac6-9210-8c7f3de51999";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94f4ccc4-d6f6-4ac6-9210-8c7f3de51999>.
+    
+<http://data.lblod.info/id/remote-data-objects/dce7241d-49ac-4f51-98b6-ab1e089be622> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dce7241d-49ac-4f51-98b6-ab1e089be622";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dce7241d-49ac-4f51-98b6-ab1e089be622>.
+    
+<http://data.lblod.info/id/remote-data-objects/36ca2e90-144d-48ea-8b8f-137dfc702179> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36ca2e90-144d-48ea-8b8f-137dfc702179";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_01-06-2022_69417.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36ca2e90-144d-48ea-8b8f-137dfc702179>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b085f4e-487c-4a4e-b9be-c79600bd6297> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b085f4e-487c-4a4e-b9be-c79600bd6297";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_01-06-2022_69423.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b085f4e-487c-4a4e-b9be-c79600bd6297>.
+    
+<http://data.lblod.info/id/remote-data-objects/472e9e3f-781f-4388-a856-3f4e1be9b358> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "472e9e3f-781f-4388-a856-3f4e1be9b358";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_01-06-2022_69451.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/472e9e3f-781f-4388-a856-3f4e1be9b358>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f9a30e6-0a70-4037-84d3-4254288dce4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f9a30e6-0a70-4037-84d3-4254288dce4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_01-06-2022_69458.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f9a30e6-0a70-4037-84d3-4254288dce4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d39db982-137c-438c-8bb6-83e58415a0c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d39db982-137c-438c-8bb6-83e58415a0c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_01-12-2021_64638.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d39db982-137c-438c-8bb6-83e58415a0c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/95c91150-f9e4-4ef7-964e-1604ea6b022d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95c91150-f9e4-4ef7-964e-1604ea6b022d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_01-12-2021_64657.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95c91150-f9e4-4ef7-964e-1604ea6b022d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d509404b-17c9-4855-9a88-0fe8dd44bfed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d509404b-17c9-4855-9a88-0fe8dd44bfed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_01-12-2021_64721.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d509404b-17c9-4855-9a88-0fe8dd44bfed>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a0958b6-7265-4cfc-9007-ecf3ee5e99d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a0958b6-7265-4cfc-9007-ecf3ee5e99d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_02-02-2022_66124.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a0958b6-7265-4cfc-9007-ecf3ee5e99d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a35d7a1-6372-4179-b7d8-1526d434d050> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a35d7a1-6372-4179-b7d8-1526d434d050";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_02-03-2022_66799.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a35d7a1-6372-4179-b7d8-1526d434d050>.
+    
+<http://data.lblod.info/id/remote-data-objects/25b9eb8e-1662-4d83-9842-5eedd941f74c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25b9eb8e-1662-4d83-9842-5eedd941f74c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_02-03-2022_66914.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25b9eb8e-1662-4d83-9842-5eedd941f74c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e6ddd3a-6b3e-4a89-8480-71468bddcbf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e6ddd3a-6b3e-4a89-8480-71468bddcbf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_02-03-2022_66918.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e6ddd3a-6b3e-4a89-8480-71468bddcbf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/59be8dd7-c190-491a-b8ab-609a56b45015> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59be8dd7-c190-491a-b8ab-609a56b45015";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_02-03-2022_66964.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59be8dd7-c190-491a-b8ab-609a56b45015>.
+    
+<http://data.lblod.info/id/remote-data-objects/61744dc6-dedc-410b-bd03-12fde5642f4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61744dc6-dedc-410b-bd03-12fde5642f4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_02-03-2022_66968.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61744dc6-dedc-410b-bd03-12fde5642f4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e006fd44-6577-4bda-86de-6fb3c0917a5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e006fd44-6577-4bda-86de-6fb3c0917a5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_02-03-2022_66978.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e006fd44-6577-4bda-86de-6fb3c0917a5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/911c7a39-814a-4f32-a249-80aa2830818f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "911c7a39-814a-4f32-a249-80aa2830818f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_02-03-2022_66997.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/911c7a39-814a-4f32-a249-80aa2830818f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ae1c01d-6bc1-432f-8424-9b89a0275f53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ae1c01d-6bc1-432f-8424-9b89a0275f53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_02-03-2022_67008.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ae1c01d-6bc1-432f-8424-9b89a0275f53>.
+    
+<http://data.lblod.info/id/remote-data-objects/0866ddd4-82c0-4c3a-9538-e4bbbcb713f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0866ddd4-82c0-4c3a-9538-e4bbbcb713f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_02-03-2022_67060.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0866ddd4-82c0-4c3a-9538-e4bbbcb713f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc37b41c-2328-4ee2-977e-d3fa20b2a27d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc37b41c-2328-4ee2-977e-d3fa20b2a27d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_03-11-2021_63905.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc37b41c-2328-4ee2-977e-d3fa20b2a27d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcf1edfc-30d0-4cb9-8afe-16ef88363bc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcf1edfc-30d0-4cb9-8afe-16ef88363bc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_04-05-2022_68462.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcf1edfc-30d0-4cb9-8afe-16ef88363bc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ff48858-da55-4a08-ae1d-c349114307d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ff48858-da55-4a08-ae1d-c349114307d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_04-05-2022_68611.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ff48858-da55-4a08-ae1d-c349114307d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd330fe9-3ee7-428e-9c98-08dbf27a9ed5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd330fe9-3ee7-428e-9c98-08dbf27a9ed5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_04-05-2022_68629.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd330fe9-3ee7-428e-9c98-08dbf27a9ed5>.
+    
+<http://data.lblod.info/id/remote-data-objects/54e24373-b4e9-4fec-9750-46cfdf7355c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54e24373-b4e9-4fec-9750-46cfdf7355c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_04-05-2022_68630.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54e24373-b4e9-4fec-9750-46cfdf7355c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/219593b3-3744-4336-8db5-5c7aed8286ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "219593b3-3744-4336-8db5-5c7aed8286ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_04-05-2022_68662.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/219593b3-3744-4336-8db5-5c7aed8286ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c1ab693-fc91-4504-adfb-3481ee033af6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c1ab693-fc91-4504-adfb-3481ee033af6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_04-05-2022_68669.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c1ab693-fc91-4504-adfb-3481ee033af6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2411a683-ee53-464d-a89e-ed52353c2dcb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2411a683-ee53-464d-a89e-ed52353c2dcb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_06-04-2022_68004.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2411a683-ee53-464d-a89e-ed52353c2dcb>.
+    
+<http://data.lblod.info/id/remote-data-objects/31177ea7-cbf4-4b51-b330-5e5ae92070cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31177ea7-cbf4-4b51-b330-5e5ae92070cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_06-07-2022_70204.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31177ea7-cbf4-4b51-b330-5e5ae92070cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/71f86725-f16c-4477-ae03-406d524af643> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71f86725-f16c-4477-ae03-406d524af643";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_06-07-2022_70206.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71f86725-f16c-4477-ae03-406d524af643>.
+    
+<http://data.lblod.info/id/remote-data-objects/8802ce63-3b8b-47c0-96ff-38593b45252a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8802ce63-3b8b-47c0-96ff-38593b45252a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_06-07-2022_70207.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8802ce63-3b8b-47c0-96ff-38593b45252a>.
+    
+<http://data.lblod.info/id/remote-data-objects/301d0245-23c8-4c19-a08a-b33dbe065035> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "301d0245-23c8-4c19-a08a-b33dbe065035";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_06-07-2022_70305.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/301d0245-23c8-4c19-a08a-b33dbe065035>.
+    
+<http://data.lblod.info/id/remote-data-objects/adad6594-c4b9-435a-b680-35a7e920eb90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "adad6594-c4b9-435a-b680-35a7e920eb90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_06-07-2022_70306.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/adad6594-c4b9-435a-b680-35a7e920eb90>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a096f53-0190-453b-a13c-af811dde2317> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a096f53-0190-453b-a13c-af811dde2317";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_06-07-2022_70378.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a096f53-0190-453b-a13c-af811dde2317>.
+    
+<http://data.lblod.info/id/remote-data-objects/6237a078-cc10-4bd4-b902-840d381e33b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6237a078-cc10-4bd4-b902-840d381e33b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_06-10-2021_63254.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6237a078-cc10-4bd4-b902-840d381e33b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a6e6cfd-b1e1-4ad6-9701-c6e35b51acc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a6e6cfd-b1e1-4ad6-9701-c6e35b51acc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_06-10-2021_63287.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a6e6cfd-b1e1-4ad6-9701-c6e35b51acc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a205fd61-9de4-4c69-8bd2-e106ca40ae9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a205fd61-9de4-4c69-8bd2-e106ca40ae9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_08-06-2022_69575.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a205fd61-9de4-4c69-8bd2-e106ca40ae9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cf7420e-9cf2-4cd0-91ed-04930eaa8a9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cf7420e-9cf2-4cd0-91ed-04930eaa8a9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_08-06-2022_69576.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cf7420e-9cf2-4cd0-91ed-04930eaa8a9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/df286e8f-bf67-4d64-9f45-bf909081b01b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df286e8f-bf67-4d64-9f45-bf909081b01b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_08-06-2022_69578.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df286e8f-bf67-4d64-9f45-bf909081b01b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9ee89bc-775f-4367-808a-7ef6233a7251> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9ee89bc-775f-4367-808a-7ef6233a7251";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_08-06-2022_69580.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9ee89bc-775f-4367-808a-7ef6233a7251>.
+    
+<http://data.lblod.info/id/remote-data-objects/48f5e657-3e85-45e6-ad83-1c5adc33434e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48f5e657-3e85-45e6-ad83-1c5adc33434e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_08-06-2022_69581.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48f5e657-3e85-45e6-ad83-1c5adc33434e>.
+    
+<http://data.lblod.info/id/remote-data-objects/74e6b9e2-7fc0-432d-88a1-6de45aaac2f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74e6b9e2-7fc0-432d-88a1-6de45aaac2f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_08-06-2022_69582.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74e6b9e2-7fc0-432d-88a1-6de45aaac2f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfcaed9e-be22-44e4-afc7-c2bf5ee71cfb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfcaed9e-be22-44e4-afc7-c2bf5ee71cfb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_08-06-2022_69583.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfcaed9e-be22-44e4-afc7-c2bf5ee71cfb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9c656e2-07ff-42f3-a23b-7d030a61885b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9c656e2-07ff-42f3-a23b-7d030a61885b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_08-12-2021_64811.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9c656e2-07ff-42f3-a23b-7d030a61885b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9547aa4-a876-42d3-9519-f37abadcb0bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9547aa4-a876-42d3-9519-f37abadcb0bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_09-02-2022_66358.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9547aa4-a876-42d3-9519-f37abadcb0bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac1b16ce-61b4-4c72-9c39-f91115729b69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac1b16ce-61b4-4c72-9c39-f91115729b69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_09-02-2022_66359.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac1b16ce-61b4-4c72-9c39-f91115729b69>.
+    
+<http://data.lblod.info/id/remote-data-objects/99035cfe-c20f-4de3-a6c8-4d286b2d0478> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99035cfe-c20f-4de3-a6c8-4d286b2d0478";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_09-02-2022_66360.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99035cfe-c20f-4de3-a6c8-4d286b2d0478>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d3dcf28-f5b8-49ff-80da-d31383fb524c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d3dcf28-f5b8-49ff-80da-d31383fb524c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_09-03-2022_67035.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/acff72a2-4176-4bc8-a423-0f170c878124> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d3dcf28-f5b8-49ff-80da-d31383fb524c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201716-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201716-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201716-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201716-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c86ec363-1319-49c7-ad7b-5eb32044f052> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c86ec363-1319-49c7-ad7b-5eb32044f052";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4addad7e-c854-40d8-a96c-5014c7cf0d3c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ede34f8c-9e14-4e84-bb89-fa17e816362b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ede34f8c-9e14-4e84-bb89-fa17e816362b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c>.
+
+  <http://redpencil.data.gift/id/task/aae7154f-8a8c-46c4-84a3-1cec87aede0d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "aae7154f-8a8c-46c4-84a3-1cec87aede0d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c86ec363-1319-49c7-ad7b-5eb32044f052>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ede34f8c-9e14-4e84-bb89-fa17e816362b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/697a3c6d-9791-4e3e-9113-8d461601f353> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "697a3c6d-9791-4e3e-9113-8d461601f353";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_09-03-2022_67053.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/697a3c6d-9791-4e3e-9113-8d461601f353>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f1248b2-a570-4d0a-bd0c-34820b11a660> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f1248b2-a570-4d0a-bd0c-34820b11a660";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_09-03-2022_67056.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f1248b2-a570-4d0a-bd0c-34820b11a660>.
+    
+<http://data.lblod.info/id/remote-data-objects/9682a92b-7443-42cb-a979-88aabefbdabd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9682a92b-7443-42cb-a979-88aabefbdabd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_09-03-2022_67108.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9682a92b-7443-42cb-a979-88aabefbdabd>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fb15b19-3bf0-4db7-8e60-bdacbdb3e06c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fb15b19-3bf0-4db7-8e60-bdacbdb3e06c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_09-03-2022_67206.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fb15b19-3bf0-4db7-8e60-bdacbdb3e06c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1612025a-c116-4872-8a56-208b4fa44928> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1612025a-c116-4872-8a56-208b4fa44928";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_09-03-2022_67238.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1612025a-c116-4872-8a56-208b4fa44928>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a0bb2a8-1109-4102-84f0-013d31f009a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a0bb2a8-1109-4102-84f0-013d31f009a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_09-03-2022_67246.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a0bb2a8-1109-4102-84f0-013d31f009a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/896b5996-7f96-4731-b81c-523e1a9b6123> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "896b5996-7f96-4731-b81c-523e1a9b6123";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_10-11-2021_64137.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/896b5996-7f96-4731-b81c-523e1a9b6123>.
+    
+<http://data.lblod.info/id/remote-data-objects/8de128b0-9fc5-4c29-8051-53860c269d36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8de128b0-9fc5-4c29-8051-53860c269d36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_10-11-2021_64142.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8de128b0-9fc5-4c29-8051-53860c269d36>.
+    
+<http://data.lblod.info/id/remote-data-objects/26138b7f-1c77-4b6e-996b-b95f6360fdaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26138b7f-1c77-4b6e-996b-b95f6360fdaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_10-11-2021_64143.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26138b7f-1c77-4b6e-996b-b95f6360fdaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/76d2cecc-8724-4bb1-8a7e-3836cf797f22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76d2cecc-8724-4bb1-8a7e-3836cf797f22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_10-11-2021_64150.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76d2cecc-8724-4bb1-8a7e-3836cf797f22>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1b6325b-b58c-4aaf-ac03-6a56e49c6b24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1b6325b-b58c-4aaf-ac03-6a56e49c6b24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_11-05-2022_68825.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1b6325b-b58c-4aaf-ac03-6a56e49c6b24>.
+    
+<http://data.lblod.info/id/remote-data-objects/a18726e5-7b18-470d-9292-704261414465> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a18726e5-7b18-470d-9292-704261414465";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_11-05-2022_68826.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a18726e5-7b18-470d-9292-704261414465>.
+    
+<http://data.lblod.info/id/remote-data-objects/65e3b0b2-d245-44c4-915d-3724967b4cfd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65e3b0b2-d245-44c4-915d-3724967b4cfd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_11-05-2022_68827.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65e3b0b2-d245-44c4-915d-3724967b4cfd>.
+    
+<http://data.lblod.info/id/remote-data-objects/72c00dae-2395-44e7-9f3f-2de163d68f7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72c00dae-2395-44e7-9f3f-2de163d68f7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_12-01-2022_65589.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72c00dae-2395-44e7-9f3f-2de163d68f7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6ddd410-8dbe-4374-9fb0-8a2bdd8ead2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6ddd410-8dbe-4374-9fb0-8a2bdd8ead2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_12-01-2022_65613.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6ddd410-8dbe-4374-9fb0-8a2bdd8ead2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/072daa81-a8ab-4c49-9209-d4fde4cc08ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "072daa81-a8ab-4c49-9209-d4fde4cc08ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_12-01-2022_65615.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/072daa81-a8ab-4c49-9209-d4fde4cc08ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/c288eccc-3c3b-4123-880b-5b3969a13053> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c288eccc-3c3b-4123-880b-5b3969a13053";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-04-2022_68123.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c288eccc-3c3b-4123-880b-5b3969a13053>.
+    
+<http://data.lblod.info/id/remote-data-objects/92029812-015e-4925-ba5a-9390d5f880b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92029812-015e-4925-ba5a-9390d5f880b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-04-2022_68124.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92029812-015e-4925-ba5a-9390d5f880b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d1345c6-6354-4f19-bcf8-c91a64473a98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d1345c6-6354-4f19-bcf8-c91a64473a98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-04-2022_68125.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d1345c6-6354-4f19-bcf8-c91a64473a98>.
+    
+<http://data.lblod.info/id/remote-data-objects/36f43ce8-a138-45c7-9f9f-53dee8f1d3ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36f43ce8-a138-45c7-9f9f-53dee8f1d3ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-04-2022_68132.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36f43ce8-a138-45c7-9f9f-53dee8f1d3ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/3850bc38-4e35-4905-a939-63b1f9e03f80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3850bc38-4e35-4905-a939-63b1f9e03f80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-04-2022_68133.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3850bc38-4e35-4905-a939-63b1f9e03f80>.
+    
+<http://data.lblod.info/id/remote-data-objects/8767a91d-f366-49ea-b15c-ed4545c1fe65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8767a91d-f366-49ea-b15c-ed4545c1fe65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-04-2022_68135.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8767a91d-f366-49ea-b15c-ed4545c1fe65>.
+    
+<http://data.lblod.info/id/remote-data-objects/04967319-f05c-4441-9cdc-a29ad25cd266> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04967319-f05c-4441-9cdc-a29ad25cd266";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-04-2022_68136.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04967319-f05c-4441-9cdc-a29ad25cd266>.
+    
+<http://data.lblod.info/id/remote-data-objects/76656265-4f9f-468e-8a4d-6a9e5d9f1bbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76656265-4f9f-468e-8a4d-6a9e5d9f1bbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-04-2022_68137.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76656265-4f9f-468e-8a4d-6a9e5d9f1bbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/96e63305-c888-444b-a7c4-0f2017c9626b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96e63305-c888-444b-a7c4-0f2017c9626b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-04-2022_68138.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96e63305-c888-444b-a7c4-0f2017c9626b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f96d813-f648-4168-b0c9-4bbb94086afd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f96d813-f648-4168-b0c9-4bbb94086afd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-07-2022_70365.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f96d813-f648-4168-b0c9-4bbb94086afd>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cdd2303-d559-4a78-8531-5e6ff4228b75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cdd2303-d559-4a78-8531-5e6ff4228b75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-07-2022_70399.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cdd2303-d559-4a78-8531-5e6ff4228b75>.
+    
+<http://data.lblod.info/id/remote-data-objects/11c920e9-bcf1-48cf-b32a-dcda9dc1fbff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11c920e9-bcf1-48cf-b32a-dcda9dc1fbff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-07-2022_70409.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11c920e9-bcf1-48cf-b32a-dcda9dc1fbff>.
+    
+<http://data.lblod.info/id/remote-data-objects/b691a0ee-d04e-4b51-b929-14d2d698db4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b691a0ee-d04e-4b51-b929-14d2d698db4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-07-2022_70486.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b691a0ee-d04e-4b51-b929-14d2d698db4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/75d8bd68-2830-4ad2-a81e-c4e26dec0d87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75d8bd68-2830-4ad2-a81e-c4e26dec0d87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-07-2022_70487.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75d8bd68-2830-4ad2-a81e-c4e26dec0d87>.
+    
+<http://data.lblod.info/id/remote-data-objects/cec387be-962d-4618-ba80-007ea16cb3d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cec387be-962d-4618-ba80-007ea16cb3d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-07-2022_70488.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cec387be-962d-4618-ba80-007ea16cb3d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e8c2743-2515-4fde-b005-181fef6d0be1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e8c2743-2515-4fde-b005-181fef6d0be1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-10-2021_62004.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e8c2743-2515-4fde-b005-181fef6d0be1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9007b9f8-d404-4328-b990-2070d5880f44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9007b9f8-d404-4328-b990-2070d5880f44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_13-10-2021_63500.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9007b9f8-d404-4328-b990-2070d5880f44>.
+    
+<http://data.lblod.info/id/remote-data-objects/69275363-4b09-4f1a-8dd2-4b767504435e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69275363-4b09-4f1a-8dd2-4b767504435e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_15-06-2022_69749.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69275363-4b09-4f1a-8dd2-4b767504435e>.
+    
+<http://data.lblod.info/id/remote-data-objects/15ae72c1-ad8a-494d-a269-452e3b90faf0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15ae72c1-ad8a-494d-a269-452e3b90faf0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_15-06-2022_69750.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15ae72c1-ad8a-494d-a269-452e3b90faf0>.
+    
+<http://data.lblod.info/id/remote-data-objects/11346fdb-4bf5-4fdd-8960-5037c8b85e69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11346fdb-4bf5-4fdd-8960-5037c8b85e69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_15-06-2022_69753.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11346fdb-4bf5-4fdd-8960-5037c8b85e69>.
+    
+<http://data.lblod.info/id/remote-data-objects/58c2bb57-7b45-4871-9f10-535a119df941> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58c2bb57-7b45-4871-9f10-535a119df941";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_15-06-2022_69755.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58c2bb57-7b45-4871-9f10-535a119df941>.
+    
+<http://data.lblod.info/id/remote-data-objects/a803db47-dfd4-491f-82cb-e6f0272ac40a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a803db47-dfd4-491f-82cb-e6f0272ac40a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_15-06-2022_69757.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a803db47-dfd4-491f-82cb-e6f0272ac40a>.
+    
+<http://data.lblod.info/id/remote-data-objects/cda306a5-6edf-45e0-b00f-552766796866> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cda306a5-6edf-45e0-b00f-552766796866";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_15-06-2022_69758.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cda306a5-6edf-45e0-b00f-552766796866>.
+    
+<http://data.lblod.info/id/remote-data-objects/106408ec-7a6a-4feb-bd51-5d72b60a1c7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "106408ec-7a6a-4feb-bd51-5d72b60a1c7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_15-06-2022_69772.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/106408ec-7a6a-4feb-bd51-5d72b60a1c7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d41c24c-2b4c-417c-8dcc-943a2f05fdf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d41c24c-2b4c-417c-8dcc-943a2f05fdf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_15-06-2022_69775.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d41c24c-2b4c-417c-8dcc-943a2f05fdf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0faa82f-836a-47af-897b-7d620ccbdcaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0faa82f-836a-47af-897b-7d620ccbdcaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_15-06-2022_69797.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0faa82f-836a-47af-897b-7d620ccbdcaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/f70d8722-f157-4041-b290-5c6c31740f2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f70d8722-f157-4041-b290-5c6c31740f2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_15-06-2022_69810.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f70d8722-f157-4041-b290-5c6c31740f2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa7f71bb-f563-401d-b329-261d94c0262f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa7f71bb-f563-401d-b329-261d94c0262f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_15-12-2021_65018.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa7f71bb-f563-401d-b329-261d94c0262f>.
+    
+<http://data.lblod.info/id/remote-data-objects/16d67356-c85a-41c9-9618-e84c78c4a95e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16d67356-c85a-41c9-9618-e84c78c4a95e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_15-12-2021_65027.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16d67356-c85a-41c9-9618-e84c78c4a95e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f710016-241b-40f1-be7c-9602d2778338> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f710016-241b-40f1-be7c-9602d2778338";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_16-02-2022_66555.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f710016-241b-40f1-be7c-9602d2778338>.
+    
+<http://data.lblod.info/id/remote-data-objects/948fd186-132f-432c-8886-cd680d3ab963> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "948fd186-132f-432c-8886-cd680d3ab963";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_16-02-2022_66568.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/948fd186-132f-432c-8886-cd680d3ab963>.
+    
+<http://data.lblod.info/id/remote-data-objects/0db3aeee-4976-4e20-b9d8-c00be3b324de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0db3aeee-4976-4e20-b9d8-c00be3b324de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_16-03-2022_67398.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0db3aeee-4976-4e20-b9d8-c00be3b324de>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ec4932d-6a09-4416-84ed-828cc319d249> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ec4932d-6a09-4416-84ed-828cc319d249";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_16-03-2022_67403.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ec4932d-6a09-4416-84ed-828cc319d249>.
+    
+<http://data.lblod.info/id/remote-data-objects/385d25d6-f235-4d8e-9f8b-27779361879e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "385d25d6-f235-4d8e-9f8b-27779361879e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_16-03-2022_67417.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4addad7e-c854-40d8-a96c-5014c7cf0d3c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/385d25d6-f235-4d8e-9f8b-27779361879e>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201717-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201717-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201717-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201717-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/bdbd2590-bf92-4385-b37b-2409f2a5f703> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bdbd2590-bf92-4385-b37b-2409f2a5f703";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/dced0552-dbae-454e-8ecd-1f0c28699470> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dced0552-dbae-454e-8ecd-1f0c28699470";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e>.
+
+  <http://redpencil.data.gift/id/task/37f8feb2-68bb-4421-a6eb-044c70176db2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "37f8feb2-68bb-4421-a6eb-044c70176db2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/bdbd2590-bf92-4385-b37b-2409f2a5f703>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/dced0552-dbae-454e-8ecd-1f0c28699470>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/3e48410f-3c26-430e-bb36-beb377f076eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e48410f-3c26-430e-bb36-beb377f076eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_16-03-2022_67419.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e48410f-3c26-430e-bb36-beb377f076eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c6f8f9c-7108-4763-b907-fead68d052b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c6f8f9c-7108-4763-b907-fead68d052b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_17-11-2021_64258.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c6f8f9c-7108-4763-b907-fead68d052b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bfb7016-4098-4069-86fa-43782c0ef5c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bfb7016-4098-4069-86fa-43782c0ef5c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_17-11-2021_64269.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bfb7016-4098-4069-86fa-43782c0ef5c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1aaa842-f71c-4916-ae8d-0cf33c0589c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1aaa842-f71c-4916-ae8d-0cf33c0589c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_17-11-2021_64274.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1aaa842-f71c-4916-ae8d-0cf33c0589c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba43d8a6-9d43-4fd6-bee7-9307a3635476> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba43d8a6-9d43-4fd6-bee7-9307a3635476";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_17-11-2021_64276.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba43d8a6-9d43-4fd6-bee7-9307a3635476>.
+    
+<http://data.lblod.info/id/remote-data-objects/56b27620-41ff-448c-a8fc-222deb11846d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56b27620-41ff-448c-a8fc-222deb11846d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_17-11-2021_64277.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56b27620-41ff-448c-a8fc-222deb11846d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7070352b-082a-4b67-92cd-b148bac8adb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7070352b-082a-4b67-92cd-b148bac8adb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_18-05-2022_68828.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7070352b-082a-4b67-92cd-b148bac8adb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8460a42-afa6-48ef-aeda-b6b134e681fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8460a42-afa6-48ef-aeda-b6b134e681fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_18-05-2022_69016.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8460a42-afa6-48ef-aeda-b6b134e681fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d35dcbb-024b-4956-a658-d71f9b4e2981> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d35dcbb-024b-4956-a658-d71f9b4e2981";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_18-05-2022_69040.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d35dcbb-024b-4956-a658-d71f9b4e2981>.
+    
+<http://data.lblod.info/id/remote-data-objects/9778270f-20b4-441d-9da3-5b50f515c301> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9778270f-20b4-441d-9da3-5b50f515c301";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_18-05-2022_69052.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9778270f-20b4-441d-9da3-5b50f515c301>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f146342-97a0-4f3c-ba20-7b378ab068ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f146342-97a0-4f3c-ba20-7b378ab068ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_19-01-2022_65811.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f146342-97a0-4f3c-ba20-7b378ab068ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fb1abc3-c508-4ff6-90d3-01c63e727836> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fb1abc3-c508-4ff6-90d3-01c63e727836";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_20-04-2022_68270.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fb1abc3-c508-4ff6-90d3-01c63e727836>.
+    
+<http://data.lblod.info/id/remote-data-objects/a765d5bc-b0a7-4da9-9791-b89f9058b289> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a765d5bc-b0a7-4da9-9791-b89f9058b289";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_20-04-2022_68272.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a765d5bc-b0a7-4da9-9791-b89f9058b289>.
+    
+<http://data.lblod.info/id/remote-data-objects/57c18a6f-2663-4759-9185-88bfeae64517> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57c18a6f-2663-4759-9185-88bfeae64517";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_20-04-2022_68297.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57c18a6f-2663-4759-9185-88bfeae64517>.
+    
+<http://data.lblod.info/id/remote-data-objects/c77b3eaf-194b-48be-a204-24e5ab583370> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c77b3eaf-194b-48be-a204-24e5ab583370";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_20-04-2022_68306.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c77b3eaf-194b-48be-a204-24e5ab583370>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5b720aa-a142-40e0-b2fd-4988a06d2587> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5b720aa-a142-40e0-b2fd-4988a06d2587";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_20-04-2022_68308.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5b720aa-a142-40e0-b2fd-4988a06d2587>.
+    
+<http://data.lblod.info/id/remote-data-objects/746d7fe0-10a4-49f9-9750-687906211b1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "746d7fe0-10a4-49f9-9750-687906211b1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_20-07-2022_70588.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/746d7fe0-10a4-49f9-9750-687906211b1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d97e5a83-c4ca-479d-b9b1-c9f22892d769> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d97e5a83-c4ca-479d-b9b1-c9f22892d769";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_20-07-2022_70589.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d97e5a83-c4ca-479d-b9b1-c9f22892d769>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f3e0732-178d-4268-a2bf-043a5045b774> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f3e0732-178d-4268-a2bf-043a5045b774";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_20-07-2022_70590.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f3e0732-178d-4268-a2bf-043a5045b774>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ffd74f5-b77d-45f1-9d8d-c358e863c746> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ffd74f5-b77d-45f1-9d8d-c358e863c746";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_20-07-2022_70591.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ffd74f5-b77d-45f1-9d8d-c358e863c746>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb1c66a2-da15-4319-8d20-c90bd1379b64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb1c66a2-da15-4319-8d20-c90bd1379b64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_20-07-2022_70593.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb1c66a2-da15-4319-8d20-c90bd1379b64>.
+    
+<http://data.lblod.info/id/remote-data-objects/981f6013-ec99-4b74-a7d8-bfd47ef837c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "981f6013-ec99-4b74-a7d8-bfd47ef837c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_20-07-2022_70594.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/981f6013-ec99-4b74-a7d8-bfd47ef837c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/766c0900-f015-44d1-a0f7-ed6a4861dadc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "766c0900-f015-44d1-a0f7-ed6a4861dadc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_20-07-2022_70595.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/766c0900-f015-44d1-a0f7-ed6a4861dadc>.
+    
+<http://data.lblod.info/id/remote-data-objects/8729e948-d523-4169-a42e-558a22a74863> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8729e948-d523-4169-a42e-558a22a74863";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_20-07-2022_70597.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8729e948-d523-4169-a42e-558a22a74863>.
+    
+<http://data.lblod.info/id/remote-data-objects/75521c04-ddbb-471f-b229-2f324871ffda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75521c04-ddbb-471f-b229-2f324871ffda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_20-07-2022_70598.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75521c04-ddbb-471f-b229-2f324871ffda>.
+    
+<http://data.lblod.info/id/remote-data-objects/b784d92c-0edc-4c37-ac08-59a5dfad88b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b784d92c-0edc-4c37-ac08-59a5dfad88b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_20-10-2021_63607.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b784d92c-0edc-4c37-ac08-59a5dfad88b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c74cd8a-e244-4de6-b3d7-3841f8281429> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c74cd8a-e244-4de6-b3d7-3841f8281429";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_22-06-2022_69936.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c74cd8a-e244-4de6-b3d7-3841f8281429>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f64f336-9f6b-45e1-9761-4020ef81ac66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f64f336-9f6b-45e1-9761-4020ef81ac66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_22-06-2022_69937.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f64f336-9f6b-45e1-9761-4020ef81ac66>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebb33db4-27ba-42e8-8caa-cd52225e7236> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebb33db4-27ba-42e8-8caa-cd52225e7236";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_22-06-2022_69938.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebb33db4-27ba-42e8-8caa-cd52225e7236>.
+    
+<http://data.lblod.info/id/remote-data-objects/281f8188-17ce-4c31-8271-6b8feb228fe1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "281f8188-17ce-4c31-8271-6b8feb228fe1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_22-06-2022_69939.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/281f8188-17ce-4c31-8271-6b8feb228fe1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8c4c9e8-88db-44b3-bdfb-49b99437d0b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8c4c9e8-88db-44b3-bdfb-49b99437d0b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_23-02-2022_66714.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8c4c9e8-88db-44b3-bdfb-49b99437d0b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/15806c05-7cb8-4f9d-a432-f17937901daa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15806c05-7cb8-4f9d-a432-f17937901daa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_23-02-2022_66730.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15806c05-7cb8-4f9d-a432-f17937901daa>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2da2fbc-1094-4914-9307-1e8026588a52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2da2fbc-1094-4914-9307-1e8026588a52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_23-02-2022_66731.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2da2fbc-1094-4914-9307-1e8026588a52>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c567387-64a2-4439-97d4-f89b096b082c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c567387-64a2-4439-97d4-f89b096b082c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_23-02-2022_66764.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c567387-64a2-4439-97d4-f89b096b082c>.
+    
+<http://data.lblod.info/id/remote-data-objects/14bbf266-ea69-4e6f-87a1-ae15bc08eed7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14bbf266-ea69-4e6f-87a1-ae15bc08eed7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_23-02-2022_66786.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14bbf266-ea69-4e6f-87a1-ae15bc08eed7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2653700c-e762-4a58-b438-3bf34f987c9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2653700c-e762-4a58-b438-3bf34f987c9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_23-02-2022_66800.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2653700c-e762-4a58-b438-3bf34f987c9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9939ed29-fdbf-4db7-8fc1-85ef58b9c56d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9939ed29-fdbf-4db7-8fc1-85ef58b9c56d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_23-03-2022_67311.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9939ed29-fdbf-4db7-8fc1-85ef58b9c56d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddb42585-912b-4da0-b233-b11eb55739de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddb42585-912b-4da0-b233-b11eb55739de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_23-03-2022_67561.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddb42585-912b-4da0-b233-b11eb55739de>.
+    
+<http://data.lblod.info/id/remote-data-objects/98b7b75a-8549-464c-85ad-c86d0390dfc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98b7b75a-8549-464c-85ad-c86d0390dfc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_23-03-2022_67562.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98b7b75a-8549-464c-85ad-c86d0390dfc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/241d9893-2b67-463f-a591-c114fb5b07c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "241d9893-2b67-463f-a591-c114fb5b07c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_23-12-2021_65461.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/241d9893-2b67-463f-a591-c114fb5b07c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/340e6a7f-3ea7-4018-9ab0-733804a15cab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "340e6a7f-3ea7-4018-9ab0-733804a15cab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_24-11-2021_64266.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/340e6a7f-3ea7-4018-9ab0-733804a15cab>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6dfcc94-9f1a-40da-9751-42ec2f58a52e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6dfcc94-9f1a-40da-9751-42ec2f58a52e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_24-11-2021_64317.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6dfcc94-9f1a-40da-9751-42ec2f58a52e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ba328dc-2b68-4f0e-9e8f-3ad865f571ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ba328dc-2b68-4f0e-9e8f-3ad865f571ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_24-11-2021_64417.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ba328dc-2b68-4f0e-9e8f-3ad865f571ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/89f23b1b-eb45-4ad0-b1ed-c76ae886c430> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89f23b1b-eb45-4ad0-b1ed-c76ae886c430";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_24-11-2021_64485.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89f23b1b-eb45-4ad0-b1ed-c76ae886c430>.
+    
+<http://data.lblod.info/id/remote-data-objects/88b71c6e-72ea-4bcb-8505-93a12878d4e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88b71c6e-72ea-4bcb-8505-93a12878d4e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_24-11-2021_64503.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88b71c6e-72ea-4bcb-8505-93a12878d4e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/b872023c-f301-4592-9585-39b5d94a2334> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b872023c-f301-4592-9585-39b5d94a2334";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_24-11-2021_64571.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b872023c-f301-4592-9585-39b5d94a2334>.
+    
+<http://data.lblod.info/id/remote-data-objects/30265432-5546-4d7c-9153-fe6abad2258f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30265432-5546-4d7c-9153-fe6abad2258f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_25-05-2022_69248.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30265432-5546-4d7c-9153-fe6abad2258f>.
+    
+<http://data.lblod.info/id/remote-data-objects/45847488-e4cc-44e8-ae54-c44147856c23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45847488-e4cc-44e8-ae54-c44147856c23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_25-05-2022_69249.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45847488-e4cc-44e8-ae54-c44147856c23>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5ac57e0-2064-4461-9b74-9f6805981780> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5ac57e0-2064-4461-9b74-9f6805981780";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_25-05-2022_69252.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5ac57e0-2064-4461-9b74-9f6805981780>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fbfcf0a-20c0-4a7b-bedd-e23700a2f9e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fbfcf0a-20c0-4a7b-bedd-e23700a2f9e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_25-05-2022_69253.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f7df43f-54c7-4ce1-b2fc-07f2aae4d66e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fbfcf0a-20c0-4a7b-bedd-e23700a2f9e7>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201718-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201718-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201718-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201718-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b6908c34-3911-4692-b7a9-47fac5d52466> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b6908c34-3911-4692-b7a9-47fac5d52466";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/064f3917-1b56-4fdf-b24f-27d8c8656ac6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "064f3917-1b56-4fdf-b24f-27d8c8656ac6";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8>.
+
+  <http://redpencil.data.gift/id/task/8e80fcb3-a176-440d-bbad-819992b2015b> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8e80fcb3-a176-440d-bbad-819992b2015b";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b6908c34-3911-4692-b7a9-47fac5d52466>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/064f3917-1b56-4fdf-b24f-27d8c8656ac6>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/93c3811a-a19b-4079-adf0-213202e8ab36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93c3811a-a19b-4079-adf0-213202e8ab36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_25-05-2022_69254.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93c3811a-a19b-4079-adf0-213202e8ab36>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e0fe060-f353-4268-ab05-bb7b2a96d1b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e0fe060-f353-4268-ab05-bb7b2a96d1b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_25-05-2022_69256.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e0fe060-f353-4268-ab05-bb7b2a96d1b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b4ca318-e572-4228-94a8-4eac436ecb09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b4ca318-e572-4228-94a8-4eac436ecb09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_25-05-2022_69257.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b4ca318-e572-4228-94a8-4eac436ecb09>.
+    
+<http://data.lblod.info/id/remote-data-objects/27c006fd-b0aa-4c06-a20d-39db324a4713> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27c006fd-b0aa-4c06-a20d-39db324a4713";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_25-05-2022_69259.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27c006fd-b0aa-4c06-a20d-39db324a4713>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac49343d-bf4c-48fa-9e92-32c9ed33e666> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac49343d-bf4c-48fa-9e92-32c9ed33e666";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_25-05-2022_69260.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac49343d-bf4c-48fa-9e92-32c9ed33e666>.
+    
+<http://data.lblod.info/id/remote-data-objects/806188cf-cdf0-4301-ae45-e4d0ac388d84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "806188cf-cdf0-4301-ae45-e4d0ac388d84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_25-05-2022_69262.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/806188cf-cdf0-4301-ae45-e4d0ac388d84>.
+    
+<http://data.lblod.info/id/remote-data-objects/adb9cbd9-76ad-41e7-8481-cf0911d1a558> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "adb9cbd9-76ad-41e7-8481-cf0911d1a558";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_25-05-2022_69263.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/adb9cbd9-76ad-41e7-8481-cf0911d1a558>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4329b52-fa1a-4e9a-976d-1bcd108bde2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4329b52-fa1a-4e9a-976d-1bcd108bde2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_25-05-2022_69264.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4329b52-fa1a-4e9a-976d-1bcd108bde2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee31cdb4-af66-4b95-aec8-ac8fec6158a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee31cdb4-af66-4b95-aec8-ac8fec6158a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_26-01-2022_65956.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee31cdb4-af66-4b95-aec8-ac8fec6158a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/124b630c-668b-4af7-bc84-83556de5e3ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "124b630c-668b-4af7-bc84-83556de5e3ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_27-04-2022_68451.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/124b630c-668b-4af7-bc84-83556de5e3ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b40f2a3-e010-48f1-87d0-fb5f61affef6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b40f2a3-e010-48f1-87d0-fb5f61affef6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_27-04-2022_68455.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b40f2a3-e010-48f1-87d0-fb5f61affef6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1020aeab-41d7-484b-ada7-17bb9ec0ce6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1020aeab-41d7-484b-ada7-17bb9ec0ce6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_27-04-2022_68456.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1020aeab-41d7-484b-ada7-17bb9ec0ce6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/25887037-c478-40e4-b748-9cae9d791e29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25887037-c478-40e4-b748-9cae9d791e29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_27-04-2022_68482.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25887037-c478-40e4-b748-9cae9d791e29>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e9f8c11-c45a-4cd9-94b5-53a3d8d14437> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e9f8c11-c45a-4cd9-94b5-53a3d8d14437";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_27-10-2021_63609.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e9f8c11-c45a-4cd9-94b5-53a3d8d14437>.
+    
+<http://data.lblod.info/id/remote-data-objects/00ac1f34-1052-4d44-88c1-58be2261c196> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00ac1f34-1052-4d44-88c1-58be2261c196";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_27-10-2021_63802.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00ac1f34-1052-4d44-88c1-58be2261c196>.
+    
+<http://data.lblod.info/id/remote-data-objects/090ffb25-0843-4fe1-84ac-cff3bf234e73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "090ffb25-0843-4fe1-84ac-cff3bf234e73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_27-10-2021_63831.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/090ffb25-0843-4fe1-84ac-cff3bf234e73>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dbddc2d-8a65-44f0-b66d-e1c61ad9efcf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dbddc2d-8a65-44f0-b66d-e1c61ad9efcf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_29-03-2022_67592.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dbddc2d-8a65-44f0-b66d-e1c61ad9efcf>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6acb48e-8931-496b-8331-19c457eb3f3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6acb48e-8931-496b-8331-19c457eb3f3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_29-03-2022_67708.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6acb48e-8931-496b-8331-19c457eb3f3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/42c54eed-4bfd-4fd7-a17e-5bd39e4a9959> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42c54eed-4bfd-4fd7-a17e-5bd39e4a9959";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_29-03-2022_67755.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42c54eed-4bfd-4fd7-a17e-5bd39e4a9959>.
+    
+<http://data.lblod.info/id/remote-data-objects/f92bdc1a-d170-45c9-a239-38551c937fdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f92bdc1a-d170-45c9-a239-38551c937fdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_29-03-2022_67767.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f92bdc1a-d170-45c9-a239-38551c937fdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7042c5d-032a-47dc-bbfb-ba5207ca9462> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7042c5d-032a-47dc-bbfb-ba5207ca9462";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_29-03-2022_67769.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7042c5d-032a-47dc-bbfb-ba5207ca9462>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b4430d0-ef97-4e6c-aab9-f19a4cdf941a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b4430d0-ef97-4e6c-aab9-f19a4cdf941a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_29-03-2022_67805.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b4430d0-ef97-4e6c-aab9-f19a4cdf941a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4553b8fd-fc31-4f0f-a1fd-b7aec279e741> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4553b8fd-fc31-4f0f-a1fd-b7aec279e741";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_29-06-2022_70113.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4553b8fd-fc31-4f0f-a1fd-b7aec279e741>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d9d0285-c73c-4296-957f-cb25bc266f2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d9d0285-c73c-4296-957f-cb25bc266f2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_29-06-2022_70114.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d9d0285-c73c-4296-957f-cb25bc266f2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0869c61f-eaca-4d06-9245-bea20a998dd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0869c61f-eaca-4d06-9245-bea20a998dd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_29-06-2022_70121.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0869c61f-eaca-4d06-9245-bea20a998dd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d4d0147-6721-44c4-b649-3edb7fdbfa60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d4d0147-6721-44c4-b649-3edb7fdbfa60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_29-06-2022_70125.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d4d0147-6721-44c4-b649-3edb7fdbfa60>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b432e5b-e988-466e-8c0b-e0565b527cf4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b432e5b-e988-466e-8c0b-e0565b527cf4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_29-06-2022_70126.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b432e5b-e988-466e-8c0b-e0565b527cf4>.
+    
+<http://data.lblod.info/id/remote-data-objects/2df8cc94-2cad-49c7-86b5-d195f7e24361> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2df8cc94-2cad-49c7-86b5-d195f7e24361";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_29-06-2022_70127.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2df8cc94-2cad-49c7-86b5-d195f7e24361>.
+    
+<http://data.lblod.info/id/remote-data-objects/34fb8311-c65d-476d-af45-564471e51c06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34fb8311-c65d-476d-af45-564471e51c06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/1cac47afd73998d062673b58261c4017e5643c007cb56b49ec4e3c32ad23d5fc/GetPublication?filename=Uittreksels_29-06-2022_70140.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34fb8311-c65d-476d-af45-564471e51c06>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7a6fd59-4491-4c3a-9ee5-7c17b1295776> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7a6fd59-4491-4c3a-9ee5-7c17b1295776";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7a6fd59-4491-4c3a-9ee5-7c17b1295776>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e98add0-5390-4bff-926f-6c30cc325978> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e98add0-5390-4bff-926f-6c30cc325978";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e98add0-5390-4bff-926f-6c30cc325978>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ace6e2f-6a00-4d20-a949-ad0d6890d174> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ace6e2f-6a00-4d20-a949-ad0d6890d174";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ace6e2f-6a00-4d20-a949-ad0d6890d174>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0dcfeea-453f-4922-a976-e94d62f0009a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0dcfeea-453f-4922-a976-e94d62f0009a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0dcfeea-453f-4922-a976-e94d62f0009a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c83da199-f7e0-47e7-a3f9-e5ea416d2c72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c83da199-f7e0-47e7-a3f9-e5ea416d2c72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c83da199-f7e0-47e7-a3f9-e5ea416d2c72>.
+    
+<http://data.lblod.info/id/remote-data-objects/05bead17-3d53-490b-a4c8-5c5cdc0074b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05bead17-3d53-490b-a4c8-5c5cdc0074b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05bead17-3d53-490b-a4c8-5c5cdc0074b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2248d875-2949-40a7-839c-52db9f9bec45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2248d875-2949-40a7-839c-52db9f9bec45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2248d875-2949-40a7-839c-52db9f9bec45>.
+    
+<http://data.lblod.info/id/remote-data-objects/0528ecf3-12be-4ce5-99ed-45da1a1eb1df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0528ecf3-12be-4ce5-99ed-45da1a1eb1df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0528ecf3-12be-4ce5-99ed-45da1a1eb1df>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdf6d88e-2e30-4b50-a9a4-73c9c3392a61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdf6d88e-2e30-4b50-a9a4-73c9c3392a61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdf6d88e-2e30-4b50-a9a4-73c9c3392a61>.
+    
+<http://data.lblod.info/id/remote-data-objects/49eb9085-f037-42a8-be90-0498fa66cf8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49eb9085-f037-42a8-be90-0498fa66cf8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49eb9085-f037-42a8-be90-0498fa66cf8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f2327ff-32e9-4a76-9d25-2221e1b64ee8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f2327ff-32e9-4a76-9d25-2221e1b64ee8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f2327ff-32e9-4a76-9d25-2221e1b64ee8>.
+    
+<http://data.lblod.info/id/remote-data-objects/17245910-fa23-4343-bcbc-412ddd598d7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17245910-fa23-4343-bcbc-412ddd598d7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17245910-fa23-4343-bcbc-412ddd598d7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7e1707b-afbd-44a8-855d-2623c5a55333> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7e1707b-afbd-44a8-855d-2623c5a55333";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7e1707b-afbd-44a8-855d-2623c5a55333>.
+    
+<http://data.lblod.info/id/remote-data-objects/271d55b0-3a85-47b5-b7fa-b902843635c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "271d55b0-3a85-47b5-b7fa-b902843635c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/271d55b0-3a85-47b5-b7fa-b902843635c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ae4d45f-808b-4380-9b29-7ca00cafb913> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ae4d45f-808b-4380-9b29-7ca00cafb913";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ae4d45f-808b-4380-9b29-7ca00cafb913>.
+    
+<http://data.lblod.info/id/remote-data-objects/257d8fd6-9e93-487c-88be-0275ee4eb21d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "257d8fd6-9e93-487c-88be-0275ee4eb21d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/257d8fd6-9e93-487c-88be-0275ee4eb21d>.
+    
+<http://data.lblod.info/id/remote-data-objects/82282c70-152f-4c70-bae7-0dc3046924d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82282c70-152f-4c70-bae7-0dc3046924d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82282c70-152f-4c70-bae7-0dc3046924d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/63fea2f6-abee-4ee7-9bfb-c4086658158c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63fea2f6-abee-4ee7-9bfb-c4086658158c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63fea2f6-abee-4ee7-9bfb-c4086658158c>.
+    
+<http://data.lblod.info/id/remote-data-objects/40d67379-b19d-4348-b19b-3b5b16f4cfce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40d67379-b19d-4348-b19b-3b5b16f4cfce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40d67379-b19d-4348-b19b-3b5b16f4cfce>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cd59837-a1e0-488d-901a-d9726e2742c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cd59837-a1e0-488d-901a-d9726e2742c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cd59837-a1e0-488d-901a-d9726e2742c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c812123e-5ce4-4151-82e7-053dae0cefbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c812123e-5ce4-4151-82e7-053dae0cefbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/3ba6ba52-2ecb-4fb7-ad22-2ebd43ab7aa8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c812123e-5ce4-4151-82e7-053dae0cefbb>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201719-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201719-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201719-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201719-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e7362ac0-f672-4bb7-9a59-4c7403a140bc> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e7362ac0-f672-4bb7-9a59-4c7403a140bc";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a6615d99-03ac-4db1-ba37-868cbc6e0607";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/071bb254-4d89-465f-9661-adbbfdce4bda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "071bb254-4d89-465f-9661-adbbfdce4bda";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607>.
+
+  <http://redpencil.data.gift/id/task/7050d5ff-d570-44c1-a61c-303a8485f9d3> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7050d5ff-d570-44c1-a61c-303a8485f9d3";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e7362ac0-f672-4bb7-9a59-4c7403a140bc>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/071bb254-4d89-465f-9661-adbbfdce4bda>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/ea081ce1-d59e-4d21-8eac-39af3eddb115> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea081ce1-d59e-4d21-8eac-39af3eddb115";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea081ce1-d59e-4d21-8eac-39af3eddb115>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4b1a443-7dc9-4851-ae78-bbce070f6a9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4b1a443-7dc9-4851-ae78-bbce070f6a9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4b1a443-7dc9-4851-ae78-bbce070f6a9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff03625f-f118-4acd-a393-4b475f8a58e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff03625f-f118-4acd-a393-4b475f8a58e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff03625f-f118-4acd-a393-4b475f8a58e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8280aa4-2fae-4969-81f3-85f574fb2b16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8280aa4-2fae-4969-81f3-85f574fb2b16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8280aa4-2fae-4969-81f3-85f574fb2b16>.
+    
+<http://data.lblod.info/id/remote-data-objects/d633e097-28ee-400a-b90a-3c3ded74122a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d633e097-28ee-400a-b90a-3c3ded74122a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d633e097-28ee-400a-b90a-3c3ded74122a>.
+    
+<http://data.lblod.info/id/remote-data-objects/aaf3158c-832c-4ac6-a1da-7ae90af873b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aaf3158c-832c-4ac6-a1da-7ae90af873b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aaf3158c-832c-4ac6-a1da-7ae90af873b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/62f45a59-6920-40d2-8dc0-8340354361c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62f45a59-6920-40d2-8dc0-8340354361c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62f45a59-6920-40d2-8dc0-8340354361c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/705579bf-df82-4b1e-a786-742d99df7f87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "705579bf-df82-4b1e-a786-742d99df7f87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/705579bf-df82-4b1e-a786-742d99df7f87>.
+    
+<http://data.lblod.info/id/remote-data-objects/6811fcae-b88b-4a91-a314-067b038d4c19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6811fcae-b88b-4a91-a314-067b038d4c19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6811fcae-b88b-4a91-a314-067b038d4c19>.
+    
+<http://data.lblod.info/id/remote-data-objects/c73f37cf-d5b0-443d-8981-243e4c622e95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c73f37cf-d5b0-443d-8981-243e4c622e95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c73f37cf-d5b0-443d-8981-243e4c622e95>.
+    
+<http://data.lblod.info/id/remote-data-objects/daeabf4e-4524-481a-b032-ee0b66235d7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "daeabf4e-4524-481a-b032-ee0b66235d7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/daeabf4e-4524-481a-b032-ee0b66235d7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6412fb37-045c-4718-a903-e7a052c6a5b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6412fb37-045c-4718-a903-e7a052c6a5b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Uittreksels_01-03-2022_65904.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6412fb37-045c-4718-a903-e7a052c6a5b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9a73e98-0b7e-4e10-83f0-f4139b0b7fe1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9a73e98-0b7e-4e10-83f0-f4139b0b7fe1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Uittreksels_05-10-2021_58920.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9a73e98-0b7e-4e10-83f0-f4139b0b7fe1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4d47b18-dc42-4bed-ba15-b33108cbb9f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4d47b18-dc42-4bed-ba15-b33108cbb9f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Uittreksels_07-06-2022_69152.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4d47b18-dc42-4bed-ba15-b33108cbb9f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/61006ecf-ca59-4cb8-a128-244e03fe7927> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61006ecf-ca59-4cb8-a128-244e03fe7927";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Uittreksels_07-12-2021_64421.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61006ecf-ca59-4cb8-a128-244e03fe7927>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8c9fe2b-8649-447a-99e4-62e9f01c029a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8c9fe2b-8649-447a-99e4-62e9f01c029a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Uittreksels_11-01-2022_65326.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8c9fe2b-8649-447a-99e4-62e9f01c029a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d26f74a-8ce2-4b07-a97e-f782592f01fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d26f74a-8ce2-4b07-a97e-f782592f01fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Uittreksels_11-01-2022_65423.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d26f74a-8ce2-4b07-a97e-f782592f01fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c539a130-55a7-4bda-b77e-d8a9fbc0f389> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c539a130-55a7-4bda-b77e-d8a9fbc0f389";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/80484554876c7387cc4bd1a43480158e50be8e05eaa0821970223b0fc7eff8c1/GetPublication?filename=Uittreksels_15-12-2021_64519.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c539a130-55a7-4bda-b77e-d8a9fbc0f389>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b7c2c75-f952-4df7-ac15-87a9e0892b22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b7c2c75-f952-4df7-ac15-87a9e0892b22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b7c2c75-f952-4df7-ac15-87a9e0892b22>.
+    
+<http://data.lblod.info/id/remote-data-objects/b01fca28-b534-4111-ac97-6b40fec83cd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b01fca28-b534-4111-ac97-6b40fec83cd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_01-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b01fca28-b534-4111-ac97-6b40fec83cd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea5b52c4-f1be-42e1-bcdb-53444c5f8f30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea5b52c4-f1be-42e1-bcdb-53444c5f8f30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_02-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea5b52c4-f1be-42e1-bcdb-53444c5f8f30>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd59ab48-f651-45e1-ba3b-25af6f1e01b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd59ab48-f651-45e1-ba3b-25af6f1e01b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_02-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd59ab48-f651-45e1-ba3b-25af6f1e01b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8dbdc7db-1935-4391-9708-71514afdaf81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8dbdc7db-1935-4391-9708-71514afdaf81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8dbdc7db-1935-4391-9708-71514afdaf81>.
+    
+<http://data.lblod.info/id/remote-data-objects/87d3cae9-adf1-4d27-8b91-3cfbef647b5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87d3cae9-adf1-4d27-8b91-3cfbef647b5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87d3cae9-adf1-4d27-8b91-3cfbef647b5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf180f94-8915-42ec-8f2d-2a0645b4370c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf180f94-8915-42ec-8f2d-2a0645b4370c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf180f94-8915-42ec-8f2d-2a0645b4370c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b74df13a-4eea-4ec3-b51a-fa69717b90d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b74df13a-4eea-4ec3-b51a-fa69717b90d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_06-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b74df13a-4eea-4ec3-b51a-fa69717b90d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1de0118e-5dd8-4a7a-b378-e9f31a794afd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1de0118e-5dd8-4a7a-b378-e9f31a794afd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_06-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1de0118e-5dd8-4a7a-b378-e9f31a794afd>.
+    
+<http://data.lblod.info/id/remote-data-objects/c07138f0-fcc1-4f8f-a736-83db3885defd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c07138f0-fcc1-4f8f-a736-83db3885defd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_06-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c07138f0-fcc1-4f8f-a736-83db3885defd>.
+    
+<http://data.lblod.info/id/remote-data-objects/082a7e98-f127-46b5-ab8c-9a4b46bc30ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "082a7e98-f127-46b5-ab8c-9a4b46bc30ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_08-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/082a7e98-f127-46b5-ab8c-9a4b46bc30ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/b07055a9-d820-45cb-ba1f-0c5162c150d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b07055a9-d820-45cb-ba1f-0c5162c150d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_08-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b07055a9-d820-45cb-ba1f-0c5162c150d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2774ed92-79ec-4486-8fc5-488c0b054921> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2774ed92-79ec-4486-8fc5-488c0b054921";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2774ed92-79ec-4486-8fc5-488c0b054921>.
+    
+<http://data.lblod.info/id/remote-data-objects/e16cd15a-ecab-4a6e-b544-95d78de35427> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e16cd15a-ecab-4a6e-b544-95d78de35427";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e16cd15a-ecab-4a6e-b544-95d78de35427>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ac34d15-7fb3-48ad-ac72-3f95e9580404> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ac34d15-7fb3-48ad-ac72-3f95e9580404";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_10-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ac34d15-7fb3-48ad-ac72-3f95e9580404>.
+    
+<http://data.lblod.info/id/remote-data-objects/c744f06b-7b70-4a55-a8d7-2f12329cd2d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c744f06b-7b70-4a55-a8d7-2f12329cd2d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_11-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c744f06b-7b70-4a55-a8d7-2f12329cd2d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd252843-8939-4f3a-884b-a25f9b912617> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd252843-8939-4f3a-884b-a25f9b912617";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_12-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd252843-8939-4f3a-884b-a25f9b912617>.
+    
+<http://data.lblod.info/id/remote-data-objects/9104b6dc-6a16-4ea6-85c2-8b49f4d955c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9104b6dc-6a16-4ea6-85c2-8b49f4d955c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_13-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9104b6dc-6a16-4ea6-85c2-8b49f4d955c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/66a8517c-0567-46eb-8424-35bc4065cdc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66a8517c-0567-46eb-8424-35bc4065cdc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_13-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66a8517c-0567-46eb-8424-35bc4065cdc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6fdc53c-95aa-4e25-81bf-797953567ef5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6fdc53c-95aa-4e25-81bf-797953567ef5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6fdc53c-95aa-4e25-81bf-797953567ef5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a9f11bd-07fc-45ad-9413-2f9e7948482e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a9f11bd-07fc-45ad-9413-2f9e7948482e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a9f11bd-07fc-45ad-9413-2f9e7948482e>.
+    
+<http://data.lblod.info/id/remote-data-objects/32f2f062-a16d-421a-8b52-718bea1c012e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32f2f062-a16d-421a-8b52-718bea1c012e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32f2f062-a16d-421a-8b52-718bea1c012e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d930d201-09e5-4075-b7b8-1dc258d2f328> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d930d201-09e5-4075-b7b8-1dc258d2f328";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_16-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d930d201-09e5-4075-b7b8-1dc258d2f328>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe6b2277-94b1-49a2-9385-849e3d8779fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe6b2277-94b1-49a2-9385-849e3d8779fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_16-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe6b2277-94b1-49a2-9385-849e3d8779fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/01c6fc50-2999-4074-97ab-047bef3eed29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01c6fc50-2999-4074-97ab-047bef3eed29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01c6fc50-2999-4074-97ab-047bef3eed29>.
+    
+<http://data.lblod.info/id/remote-data-objects/5da3b32b-676a-48c1-ac29-6f44f993fadc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5da3b32b-676a-48c1-ac29-6f44f993fadc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_18-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5da3b32b-676a-48c1-ac29-6f44f993fadc>.
+    
+<http://data.lblod.info/id/remote-data-objects/2aa8b0cf-faab-4a2a-8b7e-b19441408dc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2aa8b0cf-faab-4a2a-8b7e-b19441408dc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_19-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2aa8b0cf-faab-4a2a-8b7e-b19441408dc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb394687-277f-44c7-91ac-a4f11d2ed4ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb394687-277f-44c7-91ac-a4f11d2ed4ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_20-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb394687-277f-44c7-91ac-a4f11d2ed4ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/38a98265-69ee-4dab-b2a9-4f191f499631> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38a98265-69ee-4dab-b2a9-4f191f499631";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_20-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38a98265-69ee-4dab-b2a9-4f191f499631>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4ce43fe-2eb6-40ba-bc98-1fabd0588379> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4ce43fe-2eb6-40ba-bc98-1fabd0588379";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_20-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4ce43fe-2eb6-40ba-bc98-1fabd0588379>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5957c92-f4b1-4280-9a89-33fda40a2b67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5957c92-f4b1-4280-9a89-33fda40a2b67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5957c92-f4b1-4280-9a89-33fda40a2b67>.
+    
+<http://data.lblod.info/id/remote-data-objects/bea755d3-c668-4e2c-a85e-054966d2d19c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bea755d3-c668-4e2c-a85e-054966d2d19c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a6615d99-03ac-4db1-ba37-868cbc6e0607> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bea755d3-c668-4e2c-a85e-054966d2d19c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201720-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201720-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201720-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201720-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/059cc45d-c6fc-493d-9239-f49bb0ab9576> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "059cc45d-c6fc-493d-9239-f49bb0ab9576";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0158c993-e681-4b7b-a32f-37d84302dc86";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/05d58b7e-4720-4105-b809-1d2f87977f6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "05d58b7e-4720-4105-b809-1d2f87977f6f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86>.
+
+  <http://redpencil.data.gift/id/task/c9a67183-8f97-4754-80ab-cc7a848f2386> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c9a67183-8f97-4754-80ab-cc7a848f2386";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/059cc45d-c6fc-493d-9239-f49bb0ab9576>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/05d58b7e-4720-4105-b809-1d2f87977f6f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/48325232-e291-464a-838f-3a41865397a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48325232-e291-464a-838f-3a41865397a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48325232-e291-464a-838f-3a41865397a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/db8901df-670d-43f7-be94-93fb016cccf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db8901df-670d-43f7-be94-93fb016cccf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db8901df-670d-43f7-be94-93fb016cccf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/314f2d20-d946-4829-a344-39a9520c3899> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "314f2d20-d946-4829-a344-39a9520c3899";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_24-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/314f2d20-d946-4829-a344-39a9520c3899>.
+    
+<http://data.lblod.info/id/remote-data-objects/da3752b0-60ab-4ce3-9092-1c975ad615f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da3752b0-60ab-4ce3-9092-1c975ad615f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da3752b0-60ab-4ce3-9092-1c975ad615f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/83c94a9c-0cbe-4491-922d-1583b6f46a5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83c94a9c-0cbe-4491-922d-1583b6f46a5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83c94a9c-0cbe-4491-922d-1583b6f46a5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc020922-48dc-48c7-9906-29099f8c979f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc020922-48dc-48c7-9906-29099f8c979f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc020922-48dc-48c7-9906-29099f8c979f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e36fbfe-53ab-4886-9917-d91e456b470f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e36fbfe-53ab-4886-9917-d91e456b470f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e36fbfe-53ab-4886-9917-d91e456b470f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d3d0edf-afdc-49c3-8e84-bcacc5eaad8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d3d0edf-afdc-49c3-8e84-bcacc5eaad8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d3d0edf-afdc-49c3-8e84-bcacc5eaad8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6299a403-109b-4a0b-aabe-3d164974b511> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6299a403-109b-4a0b-aabe-3d164974b511";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6299a403-109b-4a0b-aabe-3d164974b511>.
+    
+<http://data.lblod.info/id/remote-data-objects/993dac07-5245-4c28-9613-f727b1085a18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "993dac07-5245-4c28-9613-f727b1085a18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_29-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/993dac07-5245-4c28-9613-f727b1085a18>.
+    
+<http://data.lblod.info/id/remote-data-objects/0642870c-c889-48e2-b81d-3a4e646b8d3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0642870c-c889-48e2-b81d-3a4e646b8d3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/8064f70c-26b7-444e-81ce-20d3e550d60d/GetPublication?filename=Uittreksels_29-03-2022_67714.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0642870c-c889-48e2-b81d-3a4e646b8d3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4fa977f-35e3-4048-bad2-c102b442a200> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4fa977f-35e3-4048-bad2-c102b442a200";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4fa977f-35e3-4048-bad2-c102b442a200>.
+    
+<http://data.lblod.info/id/remote-data-objects/7360ad96-50dd-4c64-970b-939f59a80b49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7360ad96-50dd-4c64-970b-939f59a80b49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7360ad96-50dd-4c64-970b-939f59a80b49>.
+    
+<http://data.lblod.info/id/remote-data-objects/273fd867-5ea5-46b3-a561-4bdae756110d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "273fd867-5ea5-46b3-a561-4bdae756110d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/273fd867-5ea5-46b3-a561-4bdae756110d>.
+    
+<http://data.lblod.info/id/remote-data-objects/42954311-20d3-4054-a9e5-983abd033933> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42954311-20d3-4054-a9e5-983abd033933";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_02-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42954311-20d3-4054-a9e5-983abd033933>.
+    
+<http://data.lblod.info/id/remote-data-objects/c84ca433-b344-4ff2-9605-6ff2c32560b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c84ca433-b344-4ff2-9605-6ff2c32560b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c84ca433-b344-4ff2-9605-6ff2c32560b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/30f7a8de-5451-4e6c-b795-c36e6329fa5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30f7a8de-5451-4e6c-b795-c36e6329fa5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30f7a8de-5451-4e6c-b795-c36e6329fa5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a496e4b4-5832-43cb-91fb-77efe8efec8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a496e4b4-5832-43cb-91fb-77efe8efec8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a496e4b4-5832-43cb-91fb-77efe8efec8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/53861329-b94a-41f4-89ee-f67a8c123f95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53861329-b94a-41f4-89ee-f67a8c123f95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_06-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53861329-b94a-41f4-89ee-f67a8c123f95>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1216643-e090-4329-8608-2f5f14ddc1ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1216643-e090-4329-8608-2f5f14ddc1ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_07-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1216643-e090-4329-8608-2f5f14ddc1ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fa6748c-2a31-4e52-8d32-1447c76d30a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fa6748c-2a31-4e52-8d32-1447c76d30a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fa6748c-2a31-4e52-8d32-1447c76d30a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e2ef9bb-cae7-4b19-b3fe-c3b7ff1f3be8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e2ef9bb-cae7-4b19-b3fe-c3b7ff1f3be8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e2ef9bb-cae7-4b19-b3fe-c3b7ff1f3be8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c83d9744-3f21-40cc-a58e-63effc7663c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c83d9744-3f21-40cc-a58e-63effc7663c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_09-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c83d9744-3f21-40cc-a58e-63effc7663c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e5d1e8c-16cb-4550-a1c4-9fff0f981c3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e5d1e8c-16cb-4550-a1c4-9fff0f981c3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e5d1e8c-16cb-4550-a1c4-9fff0f981c3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2163bffb-37e1-47b8-9ee2-693125dfa859> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2163bffb-37e1-47b8-9ee2-693125dfa859";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2163bffb-37e1-47b8-9ee2-693125dfa859>.
+    
+<http://data.lblod.info/id/remote-data-objects/df24279a-5f09-4406-8c61-760c86ec9692> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df24279a-5f09-4406-8c61-760c86ec9692";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df24279a-5f09-4406-8c61-760c86ec9692>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cfdbaae-9215-4b20-87b5-80eac0eae17b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cfdbaae-9215-4b20-87b5-80eac0eae17b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cfdbaae-9215-4b20-87b5-80eac0eae17b>.
+    
+<http://data.lblod.info/id/remote-data-objects/58a91ff7-d1ae-455f-b762-932e8dcf222f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58a91ff7-d1ae-455f-b762-932e8dcf222f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_12-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58a91ff7-d1ae-455f-b762-932e8dcf222f>.
+    
+<http://data.lblod.info/id/remote-data-objects/55e76e12-d9c6-49ba-85ac-80f40e29b3ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55e76e12-d9c6-49ba-85ac-80f40e29b3ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55e76e12-d9c6-49ba-85ac-80f40e29b3ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/eab5f048-c125-458f-b6a7-3d43c7056dd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eab5f048-c125-458f-b6a7-3d43c7056dd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eab5f048-c125-458f-b6a7-3d43c7056dd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c47f4671-8a03-406f-8882-dfee95dd5633> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c47f4671-8a03-406f-8882-dfee95dd5633";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c47f4671-8a03-406f-8882-dfee95dd5633>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4004dce-545b-4f6b-8f66-f5cd012a9ea8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4004dce-545b-4f6b-8f66-f5cd012a9ea8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4004dce-545b-4f6b-8f66-f5cd012a9ea8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8137d886-8109-49b4-a82c-e9342ba4a06a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8137d886-8109-49b4-a82c-e9342ba4a06a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_14-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8137d886-8109-49b4-a82c-e9342ba4a06a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d8292b3-2914-4e55-a13f-175173cb79ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d8292b3-2914-4e55-a13f-175173cb79ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d8292b3-2914-4e55-a13f-175173cb79ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/141739c5-d1bc-46ef-9ce9-ded6efaf9d73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "141739c5-d1bc-46ef-9ce9-ded6efaf9d73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/141739c5-d1bc-46ef-9ce9-ded6efaf9d73>.
+    
+<http://data.lblod.info/id/remote-data-objects/e934be5d-2f76-4c7f-ae32-eff19a729210> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e934be5d-2f76-4c7f-ae32-eff19a729210";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e934be5d-2f76-4c7f-ae32-eff19a729210>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ef1a5d8-bd31-4b43-823b-0ef7f6d6cc91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ef1a5d8-bd31-4b43-823b-0ef7f6d6cc91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ef1a5d8-bd31-4b43-823b-0ef7f6d6cc91>.
+    
+<http://data.lblod.info/id/remote-data-objects/9081bb60-bc0d-48f3-9192-266c4b4dde7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9081bb60-bc0d-48f3-9192-266c4b4dde7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9081bb60-bc0d-48f3-9192-266c4b4dde7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/608e4214-2b74-4e94-8a13-d6d42f9d3d8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "608e4214-2b74-4e94-8a13-d6d42f9d3d8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/608e4214-2b74-4e94-8a13-d6d42f9d3d8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a38e725b-af65-4c20-8fca-430bdc831dc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a38e725b-af65-4c20-8fca-430bdc831dc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_16-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a38e725b-af65-4c20-8fca-430bdc831dc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6c1a16e-65b3-41d2-ba31-ff03ac015497> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6c1a16e-65b3-41d2-ba31-ff03ac015497";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6c1a16e-65b3-41d2-ba31-ff03ac015497>.
+    
+<http://data.lblod.info/id/remote-data-objects/08e37b1b-6cf7-4aed-b78f-f51ff13f370c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08e37b1b-6cf7-4aed-b78f-f51ff13f370c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08e37b1b-6cf7-4aed-b78f-f51ff13f370c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3301f0c6-7bf2-4324-ad0c-19865d196609> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3301f0c6-7bf2-4324-ad0c-19865d196609";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3301f0c6-7bf2-4324-ad0c-19865d196609>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d503fb7-176d-424d-b4f8-4ed7733fe337> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d503fb7-176d-424d-b4f8-4ed7733fe337";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d503fb7-176d-424d-b4f8-4ed7733fe337>.
+    
+<http://data.lblod.info/id/remote-data-objects/79586be4-21b6-4f88-8cdb-adf0138c61be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79586be4-21b6-4f88-8cdb-adf0138c61be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79586be4-21b6-4f88-8cdb-adf0138c61be>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2c3ccb2-a91f-4b53-aeff-40ec8e83dde3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2c3ccb2-a91f-4b53-aeff-40ec8e83dde3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_20-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2c3ccb2-a91f-4b53-aeff-40ec8e83dde3>.
+    
+<http://data.lblod.info/id/remote-data-objects/39a7c461-fb8f-4544-a935-70077761e6b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39a7c461-fb8f-4544-a935-70077761e6b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39a7c461-fb8f-4544-a935-70077761e6b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/274c839f-53c6-45a4-ac7a-13f171ed7306> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "274c839f-53c6-45a4-ac7a-13f171ed7306";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/274c839f-53c6-45a4-ac7a-13f171ed7306>.
+    
+<http://data.lblod.info/id/remote-data-objects/33185610-7831-4cd2-babc-c93d704bf397> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33185610-7831-4cd2-babc-c93d704bf397";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_22-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33185610-7831-4cd2-babc-c93d704bf397>.
+    
+<http://data.lblod.info/id/remote-data-objects/7896ddc1-df0f-46cc-ba4a-bb6c5b53f485> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7896ddc1-df0f-46cc-ba4a-bb6c5b53f485";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0158c993-e681-4b7b-a32f-37d84302dc86> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7896ddc1-df0f-46cc-ba4a-bb6c5b53f485>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201722-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201722-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201722-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201722-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a049d413-ab18-4df0-a1fd-493253005832> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a049d413-ab18-4df0-a1fd-493253005832";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "defccc52-57da-4e41-81b2-cb743f051bd0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/60f92092-163b-4da3-a5dc-0d71783f100a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "60f92092-163b-4da3-a5dc-0d71783f100a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0>.
+
+  <http://redpencil.data.gift/id/task/db266eb7-28d2-4f80-823d-2a40d003a39e> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "db266eb7-28d2-4f80-823d-2a40d003a39e";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a049d413-ab18-4df0-a1fd-493253005832>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/60f92092-163b-4da3-a5dc-0d71783f100a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/49f707e2-9bf3-4776-8e76-12fa8c89b0bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49f707e2-9bf3-4776-8e76-12fa8c89b0bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49f707e2-9bf3-4776-8e76-12fa8c89b0bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8dddf96-4f68-4cbd-b885-2d65edcffa97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8dddf96-4f68-4cbd-b885-2d65edcffa97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8dddf96-4f68-4cbd-b885-2d65edcffa97>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb0384c0-9c00-4ece-8dac-1360b8279852> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb0384c0-9c00-4ece-8dac-1360b8279852";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb0384c0-9c00-4ece-8dac-1360b8279852>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e418925-d471-40ac-8bdf-6d6b9198ccaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e418925-d471-40ac-8bdf-6d6b9198ccaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e418925-d471-40ac-8bdf-6d6b9198ccaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c009e10-07f0-4679-af83-b7a6183ba076> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c009e10-07f0-4679-af83-b7a6183ba076";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c009e10-07f0-4679-af83-b7a6183ba076>.
+    
+<http://data.lblod.info/id/remote-data-objects/e651b75b-5610-4eb3-8e97-1b1da1914645> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e651b75b-5610-4eb3-8e97-1b1da1914645";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e651b75b-5610-4eb3-8e97-1b1da1914645>.
+    
+<http://data.lblod.info/id/remote-data-objects/99ac3c89-91ce-4f00-82c7-2eef8e4d2879> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99ac3c89-91ce-4f00-82c7-2eef8e4d2879";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99ac3c89-91ce-4f00-82c7-2eef8e4d2879>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6ba2448-5ec1-45af-b78e-abd433db82e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6ba2448-5ec1-45af-b78e-abd433db82e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_27-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6ba2448-5ec1-45af-b78e-abd433db82e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/31a68036-6130-4ff8-a714-e56d1e95d34e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31a68036-6130-4ff8-a714-e56d1e95d34e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31a68036-6130-4ff8-a714-e56d1e95d34e>.
+    
+<http://data.lblod.info/id/remote-data-objects/798c891e-70f8-40df-b28c-b5035a768341> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "798c891e-70f8-40df-b28c-b5035a768341";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/798c891e-70f8-40df-b28c-b5035a768341>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb191a0a-c143-4b5e-8370-e9c76225d3c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb191a0a-c143-4b5e-8370-e9c76225d3c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_28-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb191a0a-c143-4b5e-8370-e9c76225d3c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a76172e5-60c2-423e-bc75-82d8306c86c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a76172e5-60c2-423e-bc75-82d8306c86c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a76172e5-60c2-423e-bc75-82d8306c86c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa0913ce-836a-45a6-83f6-97ccd3f9764a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa0913ce-836a-45a6-83f6-97ccd3f9764a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa0913ce-836a-45a6-83f6-97ccd3f9764a>.
+    
+<http://data.lblod.info/id/remote-data-objects/77edd45c-5856-4d35-96f8-ff1ceb7c5f15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77edd45c-5856-4d35-96f8-ff1ceb7c5f15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77edd45c-5856-4d35-96f8-ff1ceb7c5f15>.
+    
+<http://data.lblod.info/id/remote-data-objects/726490f7-1032-48de-8bd4-6d62678ea0ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "726490f7-1032-48de-8bd4-6d62678ea0ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/726490f7-1032-48de-8bd4-6d62678ea0ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e22877a-a798-4cac-b8de-335af3c46fe2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e22877a-a798-4cac-b8de-335af3c46fe2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=BesluitenLijstUitspraak_burgemeester_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e22877a-a798-4cac-b8de-335af3c46fe2>.
+    
+<http://data.lblod.info/id/remote-data-objects/7559e15d-f618-4e77-ae74-a8c0ab2f361b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7559e15d-f618-4e77-ae74-a8c0ab2f361b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=Uittreksels_01-03-2022_67059.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7559e15d-f618-4e77-ae74-a8c0ab2f361b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f839ce7b-3cd0-419c-aecc-18df91a7b569> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f839ce7b-3cd0-419c-aecc-18df91a7b569";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=Uittreksels_01-10-2021_63265.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f839ce7b-3cd0-419c-aecc-18df91a7b569>.
+    
+<http://data.lblod.info/id/remote-data-objects/07082610-d5d7-4fcf-83eb-b8f2ce73e362> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07082610-d5d7-4fcf-83eb-b8f2ce73e362";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=Uittreksels_13-10-2021_63574.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07082610-d5d7-4fcf-83eb-b8f2ce73e362>.
+    
+<http://data.lblod.info/id/remote-data-objects/8695448f-7ff5-4c69-b2eb-0e09f94e9c69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8695448f-7ff5-4c69-b2eb-0e09f94e9c69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=Uittreksels_19-10-2021_63764.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8695448f-7ff5-4c69-b2eb-0e09f94e9c69>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fa92e83-10f4-4fbb-9e85-eb74d8fe7684> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fa92e83-10f4-4fbb-9e85-eb74d8fe7684";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/ba90e03ee1b1b11fea1dad5e50ff53f1e05e014c6c895ed05545a2f2d2ceebd5/GetPublication?filename=Uittreksels_19-10-2021_63766.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fa92e83-10f4-4fbb-9e85-eb74d8fe7684>.
+    
+<http://data.lblod.info/id/remote-data-objects/dce1947f-1abe-4059-8bd6-314c440ddfb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dce1947f-1abe-4059-8bd6-314c440ddfb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Agenda_Gemeenteraad_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dce1947f-1abe-4059-8bd6-314c440ddfb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ef3a222-8e9e-4ef1-912c-769182a8834e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ef3a222-8e9e-4ef1-912c-769182a8834e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Agenda_Gemeenteraad_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ef3a222-8e9e-4ef1-912c-769182a8834e>.
+    
+<http://data.lblod.info/id/remote-data-objects/60694dc9-7596-48d0-86b9-0b15e246db3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60694dc9-7596-48d0-86b9-0b15e246db3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Agenda_Gemeenteraad_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60694dc9-7596-48d0-86b9-0b15e246db3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a5d5235-2ec9-4090-82ff-7677aac4aae3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a5d5235-2ec9-4090-82ff-7677aac4aae3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Agenda_Gemeenteraad_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a5d5235-2ec9-4090-82ff-7677aac4aae3>.
+    
+<http://data.lblod.info/id/remote-data-objects/861e042c-b767-41cc-9598-fe8d9177bc9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "861e042c-b767-41cc-9598-fe8d9177bc9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Agenda_Gemeenteraad_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/861e042c-b767-41cc-9598-fe8d9177bc9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c394f966-bf52-4d51-9085-daf881bc3b18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c394f966-bf52-4d51-9085-daf881bc3b18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Agenda_Gemeenteraad_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c394f966-bf52-4d51-9085-daf881bc3b18>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4a17616-7fd9-496e-b163-e79700f6c5de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4a17616-7fd9-496e-b163-e79700f6c5de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Agenda_Gemeenteraad_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4a17616-7fd9-496e-b163-e79700f6c5de>.
+    
+<http://data.lblod.info/id/remote-data-objects/4752b239-4e12-442a-a1e7-cb387f681eec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4752b239-4e12-442a-a1e7-cb387f681eec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Agenda_Gemeenteraad_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4752b239-4e12-442a-a1e7-cb387f681eec>.
+    
+<http://data.lblod.info/id/remote-data-objects/0278a539-7d3d-4cc5-b648-a322e3f426cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0278a539-7d3d-4cc5-b648-a322e3f426cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Agenda_Gemeenteraad_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0278a539-7d3d-4cc5-b648-a322e3f426cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e5a9f59-92ff-48ef-ade4-55f71860ab3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e5a9f59-92ff-48ef-ade4-55f71860ab3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Agenda_Gemeenteraad_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e5a9f59-92ff-48ef-ade4-55f71860ab3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/46c13530-8fc4-41db-8927-f04ee258138e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46c13530-8fc4-41db-8927-f04ee258138e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Agenda_Gemeenteraad_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46c13530-8fc4-41db-8927-f04ee258138e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0df4f3a4-6112-4f85-a3e2-050fc4f17bbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0df4f3a4-6112-4f85-a3e2-050fc4f17bbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0df4f3a4-6112-4f85-a3e2-050fc4f17bbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/75a2a609-d5ae-471d-854e-7300186d2bef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75a2a609-d5ae-471d-854e-7300186d2bef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75a2a609-d5ae-471d-854e-7300186d2bef>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e3899e3-f1a6-4eed-922b-fc9d58e8d357> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e3899e3-f1a6-4eed-922b-fc9d58e8d357";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e3899e3-f1a6-4eed-922b-fc9d58e8d357>.
+    
+<http://data.lblod.info/id/remote-data-objects/238671de-81f5-4f82-9b5d-7c3cfc431979> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "238671de-81f5-4f82-9b5d-7c3cfc431979";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/238671de-81f5-4f82-9b5d-7c3cfc431979>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2d1a46b-d144-4e7d-8c07-1d9912c918b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2d1a46b-d144-4e7d-8c07-1d9912c918b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2d1a46b-d144-4e7d-8c07-1d9912c918b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc512b4f-8607-4e4a-aab6-c52c6a437257> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc512b4f-8607-4e4a-aab6-c52c6a437257";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc512b4f-8607-4e4a-aab6-c52c6a437257>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6405e57-9a72-4eb9-b988-9d94d3f2afa2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6405e57-9a72-4eb9-b988-9d94d3f2afa2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6405e57-9a72-4eb9-b988-9d94d3f2afa2>.
+    
+<http://data.lblod.info/id/remote-data-objects/def73c8c-c013-493b-b1cd-ba0d07581964> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "def73c8c-c013-493b-b1cd-ba0d07581964";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/def73c8c-c013-493b-b1cd-ba0d07581964>.
+    
+<http://data.lblod.info/id/remote-data-objects/9eb29c54-ce77-43a3-90b6-b9c09efc4743> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9eb29c54-ce77-43a3-90b6-b9c09efc4743";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9eb29c54-ce77-43a3-90b6-b9c09efc4743>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4679c15-49ce-460e-b0e1-7f0e98fedcfc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4679c15-49ce-460e-b0e1-7f0e98fedcfc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4679c15-49ce-460e-b0e1-7f0e98fedcfc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c04c9231-5e62-4b0a-b972-ad96c8653a99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c04c9231-5e62-4b0a-b972-ad96c8653a99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c04c9231-5e62-4b0a-b972-ad96c8653a99>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ccd392b-1b43-4725-b01b-b1d658cd9eee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ccd392b-1b43-4725-b01b-b1d658cd9eee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Notulen_Gemeenteraad_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ccd392b-1b43-4725-b01b-b1d658cd9eee>.
+    
+<http://data.lblod.info/id/remote-data-objects/aff05707-60a6-4e3b-8162-560621c0deb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aff05707-60a6-4e3b-8162-560621c0deb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Notulen_Gemeenteraad_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aff05707-60a6-4e3b-8162-560621c0deb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/97a35358-0471-4450-b7ac-07543394f99a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97a35358-0471-4450-b7ac-07543394f99a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Notulen_Gemeenteraad_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97a35358-0471-4450-b7ac-07543394f99a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3b91992-f897-434b-a50e-aabd440c5775> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3b91992-f897-434b-a50e-aabd440c5775";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Notulen_Gemeenteraad_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3b91992-f897-434b-a50e-aabd440c5775>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7a49959-0ede-4468-aca1-c31a0b278364> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7a49959-0ede-4468-aca1-c31a0b278364";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Notulen_Gemeenteraad_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7a49959-0ede-4468-aca1-c31a0b278364>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0f5669c-5c7a-473c-93b3-0e64fbc786f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0f5669c-5c7a-473c-93b3-0e64fbc786f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Notulen_Gemeenteraad_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0f5669c-5c7a-473c-93b3-0e64fbc786f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d521119-e7c5-4d01-a5aa-2d085c5bd202> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d521119-e7c5-4d01-a5aa-2d085c5bd202";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Notulen_Gemeenteraad_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/defccc52-57da-4e41-81b2-cb743f051bd0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d521119-e7c5-4d01-a5aa-2d085c5bd202>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201723-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201723-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201723-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201723-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c6035b84-b406-4c6c-afc3-2cb9fb44d70f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c6035b84-b406-4c6c-afc3-2cb9fb44d70f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ea88fb98-ebad-4b27-94c9-d4f9974f5c25";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/96d98e0e-b681-4216-b623-a017f0f637f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "96d98e0e-b681-4216-b623-a017f0f637f3";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25>.
+
+  <http://redpencil.data.gift/id/task/da65117d-be99-42e7-82e7-1d93da4540b8> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "da65117d-be99-42e7-82e7-1d93da4540b8";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c6035b84-b406-4c6c-afc3-2cb9fb44d70f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/96d98e0e-b681-4216-b623-a017f0f637f3>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/f023d571-a410-4451-9fe8-240d29f7d04f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f023d571-a410-4451-9fe8-240d29f7d04f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Notulen_Gemeenteraad_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f023d571-a410-4451-9fe8-240d29f7d04f>.
+    
+<http://data.lblod.info/id/remote-data-objects/972bf0d1-8e8e-431c-9b4e-79413579f989> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "972bf0d1-8e8e-431c-9b4e-79413579f989";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Notulen_Gemeenteraad_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/972bf0d1-8e8e-431c-9b4e-79413579f989>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce2947b1-8796-433c-bfa2-7af068c082f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce2947b1-8796-433c-bfa2-7af068c082f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Notulen_Gemeenteraad_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce2947b1-8796-433c-bfa2-7af068c082f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3482101-5f8b-44f5-bb39-f4ed5b062c6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3482101-5f8b-44f5-bb39-f4ed5b062c6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_03-05-2022_68120.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3482101-5f8b-44f5-bb39-f4ed5b062c6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9aa7e75-d2c7-4dda-b4c7-64518a9f3a20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9aa7e75-d2c7-4dda-b4c7-64518a9f3a20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_03-05-2022_68243.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9aa7e75-d2c7-4dda-b4c7-64518a9f3a20>.
+    
+<http://data.lblod.info/id/remote-data-objects/c604faca-8df4-4542-846b-f5c42457ac87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c604faca-8df4-4542-846b-f5c42457ac87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_05-04-2022_67359.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c604faca-8df4-4542-846b-f5c42457ac87>.
+    
+<http://data.lblod.info/id/remote-data-objects/52f20277-e773-41b6-94f7-df9242aaa607> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52f20277-e773-41b6-94f7-df9242aaa607";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_05-07-2022_69486.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52f20277-e773-41b6-94f7-df9242aaa607>.
+    
+<http://data.lblod.info/id/remote-data-objects/d038cf0a-0468-4372-91b7-9c80c8262639> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d038cf0a-0468-4372-91b7-9c80c8262639";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_05-07-2022_69721.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d038cf0a-0468-4372-91b7-9c80c8262639>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3bf19d0-e7c3-4062-bb34-869ab18068a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3bf19d0-e7c3-4062-bb34-869ab18068a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_05-07-2022_70000.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3bf19d0-e7c3-4062-bb34-869ab18068a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9be46a6-edc9-4a1b-9935-c8e45d8cb6f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9be46a6-edc9-4a1b-9935-c8e45d8cb6f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_05-10-2021_58514.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9be46a6-edc9-4a1b-9935-c8e45d8cb6f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/71026b90-d6b4-46db-b490-61b9c7545cf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71026b90-d6b4-46db-b490-61b9c7545cf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_05-10-2021_58922.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71026b90-d6b4-46db-b490-61b9c7545cf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/767619c2-5650-424c-bc8e-1c459844cc30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "767619c2-5650-424c-bc8e-1c459844cc30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_05-10-2021_58947.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/767619c2-5650-424c-bc8e-1c459844cc30>.
+    
+<http://data.lblod.info/id/remote-data-objects/2766b4c9-5f3f-449e-90a6-a092dcc63a9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2766b4c9-5f3f-449e-90a6-a092dcc63a9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_05-10-2021_58949.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2766b4c9-5f3f-449e-90a6-a092dcc63a9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a20eed14-bb17-4ea8-98ee-5bfff95e7fd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a20eed14-bb17-4ea8-98ee-5bfff95e7fd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_05-10-2021_58950.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a20eed14-bb17-4ea8-98ee-5bfff95e7fd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea5185ab-7afe-4351-8e1d-cd06de44aae8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea5185ab-7afe-4351-8e1d-cd06de44aae8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_05-10-2021_58951.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea5185ab-7afe-4351-8e1d-cd06de44aae8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5c457a9-e8ab-4e19-9724-5ec88e4f51e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5c457a9-e8ab-4e19-9724-5ec88e4f51e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_05-10-2021_59976.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5c457a9-e8ab-4e19-9724-5ec88e4f51e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/600be7be-6cb6-4295-b090-d5ac5f14eb82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "600be7be-6cb6-4295-b090-d5ac5f14eb82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_07-06-2022_69150.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/600be7be-6cb6-4295-b090-d5ac5f14eb82>.
+    
+<http://data.lblod.info/id/remote-data-objects/97891a4e-2083-4ce2-96a6-4bba2acffb7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97891a4e-2083-4ce2-96a6-4bba2acffb7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_07-06-2022_69151.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97891a4e-2083-4ce2-96a6-4bba2acffb7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7adbf7b-c594-43cc-a45b-1b198dd63700> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7adbf7b-c594-43cc-a45b-1b198dd63700";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_07-06-2022_69187.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7adbf7b-c594-43cc-a45b-1b198dd63700>.
+    
+<http://data.lblod.info/id/remote-data-objects/038a4106-4976-44e1-a2de-41d38bcc26fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "038a4106-4976-44e1-a2de-41d38bcc26fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_07-12-2021_64423.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/038a4106-4976-44e1-a2de-41d38bcc26fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/b65f8e61-eec0-47b0-a0ee-4ded8ddfcf56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b65f8e61-eec0-47b0-a0ee-4ded8ddfcf56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_11-01-2022_58184.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b65f8e61-eec0-47b0-a0ee-4ded8ddfcf56>.
+    
+<http://data.lblod.info/id/remote-data-objects/33e79b54-c1e4-43f5-907d-4ee4d3d764d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33e79b54-c1e4-43f5-907d-4ee4d3d764d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_11-01-2022_65285.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33e79b54-c1e4-43f5-907d-4ee4d3d764d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4477973a-78cd-4d68-9147-4d4236bd920f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4477973a-78cd-4d68-9147-4d4236bd920f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_15-12-2021_64517.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4477973a-78cd-4d68-9147-4d4236bd920f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e0fb9c8-5f7b-4656-a825-a737101757c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e0fb9c8-5f7b-4656-a825-a737101757c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_15-12-2021_64518.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e0fb9c8-5f7b-4656-a825-a737101757c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b203f3ef-5570-47f6-9154-9cd454f16bad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b203f3ef-5570-47f6-9154-9cd454f16bad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.waregem.be/LBLODWeb/Home/Overzicht/cc4a623692b30c922e298f0aa3d9d9a7e235617c884e2fd39d14afc4d7a0f925/GetPublication?filename=Uittreksels_15-12-2021_64637.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b203f3ef-5570-47f6-9154-9cd454f16bad>.
+    
+<http://data.lblod.info/id/remote-data-objects/11d67107-bb7d-4b68-a891-909c93e90850> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11d67107-bb7d-4b68-a891-909c93e90850";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/0016221b1e3d6da37d3a6e1091bd11b0eb346de6f0caaa79ba867f7e9da65cc5/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11d67107-bb7d-4b68-a891-909c93e90850>.
+    
+<http://data.lblod.info/id/remote-data-objects/75c45a76-d197-4398-ac00-577e31be4c95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75c45a76-d197-4398-ac00-577e31be4c95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/0016221b1e3d6da37d3a6e1091bd11b0eb346de6f0caaa79ba867f7e9da65cc5/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75c45a76-d197-4398-ac00-577e31be4c95>.
+    
+<http://data.lblod.info/id/remote-data-objects/854b41a7-64c3-448e-808d-a40c2e03041c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "854b41a7-64c3-448e-808d-a40c2e03041c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/0016221b1e3d6da37d3a6e1091bd11b0eb346de6f0caaa79ba867f7e9da65cc5/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/854b41a7-64c3-448e-808d-a40c2e03041c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9d54f37-c336-47cc-a133-a9301adeb6de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9d54f37-c336-47cc-a133-a9301adeb6de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/0016221b1e3d6da37d3a6e1091bd11b0eb346de6f0caaa79ba867f7e9da65cc5/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9d54f37-c336-47cc-a133-a9301adeb6de>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b28a742-693e-42ce-9cf4-ab66663d61d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b28a742-693e-42ce-9cf4-ab66663d61d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/0016221b1e3d6da37d3a6e1091bd11b0eb346de6f0caaa79ba867f7e9da65cc5/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b28a742-693e-42ce-9cf4-ab66663d61d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d51ce21e-c73a-4db8-9518-0c6a30fc6b4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d51ce21e-c73a-4db8-9518-0c6a30fc6b4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/0016221b1e3d6da37d3a6e1091bd11b0eb346de6f0caaa79ba867f7e9da65cc5/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d51ce21e-c73a-4db8-9518-0c6a30fc6b4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8477965-4f2a-4b72-9fec-544909ddb7f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8477965-4f2a-4b72-9fec-544909ddb7f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/0016221b1e3d6da37d3a6e1091bd11b0eb346de6f0caaa79ba867f7e9da65cc5/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8477965-4f2a-4b72-9fec-544909ddb7f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e01dd4d-7b5d-4b5f-9b64-8b8bfc0ad9bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e01dd4d-7b5d-4b5f-9b64-8b8bfc0ad9bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/0016221b1e3d6da37d3a6e1091bd11b0eb346de6f0caaa79ba867f7e9da65cc5/GetPublication?filename=BesluitenLijstUitspraak_OCMW-raad_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e01dd4d-7b5d-4b5f-9b64-8b8bfc0ad9bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d08253c-d794-43a3-9c83-6604401bc4c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d08253c-d794-43a3-9c83-6604401bc4c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/0016221b1e3d6da37d3a6e1091bd11b0eb346de6f0caaa79ba867f7e9da65cc5/GetPublication?filename=Notulen_OCMW-raad_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d08253c-d794-43a3-9c83-6604401bc4c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f8915fd-b3dc-4507-9f55-359e4853e91c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f8915fd-b3dc-4507-9f55-359e4853e91c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/0016221b1e3d6da37d3a6e1091bd11b0eb346de6f0caaa79ba867f7e9da65cc5/GetPublication?filename=Uittreksels_10-05-2022_48650.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f8915fd-b3dc-4507-9f55-359e4853e91c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb440568-04ba-4c01-b7d7-6b0e67af808f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb440568-04ba-4c01-b7d7-6b0e67af808f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/0016221b1e3d6da37d3a6e1091bd11b0eb346de6f0caaa79ba867f7e9da65cc5/GetPublication?filename=Uittreksels_21-12-2021_45239.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb440568-04ba-4c01-b7d7-6b0e67af808f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e5d2496-eca7-4de0-9fd5-997488233778> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e5d2496-eca7-4de0-9fd5-997488233778";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/0016221b1e3d6da37d3a6e1091bd11b0eb346de6f0caaa79ba867f7e9da65cc5/GetPublication?filename=Uittreksels_30-11-2021_28483.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e5d2496-eca7-4de0-9fd5-997488233778>.
+    
+<http://data.lblod.info/id/remote-data-objects/50e3545c-cddd-4f15-af06-03d647cee790> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50e3545c-cddd-4f15-af06-03d647cee790";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50e3545c-cddd-4f15-af06-03d647cee790>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf92a56f-1565-4b41-8b83-1a1270ee5f17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf92a56f-1565-4b41-8b83-1a1270ee5f17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf92a56f-1565-4b41-8b83-1a1270ee5f17>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f75e182-8dfb-4609-8e8b-094a0c19c3ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f75e182-8dfb-4609-8e8b-094a0c19c3ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f75e182-8dfb-4609-8e8b-094a0c19c3ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/15fa4f58-20ea-47df-8839-2b120fabf858> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15fa4f58-20ea-47df-8839-2b120fabf858";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15fa4f58-20ea-47df-8839-2b120fabf858>.
+    
+<http://data.lblod.info/id/remote-data-objects/b63423d6-ac0b-4a75-ba84-2bf7120172b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b63423d6-ac0b-4a75-ba84-2bf7120172b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b63423d6-ac0b-4a75-ba84-2bf7120172b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/854fb31f-c69a-403a-acd2-97aa2b245178> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "854fb31f-c69a-403a-acd2-97aa2b245178";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/854fb31f-c69a-403a-acd2-97aa2b245178>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7b29e9a-2e90-4a9b-bc4d-2505e804294b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7b29e9a-2e90-4a9b-bc4d-2505e804294b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7b29e9a-2e90-4a9b-bc4d-2505e804294b>.
+    
+<http://data.lblod.info/id/remote-data-objects/20cb4b7e-4bd5-4365-96c1-623b0823ec5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20cb4b7e-4bd5-4365-96c1-623b0823ec5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20cb4b7e-4bd5-4365-96c1-623b0823ec5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/122e94d9-9e06-4ee6-970b-5dfc29011a98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "122e94d9-9e06-4ee6-970b-5dfc29011a98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/122e94d9-9e06-4ee6-970b-5dfc29011a98>.
+    
+<http://data.lblod.info/id/remote-data-objects/02373153-cea3-4ea6-b983-e79c1cdc3a1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02373153-cea3-4ea6-b983-e79c1cdc3a1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Notulen_Gemeenteraad_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02373153-cea3-4ea6-b983-e79c1cdc3a1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/281fbf95-8b57-4525-a586-53e15aec5870> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "281fbf95-8b57-4525-a586-53e15aec5870";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_01-02-2022_47468.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/281fbf95-8b57-4525-a586-53e15aec5870>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3b4b4cc-a18d-4c2e-846c-74139ce2e4de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3b4b4cc-a18d-4c2e-846c-74139ce2e4de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_01-03-2022_47957.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3b4b4cc-a18d-4c2e-846c-74139ce2e4de>.
+    
+<http://data.lblod.info/id/remote-data-objects/11e025bc-f7d6-4f33-9b69-5fe161150617> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11e025bc-f7d6-4f33-9b69-5fe161150617";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_10-05-2022_48600.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea88fb98-ebad-4b27-94c9-d4f9974f5c25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11e025bc-f7d6-4f33-9b69-5fe161150617>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201724-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201724-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201724-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201724-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7eb55416-69ec-4b7c-abaf-1936f705dea2> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7eb55416-69ec-4b7c-abaf-1936f705dea2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f610a395-01a2-4295-9366-5904c4d4bf95";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9d442bf2-4087-463b-b33e-02b905a66b08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9d442bf2-4087-463b-b33e-02b905a66b08";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95>.
+
+  <http://redpencil.data.gift/id/task/caabcbd5-f3ee-4dbb-8b98-1617f0347bda> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "caabcbd5-f3ee-4dbb-8b98-1617f0347bda";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7eb55416-69ec-4b7c-abaf-1936f705dea2>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9d442bf2-4087-463b-b33e-02b905a66b08>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/80378682-3707-4227-ae1b-ed12027f2ebc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80378682-3707-4227-ae1b-ed12027f2ebc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_10-05-2022_48634.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80378682-3707-4227-ae1b-ed12027f2ebc>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfcaf0dd-8590-4d40-90e3-90a62d6326d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfcaf0dd-8590-4d40-90e3-90a62d6326d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_10-05-2022_48635.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfcaf0dd-8590-4d40-90e3-90a62d6326d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b6fb71c-fb9c-4a00-8bbb-658c735654f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b6fb71c-fb9c-4a00-8bbb-658c735654f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_10-05-2022_48642.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b6fb71c-fb9c-4a00-8bbb-658c735654f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/aba08348-446a-4a50-9cd2-4edc818d797b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aba08348-446a-4a50-9cd2-4edc818d797b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_10-05-2022_48643.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aba08348-446a-4a50-9cd2-4edc818d797b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba23d312-54e9-441a-86d5-22174a6dbd3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba23d312-54e9-441a-86d5-22174a6dbd3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_10-05-2022_48698.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba23d312-54e9-441a-86d5-22174a6dbd3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f425bf67-e9cc-4661-8d9c-b991cee20c2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f425bf67-e9cc-4661-8d9c-b991cee20c2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_10-05-2022_48805.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f425bf67-e9cc-4661-8d9c-b991cee20c2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b247f211-19c6-4922-aaec-c7c525b7a131> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b247f211-19c6-4922-aaec-c7c525b7a131";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_10-05-2022_48806.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b247f211-19c6-4922-aaec-c7c525b7a131>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3998ddd-5851-4bdf-adbf-274e523a3b09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3998ddd-5851-4bdf-adbf-274e523a3b09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_10-05-2022_48807.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3998ddd-5851-4bdf-adbf-274e523a3b09>.
+    
+<http://data.lblod.info/id/remote-data-objects/392110fc-cfba-4142-83c8-9cf285780071> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "392110fc-cfba-4142-83c8-9cf285780071";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_10-05-2022_48808.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/392110fc-cfba-4142-83c8-9cf285780071>.
+    
+<http://data.lblod.info/id/remote-data-objects/066c7bf6-6b05-4f18-b7eb-044ec4cda2ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "066c7bf6-6b05-4f18-b7eb-044ec4cda2ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_10-05-2022_48809.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/066c7bf6-6b05-4f18-b7eb-044ec4cda2ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/82748d5a-e672-40a3-bd59-3bce543dc066> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82748d5a-e672-40a3-bd59-3bce543dc066";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_12-04-2022_48317.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82748d5a-e672-40a3-bd59-3bce543dc066>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa36c3b4-e70a-46b1-8b96-65ef0446d667> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa36c3b4-e70a-46b1-8b96-65ef0446d667";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_12-04-2022_48318.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa36c3b4-e70a-46b1-8b96-65ef0446d667>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e979718-d233-43c3-b7aa-80734e82b0b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e979718-d233-43c3-b7aa-80734e82b0b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_12-04-2022_48319.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e979718-d233-43c3-b7aa-80734e82b0b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/596b1c9a-4133-4ca4-a768-c45c3b2a54b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "596b1c9a-4133-4ca4-a768-c45c3b2a54b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_12-04-2022_48320.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/596b1c9a-4133-4ca4-a768-c45c3b2a54b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4adde63-5205-4e8b-adb3-ff561c9e76a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4adde63-5205-4e8b-adb3-ff561c9e76a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_21-12-2021_45237.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4adde63-5205-4e8b-adb3-ff561c9e76a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4055673-1c42-4337-8c4b-91a182bbea97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4055673-1c42-4337-8c4b-91a182bbea97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_21-12-2021_45238.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4055673-1c42-4337-8c4b-91a182bbea97>.
+    
+<http://data.lblod.info/id/remote-data-objects/c84eba82-dd71-4bb9-a7f6-d2faf91daf7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c84eba82-dd71-4bb9-a7f6-d2faf91daf7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_26-10-2021_44843.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c84eba82-dd71-4bb9-a7f6-d2faf91daf7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e80030d6-6901-4112-bf64-05c95019d52c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e80030d6-6901-4112-bf64-05c95019d52c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_26-10-2021_44852.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e80030d6-6901-4112-bf64-05c95019d52c>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa0132b3-dbd7-4b50-b7af-ff10623dd906> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa0132b3-dbd7-4b50-b7af-ff10623dd906";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_26-10-2021_44942.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa0132b3-dbd7-4b50-b7af-ff10623dd906>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e4462b6-cb9a-4145-af44-671251021478> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e4462b6-cb9a-4145-af44-671251021478";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_26-10-2021_45013.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e4462b6-cb9a-4145-af44-671251021478>.
+    
+<http://data.lblod.info/id/remote-data-objects/495d609b-4ba8-4af2-afb4-6ef964d26fde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "495d609b-4ba8-4af2-afb4-6ef964d26fde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_30-11-2021_28453.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/495d609b-4ba8-4af2-afb4-6ef964d26fde>.
+    
+<http://data.lblod.info/id/remote-data-objects/52c66f08-5253-49ab-934e-e28c7261edf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52c66f08-5253-49ab-934e-e28c7261edf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_30-11-2021_45323.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52c66f08-5253-49ab-934e-e28c7261edf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc592527-3be0-481e-b689-608b33454f8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc592527-3be0-481e-b689-608b33454f8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_30-11-2021_45327.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc592527-3be0-481e-b689-608b33454f8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/365672dd-d97c-4a9b-95e5-5ab02e816f04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "365672dd-d97c-4a9b-95e5-5ab02e816f04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/04df980d13852d39e8527e9a474db264c1a57ffe8131319c3c820ef24330a4d9/GetPublication?filename=Uittreksels_30-11-2021_45428.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/365672dd-d97c-4a9b-95e5-5ab02e816f04>.
+    
+<http://data.lblod.info/id/remote-data-objects/080fc213-386f-4939-b45c-3002cc7098b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "080fc213-386f-4939-b45c-3002cc7098b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/329450d0444d950ee29fc65e8abb1e9eedd3c20d8ae581d2cc0913b2a3e6a8ed/GetPublication?filename=Uittreksels_10-05-2022_48961.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/080fc213-386f-4939-b45c-3002cc7098b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/661fdcf0-2f4d-40f0-9745-5302cdd157ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "661fdcf0-2f4d-40f0-9745-5302cdd157ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/329450d0444d950ee29fc65e8abb1e9eedd3c20d8ae581d2cc0913b2a3e6a8ed/GetPublication?filename=Uittreksels_13-05-2022_48878.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/661fdcf0-2f4d-40f0-9745-5302cdd157ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/0efe0276-67a6-4f75-9249-946c88efc6a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0efe0276-67a6-4f75-9249-946c88efc6a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/329450d0444d950ee29fc65e8abb1e9eedd3c20d8ae581d2cc0913b2a3e6a8ed/GetPublication?filename=Uittreksels_15-06-2022_49174.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0efe0276-67a6-4f75-9249-946c88efc6a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ece2920-16af-43b3-87d3-6b399aecfd82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ece2920-16af-43b3-87d3-6b399aecfd82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/329450d0444d950ee29fc65e8abb1e9eedd3c20d8ae581d2cc0913b2a3e6a8ed/GetPublication?filename=Uittreksels_18-05-2022_48935.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ece2920-16af-43b3-87d3-6b399aecfd82>.
+    
+<http://data.lblod.info/id/remote-data-objects/7083508c-d4e9-440d-ac6e-a3407ca71b3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7083508c-d4e9-440d-ac6e-a3407ca71b3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/329450d0444d950ee29fc65e8abb1e9eedd3c20d8ae581d2cc0913b2a3e6a8ed/GetPublication?filename=Uittreksels_28-10-2021_45405.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7083508c-d4e9-440d-ac6e-a3407ca71b3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7865709-b7f4-4eb4-81ab-a1adfcf6c3c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7865709-b7f4-4eb4-81ab-a1adfcf6c3c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7865709-b7f4-4eb4-81ab-a1adfcf6c3c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/016cb4f7-4ec9-4d3a-9dab-2c7567322efb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "016cb4f7-4ec9-4d3a-9dab-2c7567322efb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/016cb4f7-4ec9-4d3a-9dab-2c7567322efb>.
+    
+<http://data.lblod.info/id/remote-data-objects/10fc93a8-5630-46e6-89dc-8eed77a6aa83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10fc93a8-5630-46e6-89dc-8eed77a6aa83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10fc93a8-5630-46e6-89dc-8eed77a6aa83>.
+    
+<http://data.lblod.info/id/remote-data-objects/17dce9c4-e692-49f8-aa24-b0ab26b985c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17dce9c4-e692-49f8-aa24-b0ab26b985c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17dce9c4-e692-49f8-aa24-b0ab26b985c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/93caa136-015b-4f52-9f55-be0e88b13a3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93caa136-015b-4f52-9f55-be0e88b13a3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93caa136-015b-4f52-9f55-be0e88b13a3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/190a575d-e957-4809-8b17-2cc58d223b53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "190a575d-e957-4809-8b17-2cc58d223b53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/190a575d-e957-4809-8b17-2cc58d223b53>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd5a2924-2384-4d20-be72-99eb02910c22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd5a2924-2384-4d20-be72-99eb02910c22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd5a2924-2384-4d20-be72-99eb02910c22>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2291902-cc91-4ee8-a821-eda81f22be82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2291902-cc91-4ee8-a821-eda81f22be82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2291902-cc91-4ee8-a821-eda81f22be82>.
+    
+<http://data.lblod.info/id/remote-data-objects/4345c276-fce9-4b59-916a-1982898da5fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4345c276-fce9-4b59-916a-1982898da5fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4345c276-fce9-4b59-916a-1982898da5fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d01a308-e1a9-479e-834d-032ccb118e86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d01a308-e1a9-479e-834d-032ccb118e86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d01a308-e1a9-479e-834d-032ccb118e86>.
+    
+<http://data.lblod.info/id/remote-data-objects/b06973bc-ae31-408b-8e89-35931e30fe4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b06973bc-ae31-408b-8e89-35931e30fe4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b06973bc-ae31-408b-8e89-35931e30fe4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/08bb77e0-aede-4bed-9eb3-779722aec06c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08bb77e0-aede-4bed-9eb3-779722aec06c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08bb77e0-aede-4bed-9eb3-779722aec06c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d04f7687-d445-4670-bcd8-f843c3848486> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d04f7687-d445-4670-bcd8-f843c3848486";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d04f7687-d445-4670-bcd8-f843c3848486>.
+    
+<http://data.lblod.info/id/remote-data-objects/9097a1a5-5e3e-47d2-bd6f-bd3e204cdfe7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9097a1a5-5e3e-47d2-bd6f-bd3e204cdfe7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9097a1a5-5e3e-47d2-bd6f-bd3e204cdfe7>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc4dccd1-8cf7-4931-b022-b01e6ed2cd10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc4dccd1-8cf7-4931-b022-b01e6ed2cd10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc4dccd1-8cf7-4931-b022-b01e6ed2cd10>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4c03c33-c487-4c90-949f-9e64ce894715> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4c03c33-c487-4c90-949f-9e64ce894715";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4c03c33-c487-4c90-949f-9e64ce894715>.
+    
+<http://data.lblod.info/id/remote-data-objects/97c46045-b230-482a-9811-2d7beae576bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97c46045-b230-482a-9811-2d7beae576bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97c46045-b230-482a-9811-2d7beae576bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0b0b605-4f4c-45f6-bd81-81916a8e3597> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0b0b605-4f4c-45f6-bd81-81916a8e3597";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0b0b605-4f4c-45f6-bd81-81916a8e3597>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5924c23-97e4-466c-b60c-ec74fd5243e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5924c23-97e4-466c-b60c-ec74fd5243e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5924c23-97e4-466c-b60c-ec74fd5243e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/80ca04a9-f9e8-460c-9eaa-29e6028980df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80ca04a9-f9e8-460c-9eaa-29e6028980df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80ca04a9-f9e8-460c-9eaa-29e6028980df>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4caf061-1a4e-433b-a86d-5b7ad03ac576> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4caf061-1a4e-433b-a86d-5b7ad03ac576";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f610a395-01a2-4295-9366-5904c4d4bf95> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4caf061-1a4e-433b-a86d-5b7ad03ac576>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201725-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201725-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201725-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201725-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/4e9729b1-5f9b-47c4-baa2-ceefd0361871> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4e9729b1-5f9b-47c4-baa2-ceefd0361871";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "613b8395-4fdc-4b44-8afc-7fdfa21f637a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6c6eb83a-3803-4822-8555-4dc65c8433dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6c6eb83a-3803-4822-8555-4dc65c8433dc";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a>.
+
+  <http://redpencil.data.gift/id/task/863df4f0-7550-4c68-b8a4-281fe260db54> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "863df4f0-7550-4c68-b8a4-281fe260db54";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/4e9729b1-5f9b-47c4-baa2-ceefd0361871>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6c6eb83a-3803-4822-8555-4dc65c8433dc>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/53fbaf0f-970e-4e47-8a2f-0f736b87722a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53fbaf0f-970e-4e47-8a2f-0f736b87722a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53fbaf0f-970e-4e47-8a2f-0f736b87722a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a072dde9-a9dc-450d-9cda-2ce1e8e2d72c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a072dde9-a9dc-450d-9cda-2ce1e8e2d72c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a072dde9-a9dc-450d-9cda-2ce1e8e2d72c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c3709b1-5603-433b-88c2-a225b861c818> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c3709b1-5603-433b-88c2-a225b861c818";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c3709b1-5603-433b-88c2-a225b861c818>.
+    
+<http://data.lblod.info/id/remote-data-objects/94e39ba6-d79a-4295-a901-83a636ddb289> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94e39ba6-d79a-4295-a901-83a636ddb289";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94e39ba6-d79a-4295-a901-83a636ddb289>.
+    
+<http://data.lblod.info/id/remote-data-objects/b648ed49-596b-4b76-b1f5-7c07f0ba527c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b648ed49-596b-4b76-b1f5-7c07f0ba527c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b648ed49-596b-4b76-b1f5-7c07f0ba527c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ba02f12-e451-48d5-9ea7-213fd5b334cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ba02f12-e451-48d5-9ea7-213fd5b334cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ba02f12-e451-48d5-9ea7-213fd5b334cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddbdc2fb-8199-45c8-a438-7d89e5404eaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddbdc2fb-8199-45c8-a438-7d89e5404eaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddbdc2fb-8199-45c8-a438-7d89e5404eaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5504ee8-fef1-4895-aa0a-4f93d617e7f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5504ee8-fef1-4895-aa0a-4f93d617e7f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5504ee8-fef1-4895-aa0a-4f93d617e7f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c653c766-de0d-48e0-b6f0-c6a7a4ec4849> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c653c766-de0d-48e0-b6f0-c6a7a4ec4849";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c653c766-de0d-48e0-b6f0-c6a7a4ec4849>.
+    
+<http://data.lblod.info/id/remote-data-objects/92bde90c-17e9-4c85-a51f-73f6fb56226c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92bde90c-17e9-4c85-a51f-73f6fb56226c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92bde90c-17e9-4c85-a51f-73f6fb56226c>.
+    
+<http://data.lblod.info/id/remote-data-objects/792e9c34-f44e-4956-88cd-3c5df165bec6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "792e9c34-f44e-4956-88cd-3c5df165bec6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/792e9c34-f44e-4956-88cd-3c5df165bec6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0642efd4-16ac-4892-92e9-1cab05f44b8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0642efd4-16ac-4892-92e9-1cab05f44b8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0642efd4-16ac-4892-92e9-1cab05f44b8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/37346053-7378-4129-9d9f-69ef6877a8ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37346053-7378-4129-9d9f-69ef6877a8ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=Uittreksels_09-05-2022_48780.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37346053-7378-4129-9d9f-69ef6877a8ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/96211c53-537d-42a5-b086-7e764d66ca11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96211c53-537d-42a5-b086-7e764d66ca11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=Uittreksels_20-12-2021_46848.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96211c53-537d-42a5-b086-7e764d66ca11>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0a654dd-9173-408b-8682-1125b490fdfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0a654dd-9173-408b-8682-1125b490fdfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/4815db4b15c5f0e32e6b95718c20c9dae85d761becb8418d940dc3a1e94ed98c/GetPublication?filename=Uittreksels_24-01-2022_47531.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0a654dd-9173-408b-8682-1125b490fdfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cf1b12b-86b3-4390-aacd-d2a575593ac1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cf1b12b-86b3-4390-aacd-d2a575593ac1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cf1b12b-86b3-4390-aacd-d2a575593ac1>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f190a23-8197-468c-830b-1a7b6ed5fb49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f190a23-8197-468c-830b-1a7b6ed5fb49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f190a23-8197-468c-830b-1a7b6ed5fb49>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d2aacf2-f0c5-4cf3-9cb0-45eff08d0d0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d2aacf2-f0c5-4cf3-9cb0-45eff08d0d0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d2aacf2-f0c5-4cf3-9cb0-45eff08d0d0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae044291-76d6-488a-8842-6cb02830cebf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae044291-76d6-488a-8842-6cb02830cebf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae044291-76d6-488a-8842-6cb02830cebf>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9d0a6ec-d6e7-482b-a40a-c68516a86134> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9d0a6ec-d6e7-482b-a40a-c68516a86134";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9d0a6ec-d6e7-482b-a40a-c68516a86134>.
+    
+<http://data.lblod.info/id/remote-data-objects/9da4ca0b-4edc-442a-926f-51a38d4f668f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9da4ca0b-4edc-442a-926f-51a38d4f668f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9da4ca0b-4edc-442a-926f-51a38d4f668f>.
+    
+<http://data.lblod.info/id/remote-data-objects/af105cc0-617f-44b6-b37a-3e2b6a9fb93e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af105cc0-617f-44b6-b37a-3e2b6a9fb93e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af105cc0-617f-44b6-b37a-3e2b6a9fb93e>.
+    
+<http://data.lblod.info/id/remote-data-objects/614bc59a-91bb-4915-b92c-14cff94d6702> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "614bc59a-91bb-4915-b92c-14cff94d6702";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/614bc59a-91bb-4915-b92c-14cff94d6702>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7a31669-992a-443b-be91-cda4707bd01d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7a31669-992a-443b-be91-cda4707bd01d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7a31669-992a-443b-be91-cda4707bd01d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b45fe6b4-f872-4d9c-a29f-6be7b6b58598> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b45fe6b4-f872-4d9c-a29f-6be7b6b58598";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b45fe6b4-f872-4d9c-a29f-6be7b6b58598>.
+    
+<http://data.lblod.info/id/remote-data-objects/13f48500-f82c-47f6-9491-d6f5a6e617e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13f48500-f82c-47f6-9491-d6f5a6e617e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13f48500-f82c-47f6-9491-d6f5a6e617e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9081e16-cd2b-4414-a112-fffff6ae4548> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9081e16-cd2b-4414-a112-fffff6ae4548";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9081e16-cd2b-4414-a112-fffff6ae4548>.
+    
+<http://data.lblod.info/id/remote-data-objects/7103adb4-0324-4c05-b5d7-3cb868fb8e18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7103adb4-0324-4c05-b5d7-3cb868fb8e18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7103adb4-0324-4c05-b5d7-3cb868fb8e18>.
+    
+<http://data.lblod.info/id/remote-data-objects/1dcbbf93-efca-45c1-b95d-910d39bf5094> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1dcbbf93-efca-45c1-b95d-910d39bf5094";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1dcbbf93-efca-45c1-b95d-910d39bf5094>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a2460ab-169b-4039-9670-a5e5eb1d2b3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a2460ab-169b-4039-9670-a5e5eb1d2b3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a2460ab-169b-4039-9670-a5e5eb1d2b3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/38db7ff9-27ff-4123-9d83-c752aa657452> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38db7ff9-27ff-4123-9d83-c752aa657452";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38db7ff9-27ff-4123-9d83-c752aa657452>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ad8b631-a63d-4cad-b95b-87941d1ad182> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ad8b631-a63d-4cad-b95b-87941d1ad182";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ad8b631-a63d-4cad-b95b-87941d1ad182>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3f82afc-26ed-4ea2-8cc3-af569458a6b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3f82afc-26ed-4ea2-8cc3-af569458a6b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3f82afc-26ed-4ea2-8cc3-af569458a6b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e96c8129-07ce-4233-8bb8-de4048810c15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e96c8129-07ce-4233-8bb8-de4048810c15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e96c8129-07ce-4233-8bb8-de4048810c15>.
+    
+<http://data.lblod.info/id/remote-data-objects/afd62236-fddf-4235-9cef-2f875d0c61b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afd62236-fddf-4235-9cef-2f875d0c61b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afd62236-fddf-4235-9cef-2f875d0c61b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1706e9b0-4014-4558-98f7-5d068e86b768> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1706e9b0-4014-4558-98f7-5d068e86b768";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1706e9b0-4014-4558-98f7-5d068e86b768>.
+    
+<http://data.lblod.info/id/remote-data-objects/84f8cf98-6955-43e6-91c2-a1431599452a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84f8cf98-6955-43e6-91c2-a1431599452a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84f8cf98-6955-43e6-91c2-a1431599452a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7789a3dc-84be-42a9-82ba-8cc8f823d9b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7789a3dc-84be-42a9-82ba-8cc8f823d9b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7789a3dc-84be-42a9-82ba-8cc8f823d9b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0f30986-80e5-402b-a500-d9339142b90c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0f30986-80e5-402b-a500-d9339142b90c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0f30986-80e5-402b-a500-d9339142b90c>.
+    
+<http://data.lblod.info/id/remote-data-objects/90ebc2a1-e819-4576-81b5-94f4db1390da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90ebc2a1-e819-4576-81b5-94f4db1390da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90ebc2a1-e819-4576-81b5-94f4db1390da>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0d14289-ccfa-4c64-bc1a-54554193b351> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0d14289-ccfa-4c64-bc1a-54554193b351";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0d14289-ccfa-4c64-bc1a-54554193b351>.
+    
+<http://data.lblod.info/id/remote-data-objects/874dc721-72bd-4cd0-9652-94ed65f18544> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "874dc721-72bd-4cd0-9652-94ed65f18544";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/874dc721-72bd-4cd0-9652-94ed65f18544>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1376c96-4530-4210-945e-a2e7afdb56f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1376c96-4530-4210-945e-a2e7afdb56f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1376c96-4530-4210-945e-a2e7afdb56f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5a5d119-3bf4-472c-8ea8-788354a65818> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5a5d119-3bf4-472c-8ea8-788354a65818";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5a5d119-3bf4-472c-8ea8-788354a65818>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4d19545-b3cd-440e-b4ec-a27d5e22fc3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4d19545-b3cd-440e-b4ec-a27d5e22fc3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4d19545-b3cd-440e-b4ec-a27d5e22fc3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/14558b1c-1423-4e97-8496-9119c927c864> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14558b1c-1423-4e97-8496-9119c927c864";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14558b1c-1423-4e97-8496-9119c927c864>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddf42000-34e3-4421-94b8-8b5e5ca9fe0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddf42000-34e3-4421-94b8-8b5e5ca9fe0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddf42000-34e3-4421-94b8-8b5e5ca9fe0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/710f2380-04b7-406f-8488-1efb046abc71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "710f2380-04b7-406f-8488-1efb046abc71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/710f2380-04b7-406f-8488-1efb046abc71>.
+    
+<http://data.lblod.info/id/remote-data-objects/924fa5c9-6d02-440a-84d5-d264a5b21615> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "924fa5c9-6d02-440a-84d5-d264a5b21615";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_02-05-2022_48620.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/924fa5c9-6d02-440a-84d5-d264a5b21615>.
+    
+<http://data.lblod.info/id/remote-data-objects/283d90f2-7675-4189-9701-a658daabe0e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "283d90f2-7675-4189-9701-a658daabe0e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_03-01-2022_47167.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/613b8395-4fdc-4b44-8afc-7fdfa21f637a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/283d90f2-7675-4189-9701-a658daabe0e3>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201727-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201727-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201727-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201727-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/08f53cb5-e33a-4812-a52a-0208337f505e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "08f53cb5-e33a-4812-a52a-0208337f505e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a871a6ec-80f9-43b7-a39b-54776cbd29be";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/be5cb0e1-35d6-4a8c-91a8-5100dd89851c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "be5cb0e1-35d6-4a8c-91a8-5100dd89851c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be>.
+
+  <http://redpencil.data.gift/id/task/48cb18e8-87d0-458e-982b-8e619bb27640> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "48cb18e8-87d0-458e-982b-8e619bb27640";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/08f53cb5-e33a-4812-a52a-0208337f505e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/be5cb0e1-35d6-4a8c-91a8-5100dd89851c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/2c30ce48-a5d7-42f0-8850-14402987d7cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c30ce48-a5d7-42f0-8850-14402987d7cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_04-07-2022_49317.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c30ce48-a5d7-42f0-8850-14402987d7cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa9ab1c9-ab32-4d03-90b7-f1b421706c88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa9ab1c9-ab32-4d03-90b7-f1b421706c88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_04-07-2022_49352.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa9ab1c9-ab32-4d03-90b7-f1b421706c88>.
+    
+<http://data.lblod.info/id/remote-data-objects/b561504b-a9c2-43c6-8c60-c77bccade926> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b561504b-a9c2-43c6-8c60-c77bccade926";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_04-07-2022_49353.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b561504b-a9c2-43c6-8c60-c77bccade926>.
+    
+<http://data.lblod.info/id/remote-data-objects/d03fbc25-d5f8-4d72-a09c-9f3db92d20d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d03fbc25-d5f8-4d72-a09c-9f3db92d20d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_04-10-2021_44913.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d03fbc25-d5f8-4d72-a09c-9f3db92d20d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/76fb8607-c7a4-415b-a1e7-b5fc42ce0ce9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76fb8607-c7a4-415b-a1e7-b5fc42ce0ce9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_04-10-2021_45018.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76fb8607-c7a4-415b-a1e7-b5fc42ce0ce9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d124c330-98c1-42d7-b185-d7fb9b6be5d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d124c330-98c1-42d7-b185-d7fb9b6be5d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_04-10-2021_45020.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d124c330-98c1-42d7-b185-d7fb9b6be5d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/93306d92-de6e-48e2-b2de-21ad3ceaf6d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93306d92-de6e-48e2-b2de-21ad3ceaf6d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_04-10-2021_45021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93306d92-de6e-48e2-b2de-21ad3ceaf6d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2046cf03-0017-4c2b-9192-42485bad57be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2046cf03-0017-4c2b-9192-42485bad57be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_04-10-2021_45022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2046cf03-0017-4c2b-9192-42485bad57be>.
+    
+<http://data.lblod.info/id/remote-data-objects/1961b652-cf2a-4f54-a94a-edaf3b14b55b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1961b652-cf2a-4f54-a94a-edaf3b14b55b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_07-02-2022_47732.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1961b652-cf2a-4f54-a94a-edaf3b14b55b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe311762-0e6a-4f84-8620-6efa4e27e30c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe311762-0e6a-4f84-8620-6efa4e27e30c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_07-02-2022_47733.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe311762-0e6a-4f84-8620-6efa4e27e30c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ae33886-a67f-4d80-a168-e147f397c820> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ae33886-a67f-4d80-a168-e147f397c820";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_07-03-2022_48066.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ae33886-a67f-4d80-a168-e147f397c820>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e144337-f106-418e-9472-8e55b314449a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e144337-f106-418e-9472-8e55b314449a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_07-03-2022_48067.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e144337-f106-418e-9472-8e55b314449a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2300dc55-13dc-42be-88d8-6077a3eae190> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2300dc55-13dc-42be-88d8-6077a3eae190";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_07-03-2022_48100.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2300dc55-13dc-42be-88d8-6077a3eae190>.
+    
+<http://data.lblod.info/id/remote-data-objects/c498cbf3-b35a-4c3b-acb7-496655ebd669> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c498cbf3-b35a-4c3b-acb7-496655ebd669";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_08-11-2021_45392.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c498cbf3-b35a-4c3b-acb7-496655ebd669>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ab58425-ce9b-4523-a8c9-9c6d2ff6d690> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ab58425-ce9b-4523-a8c9-9c6d2ff6d690";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_08-11-2021_45394.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ab58425-ce9b-4523-a8c9-9c6d2ff6d690>.
+    
+<http://data.lblod.info/id/remote-data-objects/190d5dc9-9aba-44be-b09b-2ea4f6ebc64a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "190d5dc9-9aba-44be-b09b-2ea4f6ebc64a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_09-05-2022_48460.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/190d5dc9-9aba-44be-b09b-2ea4f6ebc64a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4727a9ae-1346-41d4-89cd-41b5b95bc1fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4727a9ae-1346-41d4-89cd-41b5b95bc1fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_09-05-2022_48727.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4727a9ae-1346-41d4-89cd-41b5b95bc1fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f20dd6a-7f38-4321-bebb-bb6367bda688> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f20dd6a-7f38-4321-bebb-bb6367bda688";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_11-04-2022_48362.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f20dd6a-7f38-4321-bebb-bb6367bda688>.
+    
+<http://data.lblod.info/id/remote-data-objects/6337b43e-78e2-4caf-8fd8-cd81a8b1a165> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6337b43e-78e2-4caf-8fd8-cd81a8b1a165";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_13-06-2022_49072.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6337b43e-78e2-4caf-8fd8-cd81a8b1a165>.
+    
+<http://data.lblod.info/id/remote-data-objects/76dda3d5-4cbe-4f2e-957e-711b668acb1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76dda3d5-4cbe-4f2e-957e-711b668acb1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_13-06-2022_49076.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76dda3d5-4cbe-4f2e-957e-711b668acb1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/40a43a59-4fa6-4565-9b0f-289ab298649f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40a43a59-4fa6-4565-9b0f-289ab298649f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_13-06-2022_49077.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40a43a59-4fa6-4565-9b0f-289ab298649f>.
+    
+<http://data.lblod.info/id/remote-data-objects/902e4881-ce4a-404b-a4c5-5da90a94ef77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "902e4881-ce4a-404b-a4c5-5da90a94ef77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_13-06-2022_49078.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/902e4881-ce4a-404b-a4c5-5da90a94ef77>.
+    
+<http://data.lblod.info/id/remote-data-objects/1af146d3-8daa-4207-b510-b8f070e361a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1af146d3-8daa-4207-b510-b8f070e361a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_13-06-2022_49097.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1af146d3-8daa-4207-b510-b8f070e361a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad509fad-877d-44c2-99ad-efa3b6d77c4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad509fad-877d-44c2-99ad-efa3b6d77c4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_14-02-2022_47842.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad509fad-877d-44c2-99ad-efa3b6d77c4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/232185f3-fd71-4ee7-93df-47beda4eb143> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "232185f3-fd71-4ee7-93df-47beda4eb143";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_14-02-2022_47863.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/232185f3-fd71-4ee7-93df-47beda4eb143>.
+    
+<http://data.lblod.info/id/remote-data-objects/501f9b40-81db-4bd8-ad8b-dcd8275e4ec4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "501f9b40-81db-4bd8-ad8b-dcd8275e4ec4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_14-02-2022_47866.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/501f9b40-81db-4bd8-ad8b-dcd8275e4ec4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef1db93e-3b86-4155-bedb-b85205f9dd73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef1db93e-3b86-4155-bedb-b85205f9dd73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_14-02-2022_47904.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef1db93e-3b86-4155-bedb-b85205f9dd73>.
+    
+<http://data.lblod.info/id/remote-data-objects/48641645-984d-4681-aee9-d5ad039016c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48641645-984d-4681-aee9-d5ad039016c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_14-02-2022_47905.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48641645-984d-4681-aee9-d5ad039016c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/8af6a731-6434-4d1b-be13-d30fbedb32bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8af6a731-6434-4d1b-be13-d30fbedb32bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_15-07-2022_49346.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8af6a731-6434-4d1b-be13-d30fbedb32bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2b617db-358e-4557-beb2-0229a3f6ba5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2b617db-358e-4557-beb2-0229a3f6ba5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_15-07-2022_49347.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2b617db-358e-4557-beb2-0229a3f6ba5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6de824ac-d4fc-443b-8275-9e51b10d2774> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6de824ac-d4fc-443b-8275-9e51b10d2774";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_15-07-2022_49348.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6de824ac-d4fc-443b-8275-9e51b10d2774>.
+    
+<http://data.lblod.info/id/remote-data-objects/8efa57a0-f4a1-4586-a791-526ab35cbcfb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8efa57a0-f4a1-4586-a791-526ab35cbcfb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_15-07-2022_49354.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8efa57a0-f4a1-4586-a791-526ab35cbcfb>.
+    
+<http://data.lblod.info/id/remote-data-objects/bead1bad-cebc-4c8e-8f23-9f1bcc5e77f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bead1bad-cebc-4c8e-8f23-9f1bcc5e77f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_15-07-2022_49355.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bead1bad-cebc-4c8e-8f23-9f1bcc5e77f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/34c63a5c-f7f6-482f-831c-a6775c2fc037> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34c63a5c-f7f6-482f-831c-a6775c2fc037";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_15-07-2022_49356.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34c63a5c-f7f6-482f-831c-a6775c2fc037>.
+    
+<http://data.lblod.info/id/remote-data-objects/697c4152-5fe6-438d-b8cc-1ac80568402a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "697c4152-5fe6-438d-b8cc-1ac80568402a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_15-07-2022_49357.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/697c4152-5fe6-438d-b8cc-1ac80568402a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5dc3358-75d0-4171-a133-368ec19a1d72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5dc3358-75d0-4171-a133-368ec19a1d72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_15-07-2022_49358.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5dc3358-75d0-4171-a133-368ec19a1d72>.
+    
+<http://data.lblod.info/id/remote-data-objects/84c5c891-fc76-4562-a0e1-bb119c1084e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84c5c891-fc76-4562-a0e1-bb119c1084e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_16-05-2022_48880.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84c5c891-fc76-4562-a0e1-bb119c1084e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6c75645-9540-466b-b11e-a83f2590644f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6c75645-9540-466b-b11e-a83f2590644f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_17-01-2022_47440.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6c75645-9540-466b-b11e-a83f2590644f>.
+    
+<http://data.lblod.info/id/remote-data-objects/742460ea-d7ea-4da0-8992-05494ea9b5c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "742460ea-d7ea-4da0-8992-05494ea9b5c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_20-12-2021_46845.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/742460ea-d7ea-4da0-8992-05494ea9b5c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/79bd9a17-be49-46ad-b17c-3706e9a3979f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79bd9a17-be49-46ad-b17c-3706e9a3979f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_21-03-2022_48211.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79bd9a17-be49-46ad-b17c-3706e9a3979f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e297980a-b1b9-4174-9b7c-8c3780a622f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e297980a-b1b9-4174-9b7c-8c3780a622f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_23-05-2022_48881.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e297980a-b1b9-4174-9b7c-8c3780a622f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/59f83894-ab57-45c1-8f42-9ac21034766a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59f83894-ab57-45c1-8f42-9ac21034766a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_23-05-2022_48883.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59f83894-ab57-45c1-8f42-9ac21034766a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a09984aa-d293-48e6-8b06-3d3b83b9a2dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a09984aa-d293-48e6-8b06-3d3b83b9a2dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_23-05-2022_48884.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a09984aa-d293-48e6-8b06-3d3b83b9a2dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d00c5de-75eb-4848-a9ee-301398fbd9a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d00c5de-75eb-4848-a9ee-301398fbd9a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_23-05-2022_48934.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d00c5de-75eb-4848-a9ee-301398fbd9a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/01fd6f58-59df-4568-9134-696859df16d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01fd6f58-59df-4568-9134-696859df16d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_23-05-2022_48946.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01fd6f58-59df-4568-9134-696859df16d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/8288f9ba-1a23-416b-8ef6-77441ad4b3a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8288f9ba-1a23-416b-8ef6-77441ad4b3a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_24-01-2022_47492.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8288f9ba-1a23-416b-8ef6-77441ad4b3a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f8e3ef5-a1fc-4f94-b8e3-fc5a060e0b62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f8e3ef5-a1fc-4f94-b8e3-fc5a060e0b62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_24-01-2022_47525.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f8e3ef5-a1fc-4f94-b8e3-fc5a060e0b62>.
+    
+<http://data.lblod.info/id/remote-data-objects/a30d1e50-7ac0-4d66-b7af-82c2dfc3d7aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a30d1e50-7ac0-4d66-b7af-82c2dfc3d7aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_24-01-2022_47529.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a30d1e50-7ac0-4d66-b7af-82c2dfc3d7aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/f400edb8-c3f8-4838-8811-b8e1d39c8ea1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f400edb8-c3f8-4838-8811-b8e1d39c8ea1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_24-01-2022_47545.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f400edb8-c3f8-4838-8811-b8e1d39c8ea1>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ca26d84-d781-467b-8190-d56ef92493be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ca26d84-d781-467b-8190-d56ef92493be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_30-05-2022_48955.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a871a6ec-80f9-43b7-a39b-54776cbd29be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ca26d84-d781-467b-8190-d56ef92493be>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201728-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201728-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201728-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201728-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b4f3a5be-3325-41e9-ba80-47eee9cd58fd> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b4f3a5be-3325-41e9-ba80-47eee9cd58fd";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bdeb3deb-a1b9-492c-951e-7cb5f03cd006";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b6357b98-4ca7-4105-925e-b716a5600557> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b6357b98-4ca7-4105-925e-b716a5600557";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006>.
+
+  <http://redpencil.data.gift/id/task/194afe3e-8868-4b5e-bdae-d55d65115ccc> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "194afe3e-8868-4b5e-bdae-d55d65115ccc";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b4f3a5be-3325-41e9-ba80-47eee9cd58fd>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b6357b98-4ca7-4105-925e-b716a5600557>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/0c3c484f-9b77-4315-ae1a-b3c297c13d6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c3c484f-9b77-4315-ae1a-b3c297c13d6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_30-05-2022_48956.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c3c484f-9b77-4315-ae1a-b3c297c13d6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfb015a0-0173-41fe-82d7-8defb874d474> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfb015a0-0173-41fe-82d7-8defb874d474";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_30-05-2022_48957.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfb015a0-0173-41fe-82d7-8defb874d474>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ef9ff98-169f-4720-954b-a26eb000d2ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ef9ff98-169f-4720-954b-a26eb000d2ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_30-05-2022_48966.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ef9ff98-169f-4720-954b-a26eb000d2ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/53e25474-e312-4e21-99b5-73642b6303d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53e25474-e312-4e21-99b5-73642b6303d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_30-05-2022_48972.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53e25474-e312-4e21-99b5-73642b6303d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c49cf69-e07b-4ea4-b341-5287624b58e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c49cf69-e07b-4ea4-b341-5287624b58e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wervik.be/LBLODWeb/Home/Overzicht/b769e52075e734050a1af03546cf4a8cae2ceeab6003e9bb4192d501e9ef0d70/GetPublication?filename=Uittreksels_31-01-2022_47697.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c49cf69-e07b-4ea4-b341-5287624b58e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6a01829-fee6-455f-abc3-4b9f07434e29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6a01829-fee6-455f-abc3-4b9f07434e29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Agenda_gemeenteraad_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6a01829-fee6-455f-abc3-4b9f07434e29>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbbb99d2-49d7-4d49-aad0-5695da19834b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbbb99d2-49d7-4d49-aad0-5695da19834b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Agenda_gemeenteraad_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbbb99d2-49d7-4d49-aad0-5695da19834b>.
+    
+<http://data.lblod.info/id/remote-data-objects/272cefd7-23c9-4509-acf6-39defc870a5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "272cefd7-23c9-4509-acf6-39defc870a5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Agenda_gemeenteraad_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/272cefd7-23c9-4509-acf6-39defc870a5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d4ae5a8-4543-4410-ab6a-51b5e271022f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d4ae5a8-4543-4410-ab6a-51b5e271022f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Agenda_gemeenteraad_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d4ae5a8-4543-4410-ab6a-51b5e271022f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f723aadb-71bb-49e7-afa8-a1ecb3db8a1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f723aadb-71bb-49e7-afa8-a1ecb3db8a1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Agenda_gemeenteraad_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f723aadb-71bb-49e7-afa8-a1ecb3db8a1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8e0c332-165f-4786-9358-d59d77294d4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8e0c332-165f-4786-9358-d59d77294d4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Agenda_gemeenteraad_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8e0c332-165f-4786-9358-d59d77294d4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0461a71f-f9f7-49d2-8b28-85dcf358efa0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0461a71f-f9f7-49d2-8b28-85dcf358efa0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Agenda_gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0461a71f-f9f7-49d2-8b28-85dcf358efa0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a41fb9c-8fcb-4abf-9329-3310a8ed3b5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a41fb9c-8fcb-4abf-9329-3310a8ed3b5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Agenda_gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a41fb9c-8fcb-4abf-9329-3310a8ed3b5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d79def22-5097-4abc-b32f-3025f5641c35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d79def22-5097-4abc-b32f-3025f5641c35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d79def22-5097-4abc-b32f-3025f5641c35>.
+    
+<http://data.lblod.info/id/remote-data-objects/01789dd7-eea3-4ec4-ac1d-a6e4e54b6baf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01789dd7-eea3-4ec4-ac1d-a6e4e54b6baf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01789dd7-eea3-4ec4-ac1d-a6e4e54b6baf>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9a777d8-84e3-4e8b-92e1-e41f34c2ba5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9a777d8-84e3-4e8b-92e1-e41f34c2ba5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9a777d8-84e3-4e8b-92e1-e41f34c2ba5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c972f2b0-f83c-4a30-a8ec-047546c471a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c972f2b0-f83c-4a30-a8ec-047546c471a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c972f2b0-f83c-4a30-a8ec-047546c471a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/b03113f8-174d-423b-bb6d-eca4113ba208> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b03113f8-174d-423b-bb6d-eca4113ba208";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b03113f8-174d-423b-bb6d-eca4113ba208>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd06aeaf-6444-456a-bc07-a71dd5f74367> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd06aeaf-6444-456a-bc07-a71dd5f74367";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_22-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd06aeaf-6444-456a-bc07-a71dd5f74367>.
+    
+<http://data.lblod.info/id/remote-data-objects/1174fbfe-363e-4cdd-a09b-e9d4158ce07a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1174fbfe-363e-4cdd-a09b-e9d4158ce07a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1174fbfe-363e-4cdd-a09b-e9d4158ce07a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d6e2965-68bf-4ef8-bec3-046a0f2c275d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d6e2965-68bf-4ef8-bec3-046a0f2c275d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=BesluitenLijstUitspraak_gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d6e2965-68bf-4ef8-bec3-046a0f2c275d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2a63c01-639a-4aa0-9c2d-cf8ac53a68df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2a63c01-639a-4aa0-9c2d-cf8ac53a68df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Notulen_gemeenteraad_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2a63c01-639a-4aa0-9c2d-cf8ac53a68df>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f77e90c-7dc7-420b-aa85-4ead5697d6a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f77e90c-7dc7-420b-aa85-4ead5697d6a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Notulen_gemeenteraad_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f77e90c-7dc7-420b-aa85-4ead5697d6a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/33916877-aed1-4c18-873c-77032012dda3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33916877-aed1-4c18-873c-77032012dda3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Notulen_gemeenteraad_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33916877-aed1-4c18-873c-77032012dda3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d362f51d-72dc-4c78-9ce8-022ecceeb4ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d362f51d-72dc-4c78-9ce8-022ecceeb4ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Notulen_gemeenteraad_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d362f51d-72dc-4c78-9ce8-022ecceeb4ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/eae52120-27f8-480e-9a72-f0c1b95abd25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eae52120-27f8-480e-9a72-f0c1b95abd25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Notulen_gemeenteraad_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eae52120-27f8-480e-9a72-f0c1b95abd25>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac3a6cc9-4179-447c-82b5-ac201c66b5c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac3a6cc9-4179-447c-82b5-ac201c66b5c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Notulen_gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac3a6cc9-4179-447c-82b5-ac201c66b5c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c12255e0-7073-4b44-9d23-60c6d8f2c9ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c12255e0-7073-4b44-9d23-60c6d8f2c9ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Notulen_gemeenteraad_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c12255e0-7073-4b44-9d23-60c6d8f2c9ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/27cac802-6488-4ef4-8ec5-343f59448cf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27cac802-6488-4ef4-8ec5-343f59448cf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-02-2022_47997.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27cac802-6488-4ef4-8ec5-343f59448cf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba1d1860-d4e8-42a2-b819-9e7a12b0e3bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba1d1860-d4e8-42a2-b819-9e7a12b0e3bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-02-2022_47998.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba1d1860-d4e8-42a2-b819-9e7a12b0e3bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d98f35b7-7e0f-443e-9539-c50904fbb0ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d98f35b7-7e0f-443e-9539-c50904fbb0ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-02-2022_47999.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d98f35b7-7e0f-443e-9539-c50904fbb0ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/77f321d8-2b41-4eb1-9c0a-ad7d36927ea7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77f321d8-2b41-4eb1-9c0a-ad7d36927ea7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-02-2022_48000.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77f321d8-2b41-4eb1-9c0a-ad7d36927ea7>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f1a7998-5e5c-41f7-8de3-9c01e5d9102c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f1a7998-5e5c-41f7-8de3-9c01e5d9102c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-02-2022_48298.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f1a7998-5e5c-41f7-8de3-9c01e5d9102c>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbbff6ff-43bd-4cc5-a15f-0f0b53d9463e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbbff6ff-43bd-4cc5-a15f-0f0b53d9463e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-02-2022_48300.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbbff6ff-43bd-4cc5-a15f-0f0b53d9463e>.
+    
+<http://data.lblod.info/id/remote-data-objects/54fa0f43-2aee-4d88-887d-0b30539e5ad7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54fa0f43-2aee-4d88-887d-0b30539e5ad7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-02-2022_48308.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54fa0f43-2aee-4d88-887d-0b30539e5ad7>.
+    
+<http://data.lblod.info/id/remote-data-objects/589ea44a-ef9e-47a0-a6cf-3e57dfdf7a78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "589ea44a-ef9e-47a0-a6cf-3e57dfdf7a78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-02-2022_48345.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/589ea44a-ef9e-47a0-a6cf-3e57dfdf7a78>.
+    
+<http://data.lblod.info/id/remote-data-objects/14578e54-ad41-47f6-bf5b-595e2722f690> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14578e54-ad41-47f6-bf5b-595e2722f690";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-02-2022_48372.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14578e54-ad41-47f6-bf5b-595e2722f690>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa0af35c-adb5-465c-9fa9-243f2768150d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa0af35c-adb5-465c-9fa9-243f2768150d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-02-2022_48384.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa0af35c-adb5-465c-9fa9-243f2768150d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4753732a-20df-4352-95fa-b5e81d8a9c19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4753732a-20df-4352-95fa-b5e81d8a9c19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-12-2021_46450.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4753732a-20df-4352-95fa-b5e81d8a9c19>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb297335-9a59-4ec6-b4e8-3b6edf1059db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb297335-9a59-4ec6-b4e8-3b6edf1059db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-12-2021_46451.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb297335-9a59-4ec6-b4e8-3b6edf1059db>.
+    
+<http://data.lblod.info/id/remote-data-objects/0eb37036-7be8-47aa-946c-5d569095cd27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0eb37036-7be8-47aa-946c-5d569095cd27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-12-2021_46596.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0eb37036-7be8-47aa-946c-5d569095cd27>.
+    
+<http://data.lblod.info/id/remote-data-objects/64f17805-5284-4238-b01a-8d5323eec9b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64f17805-5284-4238-b01a-8d5323eec9b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-12-2021_47014.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64f17805-5284-4238-b01a-8d5323eec9b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/076f833f-4a9f-406f-871f-9cec5a329965> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "076f833f-4a9f-406f-871f-9cec5a329965";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-12-2021_47064.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/076f833f-4a9f-406f-871f-9cec5a329965>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bb6ad36-9778-44c5-9af7-0d99322c845e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bb6ad36-9778-44c5-9af7-0d99322c845e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-12-2021_47067.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bb6ad36-9778-44c5-9af7-0d99322c845e>.
+    
+<http://data.lblod.info/id/remote-data-objects/53db7ee2-bf1b-4b6c-9b96-5a44a642ce5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53db7ee2-bf1b-4b6c-9b96-5a44a642ce5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-12-2021_47078.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53db7ee2-bf1b-4b6c-9b96-5a44a642ce5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3f50756-81f9-45aa-b25a-c4979b87496a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3f50756-81f9-45aa-b25a-c4979b87496a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_15-12-2021_47159.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3f50756-81f9-45aa-b25a-c4979b87496a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0a7127a-73a5-4668-bd8e-2fe2f844d55d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0a7127a-73a5-4668-bd8e-2fe2f844d55d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_18-01-2022_47623.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0a7127a-73a5-4668-bd8e-2fe2f844d55d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1e8c107-09aa-4d03-bdd3-f1f7e1276f92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1e8c107-09aa-4d03-bdd3-f1f7e1276f92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_19-04-2022_49151.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1e8c107-09aa-4d03-bdd3-f1f7e1276f92>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a820422-7e5d-48a6-9765-f506012db965> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a820422-7e5d-48a6-9765-f506012db965";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_19-04-2022_49156.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a820422-7e5d-48a6-9765-f506012db965>.
+    
+<http://data.lblod.info/id/remote-data-objects/16eeb9fc-ee5b-40a7-acf9-2009ff29850a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16eeb9fc-ee5b-40a7-acf9-2009ff29850a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_19-04-2022_49188.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bdeb3deb-a1b9-492c-951e-7cb5f03cd006> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16eeb9fc-ee5b-40a7-acf9-2009ff29850a>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201729-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201729-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201729-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201729-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7dac5c6b-19dd-4860-a4c9-8ec6d14f4f9a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7dac5c6b-19dd-4860-a4c9-8ec6d14f4f9a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b7e39994-29f6-4ff8-a6fe-c813d1452f42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b7e39994-29f6-4ff8-a6fe-c813d1452f42";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc>.
+
+  <http://redpencil.data.gift/id/task/912edc7b-f80f-48b1-a257-8d8ae4dc6a5b> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "912edc7b-f80f-48b1-a257-8d8ae4dc6a5b";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7dac5c6b-19dd-4860-a4c9-8ec6d14f4f9a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b7e39994-29f6-4ff8-a6fe-c813d1452f42>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/43429af4-dd95-4acf-9ee3-3723fa1f381b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43429af4-dd95-4acf-9ee3-3723fa1f381b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_19-04-2022_49212.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43429af4-dd95-4acf-9ee3-3723fa1f381b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9c8b543-82a7-44f6-abff-ff6b88d6191f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9c8b543-82a7-44f6-abff-ff6b88d6191f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_19-04-2022_49281.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9c8b543-82a7-44f6-abff-ff6b88d6191f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2a68935-f0df-438c-ac6f-ed0aa00fea50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2a68935-f0df-438c-ac6f-ed0aa00fea50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_22-03-2022_48013.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2a68935-f0df-438c-ac6f-ed0aa00fea50>.
+    
+<http://data.lblod.info/id/remote-data-objects/61a70c70-dbc0-4039-8701-5495459b6c6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61a70c70-dbc0-4039-8701-5495459b6c6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_22-03-2022_48796.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61a70c70-dbc0-4039-8701-5495459b6c6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/22ac8c78-0447-4683-8b37-214089ca13cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22ac8c78-0447-4683-8b37-214089ca13cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_22-06-2022_50531.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22ac8c78-0447-4683-8b37-214089ca13cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7162b57-696e-4240-88a0-606ca5b125b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7162b57-696e-4240-88a0-606ca5b125b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_22-06-2022_50757.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7162b57-696e-4240-88a0-606ca5b125b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c8b2d30-7f21-4a5d-b6ed-5381798cd200> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c8b2d30-7f21-4a5d-b6ed-5381798cd200";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_22-06-2022_50758.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c8b2d30-7f21-4a5d-b6ed-5381798cd200>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfa4753b-2519-4adc-8a0b-033b4c257396> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfa4753b-2519-4adc-8a0b-033b4c257396";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_22-06-2022_50759.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfa4753b-2519-4adc-8a0b-033b4c257396>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fb22d5b-1b34-4f4c-9e7b-e7805c87418a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fb22d5b-1b34-4f4c-9e7b-e7805c87418a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_22-06-2022_50760.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fb22d5b-1b34-4f4c-9e7b-e7805c87418a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea1faea8-173c-4227-9a03-48224039280f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea1faea8-173c-4227-9a03-48224039280f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_22-06-2022_50761.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea1faea8-173c-4227-9a03-48224039280f>.
+    
+<http://data.lblod.info/id/remote-data-objects/141f43c4-fd88-48f0-be84-d2d127818b90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "141f43c4-fd88-48f0-be84-d2d127818b90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_22-06-2022_50762.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/141f43c4-fd88-48f0-be84-d2d127818b90>.
+    
+<http://data.lblod.info/id/remote-data-objects/4932419b-3bdf-4c31-8f3a-ce50475a8801> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4932419b-3bdf-4c31-8f3a-ce50475a8801";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_22-06-2022_50770.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4932419b-3bdf-4c31-8f3a-ce50475a8801>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5523f66-e1c2-4a9f-abea-afc0c3c1e498> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5523f66-e1c2-4a9f-abea-afc0c3c1e498";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_22-06-2022_50912.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5523f66-e1c2-4a9f-abea-afc0c3c1e498>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ab22146-7347-46e2-8464-a6ce73e1cd02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ab22146-7347-46e2-8464-a6ce73e1cd02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_22-06-2022_52057.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ab22146-7347-46e2-8464-a6ce73e1cd02>.
+    
+<http://data.lblod.info/id/remote-data-objects/10cbf07e-6162-4808-af32-60c6993ff7ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10cbf07e-6162-4808-af32-60c6993ff7ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_24-05-2022_49208.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10cbf07e-6162-4808-af32-60c6993ff7ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d2530aa-a087-42f6-ac2f-cac107a599ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d2530aa-a087-42f6-ac2f-cac107a599ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_24-05-2022_49396.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d2530aa-a087-42f6-ac2f-cac107a599ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/730938d7-42f3-4837-b166-8328d561ef95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "730938d7-42f3-4837-b166-8328d561ef95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_24-05-2022_50551.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/730938d7-42f3-4837-b166-8328d561ef95>.
+    
+<http://data.lblod.info/id/remote-data-objects/c782b4f5-fa99-4575-ae00-44e7fb5666e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c782b4f5-fa99-4575-ae00-44e7fb5666e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_24-05-2022_50624.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c782b4f5-fa99-4575-ae00-44e7fb5666e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ee51b20-2a8a-4202-815c-ecd59d910b3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ee51b20-2a8a-4202-815c-ecd59d910b3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_24-05-2022_50625.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ee51b20-2a8a-4202-815c-ecd59d910b3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d23767d1-7c0e-47de-94b4-6dcdd249bf10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d23767d1-7c0e-47de-94b4-6dcdd249bf10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_24-05-2022_50626.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d23767d1-7c0e-47de-94b4-6dcdd249bf10>.
+    
+<http://data.lblod.info/id/remote-data-objects/acdda324-5c23-489d-9ce9-33cadbaf6e59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acdda324-5c23-489d-9ce9-33cadbaf6e59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_24-05-2022_50628.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acdda324-5c23-489d-9ce9-33cadbaf6e59>.
+    
+<http://data.lblod.info/id/remote-data-objects/da367f58-8879-4498-a6c9-b8c8677fcda7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da367f58-8879-4498-a6c9-b8c8677fcda7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_24-05-2022_50629.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da367f58-8879-4498-a6c9-b8c8677fcda7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9e54aaf-8d80-498f-a77b-65348be53757> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9e54aaf-8d80-498f-a77b-65348be53757";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_24-05-2022_50630.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9e54aaf-8d80-498f-a77b-65348be53757>.
+    
+<http://data.lblod.info/id/remote-data-objects/807c3bef-b0ef-44ee-addd-a66a8775f3ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "807c3bef-b0ef-44ee-addd-a66a8775f3ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_24-05-2022_50631.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/807c3bef-b0ef-44ee-addd-a66a8775f3ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/25e9a6c0-875d-4274-9fa8-d654ebd45e5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25e9a6c0-875d-4274-9fa8-d654ebd45e5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_24-05-2022_50632.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25e9a6c0-875d-4274-9fa8-d654ebd45e5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5c01cf7-f4d0-491b-95be-960c53ab8686> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5c01cf7-f4d0-491b-95be-960c53ab8686";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_24-05-2022_50657.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5c01cf7-f4d0-491b-95be-960c53ab8686>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e5fa587-a0ef-4535-a878-d54070a81a65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e5fa587-a0ef-4535-a878-d54070a81a65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_24-05-2022_50702.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e5fa587-a0ef-4535-a878-d54070a81a65>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bd9a748-19a2-4b66-a13b-1620d9372cb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bd9a748-19a2-4b66-a13b-1620d9372cb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_24-05-2022_50707.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bd9a748-19a2-4b66-a13b-1620d9372cb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/88022077-6e83-4b4d-8dea-2dfd63bfdc92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88022077-6e83-4b4d-8dea-2dfd63bfdc92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_24-05-2022_50708.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88022077-6e83-4b4d-8dea-2dfd63bfdc92>.
+    
+<http://data.lblod.info/id/remote-data-objects/81291db0-bb05-4e7e-88d7-1b9352b5f333> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81291db0-bb05-4e7e-88d7-1b9352b5f333";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_24-05-2022_50710.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81291db0-bb05-4e7e-88d7-1b9352b5f333>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef175db7-e894-4d6d-ab8b-1432b42ae361> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef175db7-e894-4d6d-ab8b-1432b42ae361";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_26-10-2021_45011.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef175db7-e894-4d6d-ab8b-1432b42ae361>.
+    
+<http://data.lblod.info/id/remote-data-objects/585dc3c6-2fbf-4165-a4b7-bff2aec6d4c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "585dc3c6-2fbf-4165-a4b7-bff2aec6d4c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_26-10-2021_45126.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/585dc3c6-2fbf-4165-a4b7-bff2aec6d4c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8294abd-8c15-48e4-94fa-a7deea5ce48d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8294abd-8c15-48e4-94fa-a7deea5ce48d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/6a89aa75da99b90b35da92fc14a4b41a60e95a9bde58e076db73676455bbca46/GetPublication?filename=Uittreksels_26-10-2021_45127.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8294abd-8c15-48e4-94fa-a7deea5ce48d>.
+    
+<http://data.lblod.info/id/remote-data-objects/872c0b5c-0808-4ca5-871c-f030350854f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "872c0b5c-0808-4ca5-871c-f030350854f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/857e216f524bd8ece6f46277f0b601e73fc48fa563edb08beb4723b2ef587d46/GetPublication?filename=Uittreksels_16-02-2022_48624.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/872c0b5c-0808-4ca5-871c-f030350854f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2967f8d-c5d5-4382-b289-924e81daa335> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2967f8d-c5d5-4382-b289-924e81daa335";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/857e216f524bd8ece6f46277f0b601e73fc48fa563edb08beb4723b2ef587d46/GetPublication?filename=Uittreksels_25-10-2021_46361.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2967f8d-c5d5-4382-b289-924e81daa335>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca12fea4-7c7a-445d-a840-57762ffcfd3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca12fea4-7c7a-445d-a840-57762ffcfd3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/857e216f524bd8ece6f46277f0b601e73fc48fa563edb08beb4723b2ef587d46/GetPublication?filename=Uittreksels_26-10-2021_46372.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca12fea4-7c7a-445d-a840-57762ffcfd3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0b10605-f2b2-443a-962b-aae040eb0f19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0b10605-f2b2-443a-962b-aae040eb0f19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/857e216f524bd8ece6f46277f0b601e73fc48fa563edb08beb4723b2ef587d46/GetPublication?filename=Uittreksels_30-11-2021_47151.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0b10605-f2b2-443a-962b-aae040eb0f19>.
+    
+<http://data.lblod.info/id/remote-data-objects/b628b2a2-7771-454a-8f6c-ddd70c98bd63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b628b2a2-7771-454a-8f6c-ddd70c98bd63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b628b2a2-7771-454a-8f6c-ddd70c98bd63>.
+    
+<http://data.lblod.info/id/remote-data-objects/36624a2c-c3d1-409e-ab83-d2e4be5148a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36624a2c-c3d1-409e-ab83-d2e4be5148a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36624a2c-c3d1-409e-ab83-d2e4be5148a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d3feace-ea42-43a9-811f-edf55bb4b276> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d3feace-ea42-43a9-811f-edf55bb4b276";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d3feace-ea42-43a9-811f-edf55bb4b276>.
+    
+<http://data.lblod.info/id/remote-data-objects/860f6c03-dd7a-4ad1-884d-a076148f2652> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "860f6c03-dd7a-4ad1-884d-a076148f2652";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/860f6c03-dd7a-4ad1-884d-a076148f2652>.
+    
+<http://data.lblod.info/id/remote-data-objects/19bf4201-072a-4795-baeb-08f4824cd627> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19bf4201-072a-4795-baeb-08f4824cd627";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_05-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19bf4201-072a-4795-baeb-08f4824cd627>.
+    
+<http://data.lblod.info/id/remote-data-objects/76001d70-d413-4d03-9e1c-e082039fbcc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76001d70-d413-4d03-9e1c-e082039fbcc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76001d70-d413-4d03-9e1c-e082039fbcc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/212e781f-37e9-4a20-bb8e-0f1be9d46fe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "212e781f-37e9-4a20-bb8e-0f1be9d46fe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/212e781f-37e9-4a20-bb8e-0f1be9d46fe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfc96334-d74e-44cf-867a-5099f7d794d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfc96334-d74e-44cf-867a-5099f7d794d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfc96334-d74e-44cf-867a-5099f7d794d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a364bd4d-16f4-41e6-a137-b4173e62de59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a364bd4d-16f4-41e6-a137-b4173e62de59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a364bd4d-16f4-41e6-a137-b4173e62de59>.
+    
+<http://data.lblod.info/id/remote-data-objects/13dd2b5c-09da-4feb-8938-597df8608027> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13dd2b5c-09da-4feb-8938-597df8608027";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13dd2b5c-09da-4feb-8938-597df8608027>.
+    
+<http://data.lblod.info/id/remote-data-objects/05935722-d75f-417b-a2cc-55f3a17a2f82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05935722-d75f-417b-a2cc-55f3a17a2f82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_10-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05935722-d75f-417b-a2cc-55f3a17a2f82>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ed088e6-6d03-4bcf-89ab-1db032491ada> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ed088e6-6d03-4bcf-89ab-1db032491ada";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ed088e6-6d03-4bcf-89ab-1db032491ada>.
+    
+<http://data.lblod.info/id/remote-data-objects/c646c259-22af-4a78-8089-452ec81c1c63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c646c259-22af-4a78-8089-452ec81c1c63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a480fe0c-db87-4c3b-a6cb-a9cc8337e6cc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c646c259-22af-4a78-8089-452ec81c1c63>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201730-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201730-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201730-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201730-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/42c3ca03-f3ee-4380-9cb0-8b6502159032> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "42c3ca03-f3ee-4380-9cb0-8b6502159032";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "58090da0-c212-4b3d-92b0-11cc7c6ba5e4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/aa44bd6c-4e61-4d7b-ae3c-98964e21495d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "aa44bd6c-4e61-4d7b-ae3c-98964e21495d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4>.
+
+  <http://redpencil.data.gift/id/task/819ff6b9-1f42-40de-88ab-08dbfaab9e3d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "819ff6b9-1f42-40de-88ab-08dbfaab9e3d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/42c3ca03-f3ee-4380-9cb0-8b6502159032>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/aa44bd6c-4e61-4d7b-ae3c-98964e21495d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/981a1bb0-a08e-430d-90fe-450851e9fb11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "981a1bb0-a08e-430d-90fe-450851e9fb11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/981a1bb0-a08e-430d-90fe-450851e9fb11>.
+    
+<http://data.lblod.info/id/remote-data-objects/15ba30dd-6a3b-4c25-b978-be0667195b56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15ba30dd-6a3b-4c25-b978-be0667195b56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15ba30dd-6a3b-4c25-b978-be0667195b56>.
+    
+<http://data.lblod.info/id/remote-data-objects/aea6c48f-46df-46a7-91ac-b11f685033d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aea6c48f-46df-46a7-91ac-b11f685033d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aea6c48f-46df-46a7-91ac-b11f685033d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c62201a3-542a-473a-878d-40c9ebf4c384> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c62201a3-542a-473a-878d-40c9ebf4c384";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c62201a3-542a-473a-878d-40c9ebf4c384>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c7dbc3d-afce-4d4c-881c-b05743ec68db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c7dbc3d-afce-4d4c-881c-b05743ec68db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c7dbc3d-afce-4d4c-881c-b05743ec68db>.
+    
+<http://data.lblod.info/id/remote-data-objects/c134c371-c7cb-46d8-aa77-660bd847ebd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c134c371-c7cb-46d8-aa77-660bd847ebd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c134c371-c7cb-46d8-aa77-660bd847ebd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a2e7b6c-e6aa-4793-b45e-22f64965c8a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a2e7b6c-e6aa-4793-b45e-22f64965c8a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a2e7b6c-e6aa-4793-b45e-22f64965c8a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/53732ed2-ffa6-4de1-848f-aa2b6cf1258d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53732ed2-ffa6-4de1-848f-aa2b6cf1258d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53732ed2-ffa6-4de1-848f-aa2b6cf1258d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bafaa458-88aa-4549-bb4a-659206e41699> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bafaa458-88aa-4549-bb4a-659206e41699";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bafaa458-88aa-4549-bb4a-659206e41699>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d5828fd-c59b-464a-a03b-7a260731297c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d5828fd-c59b-464a-a03b-7a260731297c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d5828fd-c59b-464a-a03b-7a260731297c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ffc02b8-f549-41a2-b901-616b0f416b9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ffc02b8-f549-41a2-b901-616b0f416b9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ffc02b8-f549-41a2-b901-616b0f416b9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e70cc5c8-c836-429c-a158-a5fd7f6ad420> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e70cc5c8-c836-429c-a158-a5fd7f6ad420";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e70cc5c8-c836-429c-a158-a5fd7f6ad420>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdee5b65-a879-49d5-bd61-4d36fe442868> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdee5b65-a879-49d5-bd61-4d36fe442868";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdee5b65-a879-49d5-bd61-4d36fe442868>.
+    
+<http://data.lblod.info/id/remote-data-objects/91d59ecf-6ebf-4be9-9518-16fa54134246> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91d59ecf-6ebf-4be9-9518-16fa54134246";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91d59ecf-6ebf-4be9-9518-16fa54134246>.
+    
+<http://data.lblod.info/id/remote-data-objects/f565595d-e466-4e02-b88b-22118bc7f864> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f565595d-e466-4e02-b88b-22118bc7f864";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f565595d-e466-4e02-b88b-22118bc7f864>.
+    
+<http://data.lblod.info/id/remote-data-objects/184b2edf-f12c-4327-9271-139e4f85384b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "184b2edf-f12c-4327-9271-139e4f85384b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/184b2edf-f12c-4327-9271-139e4f85384b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad585336-9bc8-4454-85e7-547623a18f4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad585336-9bc8-4454-85e7-547623a18f4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad585336-9bc8-4454-85e7-547623a18f4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d3400e6-ac7f-4501-8175-5f0f215d1b0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d3400e6-ac7f-4501-8175-5f0f215d1b0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d3400e6-ac7f-4501-8175-5f0f215d1b0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/298c467d-1c08-41fb-a2d3-4cbc45b034da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "298c467d-1c08-41fb-a2d3-4cbc45b034da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/298c467d-1c08-41fb-a2d3-4cbc45b034da>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef47aad7-41db-469b-8b89-1c20916147a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef47aad7-41db-469b-8b89-1c20916147a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef47aad7-41db-469b-8b89-1c20916147a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dc7a884-6658-429d-987a-3cf6fd98d50c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dc7a884-6658-429d-987a-3cf6fd98d50c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dc7a884-6658-429d-987a-3cf6fd98d50c>.
+    
+<http://data.lblod.info/id/remote-data-objects/58314148-4505-40e8-9646-c15a53412fb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58314148-4505-40e8-9646-c15a53412fb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58314148-4505-40e8-9646-c15a53412fb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/083dc395-fb55-4c37-b7f9-3696bfa75768> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "083dc395-fb55-4c37-b7f9-3696bfa75768";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/083dc395-fb55-4c37-b7f9-3696bfa75768>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0cc01e7-3deb-4823-932b-39f97a24b27f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0cc01e7-3deb-4823-932b-39f97a24b27f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0cc01e7-3deb-4823-932b-39f97a24b27f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bc5daac-81fd-4bdb-8822-91065fe858cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bc5daac-81fd-4bdb-8822-91065fe858cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=BesluitenLijstUitspraak_college%20van%20burgemeester%20en%20schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bc5daac-81fd-4bdb-8822-91065fe858cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/857a88c7-3d2a-414f-be08-98f2307f08c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "857a88c7-3d2a-414f-be08-98f2307f08c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/86881db3f032d44b7a14f6cc00b1b226de29ea5a6a96a4e20f5d0eb1dda0686c/GetPublication?filename=Uittreksels_28-03-2022_48571.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/857a88c7-3d2a-414f-be08-98f2307f08c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0217386-8e19-418c-b2d5-1d11d804ea6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0217386-8e19-418c-b2d5-1d11d804ea6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0217386-8e19-418c-b2d5-1d11d804ea6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd235294-a163-4d98-87a7-f097e51a5cde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd235294-a163-4d98-87a7-f097e51a5cde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd235294-a163-4d98-87a7-f097e51a5cde>.
+    
+<http://data.lblod.info/id/remote-data-objects/b99d20b1-a38c-4183-8c9c-95ca976d5984> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b99d20b1-a38c-4183-8c9c-95ca976d5984";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b99d20b1-a38c-4183-8c9c-95ca976d5984>.
+    
+<http://data.lblod.info/id/remote-data-objects/60f82e52-0788-4fd7-8e2c-a7e4ac8c005d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60f82e52-0788-4fd7-8e2c-a7e4ac8c005d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60f82e52-0788-4fd7-8e2c-a7e4ac8c005d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cf33a7c-a494-41d3-ac63-22c8af92a831> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cf33a7c-a494-41d3-ac63-22c8af92a831";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cf33a7c-a494-41d3-ac63-22c8af92a831>.
+    
+<http://data.lblod.info/id/remote-data-objects/da0801b3-996d-4d18-8ec4-30c69cf6be29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da0801b3-996d-4d18-8ec4-30c69cf6be29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da0801b3-996d-4d18-8ec4-30c69cf6be29>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9bcb400-7d4b-4343-93e8-0c409967053b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9bcb400-7d4b-4343-93e8-0c409967053b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9bcb400-7d4b-4343-93e8-0c409967053b>.
+    
+<http://data.lblod.info/id/remote-data-objects/eadaa244-c56f-4bdd-b27a-1a789fa6e476> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eadaa244-c56f-4bdd-b27a-1a789fa6e476";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eadaa244-c56f-4bdd-b27a-1a789fa6e476>.
+    
+<http://data.lblod.info/id/remote-data-objects/83692097-a524-4c84-b26b-20d04857300e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83692097-a524-4c84-b26b-20d04857300e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_21-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83692097-a524-4c84-b26b-20d04857300e>.
+    
+<http://data.lblod.info/id/remote-data-objects/55ef644b-e1e8-4e18-83ce-4e87b7121179> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55ef644b-e1e8-4e18-83ce-4e87b7121179";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55ef644b-e1e8-4e18-83ce-4e87b7121179>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f94782e-0db2-4e6a-aa0b-3f280a66249d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f94782e-0db2-4e6a-aa0b-3f280a66249d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_25-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f94782e-0db2-4e6a-aa0b-3f280a66249d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6062a23-73ee-4cb2-b2e5-54efe5a228bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6062a23-73ee-4cb2-b2e5-54efe5a228bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6062a23-73ee-4cb2-b2e5-54efe5a228bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba3eb3ea-9e8a-4c48-8512-df92727710c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba3eb3ea-9e8a-4c48-8512-df92727710c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_26-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba3eb3ea-9e8a-4c48-8512-df92727710c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c82b786-4cb8-4bfb-88dd-35f59256f814> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c82b786-4cb8-4bfb-88dd-35f59256f814";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c82b786-4cb8-4bfb-88dd-35f59256f814>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fb2e192-bd6a-4cbc-a337-2fb70147953e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fb2e192-bd6a-4cbc-a337-2fb70147953e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fb2e192-bd6a-4cbc-a337-2fb70147953e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6158f884-8265-487e-ae45-7fc3d2512839> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6158f884-8265-487e-ae45-7fc3d2512839";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6158f884-8265-487e-ae45-7fc3d2512839>.
+    
+<http://data.lblod.info/id/remote-data-objects/94351277-4c93-4871-8299-adad6df68342> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94351277-4c93-4871-8299-adad6df68342";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/87fa48c5-c57d-4f8f-9106-791d420f0c86/GetPublication?filename=BesluitenLijstUitspraak_vast%20bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94351277-4c93-4871-8299-adad6df68342>.
+    
+<http://data.lblod.info/id/remote-data-objects/50124220-606b-4b2c-8228-b34eaa3f09fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50124220-606b-4b2c-8228-b34eaa3f09fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50124220-606b-4b2c-8228-b34eaa3f09fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/a80c802a-19ba-4c15-b648-dd7776840c65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a80c802a-19ba-4c15-b648-dd7776840c65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a80c802a-19ba-4c15-b648-dd7776840c65>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d480c20-6585-4997-a450-ddf2f77fbaab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d480c20-6585-4997-a450-ddf2f77fbaab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_19-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d480c20-6585-4997-a450-ddf2f77fbaab>.
+    
+<http://data.lblod.info/id/remote-data-objects/63545857-cfb9-4005-ae85-7d138a9b4652> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63545857-cfb9-4005-ae85-7d138a9b4652";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63545857-cfb9-4005-ae85-7d138a9b4652>.
+    
+<http://data.lblod.info/id/remote-data-objects/aed62b15-6661-4f8d-bdce-562d4f221d20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aed62b15-6661-4f8d-bdce-562d4f221d20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aed62b15-6661-4f8d-bdce-562d4f221d20>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f2d59fc-799f-4d2b-b06d-51796c2c93fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f2d59fc-799f-4d2b-b06d-51796c2c93fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f2d59fc-799f-4d2b-b06d-51796c2c93fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1c6ae41-0248-4835-9ce7-7c785a72a07a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1c6ae41-0248-4835-9ce7-7c785a72a07a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/58090da0-c212-4b3d-92b0-11cc7c6ba5e4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1c6ae41-0248-4835-9ce7-7c785a72a07a>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201732-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201732-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201732-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201732-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/af37512c-9e1a-4a9c-a130-f5cf1bbabf3c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "af37512c-9e1a-4a9c-a130-f5cf1bbabf3c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/fa5a7dc7-56e9-4ec6-b8d0-cd75348381ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fa5a7dc7-56e9-4ec6-b8d0-cd75348381ec";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0>.
+
+  <http://redpencil.data.gift/id/task/db763375-28da-44ac-b11f-e0d77ba826df> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "db763375-28da-44ac-b11f-e0d77ba826df";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/af37512c-9e1a-4a9c-a130-f5cf1bbabf3c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/fa5a7dc7-56e9-4ec6-b8d0-cd75348381ec>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a45d8e53-2b7b-4d9c-bbc8-632ac7533b45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a45d8e53-2b7b-4d9c-bbc8-632ac7533b45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Agenda_raad%20voor%20maatschappelijk%20welzijn_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a45d8e53-2b7b-4d9c-bbc8-632ac7533b45>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fadb263-de40-4d93-b0cb-cb606c60f11e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fadb263-de40-4d93-b0cb-cb606c60f11e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fadb263-de40-4d93-b0cb-cb606c60f11e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2aaaa1e5-8430-487f-bed3-822d91201b8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2aaaa1e5-8430-487f-bed3-822d91201b8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2aaaa1e5-8430-487f-bed3-822d91201b8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b448f3de-c2e8-4244-b670-49e8ede0854e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b448f3de-c2e8-4244-b670-49e8ede0854e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_19-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b448f3de-c2e8-4244-b670-49e8ede0854e>.
+    
+<http://data.lblod.info/id/remote-data-objects/680af53e-e86b-44e5-8b64-be2d6b2e8bfb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "680af53e-e86b-44e5-8b64-be2d6b2e8bfb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/680af53e-e86b-44e5-8b64-be2d6b2e8bfb>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3d49c7a-3ac3-4aa0-84be-b31618653c1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3d49c7a-3ac3-4aa0-84be-b31618653c1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3d49c7a-3ac3-4aa0-84be-b31618653c1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b79312b0-ff93-4ae6-b147-6fdfcb35ddfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b79312b0-ff93-4ae6-b147-6fdfcb35ddfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b79312b0-ff93-4ae6-b147-6fdfcb35ddfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0c8f6a0-a9ed-4910-a501-e411b0255b7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0c8f6a0-a9ed-4910-a501-e411b0255b7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0c8f6a0-a9ed-4910-a501-e411b0255b7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/adf26071-1b25-4a84-bc4d-a312d94abf88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "adf26071-1b25-4a84-bc4d-a312d94abf88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=BesluitenLijstUitspraak_raad%20voor%20maatschappelijk%20welzijn_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/adf26071-1b25-4a84-bc4d-a312d94abf88>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0bf66b7-ed39-44cc-89f7-bbcacdb48238> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0bf66b7-ed39-44cc-89f7-bbcacdb48238";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0bf66b7-ed39-44cc-89f7-bbcacdb48238>.
+    
+<http://data.lblod.info/id/remote-data-objects/765af117-7089-4041-baed-59621de6c155> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "765af117-7089-4041-baed-59621de6c155";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/765af117-7089-4041-baed-59621de6c155>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce4f6f55-dfee-43fc-b6f1-613b88e157ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce4f6f55-dfee-43fc-b6f1-613b88e157ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_19-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce4f6f55-dfee-43fc-b6f1-613b88e157ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/39949c2d-aa77-4ee2-9cfb-d00f3f049e1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39949c2d-aa77-4ee2-9cfb-d00f3f049e1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39949c2d-aa77-4ee2-9cfb-d00f3f049e1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/72f8e6dc-6f84-4d30-9945-1b6fc915d9cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72f8e6dc-6f84-4d30-9945-1b6fc915d9cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72f8e6dc-6f84-4d30-9945-1b6fc915d9cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/bedd96a0-366a-4cdd-b280-81cb61e621bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bedd96a0-366a-4cdd-b280-81cb61e621bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bedd96a0-366a-4cdd-b280-81cb61e621bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ba16a17-130a-4fe6-8eed-20415bb2885b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ba16a17-130a-4fe6-8eed-20415bb2885b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Notulen_raad%20voor%20maatschappelijk%20welzijn_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ba16a17-130a-4fe6-8eed-20415bb2885b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8dedf3e-329d-4dcd-a3ed-3457be3b8556> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8dedf3e-329d-4dcd-a3ed-3457be3b8556";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Uittreksels_14-12-2021_46588.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8dedf3e-329d-4dcd-a3ed-3457be3b8556>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d33e791-930d-4213-9c63-d6b3dabee752> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d33e791-930d-4213-9c63-d6b3dabee752";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Uittreksels_14-12-2021_47077.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d33e791-930d-4213-9c63-d6b3dabee752>.
+    
+<http://data.lblod.info/id/remote-data-objects/184d9122-569f-4d18-9dd6-d357f712d4d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "184d9122-569f-4d18-9dd6-d357f712d4d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Uittreksels_19-01-2022_47624.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/184d9122-569f-4d18-9dd6-d357f712d4d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e33eca79-4615-46b4-9272-ea3f0c73617a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e33eca79-4615-46b4-9272-ea3f0c73617a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wetteren.be/LBLODWeb/Home/Overzicht/b5db6f0381552596a52b57630675c3605c5dc2b4d586588b772195a438dca98e/GetPublication?filename=Uittreksels_21-06-2022_50914.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e33eca79-4615-46b4-9272-ea3f0c73617a>.
+    
+<http://data.lblod.info/id/remote-data-objects/68f4afbe-bb49-4ea1-b091-28880e9f4d2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68f4afbe-bb49-4ea1-b091-28880e9f4d2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68f4afbe-bb49-4ea1-b091-28880e9f4d2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d68e4b75-5fdd-47a9-b21e-d3cea4152751> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d68e4b75-5fdd-47a9-b21e-d3cea4152751";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d68e4b75-5fdd-47a9-b21e-d3cea4152751>.
+    
+<http://data.lblod.info/id/remote-data-objects/151e63d6-6fe2-4e38-83a6-bdbfe3208724> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "151e63d6-6fe2-4e38-83a6-bdbfe3208724";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/151e63d6-6fe2-4e38-83a6-bdbfe3208724>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b194175-7e06-4a43-a2b2-36b57284d0b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b194175-7e06-4a43-a2b2-36b57284d0b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_03-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b194175-7e06-4a43-a2b2-36b57284d0b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/378deffc-251e-4151-8c56-917a5a0b74bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "378deffc-251e-4151-8c56-917a5a0b74bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/378deffc-251e-4151-8c56-917a5a0b74bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/acf7a067-152b-47d0-9fcf-03761b2f7f09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acf7a067-152b-47d0-9fcf-03761b2f7f09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_05-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acf7a067-152b-47d0-9fcf-03761b2f7f09>.
+    
+<http://data.lblod.info/id/remote-data-objects/47557b27-e2ed-4640-9f13-06646355745f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47557b27-e2ed-4640-9f13-06646355745f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47557b27-e2ed-4640-9f13-06646355745f>.
+    
+<http://data.lblod.info/id/remote-data-objects/31131540-190c-4e5a-9e08-c11d107ab661> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31131540-190c-4e5a-9e08-c11d107ab661";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31131540-190c-4e5a-9e08-c11d107ab661>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffa25f5f-7389-430c-9ef7-19a74fbdc800> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffa25f5f-7389-430c-9ef7-19a74fbdc800";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffa25f5f-7389-430c-9ef7-19a74fbdc800>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea6fc539-5e2f-4643-9b1b-f982de15c842> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea6fc539-5e2f-4643-9b1b-f982de15c842";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea6fc539-5e2f-4643-9b1b-f982de15c842>.
+    
+<http://data.lblod.info/id/remote-data-objects/89a9e25b-d2c1-487c-837e-e66baa5c62e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89a9e25b-d2c1-487c-837e-e66baa5c62e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_10-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89a9e25b-d2c1-487c-837e-e66baa5c62e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/32f25dde-8e8e-4f03-90a0-2f93314c3b20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32f25dde-8e8e-4f03-90a0-2f93314c3b20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_10-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32f25dde-8e8e-4f03-90a0-2f93314c3b20>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0ec7fe2-083e-4a33-96a8-691ffd81bff7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0ec7fe2-083e-4a33-96a8-691ffd81bff7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0ec7fe2-083e-4a33-96a8-691ffd81bff7>.
+    
+<http://data.lblod.info/id/remote-data-objects/091d7f61-9638-49ff-911e-f12135145cee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "091d7f61-9638-49ff-911e-f12135145cee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/091d7f61-9638-49ff-911e-f12135145cee>.
+    
+<http://data.lblod.info/id/remote-data-objects/e94fc65b-2f89-41e2-acb1-66ee19521d59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e94fc65b-2f89-41e2-acb1-66ee19521d59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e94fc65b-2f89-41e2-acb1-66ee19521d59>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb81991e-83b0-48b0-919e-b23d14a6c943> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb81991e-83b0-48b0-919e-b23d14a6c943";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb81991e-83b0-48b0-919e-b23d14a6c943>.
+    
+<http://data.lblod.info/id/remote-data-objects/1de78357-607d-4cda-93ab-618bdfcec7b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1de78357-607d-4cda-93ab-618bdfcec7b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1de78357-607d-4cda-93ab-618bdfcec7b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/edc80be0-26f6-4b47-8a79-1ed144dc8b21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edc80be0-26f6-4b47-8a79-1ed144dc8b21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edc80be0-26f6-4b47-8a79-1ed144dc8b21>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb6b2e07-7ab4-4b48-abfc-8dfe79081506> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb6b2e07-7ab4-4b48-abfc-8dfe79081506";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb6b2e07-7ab4-4b48-abfc-8dfe79081506>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8fbc707-c167-4e3a-a4d7-d84d376197d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8fbc707-c167-4e3a-a4d7-d84d376197d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8fbc707-c167-4e3a-a4d7-d84d376197d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/879c6b1a-7d44-4bb0-850f-55cf3cdde980> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "879c6b1a-7d44-4bb0-850f-55cf3cdde980";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/879c6b1a-7d44-4bb0-850f-55cf3cdde980>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c76271e-0367-4c13-9b92-e802d23daeba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c76271e-0367-4c13-9b92-e802d23daeba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c76271e-0367-4c13-9b92-e802d23daeba>.
+    
+<http://data.lblod.info/id/remote-data-objects/026eb1f7-7d1f-47aa-a91d-66b6e02c4e20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "026eb1f7-7d1f-47aa-a91d-66b6e02c4e20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/026eb1f7-7d1f-47aa-a91d-66b6e02c4e20>.
+    
+<http://data.lblod.info/id/remote-data-objects/99e9a8e4-f979-4e79-819b-be5cd08d970c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99e9a8e4-f979-4e79-819b-be5cd08d970c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99e9a8e4-f979-4e79-819b-be5cd08d970c>.
+    
+<http://data.lblod.info/id/remote-data-objects/72e15282-d4eb-4388-b958-f12ce348c96e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72e15282-d4eb-4388-b958-f12ce348c96e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72e15282-d4eb-4388-b958-f12ce348c96e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dd63174-c344-4f83-b8f4-5dedd40e5b5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dd63174-c344-4f83-b8f4-5dedd40e5b5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dd63174-c344-4f83-b8f4-5dedd40e5b5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f5f7f08-15f3-4189-aa71-6202509a5638> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f5f7f08-15f3-4189-aa71-6202509a5638";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f5f7f08-15f3-4189-aa71-6202509a5638>.
+    
+<http://data.lblod.info/id/remote-data-objects/569bbeb1-c9ba-403f-84e7-13dd2458f93d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "569bbeb1-c9ba-403f-84e7-13dd2458f93d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/569bbeb1-c9ba-403f-84e7-13dd2458f93d>.
+    
+<http://data.lblod.info/id/remote-data-objects/69712a1a-244b-4f40-9209-3a7579ddb21e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69712a1a-244b-4f40-9209-3a7579ddb21e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69712a1a-244b-4f40-9209-3a7579ddb21e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b7d1dbb-cc32-455d-b98a-953f35409fd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b7d1dbb-cc32-455d-b98a-953f35409fd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/621a6065-e25b-4ff3-b7b1-e8b1aaa2bea0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b7d1dbb-cc32-455d-b98a-953f35409fd3>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201733-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201733-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201733-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201733-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3840104a-1002-42d3-868b-8fe41c345994> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3840104a-1002-42d3-868b-8fe41c345994";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "34ee1541-4597-43b2-81da-fc574054ebe4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6c985e2c-8e93-44db-aea8-de1c17568ed3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6c985e2c-8e93-44db-aea8-de1c17568ed3";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4>.
+
+  <http://redpencil.data.gift/id/task/24d70e1e-c248-4131-8dc2-b63e6fc2120f> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "24d70e1e-c248-4131-8dc2-b63e6fc2120f";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3840104a-1002-42d3-868b-8fe41c345994>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6c985e2c-8e93-44db-aea8-de1c17568ed3>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/12f9c399-2db0-46ec-a29e-f89f59d67f7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12f9c399-2db0-46ec-a29e-f89f59d67f7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12f9c399-2db0-46ec-a29e-f89f59d67f7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/01adbdac-64c1-4103-961a-e284155f33e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01adbdac-64c1-4103-961a-e284155f33e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01adbdac-64c1-4103-961a-e284155f33e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/383f26c2-d2d8-4fa2-bb39-c54050f6379e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "383f26c2-d2d8-4fa2-bb39-c54050f6379e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_26-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/383f26c2-d2d8-4fa2-bb39-c54050f6379e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e04df886-ba38-4f4f-b89b-4176842176c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e04df886-ba38-4f4f-b89b-4176842176c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e04df886-ba38-4f4f-b89b-4176842176c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c97e9a58-b60f-40c4-a1db-c2ba082679ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c97e9a58-b60f-40c4-a1db-c2ba082679ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c97e9a58-b60f-40c4-a1db-c2ba082679ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c295b2f-7b74-41e0-aeb5-159fdfabe597> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c295b2f-7b74-41e0-aeb5-159fdfabe597";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c295b2f-7b74-41e0-aeb5-159fdfabe597>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a0c23fe-46fa-4b37-be77-e796e1e8e18f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a0c23fe-46fa-4b37-be77-e796e1e8e18f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a0c23fe-46fa-4b37-be77-e796e1e8e18f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a92ee546-f291-43bd-8a10-7d23104dccf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a92ee546-f291-43bd-8a10-7d23104dccf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/1d49dd8f3f96828232c6c4058ccd132bc3d7e582cb23d5baca6bcae5ba84ea37/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_31-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a92ee546-f291-43bd-8a10-7d23104dccf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/010a19a2-2168-4cc3-bfc0-fda00b7c2a29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "010a19a2-2168-4cc3-bfc0-fda00b7c2a29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/010a19a2-2168-4cc3-bfc0-fda00b7c2a29>.
+    
+<http://data.lblod.info/id/remote-data-objects/833c678b-7126-4ec2-9ac7-1aa7ad66902e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "833c678b-7126-4ec2-9ac7-1aa7ad66902e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/833c678b-7126-4ec2-9ac7-1aa7ad66902e>.
+    
+<http://data.lblod.info/id/remote-data-objects/604e4d0e-e1cf-40c7-9398-53af5cd44859> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "604e4d0e-e1cf-40c7-9398-53af5cd44859";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/604e4d0e-e1cf-40c7-9398-53af5cd44859>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1144229-9f5c-4b7a-bd6c-40106faf7c21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1144229-9f5c-4b7a-bd6c-40106faf7c21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1144229-9f5c-4b7a-bd6c-40106faf7c21>.
+    
+<http://data.lblod.info/id/remote-data-objects/374c12e0-5271-4359-8e2d-36aae2327273> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "374c12e0-5271-4359-8e2d-36aae2327273";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/374c12e0-5271-4359-8e2d-36aae2327273>.
+    
+<http://data.lblod.info/id/remote-data-objects/56366606-3a9b-4907-afe4-4c0d54efd02d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56366606-3a9b-4907-afe4-4c0d54efd02d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56366606-3a9b-4907-afe4-4c0d54efd02d>.
+    
+<http://data.lblod.info/id/remote-data-objects/22b5585e-c7e3-4c53-bc6a-4d37bc8076ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22b5585e-c7e3-4c53-bc6a-4d37bc8076ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_05-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22b5585e-c7e3-4c53-bc6a-4d37bc8076ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7b100ed-8be7-4400-ae3d-6105b28af388> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7b100ed-8be7-4400-ae3d-6105b28af388";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7b100ed-8be7-4400-ae3d-6105b28af388>.
+    
+<http://data.lblod.info/id/remote-data-objects/37579b8c-e80e-4c85-8e80-c5f00d437eba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37579b8c-e80e-4c85-8e80-c5f00d437eba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37579b8c-e80e-4c85-8e80-c5f00d437eba>.
+    
+<http://data.lblod.info/id/remote-data-objects/d833886d-e535-48a5-a22e-2a61a6de30b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d833886d-e535-48a5-a22e-2a61a6de30b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d833886d-e535-48a5-a22e-2a61a6de30b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/15589076-9edc-4216-b1a9-cfecb1c864a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15589076-9edc-4216-b1a9-cfecb1c864a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15589076-9edc-4216-b1a9-cfecb1c864a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dd690ba-30c1-4433-8ed2-510f9c7e35cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dd690ba-30c1-4433-8ed2-510f9c7e35cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dd690ba-30c1-4433-8ed2-510f9c7e35cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/93fa4ee2-093c-4465-af67-1635e87d470d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93fa4ee2-093c-4465-af67-1635e87d470d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93fa4ee2-093c-4465-af67-1635e87d470d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa1422ae-f95e-4748-bb62-ef8735dfddd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa1422ae-f95e-4748-bb62-ef8735dfddd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa1422ae-f95e-4748-bb62-ef8735dfddd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c46124b-e655-4f52-af56-89e88e0e1569> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c46124b-e655-4f52-af56-89e88e0e1569";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c46124b-e655-4f52-af56-89e88e0e1569>.
+    
+<http://data.lblod.info/id/remote-data-objects/b156f64c-4fdd-44b8-8695-81f1a97a8053> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b156f64c-4fdd-44b8-8695-81f1a97a8053";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b156f64c-4fdd-44b8-8695-81f1a97a8053>.
+    
+<http://data.lblod.info/id/remote-data-objects/51147fef-dc1e-4703-8cd7-2f58f5cdab56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51147fef-dc1e-4703-8cd7-2f58f5cdab56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51147fef-dc1e-4703-8cd7-2f58f5cdab56>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ade2aad-43a0-44ce-9ce6-931041993b87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ade2aad-43a0-44ce-9ce6-931041993b87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ade2aad-43a0-44ce-9ce6-931041993b87>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bdc6c00-043b-4504-8377-92df65c6037d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bdc6c00-043b-4504-8377-92df65c6037d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bdc6c00-043b-4504-8377-92df65c6037d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1760154a-3374-483d-b935-95ffb029e64a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1760154a-3374-483d-b935-95ffb029e64a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1760154a-3374-483d-b935-95ffb029e64a>.
+    
+<http://data.lblod.info/id/remote-data-objects/04af0339-ddd7-4621-ac5f-923f47bc6613> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04af0339-ddd7-4621-ac5f-923f47bc6613";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04af0339-ddd7-4621-ac5f-923f47bc6613>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5665f81-8d86-4cf6-82a0-c2806449c847> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5665f81-8d86-4cf6-82a0-c2806449c847";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5665f81-8d86-4cf6-82a0-c2806449c847>.
+    
+<http://data.lblod.info/id/remote-data-objects/3532e087-90b9-4486-b916-73423da9ee6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3532e087-90b9-4486-b916-73423da9ee6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3532e087-90b9-4486-b916-73423da9ee6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7312e05-f3be-47df-bfa8-8b402ba67d47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7312e05-f3be-47df-bfa8-8b402ba67d47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7312e05-f3be-47df-bfa8-8b402ba67d47>.
+    
+<http://data.lblod.info/id/remote-data-objects/a764acac-060e-4ca0-b3bf-eedde81381a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a764acac-060e-4ca0-b3bf-eedde81381a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a764acac-060e-4ca0-b3bf-eedde81381a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/6da7aea9-3f3f-4f32-ba1d-5c18822260de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6da7aea9-3f3f-4f32-ba1d-5c18822260de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6da7aea9-3f3f-4f32-ba1d-5c18822260de>.
+    
+<http://data.lblod.info/id/remote-data-objects/25e9e9c5-bcc0-4a8e-aced-54ef72169fe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25e9e9c5-bcc0-4a8e-aced-54ef72169fe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25e9e9c5-bcc0-4a8e-aced-54ef72169fe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/87d8037e-14ed-4daf-976e-bba5017ff952> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87d8037e-14ed-4daf-976e-bba5017ff952";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87d8037e-14ed-4daf-976e-bba5017ff952>.
+    
+<http://data.lblod.info/id/remote-data-objects/81f381a6-bbb7-4958-a7c1-4fb24ea67809> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81f381a6-bbb7-4958-a7c1-4fb24ea67809";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81f381a6-bbb7-4958-a7c1-4fb24ea67809>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dd12155-327e-472c-b113-f4a9780b7dc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dd12155-327e-472c-b113-f4a9780b7dc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dd12155-327e-472c-b113-f4a9780b7dc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc866b35-94c7-4bd0-b139-1883ee60f9c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc866b35-94c7-4bd0-b139-1883ee60f9c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc866b35-94c7-4bd0-b139-1883ee60f9c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e23a1bd-e9a8-4ea3-9c6c-30ab8b1d02c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e23a1bd-e9a8-4ea3-9c6c-30ab8b1d02c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e23a1bd-e9a8-4ea3-9c6c-30ab8b1d02c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2d53681-1f23-4266-ad1b-14544ddfce51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2d53681-1f23-4266-ad1b-14544ddfce51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2d53681-1f23-4266-ad1b-14544ddfce51>.
+    
+<http://data.lblod.info/id/remote-data-objects/feeb69db-123d-4853-8b04-0ba776a419fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "feeb69db-123d-4853-8b04-0ba776a419fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/feeb69db-123d-4853-8b04-0ba776a419fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/14e8ee94-e3d8-4351-b09f-9c3f0315aee0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14e8ee94-e3d8-4351-b09f-9c3f0315aee0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_26-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14e8ee94-e3d8-4351-b09f-9c3f0315aee0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3a5e321-a442-4583-aa27-f275a706c501> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3a5e321-a442-4583-aa27-f275a706c501";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3a5e321-a442-4583-aa27-f275a706c501>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c76110b-4924-4659-83bc-e3ca0eedd2e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c76110b-4924-4659-83bc-e3ca0eedd2e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c76110b-4924-4659-83bc-e3ca0eedd2e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/678d0619-3962-4b88-b6e6-fdb9a7c65552> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "678d0619-3962-4b88-b6e6-fdb9a7c65552";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/678d0619-3962-4b88-b6e6-fdb9a7c65552>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cb5a984-d2a4-4f9e-84a9-85604fb0357f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cb5a984-d2a4-4f9e-84a9-85604fb0357f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cb5a984-d2a4-4f9e-84a9-85604fb0357f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d36e712-79af-4fe0-9f39-4754fb5988a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d36e712-79af-4fe0-9f39-4754fb5988a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/26adadd80b312b9735796f6d8ecf6b15c90f370f18454cf639b984e4a1da8847/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_31-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d36e712-79af-4fe0-9f39-4754fb5988a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c145042-09d6-46c1-bd3a-37dc7cbc6fd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c145042-09d6-46c1-bd3a-37dc7cbc6fd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Agenda_Gemeenteraad_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c145042-09d6-46c1-bd3a-37dc7cbc6fd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/1260e0ee-8883-4be8-8b6a-3f01c3adb6d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1260e0ee-8883-4be8-8b6a-3f01c3adb6d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Agenda_Gemeenteraad_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34ee1541-4597-43b2-81da-fc574054ebe4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1260e0ee-8883-4be8-8b6a-3f01c3adb6d2>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201734-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201734-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201734-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201734-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f1d5cf08-3570-48e7-9423-3a1ed32d28c6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f1d5cf08-3570-48e7-9423-3a1ed32d28c6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2d044e8d-9dc2-44f6-90cf-bc2efb59acd8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b2188ceb-fa9b-492f-abe1-3b918d38172b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b2188ceb-fa9b-492f-abe1-3b918d38172b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8>.
+
+  <http://redpencil.data.gift/id/task/2b7b28a4-614d-441c-b828-10ecee392f02> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2b7b28a4-614d-441c-b828-10ecee392f02";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f1d5cf08-3570-48e7-9423-3a1ed32d28c6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b2188ceb-fa9b-492f-abe1-3b918d38172b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/da24828e-89ea-4d8d-8926-6d6e612270c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da24828e-89ea-4d8d-8926-6d6e612270c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Agenda_Gemeenteraad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da24828e-89ea-4d8d-8926-6d6e612270c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/12125c52-7b98-4fb1-ae9d-63187ad4280c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12125c52-7b98-4fb1-ae9d-63187ad4280c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Agenda_Gemeenteraad_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12125c52-7b98-4fb1-ae9d-63187ad4280c>.
+    
+<http://data.lblod.info/id/remote-data-objects/efd0454e-c3e4-4d6a-9658-f4908fa75c9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efd0454e-c3e4-4d6a-9658-f4908fa75c9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Agenda_Gemeenteraad_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efd0454e-c3e4-4d6a-9658-f4908fa75c9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/27349dca-fbc5-4222-82ac-2fba7c681938> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27349dca-fbc5-4222-82ac-2fba7c681938";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Agenda_Gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27349dca-fbc5-4222-82ac-2fba7c681938>.
+    
+<http://data.lblod.info/id/remote-data-objects/34113437-b6ab-461e-800d-61ec045bd16b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34113437-b6ab-461e-800d-61ec045bd16b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Agenda_Gemeenteraad_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34113437-b6ab-461e-800d-61ec045bd16b>.
+    
+<http://data.lblod.info/id/remote-data-objects/66112b79-42ac-424c-973c-b11bc24776f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66112b79-42ac-424c-973c-b11bc24776f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Agenda_Gemeenteraad_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66112b79-42ac-424c-973c-b11bc24776f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/98d02a87-22b5-443a-b697-5e7a5e72a475> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98d02a87-22b5-443a-b697-5e7a5e72a475";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Agenda_Gemeenteraad_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98d02a87-22b5-443a-b697-5e7a5e72a475>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee8b3b65-bf46-47fd-9931-2da0e186c7fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee8b3b65-bf46-47fd-9931-2da0e186c7fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Agenda_Gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee8b3b65-bf46-47fd-9931-2da0e186c7fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/249a48b6-3234-4cf2-b618-67a3f613918b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "249a48b6-3234-4cf2-b618-67a3f613918b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/249a48b6-3234-4cf2-b618-67a3f613918b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5bc9e90-4cb5-4698-86be-579ab71a986c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5bc9e90-4cb5-4698-86be-579ab71a986c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5bc9e90-4cb5-4698-86be-579ab71a986c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7480dd14-5f6d-43dd-bd76-f0f76ef5f3dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7480dd14-5f6d-43dd-bd76-f0f76ef5f3dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7480dd14-5f6d-43dd-bd76-f0f76ef5f3dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b8b2b2b-3fac-4c24-8375-28718e750eaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b8b2b2b-3fac-4c24-8375-28718e750eaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b8b2b2b-3fac-4c24-8375-28718e750eaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f9ad4b1-f6c1-4e46-8323-c2c5039e43e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f9ad4b1-f6c1-4e46-8323-c2c5039e43e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f9ad4b1-f6c1-4e46-8323-c2c5039e43e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/24794e0d-4aa1-409b-b5f9-640f2b2608bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24794e0d-4aa1-409b-b5f9-640f2b2608bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24794e0d-4aa1-409b-b5f9-640f2b2608bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/27430a7a-d2ce-4145-a34f-20e17a3d079b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27430a7a-d2ce-4145-a34f-20e17a3d079b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27430a7a-d2ce-4145-a34f-20e17a3d079b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6144fbfe-f8eb-4ca9-bb40-f7b49d2502b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6144fbfe-f8eb-4ca9-bb40-f7b49d2502b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6144fbfe-f8eb-4ca9-bb40-f7b49d2502b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf82bd53-17fe-4934-9756-e180582b65fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf82bd53-17fe-4934-9756-e180582b65fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf82bd53-17fe-4934-9756-e180582b65fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/b434c450-1989-4648-94e0-149df76505ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b434c450-1989-4648-94e0-149df76505ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_13-10-2021_21506.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b434c450-1989-4648-94e0-149df76505ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/28111b16-fac1-40f8-a4c3-858dac947171> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28111b16-fac1-40f8-a4c3-858dac947171";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_17-11-2021_21915.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28111b16-fac1-40f8-a4c3-858dac947171>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e638467-5d05-418f-be94-76a94d96cd4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e638467-5d05-418f-be94-76a94d96cd4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_17-11-2021_21916.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e638467-5d05-418f-be94-76a94d96cd4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a34452d-b16a-4bc4-9335-28e0869b56d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a34452d-b16a-4bc4-9335-28e0869b56d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_17-11-2021_21936.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a34452d-b16a-4bc4-9335-28e0869b56d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/02c1c404-a858-48c8-a18a-d614288bf9ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02c1c404-a858-48c8-a18a-d614288bf9ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_22-12-2021_22089.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02c1c404-a858-48c8-a18a-d614288bf9ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/8032d0bc-92c0-48d5-8f89-bfeeead60303> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8032d0bc-92c0-48d5-8f89-bfeeead60303";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_22-12-2021_22147.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8032d0bc-92c0-48d5-8f89-bfeeead60303>.
+    
+<http://data.lblod.info/id/remote-data-objects/534d4f00-051f-4067-b35d-9a828b40a9a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "534d4f00-051f-4067-b35d-9a828b40a9a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_22-12-2021_22149.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/534d4f00-051f-4067-b35d-9a828b40a9a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0516b1c-5eb1-487d-8935-b2828548ef1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0516b1c-5eb1-487d-8935-b2828548ef1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_22-12-2021_22183.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0516b1c-5eb1-487d-8935-b2828548ef1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c6f700f-edea-4300-9e22-ab4275b4e514> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c6f700f-edea-4300-9e22-ab4275b4e514";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_22-12-2021_22199.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c6f700f-edea-4300-9e22-ab4275b4e514>.
+    
+<http://data.lblod.info/id/remote-data-objects/eafdbd10-1733-4073-91e4-40869ae28aba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eafdbd10-1733-4073-91e4-40869ae28aba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_23-03-2022_22760.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eafdbd10-1733-4073-91e4-40869ae28aba>.
+    
+<http://data.lblod.info/id/remote-data-objects/5848965c-4bda-41ad-aee4-5d90bcec3571> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5848965c-4bda-41ad-aee4-5d90bcec3571";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_23-03-2022_22825.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5848965c-4bda-41ad-aee4-5d90bcec3571>.
+    
+<http://data.lblod.info/id/remote-data-objects/0049e363-cdc8-4ded-8d6b-4e863106e51b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0049e363-cdc8-4ded-8d6b-4e863106e51b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_23-03-2022_22902.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0049e363-cdc8-4ded-8d6b-4e863106e51b>.
+    
+<http://data.lblod.info/id/remote-data-objects/abe669f0-5990-40cd-b40d-51df4878a070> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abe669f0-5990-40cd-b40d-51df4878a070";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_23-03-2022_22938.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abe669f0-5990-40cd-b40d-51df4878a070>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b5303e1-74f9-435b-8f47-8a1b602c73bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b5303e1-74f9-435b-8f47-8a1b602c73bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_23-03-2022_23020.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b5303e1-74f9-435b-8f47-8a1b602c73bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/72dad93b-f111-4b9a-86cd-92e4241a60be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72dad93b-f111-4b9a-86cd-92e4241a60be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_24-05-2022_23477.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72dad93b-f111-4b9a-86cd-92e4241a60be>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef54f098-9748-4db8-9b24-d89844b666c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef54f098-9748-4db8-9b24-d89844b666c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_24-05-2022_23538.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef54f098-9748-4db8-9b24-d89844b666c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b78afab4-03bb-494d-8a6b-dbc214452cdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b78afab4-03bb-494d-8a6b-dbc214452cdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_24-05-2022_23691.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b78afab4-03bb-494d-8a6b-dbc214452cdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/69b89baf-f373-41a0-a3df-869625eaa9bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69b89baf-f373-41a0-a3df-869625eaa9bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_26-01-2022_22395.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69b89baf-f373-41a0-a3df-869625eaa9bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3e65c62-3fac-47bd-9bff-ce9a2ef1a87d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3e65c62-3fac-47bd-9bff-ce9a2ef1a87d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_26-01-2022_22399.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3e65c62-3fac-47bd-9bff-ce9a2ef1a87d>.
+    
+<http://data.lblod.info/id/remote-data-objects/55a3df96-fd59-4431-9602-e0a1718c3831> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55a3df96-fd59-4431-9602-e0a1718c3831";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_27-04-2022_23238.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55a3df96-fd59-4431-9602-e0a1718c3831>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e9b6928-a9ea-4b4d-bff6-1e00622f36b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e9b6928-a9ea-4b4d-bff6-1e00622f36b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_27-04-2022_23246.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e9b6928-a9ea-4b4d-bff6-1e00622f36b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1c4aa36-a82a-4d6b-9667-144980c00ab0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1c4aa36-a82a-4d6b-9667-144980c00ab0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_27-04-2022_23247.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1c4aa36-a82a-4d6b-9667-144980c00ab0>.
+    
+<http://data.lblod.info/id/remote-data-objects/66a6cdb3-3e44-41f0-9d36-316802cf5e38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66a6cdb3-3e44-41f0-9d36-316802cf5e38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_27-04-2022_23248.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66a6cdb3-3e44-41f0-9d36-316802cf5e38>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bb96064-5159-4f98-bdac-55b329d07d86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bb96064-5159-4f98-bdac-55b329d07d86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_29-06-2022_24300.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bb96064-5159-4f98-bdac-55b329d07d86>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d88690a-081e-4d4a-9df1-11a55c7b1bc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d88690a-081e-4d4a-9df1-11a55c7b1bc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_29-06-2022_24304.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d88690a-081e-4d4a-9df1-11a55c7b1bc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cf88b10-e002-4a5d-a40c-c1d1a0bcc771> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cf88b10-e002-4a5d-a40c-c1d1a0bcc771";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_29-06-2022_24305.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cf88b10-e002-4a5d-a40c-c1d1a0bcc771>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f9c0a4b-5b42-4f79-8ba1-75bd0019a781> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f9c0a4b-5b42-4f79-8ba1-75bd0019a781";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_29-06-2022_24306.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f9c0a4b-5b42-4f79-8ba1-75bd0019a781>.
+    
+<http://data.lblod.info/id/remote-data-objects/595c8719-c8b4-45b1-9045-e6912cf076e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "595c8719-c8b4-45b1-9045-e6912cf076e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_29-06-2022_24307.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/595c8719-c8b4-45b1-9045-e6912cf076e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/767578ad-13ac-4579-8b21-5e15cf104236> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "767578ad-13ac-4579-8b21-5e15cf104236";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/719daacb2e1ac415ddab43b083e5fa03fedcb97891522726a89e733936f099bf/GetPublication?filename=Uittreksels_29-06-2022_24311.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/767578ad-13ac-4579-8b21-5e15cf104236>.
+    
+<http://data.lblod.info/id/remote-data-objects/81d1ca50-56e1-4a9e-9f89-3f0d7074264c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81d1ca50-56e1-4a9e-9f89-3f0d7074264c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81d1ca50-56e1-4a9e-9f89-3f0d7074264c>.
+    
+<http://data.lblod.info/id/remote-data-objects/15e8841a-3061-4bee-ae8c-b1a748f4764e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15e8841a-3061-4bee-ae8c-b1a748f4764e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15e8841a-3061-4bee-ae8c-b1a748f4764e>.
+    
+<http://data.lblod.info/id/remote-data-objects/293b666d-d839-49b0-8532-acbe45720b50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "293b666d-d839-49b0-8532-acbe45720b50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/293b666d-d839-49b0-8532-acbe45720b50>.
+    
+<http://data.lblod.info/id/remote-data-objects/104c25f3-9002-4498-8a46-5165151ec547> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "104c25f3-9002-4498-8a46-5165151ec547";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2d044e8d-9dc2-44f6-90cf-bc2efb59acd8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/104c25f3-9002-4498-8a46-5165151ec547>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201735-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201735-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201735-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201735-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7c51a1f7-e4b7-4f75-8932-5bfa5c0f9329> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7c51a1f7-e4b7-4f75-8932-5bfa5c0f9329";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b2038f90-266a-4672-9eb8-5311f3177126";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/dac31407-705b-45d2-9d5a-915d67b7723e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dac31407-705b-45d2-9d5a-915d67b7723e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126>.
+
+  <http://redpencil.data.gift/id/task/efbc8aa0-d013-412f-8f4d-1d7739e0d567> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "efbc8aa0-d013-412f-8f4d-1d7739e0d567";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7c51a1f7-e4b7-4f75-8932-5bfa5c0f9329>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/dac31407-705b-45d2-9d5a-915d67b7723e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e9d89a56-15f2-4eae-aa3f-dfa0b297a4bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9d89a56-15f2-4eae-aa3f-dfa0b297a4bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9d89a56-15f2-4eae-aa3f-dfa0b297a4bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/de872e4c-e764-4edb-a950-421f131fae27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de872e4c-e764-4edb-a950-421f131fae27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de872e4c-e764-4edb-a950-421f131fae27>.
+    
+<http://data.lblod.info/id/remote-data-objects/72a15ba4-b48e-49c2-bb06-5f34f8fca240> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72a15ba4-b48e-49c2-bb06-5f34f8fca240";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72a15ba4-b48e-49c2-bb06-5f34f8fca240>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2bad09a-2998-4601-a5a2-d440d9312ccd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2bad09a-2998-4601-a5a2-d440d9312ccd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2bad09a-2998-4601-a5a2-d440d9312ccd>.
+    
+<http://data.lblod.info/id/remote-data-objects/46a12384-1c86-482e-97c3-240f9ef8e34f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46a12384-1c86-482e-97c3-240f9ef8e34f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46a12384-1c86-482e-97c3-240f9ef8e34f>.
+    
+<http://data.lblod.info/id/remote-data-objects/867a9db5-91f1-4017-b73f-e5122dad5fac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "867a9db5-91f1-4017-b73f-e5122dad5fac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/867a9db5-91f1-4017-b73f-e5122dad5fac>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d73d6c9-4d19-48d4-b1ec-eb44bd55018d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d73d6c9-4d19-48d4-b1ec-eb44bd55018d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_17-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d73d6c9-4d19-48d4-b1ec-eb44bd55018d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd9b31e6-4c02-479b-833f-770b373bde5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd9b31e6-4c02-479b-833f-770b373bde5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_22-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd9b31e6-4c02-479b-833f-770b373bde5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/89871bd6-6b73-4ab2-8b99-0288c13addaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89871bd6-6b73-4ab2-8b99-0288c13addaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89871bd6-6b73-4ab2-8b99-0288c13addaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/9bafc76d-3c80-412b-845c-4bba0e9d3261> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9bafc76d-3c80-412b-845c-4bba0e9d3261";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_23-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9bafc76d-3c80-412b-845c-4bba0e9d3261>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8f6e7a6-0e16-4144-975f-31a7e5ecb81c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8f6e7a6-0e16-4144-975f-31a7e5ecb81c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8f6e7a6-0e16-4144-975f-31a7e5ecb81c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f791d91-266a-41b2-a481-bfbbc23c4393> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f791d91-266a-41b2-a481-bfbbc23c4393";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_27-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f791d91-266a-41b2-a481-bfbbc23c4393>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bb73131-cae1-4026-ba2a-631654204166> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bb73131-cae1-4026-ba2a-631654204166";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wichelen.be/LBLODWeb/Home/Overzicht/f9dbe81dfe82f804419e25d12ef402f1f966895b129a2a1d2438a64151528586/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bb73131-cae1-4026-ba2a-631654204166>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ac5e73c-8ca0-47e5-837b-c4036868f351> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ac5e73c-8ca0-47e5-837b-c4036868f351";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ac5e73c-8ca0-47e5-837b-c4036868f351>.
+    
+<http://data.lblod.info/id/remote-data-objects/69073873-4444-4fe9-a317-b0f45d2bd5e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69073873-4444-4fe9-a317-b0f45d2bd5e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69073873-4444-4fe9-a317-b0f45d2bd5e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fa9366c-6259-4b8d-84ac-24d5cae3e5b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fa9366c-6259-4b8d-84ac-24d5cae3e5b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fa9366c-6259-4b8d-84ac-24d5cae3e5b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/44c4129c-d9ca-4f72-acca-298d24db51bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44c4129c-d9ca-4f72-acca-298d24db51bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_01-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44c4129c-d9ca-4f72-acca-298d24db51bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/90410f6e-03b6-4b11-bede-91b26e22342d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90410f6e-03b6-4b11-bede-91b26e22342d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90410f6e-03b6-4b11-bede-91b26e22342d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9f8a4ac-81dd-41b9-a5f2-0a340afce022> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9f8a4ac-81dd-41b9-a5f2-0a340afce022";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9f8a4ac-81dd-41b9-a5f2-0a340afce022>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd4f6ceb-0aa3-4c7d-9c90-854c4c7e813f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd4f6ceb-0aa3-4c7d-9c90-854c4c7e813f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd4f6ceb-0aa3-4c7d-9c90-854c4c7e813f>.
+    
+<http://data.lblod.info/id/remote-data-objects/06180ab3-d1e4-4774-8ad9-79aaaab4b04b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06180ab3-d1e4-4774-8ad9-79aaaab4b04b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06180ab3-d1e4-4774-8ad9-79aaaab4b04b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bda3a34-4643-4305-9a08-246a841736ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bda3a34-4643-4305-9a08-246a841736ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bda3a34-4643-4305-9a08-246a841736ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2873856-4071-426b-b823-23f2f6658878> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2873856-4071-426b-b823-23f2f6658878";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2873856-4071-426b-b823-23f2f6658878>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe929b96-fa21-495b-ba5d-4d6425294ef4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe929b96-fa21-495b-ba5d-4d6425294ef4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe929b96-fa21-495b-ba5d-4d6425294ef4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e52470c-8587-4d0b-b752-72e0bb9164a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e52470c-8587-4d0b-b752-72e0bb9164a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e52470c-8587-4d0b-b752-72e0bb9164a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3eb3095-e789-4cd7-aeb0-05a2b9122333> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3eb3095-e789-4cd7-aeb0-05a2b9122333";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3eb3095-e789-4cd7-aeb0-05a2b9122333>.
+    
+<http://data.lblod.info/id/remote-data-objects/afee6392-862e-419f-b5ad-cbeb39e766ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afee6392-862e-419f-b5ad-cbeb39e766ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afee6392-862e-419f-b5ad-cbeb39e766ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb896623-73fb-4b06-8cd4-cf7f6c0b0116> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb896623-73fb-4b06-8cd4-cf7f6c0b0116";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb896623-73fb-4b06-8cd4-cf7f6c0b0116>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecff505c-cbde-4491-8225-188a0aa689da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecff505c-cbde-4491-8225-188a0aa689da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecff505c-cbde-4491-8225-188a0aa689da>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c988ef9-e095-4c83-ba68-009a8cfa39ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c988ef9-e095-4c83-ba68-009a8cfa39ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c988ef9-e095-4c83-ba68-009a8cfa39ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab693123-146b-4910-aff8-b27e9ba97757> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab693123-146b-4910-aff8-b27e9ba97757";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab693123-146b-4910-aff8-b27e9ba97757>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1e61072-3447-4f20-842f-a8dff2f369d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1e61072-3447-4f20-842f-a8dff2f369d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1e61072-3447-4f20-842f-a8dff2f369d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc57d248-e36b-457b-913f-16ec03d59017> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc57d248-e36b-457b-913f-16ec03d59017";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc57d248-e36b-457b-913f-16ec03d59017>.
+    
+<http://data.lblod.info/id/remote-data-objects/243b3d6f-4709-45af-9492-f128aaab2c73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "243b3d6f-4709-45af-9492-f128aaab2c73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/243b3d6f-4709-45af-9492-f128aaab2c73>.
+    
+<http://data.lblod.info/id/remote-data-objects/9111000d-e347-413b-b6e8-7ce43432ff3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9111000d-e347-413b-b6e8-7ce43432ff3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9111000d-e347-413b-b6e8-7ce43432ff3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/634ce0c3-9c44-4a4d-bd71-155bfdc552f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "634ce0c3-9c44-4a4d-bd71-155bfdc552f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/634ce0c3-9c44-4a4d-bd71-155bfdc552f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/340d12b9-7bb2-418c-9dcb-fc55e1f133c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "340d12b9-7bb2-418c-9dcb-fc55e1f133c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/340d12b9-7bb2-418c-9dcb-fc55e1f133c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/214122f5-9a8a-486d-881e-1d43727f8230> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "214122f5-9a8a-486d-881e-1d43727f8230";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/214122f5-9a8a-486d-881e-1d43727f8230>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff79490b-1730-4696-8934-918058cd56d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff79490b-1730-4696-8934-918058cd56d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff79490b-1730-4696-8934-918058cd56d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/69e69a4f-1c1c-406c-95d1-b566b0a5f69e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69e69a4f-1c1c-406c-95d1-b566b0a5f69e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69e69a4f-1c1c-406c-95d1-b566b0a5f69e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d7c470c-1de1-487c-bcd5-bf58cfc91750> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d7c470c-1de1-487c-bcd5-bf58cfc91750";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d7c470c-1de1-487c-bcd5-bf58cfc91750>.
+    
+<http://data.lblod.info/id/remote-data-objects/e54021bf-546d-4d6f-b95f-ef69c0959ab1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e54021bf-546d-4d6f-b95f-ef69c0959ab1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e54021bf-546d-4d6f-b95f-ef69c0959ab1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8af77054-cedb-4873-b434-cd22653cf00d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8af77054-cedb-4873-b434-cd22653cf00d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8af77054-cedb-4873-b434-cd22653cf00d>.
+    
+<http://data.lblod.info/id/remote-data-objects/02db02dd-103a-4b39-a4ae-f203ba78d4ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02db02dd-103a-4b39-a4ae-f203ba78d4ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02db02dd-103a-4b39-a4ae-f203ba78d4ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/79c1380e-2e73-49cf-8d48-6020e0a95be5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79c1380e-2e73-49cf-8d48-6020e0a95be5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79c1380e-2e73-49cf-8d48-6020e0a95be5>.
+    
+<http://data.lblod.info/id/remote-data-objects/552db644-c541-46f2-950d-3ed04ff881a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "552db644-c541-46f2-950d-3ed04ff881a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/552db644-c541-46f2-950d-3ed04ff881a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c79826a0-c603-4690-8485-71f2be4c208c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c79826a0-c603-4690-8485-71f2be4c208c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c79826a0-c603-4690-8485-71f2be4c208c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f188d09-a41c-4ebf-bd63-f7f14f55284f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f188d09-a41c-4ebf-bd63-f7f14f55284f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f188d09-a41c-4ebf-bd63-f7f14f55284f>.
+    
+<http://data.lblod.info/id/remote-data-objects/06e020da-2549-4039-bc22-69a286c54675> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06e020da-2549-4039-bc22-69a286c54675";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06e020da-2549-4039-bc22-69a286c54675>.
+    
+<http://data.lblod.info/id/remote-data-objects/a679bdb2-00fb-49a1-b1df-17ce2a529b9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a679bdb2-00fb-49a1-b1df-17ce2a529b9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b2038f90-266a-4672-9eb8-5311f3177126> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a679bdb2-00fb-49a1-b1df-17ce2a529b9f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201736-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201736-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201736-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201736-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b4634ac4-1d0d-4822-b9cf-c6dd8f475ef0> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b4634ac4-1d0d-4822-b9cf-c6dd8f475ef0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8e28f21b-57c6-428d-a53c-8693741d6fbc";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9daefce2-ba6a-4bcd-988f-24dd9cfabed8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9daefce2-ba6a-4bcd-988f-24dd9cfabed8";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc>.
+
+  <http://redpencil.data.gift/id/task/1c601381-ab5a-471c-aa74-18c65da1cb2c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1c601381-ab5a-471c-aa74-18c65da1cb2c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b4634ac4-1d0d-4822-b9cf-c6dd8f475ef0>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9daefce2-ba6a-4bcd-988f-24dd9cfabed8>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/755337c2-6663-4daa-8147-90798023c0e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "755337c2-6663-4daa-8147-90798023c0e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/755337c2-6663-4daa-8147-90798023c0e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d62e184b-818e-4cda-a6ad-7ce00c77cbdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d62e184b-818e-4cda-a6ad-7ce00c77cbdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d62e184b-818e-4cda-a6ad-7ce00c77cbdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ecdf66d-25bc-4f9f-a4b8-943d1ea25456> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ecdf66d-25bc-4f9f-a4b8-943d1ea25456";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ecdf66d-25bc-4f9f-a4b8-943d1ea25456>.
+    
+<http://data.lblod.info/id/remote-data-objects/01a9773e-7007-4489-bbd5-5d7686c349c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01a9773e-7007-4489-bbd5-5d7686c349c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01a9773e-7007-4489-bbd5-5d7686c349c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/04d4b21c-0ae6-486f-b20b-8fc0ea2b87ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04d4b21c-0ae6-486f-b20b-8fc0ea2b87ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04d4b21c-0ae6-486f-b20b-8fc0ea2b87ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/05de2a25-06a0-44c4-9155-71cd512c7fed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05de2a25-06a0-44c4-9155-71cd512c7fed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05de2a25-06a0-44c4-9155-71cd512c7fed>.
+    
+<http://data.lblod.info/id/remote-data-objects/188a511a-68e6-4d8e-84c3-a3675fb55449> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "188a511a-68e6-4d8e-84c3-a3675fb55449";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/188a511a-68e6-4d8e-84c3-a3675fb55449>.
+    
+<http://data.lblod.info/id/remote-data-objects/8405e5d2-e948-4157-832b-2550f583f3c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8405e5d2-e948-4157-832b-2550f583f3c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_01-02-2022_28564.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8405e5d2-e948-4157-832b-2550f583f3c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e428861-a1ec-4bd7-a1e8-c8195396e85c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e428861-a1ec-4bd7-a1e8-c8195396e85c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_01-02-2022_28592.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e428861-a1ec-4bd7-a1e8-c8195396e85c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8d1811a-7c53-4f1c-b53b-d2aa02a53638> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8d1811a-7c53-4f1c-b53b-d2aa02a53638";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_01-06-2022_30882.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8d1811a-7c53-4f1c-b53b-d2aa02a53638>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2f87d3b-0710-4f0d-9e56-f8deeef75208> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2f87d3b-0710-4f0d-9e56-f8deeef75208";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_04-05-2022_30501.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2f87d3b-0710-4f0d-9e56-f8deeef75208>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a46e309-965a-4c50-974c-247301be1f02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a46e309-965a-4c50-974c-247301be1f02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_04-05-2022_30560.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a46e309-965a-4c50-974c-247301be1f02>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b5dfc37-60a5-4e78-aabb-490c3f6620b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b5dfc37-60a5-4e78-aabb-490c3f6620b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_04-05-2022_30561.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b5dfc37-60a5-4e78-aabb-490c3f6620b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd0060ae-ac53-4e28-8f39-5950342a4ae5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd0060ae-ac53-4e28-8f39-5950342a4ae5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_05-04-2022_30014.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd0060ae-ac53-4e28-8f39-5950342a4ae5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0936802e-48fb-4ffc-93da-b4c99341fd92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0936802e-48fb-4ffc-93da-b4c99341fd92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_07-06-2022_30924.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0936802e-48fb-4ffc-93da-b4c99341fd92>.
+    
+<http://data.lblod.info/id/remote-data-objects/c785efed-fbb0-4ade-a318-544e54a8005c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c785efed-fbb0-4ade-a318-544e54a8005c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_07-06-2022_30980.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c785efed-fbb0-4ade-a318-544e54a8005c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c52b368c-ee06-4ac6-9800-ff83b6bd527e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c52b368c-ee06-4ac6-9800-ff83b6bd527e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_07-06-2022_31013.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c52b368c-ee06-4ac6-9800-ff83b6bd527e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc745ba5-722e-4ca3-b9c6-0d28d384b77f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc745ba5-722e-4ca3-b9c6-0d28d384b77f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_08-02-2022_28570.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc745ba5-722e-4ca3-b9c6-0d28d384b77f>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa158736-5afb-4398-b89d-b5a8ef6092ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa158736-5afb-4398-b89d-b5a8ef6092ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_10-05-2022_30273.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa158736-5afb-4398-b89d-b5a8ef6092ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/6929c36b-5c89-4b4c-96b9-f7b562deb8e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6929c36b-5c89-4b4c-96b9-f7b562deb8e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_10-05-2022_30274.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6929c36b-5c89-4b4c-96b9-f7b562deb8e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3afa9a1-6eb8-4a5c-8bba-b6fe73ca1c7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3afa9a1-6eb8-4a5c-8bba-b6fe73ca1c7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_10-05-2022_30601.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3afa9a1-6eb8-4a5c-8bba-b6fe73ca1c7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d20b99ad-7f16-47ed-b028-96d2d8bd8789> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d20b99ad-7f16-47ed-b028-96d2d8bd8789";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_10-05-2022_30604.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d20b99ad-7f16-47ed-b028-96d2d8bd8789>.
+    
+<http://data.lblod.info/id/remote-data-objects/a85e3e49-9535-4867-ab30-fc2763ec031e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a85e3e49-9535-4867-ab30-fc2763ec031e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_12-04-2022_30221.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a85e3e49-9535-4867-ab30-fc2763ec031e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0676dca3-d3ea-444a-8875-6215900b067f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0676dca3-d3ea-444a-8875-6215900b067f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_12-04-2022_30321.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0676dca3-d3ea-444a-8875-6215900b067f>.
+    
+<http://data.lblod.info/id/remote-data-objects/271465d9-0309-4f0d-b21b-684805e2839a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "271465d9-0309-4f0d-b21b-684805e2839a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_12-04-2022_30358.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/271465d9-0309-4f0d-b21b-684805e2839a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b5bab87-b3bb-42a6-a298-ed4a2becb03d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b5bab87-b3bb-42a6-a298-ed4a2becb03d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_12-07-2022_30965.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b5bab87-b3bb-42a6-a298-ed4a2becb03d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a99b9ab9-d5f4-4836-838b-8c5b79996feb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a99b9ab9-d5f4-4836-838b-8c5b79996feb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_12-07-2022_31404.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a99b9ab9-d5f4-4836-838b-8c5b79996feb>.
+    
+<http://data.lblod.info/id/remote-data-objects/54632c87-f4f3-40d8-83e1-cdd9c4041661> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54632c87-f4f3-40d8-83e1-cdd9c4041661";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_14-12-2021_28020.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54632c87-f4f3-40d8-83e1-cdd9c4041661>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b35f2cb-362a-4a0b-93e1-ed675675e5e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b35f2cb-362a-4a0b-93e1-ed675675e5e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_15-06-2022_30922.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b35f2cb-362a-4a0b-93e1-ed675675e5e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4464f891-4282-4cb2-a494-6054dbd259c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4464f891-4282-4cb2-a494-6054dbd259c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_16-03-2022_30078.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4464f891-4282-4cb2-a494-6054dbd259c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/06a86a1d-cae8-44df-a356-3dc7e24fbbcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06a86a1d-cae8-44df-a356-3dc7e24fbbcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_16-11-2021_23651.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06a86a1d-cae8-44df-a356-3dc7e24fbbcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/10499bd9-dd82-4b06-8dce-e875175d1ad9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10499bd9-dd82-4b06-8dce-e875175d1ad9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_21-06-2022_30993.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10499bd9-dd82-4b06-8dce-e875175d1ad9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea0bc162-376d-4745-8c12-71e9afa85712> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea0bc162-376d-4745-8c12-71e9afa85712";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_21-06-2022_31084.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea0bc162-376d-4745-8c12-71e9afa85712>.
+    
+<http://data.lblod.info/id/remote-data-objects/702156f7-6354-40ab-90c7-9ae35ea33cc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "702156f7-6354-40ab-90c7-9ae35ea33cc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_21-06-2022_31150.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/702156f7-6354-40ab-90c7-9ae35ea33cc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9f70dab-888d-4a06-9a7a-f472ba9d24a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9f70dab-888d-4a06-9a7a-f472ba9d24a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_21-06-2022_31160.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9f70dab-888d-4a06-9a7a-f472ba9d24a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/272b1d9e-c9c7-4076-90f9-b9c79a2abd13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "272b1d9e-c9c7-4076-90f9-b9c79a2abd13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_21-06-2022_31179.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/272b1d9e-c9c7-4076-90f9-b9c79a2abd13>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2fd34fc-27c5-4bcb-9a5f-79ae6547e153> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2fd34fc-27c5-4bcb-9a5f-79ae6547e153";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_21-06-2022_31190.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2fd34fc-27c5-4bcb-9a5f-79ae6547e153>.
+    
+<http://data.lblod.info/id/remote-data-objects/09af8947-b4d8-4ed1-9aeb-317879be2d1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09af8947-b4d8-4ed1-9aeb-317879be2d1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_22-03-2022_30130.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09af8947-b4d8-4ed1-9aeb-317879be2d1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fa30479-42ea-4d1b-ad56-a73fb4b59133> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fa30479-42ea-4d1b-ad56-a73fb4b59133";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_24-05-2022_30341.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fa30479-42ea-4d1b-ad56-a73fb4b59133>.
+    
+<http://data.lblod.info/id/remote-data-objects/af7db1f1-93bc-4c2c-82d0-f3782ed2f653> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af7db1f1-93bc-4c2c-82d0-f3782ed2f653";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_24-05-2022_30816.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af7db1f1-93bc-4c2c-82d0-f3782ed2f653>.
+    
+<http://data.lblod.info/id/remote-data-objects/75792473-0620-4290-ac1d-1138264cee81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75792473-0620-4290-ac1d-1138264cee81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_26-04-2022_30017.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75792473-0620-4290-ac1d-1138264cee81>.
+    
+<http://data.lblod.info/id/remote-data-objects/52d740a6-c3a5-4b76-912d-c9c9c3c76346> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52d740a6-c3a5-4b76-912d-c9c9c3c76346";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_26-04-2022_30201.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52d740a6-c3a5-4b76-912d-c9c9c3c76346>.
+    
+<http://data.lblod.info/id/remote-data-objects/19320ff6-82e2-4357-83e6-35a352e3ce0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19320ff6-82e2-4357-83e6-35a352e3ce0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_26-04-2022_30465.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19320ff6-82e2-4357-83e6-35a352e3ce0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e922322-c7df-4cca-99f9-f405913dbfb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e922322-c7df-4cca-99f9-f405913dbfb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_26-04-2022_30506.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e922322-c7df-4cca-99f9-f405913dbfb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0329e6cf-d10f-4432-b58e-bc4186ddfc06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0329e6cf-d10f-4432-b58e-bc4186ddfc06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_26-04-2022_30507.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0329e6cf-d10f-4432-b58e-bc4186ddfc06>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c83738f-b7de-4691-8aef-64564b12756e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c83738f-b7de-4691-8aef-64564b12756e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_28-06-2022_30866.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c83738f-b7de-4691-8aef-64564b12756e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8496adbb-3f33-419c-9dc8-4f87aeeeea30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8496adbb-3f33-419c-9dc8-4f87aeeeea30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_29-03-2022_29774.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8496adbb-3f33-419c-9dc8-4f87aeeeea30>.
+    
+<http://data.lblod.info/id/remote-data-objects/31d2b531-4233-40d7-afa2-15c3b8c4b617> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31d2b531-4233-40d7-afa2-15c3b8c4b617";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_29-03-2022_30116.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31d2b531-4233-40d7-afa2-15c3b8c4b617>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ee1e9f8-9656-460c-ab9b-fa03dac74b34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ee1e9f8-9656-460c-ab9b-fa03dac74b34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/7a242e2b82979337b896c57c70c09da158036277fca56490fb249d6dd9c3be09/GetPublication?filename=Uittreksels_29-03-2022_30127.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ee1e9f8-9656-460c-ab9b-fa03dac74b34>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef5ba7fd-36a6-44c3-943d-0acd6efe63b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef5ba7fd-36a6-44c3-943d-0acd6efe63b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Agenda_Gemeenteraad_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8e28f21b-57c6-428d-a53c-8693741d6fbc> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef5ba7fd-36a6-44c3-943d-0acd6efe63b2>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201738-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201738-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201738-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201738-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/4ca475d4-749f-49d5-a0a2-5b794aa85c39> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4ca475d4-749f-49d5-a0a2-5b794aa85c39";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "faa3b73d-06a9-4009-acb6-67fabd2cbedd";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b0d7ddfe-eff3-48af-8607-0a6033b8b680> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b0d7ddfe-eff3-48af-8607-0a6033b8b680";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd>.
+
+  <http://redpencil.data.gift/id/task/0a32fb87-2793-4efd-b47d-0feae250e21b> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0a32fb87-2793-4efd-b47d-0feae250e21b";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/4ca475d4-749f-49d5-a0a2-5b794aa85c39>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b0d7ddfe-eff3-48af-8607-0a6033b8b680>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/1edb79ef-6908-4c48-81ae-41739fdab168> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1edb79ef-6908-4c48-81ae-41739fdab168";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Agenda_Gemeenteraad_11-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1edb79ef-6908-4c48-81ae-41739fdab168>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a733fb4-e5dc-4d67-b18f-aef8f5847d74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a733fb4-e5dc-4d67-b18f-aef8f5847d74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Agenda_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a733fb4-e5dc-4d67-b18f-aef8f5847d74>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7a0946f-f69c-4ff8-a644-9cc7894600eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7a0946f-f69c-4ff8-a644-9cc7894600eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Agenda_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7a0946f-f69c-4ff8-a644-9cc7894600eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/89eb6bd3-0be6-40c1-a3ea-cf6015494f9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89eb6bd3-0be6-40c1-a3ea-cf6015494f9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Agenda_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89eb6bd3-0be6-40c1-a3ea-cf6015494f9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a879cd57-91a9-47a1-8e0e-9a6ff274546b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a879cd57-91a9-47a1-8e0e-9a6ff274546b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Agenda_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a879cd57-91a9-47a1-8e0e-9a6ff274546b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2880eb6-e390-46ee-b903-2d1e4a8484d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2880eb6-e390-46ee-b903-2d1e4a8484d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Agenda_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2880eb6-e390-46ee-b903-2d1e4a8484d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/68e16bb4-34f8-4f4b-bf24-d388cdea6a24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68e16bb4-34f8-4f4b-bf24-d388cdea6a24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Agenda_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68e16bb4-34f8-4f4b-bf24-d388cdea6a24>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e1cf4b6-de3c-4d6e-865e-1475814bdb67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e1cf4b6-de3c-4d6e-865e-1475814bdb67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Agenda_Gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e1cf4b6-de3c-4d6e-865e-1475814bdb67>.
+    
+<http://data.lblod.info/id/remote-data-objects/6449c7f7-ba4d-49b5-a8e9-743043a14be3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6449c7f7-ba4d-49b5-a8e9-743043a14be3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Agenda_Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6449c7f7-ba4d-49b5-a8e9-743043a14be3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bb74bf4-7c3a-455c-aaab-df5cad5d49f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bb74bf4-7c3a-455c-aaab-df5cad5d49f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bb74bf4-7c3a-455c-aaab-df5cad5d49f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/beb7a2c7-2564-4d49-b61e-eec161533b8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "beb7a2c7-2564-4d49-b61e-eec161533b8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_11-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/beb7a2c7-2564-4d49-b61e-eec161533b8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a19b0338-0ae1-4d2f-865a-aaeef6f636ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a19b0338-0ae1-4d2f-865a-aaeef6f636ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a19b0338-0ae1-4d2f-865a-aaeef6f636ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/7155ca2b-cc1f-4279-8eca-e07bb319056f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7155ca2b-cc1f-4279-8eca-e07bb319056f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7155ca2b-cc1f-4279-8eca-e07bb319056f>.
+    
+<http://data.lblod.info/id/remote-data-objects/258c9547-76b5-4488-9ba8-bfe9dc9ad7d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "258c9547-76b5-4488-9ba8-bfe9dc9ad7d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/258c9547-76b5-4488-9ba8-bfe9dc9ad7d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7825cdea-39a1-40c3-8465-cef71bb271bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7825cdea-39a1-40c3-8465-cef71bb271bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7825cdea-39a1-40c3-8465-cef71bb271bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/1dc69299-b774-449b-a2b3-7f4f91890806> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1dc69299-b774-449b-a2b3-7f4f91890806";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1dc69299-b774-449b-a2b3-7f4f91890806>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae9dd6a2-4594-466b-8655-d1d48b1c9713> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae9dd6a2-4594-466b-8655-d1d48b1c9713";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae9dd6a2-4594-466b-8655-d1d48b1c9713>.
+    
+<http://data.lblod.info/id/remote-data-objects/660f1b55-8556-40b4-bcd2-19b9c40bba2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "660f1b55-8556-40b4-bcd2-19b9c40bba2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/660f1b55-8556-40b4-bcd2-19b9c40bba2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb765e5e-56d6-4542-b442-eaeb2d86e34c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb765e5e-56d6-4542-b442-eaeb2d86e34c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb765e5e-56d6-4542-b442-eaeb2d86e34c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b81dab82-89d7-42e1-bffb-c2dccb3d9f36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b81dab82-89d7-42e1-bffb-c2dccb3d9f36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Notulen_Gemeenteraad_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b81dab82-89d7-42e1-bffb-c2dccb3d9f36>.
+    
+<http://data.lblod.info/id/remote-data-objects/43f91735-18f1-4292-9763-4b3427a0881b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43f91735-18f1-4292-9763-4b3427a0881b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Notulen_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43f91735-18f1-4292-9763-4b3427a0881b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d19c660b-d329-4f77-b9cc-6f20c5bef407> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d19c660b-d329-4f77-b9cc-6f20c5bef407";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Notulen_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d19c660b-d329-4f77-b9cc-6f20c5bef407>.
+    
+<http://data.lblod.info/id/remote-data-objects/eff5effe-57b1-4c61-b36d-9c616b26ab22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eff5effe-57b1-4c61-b36d-9c616b26ab22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Notulen_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eff5effe-57b1-4c61-b36d-9c616b26ab22>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ed30a49-c77a-4587-b8d8-a8062fe670e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ed30a49-c77a-4587-b8d8-a8062fe670e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Notulen_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ed30a49-c77a-4587-b8d8-a8062fe670e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/8257df89-2846-43d3-b58a-2d5ba78cbb8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8257df89-2846-43d3-b58a-2d5ba78cbb8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Notulen_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8257df89-2846-43d3-b58a-2d5ba78cbb8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fba99bf-33c9-4a03-b3f0-412b5f6da148> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fba99bf-33c9-4a03-b3f0-412b5f6da148";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Notulen_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fba99bf-33c9-4a03-b3f0-412b5f6da148>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a9deb28-7663-4567-b295-8a946c7a015a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a9deb28-7663-4567-b295-8a946c7a015a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Notulen_Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a9deb28-7663-4567-b295-8a946c7a015a>.
+    
+<http://data.lblod.info/id/remote-data-objects/62844b56-5f54-46dd-b922-5fc7a788706b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62844b56-5f54-46dd-b922-5fc7a788706b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_11-07-2022_31346.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62844b56-5f54-46dd-b922-5fc7a788706b>.
+    
+<http://data.lblod.info/id/remote-data-objects/216e13a7-0d13-48e6-935d-9c5bff4ec623> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "216e13a7-0d13-48e6-935d-9c5bff4ec623";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_11-07-2022_31348.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/216e13a7-0d13-48e6-935d-9c5bff4ec623>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d4046bc-9bd9-4f97-93b3-77ca161f801f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d4046bc-9bd9-4f97-93b3-77ca161f801f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_11-07-2022_31349.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d4046bc-9bd9-4f97-93b3-77ca161f801f>.
+    
+<http://data.lblod.info/id/remote-data-objects/53094510-3f5b-4946-9128-e837ab7ed089> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53094510-3f5b-4946-9128-e837ab7ed089";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_11-07-2022_31350.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53094510-3f5b-4946-9128-e837ab7ed089>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d2a0b87-88fb-4664-bace-f7438b72d8ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d2a0b87-88fb-4664-bace-f7438b72d8ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_11-07-2022_31352.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d2a0b87-88fb-4664-bace-f7438b72d8ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/0064c553-c974-447b-9dd1-b2d91147c735> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0064c553-c974-447b-9dd1-b2d91147c735";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_16-12-2021_23504.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0064c553-c974-447b-9dd1-b2d91147c735>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ff41062-9624-4b20-8d70-8d1e99ad117c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ff41062-9624-4b20-8d70-8d1e99ad117c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_16-12-2021_23506.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ff41062-9624-4b20-8d70-8d1e99ad117c>.
+    
+<http://data.lblod.info/id/remote-data-objects/66af5f20-f01e-4d99-b55f-05bde5dc083b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66af5f20-f01e-4d99-b55f-05bde5dc083b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_16-12-2021_27717.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66af5f20-f01e-4d99-b55f-05bde5dc083b>.
+    
+<http://data.lblod.info/id/remote-data-objects/825d613b-12e5-47f3-9e3b-1f9d7e20c564> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "825d613b-12e5-47f3-9e3b-1f9d7e20c564";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_16-12-2021_27718.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/825d613b-12e5-47f3-9e3b-1f9d7e20c564>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ad022d8-5af7-4805-b0e2-b24dc43ed6d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ad022d8-5af7-4805-b0e2-b24dc43ed6d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_16-12-2021_27719.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ad022d8-5af7-4805-b0e2-b24dc43ed6d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/16684dc4-1995-461b-899d-e7dd9be8624b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16684dc4-1995-461b-899d-e7dd9be8624b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_16-12-2021_27912.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16684dc4-1995-461b-899d-e7dd9be8624b>.
+    
+<http://data.lblod.info/id/remote-data-objects/500a446a-1138-4d68-a21a-b250d12fbca3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "500a446a-1138-4d68-a21a-b250d12fbca3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_16-12-2021_27983.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/500a446a-1138-4d68-a21a-b250d12fbca3>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b08f290-b69c-48c1-aa94-1f72c028bc3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b08f290-b69c-48c1-aa94-1f72c028bc3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_24-02-2022_28628.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b08f290-b69c-48c1-aa94-1f72c028bc3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d137fa7f-7d63-4c60-ad14-f75ae3ea3873> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d137fa7f-7d63-4c60-ad14-f75ae3ea3873";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_24-02-2022_29698.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d137fa7f-7d63-4c60-ad14-f75ae3ea3873>.
+    
+<http://data.lblod.info/id/remote-data-objects/b62c0154-0e05-45d0-96ef-68be44521747> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b62c0154-0e05-45d0-96ef-68be44521747";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_24-02-2022_29779.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b62c0154-0e05-45d0-96ef-68be44521747>.
+    
+<http://data.lblod.info/id/remote-data-objects/d54283df-e154-4d55-9439-45156d16e855> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d54283df-e154-4d55-9439-45156d16e855";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_27-01-2022_28366.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d54283df-e154-4d55-9439-45156d16e855>.
+    
+<http://data.lblod.info/id/remote-data-objects/50cc71a9-4c32-48eb-9c37-6f851d1fff26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50cc71a9-4c32-48eb-9c37-6f851d1fff26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_27-01-2022_28367.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50cc71a9-4c32-48eb-9c37-6f851d1fff26>.
+    
+<http://data.lblod.info/id/remote-data-objects/28f349d4-a3c1-4f70-8930-ca79123639e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28f349d4-a3c1-4f70-8930-ca79123639e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_28-04-2022_30485.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28f349d4-a3c1-4f70-8930-ca79123639e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9d0ade3-8424-4b32-8a77-baf4450f21e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9d0ade3-8424-4b32-8a77-baf4450f21e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_28-10-2021_23553.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9d0ade3-8424-4b32-8a77-baf4450f21e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/04f27766-c8bb-420e-abc6-3edde2b2139d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04f27766-c8bb-420e-abc6-3edde2b2139d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/910acbb1f91a04a58c6a73bc8dc007172ff6b107b33a4655bd0d0914d58f7c69/GetPublication?filename=Uittreksels_31-03-2022_28609.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04f27766-c8bb-420e-abc6-3edde2b2139d>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbbebd55-60f4-4627-b1ef-9cb1a81a4450> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbbebd55-60f4-4627-b1ef-9cb1a81a4450";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbbebd55-60f4-4627-b1ef-9cb1a81a4450>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bdc13d7-40f8-4123-b233-30691263a11d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bdc13d7-40f8-4123-b233-30691263a11d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bdc13d7-40f8-4123-b233-30691263a11d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0889c5c8-3728-4940-8a4f-fe4243e938e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0889c5c8-3728-4940-8a4f-fe4243e938e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_17-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/faa3b73d-06a9-4009-acb6-67fabd2cbedd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0889c5c8-3728-4940-8a4f-fe4243e938e0>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201739-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201739-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201739-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201739-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3440c120-452e-4374-a3c4-9f212e3966d8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3440c120-452e-4374-a3c4-9f212e3966d8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/bc7ebdb4-5bc1-46de-b5dc-77e3662a9269> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bc7ebdb4-5bc1-46de-b5dc-77e3662a9269";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9>.
+
+  <http://redpencil.data.gift/id/task/0ecb1a5e-0fcf-476f-9884-34aef516b222> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0ecb1a5e-0fcf-476f-9884-34aef516b222";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3440c120-452e-4374-a3c4-9f212e3966d8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/bc7ebdb4-5bc1-46de-b5dc-77e3662a9269>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b0921076-bdbe-4b91-813d-37cdf62ff9cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0921076-bdbe-4b91-813d-37cdf62ff9cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0921076-bdbe-4b91-813d-37cdf62ff9cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/22f6a2f3-2bdf-4a5b-9cd3-8020a7f774c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22f6a2f3-2bdf-4a5b-9cd3-8020a7f774c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_20-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22f6a2f3-2bdf-4a5b-9cd3-8020a7f774c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/18cf99e9-d027-49c9-bcc6-80079d8a0a92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18cf99e9-d027-49c9-bcc6-80079d8a0a92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18cf99e9-d027-49c9-bcc6-80079d8a0a92>.
+    
+<http://data.lblod.info/id/remote-data-objects/5949b19c-8359-4217-8bd8-77705e78d1a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5949b19c-8359-4217-8bd8-77705e78d1a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5949b19c-8359-4217-8bd8-77705e78d1a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3c1d990-f9fc-4c1a-b369-31e213bc8495> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3c1d990-f9fc-4c1a-b369-31e213bc8495";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_02-03-2022_29976.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3c1d990-f9fc-4c1a-b369-31e213bc8495>.
+    
+<http://data.lblod.info/id/remote-data-objects/a679980d-59fe-4571-9b37-b9bd7e883d7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a679980d-59fe-4571-9b37-b9bd7e883d7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_04-10-2021_23372.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a679980d-59fe-4571-9b37-b9bd7e883d7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fef55a07-858a-4cf4-87cd-212c49637072> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fef55a07-858a-4cf4-87cd-212c49637072";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_06-12-2021_27870.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fef55a07-858a-4cf4-87cd-212c49637072>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e6377d6-ac84-4dca-bf0a-bd875b578491> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e6377d6-ac84-4dca-bf0a-bd875b578491";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_06-12-2021_27951.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e6377d6-ac84-4dca-bf0a-bd875b578491>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7a2a082-22fd-4f34-bcf2-b9c737c404e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7a2a082-22fd-4f34-bcf2-b9c737c404e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_08-11-2021_27646.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7a2a082-22fd-4f34-bcf2-b9c737c404e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d675bc0f-68b4-4cb0-8cb1-5a185b775730> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d675bc0f-68b4-4cb0-8cb1-5a185b775730";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_12-04-2022_30206.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d675bc0f-68b4-4cb0-8cb1-5a185b775730>.
+    
+<http://data.lblod.info/id/remote-data-objects/46a73e6a-c942-48b2-b2f2-67b28f87c81c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46a73e6a-c942-48b2-b2f2-67b28f87c81c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_15-06-2022_31164.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46a73e6a-c942-48b2-b2f2-67b28f87c81c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b7ab176-385e-4d32-8f32-87106e29bc12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b7ab176-385e-4d32-8f32-87106e29bc12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_17-06-2022_31186.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b7ab176-385e-4d32-8f32-87106e29bc12>.
+    
+<http://data.lblod.info/id/remote-data-objects/04483fc9-1c7b-4d69-b2e8-3b25f9aa0518> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04483fc9-1c7b-4d69-b2e8-3b25f9aa0518";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_18-01-2022_28413.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04483fc9-1c7b-4d69-b2e8-3b25f9aa0518>.
+    
+<http://data.lblod.info/id/remote-data-objects/792be3e3-e220-4439-8638-fbd07a1fb387> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "792be3e3-e220-4439-8638-fbd07a1fb387";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_18-03-2022_30143.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/792be3e3-e220-4439-8638-fbd07a1fb387>.
+    
+<http://data.lblod.info/id/remote-data-objects/65e85074-c111-4f5c-8616-057fa8cca4c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65e85074-c111-4f5c-8616-057fa8cca4c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_18-07-2022_31500.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65e85074-c111-4f5c-8616-057fa8cca4c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9298156-7d83-4fd9-acff-485a60539c65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9298156-7d83-4fd9-acff-485a60539c65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_18-10-2021_23603.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9298156-7d83-4fd9-acff-485a60539c65>.
+    
+<http://data.lblod.info/id/remote-data-objects/989de1c8-260b-44dd-a1ec-22bffec238fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "989de1c8-260b-44dd-a1ec-22bffec238fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_19-07-2022_31504.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/989de1c8-260b-44dd-a1ec-22bffec238fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/e44ecb8c-7a9b-4ed3-ad12-bdc2bc85d16d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e44ecb8c-7a9b-4ed3-ad12-bdc2bc85d16d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_19-07-2022_31505.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e44ecb8c-7a9b-4ed3-ad12-bdc2bc85d16d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d45918f-42e5-4704-a263-c106bdd0e879> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d45918f-42e5-4704-a263-c106bdd0e879";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_20-10-2021_23628.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d45918f-42e5-4704-a263-c106bdd0e879>.
+    
+<http://data.lblod.info/id/remote-data-objects/949e4146-8994-4c42-9e68-30796ea0a5ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "949e4146-8994-4c42-9e68-30796ea0a5ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_22-11-2021_27785.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/949e4146-8994-4c42-9e68-30796ea0a5ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/4487b825-a1bf-42c3-9309-2d0188fbf453> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4487b825-a1bf-42c3-9309-2d0188fbf453";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_25-04-2022_30558.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4487b825-a1bf-42c3-9309-2d0188fbf453>.
+    
+<http://data.lblod.info/id/remote-data-objects/7284388c-9069-489a-8690-33399053fe43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7284388c-9069-489a-8690-33399053fe43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_25-05-2022_30892.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7284388c-9069-489a-8690-33399053fe43>.
+    
+<http://data.lblod.info/id/remote-data-objects/7702fab2-c5a8-4ba3-82de-d529623614b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7702fab2-c5a8-4ba3-82de-d529623614b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_26-10-2021_27536.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7702fab2-c5a8-4ba3-82de-d529623614b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/3800f374-1642-4bd9-a684-4ba5c76b600a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3800f374-1642-4bd9-a684-4ba5c76b600a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_28-04-2022_30565.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3800f374-1642-4bd9-a684-4ba5c76b600a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7592905f-78bb-40ce-9ca5-7b295e010971> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7592905f-78bb-40ce-9ca5-7b295e010971";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/a153c6fea2a308999d09566ee5017f98306d12b7eff107051ce182616ffb7ceb/GetPublication?filename=Uittreksels_31-03-2022_30269.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7592905f-78bb-40ce-9ca5-7b295e010971>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a4bf039-573f-4f52-b127-871051aa4a6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a4bf039-573f-4f52-b127-871051aa4a6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a4bf039-573f-4f52-b127-871051aa4a6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/055f8e5a-32fb-4cbd-a7cc-3f3773fd24ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "055f8e5a-32fb-4cbd-a7cc-3f3773fd24ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_11-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/055f8e5a-32fb-4cbd-a7cc-3f3773fd24ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ab383b9-e02b-4962-9f68-ae6a09298360> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ab383b9-e02b-4962-9f68-ae6a09298360";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ab383b9-e02b-4962-9f68-ae6a09298360>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cf16089-f2e4-4c21-b152-b491e6827140> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cf16089-f2e4-4c21-b152-b491e6827140";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cf16089-f2e4-4c21-b152-b491e6827140>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b193539-6725-4b09-9110-824678a21ce7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b193539-6725-4b09-9110-824678a21ce7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b193539-6725-4b09-9110-824678a21ce7>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e0b6375-736d-46a2-88bf-77004d85560b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e0b6375-736d-46a2-88bf-77004d85560b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e0b6375-736d-46a2-88bf-77004d85560b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0c8f82f-ef24-4e38-a1fd-ad5238755010> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0c8f82f-ef24-4e38-a1fd-ad5238755010";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0c8f82f-ef24-4e38-a1fd-ad5238755010>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cc8bd1d-7367-42d6-a9a0-056ccc99bbc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cc8bd1d-7367-42d6-a9a0-056ccc99bbc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cc8bd1d-7367-42d6-a9a0-056ccc99bbc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/933ac1b1-2dbb-4910-b6dd-f33b82f13981> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "933ac1b1-2dbb-4910-b6dd-f33b82f13981";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/933ac1b1-2dbb-4910-b6dd-f33b82f13981>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f7b5762-9b1f-4cac-93b1-0303ee5df88a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f7b5762-9b1f-4cac-93b1-0303ee5df88a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Agenda_Raad%20voor%20Maatschappelijk%20Welzijn_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f7b5762-9b1f-4cac-93b1-0303ee5df88a>.
+    
+<http://data.lblod.info/id/remote-data-objects/94c96cc5-b8ae-44a4-9919-8a2349fe0eba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94c96cc5-b8ae-44a4-9919-8a2349fe0eba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94c96cc5-b8ae-44a4-9919-8a2349fe0eba>.
+    
+<http://data.lblod.info/id/remote-data-objects/4710def0-f82e-481b-91b6-02803a963a1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4710def0-f82e-481b-91b6-02803a963a1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_11-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4710def0-f82e-481b-91b6-02803a963a1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea13a036-59c6-4128-9d24-26ae81ebd41d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea13a036-59c6-4128-9d24-26ae81ebd41d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea13a036-59c6-4128-9d24-26ae81ebd41d>.
+    
+<http://data.lblod.info/id/remote-data-objects/303f03b4-5d9b-47d6-94e6-f29b44c44805> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "303f03b4-5d9b-47d6-94e6-f29b44c44805";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/303f03b4-5d9b-47d6-94e6-f29b44c44805>.
+    
+<http://data.lblod.info/id/remote-data-objects/27adc20a-9def-4568-9803-3fe8ac799086> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27adc20a-9def-4568-9803-3fe8ac799086";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27adc20a-9def-4568-9803-3fe8ac799086>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba015291-4ec2-4826-97f5-a24daf523eb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba015291-4ec2-4826-97f5-a24daf523eb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba015291-4ec2-4826-97f5-a24daf523eb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/963ba8a8-f5dd-49b4-9156-a73af9803367> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "963ba8a8-f5dd-49b4-9156-a73af9803367";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/963ba8a8-f5dd-49b4-9156-a73af9803367>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb471848-a69e-493a-a3bc-6dc09f5e906c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb471848-a69e-493a-a3bc-6dc09f5e906c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb471848-a69e-493a-a3bc-6dc09f5e906c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9388e2c7-6800-49cb-b913-ce8c192e47e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9388e2c7-6800-49cb-b913-ce8c192e47e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9388e2c7-6800-49cb-b913-ce8c192e47e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/26e2516c-20b4-4b13-a410-36a3de4de777> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26e2516c-20b4-4b13-a410-36a3de4de777";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20Maatschappelijk%20Welzijn_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26e2516c-20b4-4b13-a410-36a3de4de777>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b86fca3-53e5-40a1-b85f-c48ff7cba2b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b86fca3-53e5-40a1-b85f-c48ff7cba2b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b86fca3-53e5-40a1-b85f-c48ff7cba2b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d213fe3f-5a41-4602-a48e-d1901c4f50c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d213fe3f-5a41-4602-a48e-d1901c4f50c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d213fe3f-5a41-4602-a48e-d1901c4f50c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bf18d66-02bc-4d89-8029-4ab6341a6b47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bf18d66-02bc-4d89-8029-4ab6341a6b47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bf18d66-02bc-4d89-8029-4ab6341a6b47>.
+    
+<http://data.lblod.info/id/remote-data-objects/9aa39d39-033b-4af0-a5d1-4c2109215d34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9aa39d39-033b-4af0-a5d1-4c2109215d34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9aa39d39-033b-4af0-a5d1-4c2109215d34>.
+    
+<http://data.lblod.info/id/remote-data-objects/e56b294b-006f-4106-9508-1c8f8d226bc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e56b294b-006f-4106-9508-1c8f8d226bc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24e1d3f3-0cb6-43be-91cc-c0fa04cc47f9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e56b294b-006f-4106-9508-1c8f8d226bc7>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201740-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201740-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201740-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201740-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/362a831c-6b61-4270-8120-46d0363f72a2> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "362a831c-6b61-4270-8120-46d0363f72a2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2365d58f-a082-4a9e-aa0a-7b93a602c210";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f599af62-f37d-4492-a025-d571110812e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f599af62-f37d-4492-a025-d571110812e8";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210>.
+
+  <http://redpencil.data.gift/id/task/95c0af7c-a909-41a3-ba5e-e55200951c6a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "95c0af7c-a909-41a3-ba5e-e55200951c6a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/362a831c-6b61-4270-8120-46d0363f72a2>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f599af62-f37d-4492-a025-d571110812e8>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4d61c4af-06c8-45a6-b54f-e8d493c9a6cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d61c4af-06c8-45a6-b54f-e8d493c9a6cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d61c4af-06c8-45a6-b54f-e8d493c9a6cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/35567df4-6c32-4f00-9ec0-511e478ff739> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35567df4-6c32-4f00-9ec0-511e478ff739";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35567df4-6c32-4f00-9ec0-511e478ff739>.
+    
+<http://data.lblod.info/id/remote-data-objects/2314aea6-a844-4aa0-acd3-0f9c2d8b2bf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2314aea6-a844-4aa0-acd3-0f9c2d8b2bf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2314aea6-a844-4aa0-acd3-0f9c2d8b2bf9>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd75aefd-1258-4d8d-95d8-8c94592672f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd75aefd-1258-4d8d-95d8-8c94592672f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd75aefd-1258-4d8d-95d8-8c94592672f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/cff8a5d5-d91a-4bfd-bc3a-6a19b2466234> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cff8a5d5-d91a-4bfd-bc3a-6a19b2466234";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Uittreksels_16-12-2021_27715.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cff8a5d5-d91a-4bfd-bc3a-6a19b2466234>.
+    
+<http://data.lblod.info/id/remote-data-objects/7721c2a9-416f-464f-a37e-e1d971ddd6ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7721c2a9-416f-464f-a37e-e1d971ddd6ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Uittreksels_16-12-2021_27913.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7721c2a9-416f-464f-a37e-e1d971ddd6ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/157d2e87-8361-4963-98c2-10908f1daca9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "157d2e87-8361-4963-98c2-10908f1daca9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Uittreksels_24-02-2022_28629.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/157d2e87-8361-4963-98c2-10908f1daca9>.
+    
+<http://data.lblod.info/id/remote-data-objects/673b3b28-3c07-4fa1-9ff1-4400af2643e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "673b3b28-3c07-4fa1-9ff1-4400af2643e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Uittreksels_24-02-2022_29696.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/673b3b28-3c07-4fa1-9ff1-4400af2643e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f910052a-3b2c-49da-a844-e58407b1d78f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f910052a-3b2c-49da-a844-e58407b1d78f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Uittreksels_30-06-2022_31008.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f910052a-3b2c-49da-a844-e58407b1d78f>.
+    
+<http://data.lblod.info/id/remote-data-objects/092e6230-4623-4bd6-8a7d-184c8ce70031> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "092e6230-4623-4bd6-8a7d-184c8ce70031";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Uittreksels_30-06-2022_31104.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/092e6230-4623-4bd6-8a7d-184c8ce70031>.
+    
+<http://data.lblod.info/id/remote-data-objects/0eb542ce-9ea0-4b44-8d59-8dedf0a22305> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0eb542ce-9ea0-4b44-8d59-8dedf0a22305";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/d62037a31c0cbd6f945f70323e3743a23b79eccccf9464fa0b213181907304b4/GetPublication?filename=Uittreksels_31-03-2022_28612.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0eb542ce-9ea0-4b44-8d59-8dedf0a22305>.
+    
+<http://data.lblod.info/id/remote-data-objects/382070f1-40c9-46f5-bf87-a94c543675a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "382070f1-40c9-46f5-bf87-a94c543675a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/382070f1-40c9-46f5-bf87-a94c543675a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee2d96db-65e8-41f3-94f8-048fd36b04b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee2d96db-65e8-41f3-94f8-048fd36b04b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee2d96db-65e8-41f3-94f8-048fd36b04b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/25fe65b4-12a4-45bb-bda4-d1d409acc477> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25fe65b4-12a4-45bb-bda4-d1d409acc477";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25fe65b4-12a4-45bb-bda4-d1d409acc477>.
+    
+<http://data.lblod.info/id/remote-data-objects/68d45311-03ce-4d1c-aee2-48d98ae39dad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68d45311-03ce-4d1c-aee2-48d98ae39dad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68d45311-03ce-4d1c-aee2-48d98ae39dad>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2fd50eb-3d60-4c99-8709-d64db4d8c1c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2fd50eb-3d60-4c99-8709-d64db4d8c1c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_03-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2fd50eb-3d60-4c99-8709-d64db4d8c1c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/70aa93f7-9865-48e6-9674-0061c16a60ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70aa93f7-9865-48e6-9674-0061c16a60ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70aa93f7-9865-48e6-9674-0061c16a60ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/f083225e-ec69-4adf-b63d-bf1c955b43b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f083225e-ec69-4adf-b63d-bf1c955b43b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f083225e-ec69-4adf-b63d-bf1c955b43b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/83c9ba5a-b0aa-4cb2-8610-1412b9aa3e26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83c9ba5a-b0aa-4cb2-8610-1412b9aa3e26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83c9ba5a-b0aa-4cb2-8610-1412b9aa3e26>.
+    
+<http://data.lblod.info/id/remote-data-objects/26ca8db0-6e13-4128-bd39-768e1d4c1680> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26ca8db0-6e13-4128-bd39-768e1d4c1680";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26ca8db0-6e13-4128-bd39-768e1d4c1680>.
+    
+<http://data.lblod.info/id/remote-data-objects/11cdbc54-805f-45cf-9aa5-a98bec0eba53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11cdbc54-805f-45cf-9aa5-a98bec0eba53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11cdbc54-805f-45cf-9aa5-a98bec0eba53>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ecce0a4-8613-436a-ad30-59c3646da555> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ecce0a4-8613-436a-ad30-59c3646da555";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ecce0a4-8613-436a-ad30-59c3646da555>.
+    
+<http://data.lblod.info/id/remote-data-objects/52499440-84a6-4c24-94a5-71e8f4d78713> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52499440-84a6-4c24-94a5-71e8f4d78713";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52499440-84a6-4c24-94a5-71e8f4d78713>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca952e83-2a67-420a-b48d-a14bfd253b51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca952e83-2a67-420a-b48d-a14bfd253b51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca952e83-2a67-420a-b48d-a14bfd253b51>.
+    
+<http://data.lblod.info/id/remote-data-objects/8137f1fa-bb9c-45e9-8f69-4ec4306b078d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8137f1fa-bb9c-45e9-8f69-4ec4306b078d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8137f1fa-bb9c-45e9-8f69-4ec4306b078d>.
+    
+<http://data.lblod.info/id/remote-data-objects/eabc9c6e-f292-4b47-8fe1-5f5fb79b8038> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eabc9c6e-f292-4b47-8fe1-5f5fb79b8038";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eabc9c6e-f292-4b47-8fe1-5f5fb79b8038>.
+    
+<http://data.lblod.info/id/remote-data-objects/c17703c4-468f-4d7b-b7a3-7a2e53c780dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c17703c4-468f-4d7b-b7a3-7a2e53c780dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c17703c4-468f-4d7b-b7a3-7a2e53c780dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/e274659e-fded-4ec9-a596-59dd2cc21453> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e274659e-fded-4ec9-a596-59dd2cc21453";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e274659e-fded-4ec9-a596-59dd2cc21453>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6a9e268-be7a-4385-89d5-50ca008e9faf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6a9e268-be7a-4385-89d5-50ca008e9faf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6a9e268-be7a-4385-89d5-50ca008e9faf>.
+    
+<http://data.lblod.info/id/remote-data-objects/800ccf83-f231-40c8-9b9c-7a11e5af601b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "800ccf83-f231-40c8-9b9c-7a11e5af601b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/800ccf83-f231-40c8-9b9c-7a11e5af601b>.
+    
+<http://data.lblod.info/id/remote-data-objects/55847dd0-51e9-44ec-86ee-092d514800c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55847dd0-51e9-44ec-86ee-092d514800c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55847dd0-51e9-44ec-86ee-092d514800c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/172d5cc7-02ef-4d84-b2fa-25e3a63c5eaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "172d5cc7-02ef-4d84-b2fa-25e3a63c5eaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/172d5cc7-02ef-4d84-b2fa-25e3a63c5eaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/94a97cb4-a8c9-473c-90e8-fb4f622a5bc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94a97cb4-a8c9-473c-90e8-fb4f622a5bc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94a97cb4-a8c9-473c-90e8-fb4f622a5bc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc8c4638-b187-41e0-b6bf-2854fb46529d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc8c4638-b187-41e0-b6bf-2854fb46529d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc8c4638-b187-41e0-b6bf-2854fb46529d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b077979-c873-48dd-9f38-74abee435e7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b077979-c873-48dd-9f38-74abee435e7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_16-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b077979-c873-48dd-9f38-74abee435e7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2b36598-d4d9-4bf3-b838-3a8df617ccb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2b36598-d4d9-4bf3-b838-3a8df617ccb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2b36598-d4d9-4bf3-b838-3a8df617ccb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/020da9e7-f6bc-4502-a094-8ed78fab145b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "020da9e7-f6bc-4502-a094-8ed78fab145b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/020da9e7-f6bc-4502-a094-8ed78fab145b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3ca62f2-f54c-4457-9af2-9a45bb8ee7e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3ca62f2-f54c-4457-9af2-9a45bb8ee7e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3ca62f2-f54c-4457-9af2-9a45bb8ee7e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c22c69f-7ed0-490c-b513-af048ec64449> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c22c69f-7ed0-490c-b513-af048ec64449";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c22c69f-7ed0-490c-b513-af048ec64449>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee669b3e-b853-4d56-976e-ea4d312ee0b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee669b3e-b853-4d56-976e-ea4d312ee0b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee669b3e-b853-4d56-976e-ea4d312ee0b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/377c59a7-bdeb-4cf8-8a07-e337233e9ddd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "377c59a7-bdeb-4cf8-8a07-e337233e9ddd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/377c59a7-bdeb-4cf8-8a07-e337233e9ddd>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2a2fa08-f240-4f59-b819-19f3eaf49bcf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2a2fa08-f240-4f59-b819-19f3eaf49bcf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2a2fa08-f240-4f59-b819-19f3eaf49bcf>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b637535-d405-4f73-9e34-0c035e56e047> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b637535-d405-4f73-9e34-0c035e56e047";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b637535-d405-4f73-9e34-0c035e56e047>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d1ed237-2064-4b7e-8a46-eae0f1d05c62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d1ed237-2064-4b7e-8a46-eae0f1d05c62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d1ed237-2064-4b7e-8a46-eae0f1d05c62>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e63f730-2ee5-4e6e-a661-b51ae3a041c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e63f730-2ee5-4e6e-a661-b51ae3a041c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e63f730-2ee5-4e6e-a661-b51ae3a041c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc3accaf-80a3-4642-89a8-29cd80491c32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc3accaf-80a3-4642-89a8-29cd80491c32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc3accaf-80a3-4642-89a8-29cd80491c32>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e33d876-02e7-4731-b743-a618bea46ec0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e33d876-02e7-4731-b743-a618bea46ec0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e33d876-02e7-4731-b743-a618bea46ec0>.
+    
+<http://data.lblod.info/id/remote-data-objects/99771815-b5c6-40e1-b44c-6954d168ed34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99771815-b5c6-40e1-b44c-6954d168ed34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99771815-b5c6-40e1-b44c-6954d168ed34>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4a9440b-74e1-4f14-a28d-421aa640d2ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4a9440b-74e1-4f14-a28d-421aa640d2ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_27-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4a9440b-74e1-4f14-a28d-421aa640d2ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/60fef7a9-21de-408c-987e-fd9fd1355999> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60fef7a9-21de-408c-987e-fd9fd1355999";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2365d58f-a082-4a9e-aa0a-7b93a602c210> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60fef7a9-21de-408c-987e-fd9fd1355999>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201741-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201741-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201741-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201741-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/ed097666-49f9-41f1-a42f-39797d609676> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ed097666-49f9-41f1-a42f-39797d609676";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e05c8fb6-ecf6-4e1d-95bd-58822aaa2106";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6fc21a5c-eeb6-4558-9ef1-99115726df80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6fc21a5c-eeb6-4558-9ef1-99115726df80";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106>.
+
+  <http://redpencil.data.gift/id/task/946ab459-a880-4bd0-9ddc-3f96c4bff10c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "946ab459-a880-4bd0-9ddc-3f96c4bff10c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/ed097666-49f9-41f1-a42f-39797d609676>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6fc21a5c-eeb6-4558-9ef1-99115726df80>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/ad36b73c-ec05-4f07-8cf9-ba6bc47d6ade> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad36b73c-ec05-4f07-8cf9-ba6bc47d6ade";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad36b73c-ec05-4f07-8cf9-ba6bc47d6ade>.
+    
+<http://data.lblod.info/id/remote-data-objects/667ccc4a-ff0c-453c-bc2c-0c9276275538> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "667ccc4a-ff0c-453c-bc2c-0c9276275538";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/667ccc4a-ff0c-453c-bc2c-0c9276275538>.
+    
+<http://data.lblod.info/id/remote-data-objects/888203d9-6ae1-492c-aad2-57cfbe0a6ba2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "888203d9-6ae1-492c-aad2-57cfbe0a6ba2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=Uittreksels_08-02-2022_28571.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/888203d9-6ae1-492c-aad2-57cfbe0a6ba2>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ed3a7f5-45f9-4099-8a02-e2d9e6eb3d8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ed3a7f5-45f9-4099-8a02-e2d9e6eb3d8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=Uittreksels_15-02-2022_29741.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ed3a7f5-45f9-4099-8a02-e2d9e6eb3d8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e9150f6-6049-470d-a6b1-a98252c35a13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e9150f6-6049-470d-a6b1-a98252c35a13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=Uittreksels_16-11-2021_23650.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e9150f6-6049-470d-a6b1-a98252c35a13>.
+    
+<http://data.lblod.info/id/remote-data-objects/666abd18-0887-45a2-bbd4-d7e50f94b2a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "666abd18-0887-45a2-bbd4-d7e50f94b2a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wielsbeke.be/LBLODWeb/Home/Overzicht/fdf5fd5a691b88f42576e387a4ed63334d1977b09ac99c08b27bbdf445456b54/GetPublication?filename=Uittreksels_21-06-2022_31006.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/666abd18-0887-45a2-bbd4-d7e50f94b2a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7bf0b36-f8a9-4856-97eb-bd59f7f9dc5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7bf0b36-f8a9-4856-97eb-bd59f7f9dc5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Agenda_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7bf0b36-f8a9-4856-97eb-bd59f7f9dc5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e870fff-a2f2-46d2-8914-a1a6cf52d7c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e870fff-a2f2-46d2-8914-a1a6cf52d7c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Agenda_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e870fff-a2f2-46d2-8914-a1a6cf52d7c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc13fbb6-798d-4017-8414-48c8620a914c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc13fbb6-798d-4017-8414-48c8620a914c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Agenda_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc13fbb6-798d-4017-8414-48c8620a914c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae590538-967e-4e39-9367-0f702dc998c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae590538-967e-4e39-9367-0f702dc998c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Agenda_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae590538-967e-4e39-9367-0f702dc998c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c92e456-05ad-462d-8b7e-b5299dc13145> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c92e456-05ad-462d-8b7e-b5299dc13145";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Agenda_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c92e456-05ad-462d-8b7e-b5299dc13145>.
+    
+<http://data.lblod.info/id/remote-data-objects/b84b7741-9985-4b31-85c5-b022b9d25e6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b84b7741-9985-4b31-85c5-b022b9d25e6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Agenda_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b84b7741-9985-4b31-85c5-b022b9d25e6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fd6f1fd-c8f8-4ac5-bc18-751307a56485> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fd6f1fd-c8f8-4ac5-bc18-751307a56485";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Agenda_Gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fd6f1fd-c8f8-4ac5-bc18-751307a56485>.
+    
+<http://data.lblod.info/id/remote-data-objects/3068b295-b900-45c0-ba26-32c085614670> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3068b295-b900-45c0-ba26-32c085614670";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Agenda_Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3068b295-b900-45c0-ba26-32c085614670>.
+    
+<http://data.lblod.info/id/remote-data-objects/791eb8e8-adde-446d-87f6-05ea05b73ca6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "791eb8e8-adde-446d-87f6-05ea05b73ca6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Agenda_Gemeenteraad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/791eb8e8-adde-446d-87f6-05ea05b73ca6>.
+    
+<http://data.lblod.info/id/remote-data-objects/4797711e-56da-4fbd-b59f-efb082b91df1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4797711e-56da-4fbd-b59f-efb082b91df1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=BesluitenLijst_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4797711e-56da-4fbd-b59f-efb082b91df1>.
+    
+<http://data.lblod.info/id/remote-data-objects/469fea11-f675-4cba-a0d4-bcc0b068079a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "469fea11-f675-4cba-a0d4-bcc0b068079a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/469fea11-f675-4cba-a0d4-bcc0b068079a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1141a952-ea3b-45dd-ba67-369e4194ea8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1141a952-ea3b-45dd-ba67-369e4194ea8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1141a952-ea3b-45dd-ba67-369e4194ea8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca8edaad-55d7-4668-9fa0-e2d316f47c31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca8edaad-55d7-4668-9fa0-e2d316f47c31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca8edaad-55d7-4668-9fa0-e2d316f47c31>.
+    
+<http://data.lblod.info/id/remote-data-objects/624ef3eb-60a0-44ba-ad32-52fbefd089f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "624ef3eb-60a0-44ba-ad32-52fbefd089f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/624ef3eb-60a0-44ba-ad32-52fbefd089f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/284f9f49-df6d-4797-9d1e-743a66dc9346> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "284f9f49-df6d-4797-9d1e-743a66dc9346";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/284f9f49-df6d-4797-9d1e-743a66dc9346>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ff90b16-2eda-4bb1-95dd-6008c1215d79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ff90b16-2eda-4bb1-95dd-6008c1215d79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=BesluitenLijst_Gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ff90b16-2eda-4bb1-95dd-6008c1215d79>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa40f0d5-3a11-4bbc-80e9-38e3456ce56f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa40f0d5-3a11-4bbc-80e9-38e3456ce56f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=BesluitenLijst_Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa40f0d5-3a11-4bbc-80e9-38e3456ce56f>.
+    
+<http://data.lblod.info/id/remote-data-objects/10135072-afab-4bbc-8fda-b36c34013424> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10135072-afab-4bbc-8fda-b36c34013424";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=BesluitenLijst_Gemeenteraad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10135072-afab-4bbc-8fda-b36c34013424>.
+    
+<http://data.lblod.info/id/remote-data-objects/b666b485-b733-4015-b9d3-f036320c00b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b666b485-b733-4015-b9d3-f036320c00b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Notulen_Gemeenteraad_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b666b485-b733-4015-b9d3-f036320c00b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd672cfb-cc9c-4cf1-97d3-6719feac0bb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd672cfb-cc9c-4cf1-97d3-6719feac0bb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Notulen_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd672cfb-cc9c-4cf1-97d3-6719feac0bb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/83499c31-9e7d-4fcf-a47d-37c4c464a707> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83499c31-9e7d-4fcf-a47d-37c4c464a707";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Notulen_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83499c31-9e7d-4fcf-a47d-37c4c464a707>.
+    
+<http://data.lblod.info/id/remote-data-objects/819e5af1-83bc-4aa2-816b-74ef588eaba9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "819e5af1-83bc-4aa2-816b-74ef588eaba9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Notulen_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/819e5af1-83bc-4aa2-816b-74ef588eaba9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4205c06a-4fbf-44f8-82a3-942c48841647> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4205c06a-4fbf-44f8-82a3-942c48841647";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Notulen_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4205c06a-4fbf-44f8-82a3-942c48841647>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a632a00-0271-436b-bd15-c814b3be45ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a632a00-0271-436b-bd15-c814b3be45ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Notulen_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a632a00-0271-436b-bd15-c814b3be45ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/4989e308-075c-4552-852f-318a23014e87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4989e308-075c-4552-852f-318a23014e87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Notulen_Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4989e308-075c-4552-852f-318a23014e87>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d2619b2-ef12-4c1f-95cc-f59e905b0b35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d2619b2-ef12-4c1f-95cc-f59e905b0b35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Notulen_Gemeenteraad_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d2619b2-ef12-4c1f-95cc-f59e905b0b35>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b8aa239-1c16-4565-8f41-7158e4e6249f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b8aa239-1c16-4565-8f41-7158e4e6249f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_21-12-2021_4105.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b8aa239-1c16-4565-8f41-7158e4e6249f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7134a6d2-6582-4e0d-984a-062620cc5a0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7134a6d2-6582-4e0d-984a-062620cc5a0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_21-12-2021_4108.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7134a6d2-6582-4e0d-984a-062620cc5a0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d09e518-3f39-4121-ad2d-1a6e424b507e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d09e518-3f39-4121-ad2d-1a6e424b507e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_21-12-2021_4216.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d09e518-3f39-4121-ad2d-1a6e424b507e>.
+    
+<http://data.lblod.info/id/remote-data-objects/74251a3c-a8ee-4067-827b-4a8c579a7142> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74251a3c-a8ee-4067-827b-4a8c579a7142";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_21-12-2021_4217.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74251a3c-a8ee-4067-827b-4a8c579a7142>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ece8caf-2991-4348-9b64-9ff54b57fe49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ece8caf-2991-4348-9b64-9ff54b57fe49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_21-12-2021_4259.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ece8caf-2991-4348-9b64-9ff54b57fe49>.
+    
+<http://data.lblod.info/id/remote-data-objects/a68fa4a4-2dc5-4299-916f-c7e160c425fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a68fa4a4-2dc5-4299-916f-c7e160c425fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_21-12-2021_4276.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a68fa4a4-2dc5-4299-916f-c7e160c425fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/1684f58e-355e-46ab-a661-7c037662b7e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1684f58e-355e-46ab-a661-7c037662b7e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_21-12-2021_4277.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1684f58e-355e-46ab-a661-7c037662b7e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/cac117ac-2853-401b-9cba-7ea5ee63a57b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cac117ac-2853-401b-9cba-7ea5ee63a57b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_24-02-2022_4594.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cac117ac-2853-401b-9cba-7ea5ee63a57b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e09795ba-d8b9-4262-a775-e936a20c5915> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e09795ba-d8b9-4262-a775-e936a20c5915";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_24-02-2022_4608.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e09795ba-d8b9-4262-a775-e936a20c5915>.
+    
+<http://data.lblod.info/id/remote-data-objects/9844f39f-e602-46ff-9abb-49759fb8f262> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9844f39f-e602-46ff-9abb-49759fb8f262";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_25-11-2021_3066.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9844f39f-e602-46ff-9abb-49759fb8f262>.
+    
+<http://data.lblod.info/id/remote-data-objects/15e634f5-16b7-4cc3-9987-efbf1778ceec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15e634f5-16b7-4cc3-9987-efbf1778ceec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_25-11-2021_3968.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15e634f5-16b7-4cc3-9987-efbf1778ceec>.
+    
+<http://data.lblod.info/id/remote-data-objects/975c8ae6-cae8-4658-bef0-703785531ea9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "975c8ae6-cae8-4658-bef0-703785531ea9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_27-01-2022_4354.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/975c8ae6-cae8-4658-bef0-703785531ea9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0882cd8a-dd62-4e3b-a2a2-33bd7f000b44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0882cd8a-dd62-4e3b-a2a2-33bd7f000b44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_27-01-2022_4363.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0882cd8a-dd62-4e3b-a2a2-33bd7f000b44>.
+    
+<http://data.lblod.info/id/remote-data-objects/da2cb579-160c-4985-8b12-e765b4b0a3fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da2cb579-160c-4985-8b12-e765b4b0a3fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_27-01-2022_4385.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da2cb579-160c-4985-8b12-e765b4b0a3fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/5df73b71-4ebd-4428-94e8-3236ec9a0501> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5df73b71-4ebd-4428-94e8-3236ec9a0501";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_27-01-2022_4456.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5df73b71-4ebd-4428-94e8-3236ec9a0501>.
+    
+<http://data.lblod.info/id/remote-data-objects/c79a9b07-bc6d-4c56-9842-c4fe5616a604> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c79a9b07-bc6d-4c56-9842-c4fe5616a604";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_27-01-2022_4485.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c79a9b07-bc6d-4c56-9842-c4fe5616a604>.
+    
+<http://data.lblod.info/id/remote-data-objects/05d7ac08-05b5-4d74-b88f-6353ae4cbd16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05d7ac08-05b5-4d74-b88f-6353ae4cbd16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_27-01-2022_4489.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05d7ac08-05b5-4d74-b88f-6353ae4cbd16>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c3c1d54-7d28-4b98-b607-f2ee0b66af93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c3c1d54-7d28-4b98-b607-f2ee0b66af93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_28-04-2022_4928.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e05c8fb6-ecf6-4e1d-95bd-58822aaa2106> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c3c1d54-7d28-4b98-b607-f2ee0b66af93>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201743-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201743-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201743-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201743-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/59087916-2a85-48e7-8a0f-81f7e7641f33> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "59087916-2a85-48e7-8a0f-81f7e7641f33";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "521670f3-5e5d-45bd-ac73-3f0eb6ddddf9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d29f1bcd-5b5e-448a-a321-51cd2940bc9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d29f1bcd-5b5e-448a-a321-51cd2940bc9f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9>.
+
+  <http://redpencil.data.gift/id/task/f4fb8a0f-93c9-42a1-9887-e328c1c3b594> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f4fb8a0f-93c9-42a1-9887-e328c1c3b594";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/59087916-2a85-48e7-8a0f-81f7e7641f33>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d29f1bcd-5b5e-448a-a321-51cd2940bc9f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e4a694c8-a8e7-4a83-b9fa-daae30cb06b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4a694c8-a8e7-4a83-b9fa-daae30cb06b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_28-04-2022_5024.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4a694c8-a8e7-4a83-b9fa-daae30cb06b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/413d4143-0d5c-4441-a456-bd4fc540b95e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "413d4143-0d5c-4441-a456-bd4fc540b95e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_28-10-2021_3708.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/413d4143-0d5c-4441-a456-bd4fc540b95e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca1603a5-325b-4fbb-88f1-2fee6b1e1019> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca1603a5-325b-4fbb-88f1-2fee6b1e1019";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_28-10-2021_3712.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca1603a5-325b-4fbb-88f1-2fee6b1e1019>.
+    
+<http://data.lblod.info/id/remote-data-objects/78223251-b016-4091-bf7b-c0d4b7618bfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78223251-b016-4091-bf7b-c0d4b7618bfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_30-06-2022_6615.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78223251-b016-4091-bf7b-c0d4b7618bfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4449648-8e9b-4bad-b326-105a9c95b6dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4449648-8e9b-4bad-b326-105a9c95b6dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_30-06-2022_6620.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4449648-8e9b-4bad-b326-105a9c95b6dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/197f5b80-264e-41e1-b785-db3ef9d94d22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "197f5b80-264e-41e1-b785-db3ef9d94d22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_30-06-2022_6623.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/197f5b80-264e-41e1-b785-db3ef9d94d22>.
+    
+<http://data.lblod.info/id/remote-data-objects/e55d3508-87df-4fba-9f45-d070f6140fe1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e55d3508-87df-4fba-9f45-d070f6140fe1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/42a9375ff45a3ffa0784dcf8086152020a0ff5c81cdf81b0cbbb5ada404a0180/GetPublication?filename=Uittreksels_30-06-2022_6624.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e55d3508-87df-4fba-9f45-d070f6140fe1>.
+    
+<http://data.lblod.info/id/remote-data-objects/53167dd6-856c-403d-8298-b576c29c7dee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53167dd6-856c-403d-8298-b576c29c7dee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53167dd6-856c-403d-8298-b576c29c7dee>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ed80f96-7591-444b-a54e-d3b9a2328f2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ed80f96-7591-444b-a54e-d3b9a2328f2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ed80f96-7591-444b-a54e-d3b9a2328f2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/587f7bea-bae6-4668-bf87-ff31cae713a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "587f7bea-bae6-4668-bf87-ff31cae713a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/587f7bea-bae6-4668-bf87-ff31cae713a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/82e4de5f-1aad-4ac7-aae1-21846ff18e70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82e4de5f-1aad-4ac7-aae1-21846ff18e70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82e4de5f-1aad-4ac7-aae1-21846ff18e70>.
+    
+<http://data.lblod.info/id/remote-data-objects/97be7474-a30e-4822-822c-5d6e7bddea66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97be7474-a30e-4822-822c-5d6e7bddea66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97be7474-a30e-4822-822c-5d6e7bddea66>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a714774-19e2-4a7b-8927-5f0131f3ed92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a714774-19e2-4a7b-8927-5f0131f3ed92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a714774-19e2-4a7b-8927-5f0131f3ed92>.
+    
+<http://data.lblod.info/id/remote-data-objects/b25e853c-432e-43e4-b13f-0bd620e883aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b25e853c-432e-43e4-b13f-0bd620e883aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b25e853c-432e-43e4-b13f-0bd620e883aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/d089fe10-a54f-4337-8029-c617c6947444> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d089fe10-a54f-4337-8029-c617c6947444";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d089fe10-a54f-4337-8029-c617c6947444>.
+    
+<http://data.lblod.info/id/remote-data-objects/60054645-cfb9-4e11-a203-94c2ea45bfa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60054645-cfb9-4e11-a203-94c2ea45bfa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60054645-cfb9-4e11-a203-94c2ea45bfa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc5f82a5-eb8b-4cc8-bb2e-81f532855934> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc5f82a5-eb8b-4cc8-bb2e-81f532855934";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc5f82a5-eb8b-4cc8-bb2e-81f532855934>.
+    
+<http://data.lblod.info/id/remote-data-objects/223933a3-0f0e-4e90-98df-3013721316a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "223933a3-0f0e-4e90-98df-3013721316a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/223933a3-0f0e-4e90-98df-3013721316a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a34af334-7f5e-4fe6-b1de-a4fcaa8ddd72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a34af334-7f5e-4fe6-b1de-a4fcaa8ddd72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a34af334-7f5e-4fe6-b1de-a4fcaa8ddd72>.
+    
+<http://data.lblod.info/id/remote-data-objects/48c908b1-6a6d-4c8e-94ee-d9c17b1f0d0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48c908b1-6a6d-4c8e-94ee-d9c17b1f0d0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48c908b1-6a6d-4c8e-94ee-d9c17b1f0d0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/dea0ba5d-9b0f-426f-9562-6141da5a7345> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dea0ba5d-9b0f-426f-9562-6141da5a7345";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dea0ba5d-9b0f-426f-9562-6141da5a7345>.
+    
+<http://data.lblod.info/id/remote-data-objects/782334ef-3e31-421c-8624-df4265f91d11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "782334ef-3e31-421c-8624-df4265f91d11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/782334ef-3e31-421c-8624-df4265f91d11>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdbf84a6-06d3-478f-b249-33db6ac08116> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdbf84a6-06d3-478f-b249-33db6ac08116";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdbf84a6-06d3-478f-b249-33db6ac08116>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a3279d6-f0f1-4bad-9abd-54a5205df178> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a3279d6-f0f1-4bad-9abd-54a5205df178";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a3279d6-f0f1-4bad-9abd-54a5205df178>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ddb34e0-b1a2-4a1b-820e-a85c5f80c5f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ddb34e0-b1a2-4a1b-820e-a85c5f80c5f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ddb34e0-b1a2-4a1b-820e-a85c5f80c5f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/6354a676-68d8-4adb-9cc8-63394f9b2cbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6354a676-68d8-4adb-9cc8-63394f9b2cbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6354a676-68d8-4adb-9cc8-63394f9b2cbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/0024956f-2f42-430f-a2fa-e45c2fc1d68d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0024956f-2f42-430f-a2fa-e45c2fc1d68d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0024956f-2f42-430f-a2fa-e45c2fc1d68d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba466398-25e8-4d16-adc6-1a04046b5e37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba466398-25e8-4d16-adc6-1a04046b5e37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba466398-25e8-4d16-adc6-1a04046b5e37>.
+    
+<http://data.lblod.info/id/remote-data-objects/e519b8d3-a9ee-4af3-b379-942f4981a86f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e519b8d3-a9ee-4af3-b379-942f4981a86f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e519b8d3-a9ee-4af3-b379-942f4981a86f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0240d75-eeaa-4190-b067-734156d458a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0240d75-eeaa-4190-b067-734156d458a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0240d75-eeaa-4190-b067-734156d458a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/47a99bf7-fd55-40c3-beb3-0ba8e8f44637> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47a99bf7-fd55-40c3-beb3-0ba8e8f44637";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47a99bf7-fd55-40c3-beb3-0ba8e8f44637>.
+    
+<http://data.lblod.info/id/remote-data-objects/7eba73e0-3d3a-4981-8b11-3970a2be73cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7eba73e0-3d3a-4981-8b11-3970a2be73cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7eba73e0-3d3a-4981-8b11-3970a2be73cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/38cba705-69c5-4bec-8e76-994c80816a50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38cba705-69c5-4bec-8e76-994c80816a50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38cba705-69c5-4bec-8e76-994c80816a50>.
+    
+<http://data.lblod.info/id/remote-data-objects/a335bfde-1fc3-4063-8f40-6a7bb4ac3234> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a335bfde-1fc3-4063-8f40-6a7bb4ac3234";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a335bfde-1fc3-4063-8f40-6a7bb4ac3234>.
+    
+<http://data.lblod.info/id/remote-data-objects/75ea08db-d136-4c21-9389-567b6a53db95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75ea08db-d136-4c21-9389-567b6a53db95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75ea08db-d136-4c21-9389-567b6a53db95>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccfe4467-d3a0-4b9c-b0b5-ad0fd6bc6c43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccfe4467-d3a0-4b9c-b0b5-ad0fd6bc6c43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccfe4467-d3a0-4b9c-b0b5-ad0fd6bc6c43>.
+    
+<http://data.lblod.info/id/remote-data-objects/c807c912-63db-40f8-b401-88bba52e8862> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c807c912-63db-40f8-b401-88bba52e8862";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c807c912-63db-40f8-b401-88bba52e8862>.
+    
+<http://data.lblod.info/id/remote-data-objects/956bdfba-d54e-488e-b693-178f99d04c47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "956bdfba-d54e-488e-b693-178f99d04c47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/956bdfba-d54e-488e-b693-178f99d04c47>.
+    
+<http://data.lblod.info/id/remote-data-objects/7af678fd-0bca-4b5b-8546-6dd16495bbbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7af678fd-0bca-4b5b-8546-6dd16495bbbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7af678fd-0bca-4b5b-8546-6dd16495bbbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4acc1c2-1bf3-4ebc-9aa3-cc0ee144f5af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4acc1c2-1bf3-4ebc-9aa3-cc0ee144f5af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4acc1c2-1bf3-4ebc-9aa3-cc0ee144f5af>.
+    
+<http://data.lblod.info/id/remote-data-objects/26645d78-1bb0-4586-a3c5-6ab187ae0702> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26645d78-1bb0-4586-a3c5-6ab187ae0702";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_26-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26645d78-1bb0-4586-a3c5-6ab187ae0702>.
+    
+<http://data.lblod.info/id/remote-data-objects/781643a9-ac89-4fc4-ade6-3276a6bfc166> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "781643a9-ac89-4fc4-ade6-3276a6bfc166";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/781643a9-ac89-4fc4-ade6-3276a6bfc166>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dd0a381-8eec-47f2-b43b-c58844e8ed41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dd0a381-8eec-47f2-b43b-c58844e8ed41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dd0a381-8eec-47f2-b43b-c58844e8ed41>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbb3ea66-c8ae-4913-9240-3b4c89f98bc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbb3ea66-c8ae-4913-9240-3b4c89f98bc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbb3ea66-c8ae-4913-9240-3b4c89f98bc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0267953-3af0-4720-8ae6-1930a8ae676d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0267953-3af0-4720-8ae6-1930a8ae676d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0267953-3af0-4720-8ae6-1930a8ae676d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4437a16a-9cbc-4ab0-913d-e7d030cc1302> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4437a16a-9cbc-4ab0-913d-e7d030cc1302";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/83f68a0805626ff86742b0ddbf066ac99d38cf932194899d8e37f1643148b0d2/GetPublication?filename=BesluitenLijst_Vast%20bureau_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4437a16a-9cbc-4ab0-913d-e7d030cc1302>.
+    
+<http://data.lblod.info/id/remote-data-objects/a20224f5-cb56-40d9-8594-8ec0863d6f2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a20224f5-cb56-40d9-8594-8ec0863d6f2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a20224f5-cb56-40d9-8594-8ec0863d6f2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/757c06cf-7917-4521-bcab-465f067682fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "757c06cf-7917-4521-bcab-465f067682fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/757c06cf-7917-4521-bcab-465f067682fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/b524e577-3b84-44ae-ad19-e28f1fae653a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b524e577-3b84-44ae-ad19-e28f1fae653a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b524e577-3b84-44ae-ad19-e28f1fae653a>.
+    
+<http://data.lblod.info/id/remote-data-objects/504bda39-c1a6-4743-a4f2-f15bbbcd65ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "504bda39-c1a6-4743-a4f2-f15bbbcd65ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/521670f3-5e5d-45bd-ac73-3f0eb6ddddf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/504bda39-c1a6-4743-a4f2-f15bbbcd65ef>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201744-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201744-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201744-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201744-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/45604b93-9d07-4515-85ab-67b1c8aa4810> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "45604b93-9d07-4515-85ab-67b1c8aa4810";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0983602f-e270-400b-b7c4-8d1914c42851";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/307b6094-78af-4047-aac0-c22bcf4a41c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "307b6094-78af-4047-aac0-c22bcf4a41c7";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851>.
+
+  <http://redpencil.data.gift/id/task/1ec3e492-2bd6-4dd9-b0f7-4dd1986699d6> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1ec3e492-2bd6-4dd9-b0f7-4dd1986699d6";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/45604b93-9d07-4515-85ab-67b1c8aa4810>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/307b6094-78af-4047-aac0-c22bcf4a41c7>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/49211a3d-c1b0-46ff-a463-35ff03fef494> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49211a3d-c1b0-46ff-a463-35ff03fef494";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49211a3d-c1b0-46ff-a463-35ff03fef494>.
+    
+<http://data.lblod.info/id/remote-data-objects/e26faefd-17e3-4147-ad86-85f59643fd03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e26faefd-17e3-4147-ad86-85f59643fd03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e26faefd-17e3-4147-ad86-85f59643fd03>.
+    
+<http://data.lblod.info/id/remote-data-objects/453c125a-fbdc-4073-a8c0-a1bf40f5b9aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "453c125a-fbdc-4073-a8c0-a1bf40f5b9aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/453c125a-fbdc-4073-a8c0-a1bf40f5b9aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6ed07e7-6969-459e-a547-8bc2af527149> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6ed07e7-6969-459e-a547-8bc2af527149";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6ed07e7-6969-459e-a547-8bc2af527149>.
+    
+<http://data.lblod.info/id/remote-data-objects/912c0055-81e6-4b02-991b-95016cab7c0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "912c0055-81e6-4b02-991b-95016cab7c0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/912c0055-81e6-4b02-991b-95016cab7c0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/92c694d3-7ae3-4709-9f11-d9092f60c66a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92c694d3-7ae3-4709-9f11-d9092f60c66a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92c694d3-7ae3-4709-9f11-d9092f60c66a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b24d89ba-76c0-4a99-8578-e6f31df4c403> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b24d89ba-76c0-4a99-8578-e6f31df4c403";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b24d89ba-76c0-4a99-8578-e6f31df4c403>.
+    
+<http://data.lblod.info/id/remote-data-objects/67240ffa-edcf-40fd-9239-62f98da7c495> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67240ffa-edcf-40fd-9239-62f98da7c495";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67240ffa-edcf-40fd-9239-62f98da7c495>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcbddabc-7d5c-4ad3-8c69-e3ff8d6c8ec9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcbddabc-7d5c-4ad3-8c69-e3ff8d6c8ec9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcbddabc-7d5c-4ad3-8c69-e3ff8d6c8ec9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fe65a5d-e467-4a40-9a08-8719a9c0e9e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fe65a5d-e467-4a40-9a08-8719a9c0e9e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fe65a5d-e467-4a40-9a08-8719a9c0e9e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/0de61210-b22c-479c-87b1-2446e8024191> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0de61210-b22c-479c-87b1-2446e8024191";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0de61210-b22c-479c-87b1-2446e8024191>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4380f5f-b866-4fb2-96df-eb50b8585110> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4380f5f-b866-4fb2-96df-eb50b8585110";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4380f5f-b866-4fb2-96df-eb50b8585110>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6085384-b3ea-46e7-98a6-337b829fd58b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6085384-b3ea-46e7-98a6-337b829fd58b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6085384-b3ea-46e7-98a6-337b829fd58b>.
+    
+<http://data.lblod.info/id/remote-data-objects/82330659-31e9-44c2-bacd-e8fccd34401c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82330659-31e9-44c2-bacd-e8fccd34401c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82330659-31e9-44c2-bacd-e8fccd34401c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c6a8c8d-a2af-440f-acd8-72a63a8f580e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c6a8c8d-a2af-440f-acd8-72a63a8f580e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c6a8c8d-a2af-440f-acd8-72a63a8f580e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae231d8e-dc2d-4d8a-a8ae-363c3777060c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae231d8e-dc2d-4d8a-a8ae-363c3777060c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae231d8e-dc2d-4d8a-a8ae-363c3777060c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d4fbee2-fc55-4949-ba42-e9d2421580b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d4fbee2-fc55-4949-ba42-e9d2421580b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d4fbee2-fc55-4949-ba42-e9d2421580b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb8223ae-1e5d-4a62-8baf-f888d04920c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb8223ae-1e5d-4a62-8baf-f888d04920c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb8223ae-1e5d-4a62-8baf-f888d04920c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/f97edc16-6889-47f8-80b2-1ccb518cd333> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f97edc16-6889-47f8-80b2-1ccb518cd333";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f97edc16-6889-47f8-80b2-1ccb518cd333>.
+    
+<http://data.lblod.info/id/remote-data-objects/59644383-2df5-4e9f-b63a-e1a7deda464a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59644383-2df5-4e9f-b63a-e1a7deda464a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59644383-2df5-4e9f-b63a-e1a7deda464a>.
+    
+<http://data.lblod.info/id/remote-data-objects/25cf2bf9-e4f5-4662-919c-874a62d99742> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25cf2bf9-e4f5-4662-919c-874a62d99742";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25cf2bf9-e4f5-4662-919c-874a62d99742>.
+    
+<http://data.lblod.info/id/remote-data-objects/e322b5ef-cbff-4aaf-99ea-f04902875543> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e322b5ef-cbff-4aaf-99ea-f04902875543";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e322b5ef-cbff-4aaf-99ea-f04902875543>.
+    
+<http://data.lblod.info/id/remote-data-objects/7395af82-9ad9-4610-907a-838e1cd4b7b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7395af82-9ad9-4610-907a-838e1cd4b7b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7395af82-9ad9-4610-907a-838e1cd4b7b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/af4eea2d-5674-4e5b-8c77-85d4e50bc5b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af4eea2d-5674-4e5b-8c77-85d4e50bc5b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af4eea2d-5674-4e5b-8c77-85d4e50bc5b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1ab4f8f-14ce-4752-b0c7-e9d98a79fd8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1ab4f8f-14ce-4752-b0c7-e9d98a79fd8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1ab4f8f-14ce-4752-b0c7-e9d98a79fd8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/47457d86-0042-4729-a8db-d7380b891b17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47457d86-0042-4729-a8db-d7380b891b17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47457d86-0042-4729-a8db-d7380b891b17>.
+    
+<http://data.lblod.info/id/remote-data-objects/09393002-5044-439b-8501-1dedce00470f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09393002-5044-439b-8501-1dedce00470f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09393002-5044-439b-8501-1dedce00470f>.
+    
+<http://data.lblod.info/id/remote-data-objects/83892888-007c-4c69-a3a7-2cc63fe13c73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83892888-007c-4c69-a3a7-2cc63fe13c73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83892888-007c-4c69-a3a7-2cc63fe13c73>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b5ad908-d0ac-4ff9-89b4-9cab87cca8a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b5ad908-d0ac-4ff9-89b4-9cab87cca8a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b5ad908-d0ac-4ff9-89b4-9cab87cca8a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dba18a1-b587-4717-beef-2571d5e4d962> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dba18a1-b587-4717-beef-2571d5e4d962";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_26-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dba18a1-b587-4717-beef-2571d5e4d962>.
+    
+<http://data.lblod.info/id/remote-data-objects/394d3b54-2715-43b7-9667-db9b443a2016> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "394d3b54-2715-43b7-9667-db9b443a2016";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/394d3b54-2715-43b7-9667-db9b443a2016>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ab1bec3-548a-4109-a767-a3ef70ab517e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ab1bec3-548a-4109-a767-a3ef70ab517e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ab1bec3-548a-4109-a767-a3ef70ab517e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dae8129-b7f4-4538-adfe-929b1881fcfc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dae8129-b7f4-4538-adfe-929b1881fcfc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dae8129-b7f4-4538-adfe-929b1881fcfc>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ae0d0f8-1b65-4d3c-aad4-deedb1807046> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ae0d0f8-1b65-4d3c-aad4-deedb1807046";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ae0d0f8-1b65-4d3c-aad4-deedb1807046>.
+    
+<http://data.lblod.info/id/remote-data-objects/57282ae5-b751-4ddf-9bdb-a63c3525f6b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57282ae5-b751-4ddf-9bdb-a63c3525f6b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57282ae5-b751-4ddf-9bdb-a63c3525f6b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f01b4a41-0f79-4446-aa0b-c3966e84b172> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f01b4a41-0f79-4446-aa0b-c3966e84b172";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_01-02-2022_4570.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f01b4a41-0f79-4446-aa0b-c3966e84b172>.
+    
+<http://data.lblod.info/id/remote-data-objects/60fc8175-ce52-48ba-97b0-2e79075a90c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60fc8175-ce52-48ba-97b0-2e79075a90c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_01-03-2022_4722.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60fc8175-ce52-48ba-97b0-2e79075a90c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b13aeff-7d42-4f6c-9f19-2888f26146da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b13aeff-7d42-4f6c-9f19-2888f26146da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_04-01-2022_4297.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b13aeff-7d42-4f6c-9f19-2888f26146da>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf790a56-bf6e-4b29-a2c1-a35c11e770dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf790a56-bf6e-4b29-a2c1-a35c11e770dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_04-01-2022_4379.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf790a56-bf6e-4b29-a2c1-a35c11e770dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/153b4f73-0215-4b94-85ac-dafcdb252b5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "153b4f73-0215-4b94-85ac-dafcdb252b5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_04-01-2022_4384.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/153b4f73-0215-4b94-85ac-dafcdb252b5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4843f72-59e5-4496-ad18-bc3142aa7453> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4843f72-59e5-4496-ad18-bc3142aa7453";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_05-10-2021_3909.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4843f72-59e5-4496-ad18-bc3142aa7453>.
+    
+<http://data.lblod.info/id/remote-data-objects/32ddd285-3117-4f9d-bb83-c574b2f84133> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32ddd285-3117-4f9d-bb83-c574b2f84133";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_07-06-2022_6586.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32ddd285-3117-4f9d-bb83-c574b2f84133>.
+    
+<http://data.lblod.info/id/remote-data-objects/878d4727-0592-4bea-858a-eae00b67da22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "878d4727-0592-4bea-858a-eae00b67da22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_07-12-2021_4057.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/878d4727-0592-4bea-858a-eae00b67da22>.
+    
+<http://data.lblod.info/id/remote-data-objects/89607f50-67c5-4753-9378-17442437594e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89607f50-67c5-4753-9378-17442437594e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_07-12-2021_4201.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89607f50-67c5-4753-9378-17442437594e>.
+    
+<http://data.lblod.info/id/remote-data-objects/941242fd-e602-4e6c-a5b6-3d9e41d16994> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "941242fd-e602-4e6c-a5b6-3d9e41d16994";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_10-05-2022_6447.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/941242fd-e602-4e6c-a5b6-3d9e41d16994>.
+    
+<http://data.lblod.info/id/remote-data-objects/7870271b-787c-47b6-93b8-7aaf4c65d744> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7870271b-787c-47b6-93b8-7aaf4c65d744";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_10-05-2022_6454.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7870271b-787c-47b6-93b8-7aaf4c65d744>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc4636e3-2a46-4429-9003-0a4fb7ddfb27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc4636e3-2a46-4429-9003-0a4fb7ddfb27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_11-01-2022_4391.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc4636e3-2a46-4429-9003-0a4fb7ddfb27>.
+    
+<http://data.lblod.info/id/remote-data-objects/85fa5dfb-6001-49cc-a7ad-120a0124dc4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85fa5dfb-6001-49cc-a7ad-120a0124dc4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_11-01-2022_4403.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85fa5dfb-6001-49cc-a7ad-120a0124dc4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/104653fb-bc75-4628-be00-374fc629ca4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "104653fb-bc75-4628-be00-374fc629ca4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_11-01-2022_4459.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/104653fb-bc75-4628-be00-374fc629ca4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/75557a6d-b18d-4222-8ca9-346184d83ee5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75557a6d-b18d-4222-8ca9-346184d83ee5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_11-01-2022_4460.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0983602f-e270-400b-b7c4-8d1914c42851> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75557a6d-b18d-4222-8ca9-346184d83ee5>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201745-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201745-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201745-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201745-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/6c3c77c4-2e7f-4527-8c1f-cd808ce826db> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6c3c77c4-2e7f-4527-8c1f-cd808ce826db";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cf8d2293-1f0c-4e19-91f1-56bcef94a86a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/bcbe5e0a-770d-43c7-8c1d-d0220e6cda70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bcbe5e0a-770d-43c7-8c1d-d0220e6cda70";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a>.
+
+  <http://redpencil.data.gift/id/task/ac364a03-0c4f-453f-ac72-48550a763e6d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ac364a03-0c4f-453f-ac72-48550a763e6d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/6c3c77c4-2e7f-4527-8c1f-cd808ce826db>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/bcbe5e0a-770d-43c7-8c1d-d0220e6cda70>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/57fec0ff-431d-4797-b1b9-839dcb0a3f1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57fec0ff-431d-4797-b1b9-839dcb0a3f1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_12-04-2022_4985.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57fec0ff-431d-4797-b1b9-839dcb0a3f1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/397f651d-86f2-49bd-a3ac-cd7d9602ac62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "397f651d-86f2-49bd-a3ac-cd7d9602ac62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_12-04-2022_5019.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/397f651d-86f2-49bd-a3ac-cd7d9602ac62>.
+    
+<http://data.lblod.info/id/remote-data-objects/7346e787-3648-4ca3-951b-3b2461ef8caf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7346e787-3648-4ca3-951b-3b2461ef8caf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_12-07-2022_6500.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7346e787-3648-4ca3-951b-3b2461ef8caf>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0d57c87-34b8-4b44-a8e7-f637441e8b5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0d57c87-34b8-4b44-a8e7-f637441e8b5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_12-07-2022_6549.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0d57c87-34b8-4b44-a8e7-f637441e8b5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7883b32-8ed0-4353-bc41-1ba0fb8650b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7883b32-8ed0-4353-bc41-1ba0fb8650b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_12-07-2022_6823.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7883b32-8ed0-4353-bc41-1ba0fb8650b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e9c9f78-a8d4-433c-9950-b65a33967277> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e9c9f78-a8d4-433c-9950-b65a33967277";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_15-02-2022_4644.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e9c9f78-a8d4-433c-9950-b65a33967277>.
+    
+<http://data.lblod.info/id/remote-data-objects/36e1ae56-c861-4552-8da3-0316bf36d6ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36e1ae56-c861-4552-8da3-0316bf36d6ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_15-03-2022_4865.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36e1ae56-c861-4552-8da3-0316bf36d6ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2da59f3-439f-4e03-807d-411a8dddf6b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2da59f3-439f-4e03-807d-411a8dddf6b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_15-03-2022_4867.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2da59f3-439f-4e03-807d-411a8dddf6b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/701fc20c-0fbf-4f37-ba62-cc22f8308b98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "701fc20c-0fbf-4f37-ba62-cc22f8308b98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_21-12-2021_4333.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/701fc20c-0fbf-4f37-ba62-cc22f8308b98>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9b440a5-fb8b-4b10-b358-44f957e36dec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9b440a5-fb8b-4b10-b358-44f957e36dec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_22-03-2022_4909.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9b440a5-fb8b-4b10-b358-44f957e36dec>.
+    
+<http://data.lblod.info/id/remote-data-objects/31869cda-1e9c-4c96-98a0-7b17888cd597> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31869cda-1e9c-4c96-98a0-7b17888cd597";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_23-11-2021_4162.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31869cda-1e9c-4c96-98a0-7b17888cd597>.
+    
+<http://data.lblod.info/id/remote-data-objects/c470d9e6-75ee-4269-bf78-4d8ab08c57eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c470d9e6-75ee-4269-bf78-4d8ab08c57eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_25-01-2022_4395.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c470d9e6-75ee-4269-bf78-4d8ab08c57eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/48bee865-98ef-4e68-ab10-9a17eea9ce15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48bee865-98ef-4e68-ab10-9a17eea9ce15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_25-01-2022_4396.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48bee865-98ef-4e68-ab10-9a17eea9ce15>.
+    
+<http://data.lblod.info/id/remote-data-objects/735d7a0d-0291-48bb-be1c-cf8d8cfbe85a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "735d7a0d-0291-48bb-be1c-cf8d8cfbe85a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_25-01-2022_4490.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/735d7a0d-0291-48bb-be1c-cf8d8cfbe85a>.
+    
+<http://data.lblod.info/id/remote-data-objects/125722b1-be5b-41f9-a01a-4928cc35a9d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "125722b1-be5b-41f9-a01a-4928cc35a9d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_26-04-2022_6323.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/125722b1-be5b-41f9-a01a-4928cc35a9d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/b91091e7-4fd0-4298-8c87-69980bcf1ccf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b91091e7-4fd0-4298-8c87-69980bcf1ccf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_26-04-2022_6374.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b91091e7-4fd0-4298-8c87-69980bcf1ccf>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1fa0e12-836e-4f2a-bcc6-6cc0ee9048df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1fa0e12-836e-4f2a-bcc6-6cc0ee9048df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_26-07-2022_6677.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1fa0e12-836e-4f2a-bcc6-6cc0ee9048df>.
+    
+<http://data.lblod.info/id/remote-data-objects/83e01b62-dc99-4434-9f15-0e1aa259be1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83e01b62-dc99-4434-9f15-0e1aa259be1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_26-07-2022_6830.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83e01b62-dc99-4434-9f15-0e1aa259be1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0764cb1b-0496-4279-b23a-2303ae75de29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0764cb1b-0496-4279-b23a-2303ae75de29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_26-10-2021_3966.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0764cb1b-0496-4279-b23a-2303ae75de29>.
+    
+<http://data.lblod.info/id/remote-data-objects/aca5fbac-ad19-4b93-9d40-af5cd0c84307> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aca5fbac-ad19-4b93-9d40-af5cd0c84307";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_29-03-2022_4762.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aca5fbac-ad19-4b93-9d40-af5cd0c84307>.
+    
+<http://data.lblod.info/id/remote-data-objects/b00e7ead-df32-4559-b74e-5e3bf10a3870> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b00e7ead-df32-4559-b74e-5e3bf10a3870";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_31-05-2022_6583.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b00e7ead-df32-4559-b74e-5e3bf10a3870>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f0f3e15-3773-42cf-84ce-be5be310d6e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f0f3e15-3773-42cf-84ce-be5be310d6e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_31-05-2022_6584.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f0f3e15-3773-42cf-84ce-be5be310d6e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/f461267c-79f3-4236-96c2-1043b769d44f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f461267c-79f3-4236-96c2-1043b769d44f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/ddbb7cb2c0586dcd2d3eb5f5f2d2bc41020e1c8a7b6bce798b020a3f5a4322c3/GetPublication?filename=Uittreksels_31-05-2022_6590.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f461267c-79f3-4236-96c2-1043b769d44f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2b9f578-4768-4828-bad7-595dc9b1faba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2b9f578-4768-4828-bad7-595dc9b1faba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/eaf1590de66ae4c8f6f3bdcf5daeba7477a1f382931d72138d26b037127e4bbc/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_01-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2b9f578-4768-4828-bad7-595dc9b1faba>.
+    
+<http://data.lblod.info/id/remote-data-objects/60c64c4e-360b-4a18-b31a-9a1cd4175014> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60c64c4e-360b-4a18-b31a-9a1cd4175014";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/eaf1590de66ae4c8f6f3bdcf5daeba7477a1f382931d72138d26b037127e4bbc/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60c64c4e-360b-4a18-b31a-9a1cd4175014>.
+    
+<http://data.lblod.info/id/remote-data-objects/46a86060-e7d2-41c9-b4bc-c906f2df0ee0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46a86060-e7d2-41c9-b4bc-c906f2df0ee0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/eaf1590de66ae4c8f6f3bdcf5daeba7477a1f382931d72138d26b037127e4bbc/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46a86060-e7d2-41c9-b4bc-c906f2df0ee0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f1040a4-ab9b-4abf-9aeb-3753d2272ba0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f1040a4-ab9b-4abf-9aeb-3753d2272ba0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/eaf1590de66ae4c8f6f3bdcf5daeba7477a1f382931d72138d26b037127e4bbc/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f1040a4-ab9b-4abf-9aeb-3753d2272ba0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad140fbf-94ec-499e-bb0d-3172597dd697> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad140fbf-94ec-499e-bb0d-3172597dd697";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/eaf1590de66ae4c8f6f3bdcf5daeba7477a1f382931d72138d26b037127e4bbc/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_01-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad140fbf-94ec-499e-bb0d-3172597dd697>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b90eb48-2a52-4b97-9f2e-88b872a4ead9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b90eb48-2a52-4b97-9f2e-88b872a4ead9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/eaf1590de66ae4c8f6f3bdcf5daeba7477a1f382931d72138d26b037127e4bbc/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_01-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b90eb48-2a52-4b97-9f2e-88b872a4ead9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6c8ad1e-eca6-4809-a8ae-11daa0b4f2fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6c8ad1e-eca6-4809-a8ae-11daa0b4f2fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/eaf1590de66ae4c8f6f3bdcf5daeba7477a1f382931d72138d26b037127e4bbc/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_01-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6c8ad1e-eca6-4809-a8ae-11daa0b4f2fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/502c292d-5816-4a16-b9da-7a94624128c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "502c292d-5816-4a16-b9da-7a94624128c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/eaf1590de66ae4c8f6f3bdcf5daeba7477a1f382931d72138d26b037127e4bbc/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/502c292d-5816-4a16-b9da-7a94624128c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/af8d6699-18b7-40df-99e9-a1e62e3ffbbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af8d6699-18b7-40df-99e9-a1e62e3ffbbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/eaf1590de66ae4c8f6f3bdcf5daeba7477a1f382931d72138d26b037127e4bbc/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_01-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af8d6699-18b7-40df-99e9-a1e62e3ffbbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cb40bec-aed0-44c9-b78c-4e8d0d8d1c93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cb40bec-aed0-44c9-b78c-4e8d0d8d1c93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/eaf1590de66ae4c8f6f3bdcf5daeba7477a1f382931d72138d26b037127e4bbc/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_01-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cb40bec-aed0-44c9-b78c-4e8d0d8d1c93>.
+    
+<http://data.lblod.info/id/remote-data-objects/57de8f15-3c7a-4f3c-8e9e-04e4ace7ff4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57de8f15-3c7a-4f3c-8e9e-04e4ace7ff4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/eaf1590de66ae4c8f6f3bdcf5daeba7477a1f382931d72138d26b037127e4bbc/GetPublication?filename=Uittreksels_01-01-2022_4468.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57de8f15-3c7a-4f3c-8e9e-04e4ace7ff4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a5e6920-dc6d-4377-9c8a-b5779de1ddaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a5e6920-dc6d-4377-9c8a-b5779de1ddaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/eaf1590de66ae4c8f6f3bdcf5daeba7477a1f382931d72138d26b037127e4bbc/GetPublication?filename=Uittreksels_01-07-2022_6841.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a5e6920-dc6d-4377-9c8a-b5779de1ddaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/61b23d77-eb27-4daf-9e63-a4b39bc7167f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61b23d77-eb27-4daf-9e63-a4b39bc7167f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/eaf1590de66ae4c8f6f3bdcf5daeba7477a1f382931d72138d26b037127e4bbc/GetPublication?filename=Uittreksels_01-10-2021_4073.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61b23d77-eb27-4daf-9e63-a4b39bc7167f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8a2a4ba-8cfc-4743-b757-aae77fc534f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8a2a4ba-8cfc-4743-b757-aae77fc534f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/eaf1590de66ae4c8f6f3bdcf5daeba7477a1f382931d72138d26b037127e4bbc/GetPublication?filename=Uittreksels_01-11-2021_4121.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8a2a4ba-8cfc-4743-b757-aae77fc534f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1374e51c-e6e0-49d8-8625-160a549d4a83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1374e51c-e6e0-49d8-8625-160a549d4a83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/eaf1590de66ae4c8f6f3bdcf5daeba7477a1f382931d72138d26b037127e4bbc/GetPublication?filename=Uittreksels_01-11-2021_4148.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1374e51c-e6e0-49d8-8625-160a549d4a83>.
+    
+<http://data.lblod.info/id/remote-data-objects/26d57d06-8e0c-411d-b988-9b62b22c2642> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26d57d06-8e0c-411d-b988-9b62b22c2642";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/eaf1590de66ae4c8f6f3bdcf5daeba7477a1f382931d72138d26b037127e4bbc/GetPublication?filename=Uittreksels_01-12-2021_4221.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26d57d06-8e0c-411d-b988-9b62b22c2642>.
+    
+<http://data.lblod.info/id/remote-data-objects/521ba3a3-d530-4771-9d38-a3d722b46f1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "521ba3a3-d530-4771-9d38-a3d722b46f1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/521ba3a3-d530-4771-9d38-a3d722b46f1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4556798c-fdd3-4834-8242-e28f59ef3838> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4556798c-fdd3-4834-8242-e28f59ef3838";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4556798c-fdd3-4834-8242-e28f59ef3838>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9040be9-6f08-4eaa-826f-a4ea8077f59e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9040be9-6f08-4eaa-826f-a4ea8077f59e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9040be9-6f08-4eaa-826f-a4ea8077f59e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d611424b-8ed8-44f0-9165-75ed682f85e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d611424b-8ed8-44f0-9165-75ed682f85e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d611424b-8ed8-44f0-9165-75ed682f85e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8fc0de7-9479-4240-aebf-10d262a89c72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8fc0de7-9479-4240-aebf-10d262a89c72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8fc0de7-9479-4240-aebf-10d262a89c72>.
+    
+<http://data.lblod.info/id/remote-data-objects/7977bb48-36c9-4c77-9dbd-cbdeeebfa4e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7977bb48-36c9-4c77-9dbd-cbdeeebfa4e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7977bb48-36c9-4c77-9dbd-cbdeeebfa4e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/367443ab-8698-4e8d-a739-290e706ac160> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "367443ab-8698-4e8d-a739-290e706ac160";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/367443ab-8698-4e8d-a739-290e706ac160>.
+    
+<http://data.lblod.info/id/remote-data-objects/977b9399-e3ec-4df8-a99c-480e66a678ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "977b9399-e3ec-4df8-a99c-480e66a678ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/977b9399-e3ec-4df8-a99c-480e66a678ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc49ceea-6c89-42af-a027-b212780a2bd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc49ceea-6c89-42af-a027-b212780a2bd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc49ceea-6c89-42af-a027-b212780a2bd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9a3ce36-122c-4fd2-ae4e-2d243ccb817a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9a3ce36-122c-4fd2-ae4e-2d243ccb817a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9a3ce36-122c-4fd2-ae4e-2d243ccb817a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4239177-279f-4b9d-8a7b-ea78638bf01b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4239177-279f-4b9d-8a7b-ea78638bf01b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cf8d2293-1f0c-4e19-91f1-56bcef94a86a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4239177-279f-4b9d-8a7b-ea78638bf01b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201746-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201746-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201746-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201746-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/8f3a3d20-89b8-4b2f-a9fa-fd3e2cce2e2a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8f3a3d20-89b8-4b2f-a9fa-fd3e2cce2e2a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "15853166-f7e5-404c-91f5-5225cd1d5eb2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e768b8b2-53d4-49a1-9f20-8d36368dd5fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e768b8b2-53d4-49a1-9f20-8d36368dd5fc";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2>.
+
+  <http://redpencil.data.gift/id/task/1249030a-642d-4f53-9de5-94e842cadb9e> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1249030a-642d-4f53-9de5-94e842cadb9e";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/8f3a3d20-89b8-4b2f-a9fa-fd3e2cce2e2a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e768b8b2-53d4-49a1-9f20-8d36368dd5fc>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4c5f56e2-8a90-46b2-9cd9-1512fd7b429e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c5f56e2-8a90-46b2-9cd9-1512fd7b429e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c5f56e2-8a90-46b2-9cd9-1512fd7b429e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7efafdc-3bf8-45c9-8fb2-de96315a69de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7efafdc-3bf8-45c9-8fb2-de96315a69de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7efafdc-3bf8-45c9-8fb2-de96315a69de>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b9ee596-4c8d-43d9-891c-26b5fc008337> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b9ee596-4c8d-43d9-891c-26b5fc008337";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b9ee596-4c8d-43d9-891c-26b5fc008337>.
+    
+<http://data.lblod.info/id/remote-data-objects/51545ad0-8efb-4d5a-9fe1-1ec9bf4f1617> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51545ad0-8efb-4d5a-9fe1-1ec9bf4f1617";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51545ad0-8efb-4d5a-9fe1-1ec9bf4f1617>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7a60bd2-bbcf-4ced-b431-e088358c62ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7a60bd2-bbcf-4ced-b431-e088358c62ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7a60bd2-bbcf-4ced-b431-e088358c62ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2864f43-7144-41f4-9b77-f6a29ed4f989> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2864f43-7144-41f4-9b77-f6a29ed4f989";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2864f43-7144-41f4-9b77-f6a29ed4f989>.
+    
+<http://data.lblod.info/id/remote-data-objects/367f76f6-d0eb-49b7-bc83-e7743ef7aeba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "367f76f6-d0eb-49b7-bc83-e7743ef7aeba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/367f76f6-d0eb-49b7-bc83-e7743ef7aeba>.
+    
+<http://data.lblod.info/id/remote-data-objects/e718e910-f0ca-4e99-9031-3ddff1ec6f6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e718e910-f0ca-4e99-9031-3ddff1ec6f6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e718e910-f0ca-4e99-9031-3ddff1ec6f6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bc36ebe-a98a-4383-8e19-16072749ee68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bc36ebe-a98a-4383-8e19-16072749ee68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bc36ebe-a98a-4383-8e19-16072749ee68>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fba539d-fe36-4c5e-a7c1-d95c2fd9e8c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fba539d-fe36-4c5e-a7c1-d95c2fd9e8c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fba539d-fe36-4c5e-a7c1-d95c2fd9e8c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/be94cb4a-75f8-4973-9b30-739335554c24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be94cb4a-75f8-4973-9b30-739335554c24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be94cb4a-75f8-4973-9b30-739335554c24>.
+    
+<http://data.lblod.info/id/remote-data-objects/d94cbbbc-7d63-4e8f-a971-cd803fa29fc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d94cbbbc-7d63-4e8f-a971-cd803fa29fc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d94cbbbc-7d63-4e8f-a971-cd803fa29fc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/da2767bf-17cb-4357-9da7-01dbfdfbb125> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da2767bf-17cb-4357-9da7-01dbfdfbb125";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da2767bf-17cb-4357-9da7-01dbfdfbb125>.
+    
+<http://data.lblod.info/id/remote-data-objects/58024572-78b1-42c9-ad91-1d3da94c0f2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58024572-78b1-42c9-ad91-1d3da94c0f2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58024572-78b1-42c9-ad91-1d3da94c0f2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a09dbf5-5f18-45d3-889c-4365840d7642> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a09dbf5-5f18-45d3-889c-4365840d7642";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a09dbf5-5f18-45d3-889c-4365840d7642>.
+    
+<http://data.lblod.info/id/remote-data-objects/803bcabd-b4fc-431a-a341-2313f04eefb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "803bcabd-b4fc-431a-a341-2313f04eefb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Uittreksels_21-12-2021_4111.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/803bcabd-b4fc-431a-a341-2313f04eefb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/10185fca-cd55-4674-b238-19fef26851c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10185fca-cd55-4674-b238-19fef26851c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Uittreksels_25-11-2021_3964.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10185fca-cd55-4674-b238-19fef26851c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/736833ea-1c79-488f-bfd2-316b888a8746> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "736833ea-1c79-488f-bfd2-316b888a8746";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Uittreksels_27-01-2022_4364.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/736833ea-1c79-488f-bfd2-316b888a8746>.
+    
+<http://data.lblod.info/id/remote-data-objects/d57f9c9f-a216-4089-a967-383fdd63e8b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d57f9c9f-a216-4089-a967-383fdd63e8b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.wortegem-petegem.be/LBLODWeb/Home/Overzicht/f2769639c4c22c1321f892afa9d86286b03f404a0d47161e0b568964bee6379a/GetPublication?filename=Uittreksels_27-01-2022_4534.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d57f9c9f-a216-4089-a967-383fdd63e8b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd68e797-5a05-454b-947d-dda7c3ef5c28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd68e797-5a05-454b-947d-dda7c3ef5c28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/24dbb9783d9fc01fb0d7b18960a06ab3cf4f5d118001fb704cc9737032de2808/GetPublication?filename=BesluitenLijstUitspraak_Besluit%20Burgemeester_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd68e797-5a05-454b-947d-dda7c3ef5c28>.
+    
+<http://data.lblod.info/id/remote-data-objects/3683c816-9c78-4f69-9408-588d44618611> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3683c816-9c78-4f69-9408-588d44618611";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/24dbb9783d9fc01fb0d7b18960a06ab3cf4f5d118001fb704cc9737032de2808/GetPublication?filename=BesluitenLijstUitspraak_Besluit%20Burgemeester_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3683c816-9c78-4f69-9408-588d44618611>.
+    
+<http://data.lblod.info/id/remote-data-objects/43cf66d9-9c70-4815-8c13-11ecd38d9b7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43cf66d9-9c70-4815-8c13-11ecd38d9b7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/24dbb9783d9fc01fb0d7b18960a06ab3cf4f5d118001fb704cc9737032de2808/GetPublication?filename=BesluitenLijstUitspraak_Besluit%20Burgemeester_16-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43cf66d9-9c70-4815-8c13-11ecd38d9b7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f009090e-e6d8-4b7e-802a-f58fbca7f711> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f009090e-e6d8-4b7e-802a-f58fbca7f711";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/24dbb9783d9fc01fb0d7b18960a06ab3cf4f5d118001fb704cc9737032de2808/GetPublication?filename=BesluitenLijstUitspraak_Besluit%20Burgemeester_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f009090e-e6d8-4b7e-802a-f58fbca7f711>.
+    
+<http://data.lblod.info/id/remote-data-objects/06bba7e4-6451-48b2-bd74-d8f11848436a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06bba7e4-6451-48b2-bd74-d8f11848436a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/24dbb9783d9fc01fb0d7b18960a06ab3cf4f5d118001fb704cc9737032de2808/GetPublication?filename=BesluitenLijstUitspraak_Besluit%20Burgemeester_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06bba7e4-6451-48b2-bd74-d8f11848436a>.
+    
+<http://data.lblod.info/id/remote-data-objects/84b5ad4e-bd0e-49da-8bf5-e151cd9be0ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84b5ad4e-bd0e-49da-8bf5-e151cd9be0ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/24dbb9783d9fc01fb0d7b18960a06ab3cf4f5d118001fb704cc9737032de2808/GetPublication?filename=BesluitenLijstUitspraak_Besluit%20Burgemeester_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84b5ad4e-bd0e-49da-8bf5-e151cd9be0ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/fee54c54-0347-4357-a1bb-a6899b1751f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fee54c54-0347-4357-a1bb-a6899b1751f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/24dbb9783d9fc01fb0d7b18960a06ab3cf4f5d118001fb704cc9737032de2808/GetPublication?filename=Uittreksels_01-03-2022_8685.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fee54c54-0347-4357-a1bb-a6899b1751f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf098af0-4e73-463d-b593-315f937f4de4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf098af0-4e73-463d-b593-315f937f4de4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/24dbb9783d9fc01fb0d7b18960a06ab3cf4f5d118001fb704cc9737032de2808/GetPublication?filename=Uittreksels_28-06-2022_10843.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf098af0-4e73-463d-b593-315f937f4de4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8213d160-8fcb-46ed-bf01-b4e520067821> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8213d160-8fcb-46ed-bf01-b4e520067821";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/24dbb9783d9fc01fb0d7b18960a06ab3cf4f5d118001fb704cc9737032de2808/GetPublication?filename=Uittreksels_28-06-2022_10845.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8213d160-8fcb-46ed-bf01-b4e520067821>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3d34c49-210f-481a-8944-6a6db3db45bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3d34c49-210f-481a-8944-6a6db3db45bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Agenda_Raad%20Maatschappelijk%20Welzijn_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3d34c49-210f-481a-8944-6a6db3db45bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/320606a8-9cd0-4c46-b30a-692ac2cad29b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "320606a8-9cd0-4c46-b30a-692ac2cad29b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Agenda_Raad%20Maatschappelijk%20Welzijn_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/320606a8-9cd0-4c46-b30a-692ac2cad29b>.
+    
+<http://data.lblod.info/id/remote-data-objects/37c1c8b4-5deb-4cc5-a5e1-185881d2030c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37c1c8b4-5deb-4cc5-a5e1-185881d2030c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Agenda_Raad%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37c1c8b4-5deb-4cc5-a5e1-185881d2030c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce95e7b5-2562-478e-8ad5-06dbc883411f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce95e7b5-2562-478e-8ad5-06dbc883411f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Agenda_Raad%20Maatschappelijk%20Welzijn_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce95e7b5-2562-478e-8ad5-06dbc883411f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a4eeac1-cdbb-4f2d-af81-d80bb24ac235> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a4eeac1-cdbb-4f2d-af81-d80bb24ac235";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Agenda_Raad%20Maatschappelijk%20Welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a4eeac1-cdbb-4f2d-af81-d80bb24ac235>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fae138d-d560-4b96-a603-544f0ceaf669> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fae138d-d560-4b96-a603-544f0ceaf669";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Agenda_Raad%20Maatschappelijk%20Welzijn_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fae138d-d560-4b96-a603-544f0ceaf669>.
+    
+<http://data.lblod.info/id/remote-data-objects/98547cc1-f26c-4df2-a834-966effc933a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98547cc1-f26c-4df2-a834-966effc933a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Agenda_Raad%20Maatschappelijk%20Welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98547cc1-f26c-4df2-a834-966effc933a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/56c578ff-fd28-471e-b478-e991ca935746> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56c578ff-fd28-471e-b478-e991ca935746";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Agenda_Raad%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56c578ff-fd28-471e-b478-e991ca935746>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb9421e3-475d-4315-9d02-3455ce185e7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb9421e3-475d-4315-9d02-3455ce185e7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Agenda_Raad%20Maatschappelijk%20Welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb9421e3-475d-4315-9d02-3455ce185e7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/23c23d3c-0f42-4eca-ab52-416e0bcb9791> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23c23d3c-0f42-4eca-ab52-416e0bcb9791";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=BesluitenLijstUitspraak_Raad%20Maatschappelijk%20Welzijn_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23c23d3c-0f42-4eca-ab52-416e0bcb9791>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbbb8c68-380b-4cd0-92ac-096c382819a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbbb8c68-380b-4cd0-92ac-096c382819a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=BesluitenLijstUitspraak_Raad%20Maatschappelijk%20Welzijn_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbbb8c68-380b-4cd0-92ac-096c382819a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/24fbdafe-dab9-4e33-80a8-1a4482e0a58e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24fbdafe-dab9-4e33-80a8-1a4482e0a58e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=BesluitenLijstUitspraak_Raad%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24fbdafe-dab9-4e33-80a8-1a4482e0a58e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d7373bb-6d2b-4c83-a195-64587daf55af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d7373bb-6d2b-4c83-a195-64587daf55af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=BesluitenLijstUitspraak_Raad%20Maatschappelijk%20Welzijn_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d7373bb-6d2b-4c83-a195-64587daf55af>.
+    
+<http://data.lblod.info/id/remote-data-objects/f918e4c2-9063-498c-8781-9933ac6b737f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f918e4c2-9063-498c-8781-9933ac6b737f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=BesluitenLijstUitspraak_Raad%20Maatschappelijk%20Welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f918e4c2-9063-498c-8781-9933ac6b737f>.
+    
+<http://data.lblod.info/id/remote-data-objects/56b0ddbc-c170-433d-92b9-b7d0541d146a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56b0ddbc-c170-433d-92b9-b7d0541d146a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=BesluitenLijstUitspraak_Raad%20Maatschappelijk%20Welzijn_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56b0ddbc-c170-433d-92b9-b7d0541d146a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1291133d-2852-4b49-9f29-4f7a75d68ba8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1291133d-2852-4b49-9f29-4f7a75d68ba8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=BesluitenLijstUitspraak_Raad%20Maatschappelijk%20Welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1291133d-2852-4b49-9f29-4f7a75d68ba8>.
+    
+<http://data.lblod.info/id/remote-data-objects/50cccc53-8c15-40bb-87ff-7f09a82ab768> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50cccc53-8c15-40bb-87ff-7f09a82ab768";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=BesluitenLijstUitspraak_Raad%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50cccc53-8c15-40bb-87ff-7f09a82ab768>.
+    
+<http://data.lblod.info/id/remote-data-objects/9071a069-0b22-497c-a320-767904a59b0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9071a069-0b22-497c-a320-767904a59b0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=BesluitenLijstUitspraak_Raad%20Maatschappelijk%20Welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9071a069-0b22-497c-a320-767904a59b0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d77f12f-812c-49e0-afab-85acd901d173> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d77f12f-812c-49e0-afab-85acd901d173";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Notulen_Raad%20Maatschappelijk%20Welzijn_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d77f12f-812c-49e0-afab-85acd901d173>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6ab4b10-6ab4-4d73-b384-3e95b4e358ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6ab4b10-6ab4-4d73-b384-3e95b4e358ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Notulen_Raad%20Maatschappelijk%20Welzijn_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6ab4b10-6ab4-4d73-b384-3e95b4e358ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/352f637f-0f6e-4e30-8226-89de6b52152d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "352f637f-0f6e-4e30-8226-89de6b52152d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Notulen_Raad%20Maatschappelijk%20Welzijn_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/352f637f-0f6e-4e30-8226-89de6b52152d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d5da16b-a72d-4124-a6f3-8a76a101542b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d5da16b-a72d-4124-a6f3-8a76a101542b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Notulen_Raad%20Maatschappelijk%20Welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15853166-f7e5-404c-91f5-5225cd1d5eb2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d5da16b-a72d-4124-a6f3-8a76a101542b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201748-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201748-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201748-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201748-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/56a73cd1-7310-4878-8418-5e0d15f8e3ad> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "56a73cd1-7310-4878-8418-5e0d15f8e3ad";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e7223627-27a4-4689-83e1-a875b10c2d8c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/18ad8868-6a2b-4e1c-bb4a-0c3891560f04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "18ad8868-6a2b-4e1c-bb4a-0c3891560f04";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c>.
+
+  <http://redpencil.data.gift/id/task/5258b93b-aabc-4d6c-8ea6-179d4c6c77fc> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5258b93b-aabc-4d6c-8ea6-179d4c6c77fc";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/56a73cd1-7310-4878-8418-5e0d15f8e3ad>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/18ad8868-6a2b-4e1c-bb4a-0c3891560f04>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/19eebc20-2b31-4f9f-b87f-9b243752c8eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19eebc20-2b31-4f9f-b87f-9b243752c8eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Notulen_Raad%20Maatschappelijk%20Welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19eebc20-2b31-4f9f-b87f-9b243752c8eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7a1d8d8-7548-4641-995a-86bafcc96a1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7a1d8d8-7548-4641-995a-86bafcc96a1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Notulen_Raad%20Maatschappelijk%20Welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7a1d8d8-7548-4641-995a-86bafcc96a1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdef2ee0-3be2-4e85-99f8-2e7c57daf770> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdef2ee0-3be2-4e85-99f8-2e7c57daf770";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Notulen_Raad%20Maatschappelijk%20Welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdef2ee0-3be2-4e85-99f8-2e7c57daf770>.
+    
+<http://data.lblod.info/id/remote-data-objects/18c3501b-9683-42e4-93bb-dad63c091306> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18c3501b-9683-42e4-93bb-dad63c091306";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Uittreksels_02-06-2022_9411.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18c3501b-9683-42e4-93bb-dad63c091306>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1f378a9-7508-4f86-84c8-d03130aaee14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1f378a9-7508-4f86-84c8-d03130aaee14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/4c941c266593c0ab84fdd17a88d1f03cae3c4fb8ed978e45908d604c8d6f2acf/GetPublication?filename=Uittreksels_16-12-2021_7526.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1f378a9-7508-4f86-84c8-d03130aaee14>.
+    
+<http://data.lblod.info/id/remote-data-objects/eda73a38-ae4b-44d5-8690-84e8bc1819d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eda73a38-ae4b-44d5-8690-84e8bc1819d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Agenda_Gemeenteraad_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eda73a38-ae4b-44d5-8690-84e8bc1819d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f36c303d-5066-4e4e-bae8-a6f01158cdc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f36c303d-5066-4e4e-bae8-a6f01158cdc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Agenda_Gemeenteraad_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f36c303d-5066-4e4e-bae8-a6f01158cdc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7dc12f3-2354-42e8-a4e8-fe2c3cde4325> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7dc12f3-2354-42e8-a4e8-fe2c3cde4325";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Agenda_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7dc12f3-2354-42e8-a4e8-fe2c3cde4325>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f8dbf54-b35c-4674-9c7c-b28de51574ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f8dbf54-b35c-4674-9c7c-b28de51574ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Agenda_Gemeenteraad_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f8dbf54-b35c-4674-9c7c-b28de51574ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2746551-2f26-433d-9cff-614ecaf2ed9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2746551-2f26-433d-9cff-614ecaf2ed9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Agenda_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2746551-2f26-433d-9cff-614ecaf2ed9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/67563b97-b73c-4419-aea9-11034ae79f78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67563b97-b73c-4419-aea9-11034ae79f78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Agenda_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67563b97-b73c-4419-aea9-11034ae79f78>.
+    
+<http://data.lblod.info/id/remote-data-objects/e41e91a3-6c06-49cc-be56-c1104a834652> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e41e91a3-6c06-49cc-be56-c1104a834652";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Agenda_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e41e91a3-6c06-49cc-be56-c1104a834652>.
+    
+<http://data.lblod.info/id/remote-data-objects/e556789c-1b8a-452c-b921-d33e23d9e959> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e556789c-1b8a-452c-b921-d33e23d9e959";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Agenda_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e556789c-1b8a-452c-b921-d33e23d9e959>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2ab2fda-6c0b-44aa-8ec1-93ff1da40730> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2ab2fda-6c0b-44aa-8ec1-93ff1da40730";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Agenda_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2ab2fda-6c0b-44aa-8ec1-93ff1da40730>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d8c354d-4668-4e08-aa44-1cea63733c70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d8c354d-4668-4e08-aa44-1cea63733c70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d8c354d-4668-4e08-aa44-1cea63733c70>.
+    
+<http://data.lblod.info/id/remote-data-objects/86a1bc90-32b1-4748-81f9-1f2294b02e15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86a1bc90-32b1-4748-81f9-1f2294b02e15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86a1bc90-32b1-4748-81f9-1f2294b02e15>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0d43683-8c4a-42c0-aeff-40e7a502b1c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0d43683-8c4a-42c0-aeff-40e7a502b1c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0d43683-8c4a-42c0-aeff-40e7a502b1c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/cad3cb76-b072-423c-8aca-5ae701c617ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cad3cb76-b072-423c-8aca-5ae701c617ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cad3cb76-b072-423c-8aca-5ae701c617ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/910a8166-99f3-46f1-ad5a-3e2ba928ba06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "910a8166-99f3-46f1-ad5a-3e2ba928ba06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/910a8166-99f3-46f1-ad5a-3e2ba928ba06>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1ab8191-5ea2-4a6a-91da-a7d2d21fd66d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1ab8191-5ea2-4a6a-91da-a7d2d21fd66d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_24-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1ab8191-5ea2-4a6a-91da-a7d2d21fd66d>.
+    
+<http://data.lblod.info/id/remote-data-objects/36dc0bee-226f-4de6-ac02-1cfe26f3a1cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36dc0bee-226f-4de6-ac02-1cfe26f3a1cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36dc0bee-226f-4de6-ac02-1cfe26f3a1cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d75c1309-3e15-40ca-8bdc-c3f664ce7275> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d75c1309-3e15-40ca-8bdc-c3f664ce7275";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d75c1309-3e15-40ca-8bdc-c3f664ce7275>.
+    
+<http://data.lblod.info/id/remote-data-objects/f470d1ea-45b0-4af3-8d31-f18f6204dac0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f470d1ea-45b0-4af3-8d31-f18f6204dac0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f470d1ea-45b0-4af3-8d31-f18f6204dac0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5d7b06b-7520-4158-aa3f-4afdf2e8afd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5d7b06b-7520-4158-aa3f-4afdf2e8afd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Notulen_Gemeenteraad_02-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5d7b06b-7520-4158-aa3f-4afdf2e8afd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e482ac22-2f86-4ec9-85c1-df20860b6e0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e482ac22-2f86-4ec9-85c1-df20860b6e0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Notulen_Gemeenteraad_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e482ac22-2f86-4ec9-85c1-df20860b6e0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9875a7c6-0be8-40d3-934f-dace734e64f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9875a7c6-0be8-40d3-934f-dace734e64f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Notulen_Gemeenteraad_16-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9875a7c6-0be8-40d3-934f-dace734e64f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/612fb351-93ce-45a1-bad9-10772d52746e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "612fb351-93ce-45a1-bad9-10772d52746e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Notulen_Gemeenteraad_21-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/612fb351-93ce-45a1-bad9-10772d52746e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8670c103-4096-4dd2-840e-05ba593bf23e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8670c103-4096-4dd2-840e-05ba593bf23e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Notulen_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8670c103-4096-4dd2-840e-05ba593bf23e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa223e43-c8b2-4096-9ed1-73af157f0701> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa223e43-c8b2-4096-9ed1-73af157f0701";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Notulen_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa223e43-c8b2-4096-9ed1-73af157f0701>.
+    
+<http://data.lblod.info/id/remote-data-objects/40bb5b29-770d-4c39-b42c-6d92a55cd940> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40bb5b29-770d-4c39-b42c-6d92a55cd940";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Notulen_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40bb5b29-770d-4c39-b42c-6d92a55cd940>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9b51ab5-9228-41b6-b311-23e16cbc81cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9b51ab5-9228-41b6-b311-23e16cbc81cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Notulen_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9b51ab5-9228-41b6-b311-23e16cbc81cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe59e0b2-9c8c-46a0-a8b6-ec5868cecbb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe59e0b2-9c8c-46a0-a8b6-ec5868cecbb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_02-06-2022_10434.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe59e0b2-9c8c-46a0-a8b6-ec5868cecbb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/357c4771-905e-4d33-92f8-f434a5710b56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "357c4771-905e-4d33-92f8-f434a5710b56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_02-06-2022_10435.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/357c4771-905e-4d33-92f8-f434a5710b56>.
+    
+<http://data.lblod.info/id/remote-data-objects/de3e3568-28b4-48d3-94d5-a16cb0963716> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de3e3568-28b4-48d3-94d5-a16cb0963716";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_02-06-2022_10439.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de3e3568-28b4-48d3-94d5-a16cb0963716>.
+    
+<http://data.lblod.info/id/remote-data-objects/09111732-6441-453d-9cd6-061bf93b563e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09111732-6441-453d-9cd6-061bf93b563e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_02-06-2022_10440.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09111732-6441-453d-9cd6-061bf93b563e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddd5de1f-82eb-4fed-b673-f96613f3df62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddd5de1f-82eb-4fed-b673-f96613f3df62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_02-06-2022_10441.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddd5de1f-82eb-4fed-b673-f96613f3df62>.
+    
+<http://data.lblod.info/id/remote-data-objects/66fa40de-303a-4a31-98ea-f0a7990903ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66fa40de-303a-4a31-98ea-f0a7990903ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_02-06-2022_10442.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66fa40de-303a-4a31-98ea-f0a7990903ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec51c75d-4f52-4f69-95ab-145a1acfe02c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec51c75d-4f52-4f69-95ab-145a1acfe02c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_02-06-2022_10443.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec51c75d-4f52-4f69-95ab-145a1acfe02c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d10b060-a36c-4cc7-a2f0-9088fb758e42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d10b060-a36c-4cc7-a2f0-9088fb758e42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_02-06-2022_10456.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d10b060-a36c-4cc7-a2f0-9088fb758e42>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0730e08-80e3-4dd2-91d0-c97dbda67d3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0730e08-80e3-4dd2-91d0-c97dbda67d3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_02-06-2022_10476.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0730e08-80e3-4dd2-91d0-c97dbda67d3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1299863d-8080-4b74-8573-96fc694e20e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1299863d-8080-4b74-8573-96fc694e20e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_02-06-2022_10485.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1299863d-8080-4b74-8573-96fc694e20e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5595986-fcf2-422f-8df0-e36dbb98d929> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5595986-fcf2-422f-8df0-e36dbb98d929";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_02-06-2022_8889.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5595986-fcf2-422f-8df0-e36dbb98d929>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd97b5cc-f8fc-4eac-9570-2861f2ad375d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd97b5cc-f8fc-4eac-9570-2861f2ad375d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_02-06-2022_8890.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd97b5cc-f8fc-4eac-9570-2861f2ad375d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1239a2e7-d932-43ff-a56d-85f0159bca65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1239a2e7-d932-43ff-a56d-85f0159bca65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_02-06-2022_9099.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1239a2e7-d932-43ff-a56d-85f0159bca65>.
+    
+<http://data.lblod.info/id/remote-data-objects/7eae4957-3731-4973-aa45-51140096fc2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7eae4957-3731-4973-aa45-51140096fc2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_07-07-2022_10775.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7eae4957-3731-4973-aa45-51140096fc2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/be4345b2-a048-4d9e-8c9a-829116772330> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be4345b2-a048-4d9e-8c9a-829116772330";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_07-07-2022_10787.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be4345b2-a048-4d9e-8c9a-829116772330>.
+    
+<http://data.lblod.info/id/remote-data-objects/629d0fd9-1060-44d7-8e9d-7c89b29a29fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "629d0fd9-1060-44d7-8e9d-7c89b29a29fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_16-12-2021_7524.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/629d0fd9-1060-44d7-8e9d-7c89b29a29fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/b24924c2-d7e3-42ac-aeae-3d6c669239aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b24924c2-d7e3-42ac-aeae-3d6c669239aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_16-12-2021_7525.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b24924c2-d7e3-42ac-aeae-3d6c669239aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e1af81f-147b-4705-8f8c-2cd7f4ae2836> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e1af81f-147b-4705-8f8c-2cd7f4ae2836";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_24-02-2022_8055.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e1af81f-147b-4705-8f8c-2cd7f4ae2836>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8d8b4fb-daea-4bce-b215-99d163547280> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8d8b4fb-daea-4bce-b215-99d163547280";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_25-11-2021_7311.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e7223627-27a4-4689-83e1-a875b10c2d8c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8d8b4fb-daea-4bce-b215-99d163547280>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201749-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201749-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201749-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201749-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3b76a1bd-11a8-4305-a530-9f971a7c3cb0> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3b76a1bd-11a8-4305-a530-9f971a7c3cb0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8380262b-650c-4622-896b-de883074cd23";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/18ef110f-5822-488d-89b7-d6fc8b7b705e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "18ef110f-5822-488d-89b7-d6fc8b7b705e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23>.
+
+  <http://redpencil.data.gift/id/task/cd42a0ad-d8ff-47b0-af23-d45462cf7ede> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cd42a0ad-d8ff-47b0-af23-d45462cf7ede";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3b76a1bd-11a8-4305-a530-9f971a7c3cb0>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/18ef110f-5822-488d-89b7-d6fc8b7b705e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/daf1b7cd-484d-4366-87df-e6e40e464e13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "daf1b7cd-484d-4366-87df-e6e40e464e13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/6ab3cf503fec42702348e93645441ee4f03a22663aed5bd670bc9b68bc8ebbd0/GetPublication?filename=Uittreksels_25-11-2021_7519.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/daf1b7cd-484d-4366-87df-e6e40e464e13>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f3d75fd-4bcc-46a9-9a56-332389e0758f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f3d75fd-4bcc-46a9-9a56-332389e0758f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f3d75fd-4bcc-46a9-9a56-332389e0758f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4f304c1-b340-4ec4-a6b5-f33bd117a406> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4f304c1-b340-4ec4-a6b5-f33bd117a406";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4f304c1-b340-4ec4-a6b5-f33bd117a406>.
+    
+<http://data.lblod.info/id/remote-data-objects/5070b2e7-0770-4e4a-89d3-5a63964f3259> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5070b2e7-0770-4e4a-89d3-5a63964f3259";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5070b2e7-0770-4e4a-89d3-5a63964f3259>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae6e35d6-ba9d-492e-a080-ac38774c453a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae6e35d6-ba9d-492e-a080-ac38774c453a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae6e35d6-ba9d-492e-a080-ac38774c453a>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfd46174-5c65-4c5a-98b3-2456c7173cd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfd46174-5c65-4c5a-98b3-2456c7173cd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfd46174-5c65-4c5a-98b3-2456c7173cd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee67a084-3948-4922-beb2-cd964118fc5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee67a084-3948-4922-beb2-cd964118fc5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee67a084-3948-4922-beb2-cd964118fc5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/59bafbc0-3814-4046-a41a-f4850eecf9e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59bafbc0-3814-4046-a41a-f4850eecf9e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59bafbc0-3814-4046-a41a-f4850eecf9e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb4fb9f3-d471-4aab-b9a2-435d1735a765> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb4fb9f3-d471-4aab-b9a2-435d1735a765";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb4fb9f3-d471-4aab-b9a2-435d1735a765>.
+    
+<http://data.lblod.info/id/remote-data-objects/c38fd3a0-4482-42ac-b580-2bf7528e33be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c38fd3a0-4482-42ac-b580-2bf7528e33be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c38fd3a0-4482-42ac-b580-2bf7528e33be>.
+    
+<http://data.lblod.info/id/remote-data-objects/153158d0-86fc-4a52-a6e0-b4efc73358de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "153158d0-86fc-4a52-a6e0-b4efc73358de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/153158d0-86fc-4a52-a6e0-b4efc73358de>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1be7101-b6bc-49a1-b0a3-fc40c07ab0f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1be7101-b6bc-49a1-b0a3-fc40c07ab0f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1be7101-b6bc-49a1-b0a3-fc40c07ab0f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/eacae24c-f228-4857-ba67-5e3739862601> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eacae24c-f228-4857-ba67-5e3739862601";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eacae24c-f228-4857-ba67-5e3739862601>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bffcfc3-dc05-4e75-9195-738e518679a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bffcfc3-dc05-4e75-9195-738e518679a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bffcfc3-dc05-4e75-9195-738e518679a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdb74cb2-92c8-479e-8f28-7dba52acd3eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdb74cb2-92c8-479e-8f28-7dba52acd3eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdb74cb2-92c8-479e-8f28-7dba52acd3eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/06f315fa-948b-4e09-ae22-b3a1873498dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06f315fa-948b-4e09-ae22-b3a1873498dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06f315fa-948b-4e09-ae22-b3a1873498dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad6e9349-07d8-4968-a106-4ed8fab2ca27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad6e9349-07d8-4968-a106-4ed8fab2ca27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad6e9349-07d8-4968-a106-4ed8fab2ca27>.
+    
+<http://data.lblod.info/id/remote-data-objects/19b3fa3d-fddc-445c-ad80-2825f03d775d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19b3fa3d-fddc-445c-ad80-2825f03d775d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19b3fa3d-fddc-445c-ad80-2825f03d775d>.
+    
+<http://data.lblod.info/id/remote-data-objects/58075401-1eac-4f22-8356-3517cfe6f57d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58075401-1eac-4f22-8356-3517cfe6f57d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58075401-1eac-4f22-8356-3517cfe6f57d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b86c735c-7363-4de5-a21d-3aa553f5a8fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b86c735c-7363-4de5-a21d-3aa553f5a8fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b86c735c-7363-4de5-a21d-3aa553f5a8fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f535c94-4f29-4d8e-a088-16d4982046b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f535c94-4f29-4d8e-a088-16d4982046b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f535c94-4f29-4d8e-a088-16d4982046b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f6e0982-e817-4a96-a121-2599a1e3afff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f6e0982-e817-4a96-a121-2599a1e3afff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f6e0982-e817-4a96-a121-2599a1e3afff>.
+    
+<http://data.lblod.info/id/remote-data-objects/809ef29b-2e3e-4bfd-ac70-86ffef8f9aa7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "809ef29b-2e3e-4bfd-ac70-86ffef8f9aa7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/809ef29b-2e3e-4bfd-ac70-86ffef8f9aa7>.
+    
+<http://data.lblod.info/id/remote-data-objects/44bdee69-bdea-4bc2-8f54-771e43552208> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44bdee69-bdea-4bc2-8f54-771e43552208";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44bdee69-bdea-4bc2-8f54-771e43552208>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c60c81b-bdf9-4140-a352-1884a26e46cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c60c81b-bdf9-4140-a352-1884a26e46cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c60c81b-bdf9-4140-a352-1884a26e46cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/746e6877-da5e-47e0-a0a8-0bcfdab5a98f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "746e6877-da5e-47e0-a0a8-0bcfdab5a98f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/746e6877-da5e-47e0-a0a8-0bcfdab5a98f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2856c8c4-cc84-4805-b772-334aec6abe11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2856c8c4-cc84-4805-b772-334aec6abe11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2856c8c4-cc84-4805-b772-334aec6abe11>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ca763cf-7981-4db6-b181-4e67f3dc4121> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ca763cf-7981-4db6-b181-4e67f3dc4121";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ca763cf-7981-4db6-b181-4e67f3dc4121>.
+    
+<http://data.lblod.info/id/remote-data-objects/c206480d-b7f4-4f39-8fbb-aab2532ee3f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c206480d-b7f4-4f39-8fbb-aab2532ee3f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/8588d296ef5c88d56105c79706a1ff64aa495d415a1b05a593e91e768e94dba8/GetPublication?filename=BesluitenLijstUitspraak_Vast%20bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c206480d-b7f4-4f39-8fbb-aab2532ee3f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/653ae74f-f30e-40fb-a9d8-237149edc65b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "653ae74f-f30e-40fb-a9d8-237149edc65b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/653ae74f-f30e-40fb-a9d8-237149edc65b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f52a3cb7-07e1-45d9-83e9-678b39a49de6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f52a3cb7-07e1-45d9-83e9-678b39a49de6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f52a3cb7-07e1-45d9-83e9-678b39a49de6>.
+    
+<http://data.lblod.info/id/remote-data-objects/988d040a-f784-4992-9e53-b247711af3da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "988d040a-f784-4992-9e53-b247711af3da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/988d040a-f784-4992-9e53-b247711af3da>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3792bf8-8227-465f-98ef-32f646eecb8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3792bf8-8227-465f-98ef-32f646eecb8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3792bf8-8227-465f-98ef-32f646eecb8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bddbfdbc-c6ee-44f1-bb72-e5b11d3a9b41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bddbfdbc-c6ee-44f1-bb72-e5b11d3a9b41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bddbfdbc-c6ee-44f1-bb72-e5b11d3a9b41>.
+    
+<http://data.lblod.info/id/remote-data-objects/66c8e695-f493-434f-9d64-3e0adbe26e91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66c8e695-f493-434f-9d64-3e0adbe26e91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66c8e695-f493-434f-9d64-3e0adbe26e91>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e4c214f-bd96-49f2-99ff-8a67fafbd3af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e4c214f-bd96-49f2-99ff-8a67fafbd3af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e4c214f-bd96-49f2-99ff-8a67fafbd3af>.
+    
+<http://data.lblod.info/id/remote-data-objects/aca09297-ea3a-48b5-9702-60121939302d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aca09297-ea3a-48b5-9702-60121939302d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aca09297-ea3a-48b5-9702-60121939302d>.
+    
+<http://data.lblod.info/id/remote-data-objects/56c82f84-ab9d-46c0-ba4a-912060628b1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56c82f84-ab9d-46c0-ba4a-912060628b1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56c82f84-ab9d-46c0-ba4a-912060628b1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/35fda2dd-2e2d-490e-a9f4-6173ab81a3eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35fda2dd-2e2d-490e-a9f4-6173ab81a3eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35fda2dd-2e2d-490e-a9f4-6173ab81a3eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/7364cf2f-72e1-49c7-bfc6-b8535936938d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7364cf2f-72e1-49c7-bfc6-b8535936938d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7364cf2f-72e1-49c7-bfc6-b8535936938d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f744288b-3295-4426-8f8b-82f9e0d9b1f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f744288b-3295-4426-8f8b-82f9e0d9b1f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f744288b-3295-4426-8f8b-82f9e0d9b1f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/427f54dc-491f-4a5f-9ecf-509ccab3d13d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "427f54dc-491f-4a5f-9ecf-509ccab3d13d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/427f54dc-491f-4a5f-9ecf-509ccab3d13d>.
+    
+<http://data.lblod.info/id/remote-data-objects/78d1ae1b-119b-4e2a-a9da-2729f7e1537a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78d1ae1b-119b-4e2a-a9da-2729f7e1537a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78d1ae1b-119b-4e2a-a9da-2729f7e1537a>.
+    
+<http://data.lblod.info/id/remote-data-objects/76ddafd6-863c-4290-9377-f4c969bedaf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76ddafd6-863c-4290-9377-f4c969bedaf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76ddafd6-863c-4290-9377-f4c969bedaf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/51597eec-8153-4780-a553-e24e37bb74d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51597eec-8153-4780-a553-e24e37bb74d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51597eec-8153-4780-a553-e24e37bb74d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/04639fa9-cfce-4c43-886e-d5847fcdb8ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04639fa9-cfce-4c43-886e-d5847fcdb8ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04639fa9-cfce-4c43-886e-d5847fcdb8ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/8806cc9b-2cfc-4dea-8ad0-3880ca1fbb48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8806cc9b-2cfc-4dea-8ad0-3880ca1fbb48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8806cc9b-2cfc-4dea-8ad0-3880ca1fbb48>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fb5ba97-fec4-4749-b2cf-d3d2c79734cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fb5ba97-fec4-4749-b2cf-d3d2c79734cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fb5ba97-fec4-4749-b2cf-d3d2c79734cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/92b4b226-da2f-4057-96d6-6d4fed8203e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92b4b226-da2f-4057-96d6-6d4fed8203e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92b4b226-da2f-4057-96d6-6d4fed8203e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed813151-4042-4419-a6ea-dd9282eab1a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed813151-4042-4419-a6ea-dd9282eab1a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8380262b-650c-4622-896b-de883074cd23> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed813151-4042-4419-a6ea-dd9282eab1a9>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201750-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201750-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201750-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201750-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d70ee159-ce6b-47d5-bb7d-caf68d2cd919> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d70ee159-ce6b-47d5-bb7d-caf68d2cd919";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ee755ac9-7d67-4483-ba4f-2f595ccb99d1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/643408d6-2d96-4249-b541-4d0168808da1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "643408d6-2d96-4249-b541-4d0168808da1";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1>.
+
+  <http://redpencil.data.gift/id/task/b677c5cd-d554-4341-a0b2-5b114d5998d5> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b677c5cd-d554-4341-a0b2-5b114d5998d5";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d70ee159-ce6b-47d5-bb7d-caf68d2cd919>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/643408d6-2d96-4249-b541-4d0168808da1>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/6b3f95cb-3e13-407b-b2d4-aca1aef544ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b3f95cb-3e13-407b-b2d4-aca1aef544ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b3f95cb-3e13-407b-b2d4-aca1aef544ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b2e59fa-4a7f-4ac9-807a-34ead60b480d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b2e59fa-4a7f-4ac9-807a-34ead60b480d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b2e59fa-4a7f-4ac9-807a-34ead60b480d>.
+    
+<http://data.lblod.info/id/remote-data-objects/47a46cc6-5cc4-4ebf-8573-5884f61f1a3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47a46cc6-5cc4-4ebf-8573-5884f61f1a3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47a46cc6-5cc4-4ebf-8573-5884f61f1a3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f1f0d91-de68-410a-8d0e-c7b33b9b27c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f1f0d91-de68-410a-8d0e-c7b33b9b27c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f1f0d91-de68-410a-8d0e-c7b33b9b27c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5cc32dd-56f0-4d81-96c1-6bdd5e2b93e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5cc32dd-56f0-4d81-96c1-6bdd5e2b93e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5cc32dd-56f0-4d81-96c1-6bdd5e2b93e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/f42bcc17-3499-426c-9504-fe99931fe6ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f42bcc17-3499-426c-9504-fe99931fe6ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f42bcc17-3499-426c-9504-fe99931fe6ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c1b5271-41a9-4084-ae35-d9d5f68dabd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c1b5271-41a9-4084-ae35-d9d5f68dabd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c1b5271-41a9-4084-ae35-d9d5f68dabd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/51cdcc53-967b-4f18-83da-fcb6dcd41677> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51cdcc53-967b-4f18-83da-fcb6dcd41677";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51cdcc53-967b-4f18-83da-fcb6dcd41677>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e83cf3e-5074-4a08-baaa-dc5b70c052a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e83cf3e-5074-4a08-baaa-dc5b70c052a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e83cf3e-5074-4a08-baaa-dc5b70c052a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c048e85-3e7d-4050-9e06-b2cf61bcafca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c048e85-3e7d-4050-9e06-b2cf61bcafca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c048e85-3e7d-4050-9e06-b2cf61bcafca>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebd639ff-fe7b-4b9a-b86c-86791b76f71c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebd639ff-fe7b-4b9a-b86c-86791b76f71c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebd639ff-fe7b-4b9a-b86c-86791b76f71c>.
+    
+<http://data.lblod.info/id/remote-data-objects/86414e76-f831-4a90-9f36-68127e08e1a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86414e76-f831-4a90-9f36-68127e08e1a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86414e76-f831-4a90-9f36-68127e08e1a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/29a8b711-011e-4636-bd94-81d7c05812f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29a8b711-011e-4636-bd94-81d7c05812f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29a8b711-011e-4636-bd94-81d7c05812f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/526f45cd-28d8-4171-8ca3-02fcd4d2f193> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "526f45cd-28d8-4171-8ca3-02fcd4d2f193";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/526f45cd-28d8-4171-8ca3-02fcd4d2f193>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2f7d7fc-19df-41bc-b732-9a0b6c4c57fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2f7d7fc-19df-41bc-b732-9a0b6c4c57fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2f7d7fc-19df-41bc-b732-9a0b6c4c57fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d9604af-a769-4c03-b3e6-f3a9b0f3c8e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d9604af-a769-4c03-b3e6-f3a9b0f3c8e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d9604af-a769-4c03-b3e6-f3a9b0f3c8e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/9439dbdf-cb85-4bf0-8d8f-cabf79d3aa45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9439dbdf-cb85-4bf0-8d8f-cabf79d3aa45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9439dbdf-cb85-4bf0-8d8f-cabf79d3aa45>.
+    
+<http://data.lblod.info/id/remote-data-objects/c696569f-cdeb-4271-a0ba-7622d3509e33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c696569f-cdeb-4271-a0ba-7622d3509e33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c696569f-cdeb-4271-a0ba-7622d3509e33>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e5d2523-2a26-47fa-98ba-328780f09790> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e5d2523-2a26-47fa-98ba-328780f09790";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zele.be/LBLODWeb/Home/Overzicht/f7e0c0078489c8df1a663cd45ffb430945084bb5e34a7d6059c1fd51356423ac/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e5d2523-2a26-47fa-98ba-328780f09790>.
+    
+<http://data.lblod.info/id/remote-data-objects/5467f4c8-f7d7-4df8-bec3-79076af31123> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5467f4c8-f7d7-4df8-bec3-79076af31123";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5467f4c8-f7d7-4df8-bec3-79076af31123>.
+    
+<http://data.lblod.info/id/remote-data-objects/5845f6a1-c245-4bf5-a718-75dbd1b70df2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5845f6a1-c245-4bf5-a718-75dbd1b70df2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5845f6a1-c245-4bf5-a718-75dbd1b70df2>.
+    
+<http://data.lblod.info/id/remote-data-objects/caa5fa4e-11ea-4227-ad3a-cd3c403daddb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "caa5fa4e-11ea-4227-ad3a-cd3c403daddb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_03-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/caa5fa4e-11ea-4227-ad3a-cd3c403daddb>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d5fb454-9e09-476c-8e6b-1ed8fc508352> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d5fb454-9e09-476c-8e6b-1ed8fc508352";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d5fb454-9e09-476c-8e6b-1ed8fc508352>.
+    
+<http://data.lblod.info/id/remote-data-objects/928d1d10-7f7d-49ff-96ea-e0bcdc2ac161> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "928d1d10-7f7d-49ff-96ea-e0bcdc2ac161";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_05-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/928d1d10-7f7d-49ff-96ea-e0bcdc2ac161>.
+    
+<http://data.lblod.info/id/remote-data-objects/550d9a3a-b725-4ddf-becc-d2c3547716c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "550d9a3a-b725-4ddf-becc-d2c3547716c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_06-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/550d9a3a-b725-4ddf-becc-d2c3547716c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ad8322f-8d7b-45e0-a4c6-e231b206ad46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ad8322f-8d7b-45e0-a4c6-e231b206ad46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ad8322f-8d7b-45e0-a4c6-e231b206ad46>.
+    
+<http://data.lblod.info/id/remote-data-objects/a893e2cb-e54b-4715-901f-d444cbda438e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a893e2cb-e54b-4715-901f-d444cbda438e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_08-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a893e2cb-e54b-4715-901f-d444cbda438e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6bcf8033-f3e2-4b0d-98a9-fa6d8316cbef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bcf8033-f3e2-4b0d-98a9-fa6d8316cbef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bcf8033-f3e2-4b0d-98a9-fa6d8316cbef>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc992e78-5794-4b94-988f-3fee2ca2f624> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc992e78-5794-4b94-988f-3fee2ca2f624";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_10-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc992e78-5794-4b94-988f-3fee2ca2f624>.
+    
+<http://data.lblod.info/id/remote-data-objects/41b1ec36-74ba-4ba3-b364-55fc03dd3e09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41b1ec36-74ba-4ba3-b364-55fc03dd3e09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41b1ec36-74ba-4ba3-b364-55fc03dd3e09>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cb1ee53-1d84-45c1-8b0f-4412a2e61415> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cb1ee53-1d84-45c1-8b0f-4412a2e61415";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_11-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cb1ee53-1d84-45c1-8b0f-4412a2e61415>.
+    
+<http://data.lblod.info/id/remote-data-objects/08259ebd-5923-4659-9c01-0ba78ad3613e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08259ebd-5923-4659-9c01-0ba78ad3613e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08259ebd-5923-4659-9c01-0ba78ad3613e>.
+    
+<http://data.lblod.info/id/remote-data-objects/137eace7-0e5d-45c5-a459-744fb4f5a333> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "137eace7-0e5d-45c5-a459-744fb4f5a333";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/137eace7-0e5d-45c5-a459-744fb4f5a333>.
+    
+<http://data.lblod.info/id/remote-data-objects/3aee39b5-dc7a-4c47-b52c-90d4a5789c26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3aee39b5-dc7a-4c47-b52c-90d4a5789c26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_14-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3aee39b5-dc7a-4c47-b52c-90d4a5789c26>.
+    
+<http://data.lblod.info/id/remote-data-objects/2858c0dc-e5dd-4787-90b0-1b6ff47353d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2858c0dc-e5dd-4787-90b0-1b6ff47353d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2858c0dc-e5dd-4787-90b0-1b6ff47353d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3562286-5b47-493f-938c-01cef4b2eea3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3562286-5b47-493f-938c-01cef4b2eea3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3562286-5b47-493f-938c-01cef4b2eea3>.
+    
+<http://data.lblod.info/id/remote-data-objects/73c6db32-5b19-4f42-9281-07210f138df6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73c6db32-5b19-4f42-9281-07210f138df6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73c6db32-5b19-4f42-9281-07210f138df6>.
+    
+<http://data.lblod.info/id/remote-data-objects/31ccedd6-e3ea-4219-9a36-0124ddb89e37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31ccedd6-e3ea-4219-9a36-0124ddb89e37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31ccedd6-e3ea-4219-9a36-0124ddb89e37>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ad2b043-a828-414c-8d7b-fead56279927> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ad2b043-a828-414c-8d7b-fead56279927";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_17-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ad2b043-a828-414c-8d7b-fead56279927>.
+    
+<http://data.lblod.info/id/remote-data-objects/db31ef9b-ce3a-484b-849d-e230b18bc009> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db31ef9b-ce3a-484b-849d-e230b18bc009";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db31ef9b-ce3a-484b-849d-e230b18bc009>.
+    
+<http://data.lblod.info/id/remote-data-objects/2aa6f0a3-f07b-43bc-9090-65b527eb1081> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2aa6f0a3-f07b-43bc-9090-65b527eb1081";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_18-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2aa6f0a3-f07b-43bc-9090-65b527eb1081>.
+    
+<http://data.lblod.info/id/remote-data-objects/53bc5c1e-b4cb-43fa-88c5-f860f6c38038> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53bc5c1e-b4cb-43fa-88c5-f860f6c38038";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53bc5c1e-b4cb-43fa-88c5-f860f6c38038>.
+    
+<http://data.lblod.info/id/remote-data-objects/80ac9204-5e1d-429b-94f1-d517caf22990> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80ac9204-5e1d-429b-94f1-d517caf22990";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80ac9204-5e1d-429b-94f1-d517caf22990>.
+    
+<http://data.lblod.info/id/remote-data-objects/2eda7d39-53c4-42a3-bf53-139e56059215> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2eda7d39-53c4-42a3-bf53-139e56059215";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_21-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2eda7d39-53c4-42a3-bf53-139e56059215>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf677679-ac2b-4c5a-a9f7-2a0605855619> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf677679-ac2b-4c5a-a9f7-2a0605855619";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_22-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf677679-ac2b-4c5a-a9f7-2a0605855619>.
+    
+<http://data.lblod.info/id/remote-data-objects/8998e9bb-e6e5-46c9-80f6-b46f81bc7c20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8998e9bb-e6e5-46c9-80f6-b46f81bc7c20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8998e9bb-e6e5-46c9-80f6-b46f81bc7c20>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0e0450e-9ef7-4555-941c-6c1ad6089994> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0e0450e-9ef7-4555-941c-6c1ad6089994";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0e0450e-9ef7-4555-941c-6c1ad6089994>.
+    
+<http://data.lblod.info/id/remote-data-objects/64bcfd38-26c9-4427-9a54-cd8bf01d2147> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64bcfd38-26c9-4427-9a54-cd8bf01d2147";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64bcfd38-26c9-4427-9a54-cd8bf01d2147>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f2743d9-a026-486a-91cb-2a389a225264> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f2743d9-a026-486a-91cb-2a389a225264";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f2743d9-a026-486a-91cb-2a389a225264>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d33af79-1f72-4bbf-b569-a87747d89db0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d33af79-1f72-4bbf-b569-a87747d89db0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ee755ac9-7d67-4483-ba4f-2f595ccb99d1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d33af79-1f72-4bbf-b569-a87747d89db0>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201751-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201751-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201751-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201751-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3ae0a4bf-e9f3-4668-b1dd-6aad8ea5d3f9> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3ae0a4bf-e9f3-4668-b1dd-6aad8ea5d3f9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1d284b23-c12d-4c53-a96d-64dbcd8e37b7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ad52a700-cc9c-4d15-ac8e-ac416ae52cd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ad52a700-cc9c-4d15-ac8e-ac416ae52cd1";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7>.
+
+  <http://redpencil.data.gift/id/task/d275bbbc-81dd-4bb1-911d-86083342384a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d275bbbc-81dd-4bb1-911d-86083342384a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3ae0a4bf-e9f3-4668-b1dd-6aad8ea5d3f9>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ad52a700-cc9c-4d15-ac8e-ac416ae52cd1>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/76817c56-7bf4-4d2f-9edb-d93283dba2f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76817c56-7bf4-4d2f-9edb-d93283dba2f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_26-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76817c56-7bf4-4d2f-9edb-d93283dba2f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/1425a37b-1e4e-4a42-90e1-065d956f92de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1425a37b-1e4e-4a42-90e1-065d956f92de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1425a37b-1e4e-4a42-90e1-065d956f92de>.
+    
+<http://data.lblod.info/id/remote-data-objects/03a72e51-b129-46e5-9ec5-dfe432fa59b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03a72e51-b129-46e5-9ec5-dfe432fa59b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03a72e51-b129-46e5-9ec5-dfe432fa59b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/af765f2d-8ef7-4f8d-8ca0-eb9fb177302e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af765f2d-8ef7-4f8d-8ca0-eb9fb177302e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af765f2d-8ef7-4f8d-8ca0-eb9fb177302e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b057582b-d026-4e1e-8371-dfe85fd65265> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b057582b-d026-4e1e-8371-dfe85fd65265";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b057582b-d026-4e1e-8371-dfe85fd65265>.
+    
+<http://data.lblod.info/id/remote-data-objects/6da8f4f1-7e28-4713-8358-63086256d019> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6da8f4f1-7e28-4713-8358-63086256d019";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6da8f4f1-7e28-4713-8358-63086256d019>.
+    
+<http://data.lblod.info/id/remote-data-objects/9aa20db4-1782-42b4-99c8-106daa283198> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9aa20db4-1782-42b4-99c8-106daa283198";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9aa20db4-1782-42b4-99c8-106daa283198>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b3a4a22-edcc-41f8-bda5-5742dcfc6c11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b3a4a22-edcc-41f8-bda5-5742dcfc6c11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=BesluitenLijstUitspraak_College%20van%20burgemeester%20en%20schepenen_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b3a4a22-edcc-41f8-bda5-5742dcfc6c11>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7a7e56a-046a-49fd-8293-c69369101e29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7a7e56a-046a-49fd-8293-c69369101e29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_03-06-2022_2770.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7a7e56a-046a-49fd-8293-c69369101e29>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff92d2a3-df85-43e4-9d2d-d06c53305d60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff92d2a3-df85-43e4-9d2d-d06c53305d60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_03-06-2022_2771.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff92d2a3-df85-43e4-9d2d-d06c53305d60>.
+    
+<http://data.lblod.info/id/remote-data-objects/451f2786-ffcf-4908-802b-2f5c6653f0d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "451f2786-ffcf-4908-802b-2f5c6653f0d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_07-07-2022_3001.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/451f2786-ffcf-4908-802b-2f5c6653f0d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c780fc46-bf4e-410b-9431-5ffbcf441658> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c780fc46-bf4e-410b-9431-5ffbcf441658";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_13-05-2022_2478.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c780fc46-bf4e-410b-9431-5ffbcf441658>.
+    
+<http://data.lblod.info/id/remote-data-objects/662d54f9-2da7-40fb-83e7-d7d0dcdba61f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "662d54f9-2da7-40fb-83e7-d7d0dcdba61f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_13-05-2022_2484.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/662d54f9-2da7-40fb-83e7-d7d0dcdba61f>.
+    
+<http://data.lblod.info/id/remote-data-objects/72c27c2b-40ae-42cd-b6bd-0304758b70bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72c27c2b-40ae-42cd-b6bd-0304758b70bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_13-05-2022_2501.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72c27c2b-40ae-42cd-b6bd-0304758b70bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/02c914e1-968a-42db-a266-c1c96378c03e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02c914e1-968a-42db-a266-c1c96378c03e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_13-05-2022_2522.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02c914e1-968a-42db-a266-c1c96378c03e>.
+    
+<http://data.lblod.info/id/remote-data-objects/665baf68-66b7-466b-b1bf-ba040ccfafc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "665baf68-66b7-466b-b1bf-ba040ccfafc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_13-05-2022_2550.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/665baf68-66b7-466b-b1bf-ba040ccfafc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e30e548e-e621-422e-852b-6ef1991ba613> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e30e548e-e621-422e-852b-6ef1991ba613";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_13-05-2022_2595.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e30e548e-e621-422e-852b-6ef1991ba613>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dce015b-ef64-4961-8640-56b66ac0f596> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dce015b-ef64-4961-8640-56b66ac0f596";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_14-01-2022_1473.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dce015b-ef64-4961-8640-56b66ac0f596>.
+    
+<http://data.lblod.info/id/remote-data-objects/43d106d1-9335-43f5-96c2-f701be085660> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43d106d1-9335-43f5-96c2-f701be085660";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_14-01-2022_1569.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43d106d1-9335-43f5-96c2-f701be085660>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c8af45f-8515-488b-95ff-0756720f16f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c8af45f-8515-488b-95ff-0756720f16f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_18-02-2022_1797.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c8af45f-8515-488b-95ff-0756720f16f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f7e4f09-1aa2-4619-925b-f3d757d166df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f7e4f09-1aa2-4619-925b-f3d757d166df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_20-05-2022_2667.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f7e4f09-1aa2-4619-925b-f3d757d166df>.
+    
+<http://data.lblod.info/id/remote-data-objects/70db9f15-eadd-45a9-91eb-141e9afe4130> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70db9f15-eadd-45a9-91eb-141e9afe4130";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_20-05-2022_2672.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70db9f15-eadd-45a9-91eb-141e9afe4130>.
+    
+<http://data.lblod.info/id/remote-data-objects/13a40176-7836-4d72-811f-647458e9a6c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13a40176-7836-4d72-811f-647458e9a6c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_22-04-2022_2352.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13a40176-7836-4d72-811f-647458e9a6c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a610f732-b8a4-485b-952a-a12db95f84cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a610f732-b8a4-485b-952a-a12db95f84cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_22-04-2022_2388.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a610f732-b8a4-485b-952a-a12db95f84cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/42b904ee-023a-42a9-9e81-a7a56b18c23a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42b904ee-023a-42a9-9e81-a7a56b18c23a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_22-04-2022_2400.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42b904ee-023a-42a9-9e81-a7a56b18c23a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce2d89ad-9087-472d-be62-1a6a25a98029> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce2d89ad-9087-472d-be62-1a6a25a98029";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_24-06-2022_2897.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce2d89ad-9087-472d-be62-1a6a25a98029>.
+    
+<http://data.lblod.info/id/remote-data-objects/3393c43b-808b-4995-a66a-3a443d210576> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3393c43b-808b-4995-a66a-3a443d210576";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_28-01-2022_1644.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3393c43b-808b-4995-a66a-3a443d210576>.
+    
+<http://data.lblod.info/id/remote-data-objects/f16197be-b42c-4471-b878-08cbadb4941f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f16197be-b42c-4471-b878-08cbadb4941f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_28-07-2022_3126.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f16197be-b42c-4471-b878-08cbadb4941f>.
+    
+<http://data.lblod.info/id/remote-data-objects/091077a8-56ba-4c69-803d-476c685f12a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "091077a8-56ba-4c69-803d-476c685f12a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_29-06-2022_2923.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/091077a8-56ba-4c69-803d-476c685f12a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/718f1e1f-43c7-413d-aa9c-6201449d8620> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "718f1e1f-43c7-413d-aa9c-6201449d8620";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_31-03-2022_2299.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/718f1e1f-43c7-413d-aa9c-6201449d8620>.
+    
+<http://data.lblod.info/id/remote-data-objects/eaa4c6a6-9720-4bd1-8173-8d79e7835ace> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eaa4c6a6-9720-4bd1-8173-8d79e7835ace";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/4639ff3ac19d4fa9a1e0dc317d7eddb51d8c8ffe53b8f6a427b81b3fd7d3b87b/GetPublication?filename=Uittreksels_31-03-2022_2303.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eaa4c6a6-9720-4bd1-8173-8d79e7835ace>.
+    
+<http://data.lblod.info/id/remote-data-objects/3774a9e6-9da5-4310-8c23-f9e4b9f58c74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3774a9e6-9da5-4310-8c23-f9e4b9f58c74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Agenda_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3774a9e6-9da5-4310-8c23-f9e4b9f58c74>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c9a95fc-1960-433b-8f87-0eb643b4d506> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c9a95fc-1960-433b-8f87-0eb643b4d506";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Agenda_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c9a95fc-1960-433b-8f87-0eb643b4d506>.
+    
+<http://data.lblod.info/id/remote-data-objects/53780e94-0fed-4f75-a697-0dd8204ebdbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53780e94-0fed-4f75-a697-0dd8204ebdbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Agenda_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53780e94-0fed-4f75-a697-0dd8204ebdbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/df1ff0ca-00ce-426e-bb74-2ef460815e43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df1ff0ca-00ce-426e-bb74-2ef460815e43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Agenda_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df1ff0ca-00ce-426e-bb74-2ef460815e43>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1580de6-7722-420b-a728-db1f59185b3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1580de6-7722-420b-a728-db1f59185b3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Agenda_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1580de6-7722-420b-a728-db1f59185b3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad75f84d-3b58-4e7b-97d4-ac5b7256c480> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad75f84d-3b58-4e7b-97d4-ac5b7256c480";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Agenda_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad75f84d-3b58-4e7b-97d4-ac5b7256c480>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcdc95cd-80f9-4722-b187-0dece198a4ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcdc95cd-80f9-4722-b187-0dece198a4ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Agenda_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcdc95cd-80f9-4722-b187-0dece198a4ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ebc38f5-2aae-453f-807e-97090667026c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ebc38f5-2aae-453f-807e-97090667026c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Agenda_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ebc38f5-2aae-453f-807e-97090667026c>.
+    
+<http://data.lblod.info/id/remote-data-objects/33335bf4-2b7d-4c41-8714-64bc69a0af78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33335bf4-2b7d-4c41-8714-64bc69a0af78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Agenda_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33335bf4-2b7d-4c41-8714-64bc69a0af78>.
+    
+<http://data.lblod.info/id/remote-data-objects/75e72af2-5efd-4adb-b418-4700bea9ef0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75e72af2-5efd-4adb-b418-4700bea9ef0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75e72af2-5efd-4adb-b418-4700bea9ef0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7fae6ab-a690-4c9c-913e-0963cebbdedc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7fae6ab-a690-4c9c-913e-0963cebbdedc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7fae6ab-a690-4c9c-913e-0963cebbdedc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f347b0f2-3aa4-4d66-b4f5-662c6a1066d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f347b0f2-3aa4-4d66-b4f5-662c6a1066d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f347b0f2-3aa4-4d66-b4f5-662c6a1066d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6a92214-c128-415e-8406-bc1645dae989> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6a92214-c128-415e-8406-bc1645dae989";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6a92214-c128-415e-8406-bc1645dae989>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdd33998-69ad-4e30-af46-437f0d6c0602> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdd33998-69ad-4e30-af46-437f0d6c0602";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdd33998-69ad-4e30-af46-437f0d6c0602>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ae6fca7-71c8-447d-9661-a04bf4467f26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ae6fca7-71c8-447d-9661-a04bf4467f26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ae6fca7-71c8-447d-9661-a04bf4467f26>.
+    
+<http://data.lblod.info/id/remote-data-objects/afa0c60a-0c5b-4fc1-97a0-403750144a9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afa0c60a-0c5b-4fc1-97a0-403750144a9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=BesluitenLijstUitspraak_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afa0c60a-0c5b-4fc1-97a0-403750144a9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3edf9c9-40c9-403f-a5a8-2a69fd3319bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3edf9c9-40c9-403f-a5a8-2a69fd3319bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Notulen_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3edf9c9-40c9-403f-a5a8-2a69fd3319bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/46e18935-9d3e-4187-a58f-8c8d2d6df950> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46e18935-9d3e-4187-a58f-8c8d2d6df950";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Notulen_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46e18935-9d3e-4187-a58f-8c8d2d6df950>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4741a24-19d7-4e76-955f-5a4641bd0441> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4741a24-19d7-4e76-955f-5a4641bd0441";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Notulen_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1d284b23-c12d-4c53-a96d-64dbcd8e37b7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4741a24-19d7-4e76-955f-5a4641bd0441>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201753-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201753-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201753-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201753-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/8333c1ab-b503-478e-9fe8-917c1911c132> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8333c1ab-b503-478e-9fe8-917c1911c132";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cb12c2ae-5979-4fe1-ac67-2f11f020c744";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/32a6997c-29c1-4a10-bcbf-b9a0295d04a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "32a6997c-29c1-4a10-bcbf-b9a0295d04a2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744>.
+
+  <http://redpencil.data.gift/id/task/5e6c8817-a6c1-48c3-a90d-f0beac893fcd> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5e6c8817-a6c1-48c3-a90d-f0beac893fcd";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/8333c1ab-b503-478e-9fe8-917c1911c132>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/32a6997c-29c1-4a10-bcbf-b9a0295d04a2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/6e60bc73-5031-4132-bf82-0757c3e3d81d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e60bc73-5031-4132-bf82-0757c3e3d81d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Notulen_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e60bc73-5031-4132-bf82-0757c3e3d81d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7edfbfc9-95f8-4713-a824-2695516b1429> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7edfbfc9-95f8-4713-a824-2695516b1429";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Notulen_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7edfbfc9-95f8-4713-a824-2695516b1429>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e5a1654-c2d9-470b-a122-5159ecad5c9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e5a1654-c2d9-470b-a122-5159ecad5c9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Notulen_Gemeenteraad_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e5a1654-c2d9-470b-a122-5159ecad5c9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8adf3016-e498-4794-a766-2ada29ce64f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8adf3016-e498-4794-a766-2ada29ce64f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Notulen_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8adf3016-e498-4794-a766-2ada29ce64f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0912ad6-7016-462a-afbb-285d213de1e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0912ad6-7016-462a-afbb-285d213de1e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Notulen_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0912ad6-7016-462a-afbb-285d213de1e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0af2ff69-27ae-4e05-b461-522ffaa1ad84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0af2ff69-27ae-4e05-b461-522ffaa1ad84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0af2ff69-27ae-4e05-b461-522ffaa1ad84>.
+    
+<http://data.lblod.info/id/remote-data-objects/98aa5a34-f579-4bd6-bfca-c500151b4a98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98aa5a34-f579-4bd6-bfca-c500151b4a98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98aa5a34-f579-4bd6-bfca-c500151b4a98>.
+    
+<http://data.lblod.info/id/remote-data-objects/74c4a7d6-e9be-4561-b83c-c701fa285c14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74c4a7d6-e9be-4561-b83c-c701fa285c14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74c4a7d6-e9be-4561-b83c-c701fa285c14>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae18332f-bec3-4aea-96cb-a7f6438babfe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae18332f-bec3-4aea-96cb-a7f6438babfe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=ToegevoegdeAgenda_Gemeenteraad_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae18332f-bec3-4aea-96cb-a7f6438babfe>.
+    
+<http://data.lblod.info/id/remote-data-objects/f971159a-f381-4fce-bb98-90a710a798a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f971159a-f381-4fce-bb98-90a710a798a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_20-12-2021_1348.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f971159a-f381-4fce-bb98-90a710a798a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e24548c-3ebd-45d7-b8bb-50d89b3390c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e24548c-3ebd-45d7-b8bb-50d89b3390c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_20-12-2021_1349.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e24548c-3ebd-45d7-b8bb-50d89b3390c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6bd7b9e-02e6-4386-8eb1-cb90ddd374f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6bd7b9e-02e6-4386-8eb1-cb90ddd374f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_20-12-2021_1350.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6bd7b9e-02e6-4386-8eb1-cb90ddd374f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d87d0a01-e314-4434-86b5-d4058603ff71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d87d0a01-e314-4434-86b5-d4058603ff71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_20-12-2021_1351.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d87d0a01-e314-4434-86b5-d4058603ff71>.
+    
+<http://data.lblod.info/id/remote-data-objects/5274cfc5-842b-4c6f-bb1c-c6add5badf1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5274cfc5-842b-4c6f-bb1c-c6add5badf1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_20-12-2021_1382.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5274cfc5-842b-4c6f-bb1c-c6add5badf1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/30225023-f4e4-47b1-b7b0-4bbd2974133b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30225023-f4e4-47b1-b7b0-4bbd2974133b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_20-12-2021_1383.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30225023-f4e4-47b1-b7b0-4bbd2974133b>.
+    
+<http://data.lblod.info/id/remote-data-objects/049462c1-0adf-461d-8f2c-ad5f85463c26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "049462c1-0adf-461d-8f2c-ad5f85463c26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_20-12-2021_1385.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/049462c1-0adf-461d-8f2c-ad5f85463c26>.
+    
+<http://data.lblod.info/id/remote-data-objects/e53ca83f-89b4-4736-9404-214e2c53c933> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e53ca83f-89b4-4736-9404-214e2c53c933";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_20-12-2021_1387.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e53ca83f-89b4-4736-9404-214e2c53c933>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f6c793a-d2da-4ba0-afa7-f56f1cadbee2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f6c793a-d2da-4ba0-afa7-f56f1cadbee2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_21-02-2022_1610.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f6c793a-d2da-4ba0-afa7-f56f1cadbee2>.
+    
+<http://data.lblod.info/id/remote-data-objects/72833400-30b3-4dd1-a382-60aaf3b85f2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72833400-30b3-4dd1-a382-60aaf3b85f2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_21-02-2022_1745.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72833400-30b3-4dd1-a382-60aaf3b85f2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8acefe7-076b-45a3-a4d4-4ccb817cb2aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8acefe7-076b-45a3-a4d4-4ccb817cb2aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_25-10-2021_1144.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8acefe7-076b-45a3-a4d4-4ccb817cb2aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/6549a93f-a03a-4e97-9e4a-a80deef113e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6549a93f-a03a-4e97-9e4a-a80deef113e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_27-06-2022_2798.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6549a93f-a03a-4e97-9e4a-a80deef113e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/359b751d-8706-4274-8969-68eba160922d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "359b751d-8706-4274-8969-68eba160922d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_27-06-2022_2817.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/359b751d-8706-4274-8969-68eba160922d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9895243-ab49-4048-8349-cb31f8fefb18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9895243-ab49-4048-8349-cb31f8fefb18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_27-06-2022_2818.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9895243-ab49-4048-8349-cb31f8fefb18>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7c0a46d-b5ba-43b0-8aef-8a0ee3950745> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7c0a46d-b5ba-43b0-8aef-8a0ee3950745";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_27-06-2022_2843.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7c0a46d-b5ba-43b0-8aef-8a0ee3950745>.
+    
+<http://data.lblod.info/id/remote-data-objects/41195294-e1f7-47a5-b627-890ddc78b007> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41195294-e1f7-47a5-b627-890ddc78b007";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_27-06-2022_2844.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41195294-e1f7-47a5-b627-890ddc78b007>.
+    
+<http://data.lblod.info/id/remote-data-objects/7532fed4-6079-4b48-b9f7-930f57196884> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7532fed4-6079-4b48-b9f7-930f57196884";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_28-03-2022_1803.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7532fed4-6079-4b48-b9f7-930f57196884>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc062a32-aa4d-4210-a4c8-76575ea30e4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc062a32-aa4d-4210-a4c8-76575ea30e4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_28-03-2022_1968.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc062a32-aa4d-4210-a4c8-76575ea30e4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/803879af-ee25-4115-84e0-8fd4fcdb0114> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "803879af-ee25-4115-84e0-8fd4fcdb0114";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_28-03-2022_2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/803879af-ee25-4115-84e0-8fd4fcdb0114>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd0ee3a2-26a1-446f-aac8-5c0d3e75280c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd0ee3a2-26a1-446f-aac8-5c0d3e75280c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_28-03-2022_2025.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd0ee3a2-26a1-446f-aac8-5c0d3e75280c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a04fbc0-cb76-45e4-af27-65abde08fccb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a04fbc0-cb76-45e4-af27-65abde08fccb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_29-11-2021_1268.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a04fbc0-cb76-45e4-af27-65abde08fccb>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4e9c18e-2ece-4999-8355-eb2c5087c8ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4e9c18e-2ece-4999-8355-eb2c5087c8ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_29-11-2021_1271.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4e9c18e-2ece-4999-8355-eb2c5087c8ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/125e0e07-28e9-4e60-bb1f-23370e608687> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "125e0e07-28e9-4e60-bb1f-23370e608687";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_29-11-2021_1276.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/125e0e07-28e9-4e60-bb1f-23370e608687>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c8a2319-ac28-4a77-8e67-3aac660ff316> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c8a2319-ac28-4a77-8e67-3aac660ff316";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_29-11-2021_1277.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c8a2319-ac28-4a77-8e67-3aac660ff316>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce29494d-67f9-4a48-9e5d-7366bbb816c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce29494d-67f9-4a48-9e5d-7366bbb816c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_29-11-2021_1279.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce29494d-67f9-4a48-9e5d-7366bbb816c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b716705e-e8a7-4c37-8daf-e413c85d099b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b716705e-e8a7-4c37-8daf-e413c85d099b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_29-11-2021_1290.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b716705e-e8a7-4c37-8daf-e413c85d099b>.
+    
+<http://data.lblod.info/id/remote-data-objects/adc9e696-0df0-49bd-9536-015ba8157807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "adc9e696-0df0-49bd-9536-015ba8157807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_30-05-2022_2001.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/adc9e696-0df0-49bd-9536-015ba8157807>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f31a9f1-2c83-436d-99f6-7bd9d74771fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f31a9f1-2c83-436d-99f6-7bd9d74771fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_30-05-2022_2541.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f31a9f1-2c83-436d-99f6-7bd9d74771fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5350830-a9a2-42dc-b508-ebc19fbc66e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5350830-a9a2-42dc-b508-ebc19fbc66e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_30-05-2022_2673.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5350830-a9a2-42dc-b508-ebc19fbc66e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/401ac497-af8a-4f9e-a4dd-8b19087aa86a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "401ac497-af8a-4f9e-a4dd-8b19087aa86a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_30-05-2022_2693.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/401ac497-af8a-4f9e-a4dd-8b19087aa86a>.
+    
+<http://data.lblod.info/id/remote-data-objects/410c656d-c57a-44d8-a4bb-f2df5863f6ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "410c656d-c57a-44d8-a4bb-f2df5863f6ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_31-01-2022_1462.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/410c656d-c57a-44d8-a4bb-f2df5863f6ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f0cd675-d3a8-45fd-8cb0-4a6bccc2963d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f0cd675-d3a8-45fd-8cb0-4a6bccc2963d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_31-01-2022_1495.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f0cd675-d3a8-45fd-8cb0-4a6bccc2963d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa06a6ef-ae96-44fb-bd61-c9a4f96edd32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa06a6ef-ae96-44fb-bd61-c9a4f96edd32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_31-01-2022_1605.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa06a6ef-ae96-44fb-bd61-c9a4f96edd32>.
+    
+<http://data.lblod.info/id/remote-data-objects/a84c99ad-36d0-4bd0-91b3-dfcdc584efff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a84c99ad-36d0-4bd0-91b3-dfcdc584efff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_31-01-2022_1616.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a84c99ad-36d0-4bd0-91b3-dfcdc584efff>.
+    
+<http://data.lblod.info/id/remote-data-objects/397c1e43-45f9-41f3-b2e1-12927bc92d9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "397c1e43-45f9-41f3-b2e1-12927bc92d9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_31-01-2022_1617.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/397c1e43-45f9-41f3-b2e1-12927bc92d9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0df3e00-75a8-4c20-90e8-cb906c7a6990> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0df3e00-75a8-4c20-90e8-cb906c7a6990";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/668db10d7b3c31570068d134ef72d04a1778fad99f544d9458c6b8f755bc5a5b/GetPublication?filename=Uittreksels_31-01-2022_1618.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0df3e00-75a8-4c20-90e8-cb906c7a6990>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bb1009e-687f-4800-9530-3af1e0c10cde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bb1009e-687f-4800-9530-3af1e0c10cde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_01-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bb1009e-687f-4800-9530-3af1e0c10cde>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb988b1f-9708-48fb-a12a-7d05269aa181> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb988b1f-9708-48fb-a12a-7d05269aa181";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_01-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb988b1f-9708-48fb-a12a-7d05269aa181>.
+    
+<http://data.lblod.info/id/remote-data-objects/49937c94-3db4-416e-9371-32bbebb542f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49937c94-3db4-416e-9371-32bbebb542f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_02-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49937c94-3db4-416e-9371-32bbebb542f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2a6517b-17c2-4439-8864-e366531a5486> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2a6517b-17c2-4439-8864-e366531a5486";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2a6517b-17c2-4439-8864-e366531a5486>.
+    
+<http://data.lblod.info/id/remote-data-objects/554cc8e6-b57b-4703-99ce-25e3bf23e665> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "554cc8e6-b57b-4703-99ce-25e3bf23e665";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cb12c2ae-5979-4fe1-ac67-2f11f020c744> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/554cc8e6-b57b-4703-99ce-25e3bf23e665>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201754-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201754-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201754-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201754-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/bf1b631b-c231-4163-8b90-5276d016e2c1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bf1b631b-c231-4163-8b90-5276d016e2c1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "81fcfef9-fbb1-4adc-87bf-7ee93c564ef9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/2e25fb49-58f0-4ba2-a5bd-6c78a81ecbd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2e25fb49-58f0-4ba2-a5bd-6c78a81ecbd2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9>.
+
+  <http://redpencil.data.gift/id/task/fccc72d6-c99f-410e-b167-e5d1feaacdfa> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fccc72d6-c99f-410e-b167-e5d1feaacdfa";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/bf1b631b-c231-4163-8b90-5276d016e2c1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/2e25fb49-58f0-4ba2-a5bd-6c78a81ecbd2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/95a1daa1-2915-4a9a-97ee-c59518d42f8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95a1daa1-2915-4a9a-97ee-c59518d42f8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_14-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95a1daa1-2915-4a9a-97ee-c59518d42f8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/91ef5cae-37fc-45ab-abc0-ec56566f22fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91ef5cae-37fc-45ab-abc0-ec56566f22fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91ef5cae-37fc-45ab-abc0-ec56566f22fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/a050a997-befc-4dcf-b686-1a4601e43470> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a050a997-befc-4dcf-b686-1a4601e43470";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_17-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a050a997-befc-4dcf-b686-1a4601e43470>.
+    
+<http://data.lblod.info/id/remote-data-objects/07c679d2-3229-46b5-bffc-d07648def6b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07c679d2-3229-46b5-bffc-d07648def6b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_21-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07c679d2-3229-46b5-bffc-d07648def6b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfa82036-949c-418b-967d-371ebffe140f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfa82036-949c-418b-967d-371ebffe140f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfa82036-949c-418b-967d-371ebffe140f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e37c1eed-9339-46a9-9058-d1192c59337e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e37c1eed-9339-46a9-9058-d1192c59337e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_23-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e37c1eed-9339-46a9-9058-d1192c59337e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b59c22a-009f-4a54-9ef1-78c538cf65c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b59c22a-009f-4a54-9ef1-78c538cf65c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b59c22a-009f-4a54-9ef1-78c538cf65c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/866b0e71-a172-499e-b062-bdd5b2c757e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "866b0e71-a172-499e-b062-bdd5b2c757e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_25-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/866b0e71-a172-499e-b062-bdd5b2c757e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c3757e5-a264-4de5-86a5-b2c4ae05ce09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c3757e5-a264-4de5-86a5-b2c4ae05ce09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=BesluitenLijstUitspraak_Besluiten%20burgemeester_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c3757e5-a264-4de5-86a5-b2c4ae05ce09>.
+    
+<http://data.lblod.info/id/remote-data-objects/e558e695-2aea-4124-85d9-23f08937d356> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e558e695-2aea-4124-85d9-23f08937d356";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=Uittreksels_01-07-2022_2971.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e558e695-2aea-4124-85d9-23f08937d356>.
+    
+<http://data.lblod.info/id/remote-data-objects/1530b865-1963-4861-80de-b6c6ee6d9ff4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1530b865-1963-4861-80de-b6c6ee6d9ff4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=Uittreksels_04-04-2022_2439.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1530b865-1963-4861-80de-b6c6ee6d9ff4>.
+    
+<http://data.lblod.info/id/remote-data-objects/18b22038-46c8-43cf-bd66-a064f0ef1b04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18b22038-46c8-43cf-bd66-a064f0ef1b04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=Uittreksels_07-06-2022_2782.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18b22038-46c8-43cf-bd66-a064f0ef1b04>.
+    
+<http://data.lblod.info/id/remote-data-objects/811eb5c6-0bda-48fb-9338-27e63bcd0042> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "811eb5c6-0bda-48fb-9338-27e63bcd0042";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=Uittreksels_14-07-2022_3035.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/811eb5c6-0bda-48fb-9338-27e63bcd0042>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1f59bc5-9616-4e4e-a226-3e36284954d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1f59bc5-9616-4e4e-a226-3e36284954d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=Uittreksels_21-03-2022_2270.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1f59bc5-9616-4e4e-a226-3e36284954d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/96194cde-e529-41da-9385-27a103c2ded5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96194cde-e529-41da-9385-27a103c2ded5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=Uittreksels_21-03-2022_2271.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96194cde-e529-41da-9385-27a103c2ded5>.
+    
+<http://data.lblod.info/id/remote-data-objects/80f0c2b0-c98e-4b47-bb24-32c27941d6a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80f0c2b0-c98e-4b47-bb24-32c27941d6a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=Uittreksels_23-02-2022_2268.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80f0c2b0-c98e-4b47-bb24-32c27941d6a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f34280f-8f04-4d47-8072-00837c24881e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f34280f-8f04-4d47-8072-00837c24881e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=Uittreksels_23-02-2022_2269.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f34280f-8f04-4d47-8072-00837c24881e>.
+    
+<http://data.lblod.info/id/remote-data-objects/89952986-7745-4f74-a203-c6652513709b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89952986-7745-4f74-a203-c6652513709b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=Uittreksels_23-05-2022_2729.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89952986-7745-4f74-a203-c6652513709b>.
+    
+<http://data.lblod.info/id/remote-data-objects/593b5fd7-8f9b-46a3-99a1-00776ce61791> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "593b5fd7-8f9b-46a3-99a1-00776ce61791";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/71c0eb7bcec0fd24aedebd1ae7b813f777889c3a5bc561cd52ceaabb5840225f/GetPublication?filename=Uittreksels_25-05-2022_2730.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/593b5fd7-8f9b-46a3-99a1-00776ce61791>.
+    
+<http://data.lblod.info/id/remote-data-objects/df2977a8-9316-4cec-a26d-3f5a49ad1773> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df2977a8-9316-4cec-a26d-3f5a49ad1773";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df2977a8-9316-4cec-a26d-3f5a49ad1773>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c7f2262-f523-41bd-b7c8-6974a5b9df36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c7f2262-f523-41bd-b7c8-6974a5b9df36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c7f2262-f523-41bd-b7c8-6974a5b9df36>.
+    
+<http://data.lblod.info/id/remote-data-objects/de0a4743-1cc9-4ae0-a413-4903079d655f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de0a4743-1cc9-4ae0-a413-4903079d655f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de0a4743-1cc9-4ae0-a413-4903079d655f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e5e46fc-c550-43d5-b72a-ef10878aace7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e5e46fc-c550-43d5-b72a-ef10878aace7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e5e46fc-c550-43d5-b72a-ef10878aace7>.
+    
+<http://data.lblod.info/id/remote-data-objects/72e2bafc-ff16-4625-bf30-e3f4db2a0c2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72e2bafc-ff16-4625-bf30-e3f4db2a0c2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72e2bafc-ff16-4625-bf30-e3f4db2a0c2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2721958-a789-4b3b-8b17-9c6fbeb948af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2721958-a789-4b3b-8b17-9c6fbeb948af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2721958-a789-4b3b-8b17-9c6fbeb948af>.
+    
+<http://data.lblod.info/id/remote-data-objects/7aab2363-5c3d-4e88-ac98-a30cff9a9391> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7aab2363-5c3d-4e88-ac98-a30cff9a9391";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7aab2363-5c3d-4e88-ac98-a30cff9a9391>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a23d25f-2565-4007-81a4-5e2c05a92fc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a23d25f-2565-4007-81a4-5e2c05a92fc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a23d25f-2565-4007-81a4-5e2c05a92fc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbcfeb0d-0213-4581-b0be-c4f8094b84ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbcfeb0d-0213-4581-b0be-c4f8094b84ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbcfeb0d-0213-4581-b0be-c4f8094b84ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/b05d74dc-ed4d-4dad-b99f-4ca9d668941d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b05d74dc-ed4d-4dad-b99f-4ca9d668941d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b05d74dc-ed4d-4dad-b99f-4ca9d668941d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bfa7d9c-2bde-4ddd-acee-d18da52ea493> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bfa7d9c-2bde-4ddd-acee-d18da52ea493";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bfa7d9c-2bde-4ddd-acee-d18da52ea493>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ad88104-407f-4e0d-b4ef-ade2803437c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ad88104-407f-4e0d-b4ef-ade2803437c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ad88104-407f-4e0d-b4ef-ade2803437c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c96dc63b-a7bb-4f1d-89b8-fed9488a6f48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c96dc63b-a7bb-4f1d-89b8-fed9488a6f48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c96dc63b-a7bb-4f1d-89b8-fed9488a6f48>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0ef86d2-9302-4192-a142-05e741bea0bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0ef86d2-9302-4192-a142-05e741bea0bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0ef86d2-9302-4192-a142-05e741bea0bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d780a91-c438-4207-98ba-4016212eb512> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d780a91-c438-4207-98ba-4016212eb512";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d780a91-c438-4207-98ba-4016212eb512>.
+    
+<http://data.lblod.info/id/remote-data-objects/4549c3be-4294-49eb-a30b-88f43990d31c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4549c3be-4294-49eb-a30b-88f43990d31c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4549c3be-4294-49eb-a30b-88f43990d31c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f841809-11b2-4343-a8ce-6cc4211ae033> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f841809-11b2-4343-a8ce-6cc4211ae033";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=BesluitenLijstUitspraak_Raad%20voor%20maatschappelijk%20welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f841809-11b2-4343-a8ce-6cc4211ae033>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf2375c3-79b1-4586-b9df-4b887955bbcf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf2375c3-79b1-4586-b9df-4b887955bbcf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf2375c3-79b1-4586-b9df-4b887955bbcf>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca139a97-80fe-434e-b2e2-277a31ce779f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca139a97-80fe-434e-b2e2-277a31ce779f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca139a97-80fe-434e-b2e2-277a31ce779f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e50d7d4d-a9b0-44aa-bcb3-787ba85b4ae6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e50d7d4d-a9b0-44aa-bcb3-787ba85b4ae6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e50d7d4d-a9b0-44aa-bcb3-787ba85b4ae6>.
+    
+<http://data.lblod.info/id/remote-data-objects/805cfccf-871f-4f7f-b509-820e26d72d51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "805cfccf-871f-4f7f-b509-820e26d72d51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/805cfccf-871f-4f7f-b509-820e26d72d51>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae7c1b42-1add-45ad-bc0c-f971e69ab4f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae7c1b42-1add-45ad-bc0c-f971e69ab4f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae7c1b42-1add-45ad-bc0c-f971e69ab4f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebfae41a-b63b-485f-a649-b994038e123d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebfae41a-b63b-485f-a649-b994038e123d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebfae41a-b63b-485f-a649-b994038e123d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e541f678-41d4-4a48-b0b1-140f44f33e86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e541f678-41d4-4a48-b0b1-140f44f33e86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e541f678-41d4-4a48-b0b1-140f44f33e86>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5a4f4a1-df27-41b7-bd7f-503a46fc9e5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5a4f4a1-df27-41b7-bd7f-503a46fc9e5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5a4f4a1-df27-41b7-bd7f-503a46fc9e5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/60a95c03-8736-44b7-ad50-2430fb1494e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60a95c03-8736-44b7-ad50-2430fb1494e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Uittreksels_20-12-2021_1400.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60a95c03-8736-44b7-ad50-2430fb1494e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d2d509b-bf96-48f1-93f4-ef2479508945> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d2d509b-bf96-48f1-93f4-ef2479508945";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Uittreksels_20-12-2021_1401.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d2d509b-bf96-48f1-93f4-ef2479508945>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1fe6d74-4d2b-433f-b1fb-76d5400efa25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1fe6d74-4d2b-433f-b1fb-76d5400efa25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Uittreksels_25-10-2021_1132.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1fe6d74-4d2b-433f-b1fb-76d5400efa25>.
+    
+<http://data.lblod.info/id/remote-data-objects/69f258f1-526e-47e9-b84c-f672ff6b1a1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69f258f1-526e-47e9-b84c-f672ff6b1a1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Uittreksels_27-06-2022_1589.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69f258f1-526e-47e9-b84c-f672ff6b1a1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/140cda05-cf94-4353-8fdf-396362c48f95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "140cda05-cf94-4353-8fdf-396362c48f95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Uittreksels_27-06-2022_2800.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/140cda05-cf94-4353-8fdf-396362c48f95>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b9ff6d9-601b-4fb4-b4a5-a463255734cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b9ff6d9-601b-4fb4-b4a5-a463255734cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Uittreksels_29-11-2021_1285.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/81fcfef9-fbb1-4adc-87bf-7ee93c564ef9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b9ff6d9-601b-4fb4-b4a5-a463255734cc>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201755-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201755-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201755-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201755-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/cf794a1a-fa9c-4476-97fb-4a4240e32973> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cf794a1a-fa9c-4476-97fb-4a4240e32973";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a1e4852e-db7b-4ef7-851b-1787d558c583";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/1459601f-ea57-45e6-bf83-732b1660e7e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1459601f-ea57-45e6-bf83-732b1660e7e8";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583>.
+
+  <http://redpencil.data.gift/id/task/6ef4fd74-0335-4ca4-89dd-f188d6b1427d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6ef4fd74-0335-4ca4-89dd-f188d6b1427d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/cf794a1a-fa9c-4476-97fb-4a4240e32973>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/1459601f-ea57-45e6-bf83-732b1660e7e8>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/3c68ed14-6fc4-4be8-9deb-83667ddedde7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c68ed14-6fc4-4be8-9deb-83667ddedde7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Uittreksels_30-05-2022_2699.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c68ed14-6fc4-4be8-9deb-83667ddedde7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff9f4e0b-c325-4165-9b25-f50128186332> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff9f4e0b-c325-4165-9b25-f50128186332";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Uittreksels_31-01-2022_1588.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff9f4e0b-c325-4165-9b25-f50128186332>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ac301e9-3b0c-48be-ace4-9dde0d68cd3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ac301e9-3b0c-48be-ace4-9dde0d68cd3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/8e0dbd41949800c14b3a96bc0fc078ba456f1eebd9380c2bc7846870a6b388b4/GetPublication?filename=Uittreksels_31-01-2022_1606.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ac301e9-3b0c-48be-ace4-9dde0d68cd3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/13620363-8dad-486c-9230-b2aaf596f4a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13620363-8dad-486c-9230-b2aaf596f4a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_01-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13620363-8dad-486c-9230-b2aaf596f4a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/c434119b-4f05-4185-9e5a-42841bff8e23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c434119b-4f05-4185-9e5a-42841bff8e23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_03-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c434119b-4f05-4185-9e5a-42841bff8e23>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa1c34db-2c84-40b3-9ba8-c2fca7097694> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa1c34db-2c84-40b3-9ba8-c2fca7097694";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_03-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa1c34db-2c84-40b3-9ba8-c2fca7097694>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0144b92-f8c0-4867-a1ba-f258c043d6e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0144b92-f8c0-4867-a1ba-f258c043d6e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0144b92-f8c0-4867-a1ba-f258c043d6e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/05177ae6-10b7-479b-b3ce-64806a282d69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05177ae6-10b7-479b-b3ce-64806a282d69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_05-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05177ae6-10b7-479b-b3ce-64806a282d69>.
+    
+<http://data.lblod.info/id/remote-data-objects/07fc52e2-76fa-4b5b-a3ab-327a5abe6b15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07fc52e2-76fa-4b5b-a3ab-327a5abe6b15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_07-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07fc52e2-76fa-4b5b-a3ab-327a5abe6b15>.
+    
+<http://data.lblod.info/id/remote-data-objects/11cbe9dc-51cc-425b-8274-ebef1b96da28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11cbe9dc-51cc-425b-8274-ebef1b96da28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_08-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11cbe9dc-51cc-425b-8274-ebef1b96da28>.
+    
+<http://data.lblod.info/id/remote-data-objects/108041f9-e64d-4ef0-b1b9-21a0dd285bb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "108041f9-e64d-4ef0-b1b9-21a0dd285bb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_09-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/108041f9-e64d-4ef0-b1b9-21a0dd285bb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8585febf-05eb-45a0-bc71-e4c681ef2e2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8585febf-05eb-45a0-bc71-e4c681ef2e2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8585febf-05eb-45a0-bc71-e4c681ef2e2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/01d473bd-749f-4f57-b957-638757e70792> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01d473bd-749f-4f57-b957-638757e70792";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_11-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01d473bd-749f-4f57-b957-638757e70792>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b445752-b497-424a-8bef-097848c9e79c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b445752-b497-424a-8bef-097848c9e79c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b445752-b497-424a-8bef-097848c9e79c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6b24b3c-06c0-479a-81b1-2baa6e68f087> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6b24b3c-06c0-479a-81b1-2baa6e68f087";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_14-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6b24b3c-06c0-479a-81b1-2baa6e68f087>.
+    
+<http://data.lblod.info/id/remote-data-objects/80d50dac-ba6f-4db7-b142-ef51c24298e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80d50dac-ba6f-4db7-b142-ef51c24298e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80d50dac-ba6f-4db7-b142-ef51c24298e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6c3ffd6-207b-4ac9-9e2e-fb11293c3d88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6c3ffd6-207b-4ac9-9e2e-fb11293c3d88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6c3ffd6-207b-4ac9-9e2e-fb11293c3d88>.
+    
+<http://data.lblod.info/id/remote-data-objects/41843b2a-1934-4275-b8f7-f9eb84ed5cb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41843b2a-1934-4275-b8f7-f9eb84ed5cb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41843b2a-1934-4275-b8f7-f9eb84ed5cb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d7e4662-431a-4eb2-b0c6-8beae4d295aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d7e4662-431a-4eb2-b0c6-8beae4d295aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_17-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d7e4662-431a-4eb2-b0c6-8beae4d295aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/b75d8b5a-1569-447e-8bc0-2263aedda6d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b75d8b5a-1569-447e-8bc0-2263aedda6d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b75d8b5a-1569-447e-8bc0-2263aedda6d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4fe5cd2-30b6-4172-b8c4-751bffb07b90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4fe5cd2-30b6-4172-b8c4-751bffb07b90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_18-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4fe5cd2-30b6-4172-b8c4-751bffb07b90>.
+    
+<http://data.lblod.info/id/remote-data-objects/a833f386-9865-4053-8ea7-7949b2942426> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a833f386-9865-4053-8ea7-7949b2942426";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a833f386-9865-4053-8ea7-7949b2942426>.
+    
+<http://data.lblod.info/id/remote-data-objects/1df09767-c98e-48a4-aa55-b22becc465cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1df09767-c98e-48a4-aa55-b22becc465cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1df09767-c98e-48a4-aa55-b22becc465cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/366f5afc-fff6-4079-a0dc-40333ee8411a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "366f5afc-fff6-4079-a0dc-40333ee8411a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_21-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/366f5afc-fff6-4079-a0dc-40333ee8411a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b94f6b8c-0042-4ca4-b99a-3ea2460e043c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b94f6b8c-0042-4ca4-b99a-3ea2460e043c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_22-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b94f6b8c-0042-4ca4-b99a-3ea2460e043c>.
+    
+<http://data.lblod.info/id/remote-data-objects/796c0349-5ec5-4c35-a60c-d8de50f68e9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "796c0349-5ec5-4c35-a60c-d8de50f68e9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_23-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/796c0349-5ec5-4c35-a60c-d8de50f68e9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d842b33a-299b-4fcc-a220-1bbba8325cc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d842b33a-299b-4fcc-a220-1bbba8325cc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_24-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d842b33a-299b-4fcc-a220-1bbba8325cc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/0aa1f737-c1b3-4b30-b71e-05cca5e670db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0aa1f737-c1b3-4b30-b71e-05cca5e670db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0aa1f737-c1b3-4b30-b71e-05cca5e670db>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e724517-6576-4483-ae45-5c24c53af78c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e724517-6576-4483-ae45-5c24c53af78c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_25-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e724517-6576-4483-ae45-5c24c53af78c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f321579-4516-446a-8018-732881bafe3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f321579-4516-446a-8018-732881bafe3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_26-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f321579-4516-446a-8018-732881bafe3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/65aac8c2-441a-46f6-a37f-64ae4b14e3be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65aac8c2-441a-46f6-a37f-64ae4b14e3be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65aac8c2-441a-46f6-a37f-64ae4b14e3be>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7d41e6b-3022-4af5-86ea-bd4271b0f87a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7d41e6b-3022-4af5-86ea-bd4271b0f87a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7d41e6b-3022-4af5-86ea-bd4271b0f87a>.
+    
+<http://data.lblod.info/id/remote-data-objects/eab2e975-1a53-48b7-9120-bdb216d96f30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eab2e975-1a53-48b7-9120-bdb216d96f30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eab2e975-1a53-48b7-9120-bdb216d96f30>.
+    
+<http://data.lblod.info/id/remote-data-objects/510473e5-a6f4-451d-b977-921c9685bcb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "510473e5-a6f4-451d-b977-921c9685bcb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/510473e5-a6f4-451d-b977-921c9685bcb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/78882253-ba99-46d5-b5bb-a73664dbfe79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78882253-ba99-46d5-b5bb-a73664dbfe79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_29-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78882253-ba99-46d5-b5bb-a73664dbfe79>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c402616-9888-46e7-8b16-4c974c779020> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c402616-9888-46e7-8b16-4c974c779020";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=BesluitenLijstUitspraak_Vast%20Bureau_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c402616-9888-46e7-8b16-4c974c779020>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c450bf2-5fa9-4919-8c86-a6be683fab85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c450bf2-5fa9-4919-8c86-a6be683fab85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=Uittreksels_13-05-2022_2554.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c450bf2-5fa9-4919-8c86-a6be683fab85>.
+    
+<http://data.lblod.info/id/remote-data-objects/659d9676-7c4e-444c-bef8-cb9e36dde740> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "659d9676-7c4e-444c-bef8-cb9e36dde740";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zelzate.be/LBLODWeb/Home/Overzicht/ee795e94ca345bb6d99d8320bd527dee155c9ed85f7d47cd9c592b3c24fbd8ce/GetPublication?filename=Uittreksels_14-01-2022_1478.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/659d9676-7c4e-444c-bef8-cb9e36dde740>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbc8ccbf-2c8f-4997-b778-535f59f9d779> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbc8ccbf-2c8f-4997-b778-535f59f9d779";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbc8ccbf-2c8f-4997-b778-535f59f9d779>.
+    
+<http://data.lblod.info/id/remote-data-objects/65dcfc00-44db-4042-8102-0e7b3fe5c0f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65dcfc00-44db-4042-8102-0e7b3fe5c0f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65dcfc00-44db-4042-8102-0e7b3fe5c0f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cb7af6f-db46-4c61-a511-95d551fa2026> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cb7af6f-db46-4c61-a511-95d551fa2026";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cb7af6f-db46-4c61-a511-95d551fa2026>.
+    
+<http://data.lblod.info/id/remote-data-objects/83b31611-a560-4459-b548-365b2705474a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83b31611-a560-4459-b548-365b2705474a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83b31611-a560-4459-b548-365b2705474a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1f9b8c1-671d-4820-80de-bd36f2deb584> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1f9b8c1-671d-4820-80de-bd36f2deb584";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1f9b8c1-671d-4820-80de-bd36f2deb584>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a6c6ec4-2ad8-4f93-8602-319fb7d2ff50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a6c6ec4-2ad8-4f93-8602-319fb7d2ff50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a6c6ec4-2ad8-4f93-8602-319fb7d2ff50>.
+    
+<http://data.lblod.info/id/remote-data-objects/d76730c6-b941-4b62-9181-f2b4e9cceab3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d76730c6-b941-4b62-9181-f2b4e9cceab3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d76730c6-b941-4b62-9181-f2b4e9cceab3>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ec617b6-cc61-413c-9eab-94db881f3a6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ec617b6-cc61-413c-9eab-94db881f3a6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ec617b6-cc61-413c-9eab-94db881f3a6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b16ba060-1fe4-4082-aa9c-4e65c085e311> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b16ba060-1fe4-4082-aa9c-4e65c085e311";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b16ba060-1fe4-4082-aa9c-4e65c085e311>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ef2651e-2703-458b-9e5c-5cf649bf9614> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ef2651e-2703-458b-9e5c-5cf649bf9614";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ef2651e-2703-458b-9e5c-5cf649bf9614>.
+    
+<http://data.lblod.info/id/remote-data-objects/4feabd53-a902-4032-a44f-ef888fa3549e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4feabd53-a902-4032-a44f-ef888fa3549e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4feabd53-a902-4032-a44f-ef888fa3549e>.
+    
+<http://data.lblod.info/id/remote-data-objects/11b67f15-a4d8-4242-96af-4719957124de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11b67f15-a4d8-4242-96af-4719957124de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a1e4852e-db7b-4ef7-851b-1787d558c583> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11b67f15-a4d8-4242-96af-4719957124de>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201756-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201756-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201756-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201756-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/02c21d1a-cfec-4f7b-8398-b73ea0f56929> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "02c21d1a-cfec-4f7b-8398-b73ea0f56929";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a4ba4842-3373-4a34-ae2e-6b91e5b833ea";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/471756a2-2d2c-48f2-87bf-605c51ec89fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "471756a2-2d2c-48f2-87bf-605c51ec89fe";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea>.
+
+  <http://redpencil.data.gift/id/task/59052b98-3c9c-4211-8a43-b59677c438d6> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "59052b98-3c9c-4211-8a43-b59677c438d6";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/02c21d1a-cfec-4f7b-8398-b73ea0f56929>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/471756a2-2d2c-48f2-87bf-605c51ec89fe>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/1523e35b-fc28-44f9-9166-b654d360000e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1523e35b-fc28-44f9-9166-b654d360000e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1523e35b-fc28-44f9-9166-b654d360000e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9df1ba08-aec3-4562-b596-db611311076d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9df1ba08-aec3-4562-b596-db611311076d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9df1ba08-aec3-4562-b596-db611311076d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3059bac3-29f7-42c2-8be9-afcb32391e65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3059bac3-29f7-42c2-8be9-afcb32391e65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3059bac3-29f7-42c2-8be9-afcb32391e65>.
+    
+<http://data.lblod.info/id/remote-data-objects/56352b56-6337-4dd2-bc4f-3df066f4f7ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56352b56-6337-4dd2-bc4f-3df066f4f7ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56352b56-6337-4dd2-bc4f-3df066f4f7ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/228bc2ea-510f-4019-afd1-3b978b9f6fa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "228bc2ea-510f-4019-afd1-3b978b9f6fa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/228bc2ea-510f-4019-afd1-3b978b9f6fa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebdc6ee3-0314-4c61-8096-4e0bd654efe0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebdc6ee3-0314-4c61-8096-4e0bd654efe0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebdc6ee3-0314-4c61-8096-4e0bd654efe0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c288836-6a1d-43d6-a013-ef754b7f75a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c288836-6a1d-43d6-a013-ef754b7f75a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c288836-6a1d-43d6-a013-ef754b7f75a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/2310ccd4-57a5-47c3-b779-10dc3897798d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2310ccd4-57a5-47c3-b779-10dc3897798d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2310ccd4-57a5-47c3-b779-10dc3897798d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ff1e203-fb70-4c90-a4de-6c2c17d14633> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ff1e203-fb70-4c90-a4de-6c2c17d14633";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ff1e203-fb70-4c90-a4de-6c2c17d14633>.
+    
+<http://data.lblod.info/id/remote-data-objects/a642d2cc-48ec-4bba-8d29-fd698c1b66c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a642d2cc-48ec-4bba-8d29-fd698c1b66c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a642d2cc-48ec-4bba-8d29-fd698c1b66c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e007997-6978-487f-988e-7415629975c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e007997-6978-487f-988e-7415629975c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e007997-6978-487f-988e-7415629975c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2936a690-e7b4-4689-aa88-1330018cf5cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2936a690-e7b4-4689-aa88-1330018cf5cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2936a690-e7b4-4689-aa88-1330018cf5cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/03b853e3-a9dd-4d9e-8c11-73c1a8a45a94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03b853e3-a9dd-4d9e-8c11-73c1a8a45a94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03b853e3-a9dd-4d9e-8c11-73c1a8a45a94>.
+    
+<http://data.lblod.info/id/remote-data-objects/71446aaf-9e3a-448a-818c-b503b7b8d97f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71446aaf-9e3a-448a-818c-b503b7b8d97f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71446aaf-9e3a-448a-818c-b503b7b8d97f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecec84e1-b60a-463e-9e2f-f0c1da1e0f53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecec84e1-b60a-463e-9e2f-f0c1da1e0f53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecec84e1-b60a-463e-9e2f-f0c1da1e0f53>.
+    
+<http://data.lblod.info/id/remote-data-objects/22b1d9da-c966-4ee7-9e80-cd8761e4ebcb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22b1d9da-c966-4ee7-9e80-cd8761e4ebcb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22b1d9da-c966-4ee7-9e80-cd8761e4ebcb>.
+    
+<http://data.lblod.info/id/remote-data-objects/88f6ed38-6ac2-4bd5-aed7-502074c59162> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88f6ed38-6ac2-4bd5-aed7-502074c59162";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88f6ed38-6ac2-4bd5-aed7-502074c59162>.
+    
+<http://data.lblod.info/id/remote-data-objects/28f78413-0ac3-42a7-b5b2-3643d4368ee1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28f78413-0ac3-42a7-b5b2-3643d4368ee1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28f78413-0ac3-42a7-b5b2-3643d4368ee1>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd5b25b4-c13c-4fe6-ab42-06592bdb745c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd5b25b4-c13c-4fe6-ab42-06592bdb745c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd5b25b4-c13c-4fe6-ab42-06592bdb745c>.
+    
+<http://data.lblod.info/id/remote-data-objects/17d4c1f5-0aef-451e-a351-4134597a6417> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17d4c1f5-0aef-451e-a351-4134597a6417";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17d4c1f5-0aef-451e-a351-4134597a6417>.
+    
+<http://data.lblod.info/id/remote-data-objects/d66333d7-603a-4498-bfcc-65c865383d6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d66333d7-603a-4498-bfcc-65c865383d6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d66333d7-603a-4498-bfcc-65c865383d6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/cef3ca72-17f6-4254-b58a-b539c803d5e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cef3ca72-17f6-4254-b58a-b539c803d5e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cef3ca72-17f6-4254-b58a-b539c803d5e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/751a6f0a-3733-4c13-9b11-f4f942fff214> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "751a6f0a-3733-4c13-9b11-f4f942fff214";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/751a6f0a-3733-4c13-9b11-f4f942fff214>.
+    
+<http://data.lblod.info/id/remote-data-objects/354ed01c-422b-4007-88b1-658932cfaf0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "354ed01c-422b-4007-88b1-658932cfaf0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/354ed01c-422b-4007-88b1-658932cfaf0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0be2e98-372f-4727-bd2c-07895be66b0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0be2e98-372f-4727-bd2c-07895be66b0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0be2e98-372f-4727-bd2c-07895be66b0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/05c4a7d1-6921-4f3b-af6b-106f6c17778f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05c4a7d1-6921-4f3b-af6b-106f6c17778f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=BesluitenLijst_College%20van%20Burgemeester%20en%20Schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05c4a7d1-6921-4f3b-af6b-106f6c17778f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffb130be-d4d1-4a69-b59c-4e361d6d2af6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffb130be-d4d1-4a69-b59c-4e361d6d2af6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_04-04-2022_40241.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffb130be-d4d1-4a69-b59c-4e361d6d2af6>.
+    
+<http://data.lblod.info/id/remote-data-objects/924f15b0-ec81-4e11-a248-e665217f740f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "924f15b0-ec81-4e11-a248-e665217f740f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_04-07-2022_43716.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/924f15b0-ec81-4e11-a248-e665217f740f>.
+    
+<http://data.lblod.info/id/remote-data-objects/734ad97e-0fdd-401f-b168-d35672964ef0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "734ad97e-0fdd-401f-b168-d35672964ef0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_04-07-2022_44954.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/734ad97e-0fdd-401f-b168-d35672964ef0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5101af2-2b4f-4047-9782-3c19921e1e16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5101af2-2b4f-4047-9782-3c19921e1e16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_04-07-2022_44959.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5101af2-2b4f-4047-9782-3c19921e1e16>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad2cd7f6-b49d-4a85-b9d7-3ebbc7ebdd3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad2cd7f6-b49d-4a85-b9d7-3ebbc7ebdd3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_04-07-2022_46006.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad2cd7f6-b49d-4a85-b9d7-3ebbc7ebdd3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7580880-5e83-40c5-bf21-55e9759de171> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7580880-5e83-40c5-bf21-55e9759de171";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_04-07-2022_46057.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7580880-5e83-40c5-bf21-55e9759de171>.
+    
+<http://data.lblod.info/id/remote-data-objects/4584ab34-0de8-4095-9c0d-ff21e6d19f00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4584ab34-0de8-4095-9c0d-ff21e6d19f00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_07-03-2022_36881.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4584ab34-0de8-4095-9c0d-ff21e6d19f00>.
+    
+<http://data.lblod.info/id/remote-data-objects/51fa8b55-bbb5-4d02-98c2-ec84a7b05ffe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51fa8b55-bbb5-4d02-98c2-ec84a7b05ffe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_07-03-2022_36936.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51fa8b55-bbb5-4d02-98c2-ec84a7b05ffe>.
+    
+<http://data.lblod.info/id/remote-data-objects/feb5bd59-44d8-4817-b8b1-96fb178b3878> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "feb5bd59-44d8-4817-b8b1-96fb178b3878";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_07-03-2022_37974.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/feb5bd59-44d8-4817-b8b1-96fb178b3878>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2f5e3a1-9ec8-492e-8502-2227da0a3a98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2f5e3a1-9ec8-492e-8502-2227da0a3a98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_07-03-2022_38003.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2f5e3a1-9ec8-492e-8502-2227da0a3a98>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd1013ab-6091-4306-afc0-f4b8f7803aa7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd1013ab-6091-4306-afc0-f4b8f7803aa7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_07-03-2022_38061.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd1013ab-6091-4306-afc0-f4b8f7803aa7>.
+    
+<http://data.lblod.info/id/remote-data-objects/739ff5cd-beec-41ee-a0ee-a752565497f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "739ff5cd-beec-41ee-a0ee-a752565497f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_08-11-2021_30995.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/739ff5cd-beec-41ee-a0ee-a752565497f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/75c50075-5088-422a-a4eb-c511a89714f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75c50075-5088-422a-a4eb-c511a89714f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_09-05-2022_42549.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75c50075-5088-422a-a4eb-c511a89714f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f72394a-e3b9-466a-8d0c-166649d79a1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f72394a-e3b9-466a-8d0c-166649d79a1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_09-05-2022_42632.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f72394a-e3b9-466a-8d0c-166649d79a1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/35ceedcb-309c-4f82-a11b-47ef308c8ad2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35ceedcb-309c-4f82-a11b-47ef308c8ad2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_11-04-2022_40275.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35ceedcb-309c-4f82-a11b-47ef308c8ad2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ddadbe2-2aba-470e-83a6-e4e818f62b7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ddadbe2-2aba-470e-83a6-e4e818f62b7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_11-04-2022_40401.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ddadbe2-2aba-470e-83a6-e4e818f62b7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac8d33b1-9a5a-4503-8596-e50ea6242801> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac8d33b1-9a5a-4503-8596-e50ea6242801";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_11-04-2022_41428.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac8d33b1-9a5a-4503-8596-e50ea6242801>.
+    
+<http://data.lblod.info/id/remote-data-objects/e97b71a3-94e6-4a15-9012-e61510ba2f22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e97b71a3-94e6-4a15-9012-e61510ba2f22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_13-06-2022_44875.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e97b71a3-94e6-4a15-9012-e61510ba2f22>.
+    
+<http://data.lblod.info/id/remote-data-objects/d023f310-0ad5-435b-85aa-1f2bcedbad35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d023f310-0ad5-435b-85aa-1f2bcedbad35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_13-06-2022_45947.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d023f310-0ad5-435b-85aa-1f2bcedbad35>.
+    
+<http://data.lblod.info/id/remote-data-objects/727d6408-cce2-46e7-9d5e-9223cc7587fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "727d6408-cce2-46e7-9d5e-9223cc7587fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_13-06-2022_46007.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/727d6408-cce2-46e7-9d5e-9223cc7587fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/1caa2937-5f34-42b2-b6fc-082023a8c4ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1caa2937-5f34-42b2-b6fc-082023a8c4ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_14-03-2022_36974.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1caa2937-5f34-42b2-b6fc-082023a8c4ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/6db53e2c-dbdf-4de9-a59e-f4e986cb4a64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6db53e2c-dbdf-4de9-a59e-f4e986cb4a64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_14-03-2022_37989.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6db53e2c-dbdf-4de9-a59e-f4e986cb4a64>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a95edde-8ccf-408d-976e-4a0264a66d0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a95edde-8ccf-408d-976e-4a0264a66d0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_14-03-2022_37993.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a95edde-8ccf-408d-976e-4a0264a66d0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce349f5c-2a11-41e2-b3a5-55106c032e22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce349f5c-2a11-41e2-b3a5-55106c032e22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_16-05-2022_40387.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4ba4842-3373-4a34-ae2e-6b91e5b833ea> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce349f5c-2a11-41e2-b3a5-55106c032e22>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201757-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201757-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201757-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201757-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/fe0fab9d-7f02-4033-a579-9c0a841e4c1c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fe0fab9d-7f02-4033-a579-9c0a841e4c1c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fc658f68-33d1-476a-80ca-7f1d3b41040e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/164205e1-8db9-4dba-95df-5593475a6a4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "164205e1-8db9-4dba-95df-5593475a6a4a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e>.
+
+  <http://redpencil.data.gift/id/task/4f35376a-d1fe-4f3f-bd3e-3b20df4ce7ce> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4f35376a-d1fe-4f3f-bd3e-3b20df4ce7ce";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/fe0fab9d-7f02-4033-a579-9c0a841e4c1c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/164205e1-8db9-4dba-95df-5593475a6a4a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/62905807-1f09-4076-a696-ba46c0af688d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62905807-1f09-4076-a696-ba46c0af688d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_20-06-2022_41492.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62905807-1f09-4076-a696-ba46c0af688d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e5999b8-db8f-464c-a074-a8968e7a4ca0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e5999b8-db8f-464c-a074-a8968e7a4ca0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_20-06-2022_41494.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e5999b8-db8f-464c-a074-a8968e7a4ca0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c122b828-04a6-4996-b685-e2c2d83ca82d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c122b828-04a6-4996-b685-e2c2d83ca82d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_20-06-2022_42555.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c122b828-04a6-4996-b685-e2c2d83ca82d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c6109f6-b3ca-4e5c-80bb-93d614096943> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c6109f6-b3ca-4e5c-80bb-93d614096943";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_20-06-2022_44832.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c6109f6-b3ca-4e5c-80bb-93d614096943>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2cbac2c-44f3-41a4-a04d-4de3d49f2d31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2cbac2c-44f3-41a4-a04d-4de3d49f2d31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_20-06-2022_46052.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2cbac2c-44f3-41a4-a04d-4de3d49f2d31>.
+    
+<http://data.lblod.info/id/remote-data-objects/c32711de-f550-4f02-92ae-fd9674f42819> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c32711de-f550-4f02-92ae-fd9674f42819";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_21-03-2022_36880.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c32711de-f550-4f02-92ae-fd9674f42819>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b59cf68-6dcc-4c42-bac1-0c44b3219b32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b59cf68-6dcc-4c42-bac1-0c44b3219b32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_21-03-2022_36937.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b59cf68-6dcc-4c42-bac1-0c44b3219b32>.
+    
+<http://data.lblod.info/id/remote-data-objects/77781119-d94f-407d-99f3-31d6614d4f37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77781119-d94f-407d-99f3-31d6614d4f37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_21-03-2022_36938.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77781119-d94f-407d-99f3-31d6614d4f37>.
+    
+<http://data.lblod.info/id/remote-data-objects/1686ebe5-0a09-4fc4-9bd3-d5045e3256ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1686ebe5-0a09-4fc4-9bd3-d5045e3256ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_21-03-2022_39136.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1686ebe5-0a09-4fc4-9bd3-d5045e3256ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7859dde-de46-4d73-ba66-53bb2a1e31a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7859dde-de46-4d73-ba66-53bb2a1e31a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_21-03-2022_40231.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7859dde-de46-4d73-ba66-53bb2a1e31a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/78275f59-ccc1-493a-a453-c0a0b50b2b55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78275f59-ccc1-493a-a453-c0a0b50b2b55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_23-05-2022_41490.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78275f59-ccc1-493a-a453-c0a0b50b2b55>.
+    
+<http://data.lblod.info/id/remote-data-objects/843bd6f6-038f-49a3-a141-b9dcd0351f8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "843bd6f6-038f-49a3-a141-b9dcd0351f8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_23-05-2022_43799.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/843bd6f6-038f-49a3-a141-b9dcd0351f8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fc80961-5b8d-4710-a6ee-6f3beb18da55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fc80961-5b8d-4710-a6ee-6f3beb18da55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-04-2022_39127.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fc80961-5b8d-4710-a6ee-6f3beb18da55>.
+    
+<http://data.lblod.info/id/remote-data-objects/97b5fad2-1481-4c60-895f-761158adcef2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97b5fad2-1481-4c60-895f-761158adcef2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-04-2022_39129.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97b5fad2-1481-4c60-895f-761158adcef2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6a1dc35-eef8-41a4-96e8-030a458a8c42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6a1dc35-eef8-41a4-96e8-030a458a8c42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-04-2022_40302.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6a1dc35-eef8-41a4-96e8-030a458a8c42>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf939b08-d878-4355-9131-eb276d4dd5a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf939b08-d878-4355-9131-eb276d4dd5a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-04-2022_40328.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf939b08-d878-4355-9131-eb276d4dd5a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a14e8cd-6637-47ad-8f97-9c429c74a85a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a14e8cd-6637-47ad-8f97-9c429c74a85a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-04-2022_40332.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a14e8cd-6637-47ad-8f97-9c429c74a85a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1e43982-4eac-451f-aee7-3a0c906f0107> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1e43982-4eac-451f-aee7-3a0c906f0107";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-04-2022_40341.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1e43982-4eac-451f-aee7-3a0c906f0107>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd67a0a0-fbd1-478e-b4d8-8588a417928b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd67a0a0-fbd1-478e-b4d8-8588a417928b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-04-2022_40369.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd67a0a0-fbd1-478e-b4d8-8588a417928b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca29f840-3f3e-43ea-9c59-090d59ec139c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca29f840-3f3e-43ea-9c59-090d59ec139c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-04-2022_41404.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca29f840-3f3e-43ea-9c59-090d59ec139c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a77091b-a2a4-479a-ac9b-2dfd646388c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a77091b-a2a4-479a-ac9b-2dfd646388c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-04-2022_41471.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a77091b-a2a4-479a-ac9b-2dfd646388c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/58162bec-b938-4ca1-a1f6-db297327d71d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58162bec-b938-4ca1-a1f6-db297327d71d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-07-2022_44868.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58162bec-b938-4ca1-a1f6-db297327d71d>.
+    
+<http://data.lblod.info/id/remote-data-objects/682c224b-55b8-42f0-92d5-301af99947a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "682c224b-55b8-42f0-92d5-301af99947a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-07-2022_45953.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/682c224b-55b8-42f0-92d5-301af99947a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/b504f6d8-7e0f-488c-be0d-27be0b0d5c61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b504f6d8-7e0f-488c-be0d-27be0b0d5c61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-07-2022_46062.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b504f6d8-7e0f-488c-be0d-27be0b0d5c61>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd304624-0fed-41bc-a780-ae98068ebc02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd304624-0fed-41bc-a780-ae98068ebc02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-07-2022_46065.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd304624-0fed-41bc-a780-ae98068ebc02>.
+    
+<http://data.lblod.info/id/remote-data-objects/533b0d08-718d-4a86-b18e-1d330214b268> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "533b0d08-718d-4a86-b18e-1d330214b268";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-07-2022_46070.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/533b0d08-718d-4a86-b18e-1d330214b268>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0a587bf-79d7-4666-9c85-a955facc0530> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0a587bf-79d7-4666-9c85-a955facc0530";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-07-2022_46124.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0a587bf-79d7-4666-9c85-a955facc0530>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc6d4f2d-40cb-4f93-af6c-2d0087d5877a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc6d4f2d-40cb-4f93-af6c-2d0087d5877a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-07-2022_47120.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc6d4f2d-40cb-4f93-af6c-2d0087d5877a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0d1e393-2d88-4131-b030-c5fa1150bc9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0d1e393-2d88-4131-b030-c5fa1150bc9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-07-2022_47121.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0d1e393-2d88-4131-b030-c5fa1150bc9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/da6afefe-30a5-4108-bd3b-d9f135ee9cb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da6afefe-30a5-4108-bd3b-d9f135ee9cb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-07-2022_47208.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da6afefe-30a5-4108-bd3b-d9f135ee9cb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b341148a-cf06-4877-a2df-cfe260be998a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b341148a-cf06-4877-a2df-cfe260be998a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-10-2021_30695.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b341148a-cf06-4877-a2df-cfe260be998a>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc9d725e-8b1b-46ab-9961-619bdff9f83d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc9d725e-8b1b-46ab-9961-619bdff9f83d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-10-2021_30729.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc9d725e-8b1b-46ab-9961-619bdff9f83d>.
+    
+<http://data.lblod.info/id/remote-data-objects/452002e5-9c17-4aa3-ac18-bb8d6e36081a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "452002e5-9c17-4aa3-ac18-bb8d6e36081a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-10-2021_30855.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/452002e5-9c17-4aa3-ac18-bb8d6e36081a>.
+    
+<http://data.lblod.info/id/remote-data-objects/25e479ec-0391-4737-9f1f-d77e89958661> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25e479ec-0391-4737-9f1f-d77e89958661";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-10-2021_30856.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25e479ec-0391-4737-9f1f-d77e89958661>.
+    
+<http://data.lblod.info/id/remote-data-objects/65e9ab3e-4ce5-446d-ad4e-e46211ed6672> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65e9ab3e-4ce5-446d-ad4e-e46211ed6672";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_25-10-2021_30873.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65e9ab3e-4ce5-446d-ad4e-e46211ed6672>.
+    
+<http://data.lblod.info/id/remote-data-objects/6802bcc3-0f29-487a-9ec9-8696e8826ab8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6802bcc3-0f29-487a-9ec9-8696e8826ab8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_27-06-2022_46076.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6802bcc3-0f29-487a-9ec9-8696e8826ab8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a60b943-70da-4272-b6f4-49c0e3099cde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a60b943-70da-4272-b6f4-49c0e3099cde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_27-06-2022_47116.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a60b943-70da-4272-b6f4-49c0e3099cde>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2503b45-0220-4d01-b317-b051df8ad8ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2503b45-0220-4d01-b317-b051df8ad8ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_28-03-2022_39124.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2503b45-0220-4d01-b317-b051df8ad8ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ec6d808-dd7c-4e3a-b9aa-fbc5cb5c0ed9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ec6d808-dd7c-4e3a-b9aa-fbc5cb5c0ed9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_28-03-2022_39126.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ec6d808-dd7c-4e3a-b9aa-fbc5cb5c0ed9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b933959b-f8b7-4f69-a6cb-3de7f62df20a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b933959b-f8b7-4f69-a6cb-3de7f62df20a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_29-11-2021_34246.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b933959b-f8b7-4f69-a6cb-3de7f62df20a>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfa79e06-aaba-4e83-a0ce-5d65f2a45e78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfa79e06-aaba-4e83-a0ce-5d65f2a45e78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_30-05-2022_41491.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfa79e06-aaba-4e83-a0ce-5d65f2a45e78>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf37379d-d6a9-4b8c-958d-d8318f783f05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf37379d-d6a9-4b8c-958d-d8318f783f05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_30-05-2022_42626.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf37379d-d6a9-4b8c-958d-d8318f783f05>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd70ca4f-1181-4796-be5a-2ac4a1f9cf4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd70ca4f-1181-4796-be5a-2ac4a1f9cf4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_30-05-2022_44806.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd70ca4f-1181-4796-be5a-2ac4a1f9cf4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c0ed4b3-097b-4ab3-bb44-f90b16263c7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c0ed4b3-097b-4ab3-bb44-f90b16263c7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/5402d2453fcd9d47a153678e1ccae33f81b544546c6772637e94cbbff4a4c879/GetPublication?filename=Uittreksels_30-05-2022_44852.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c0ed4b3-097b-4ab3-bb44-f90b16263c7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4d4fd2d-5469-4f86-a53d-a091b4b6cd3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4d4fd2d-5469-4f86-a53d-a091b4b6cd3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_01-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4d4fd2d-5469-4f86-a53d-a091b4b6cd3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9e18a75-fd21-49b4-a4b4-29adfe3b0742> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9e18a75-fd21-49b4-a4b4-29adfe3b0742";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9e18a75-fd21-49b4-a4b4-29adfe3b0742>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b76a2bb-a101-4c2d-aa19-49c0b2750f02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b76a2bb-a101-4c2d-aa19-49c0b2750f02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_04-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b76a2bb-a101-4c2d-aa19-49c0b2750f02>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae251bc3-7fd0-46c4-850f-fc1fd1381326> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae251bc3-7fd0-46c4-850f-fc1fd1381326";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_04-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae251bc3-7fd0-46c4-850f-fc1fd1381326>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b6657ca-d808-4bb7-98da-2ff16188aeab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b6657ca-d808-4bb7-98da-2ff16188aeab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_05-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b6657ca-d808-4bb7-98da-2ff16188aeab>.
+    
+<http://data.lblod.info/id/remote-data-objects/19499721-452c-4d9e-9317-11e726723c22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19499721-452c-4d9e-9317-11e726723c22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_06-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fc658f68-33d1-476a-80ca-7f1d3b41040e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19499721-452c-4d9e-9317-11e726723c22>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201759-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201759-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201759-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201759-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/579c887c-ad42-4b5a-8fc7-e8bf353f9772> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "579c887c-ad42-4b5a-8fc7-e8bf353f9772";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "95593496-1a12-4c67-8a17-78bad2d3ba21";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ccf4136a-a262-4604-9302-bce1a931b431> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ccf4136a-a262-4604-9302-bce1a931b431";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21>.
+
+  <http://redpencil.data.gift/id/task/b5b22fdb-96d8-46b6-86d7-453cd1ae194d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b5b22fdb-96d8-46b6-86d7-453cd1ae194d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/579c887c-ad42-4b5a-8fc7-e8bf353f9772>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ccf4136a-a262-4604-9302-bce1a931b431>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7ad98ae0-33b0-476b-b8a0-17ef53950d9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ad98ae0-33b0-476b-b8a0-17ef53950d9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_08-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ad98ae0-33b0-476b-b8a0-17ef53950d9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fe16cc6-0163-403e-ae94-e9e88ffddcdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fe16cc6-0163-403e-ae94-e9e88ffddcdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_10-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fe16cc6-0163-403e-ae94-e9e88ffddcdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a2c8375-110b-4037-b6e1-0e6815c0d8bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a2c8375-110b-4037-b6e1-0e6815c0d8bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_11-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a2c8375-110b-4037-b6e1-0e6815c0d8bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bdffa9a-c484-4933-a165-057e5ec8e07f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bdffa9a-c484-4933-a165-057e5ec8e07f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_11-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bdffa9a-c484-4933-a165-057e5ec8e07f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdc72590-0a47-41ba-9686-727082cc1976> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdc72590-0a47-41ba-9686-727082cc1976";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_13-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdc72590-0a47-41ba-9686-727082cc1976>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8472ebb-05b7-4838-b9be-8c09ed030120> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8472ebb-05b7-4838-b9be-8c09ed030120";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8472ebb-05b7-4838-b9be-8c09ed030120>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5fbcab3-3f3e-4029-b4e5-36bc826462c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5fbcab3-3f3e-4029-b4e5-36bc826462c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_15-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5fbcab3-3f3e-4029-b4e5-36bc826462c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e2f5c5d-377a-4abc-ba24-01984e3df1d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e2f5c5d-377a-4abc-ba24-01984e3df1d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_15-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e2f5c5d-377a-4abc-ba24-01984e3df1d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/376beed5-f8cd-48ca-a924-464a0d2757d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "376beed5-f8cd-48ca-a924-464a0d2757d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_17-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/376beed5-f8cd-48ca-a924-464a0d2757d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ad7cc7b-bb56-4caa-93a8-888cdb5829bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ad7cc7b-bb56-4caa-93a8-888cdb5829bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ad7cc7b-bb56-4caa-93a8-888cdb5829bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2ad660e-a2f4-41c8-84d6-5aa084165499> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2ad660e-a2f4-41c8-84d6-5aa084165499";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_18-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2ad660e-a2f4-41c8-84d6-5aa084165499>.
+    
+<http://data.lblod.info/id/remote-data-objects/964d5520-3874-4be7-86d3-16ea8fe4ce24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "964d5520-3874-4be7-86d3-16ea8fe4ce24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/964d5520-3874-4be7-86d3-16ea8fe4ce24>.
+    
+<http://data.lblod.info/id/remote-data-objects/92af7fb0-3454-4982-9304-16d3edee160d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92af7fb0-3454-4982-9304-16d3edee160d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_20-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92af7fb0-3454-4982-9304-16d3edee160d>.
+    
+<http://data.lblod.info/id/remote-data-objects/11bb2099-aea7-43c9-9d68-26b998fa2183> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11bb2099-aea7-43c9-9d68-26b998fa2183";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_20-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11bb2099-aea7-43c9-9d68-26b998fa2183>.
+    
+<http://data.lblod.info/id/remote-data-objects/40fb87ad-e17d-4abd-9cee-c11f62bbc570> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40fb87ad-e17d-4abd-9cee-c11f62bbc570";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_20-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40fb87ad-e17d-4abd-9cee-c11f62bbc570>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ea0f917-7f93-4c0a-aa64-8f25dd08b7ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ea0f917-7f93-4c0a-aa64-8f25dd08b7ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_21-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ea0f917-7f93-4c0a-aa64-8f25dd08b7ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae626f56-2fd0-46bb-8bfb-d8725d9cb772> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae626f56-2fd0-46bb-8bfb-d8725d9cb772";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_22-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae626f56-2fd0-46bb-8bfb-d8725d9cb772>.
+    
+<http://data.lblod.info/id/remote-data-objects/3309be8c-fa00-42f9-9877-4458941abb7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3309be8c-fa00-42f9-9877-4458941abb7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_25-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3309be8c-fa00-42f9-9877-4458941abb7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/af78ae47-d56b-4c28-9d0d-df45c1447f78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af78ae47-d56b-4c28-9d0d-df45c1447f78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_26-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af78ae47-d56b-4c28-9d0d-df45c1447f78>.
+    
+<http://data.lblod.info/id/remote-data-objects/278a3b31-0f7d-42c5-93c1-0efe0a97e8aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "278a3b31-0f7d-42c5-93c1-0efe0a97e8aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_27-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/278a3b31-0f7d-42c5-93c1-0efe0a97e8aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f6a6d50-de76-42f8-87e6-22af7c50e62e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f6a6d50-de76-42f8-87e6-22af7c50e62e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_30-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f6a6d50-de76-42f8-87e6-22af7c50e62e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e581b92b-e7d0-46fe-b754-db0ebaef1cb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e581b92b-e7d0-46fe-b754-db0ebaef1cb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=BesluitenLijst_Besluit%20Burgemeester_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e581b92b-e7d0-46fe-b754-db0ebaef1cb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cf00825-fcd7-4f4f-ba0c-7a96fe72a9a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cf00825-fcd7-4f4f-ba0c-7a96fe72a9a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=Uittreksels_11-03-2022_38034.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cf00825-fcd7-4f4f-ba0c-7a96fe72a9a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d17c14c-5c3a-471f-b2e0-9e6253f0eb4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d17c14c-5c3a-471f-b2e0-9e6253f0eb4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/66640b85d009f3dbdad0a8bfa15003ce3e253e5ac1445a891311e222c01d3823/GetPublication?filename=Uittreksels_30-03-2022_40360.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d17c14c-5c3a-471f-b2e0-9e6253f0eb4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a938976-9c8a-4cda-8269-cec0755c8021> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a938976-9c8a-4cda-8269-cec0755c8021";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a938976-9c8a-4cda-8269-cec0755c8021>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c1557bc-9a78-445a-abea-e440b5aebaf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c1557bc-9a78-445a-abea-e440b5aebaf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c1557bc-9a78-445a-abea-e440b5aebaf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/96d34ed9-2d45-444b-921d-9759fe02095e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96d34ed9-2d45-444b-921d-9759fe02095e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96d34ed9-2d45-444b-921d-9759fe02095e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a222aac-c225-4f5d-a989-158c131f8952> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a222aac-c225-4f5d-a989-158c131f8952";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a222aac-c225-4f5d-a989-158c131f8952>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c3fad82-14f5-4056-ad9f-30ce5846fced> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c3fad82-14f5-4056-ad9f-30ce5846fced";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c3fad82-14f5-4056-ad9f-30ce5846fced>.
+    
+<http://data.lblod.info/id/remote-data-objects/3253bd3d-7a99-4db8-ae39-901842ff7958> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3253bd3d-7a99-4db8-ae39-901842ff7958";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3253bd3d-7a99-4db8-ae39-901842ff7958>.
+    
+<http://data.lblod.info/id/remote-data-objects/85fa0cfe-f3a5-4108-9037-8859955957ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85fa0cfe-f3a5-4108-9037-8859955957ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85fa0cfe-f3a5-4108-9037-8859955957ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d679627-61a4-446f-ac04-7eafc24734b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d679627-61a4-446f-ac04-7eafc24734b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d679627-61a4-446f-ac04-7eafc24734b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/880b4e5b-b96c-40b7-87e1-fe81cbda6a18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "880b4e5b-b96c-40b7-87e1-fe81cbda6a18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=BesluitenLijst_Raad%20voor%20Maatschappelijk%20Welzijn_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/880b4e5b-b96c-40b7-87e1-fe81cbda6a18>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bbb4024-0758-4ed7-bffc-0a5d92699b8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bbb4024-0758-4ed7-bffc-0a5d92699b8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bbb4024-0758-4ed7-bffc-0a5d92699b8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/847dd568-c9ab-409f-bb1d-ddceacfc1e3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "847dd568-c9ab-409f-bb1d-ddceacfc1e3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/847dd568-c9ab-409f-bb1d-ddceacfc1e3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/35c38a24-e0f1-45fd-84fc-033f97dca0c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35c38a24-e0f1-45fd-84fc-033f97dca0c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35c38a24-e0f1-45fd-84fc-033f97dca0c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2dcb483-751a-43b8-9c9d-5df0c7fcfcdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2dcb483-751a-43b8-9c9d-5df0c7fcfcdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2dcb483-751a-43b8-9c9d-5df0c7fcfcdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/65f3d0d3-2ca3-4cc9-9f30-1cb73a2fc653> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65f3d0d3-2ca3-4cc9-9f30-1cb73a2fc653";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65f3d0d3-2ca3-4cc9-9f30-1cb73a2fc653>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1c558ad-0f55-4ad6-9415-9eb84e1abc20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1c558ad-0f55-4ad6-9415-9eb84e1abc20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1c558ad-0f55-4ad6-9415-9eb84e1abc20>.
+    
+<http://data.lblod.info/id/remote-data-objects/77bb4180-db49-4552-af94-f9641d641117> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77bb4180-db49-4552-af94-f9641d641117";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77bb4180-db49-4552-af94-f9641d641117>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ab109b0-1220-4e74-a25c-e6bb7611a560> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ab109b0-1220-4e74-a25c-e6bb7611a560";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=Notulen_Raad%20voor%20Maatschappelijk%20Welzijn_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ab109b0-1220-4e74-a25c-e6bb7611a560>.
+    
+<http://data.lblod.info/id/remote-data-objects/938c73f2-dc65-44fa-b38a-b184864baf16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "938c73f2-dc65-44fa-b38a-b184864baf16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=Uittreksels_09-05-2022_41405.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/938c73f2-dc65-44fa-b38a-b184864baf16>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1f9eca6-0449-4f95-a92c-88c29adfb623> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1f9eca6-0449-4f95-a92c-88c29adfb623";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=Uittreksels_14-02-2022_35613.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1f9eca6-0449-4f95-a92c-88c29adfb623>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c2ea917-3591-4ee4-851b-c1e9572ea8bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c2ea917-3591-4ee4-851b-c1e9572ea8bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=Uittreksels_14-02-2022_35614.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c2ea917-3591-4ee4-851b-c1e9572ea8bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/01f974ba-1595-4dc3-a635-babebcd3b1f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01f974ba-1595-4dc3-a635-babebcd3b1f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=Uittreksels_14-03-2022_39218.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01f974ba-1595-4dc3-a635-babebcd3b1f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/daa36961-a214-493d-842f-b95bdd80ff3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "daa36961-a214-493d-842f-b95bdd80ff3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=Uittreksels_15-11-2021_30928.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/daa36961-a214-493d-842f-b95bdd80ff3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1f4e038-03a8-4cb8-b101-effabde6e2c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1f4e038-03a8-4cb8-b101-effabde6e2c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=Uittreksels_15-11-2021_30929.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1f4e038-03a8-4cb8-b101-effabde6e2c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d867810-239b-49c6-a954-5a976dd89294> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d867810-239b-49c6-a954-5a976dd89294";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=Uittreksels_27-06-2022_44838.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d867810-239b-49c6-a954-5a976dd89294>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d2cb92a-bd02-48ad-a7cd-8155142d27f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d2cb92a-bd02-48ad-a7cd-8155142d27f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/67e426394d8662c2e6e61409c2ae0fa73bf3be3eae97c4db67436b225e9f6f1d/GetPublication?filename=Uittreksels_27-06-2022_44929.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d2cb92a-bd02-48ad-a7cd-8155142d27f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fcaa43e-34d8-46a6-8714-332acbf7e0c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fcaa43e-34d8-46a6-8714-332acbf7e0c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:17:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/95593496-1a12-4c67-8a17-78bad2d3ba21> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fcaa43e-34d8-46a6-8714-332acbf7e0c1>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201800-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201800-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201800-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201800-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/01684a07-39c5-4cf4-bf4d-2787b024b6aa> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "01684a07-39c5-4cf4-bf4d-2787b024b6aa";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2ba5078c-932d-46b4-8950-ab2c16b935c3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4a913b12-f298-4271-bc25-213a70938ae9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4a913b12-f298-4271-bc25-213a70938ae9";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3>.
+
+  <http://redpencil.data.gift/id/task/78eca348-f4e1-4cbb-a246-37967f20d73d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "78eca348-f4e1-4cbb-a246-37967f20d73d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/01684a07-39c5-4cf4-bf4d-2787b024b6aa>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4a913b12-f298-4271-bc25-213a70938ae9>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/0c99dfa0-7c95-480d-9bab-a14ce7a4a93a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c99dfa0-7c95-480d-9bab-a14ce7a4a93a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_03-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c99dfa0-7c95-480d-9bab-a14ce7a4a93a>.
+    
+<http://data.lblod.info/id/remote-data-objects/95b3df46-c7cd-4a39-bea5-f16fd756db7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95b3df46-c7cd-4a39-bea5-f16fd756db7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95b3df46-c7cd-4a39-bea5-f16fd756db7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/afe43577-3d64-48e4-9693-d5d7f2644ef7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afe43577-3d64-48e4-9693-d5d7f2644ef7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afe43577-3d64-48e4-9693-d5d7f2644ef7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b1537aa-8df4-4646-ad5b-14da8e236a3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b1537aa-8df4-4646-ad5b-14da8e236a3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b1537aa-8df4-4646-ad5b-14da8e236a3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e277060-8860-4170-a115-7e0f49a1a511> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e277060-8860-4170-a115-7e0f49a1a511";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e277060-8860-4170-a115-7e0f49a1a511>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e84f92e-2c26-4d5b-a5d4-05ca76ebe6a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e84f92e-2c26-4d5b-a5d4-05ca76ebe6a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e84f92e-2c26-4d5b-a5d4-05ca76ebe6a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc06e280-f86d-438d-93d7-33ce80668971> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc06e280-f86d-438d-93d7-33ce80668971";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc06e280-f86d-438d-93d7-33ce80668971>.
+    
+<http://data.lblod.info/id/remote-data-objects/075dab16-aed8-42db-95c6-c3eec6354b90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "075dab16-aed8-42db-95c6-c3eec6354b90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/075dab16-aed8-42db-95c6-c3eec6354b90>.
+    
+<http://data.lblod.info/id/remote-data-objects/86f484a7-77a0-49c2-96e0-9ec976e94f1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86f484a7-77a0-49c2-96e0-9ec976e94f1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86f484a7-77a0-49c2-96e0-9ec976e94f1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bddb8dc8-fcf2-4710-851b-37241eaca1bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bddb8dc8-fcf2-4710-851b-37241eaca1bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bddb8dc8-fcf2-4710-851b-37241eaca1bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0676871-89a8-4d2f-8972-cfdec929bc55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0676871-89a8-4d2f-8972-cfdec929bc55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0676871-89a8-4d2f-8972-cfdec929bc55>.
+    
+<http://data.lblod.info/id/remote-data-objects/500f70e6-9009-424f-8467-0df214c2750b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "500f70e6-9009-424f-8467-0df214c2750b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/500f70e6-9009-424f-8467-0df214c2750b>.
+    
+<http://data.lblod.info/id/remote-data-objects/826ce1f8-ff9b-4bf8-b3aa-00cbb5dfde1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "826ce1f8-ff9b-4bf8-b3aa-00cbb5dfde1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/826ce1f8-ff9b-4bf8-b3aa-00cbb5dfde1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dc20ad1-d85f-47f2-929f-136555cf746d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dc20ad1-d85f-47f2-929f-136555cf746d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dc20ad1-d85f-47f2-929f-136555cf746d>.
+    
+<http://data.lblod.info/id/remote-data-objects/48da736d-2097-4453-9dcd-a80cc4894d6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48da736d-2097-4453-9dcd-a80cc4894d6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48da736d-2097-4453-9dcd-a80cc4894d6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/29e7bb5c-1bf4-4f7d-abf3-91ac45129140> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29e7bb5c-1bf4-4f7d-abf3-91ac45129140";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29e7bb5c-1bf4-4f7d-abf3-91ac45129140>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dd511c5-4ebb-44ec-a1bb-8bcde9dcf672> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dd511c5-4ebb-44ec-a1bb-8bcde9dcf672";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dd511c5-4ebb-44ec-a1bb-8bcde9dcf672>.
+    
+<http://data.lblod.info/id/remote-data-objects/40fa90b6-0d50-4803-971c-b5f515816fcb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40fa90b6-0d50-4803-971c-b5f515816fcb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40fa90b6-0d50-4803-971c-b5f515816fcb>.
+    
+<http://data.lblod.info/id/remote-data-objects/a95944a6-d6dc-4403-85e3-6a09ca83d0d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a95944a6-d6dc-4403-85e3-6a09ca83d0d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a95944a6-d6dc-4403-85e3-6a09ca83d0d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/544130ac-8afb-4834-8ba0-0c3f897e76b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "544130ac-8afb-4834-8ba0-0c3f897e76b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/544130ac-8afb-4834-8ba0-0c3f897e76b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/df85bc9b-7fd4-4ace-9742-d31e84ec0b2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df85bc9b-7fd4-4ace-9742-d31e84ec0b2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df85bc9b-7fd4-4ace-9742-d31e84ec0b2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f48812af-c114-41a6-8b37-a4a18be14a5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f48812af-c114-41a6-8b37-a4a18be14a5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f48812af-c114-41a6-8b37-a4a18be14a5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/60a3335e-6eaa-4270-bdbf-9d89666fc4ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60a3335e-6eaa-4270-bdbf-9d89666fc4ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60a3335e-6eaa-4270-bdbf-9d89666fc4ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/954d2b3d-aa2f-41f9-b368-5e979c8601e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "954d2b3d-aa2f-41f9-b368-5e979c8601e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/954d2b3d-aa2f-41f9-b368-5e979c8601e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/60675602-f5aa-4fc9-866f-7c3979e21718> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60675602-f5aa-4fc9-866f-7c3979e21718";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60675602-f5aa-4fc9-866f-7c3979e21718>.
+    
+<http://data.lblod.info/id/remote-data-objects/34c65c72-039f-45dd-a6e3-889e8d25ea30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34c65c72-039f-45dd-a6e3-889e8d25ea30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34c65c72-039f-45dd-a6e3-889e8d25ea30>.
+    
+<http://data.lblod.info/id/remote-data-objects/93a3766d-b129-43af-b13d-73f583e1f628> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93a3766d-b129-43af-b13d-73f583e1f628";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93a3766d-b129-43af-b13d-73f583e1f628>.
+    
+<http://data.lblod.info/id/remote-data-objects/c71e4410-5ba6-484b-a0fc-12eefab1a827> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c71e4410-5ba6-484b-a0fc-12eefab1a827";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c71e4410-5ba6-484b-a0fc-12eefab1a827>.
+    
+<http://data.lblod.info/id/remote-data-objects/09b57d3c-f62a-4215-aa86-ecd6face0b88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09b57d3c-f62a-4215-aa86-ecd6face0b88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09b57d3c-f62a-4215-aa86-ecd6face0b88>.
+    
+<http://data.lblod.info/id/remote-data-objects/91be3602-4887-4524-ba2c-01e29293013b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91be3602-4887-4524-ba2c-01e29293013b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91be3602-4887-4524-ba2c-01e29293013b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f757a474-0783-45ae-8aec-f6b575acba75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f757a474-0783-45ae-8aec-f6b575acba75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f757a474-0783-45ae-8aec-f6b575acba75>.
+    
+<http://data.lblod.info/id/remote-data-objects/07672c42-1dfa-4b4a-af14-0576ab43a3df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07672c42-1dfa-4b4a-af14-0576ab43a3df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07672c42-1dfa-4b4a-af14-0576ab43a3df>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa32a82c-1fd3-4805-8a59-2fe694ea8d59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa32a82c-1fd3-4805-8a59-2fe694ea8d59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa32a82c-1fd3-4805-8a59-2fe694ea8d59>.
+    
+<http://data.lblod.info/id/remote-data-objects/643014ea-6d05-4b8c-bcd7-3ebea656cc9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "643014ea-6d05-4b8c-bcd7-3ebea656cc9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/643014ea-6d05-4b8c-bcd7-3ebea656cc9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7c1ab77-429f-40f0-bb31-ee904c103747> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7c1ab77-429f-40f0-bb31-ee904c103747";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7c1ab77-429f-40f0-bb31-ee904c103747>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a040628-e52a-4fd1-af17-176a7dbe8728> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a040628-e52a-4fd1-af17-176a7dbe8728";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a040628-e52a-4fd1-af17-176a7dbe8728>.
+    
+<http://data.lblod.info/id/remote-data-objects/321591de-f938-4136-a27b-12e843216fe4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "321591de-f938-4136-a27b-12e843216fe4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/d51d3f2c-2281-402c-9e17-d9ff1cc4f55e/GetPublication?filename=BesluitenLijst_Vast%20Bureau_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/321591de-f938-4136-a27b-12e843216fe4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d1d447e-0def-4034-88f9-63e08ffc8efa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d1d447e-0def-4034-88f9-63e08ffc8efa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=BesluitenLijst_Gemeenteraad_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d1d447e-0def-4034-88f9-63e08ffc8efa>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b6de210-9462-4d0b-b347-301bec6086fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b6de210-9462-4d0b-b347-301bec6086fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=BesluitenLijst_Gemeenteraad_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b6de210-9462-4d0b-b347-301bec6086fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3a1c949-2df5-4391-afed-7d7a39a0c4c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3a1c949-2df5-4391-afed-7d7a39a0c4c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=BesluitenLijst_Gemeenteraad_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3a1c949-2df5-4391-afed-7d7a39a0c4c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d8c5581-6d52-4669-8e7c-61dadff77648> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d8c5581-6d52-4669-8e7c-61dadff77648";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=BesluitenLijst_Gemeenteraad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d8c5581-6d52-4669-8e7c-61dadff77648>.
+    
+<http://data.lblod.info/id/remote-data-objects/917caa52-9a6a-494a-9f88-e644c9473324> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "917caa52-9a6a-494a-9f88-e644c9473324";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=BesluitenLijst_Gemeenteraad_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/917caa52-9a6a-494a-9f88-e644c9473324>.
+    
+<http://data.lblod.info/id/remote-data-objects/c58601db-35ed-4d5c-aba9-023bb809d822> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c58601db-35ed-4d5c-aba9-023bb809d822";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=BesluitenLijst_Gemeenteraad_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c58601db-35ed-4d5c-aba9-023bb809d822>.
+    
+<http://data.lblod.info/id/remote-data-objects/8113f65a-5591-4878-b17a-ab3cc14970ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8113f65a-5591-4878-b17a-ab3cc14970ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=BesluitenLijst_Gemeenteraad_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8113f65a-5591-4878-b17a-ab3cc14970ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/4da37c2c-84c8-4b2f-b702-285493e33cba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4da37c2c-84c8-4b2f-b702-285493e33cba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=BesluitenLijst_Gemeenteraad_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4da37c2c-84c8-4b2f-b702-285493e33cba>.
+    
+<http://data.lblod.info/id/remote-data-objects/f927ff24-237a-4ce9-9580-d5f0ac5a4159> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f927ff24-237a-4ce9-9580-d5f0ac5a4159";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f927ff24-237a-4ce9-9580-d5f0ac5a4159>.
+    
+<http://data.lblod.info/id/remote-data-objects/1caac457-d875-477c-9925-2dba1556bda2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1caac457-d875-477c-9925-2dba1556bda2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Notulen_Gemeenteraad_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1caac457-d875-477c-9925-2dba1556bda2>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c3a47b3-b0fb-4812-af86-8e6d4d4653ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c3a47b3-b0fb-4812-af86-8e6d4d4653ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Notulen_Gemeenteraad_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c3a47b3-b0fb-4812-af86-8e6d4d4653ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd4a4ada-43a2-49eb-9ac2-1b1190aaec3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd4a4ada-43a2-49eb-9ac2-1b1190aaec3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Notulen_Gemeenteraad_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd4a4ada-43a2-49eb-9ac2-1b1190aaec3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/18753936-48d7-46ec-b1b0-159f9093e37d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18753936-48d7-46ec-b1b0-159f9093e37d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Notulen_Gemeenteraad_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2ba5078c-932d-46b4-8950-ab2c16b935c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18753936-48d7-46ec-b1b0-159f9093e37d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201801-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201801-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201801-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201801-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/ef4b61bf-5a0d-402c-8d10-2e4b598b561f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ef4b61bf-5a0d-402c-8d10-2e4b598b561f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5b58b474-6eaa-4e3f-b035-fad6cfaf0982";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c2d27a6a-9b78-44fa-b900-bfd7e63b697b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c2d27a6a-9b78-44fa-b900-bfd7e63b697b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982>.
+
+  <http://redpencil.data.gift/id/task/68da2c35-9ed8-4df8-b263-464736ffa1a2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "68da2c35-9ed8-4df8-b263-464736ffa1a2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/ef4b61bf-5a0d-402c-8d10-2e4b598b561f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c2d27a6a-9b78-44fa-b900-bfd7e63b697b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b69f8b83-246b-4f97-bf0f-f57327020647> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b69f8b83-246b-4f97-bf0f-f57327020647";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Notulen_Gemeenteraad_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b69f8b83-246b-4f97-bf0f-f57327020647>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4231d6d-1b31-4db5-b63d-514bede1aa6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4231d6d-1b31-4db5-b63d-514bede1aa6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Notulen_Gemeenteraad_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4231d6d-1b31-4db5-b63d-514bede1aa6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b98a128b-2b15-4ff2-917d-f166dbb0fa0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b98a128b-2b15-4ff2-917d-f166dbb0fa0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Notulen_Gemeenteraad_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b98a128b-2b15-4ff2-917d-f166dbb0fa0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dcb9894-fdb3-4fcc-a97a-7362f0f6f71d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dcb9894-fdb3-4fcc-a97a-7362f0f6f71d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Notulen_Gemeenteraad_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dcb9894-fdb3-4fcc-a97a-7362f0f6f71d>.
+    
+<http://data.lblod.info/id/remote-data-objects/db6f229c-9105-4a24-9bdc-4a828c2f8725> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db6f229c-9105-4a24-9bdc-4a828c2f8725";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_09-05-2022_40353.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db6f229c-9105-4a24-9bdc-4a828c2f8725>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d53cb15-1e63-4d62-81b1-8c39081b00ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d53cb15-1e63-4d62-81b1-8c39081b00ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_09-05-2022_41408.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d53cb15-1e63-4d62-81b1-8c39081b00ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/a34451b3-234d-4e29-83e0-a9f28a4696d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a34451b3-234d-4e29-83e0-a9f28a4696d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_09-05-2022_41409.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a34451b3-234d-4e29-83e0-a9f28a4696d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd2d6afd-fbc6-49a3-8ceb-b0d74aa69d16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd2d6afd-fbc6-49a3-8ceb-b0d74aa69d16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_10-01-2022_35513.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd2d6afd-fbc6-49a3-8ceb-b0d74aa69d16>.
+    
+<http://data.lblod.info/id/remote-data-objects/98c496a9-53cf-4473-bc1c-5fa9277b72b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98c496a9-53cf-4473-bc1c-5fa9277b72b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_13-12-2021_29274.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98c496a9-53cf-4473-bc1c-5fa9277b72b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a07dfe9-1ca9-4c7f-a724-4b69ef1de7d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a07dfe9-1ca9-4c7f-a724-4b69ef1de7d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_13-12-2021_30364.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a07dfe9-1ca9-4c7f-a724-4b69ef1de7d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/da01fd22-3e50-4de3-bd09-8a357039cfa6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da01fd22-3e50-4de3-bd09-8a357039cfa6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_13-12-2021_32129.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da01fd22-3e50-4de3-bd09-8a357039cfa6>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc03121f-fb27-49a6-932c-68cf12f7e04e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc03121f-fb27-49a6-932c-68cf12f7e04e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_13-12-2021_34167.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc03121f-fb27-49a6-932c-68cf12f7e04e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d754cd7-673e-4a58-ad63-20d22781001f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d754cd7-673e-4a58-ad63-20d22781001f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_13-12-2021_34174.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d754cd7-673e-4a58-ad63-20d22781001f>.
+    
+<http://data.lblod.info/id/remote-data-objects/747c4a10-2a7d-41f6-bcb9-e536e65f4304> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "747c4a10-2a7d-41f6-bcb9-e536e65f4304";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_14-02-2022_35610.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/747c4a10-2a7d-41f6-bcb9-e536e65f4304>.
+    
+<http://data.lblod.info/id/remote-data-objects/43b860a6-4556-4c81-8cb2-026aacfefc67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43b860a6-4556-4c81-8cb2-026aacfefc67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_14-02-2022_35611.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43b860a6-4556-4c81-8cb2-026aacfefc67>.
+    
+<http://data.lblod.info/id/remote-data-objects/8703b9a1-55bf-4ebc-8d60-9d7917eae61d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8703b9a1-55bf-4ebc-8d60-9d7917eae61d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_14-02-2022_35665.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8703b9a1-55bf-4ebc-8d60-9d7917eae61d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed6bc6cc-351e-4df5-9add-e42febcebfad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed6bc6cc-351e-4df5-9add-e42febcebfad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_14-03-2022_35711.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed6bc6cc-351e-4df5-9add-e42febcebfad>.
+    
+<http://data.lblod.info/id/remote-data-objects/222bdc3e-ae93-4d64-89b4-5fe3d05796c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "222bdc3e-ae93-4d64-89b4-5fe3d05796c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_14-03-2022_39222.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/222bdc3e-ae93-4d64-89b4-5fe3d05796c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/396137e4-7d27-4874-b47c-b7fc6ea9ba4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "396137e4-7d27-4874-b47c-b7fc6ea9ba4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_15-11-2021_30598.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/396137e4-7d27-4874-b47c-b7fc6ea9ba4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3ad942f-ea1d-45c9-b306-cc85475bab44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3ad942f-ea1d-45c9-b306-cc85475bab44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_15-11-2021_30925.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3ad942f-ea1d-45c9-b306-cc85475bab44>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0267bb9-5a9c-42ba-b561-85aa8c5ad170> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0267bb9-5a9c-42ba-b561-85aa8c5ad170";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_15-11-2021_30927.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0267bb9-5a9c-42ba-b561-85aa8c5ad170>.
+    
+<http://data.lblod.info/id/remote-data-objects/47780a2c-1b06-4d8e-8385-42fecfb0f4e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47780a2c-1b06-4d8e-8385-42fecfb0f4e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_18-10-2021_30503.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47780a2c-1b06-4d8e-8385-42fecfb0f4e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/66ba1003-e2c2-4259-b6bb-1fd8b958e44f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66ba1003-e2c2-4259-b6bb-1fd8b958e44f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_18-10-2021_30820.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66ba1003-e2c2-4259-b6bb-1fd8b958e44f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1020a0af-9846-4683-8205-1dd6f6f21ae2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1020a0af-9846-4683-8205-1dd6f6f21ae2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_27-06-2022_44825.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1020a0af-9846-4683-8205-1dd6f6f21ae2>.
+    
+<http://data.lblod.info/id/remote-data-objects/83270fd9-9765-484b-9cab-1d4ded91f121> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83270fd9-9765-484b-9cab-1d4ded91f121";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_27-06-2022_44835.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83270fd9-9765-484b-9cab-1d4ded91f121>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbdcc897-2bfd-4035-a1c5-a13b2abe571f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbdcc897-2bfd-4035-a1c5-a13b2abe571f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_27-06-2022_44927.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbdcc897-2bfd-4035-a1c5-a13b2abe571f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fd8ddd1-b950-4f84-a137-1abfe1b06fe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fd8ddd1-b950-4f84-a137-1abfe1b06fe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_27-06-2022_44930.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fd8ddd1-b950-4f84-a137-1abfe1b06fe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/13f836bc-8c29-4c7d-85cd-e08a3e5d7699> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13f836bc-8c29-4c7d-85cd-e08a3e5d7699";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_27-06-2022_44931.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13f836bc-8c29-4c7d-85cd-e08a3e5d7699>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed824f19-fc6d-4596-9ab4-e7a6bfb799f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed824f19-fc6d-4596-9ab4-e7a6bfb799f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_27-06-2022_44961.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed824f19-fc6d-4596-9ab4-e7a6bfb799f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d36c555-7810-4bfd-9187-0b1e3e3cc4af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d36c555-7810-4bfd-9187-0b1e3e3cc4af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_27-06-2022_44971.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d36c555-7810-4bfd-9187-0b1e3e3cc4af>.
+    
+<http://data.lblod.info/id/remote-data-objects/6095e353-17bb-463a-aa55-5967339ed948> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6095e353-17bb-463a-aa55-5967339ed948";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zonnebeke.be/LBLODWeb/Home/Overzicht/dbc40886b23e79d3c10b09bfb1651ce73a58003660b6b1d8cf988d9cf7aeafd1/GetPublication?filename=Uittreksels_27-06-2022_45977.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6095e353-17bb-463a-aa55-5967339ed948>.
+    
+<http://data.lblod.info/id/remote-data-objects/84cc6a32-61fd-48d3-995a-87044d965499> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84cc6a32-61fd-48d3-995a-87044d965499";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/47ba0d11a4ae458ce70c7ad77d695440fae680450e65545c748ad596cd681108/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84cc6a32-61fd-48d3-995a-87044d965499>.
+    
+<http://data.lblod.info/id/remote-data-objects/566c2f76-7fbd-4cb5-aa9d-b7c7935db91e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "566c2f76-7fbd-4cb5-aa9d-b7c7935db91e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/47ba0d11a4ae458ce70c7ad77d695440fae680450e65545c748ad596cd681108/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_02-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/566c2f76-7fbd-4cb5-aa9d-b7c7935db91e>.
+    
+<http://data.lblod.info/id/remote-data-objects/319f0312-1234-476f-9962-89508da75529> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "319f0312-1234-476f-9962-89508da75529";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/47ba0d11a4ae458ce70c7ad77d695440fae680450e65545c748ad596cd681108/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_13-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/319f0312-1234-476f-9962-89508da75529>.
+    
+<http://data.lblod.info/id/remote-data-objects/93e2d21d-341f-4a54-a63e-be02afd2fb48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93e2d21d-341f-4a54-a63e-be02afd2fb48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/47ba0d11a4ae458ce70c7ad77d695440fae680450e65545c748ad596cd681108/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93e2d21d-341f-4a54-a63e-be02afd2fb48>.
+    
+<http://data.lblod.info/id/remote-data-objects/92f90356-7c1b-478e-b9c2-4a4871f3469f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92f90356-7c1b-478e-b9c2-4a4871f3469f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/47ba0d11a4ae458ce70c7ad77d695440fae680450e65545c748ad596cd681108/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_15-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92f90356-7c1b-478e-b9c2-4a4871f3469f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b64bcaef-ce83-4f09-96c0-293382daa84d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b64bcaef-ce83-4f09-96c0-293382daa84d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/47ba0d11a4ae458ce70c7ad77d695440fae680450e65545c748ad596cd681108/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_18-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b64bcaef-ce83-4f09-96c0-293382daa84d>.
+    
+<http://data.lblod.info/id/remote-data-objects/002b7b0d-4196-46c6-b748-592befd7acfe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "002b7b0d-4196-46c6-b748-592befd7acfe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/47ba0d11a4ae458ce70c7ad77d695440fae680450e65545c748ad596cd681108/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/002b7b0d-4196-46c6-b748-592befd7acfe>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfa149c9-5129-4eba-8169-fbb1e0f47dca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfa149c9-5129-4eba-8169-fbb1e0f47dca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/47ba0d11a4ae458ce70c7ad77d695440fae680450e65545c748ad596cd681108/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfa149c9-5129-4eba-8169-fbb1e0f47dca>.
+    
+<http://data.lblod.info/id/remote-data-objects/a76ffc0c-e69a-45d4-a2b3-19dbcd8b17bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a76ffc0c-e69a-45d4-a2b3-19dbcd8b17bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/47ba0d11a4ae458ce70c7ad77d695440fae680450e65545c748ad596cd681108/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_19-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a76ffc0c-e69a-45d4-a2b3-19dbcd8b17bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b1fd0da-afed-4338-8d7a-f0781f399a7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b1fd0da-afed-4338-8d7a-f0781f399a7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/47ba0d11a4ae458ce70c7ad77d695440fae680450e65545c748ad596cd681108/GetPublication?filename=BesluitenLijst_Besluiten%20burgemeester_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b1fd0da-afed-4338-8d7a-f0781f399a7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ca82d36-f8e8-4140-88d6-f0f3555003b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ca82d36-f8e8-4140-88d6-f0f3555003b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ca82d36-f8e8-4140-88d6-f0f3555003b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c1a8a52-b81d-4a5a-a74e-15dd7aeb194e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c1a8a52-b81d-4a5a-a74e-15dd7aeb194e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c1a8a52-b81d-4a5a-a74e-15dd7aeb194e>.
+    
+<http://data.lblod.info/id/remote-data-objects/29ed1d65-ae0d-4313-9aef-a21ab6d2e7ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29ed1d65-ae0d-4313-9aef-a21ab6d2e7ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29ed1d65-ae0d-4313-9aef-a21ab6d2e7ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/5821d115-ff9a-48bd-87c8-b2022f6d0e62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5821d115-ff9a-48bd-87c8-b2022f6d0e62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5821d115-ff9a-48bd-87c8-b2022f6d0e62>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b710054-aa67-4e09-b9eb-bf142b3cc959> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b710054-aa67-4e09-b9eb-bf142b3cc959";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b710054-aa67-4e09-b9eb-bf142b3cc959>.
+    
+<http://data.lblod.info/id/remote-data-objects/414f3aa4-2524-410a-b1de-a0b98728d929> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "414f3aa4-2524-410a-b1de-a0b98728d929";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/414f3aa4-2524-410a-b1de-a0b98728d929>.
+    
+<http://data.lblod.info/id/remote-data-objects/307affdb-5068-4206-8027-46e8d9183d18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "307affdb-5068-4206-8027-46e8d9183d18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/307affdb-5068-4206-8027-46e8d9183d18>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbb71ede-87bf-41e0-ba16-37b98bb3c31b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbb71ede-87bf-41e0-ba16-37b98bb3c31b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbb71ede-87bf-41e0-ba16-37b98bb3c31b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ca457d0-3afc-41fb-8694-1a7790c89fbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ca457d0-3afc-41fb-8694-1a7790c89fbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5b58b474-6eaa-4e3f-b035-fad6cfaf0982> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ca457d0-3afc-41fb-8694-1a7790c89fbd>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201802-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201802-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201802-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201802-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/0b52fb34-b399-492b-b3dd-491534ae2803> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0b52fb34-b399-492b-b3dd-491534ae2803";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ae0d7ee7-92da-49b1-9e04-6f93950d6500";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/175b6c4d-d2bc-4d73-9a54-fb5413f718f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "175b6c4d-d2bc-4d73-9a54-fb5413f718f6";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500>.
+
+  <http://redpencil.data.gift/id/task/c693eb68-f2f4-4506-96c2-1518feb89fd3> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c693eb68-f2f4-4506-96c2-1518feb89fd3";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/0b52fb34-b399-492b-b3dd-491534ae2803>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/175b6c4d-d2bc-4d73-9a54-fb5413f718f6>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4c09897d-7633-48dc-86b6-613c00456431> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c09897d-7633-48dc-86b6-613c00456431";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c09897d-7633-48dc-86b6-613c00456431>.
+    
+<http://data.lblod.info/id/remote-data-objects/23d41685-a9c6-40a1-8c6f-d38220bf6cf7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23d41685-a9c6-40a1-8c6f-d38220bf6cf7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23d41685-a9c6-40a1-8c6f-d38220bf6cf7>.
+    
+<http://data.lblod.info/id/remote-data-objects/35c953bd-a3d2-4fa6-bff6-210ce410d7cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35c953bd-a3d2-4fa6-bff6-210ce410d7cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35c953bd-a3d2-4fa6-bff6-210ce410d7cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/091f45a1-1063-4add-96f7-69ee6cbe6c38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "091f45a1-1063-4add-96f7-69ee6cbe6c38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/091f45a1-1063-4add-96f7-69ee6cbe6c38>.
+    
+<http://data.lblod.info/id/remote-data-objects/34a1fe9c-2118-4c9c-85e6-227f31972caf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34a1fe9c-2118-4c9c-85e6-227f31972caf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34a1fe9c-2118-4c9c-85e6-227f31972caf>.
+    
+<http://data.lblod.info/id/remote-data-objects/49941c92-01e1-4768-98cf-552796fa501d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49941c92-01e1-4768-98cf-552796fa501d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49941c92-01e1-4768-98cf-552796fa501d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae359848-96bf-4c41-b663-7a4e478b1957> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae359848-96bf-4c41-b663-7a4e478b1957";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae359848-96bf-4c41-b663-7a4e478b1957>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8757af5-b7f6-43a9-8616-6a54d2e3b0bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8757af5-b7f6-43a9-8616-6a54d2e3b0bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8757af5-b7f6-43a9-8616-6a54d2e3b0bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/36ea0b25-ccdd-4a3c-8044-dafcb29e053d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36ea0b25-ccdd-4a3c-8044-dafcb29e053d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36ea0b25-ccdd-4a3c-8044-dafcb29e053d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0072d76d-7834-47e5-83cf-7c760694e486> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0072d76d-7834-47e5-83cf-7c760694e486";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0072d76d-7834-47e5-83cf-7c760694e486>.
+    
+<http://data.lblod.info/id/remote-data-objects/867a3e5d-5e2c-4f82-bb81-8c13f91ca107> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "867a3e5d-5e2c-4f82-bb81-8c13f91ca107";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/867a3e5d-5e2c-4f82-bb81-8c13f91ca107>.
+    
+<http://data.lblod.info/id/remote-data-objects/22041c9c-8d1f-4b32-94ce-604a146fb58d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22041c9c-8d1f-4b32-94ce-604a146fb58d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22041c9c-8d1f-4b32-94ce-604a146fb58d>.
+    
+<http://data.lblod.info/id/remote-data-objects/180c41fb-f3da-4b3c-922e-d9a843e53abd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "180c41fb-f3da-4b3c-922e-d9a843e53abd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/180c41fb-f3da-4b3c-922e-d9a843e53abd>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a92e54b-eff6-403c-86e1-c5b52dd8790d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a92e54b-eff6-403c-86e1-c5b52dd8790d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a92e54b-eff6-403c-86e1-c5b52dd8790d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6530f536-7c26-4460-bdbb-d53ee13a9560> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6530f536-7c26-4460-bdbb-d53ee13a9560";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6530f536-7c26-4460-bdbb-d53ee13a9560>.
+    
+<http://data.lblod.info/id/remote-data-objects/6eeebce8-f8d1-4890-9d99-557cc154e41d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6eeebce8-f8d1-4890-9d99-557cc154e41d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6eeebce8-f8d1-4890-9d99-557cc154e41d>.
+    
+<http://data.lblod.info/id/remote-data-objects/94644e20-bc2e-48b0-8e22-4ca152c0ffe7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94644e20-bc2e-48b0-8e22-4ca152c0ffe7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94644e20-bc2e-48b0-8e22-4ca152c0ffe7>.
+    
+<http://data.lblod.info/id/remote-data-objects/23e33776-94f9-43ea-ac63-3c7c1e2f4859> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23e33776-94f9-43ea-ac63-3c7c1e2f4859";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23e33776-94f9-43ea-ac63-3c7c1e2f4859>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ab1f61b-e3a2-49c6-8c8a-b447d7d3c50c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ab1f61b-e3a2-49c6-8c8a-b447d7d3c50c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ab1f61b-e3a2-49c6-8c8a-b447d7d3c50c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b6dc49a-bdfd-41fa-b482-f044fdccb29a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b6dc49a-bdfd-41fa-b482-f044fdccb29a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b6dc49a-bdfd-41fa-b482-f044fdccb29a>.
+    
+<http://data.lblod.info/id/remote-data-objects/de9cce5a-a593-4585-b380-47598565ecda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de9cce5a-a593-4585-b380-47598565ecda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de9cce5a-a593-4585-b380-47598565ecda>.
+    
+<http://data.lblod.info/id/remote-data-objects/98a665c5-bc5f-4b8f-8d35-db3cb5185738> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98a665c5-bc5f-4b8f-8d35-db3cb5185738";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98a665c5-bc5f-4b8f-8d35-db3cb5185738>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4a788e3-e456-437c-9d50-ad65d2b5293d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4a788e3-e456-437c-9d50-ad65d2b5293d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4a788e3-e456-437c-9d50-ad65d2b5293d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc834afa-85d2-4191-9b7e-ff76491af94f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc834afa-85d2-4191-9b7e-ff76491af94f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_27-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc834afa-85d2-4191-9b7e-ff76491af94f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6e9a4a1-e06a-4ab5-8898-751a04902f5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6e9a4a1-e06a-4ab5-8898-751a04902f5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6e9a4a1-e06a-4ab5-8898-751a04902f5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0244faf2-8d5b-47ff-b7b1-bfb5b0151a89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0244faf2-8d5b-47ff-b7b1-bfb5b0151a89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0244faf2-8d5b-47ff-b7b1-bfb5b0151a89>.
+    
+<http://data.lblod.info/id/remote-data-objects/a29f05d1-cdb0-4f78-899a-cd37f3fd8ef2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a29f05d1-cdb0-4f78-899a-cd37f3fd8ef2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a29f05d1-cdb0-4f78-899a-cd37f3fd8ef2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f419254b-bc60-4eaa-a040-33c05b58a074> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f419254b-bc60-4eaa-a040-33c05b58a074";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f419254b-bc60-4eaa-a040-33c05b58a074>.
+    
+<http://data.lblod.info/id/remote-data-objects/623e22d4-a4a8-49d1-b875-bf2095f4ae29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "623e22d4-a4a8-49d1-b875-bf2095f4ae29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_31-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/623e22d4-a4a8-49d1-b875-bf2095f4ae29>.
+    
+<http://data.lblod.info/id/remote-data-objects/32b19718-fd72-4260-874f-8a998d59882f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32b19718-fd72-4260-874f-8a998d59882f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_02-05-2022_37810.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32b19718-fd72-4260-874f-8a998d59882f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a64c558-78b5-4fd6-a4c5-9e6cf4979bc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a64c558-78b5-4fd6-a4c5-9e6cf4979bc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_02-05-2022_37811.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a64c558-78b5-4fd6-a4c5-9e6cf4979bc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7d7fe23-ac7b-43b2-a7a5-f16ca0d49993> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7d7fe23-ac7b-43b2-a7a5-f16ca0d49993";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_02-05-2022_38356.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7d7fe23-ac7b-43b2-a7a5-f16ca0d49993>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8b20cd4-17b0-4885-9588-24dbb7bbe9c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8b20cd4-17b0-4885-9588-24dbb7bbe9c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_02-05-2022_38514.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8b20cd4-17b0-4885-9588-24dbb7bbe9c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c69c8983-3762-436d-aeb9-ec1495c07851> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c69c8983-3762-436d-aeb9-ec1495c07851";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_02-05-2022_38515.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c69c8983-3762-436d-aeb9-ec1495c07851>.
+    
+<http://data.lblod.info/id/remote-data-objects/25a28459-42e2-4613-bb24-6442e720488f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25a28459-42e2-4613-bb24-6442e720488f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_04-04-2022_37805.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25a28459-42e2-4613-bb24-6442e720488f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bba3e6f-c0f2-4928-95af-7091616af644> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bba3e6f-c0f2-4928-95af-7091616af644";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_04-07-2022_40785.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bba3e6f-c0f2-4928-95af-7091616af644>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f0acb5b-8bdf-43d7-b916-bac6794d7579> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f0acb5b-8bdf-43d7-b916-bac6794d7579";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_04-07-2022_40801.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f0acb5b-8bdf-43d7-b916-bac6794d7579>.
+    
+<http://data.lblod.info/id/remote-data-objects/da89fc1f-2329-4747-abd0-04b8760c3a42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da89fc1f-2329-4747-abd0-04b8760c3a42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_04-07-2022_40810.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da89fc1f-2329-4747-abd0-04b8760c3a42>.
+    
+<http://data.lblod.info/id/remote-data-objects/907ec6f6-43f6-44fa-b738-1705b8e3d523> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "907ec6f6-43f6-44fa-b738-1705b8e3d523";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_04-07-2022_40825.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/907ec6f6-43f6-44fa-b738-1705b8e3d523>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d3cb273-3d51-414a-accc-92d25a80f792> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d3cb273-3d51-414a-accc-92d25a80f792";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_06-12-2021_34120.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d3cb273-3d51-414a-accc-92d25a80f792>.
+    
+<http://data.lblod.info/id/remote-data-objects/48a1a467-56b3-4750-8fda-d1e37b5ceb85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48a1a467-56b3-4750-8fda-d1e37b5ceb85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_06-12-2021_34362.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48a1a467-56b3-4750-8fda-d1e37b5ceb85>.
+    
+<http://data.lblod.info/id/remote-data-objects/feb5ea58-6bd3-474c-b666-92f594ef015b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "feb5ea58-6bd3-474c-b666-92f594ef015b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_07-02-2022_35582.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/feb5ea58-6bd3-474c-b666-92f594ef015b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e74ce0f9-afc7-4e00-ad33-56ddc1a4c297> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e74ce0f9-afc7-4e00-ad33-56ddc1a4c297";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_07-02-2022_35609.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e74ce0f9-afc7-4e00-ad33-56ddc1a4c297>.
+    
+<http://data.lblod.info/id/remote-data-objects/b60b2bd1-e8bb-422f-b93d-43a19d9890ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b60b2bd1-e8bb-422f-b93d-43a19d9890ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_07-02-2022_35711.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b60b2bd1-e8bb-422f-b93d-43a19d9890ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/49cea9d7-c16c-4884-b478-636725e14d38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49cea9d7-c16c-4884-b478-636725e14d38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_07-03-2022_36055.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49cea9d7-c16c-4884-b478-636725e14d38>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bc9dedc-97ad-400c-bad2-86d79f9af0fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bc9dedc-97ad-400c-bad2-86d79f9af0fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_07-03-2022_36249.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bc9dedc-97ad-400c-bad2-86d79f9af0fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/161ea4d8-fac5-4703-a02c-cdccd75f910d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "161ea4d8-fac5-4703-a02c-cdccd75f910d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_07-03-2022_36263.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/161ea4d8-fac5-4703-a02c-cdccd75f910d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6313eb85-d608-44bc-b326-09bfe365e667> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6313eb85-d608-44bc-b326-09bfe365e667";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_09-05-2022_39570.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6313eb85-d608-44bc-b326-09bfe365e667>.
+    
+<http://data.lblod.info/id/remote-data-objects/73a258a3-11ce-49b0-8325-f0e048172972> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73a258a3-11ce-49b0-8325-f0e048172972";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_11-04-2022_37839.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73a258a3-11ce-49b0-8325-f0e048172972>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3887947-0dd2-472b-9efd-fa939bd52a3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3887947-0dd2-472b-9efd-fa939bd52a3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_11-04-2022_37921.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae0d7ee7-92da-49b1-9e04-6f93950d6500> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3887947-0dd2-472b-9efd-fa939bd52a3d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201804-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201804-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201804-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201804-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/ec5b69c0-f0c4-4408-880e-91c0f4743258> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ec5b69c0-f0c4-4408-880e-91c0f4743258";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cd1dcff8-411b-400a-8b41-e6e46a2cc2b5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/3d8c6869-55a1-4f20-b017-84515329707c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3d8c6869-55a1-4f20-b017-84515329707c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5>.
+
+  <http://redpencil.data.gift/id/task/3fd6546d-b652-4e1c-b2dd-dc56684deb4d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3fd6546d-b652-4e1c-b2dd-dc56684deb4d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/ec5b69c0-f0c4-4408-880e-91c0f4743258>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/3d8c6869-55a1-4f20-b017-84515329707c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/1ce0cc72-9987-4ff0-bf27-0f19f039e952> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ce0cc72-9987-4ff0-bf27-0f19f039e952";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_11-04-2022_37922.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ce0cc72-9987-4ff0-bf27-0f19f039e952>.
+    
+<http://data.lblod.info/id/remote-data-objects/47644edc-e3d8-4b50-bd50-bc5aaa69dcf7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47644edc-e3d8-4b50-bd50-bc5aaa69dcf7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_11-04-2022_37923.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47644edc-e3d8-4b50-bd50-bc5aaa69dcf7>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3a002cc-7d7d-4566-8990-19694c9f1796> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3a002cc-7d7d-4566-8990-19694c9f1796";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_11-10-2021_32981.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3a002cc-7d7d-4566-8990-19694c9f1796>.
+    
+<http://data.lblod.info/id/remote-data-objects/1df35dde-16d2-45ac-8040-e0fc0045c713> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1df35dde-16d2-45ac-8040-e0fc0045c713";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_13-06-2022_36271.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1df35dde-16d2-45ac-8040-e0fc0045c713>.
+    
+<http://data.lblod.info/id/remote-data-objects/03822208-c390-4885-986a-abe0933dd2f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03822208-c390-4885-986a-abe0933dd2f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_13-06-2022_40118.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03822208-c390-4885-986a-abe0933dd2f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fa0c98d-c639-46d1-b879-a9727e273f33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fa0c98d-c639-46d1-b879-a9727e273f33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_13-06-2022_40122.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fa0c98d-c639-46d1-b879-a9727e273f33>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a41e7c8-eddb-47e5-8af1-aedd337b90fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a41e7c8-eddb-47e5-8af1-aedd337b90fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_13-06-2022_40124.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a41e7c8-eddb-47e5-8af1-aedd337b90fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/7745584d-8e79-4859-918d-8d1d7695c524> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7745584d-8e79-4859-918d-8d1d7695c524";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_13-06-2022_40128.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7745584d-8e79-4859-918d-8d1d7695c524>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e9b851a-b954-40fd-9e15-a3a4739d2a1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e9b851a-b954-40fd-9e15-a3a4739d2a1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_13-06-2022_40191.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e9b851a-b954-40fd-9e15-a3a4739d2a1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/be3fad9b-21c3-412f-a165-d35944c74e04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be3fad9b-21c3-412f-a165-d35944c74e04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_13-06-2022_40279.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be3fad9b-21c3-412f-a165-d35944c74e04>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4a25e24-48c5-4f12-81f8-939a33931a7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4a25e24-48c5-4f12-81f8-939a33931a7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_13-06-2022_40283.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4a25e24-48c5-4f12-81f8-939a33931a7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/47af9635-7bfa-49c7-82f1-8e6a5df8e8e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47af9635-7bfa-49c7-82f1-8e6a5df8e8e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_13-06-2022_40285.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47af9635-7bfa-49c7-82f1-8e6a5df8e8e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9e795f1-c973-4529-802d-6c43e104ef44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9e795f1-c973-4529-802d-6c43e104ef44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_13-06-2022_40286.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9e795f1-c973-4529-802d-6c43e104ef44>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0a59617-2738-439b-b718-3eb4429fcd7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0a59617-2738-439b-b718-3eb4429fcd7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_13-06-2022_40287.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0a59617-2738-439b-b718-3eb4429fcd7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb7a94b9-1d88-4cc8-8c05-fffb83316826> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb7a94b9-1d88-4cc8-8c05-fffb83316826";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_13-06-2022_40291.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb7a94b9-1d88-4cc8-8c05-fffb83316826>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcc2c490-07be-457c-8cef-313223bb07a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcc2c490-07be-457c-8cef-313223bb07a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_13-06-2022_40305.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcc2c490-07be-457c-8cef-313223bb07a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc004ab9-5a55-4cb2-b836-dbb17b5288af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc004ab9-5a55-4cb2-b836-dbb17b5288af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_14-02-2022_35722.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc004ab9-5a55-4cb2-b836-dbb17b5288af>.
+    
+<http://data.lblod.info/id/remote-data-objects/0016b9ae-789b-47a0-9296-99b38f2d71bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0016b9ae-789b-47a0-9296-99b38f2d71bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_14-02-2022_35729.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0016b9ae-789b-47a0-9296-99b38f2d71bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/71ebd983-7df9-4e49-a922-9714aa5cd393> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71ebd983-7df9-4e49-a922-9714aa5cd393";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_14-02-2022_35797.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71ebd983-7df9-4e49-a922-9714aa5cd393>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b48e884-1535-4418-b04a-eba5c3c3a027> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b48e884-1535-4418-b04a-eba5c3c3a027";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_14-03-2022_36288.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b48e884-1535-4418-b04a-eba5c3c3a027>.
+    
+<http://data.lblod.info/id/remote-data-objects/f07d660b-a058-411b-9d26-db121c8b1bb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f07d660b-a058-411b-9d26-db121c8b1bb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_14-03-2022_36324.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f07d660b-a058-411b-9d26-db121c8b1bb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/578cb2e6-8d6d-4a77-8b82-0546ffdcaab0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "578cb2e6-8d6d-4a77-8b82-0546ffdcaab0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_14-03-2022_36338.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/578cb2e6-8d6d-4a77-8b82-0546ffdcaab0>.
+    
+<http://data.lblod.info/id/remote-data-objects/b21eb342-b492-4c58-9f8d-76bb6089f770> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b21eb342-b492-4c58-9f8d-76bb6089f770";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_15-11-2021_33672.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b21eb342-b492-4c58-9f8d-76bb6089f770>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a5345c6-96b8-40a9-a505-bafee5dec3f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a5345c6-96b8-40a9-a505-bafee5dec3f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_15-11-2021_33748.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a5345c6-96b8-40a9-a505-bafee5dec3f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/786c10f1-0fd9-4c54-97e2-16e977abb861> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "786c10f1-0fd9-4c54-97e2-16e977abb861";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_16-05-2022_39577.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/786c10f1-0fd9-4c54-97e2-16e977abb861>.
+    
+<http://data.lblod.info/id/remote-data-objects/22fc8b74-34bf-43e7-8bfb-6d770bc74923> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22fc8b74-34bf-43e7-8bfb-6d770bc74923";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_16-05-2022_39637.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22fc8b74-34bf-43e7-8bfb-6d770bc74923>.
+    
+<http://data.lblod.info/id/remote-data-objects/39452b19-f673-4edb-b9b2-52bb7d725758> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39452b19-f673-4edb-b9b2-52bb7d725758";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_16-05-2022_39638.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39452b19-f673-4edb-b9b2-52bb7d725758>.
+    
+<http://data.lblod.info/id/remote-data-objects/b876e8a8-da1e-4f2c-924a-bd2818e79d89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b876e8a8-da1e-4f2c-924a-bd2818e79d89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_16-05-2022_39648.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b876e8a8-da1e-4f2c-924a-bd2818e79d89>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ea0aea4-a2b1-48cc-abea-edab120d223a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ea0aea4-a2b1-48cc-abea-edab120d223a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_16-05-2022_39656.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ea0aea4-a2b1-48cc-abea-edab120d223a>.
+    
+<http://data.lblod.info/id/remote-data-objects/48017b4a-1111-4058-9c7d-8b148c528238> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48017b4a-1111-4058-9c7d-8b148c528238";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_16-05-2022_39673.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48017b4a-1111-4058-9c7d-8b148c528238>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dbbdd1f-1f20-4bbd-bfed-44b3cbf24bad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dbbdd1f-1f20-4bbd-bfed-44b3cbf24bad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_16-05-2022_39678.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dbbdd1f-1f20-4bbd-bfed-44b3cbf24bad>.
+    
+<http://data.lblod.info/id/remote-data-objects/090936c0-3e14-4396-8aad-adb7f744f0bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "090936c0-3e14-4396-8aad-adb7f744f0bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_16-05-2022_39704.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/090936c0-3e14-4396-8aad-adb7f744f0bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/c89e7a0c-7eab-42ff-9779-3797a3469db0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c89e7a0c-7eab-42ff-9779-3797a3469db0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_17-01-2022_35066.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c89e7a0c-7eab-42ff-9779-3797a3469db0>.
+    
+<http://data.lblod.info/id/remote-data-objects/eeba72ba-532a-498c-af91-635b5c19b3ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eeba72ba-532a-498c-af91-635b5c19b3ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_17-01-2022_35081.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eeba72ba-532a-498c-af91-635b5c19b3ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/90969e95-7dca-4357-91f9-0add2be9a2cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90969e95-7dca-4357-91f9-0add2be9a2cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_17-01-2022_35113.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90969e95-7dca-4357-91f9-0add2be9a2cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1efac79-5cc3-403f-954c-81cf225b5ea0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1efac79-5cc3-403f-954c-81cf225b5ea0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_18-07-2022_40783.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1efac79-5cc3-403f-954c-81cf225b5ea0>.
+    
+<http://data.lblod.info/id/remote-data-objects/28f394df-0881-41be-bb39-749b940aeb4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28f394df-0881-41be-bb39-749b940aeb4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_18-07-2022_40840.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28f394df-0881-41be-bb39-749b940aeb4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/967d9c6a-41ba-44d9-bec6-79809a636f2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "967d9c6a-41ba-44d9-bec6-79809a636f2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_18-07-2022_40842.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/967d9c6a-41ba-44d9-bec6-79809a636f2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddbf1fc8-1506-40cf-b77a-b2c727922523> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddbf1fc8-1506-40cf-b77a-b2c727922523";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_18-07-2022_40844.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddbf1fc8-1506-40cf-b77a-b2c727922523>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ea10ab4-ea7b-4b57-ac7e-f7d5e3dbe715> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ea10ab4-ea7b-4b57-ac7e-f7d5e3dbe715";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_18-07-2022_40875.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ea10ab4-ea7b-4b57-ac7e-f7d5e3dbe715>.
+    
+<http://data.lblod.info/id/remote-data-objects/244b9210-1078-489e-ac9e-d425dcbfd339> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "244b9210-1078-489e-ac9e-d425dcbfd339";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_18-07-2022_40883.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/244b9210-1078-489e-ac9e-d425dcbfd339>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb3bd2e7-6610-4996-81be-197cff403b41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb3bd2e7-6610-4996-81be-197cff403b41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_18-10-2021_33114.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb3bd2e7-6610-4996-81be-197cff403b41>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca6a77ed-dcc8-4ab4-a3c3-8e2fe866ef1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca6a77ed-dcc8-4ab4-a3c3-8e2fe866ef1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_20-12-2021_34511.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca6a77ed-dcc8-4ab4-a3c3-8e2fe866ef1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d185b5d-bc6b-49fe-b5ad-1c3ae834d514> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d185b5d-bc6b-49fe-b5ad-1c3ae834d514";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_20-12-2021_34633.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d185b5d-bc6b-49fe-b5ad-1c3ae834d514>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddc613bc-5848-4c16-a68e-fb8c4a157bb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddc613bc-5848-4c16-a68e-fb8c4a157bb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_21-03-2022_36472.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddc613bc-5848-4c16-a68e-fb8c4a157bb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e61c6f32-390f-4d4b-919f-cfc0f15afb4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e61c6f32-390f-4d4b-919f-cfc0f15afb4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_21-03-2022_36478.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e61c6f32-390f-4d4b-919f-cfc0f15afb4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fd0399e-53f7-407a-bf16-b15a34c23f81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fd0399e-53f7-407a-bf16-b15a34c23f81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_21-03-2022_36491.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fd0399e-53f7-407a-bf16-b15a34c23f81>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a58efe0-cd37-4539-9f53-c4dff59da5b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a58efe0-cd37-4539-9f53-c4dff59da5b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_22-11-2021_33882.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a58efe0-cd37-4539-9f53-c4dff59da5b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d0abf77-fdac-4bc6-9e7e-c76094f01fab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d0abf77-fdac-4bc6-9e7e-c76094f01fab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_23-05-2022_39722.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d0abf77-fdac-4bc6-9e7e-c76094f01fab>.
+    
+<http://data.lblod.info/id/remote-data-objects/16b6d946-af81-4b45-8e0f-885545fc472b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16b6d946-af81-4b45-8e0f-885545fc472b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_23-05-2022_39732.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/cd1dcff8-411b-400a-8b41-e6e46a2cc2b5> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16b6d946-af81-4b45-8e0f-885545fc472b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201805-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201805-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201805-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201805-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/19870e4f-4150-4c08-8440-6963706330f1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "19870e4f-4150-4c08-8440-6963706330f1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a52beb50-b8d3-4ba9-83b4-757610aeee9e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4f63455e-4460-4cd6-8d43-6555877cc787> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4f63455e-4460-4cd6-8d43-6555877cc787";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e>.
+
+  <http://redpencil.data.gift/id/task/15b4b767-0c62-44d4-9e9a-3422ce14830f> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "15b4b767-0c62-44d4-9e9a-3422ce14830f";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/19870e4f-4150-4c08-8440-6963706330f1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4f63455e-4460-4cd6-8d43-6555877cc787>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/3d35f1d8-1a8d-484a-89b0-8f7f1f8e1e44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d35f1d8-1a8d-484a-89b0-8f7f1f8e1e44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_23-05-2022_39804.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d35f1d8-1a8d-484a-89b0-8f7f1f8e1e44>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce5d4d05-0cfe-4ab7-87a6-7e7fe15adf0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce5d4d05-0cfe-4ab7-87a6-7e7fe15adf0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_23-05-2022_39805.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce5d4d05-0cfe-4ab7-87a6-7e7fe15adf0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/abc74f36-1fdb-40bb-8162-75faf25d2b86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abc74f36-1fdb-40bb-8162-75faf25d2b86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_24-01-2022_35220.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abc74f36-1fdb-40bb-8162-75faf25d2b86>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1cb5185-95b1-4ce2-9396-56259d403242> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1cb5185-95b1-4ce2-9396-56259d403242";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_25-04-2022_38167.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1cb5185-95b1-4ce2-9396-56259d403242>.
+    
+<http://data.lblod.info/id/remote-data-objects/5314edf6-d59e-42e0-a0d9-29a0b2c17cf4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5314edf6-d59e-42e0-a0d9-29a0b2c17cf4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_25-04-2022_38175.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5314edf6-d59e-42e0-a0d9-29a0b2c17cf4>.
+    
+<http://data.lblod.info/id/remote-data-objects/60f2be35-5ade-4d51-b57e-49462ff82a79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60f2be35-5ade-4d51-b57e-49462ff82a79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_25-04-2022_38185.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60f2be35-5ade-4d51-b57e-49462ff82a79>.
+    
+<http://data.lblod.info/id/remote-data-objects/90095f30-6960-4cf4-b30d-adf8a7499971> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90095f30-6960-4cf4-b30d-adf8a7499971";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_25-10-2021_33196.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90095f30-6960-4cf4-b30d-adf8a7499971>.
+    
+<http://data.lblod.info/id/remote-data-objects/44848e08-ac5c-40e8-8562-60c6e426d8c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44848e08-ac5c-40e8-8562-60c6e426d8c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_27-06-2022_40465.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44848e08-ac5c-40e8-8562-60c6e426d8c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8a48eb2-3a13-447c-b989-c54906379827> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8a48eb2-3a13-447c-b989-c54906379827";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_27-06-2022_40475.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8a48eb2-3a13-447c-b989-c54906379827>.
+    
+<http://data.lblod.info/id/remote-data-objects/77e1c72c-c3d6-468d-aec2-2a911a67ef61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77e1c72c-c3d6-468d-aec2-2a911a67ef61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_27-06-2022_40500.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77e1c72c-c3d6-468d-aec2-2a911a67ef61>.
+    
+<http://data.lblod.info/id/remote-data-objects/fda46563-d8fc-4ab3-b786-c133ae163580> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fda46563-d8fc-4ab3-b786-c133ae163580";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_27-06-2022_40501.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fda46563-d8fc-4ab3-b786-c133ae163580>.
+    
+<http://data.lblod.info/id/remote-data-objects/c174a493-4cf3-4efe-b603-76f5bb06966a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c174a493-4cf3-4efe-b603-76f5bb06966a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_27-06-2022_40502.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c174a493-4cf3-4efe-b603-76f5bb06966a>.
+    
+<http://data.lblod.info/id/remote-data-objects/eae46a28-a70d-4d6f-b2ad-888b0bb8e4c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eae46a28-a70d-4d6f-b2ad-888b0bb8e4c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_27-06-2022_40594.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eae46a28-a70d-4d6f-b2ad-888b0bb8e4c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/50c09995-3cec-4b03-861d-edecdd2d1c14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50c09995-3cec-4b03-861d-edecdd2d1c14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_27-06-2022_40627.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50c09995-3cec-4b03-861d-edecdd2d1c14>.
+    
+<http://data.lblod.info/id/remote-data-objects/180cc035-3d31-47b1-84c0-570847d60431> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "180cc035-3d31-47b1-84c0-570847d60431";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_27-06-2022_40655.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/180cc035-3d31-47b1-84c0-570847d60431>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ef90a24-6fc7-4036-bbaf-9b58b0c3716b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ef90a24-6fc7-4036-bbaf-9b58b0c3716b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_28-03-2022_37613.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ef90a24-6fc7-4036-bbaf-9b58b0c3716b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8aa3983-0105-437f-8086-6d8fe166e0ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8aa3983-0105-437f-8086-6d8fe166e0ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_28-03-2022_37636.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8aa3983-0105-437f-8086-6d8fe166e0ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cb3c1e3-de15-4f2b-9493-1fabed17566f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cb3c1e3-de15-4f2b-9493-1fabed17566f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_28-03-2022_37698.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cb3c1e3-de15-4f2b-9493-1fabed17566f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e9fdb18-90f5-4a06-836c-b4bfe51ca288> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e9fdb18-90f5-4a06-836c-b4bfe51ca288";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_30-05-2022_39855.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e9fdb18-90f5-4a06-836c-b4bfe51ca288>.
+    
+<http://data.lblod.info/id/remote-data-objects/a58e71e0-0deb-447c-aad8-eaee4f4d4386> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a58e71e0-0deb-447c-aad8-eaee4f4d4386";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_30-05-2022_39864.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a58e71e0-0deb-447c-aad8-eaee4f4d4386>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4472d49-0ee6-4934-9600-5bcc3a4e7d12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4472d49-0ee6-4934-9600-5bcc3a4e7d12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_30-05-2022_39869.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4472d49-0ee6-4934-9600-5bcc3a4e7d12>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbb5a191-8a5a-434b-b636-56bf0ce3068a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbb5a191-8a5a-434b-b636-56bf0ce3068a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_30-05-2022_40018.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbb5a191-8a5a-434b-b636-56bf0ce3068a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e9ec51c-8876-4c91-b4e7-efcd43053f22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e9ec51c-8876-4c91-b4e7-efcd43053f22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_30-05-2022_40030.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e9ec51c-8876-4c91-b4e7-efcd43053f22>.
+    
+<http://data.lblod.info/id/remote-data-objects/9425efb0-a42f-47f1-b39a-66447c47e2a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9425efb0-a42f-47f1-b39a-66447c47e2a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_30-05-2022_40043.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9425efb0-a42f-47f1-b39a-66447c47e2a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/520c66fe-8279-4c23-ad31-0ba9b3019324> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "520c66fe-8279-4c23-ad31-0ba9b3019324";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_30-05-2022_40114.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/520c66fe-8279-4c23-ad31-0ba9b3019324>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ddaea46-5138-4cea-bf27-7410eec0e31a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ddaea46-5138-4cea-bf27-7410eec0e31a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/6b8aae2f064a9ec582828ff71d195450cbdf0201e13e6f9da91fd9a8240c8657/GetPublication?filename=Uittreksels_31-01-2022_35256.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ddaea46-5138-4cea-bf27-7410eec0e31a>.
+    
+<http://data.lblod.info/id/remote-data-objects/eaa2c57f-d5e0-406d-890e-684b9deb4fe6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eaa2c57f-d5e0-406d-890e-684b9deb4fe6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eaa2c57f-d5e0-406d-890e-684b9deb4fe6>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fd89899-25c8-44fd-8df0-7562109ead04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fd89899-25c8-44fd-8df0-7562109ead04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fd89899-25c8-44fd-8df0-7562109ead04>.
+    
+<http://data.lblod.info/id/remote-data-objects/67398717-ef19-4c6b-8b8a-d234b03f3536> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67398717-ef19-4c6b-8b8a-d234b03f3536";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67398717-ef19-4c6b-8b8a-d234b03f3536>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f1d427d-99bb-4e2a-9db7-5e1f183736dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f1d427d-99bb-4e2a-9db7-5e1f183736dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f1d427d-99bb-4e2a-9db7-5e1f183736dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/2952f514-d07e-4317-b57f-bd7e3b6524e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2952f514-d07e-4317-b57f-bd7e3b6524e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2952f514-d07e-4317-b57f-bd7e3b6524e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/66ab7b33-aafc-4e49-ad0d-18a5b1d4e30a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66ab7b33-aafc-4e49-ad0d-18a5b1d4e30a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66ab7b33-aafc-4e49-ad0d-18a5b1d4e30a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e23d2ffe-6a73-4034-b1db-8f0fe5e8ed45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e23d2ffe-6a73-4034-b1db-8f0fe5e8ed45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e23d2ffe-6a73-4034-b1db-8f0fe5e8ed45>.
+    
+<http://data.lblod.info/id/remote-data-objects/48e7568e-fed3-44d4-9aac-cb0a64fa7276> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48e7568e-fed3-44d4-9aac-cb0a64fa7276";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48e7568e-fed3-44d4-9aac-cb0a64fa7276>.
+    
+<http://data.lblod.info/id/remote-data-objects/b88d67e6-d3e8-47df-a73c-f0882188a9ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b88d67e6-d3e8-47df-a73c-f0882188a9ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b88d67e6-d3e8-47df-a73c-f0882188a9ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/5df61f4b-50ee-4e99-9d5a-5c1ee3c82b56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5df61f4b-50ee-4e99-9d5a-5c1ee3c82b56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Agenda_Raad%20voor%20maatschappelijk%20welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5df61f4b-50ee-4e99-9d5a-5c1ee3c82b56>.
+    
+<http://data.lblod.info/id/remote-data-objects/b651a518-6126-4b7c-a903-934c615ead18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b651a518-6126-4b7c-a903-934c615ead18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b651a518-6126-4b7c-a903-934c615ead18>.
+    
+<http://data.lblod.info/id/remote-data-objects/d49f9102-977c-436e-9143-b7e63c28b3be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d49f9102-977c-436e-9143-b7e63c28b3be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d49f9102-977c-436e-9143-b7e63c28b3be>.
+    
+<http://data.lblod.info/id/remote-data-objects/33ad8d0f-0c25-4768-9e8a-3c4cf48345a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33ad8d0f-0c25-4768-9e8a-3c4cf48345a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33ad8d0f-0c25-4768-9e8a-3c4cf48345a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/996b4f8e-0c61-4e1b-8741-ff742ecc5afc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "996b4f8e-0c61-4e1b-8741-ff742ecc5afc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/996b4f8e-0c61-4e1b-8741-ff742ecc5afc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d941bca8-d4dc-4d55-8c9b-f2360e074c06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d941bca8-d4dc-4d55-8c9b-f2360e074c06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d941bca8-d4dc-4d55-8c9b-f2360e074c06>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd217e15-e245-4688-bf95-516ae613f599> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd217e15-e245-4688-bf95-516ae613f599";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd217e15-e245-4688-bf95-516ae613f599>.
+    
+<http://data.lblod.info/id/remote-data-objects/f125723c-6997-4a1b-8440-53da429274e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f125723c-6997-4a1b-8440-53da429274e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f125723c-6997-4a1b-8440-53da429274e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c4e0ab2-3445-4815-b092-904fb70b063c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c4e0ab2-3445-4815-b092-904fb70b063c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c4e0ab2-3445-4815-b092-904fb70b063c>.
+    
+<http://data.lblod.info/id/remote-data-objects/25a19e87-f428-43b1-ba7a-47f8b22a186b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25a19e87-f428-43b1-ba7a-47f8b22a186b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25a19e87-f428-43b1-ba7a-47f8b22a186b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d77978d-8191-46bc-ae45-542999b9e68c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d77978d-8191-46bc-ae45-542999b9e68c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d77978d-8191-46bc-ae45-542999b9e68c>.
+    
+<http://data.lblod.info/id/remote-data-objects/42ad7bee-bbcc-4b93-9507-14bb4424c509> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42ad7bee-bbcc-4b93-9507-14bb4424c509";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42ad7bee-bbcc-4b93-9507-14bb4424c509>.
+    
+<http://data.lblod.info/id/remote-data-objects/51ddfc11-4ab2-4235-a72c-e4059a5cfa83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51ddfc11-4ab2-4235-a72c-e4059a5cfa83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51ddfc11-4ab2-4235-a72c-e4059a5cfa83>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d23347b-3c2f-4880-8b82-3cc8572b0db0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d23347b-3c2f-4880-8b82-3cc8572b0db0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d23347b-3c2f-4880-8b82-3cc8572b0db0>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ce20316-bc5c-4a38-bae1-fbeea029445e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ce20316-bc5c-4a38-bae1-fbeea029445e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a52beb50-b8d3-4ba9-83b4-757610aeee9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ce20316-bc5c-4a38-bae1-fbeea029445e>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201806-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201806-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201806-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201806-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d6e6580e-4628-49f4-934b-0a06a8a938c3> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d6e6580e-4628-49f4-934b-0a06a8a938c3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "34de2f6e-e875-4d75-b2c1-7f505e552640";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/179209f1-03ed-4fee-b65a-0a4bc9e490bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "179209f1-03ed-4fee-b65a-0a4bc9e490bc";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640>.
+
+  <http://redpencil.data.gift/id/task/7c2679bb-1dff-4599-a9b6-19d38b522133> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7c2679bb-1dff-4599-a9b6-19d38b522133";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d6e6580e-4628-49f4-934b-0a06a8a938c3>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/179209f1-03ed-4fee-b65a-0a4bc9e490bc>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/6e4a14a8-e7f0-4246-9815-cc72892588a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e4a14a8-e7f0-4246-9815-cc72892588a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e4a14a8-e7f0-4246-9815-cc72892588a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/8293b119-89dd-4eeb-b5c2-4776e767ad51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8293b119-89dd-4eeb-b5c2-4776e767ad51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8293b119-89dd-4eeb-b5c2-4776e767ad51>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd3d0de3-d8fb-4c8d-bb0c-a9c5f13a1797> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd3d0de3-d8fb-4c8d-bb0c-a9c5f13a1797";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd3d0de3-d8fb-4c8d-bb0c-a9c5f13a1797>.
+    
+<http://data.lblod.info/id/remote-data-objects/141d21aa-e92c-4949-b3c5-5352b1c5b2f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "141d21aa-e92c-4949-b3c5-5352b1c5b2f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/141d21aa-e92c-4949-b3c5-5352b1c5b2f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/79472284-d7fc-406f-b541-a09a0fd6c09f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79472284-d7fc-406f-b541-a09a0fd6c09f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79472284-d7fc-406f-b541-a09a0fd6c09f>.
+    
+<http://data.lblod.info/id/remote-data-objects/89afd85b-f17b-4873-8f2f-2c732aa9dd37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89afd85b-f17b-4873-8f2f-2c732aa9dd37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Notulen_Raad%20voor%20maatschappelijk%20welzijn_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89afd85b-f17b-4873-8f2f-2c732aa9dd37>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4e5c4b2-8562-4496-8b69-d49220c113ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4e5c4b2-8562-4496-8b69-d49220c113ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_05-01-2022_34718.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4e5c4b2-8562-4496-8b69-d49220c113ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb600970-7854-48b9-8f53-89a7c4086184> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb600970-7854-48b9-8f53-89a7c4086184";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_13-06-2022_40040.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb600970-7854-48b9-8f53-89a7c4086184>.
+    
+<http://data.lblod.info/id/remote-data-objects/742b60cc-5dba-48d0-a479-a218d05690af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "742b60cc-5dba-48d0-a479-a218d05690af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_14-02-2022_35486.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/742b60cc-5dba-48d0-a479-a218d05690af>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd31445d-c95d-4b65-b756-4883aed55dc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd31445d-c95d-4b65-b756-4883aed55dc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_15-11-2021_33008.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd31445d-c95d-4b65-b756-4883aed55dc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc4c72f1-d6cb-47aa-b94c-7ca61224f7d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc4c72f1-d6cb-47aa-b94c-7ca61224f7d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_15-11-2021_33406.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc4c72f1-d6cb-47aa-b94c-7ca61224f7d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a466bc59-ff5d-4129-a1ca-251c4b712211> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a466bc59-ff5d-4129-a1ca-251c4b712211";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_18-10-2021_32683.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a466bc59-ff5d-4129-a1ca-251c4b712211>.
+    
+<http://data.lblod.info/id/remote-data-objects/b60d534a-daf1-4aaa-ac5d-8ab87065093b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b60d534a-daf1-4aaa-ac5d-8ab87065093b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_18-10-2021_32766.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b60d534a-daf1-4aaa-ac5d-8ab87065093b>.
+    
+<http://data.lblod.info/id/remote-data-objects/343c45cd-cb2f-4f52-9c3c-ea10a0a6cefc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "343c45cd-cb2f-4f52-9c3c-ea10a0a6cefc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_18-10-2021_32832.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/343c45cd-cb2f-4f52-9c3c-ea10a0a6cefc>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd2df4bc-0678-4eb2-9a59-4000cdc3028a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd2df4bc-0678-4eb2-9a59-4000cdc3028a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_18-10-2021_32833.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd2df4bc-0678-4eb2-9a59-4000cdc3028a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f1c1a51-890c-4a2c-9aca-a26ddc14dbd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f1c1a51-890c-4a2c-9aca-a26ddc14dbd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_18-10-2021_32834.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f1c1a51-890c-4a2c-9aca-a26ddc14dbd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/4136cbee-9930-4f57-bbdb-1a4f87d54405> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4136cbee-9930-4f57-bbdb-1a4f87d54405";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_20-12-2021_34370.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4136cbee-9930-4f57-bbdb-1a4f87d54405>.
+    
+<http://data.lblod.info/id/remote-data-objects/465b5657-50e4-4781-8e74-42c248cc961f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "465b5657-50e4-4781-8e74-42c248cc961f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_24-01-2022_35089.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/465b5657-50e4-4781-8e74-42c248cc961f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b382aa7-690c-46d9-afa0-e13c50308a41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b382aa7-690c-46d9-afa0-e13c50308a41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_24-01-2022_35090.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b382aa7-690c-46d9-afa0-e13c50308a41>.
+    
+<http://data.lblod.info/id/remote-data-objects/88d82888-9a21-406c-bb8d-a2b89c53060c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88d82888-9a21-406c-bb8d-a2b89c53060c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_24-01-2022_35091.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88d82888-9a21-406c-bb8d-a2b89c53060c>.
+    
+<http://data.lblod.info/id/remote-data-objects/88877ff2-7244-444b-8eef-0af0eed2278c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88877ff2-7244-444b-8eef-0af0eed2278c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_25-04-2022_38029.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88877ff2-7244-444b-8eef-0af0eed2278c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5df1b25-de49-46d3-9cc6-87744d0b1cde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5df1b25-de49-46d3-9cc6-87744d0b1cde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_28-03-2022_36381.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5df1b25-de49-46d3-9cc6-87744d0b1cde>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdd85f00-f606-4ab3-81b6-1dfe3c1182eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdd85f00-f606-4ab3-81b6-1dfe3c1182eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d4cbbd4aa8371834d99b838dcbe9563c5d04a5cc596c0abb43e491905f2c7eea/GetPublication?filename=Uittreksels_28-03-2022_36465.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdd85f00-f606-4ab3-81b6-1dfe3c1182eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6e0f515-b65c-4b9e-b98b-06ee78ba51b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6e0f515-b65c-4b9e-b98b-06ee78ba51b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_02-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6e0f515-b65c-4b9e-b98b-06ee78ba51b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/93504937-e310-4633-b076-e0fa18b1544a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93504937-e310-4633-b076-e0fa18b1544a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93504937-e310-4633-b076-e0fa18b1544a>.
+    
+<http://data.lblod.info/id/remote-data-objects/32c96825-4909-49d6-8a32-4c3be17517bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32c96825-4909-49d6-8a32-4c3be17517bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32c96825-4909-49d6-8a32-4c3be17517bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/83ff6671-2be1-4665-a7a1-133f5e963553> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83ff6671-2be1-4665-a7a1-133f5e963553";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83ff6671-2be1-4665-a7a1-133f5e963553>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb304ba9-f2a3-4690-a9e8-37a5bb38c706> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb304ba9-f2a3-4690-a9e8-37a5bb38c706";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_06-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb304ba9-f2a3-4690-a9e8-37a5bb38c706>.
+    
+<http://data.lblod.info/id/remote-data-objects/686ca189-370b-41a8-a530-80d1c27fc35a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "686ca189-370b-41a8-a530-80d1c27fc35a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/686ca189-370b-41a8-a530-80d1c27fc35a>.
+    
+<http://data.lblod.info/id/remote-data-objects/01169068-0a03-4bc5-99f5-af196ccd47b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01169068-0a03-4bc5-99f5-af196ccd47b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01169068-0a03-4bc5-99f5-af196ccd47b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6adb8d28-a766-479e-a7e5-81a14501a651> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6adb8d28-a766-479e-a7e5-81a14501a651";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6adb8d28-a766-479e-a7e5-81a14501a651>.
+    
+<http://data.lblod.info/id/remote-data-objects/29112b0b-841b-4fdf-9006-6bf931471bf3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29112b0b-841b-4fdf-9006-6bf931471bf3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29112b0b-841b-4fdf-9006-6bf931471bf3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3d1834d-a765-494e-b6ff-38c11657b82c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3d1834d-a765-494e-b6ff-38c11657b82c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_10-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3d1834d-a765-494e-b6ff-38c11657b82c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e66edc9-a718-4ee9-a800-013662607072> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e66edc9-a718-4ee9-a800-013662607072";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e66edc9-a718-4ee9-a800-013662607072>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b0ecad4-2882-4662-a86d-26ac61fdc862> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b0ecad4-2882-4662-a86d-26ac61fdc862";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b0ecad4-2882-4662-a86d-26ac61fdc862>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c9d6c71-3d37-4309-8f90-2268156046c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c9d6c71-3d37-4309-8f90-2268156046c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c9d6c71-3d37-4309-8f90-2268156046c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6bc51ae-7b00-4e5a-a57c-6b2d211c9717> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6bc51ae-7b00-4e5a-a57c-6b2d211c9717";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_13-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6bc51ae-7b00-4e5a-a57c-6b2d211c9717>.
+    
+<http://data.lblod.info/id/remote-data-objects/6af44db5-6af9-4d73-9d3f-1ac6ec1e6cf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6af44db5-6af9-4d73-9d3f-1ac6ec1e6cf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6af44db5-6af9-4d73-9d3f-1ac6ec1e6cf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf4ad53e-e82b-453e-aa7c-ddb30510403e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf4ad53e-e82b-453e-aa7c-ddb30510403e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf4ad53e-e82b-453e-aa7c-ddb30510403e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2de3803-ec75-479c-a718-51de7d3fa467> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2de3803-ec75-479c-a718-51de7d3fa467";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2de3803-ec75-479c-a718-51de7d3fa467>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa3bb7f4-1e36-4f07-aee0-9069b69936ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa3bb7f4-1e36-4f07-aee0-9069b69936ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_17-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa3bb7f4-1e36-4f07-aee0-9069b69936ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/a61fa781-e243-4ad0-83b2-971f79da29e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a61fa781-e243-4ad0-83b2-971f79da29e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a61fa781-e243-4ad0-83b2-971f79da29e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/019047a9-9d72-4779-8f15-410d74ca5ff1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "019047a9-9d72-4779-8f15-410d74ca5ff1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/019047a9-9d72-4779-8f15-410d74ca5ff1>.
+    
+<http://data.lblod.info/id/remote-data-objects/33b11abd-8911-47d6-a0c9-cc257d6e779a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33b11abd-8911-47d6-a0c9-cc257d6e779a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33b11abd-8911-47d6-a0c9-cc257d6e779a>.
+    
+<http://data.lblod.info/id/remote-data-objects/64a38672-f274-464c-ae0a-e1b32e5e9934> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64a38672-f274-464c-ae0a-e1b32e5e9934";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64a38672-f274-464c-ae0a-e1b32e5e9934>.
+    
+<http://data.lblod.info/id/remote-data-objects/08aa8495-32c5-4b7a-b592-98b85f3149f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08aa8495-32c5-4b7a-b592-98b85f3149f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08aa8495-32c5-4b7a-b592-98b85f3149f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/61ce4306-ecc9-4ec2-8407-d0f1f98db8b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61ce4306-ecc9-4ec2-8407-d0f1f98db8b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61ce4306-ecc9-4ec2-8407-d0f1f98db8b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/811dc7e5-b13c-428b-abc3-a47f34defdbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "811dc7e5-b13c-428b-abc3-a47f34defdbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/811dc7e5-b13c-428b-abc3-a47f34defdbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8113f91-231e-432b-97d2-1eeb8dcf2614> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8113f91-231e-432b-97d2-1eeb8dcf2614";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8113f91-231e-432b-97d2-1eeb8dcf2614>.
+    
+<http://data.lblod.info/id/remote-data-objects/4500e2f8-14db-43d1-8b85-a6f8cd024845> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4500e2f8-14db-43d1-8b85-a6f8cd024845";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/34de2f6e-e875-4d75-b2c1-7f505e552640> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4500e2f8-14db-43d1-8b85-a6f8cd024845>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201807-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201807-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201807-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201807-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/274b03b2-eae1-43ab-a4e7-9046e5e2dfbe> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "274b03b2-eae1-43ab-a4e7-9046e5e2dfbe";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2371db08-4de7-423f-92cc-b818a0af62de";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/fea4ec83-deb0-443b-9f73-6e588876ef0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fea4ec83-deb0-443b-9f73-6e588876ef0a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de>.
+
+  <http://redpencil.data.gift/id/task/2483b489-c1ac-479c-b607-e95a006f5864> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2483b489-c1ac-479c-b607-e95a006f5864";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/274b03b2-eae1-43ab-a4e7-9046e5e2dfbe>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/fea4ec83-deb0-443b-9f73-6e588876ef0a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/fe1064d7-7e18-4503-92af-d0453f6918f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe1064d7-7e18-4503-92af-d0453f6918f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe1064d7-7e18-4503-92af-d0453f6918f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/1dd62739-0afe-48f3-90e2-e28f1612373c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1dd62739-0afe-48f3-90e2-e28f1612373c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1dd62739-0afe-48f3-90e2-e28f1612373c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b21fe191-770c-437b-bfca-f801d8bc4e89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b21fe191-770c-437b-bfca-f801d8bc4e89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b21fe191-770c-437b-bfca-f801d8bc4e89>.
+    
+<http://data.lblod.info/id/remote-data-objects/2136b959-4680-4ba7-8a39-4fa2aa9092f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2136b959-4680-4ba7-8a39-4fa2aa9092f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2136b959-4680-4ba7-8a39-4fa2aa9092f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/982f3f24-5107-497a-b6be-5e0b6d667a9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "982f3f24-5107-497a-b6be-5e0b6d667a9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/982f3f24-5107-497a-b6be-5e0b6d667a9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bc7328c-aa07-4a57-adc0-e9e90f199493> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bc7328c-aa07-4a57-adc0-e9e90f199493";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bc7328c-aa07-4a57-adc0-e9e90f199493>.
+    
+<http://data.lblod.info/id/remote-data-objects/56be6546-b7ab-4893-8259-2ea53f27d87d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56be6546-b7ab-4893-8259-2ea53f27d87d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/d73ff5dca3159b0e7c864e57997dbd58140e6822f1d1eafc73d9ef3c01920dfe/GetPublication?filename=BesluitenLijst_Vast%20Bureau_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56be6546-b7ab-4893-8259-2ea53f27d87d>.
+    
+<http://data.lblod.info/id/remote-data-objects/06653a10-6474-4886-a1dc-b92b5e212e42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06653a10-6474-4886-a1dc-b92b5e212e42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Agenda_Gemeenteraad_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06653a10-6474-4886-a1dc-b92b5e212e42>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbff78a9-4d3f-4904-8ac8-9fd56891fb08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbff78a9-4d3f-4904-8ac8-9fd56891fb08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Agenda_Gemeenteraad_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbff78a9-4d3f-4904-8ac8-9fd56891fb08>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1dddabc-2cc4-4bd2-b23e-838364e5cff4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1dddabc-2cc4-4bd2-b23e-838364e5cff4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Agenda_Gemeenteraad_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1dddabc-2cc4-4bd2-b23e-838364e5cff4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3da3eb3a-818e-4385-9f38-e46c13e7c904> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3da3eb3a-818e-4385-9f38-e46c13e7c904";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Agenda_Gemeenteraad_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3da3eb3a-818e-4385-9f38-e46c13e7c904>.
+    
+<http://data.lblod.info/id/remote-data-objects/22fa5b01-a907-428d-942f-44c03fc8a6d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22fa5b01-a907-428d-942f-44c03fc8a6d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Agenda_Gemeenteraad_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22fa5b01-a907-428d-942f-44c03fc8a6d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/80f4e103-d73f-438a-97bd-fb6d16129d90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80f4e103-d73f-438a-97bd-fb6d16129d90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Agenda_Gemeenteraad_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80f4e103-d73f-438a-97bd-fb6d16129d90>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1bfdc0d-8cda-4026-a962-402749e0b5fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1bfdc0d-8cda-4026-a962-402749e0b5fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Agenda_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1bfdc0d-8cda-4026-a962-402749e0b5fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4883b23-2977-4989-8b8b-06ada14cd88a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4883b23-2977-4989-8b8b-06ada14cd88a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Agenda_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4883b23-2977-4989-8b8b-06ada14cd88a>.
+    
+<http://data.lblod.info/id/remote-data-objects/29de570c-8cfb-47b8-86cb-19af3b9343eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29de570c-8cfb-47b8-86cb-19af3b9343eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Agenda_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29de570c-8cfb-47b8-86cb-19af3b9343eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c960fb94-1266-408e-825b-7bdf9a54f8c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c960fb94-1266-408e-825b-7bdf9a54f8c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Agenda_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c960fb94-1266-408e-825b-7bdf9a54f8c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/383a5eae-6b0d-44b8-bf4c-3c61278fe47d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "383a5eae-6b0d-44b8-bf4c-3c61278fe47d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=BesluitenLijst_Gemeenteraad_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/383a5eae-6b0d-44b8-bf4c-3c61278fe47d>.
+    
+<http://data.lblod.info/id/remote-data-objects/316b0669-b83f-4b37-852d-32ebcf2716fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "316b0669-b83f-4b37-852d-32ebcf2716fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=BesluitenLijst_Gemeenteraad_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/316b0669-b83f-4b37-852d-32ebcf2716fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/9458d04a-db2a-40b9-be3e-b10ba7aa20dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9458d04a-db2a-40b9-be3e-b10ba7aa20dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=BesluitenLijst_Gemeenteraad_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9458d04a-db2a-40b9-be3e-b10ba7aa20dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f995590-cda0-4102-a1a2-395d130bf798> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f995590-cda0-4102-a1a2-395d130bf798";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=BesluitenLijst_Gemeenteraad_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f995590-cda0-4102-a1a2-395d130bf798>.
+    
+<http://data.lblod.info/id/remote-data-objects/f69e18ff-3939-4225-a7cb-000e4959e7e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f69e18ff-3939-4225-a7cb-000e4959e7e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=BesluitenLijst_Gemeenteraad_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f69e18ff-3939-4225-a7cb-000e4959e7e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ff6ac78-1fbb-43ae-9aaf-809318c6c5af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ff6ac78-1fbb-43ae-9aaf-809318c6c5af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=BesluitenLijst_Gemeenteraad_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ff6ac78-1fbb-43ae-9aaf-809318c6c5af>.
+    
+<http://data.lblod.info/id/remote-data-objects/14e01e36-d666-4506-b052-db5b99ce1ba5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14e01e36-d666-4506-b052-db5b99ce1ba5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=BesluitenLijst_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14e01e36-d666-4506-b052-db5b99ce1ba5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba304180-7997-4c81-8c74-f0c7dc6c59a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba304180-7997-4c81-8c74-f0c7dc6c59a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba304180-7997-4c81-8c74-f0c7dc6c59a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1baf349-5b86-4d60-8d71-be504ea275c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1baf349-5b86-4d60-8d71-be504ea275c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1baf349-5b86-4d60-8d71-be504ea275c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/02b4795f-730e-4f29-ab1a-17df41613ab4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02b4795f-730e-4f29-ab1a-17df41613ab4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02b4795f-730e-4f29-ab1a-17df41613ab4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fadc61f-7409-4241-b8f3-34f0931d56e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fadc61f-7409-4241-b8f3-34f0931d56e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Notulen_Gemeenteraad_05-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fadc61f-7409-4241-b8f3-34f0931d56e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/18d37740-058f-45a5-acbf-7abd54b0c31e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18d37740-058f-45a5-acbf-7abd54b0c31e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Notulen_Gemeenteraad_13-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18d37740-058f-45a5-acbf-7abd54b0c31e>.
+    
+<http://data.lblod.info/id/remote-data-objects/02925ef1-66ae-4f51-b355-afd68d450ca6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02925ef1-66ae-4f51-b355-afd68d450ca6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Notulen_Gemeenteraad_14-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02925ef1-66ae-4f51-b355-afd68d450ca6>.
+    
+<http://data.lblod.info/id/remote-data-objects/49545d45-0056-46ec-9cb5-e79aa67957ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49545d45-0056-46ec-9cb5-e79aa67957ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Notulen_Gemeenteraad_15-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49545d45-0056-46ec-9cb5-e79aa67957ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d0b6112-4f09-498c-8d88-469dc30bb530> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d0b6112-4f09-498c-8d88-469dc30bb530";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Notulen_Gemeenteraad_16-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d0b6112-4f09-498c-8d88-469dc30bb530>.
+    
+<http://data.lblod.info/id/remote-data-objects/39d3a873-7265-47cc-ae87-b79a29f7b9b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39d3a873-7265-47cc-ae87-b79a29f7b9b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Notulen_Gemeenteraad_18-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39d3a873-7265-47cc-ae87-b79a29f7b9b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d32f527-a9f3-4a9a-91cd-0f2d985634c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d32f527-a9f3-4a9a-91cd-0f2d985634c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Notulen_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d32f527-a9f3-4a9a-91cd-0f2d985634c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad6ad764-09e3-4768-9dee-601b50414cb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad6ad764-09e3-4768-9dee-601b50414cb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Notulen_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad6ad764-09e3-4768-9dee-601b50414cb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9f342dc-41d0-43fb-87ba-8c9ad0f972af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9f342dc-41d0-43fb-87ba-8c9ad0f972af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Notulen_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9f342dc-41d0-43fb-87ba-8c9ad0f972af>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcbd3d07-fe24-46ee-8294-6773e8a486bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcbd3d07-fe24-46ee-8294-6773e8a486bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Notulen_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcbd3d07-fe24-46ee-8294-6773e8a486bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/48b83a51-ba6b-41a1-9b83-52f3b8458ee5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48b83a51-ba6b-41a1-9b83-52f3b8458ee5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_05-01-2022_34125.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48b83a51-ba6b-41a1-9b83-52f3b8458ee5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f1360dc-9537-4588-ba0f-390aedb225be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f1360dc-9537-4588-ba0f-390aedb225be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_05-01-2022_34126.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f1360dc-9537-4588-ba0f-390aedb225be>.
+    
+<http://data.lblod.info/id/remote-data-objects/429e266f-332b-4fef-9b22-377b28503721> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "429e266f-332b-4fef-9b22-377b28503721";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_05-01-2022_34127.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/429e266f-332b-4fef-9b22-377b28503721>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b46dd04-c1da-4607-a9f3-e58866487638> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b46dd04-c1da-4607-a9f3-e58866487638";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_05-01-2022_34128.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b46dd04-c1da-4607-a9f3-e58866487638>.
+    
+<http://data.lblod.info/id/remote-data-objects/58ee15a3-e767-4d59-8b51-5e104bcc16cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58ee15a3-e767-4d59-8b51-5e104bcc16cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_05-01-2022_34754.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58ee15a3-e767-4d59-8b51-5e104bcc16cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/3373d00c-18ae-4cfc-b86c-561c5ec6d652> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3373d00c-18ae-4cfc-b86c-561c5ec6d652";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_05-01-2022_34755.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3373d00c-18ae-4cfc-b86c-561c5ec6d652>.
+    
+<http://data.lblod.info/id/remote-data-objects/e55b64f8-4a0a-4a24-8a22-666307e87197> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e55b64f8-4a0a-4a24-8a22-666307e87197";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_05-01-2022_34790.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e55b64f8-4a0a-4a24-8a22-666307e87197>.
+    
+<http://data.lblod.info/id/remote-data-objects/85660723-5c86-423d-905c-b6f46b0b704e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85660723-5c86-423d-905c-b6f46b0b704e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_13-06-2022_40042.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85660723-5c86-423d-905c-b6f46b0b704e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e985297c-9803-407c-9193-2cc0d89aa36c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e985297c-9803-407c-9193-2cc0d89aa36c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_13-06-2022_40044.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e985297c-9803-407c-9193-2cc0d89aa36c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c111e3be-3240-4e6a-a404-b258d13cc3ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c111e3be-3240-4e6a-a404-b258d13cc3ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_13-06-2022_40045.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c111e3be-3240-4e6a-a404-b258d13cc3ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6d0b7a5-8187-4454-855d-4ab72cb3f9b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6d0b7a5-8187-4454-855d-4ab72cb3f9b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_13-06-2022_40219.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6d0b7a5-8187-4454-855d-4ab72cb3f9b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0f7289a-3fa3-4501-9dfb-a2fb36d705b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0f7289a-3fa3-4501-9dfb-a2fb36d705b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_13-06-2022_40224.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0f7289a-3fa3-4501-9dfb-a2fb36d705b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b51af94-770a-451e-9fce-11b8098f4f16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b51af94-770a-451e-9fce-11b8098f4f16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_13-06-2022_40225.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:07.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2371db08-4de7-423f-92cc-b818a0af62de> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b51af94-770a-451e-9fce-11b8098f4f16>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201809-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201809-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201809-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201809-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2e3ffaaf-ba88-466d-9648-05688d2bad4b> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2e3ffaaf-ba88-466d-9648-05688d2bad4b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "15ea033c-7960-4e32-ae63-e62b51a79eb9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6bded4b4-6ba5-4882-84b7-0708e0c7d0e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6bded4b4-6ba5-4882-84b7-0708e0c7d0e0";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9>.
+
+  <http://redpencil.data.gift/id/task/81a6771d-c600-42f1-818c-0633f5f51572> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "81a6771d-c600-42f1-818c-0633f5f51572";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2e3ffaaf-ba88-466d-9648-05688d2bad4b>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6bded4b4-6ba5-4882-84b7-0708e0c7d0e0>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a49d631a-e2f9-4d52-aded-00496aadf451> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a49d631a-e2f9-4d52-aded-00496aadf451";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_13-06-2022_40226.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a49d631a-e2f9-4d52-aded-00496aadf451>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3854a8f-e03a-46e5-9118-be1df736c716> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3854a8f-e03a-46e5-9118-be1df736c716";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_13-06-2022_40229.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3854a8f-e03a-46e5-9118-be1df736c716>.
+    
+<http://data.lblod.info/id/remote-data-objects/37c87249-b6fc-4ae6-a653-7792634379ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37c87249-b6fc-4ae6-a653-7792634379ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_13-06-2022_40230.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37c87249-b6fc-4ae6-a653-7792634379ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/90b5012e-5c75-405d-b0b0-d81f054f29b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90b5012e-5c75-405d-b0b0-d81f054f29b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_13-06-2022_40237.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90b5012e-5c75-405d-b0b0-d81f054f29b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/722bed35-5809-4e9e-9a3e-cbbdad37d2cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "722bed35-5809-4e9e-9a3e-cbbdad37d2cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_13-06-2022_40238.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/722bed35-5809-4e9e-9a3e-cbbdad37d2cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/39588406-4040-40f9-a94f-800bd122be10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39588406-4040-40f9-a94f-800bd122be10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_14-02-2022_35403.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39588406-4040-40f9-a94f-800bd122be10>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc43d15f-0d48-4d3e-8548-a8891292a773> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc43d15f-0d48-4d3e-8548-a8891292a773";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_14-02-2022_35466.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc43d15f-0d48-4d3e-8548-a8891292a773>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fcc39c0-f18c-4f17-b02b-553a050247d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fcc39c0-f18c-4f17-b02b-553a050247d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_14-02-2022_35467.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fcc39c0-f18c-4f17-b02b-553a050247d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e574da29-4d84-4f9b-990c-b8027ddfc955> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e574da29-4d84-4f9b-990c-b8027ddfc955";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_14-02-2022_35468.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e574da29-4d84-4f9b-990c-b8027ddfc955>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8cfd4fc-40d2-4810-9447-75cce182fff4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8cfd4fc-40d2-4810-9447-75cce182fff4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_14-02-2022_35469.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8cfd4fc-40d2-4810-9447-75cce182fff4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a265314a-5409-4c8b-b127-683aa0395fb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a265314a-5409-4c8b-b127-683aa0395fb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_14-02-2022_35470.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a265314a-5409-4c8b-b127-683aa0395fb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/247cc2a5-2f74-4ee2-a6e7-5c09b085e38f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "247cc2a5-2f74-4ee2-a6e7-5c09b085e38f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_14-02-2022_35471.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/247cc2a5-2f74-4ee2-a6e7-5c09b085e38f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a52f728-1d8c-4291-8c61-c3e832082e16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a52f728-1d8c-4291-8c61-c3e832082e16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_15-11-2021_33000.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a52f728-1d8c-4291-8c61-c3e832082e16>.
+    
+<http://data.lblod.info/id/remote-data-objects/a938aeaa-a1db-40dc-b34f-f8253067f579> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a938aeaa-a1db-40dc-b34f-f8253067f579";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_15-11-2021_33006.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a938aeaa-a1db-40dc-b34f-f8253067f579>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0c70993-84c5-4a39-99e9-fc74d88cd983> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0c70993-84c5-4a39-99e9-fc74d88cd983";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_15-11-2021_33078.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0c70993-84c5-4a39-99e9-fc74d88cd983>.
+    
+<http://data.lblod.info/id/remote-data-objects/e87fb54b-8d4a-42a9-a66b-d94db81fe923> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e87fb54b-8d4a-42a9-a66b-d94db81fe923";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_15-11-2021_33152.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e87fb54b-8d4a-42a9-a66b-d94db81fe923>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5f69224-eba0-4301-8256-8b2705261792> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5f69224-eba0-4301-8256-8b2705261792";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_15-11-2021_33278.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5f69224-eba0-4301-8256-8b2705261792>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8945caa-d807-4304-9a22-60767ed9bf48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8945caa-d807-4304-9a22-60767ed9bf48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_15-11-2021_33283.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8945caa-d807-4304-9a22-60767ed9bf48>.
+    
+<http://data.lblod.info/id/remote-data-objects/73d7c62f-0cfa-4353-a0b3-4ae292eb5e8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73d7c62f-0cfa-4353-a0b3-4ae292eb5e8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_15-11-2021_33398.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73d7c62f-0cfa-4353-a0b3-4ae292eb5e8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/08886a48-e809-4846-9ecb-8106b00b2690> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08886a48-e809-4846-9ecb-8106b00b2690";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_15-11-2021_33399.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08886a48-e809-4846-9ecb-8106b00b2690>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffec8496-5243-49cd-bf0c-b6c8fd8facfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffec8496-5243-49cd-bf0c-b6c8fd8facfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_15-11-2021_33400.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffec8496-5243-49cd-bf0c-b6c8fd8facfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/97dbe925-8f1c-4d2d-9340-2cbd85a3687e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97dbe925-8f1c-4d2d-9340-2cbd85a3687e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_15-11-2021_33401.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97dbe925-8f1c-4d2d-9340-2cbd85a3687e>.
+    
+<http://data.lblod.info/id/remote-data-objects/add69d0d-cf33-4526-8689-f9681dba708d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "add69d0d-cf33-4526-8689-f9681dba708d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_15-11-2021_33402.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/add69d0d-cf33-4526-8689-f9681dba708d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6030eda-0a75-4a3e-b81f-8bc91778e2e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6030eda-0a75-4a3e-b81f-8bc91778e2e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_15-11-2021_33403.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6030eda-0a75-4a3e-b81f-8bc91778e2e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5925349-2bf7-48d6-a0b4-2c6fe4c5b55f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5925349-2bf7-48d6-a0b4-2c6fe4c5b55f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_15-11-2021_33404.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5925349-2bf7-48d6-a0b4-2c6fe4c5b55f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e4abb8f-8f0f-478d-8f15-5e7b2999d1b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e4abb8f-8f0f-478d-8f15-5e7b2999d1b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_15-11-2021_33405.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e4abb8f-8f0f-478d-8f15-5e7b2999d1b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff0c2cc7-42df-47ec-91c7-b16ff1bbe6fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff0c2cc7-42df-47ec-91c7-b16ff1bbe6fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_15-11-2021_33690.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff0c2cc7-42df-47ec-91c7-b16ff1bbe6fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3d3b387-42f4-48c0-969b-bab7ae138b9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3d3b387-42f4-48c0-969b-bab7ae138b9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_16-05-2022_38451.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3d3b387-42f4-48c0-969b-bab7ae138b9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fc3875c-21d3-4ab4-8dac-22e960048b9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fc3875c-21d3-4ab4-8dac-22e960048b9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_16-05-2022_39743.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fc3875c-21d3-4ab4-8dac-22e960048b9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c23b2528-b16f-49fe-964c-753bff3fd961> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c23b2528-b16f-49fe-964c-753bff3fd961";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_18-10-2021_32681.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c23b2528-b16f-49fe-964c-753bff3fd961>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8fdf302-f0d8-46c1-bf17-285dafa02bf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8fdf302-f0d8-46c1-bf17-285dafa02bf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_18-10-2021_32765.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8fdf302-f0d8-46c1-bf17-285dafa02bf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/636062e4-f434-430b-9ca7-4f1ad272c23d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "636062e4-f434-430b-9ca7-4f1ad272c23d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_18-10-2021_32847.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/636062e4-f434-430b-9ca7-4f1ad272c23d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a92d2c78-0c4a-43a0-81fe-3a004c1ac566> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a92d2c78-0c4a-43a0-81fe-3a004c1ac566";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_18-10-2021_32850.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a92d2c78-0c4a-43a0-81fe-3a004c1ac566>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb6b906d-965f-4d7a-abae-a1432f749ca4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb6b906d-965f-4d7a-abae-a1432f749ca4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_20-12-2021_34372.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb6b906d-965f-4d7a-abae-a1432f749ca4>.
+    
+<http://data.lblod.info/id/remote-data-objects/95972a4a-efd5-4e66-a8d9-9ed8489d9d3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95972a4a-efd5-4e66-a8d9-9ed8489d9d3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_20-12-2021_34373.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95972a4a-efd5-4e66-a8d9-9ed8489d9d3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f3b1403-37c5-4291-8185-c9ed27bb60ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f3b1403-37c5-4291-8185-c9ed27bb60ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_20-12-2021_34374.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f3b1403-37c5-4291-8185-c9ed27bb60ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc52b51a-a301-457a-a8a6-d5672e17e53d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc52b51a-a301-457a-a8a6-d5672e17e53d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_20-12-2021_34579.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc52b51a-a301-457a-a8a6-d5672e17e53d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3de97454-35b1-4df3-b62e-c2bd5ddc0d95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3de97454-35b1-4df3-b62e-c2bd5ddc0d95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_20-12-2021_34582.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3de97454-35b1-4df3-b62e-c2bd5ddc0d95>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e40bdbc-5c8a-4232-839b-62f8d9b71897> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e40bdbc-5c8a-4232-839b-62f8d9b71897";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_20-12-2021_34588.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e40bdbc-5c8a-4232-839b-62f8d9b71897>.
+    
+<http://data.lblod.info/id/remote-data-objects/a440ee74-735b-46e7-b888-9d986ff69647> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a440ee74-735b-46e7-b888-9d986ff69647";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_24-01-2022_34760.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a440ee74-735b-46e7-b888-9d986ff69647>.
+    
+<http://data.lblod.info/id/remote-data-objects/d21fda41-a06e-4bf0-a15c-636880718e5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d21fda41-a06e-4bf0-a15c-636880718e5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_24-01-2022_35074.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d21fda41-a06e-4bf0-a15c-636880718e5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac7823cc-1715-43b9-b22b-6f4018779b53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac7823cc-1715-43b9-b22b-6f4018779b53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_24-01-2022_35075.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac7823cc-1715-43b9-b22b-6f4018779b53>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a6e9a8c-c378-4e00-8562-54c0a4f49d0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a6e9a8c-c378-4e00-8562-54c0a4f49d0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_24-01-2022_35076.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a6e9a8c-c378-4e00-8562-54c0a4f49d0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e8f71c7-f807-4acd-ae6b-667e2cff42ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e8f71c7-f807-4acd-ae6b-667e2cff42ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_24-01-2022_35078.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e8f71c7-f807-4acd-ae6b-667e2cff42ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2ae44d2-7ffe-454a-8840-3b708b583cf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2ae44d2-7ffe-454a-8840-3b708b583cf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_24-01-2022_35079.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2ae44d2-7ffe-454a-8840-3b708b583cf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/69706682-d95a-475a-8090-acce60561100> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69706682-d95a-475a-8090-acce60561100";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_24-01-2022_35080.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69706682-d95a-475a-8090-acce60561100>.
+    
+<http://data.lblod.info/id/remote-data-objects/c13811d4-e673-42b2-b039-429f7f71102c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c13811d4-e673-42b2-b039-429f7f71102c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_24-01-2022_35109.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c13811d4-e673-42b2-b039-429f7f71102c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b7503df-59a0-4742-ae0a-6bb81ae2882a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b7503df-59a0-4742-ae0a-6bb81ae2882a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_24-01-2022_35110.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b7503df-59a0-4742-ae0a-6bb81ae2882a>.
+    
+<http://data.lblod.info/id/remote-data-objects/72e83ad6-41e2-4d63-9ca2-82e95044f588> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72e83ad6-41e2-4d63-9ca2-82e95044f588";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_24-01-2022_35111.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72e83ad6-41e2-4d63-9ca2-82e95044f588>.
+    
+<http://data.lblod.info/id/remote-data-objects/f47719b9-61c0-4886-8e3c-d450d8754965> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f47719b9-61c0-4886-8e3c-d450d8754965";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_24-01-2022_35126.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/15ea033c-7960-4e32-ae63-e62b51a79eb9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f47719b9-61c0-4886-8e3c-d450d8754965>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201810-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201810-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201810-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201810-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/9c0a91b5-3e4d-4ad1-8faf-10e9d769b9e3> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9c0a91b5-3e4d-4ad1-8faf-10e9d769b9e3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "88a9726d-1fe6-43a3-b28e-9b06f9a850b8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/14b616c2-c292-49c0-b27c-a33c77acf3b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "14b616c2-c292-49c0-b27c-a33c77acf3b7";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8>.
+
+  <http://redpencil.data.gift/id/task/a95d9c5c-6e3e-4037-878e-936136c81d34> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a95d9c5c-6e3e-4037-878e-936136c81d34";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/9c0a91b5-3e4d-4ad1-8faf-10e9d769b9e3>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/14b616c2-c292-49c0-b27c-a33c77acf3b7>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/0e4e8bb3-5c39-45af-a5c8-9e9f9781da7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e4e8bb3-5c39-45af-a5c8-9e9f9781da7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_24-01-2022_35141.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e4e8bb3-5c39-45af-a5c8-9e9f9781da7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7805268-90e2-4b25-86d3-1e53df3aeae5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7805268-90e2-4b25-86d3-1e53df3aeae5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_24-01-2022_35144.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7805268-90e2-4b25-86d3-1e53df3aeae5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba593f29-076c-4a5a-9c42-e13b17da6c80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba593f29-076c-4a5a-9c42-e13b17da6c80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_24-01-2022_35147.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba593f29-076c-4a5a-9c42-e13b17da6c80>.
+    
+<http://data.lblod.info/id/remote-data-objects/92dae00d-aeaa-4824-af1a-4101bf326f81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92dae00d-aeaa-4824-af1a-4101bf326f81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_25-04-2022_38019.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92dae00d-aeaa-4824-af1a-4101bf326f81>.
+    
+<http://data.lblod.info/id/remote-data-objects/db700429-6ac7-47ed-869b-6c589bfadc0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db700429-6ac7-47ed-869b-6c589bfadc0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_25-04-2022_38020.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db700429-6ac7-47ed-869b-6c589bfadc0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e91692b-c346-4754-8f1e-c55dc31b4c8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e91692b-c346-4754-8f1e-c55dc31b4c8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_25-04-2022_38039.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e91692b-c346-4754-8f1e-c55dc31b4c8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ae965bf-5593-4746-b3be-14d741e93823> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ae965bf-5593-4746-b3be-14d741e93823";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_25-04-2022_38125.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ae965bf-5593-4746-b3be-14d741e93823>.
+    
+<http://data.lblod.info/id/remote-data-objects/98468e59-5ed0-497c-ab0f-ff2bd2bab53a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98468e59-5ed0-497c-ab0f-ff2bd2bab53a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_25-04-2022_38126.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98468e59-5ed0-497c-ab0f-ff2bd2bab53a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e61dae66-ee94-4f64-9044-712396e76b13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e61dae66-ee94-4f64-9044-712396e76b13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_25-04-2022_38127.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e61dae66-ee94-4f64-9044-712396e76b13>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fa87dc2-a8de-471c-bd83-fb36b35538d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fa87dc2-a8de-471c-bd83-fb36b35538d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_28-03-2022_35769.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fa87dc2-a8de-471c-bd83-fb36b35538d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a30aaa4-9528-4fbf-baed-5f91682f66ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a30aaa4-9528-4fbf-baed-5f91682f66ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_28-03-2022_35770.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a30aaa4-9528-4fbf-baed-5f91682f66ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1d1b6c5-082f-47a3-9e67-599bf0506757> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1d1b6c5-082f-47a3-9e67-599bf0506757";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_28-03-2022_35771.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1d1b6c5-082f-47a3-9e67-599bf0506757>.
+    
+<http://data.lblod.info/id/remote-data-objects/c59d47fe-2b4c-4a80-ae7a-32703dee762c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c59d47fe-2b4c-4a80-ae7a-32703dee762c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_28-03-2022_36375.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c59d47fe-2b4c-4a80-ae7a-32703dee762c>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdbfa034-27cd-4c2c-9ab3-e6242fb8e714> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdbfa034-27cd-4c2c-9ab3-e6242fb8e714";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_28-03-2022_36376.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdbfa034-27cd-4c2c-9ab3-e6242fb8e714>.
+    
+<http://data.lblod.info/id/remote-data-objects/77c10ef8-4470-4340-b612-280a87ea6514> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77c10ef8-4470-4340-b612-280a87ea6514";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_28-03-2022_36377.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77c10ef8-4470-4340-b612-280a87ea6514>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fafaf5f-5507-4cc1-b81d-e7b0c01d8966> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fafaf5f-5507-4cc1-b81d-e7b0c01d8966";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_28-03-2022_36378.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fafaf5f-5507-4cc1-b81d-e7b0c01d8966>.
+    
+<http://data.lblod.info/id/remote-data-objects/72ba2b15-838a-4b2f-bd18-40593219852a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72ba2b15-838a-4b2f-bd18-40593219852a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_28-03-2022_36379.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72ba2b15-838a-4b2f-bd18-40593219852a>.
+    
+<http://data.lblod.info/id/remote-data-objects/310d3892-05bb-49dd-96aa-78905050fa2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "310d3892-05bb-49dd-96aa-78905050fa2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_28-03-2022_36380.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/310d3892-05bb-49dd-96aa-78905050fa2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/94ec302d-ff54-43d2-be3f-79dc42e41d07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94ec302d-ff54-43d2-be3f-79dc42e41d07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_28-03-2022_36460.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94ec302d-ff54-43d2-be3f-79dc42e41d07>.
+    
+<http://data.lblod.info/id/remote-data-objects/237ed9a4-f185-49f5-a3e1-b8221d116f65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "237ed9a4-f185-49f5-a3e1-b8221d116f65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_28-03-2022_36461.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/237ed9a4-f185-49f5-a3e1-b8221d116f65>.
+    
+<http://data.lblod.info/id/remote-data-objects/0db633fe-8c59-494d-ba3a-acb11fead98a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0db633fe-8c59-494d-ba3a-acb11fead98a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_28-03-2022_36462.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0db633fe-8c59-494d-ba3a-acb11fead98a>.
+    
+<http://data.lblod.info/id/remote-data-objects/037e3860-d665-4e72-ab68-54cb17698f6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "037e3860-d665-4e72-ab68-54cb17698f6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_28-03-2022_36463.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/037e3860-d665-4e72-ab68-54cb17698f6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf1b8094-f52d-42f5-9308-42bcbb5dd6b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf1b8094-f52d-42f5-9308-42bcbb5dd6b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_28-03-2022_36464.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf1b8094-f52d-42f5-9308-42bcbb5dd6b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0297942-7b80-4a05-a1f9-6390024e7e18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0297942-7b80-4a05-a1f9-6390024e7e18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_28-03-2022_36498.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0297942-7b80-4a05-a1f9-6390024e7e18>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2691c44-577d-4101-9881-aaf53ff603e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2691c44-577d-4101-9881-aaf53ff603e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zottegem.be/LBLODWeb/Home/Overzicht/e3d9480acc0cf400e11ab7afe2bcea144038dd2ef71d77247d5159c7ce8efb1a/GetPublication?filename=Uittreksels_28-03-2022_37795.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2691c44-577d-4101-9881-aaf53ff603e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7ee6abb-fe6a-4fb7-9fbb-52278defa811> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7ee6abb-fe6a-4fb7-9fbb-52278defa811";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/90a9383d085e98082d02bed4d41abf7c6691559429a2c0011159e34302abc058/GetPublication?filename=Uittreksels_13-06-2022_5784.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7ee6abb-fe6a-4fb7-9fbb-52278defa811>.
+    
+<http://data.lblod.info/id/remote-data-objects/1211a57f-a561-4d5c-8c5f-725e92276dba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1211a57f-a561-4d5c-8c5f-725e92276dba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/90a9383d085e98082d02bed4d41abf7c6691559429a2c0011159e34302abc058/GetPublication?filename=Uittreksels_13-06-2022_5787.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1211a57f-a561-4d5c-8c5f-725e92276dba>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff9cb7eb-8dcf-49d8-a3ba-d00431e0c2a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff9cb7eb-8dcf-49d8-a3ba-d00431e0c2a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/90a9383d085e98082d02bed4d41abf7c6691559429a2c0011159e34302abc058/GetPublication?filename=Uittreksels_13-06-2022_5789.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff9cb7eb-8dcf-49d8-a3ba-d00431e0c2a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd1fb5c0-472a-4103-be1c-b753f703a7f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd1fb5c0-472a-4103-be1c-b753f703a7f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/90a9383d085e98082d02bed4d41abf7c6691559429a2c0011159e34302abc058/GetPublication?filename=Uittreksels_18-05-2022_5807.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd1fb5c0-472a-4103-be1c-b753f703a7f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/646bc01e-e513-4c76-aed3-5391ba1c811a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "646bc01e-e513-4c76-aed3-5391ba1c811a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/90a9383d085e98082d02bed4d41abf7c6691559429a2c0011159e34302abc058/GetPublication?filename=Uittreksels_18-10-2021_5085.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/646bc01e-e513-4c76-aed3-5391ba1c811a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a15f38b-093b-4455-9a5a-b64e31d6047e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a15f38b-093b-4455-9a5a-b64e31d6047e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/90a9383d085e98082d02bed4d41abf7c6691559429a2c0011159e34302abc058/GetPublication?filename=Uittreksels_20-06-2022_5858.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a15f38b-093b-4455-9a5a-b64e31d6047e>.
+    
+<http://data.lblod.info/id/remote-data-objects/930c18a9-479e-4ae6-a168-7270d8a17f6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "930c18a9-479e-4ae6-a168-7270d8a17f6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/90a9383d085e98082d02bed4d41abf7c6691559429a2c0011159e34302abc058/GetPublication?filename=Uittreksels_28-07-2022_5944.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/930c18a9-479e-4ae6-a168-7270d8a17f6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d13d195f-dd71-43ea-9ef1-4644c9500b92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d13d195f-dd71-43ea-9ef1-4644c9500b92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/90a9383d085e98082d02bed4d41abf7c6691559429a2c0011159e34302abc058/GetPublication?filename=Uittreksels_28-07-2022_5945.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d13d195f-dd71-43ea-9ef1-4644c9500b92>.
+    
+<http://data.lblod.info/id/remote-data-objects/434ae682-5a00-4e00-8361-13d2784a8a7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "434ae682-5a00-4e00-8361-13d2784a8a7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/434ae682-5a00-4e00-8361-13d2784a8a7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/26198321-3b8e-4d1e-962e-b1bebdc4665b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26198321-3b8e-4d1e-962e-b1bebdc4665b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26198321-3b8e-4d1e-962e-b1bebdc4665b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ecc3d4d-4f1d-4e3a-a1a8-e93893a9a9f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ecc3d4d-4f1d-4e3a-a1a8-e93893a9a9f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ecc3d4d-4f1d-4e3a-a1a8-e93893a9a9f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7626ea67-0e36-4c57-ac8d-0fedba4be462> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7626ea67-0e36-4c57-ac8d-0fedba4be462";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7626ea67-0e36-4c57-ac8d-0fedba4be462>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7968f5c-9ec2-4147-b201-86d362f6defa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7968f5c-9ec2-4147-b201-86d362f6defa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7968f5c-9ec2-4147-b201-86d362f6defa>.
+    
+<http://data.lblod.info/id/remote-data-objects/84f8a385-45af-4dcf-8e4d-e4ba173a45a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84f8a385-45af-4dcf-8e4d-e4ba173a45a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=BesluitenLijst_Gemeenteraad_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84f8a385-45af-4dcf-8e4d-e4ba173a45a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/b72868f2-bba3-4f52-a5b4-1b207ddafa89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b72868f2-bba3-4f52-a5b4-1b207ddafa89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=BesluitenLijst_Gemeenteraad_30-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b72868f2-bba3-4f52-a5b4-1b207ddafa89>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddec6ce8-7b50-45e9-8761-edbf851d2219> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddec6ce8-7b50-45e9-8761-edbf851d2219";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=BesluitenLijst_Gemeenteraad_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddec6ce8-7b50-45e9-8761-edbf851d2219>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b81bcac-bc18-4cb0-97c8-83f830896ec0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b81bcac-bc18-4cb0-97c8-83f830896ec0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=BesluitenLijst_Gemeenteraad_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b81bcac-bc18-4cb0-97c8-83f830896ec0>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f8ece1c-12e9-4260-8065-84a5f36c0823> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f8ece1c-12e9-4260-8065-84a5f36c0823";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=Uittreksels_25-11-2021_5178.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f8ece1c-12e9-4260-8065-84a5f36c0823>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c4e5728-00a2-43b4-bd14-ed0ba6e93579> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c4e5728-00a2-43b4-bd14-ed0ba6e93579";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=Uittreksels_28-04-2022_5721.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c4e5728-00a2-43b4-bd14-ed0ba6e93579>.
+    
+<http://data.lblod.info/id/remote-data-objects/a009964c-17e1-497a-bff0-37420baf2b31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a009964c-17e1-497a-bff0-37420baf2b31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=Uittreksels_28-04-2022_5722.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a009964c-17e1-497a-bff0-37420baf2b31>.
+    
+<http://data.lblod.info/id/remote-data-objects/6160cbe6-f66e-4e24-acfd-362a0b76f593> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6160cbe6-f66e-4e24-acfd-362a0b76f593";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=Uittreksels_28-04-2022_5723.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6160cbe6-f66e-4e24-acfd-362a0b76f593>.
+    
+<http://data.lblod.info/id/remote-data-objects/654f10ad-7000-4942-9a88-4ab17d9826f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "654f10ad-7000-4942-9a88-4ab17d9826f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=Uittreksels_30-06-2022_5873.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/654f10ad-7000-4942-9a88-4ab17d9826f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c152981f-a2d5-4092-ac82-aa33e2d97c5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c152981f-a2d5-4092-ac82-aa33e2d97c5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=Uittreksels_30-12-2021_5331.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c152981f-a2d5-4092-ac82-aa33e2d97c5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d0a89f5-1c7f-44c4-a812-f790de606270> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d0a89f5-1c7f-44c4-a812-f790de606270";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=Uittreksels_30-12-2021_5333.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d0a89f5-1c7f-44c4-a812-f790de606270>.
+    
+<http://data.lblod.info/id/remote-data-objects/625d7167-3c48-4cf2-b758-421e6daeefe0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "625d7167-3c48-4cf2-b758-421e6daeefe0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=Uittreksels_30-12-2021_5334.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/88a9726d-1fe6-43a3-b28e-9b06f9a850b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/625d7167-3c48-4cf2-b758-421e6daeefe0>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201811-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201811-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201811-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201811-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/0e142111-c257-4210-bad7-731cc83d1ace> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0e142111-c257-4210-bad7-731cc83d1ace";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1a199ee6-4d30-40d0-87e0-623c7ef4bd49";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4ec4f4cd-cf84-4528-bfd6-20a78365a6ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4ec4f4cd-cf84-4528-bfd6-20a78365a6ae";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49>.
+
+  <http://redpencil.data.gift/id/task/9c58e382-c328-4559-9bc4-8d6f2526008a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9c58e382-c328-4559-9bc4-8d6f2526008a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/0e142111-c257-4210-bad7-731cc83d1ace>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4ec4f4cd-cf84-4528-bfd6-20a78365a6ae>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/37f9850b-eccb-47da-8599-e5e8c6740e10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37f9850b-eccb-47da-8599-e5e8c6740e10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=Uittreksels_30-12-2021_5346.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37f9850b-eccb-47da-8599-e5e8c6740e10>.
+    
+<http://data.lblod.info/id/remote-data-objects/396c917e-c587-47da-8a14-957d61bec710> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "396c917e-c587-47da-8a14-957d61bec710";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/96fe474f66a91b432d2a727694f837ecb26e0c64fb7c17c9289c2c182d92c596/GetPublication?filename=Uittreksels_30-12-2021_5347.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/396c917e-c587-47da-8a14-957d61bec710>.
+    
+<http://data.lblod.info/id/remote-data-objects/6223160b-6531-47e7-8620-b7a5c437499e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6223160b-6531-47e7-8620-b7a5c437499e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/b8be61ca7a95dbe82e9ac168bd3b18cb8c96a9b66ed380c91c4ab0bde2e84832/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_24-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6223160b-6531-47e7-8620-b7a5c437499e>.
+    
+<http://data.lblod.info/id/remote-data-objects/36222544-a9a6-4c6a-a601-93ed622f34d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36222544-a9a6-4c6a-a601-93ed622f34d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/b8be61ca7a95dbe82e9ac168bd3b18cb8c96a9b66ed380c91c4ab0bde2e84832/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_25-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36222544-a9a6-4c6a-a601-93ed622f34d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2ee18a0-3cd3-4845-84e6-32f9f1f114b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2ee18a0-3cd3-4845-84e6-32f9f1f114b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/b8be61ca7a95dbe82e9ac168bd3b18cb8c96a9b66ed380c91c4ab0bde2e84832/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_27-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2ee18a0-3cd3-4845-84e6-32f9f1f114b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/367ddfa2-3b60-4c84-9b51-43e7adc98211> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "367ddfa2-3b60-4c84-9b51-43e7adc98211";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/b8be61ca7a95dbe82e9ac168bd3b18cb8c96a9b66ed380c91c4ab0bde2e84832/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_28-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/367ddfa2-3b60-4c84-9b51-43e7adc98211>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4a6b3bd-5b39-407d-b027-74ec16b2e1a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4a6b3bd-5b39-407d-b027-74ec16b2e1a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/b8be61ca7a95dbe82e9ac168bd3b18cb8c96a9b66ed380c91c4ab0bde2e84832/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_28-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4a6b3bd-5b39-407d-b027-74ec16b2e1a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f9be1c0-5e48-40c0-85ee-8f89b352bf17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f9be1c0-5e48-40c0-85ee-8f89b352bf17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/b8be61ca7a95dbe82e9ac168bd3b18cb8c96a9b66ed380c91c4ab0bde2e84832/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_30-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f9be1c0-5e48-40c0-85ee-8f89b352bf17>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb486a82-145d-46c1-a98f-fcdb803cb423> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb486a82-145d-46c1-a98f-fcdb803cb423";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/b8be61ca7a95dbe82e9ac168bd3b18cb8c96a9b66ed380c91c4ab0bde2e84832/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_30-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb486a82-145d-46c1-a98f-fcdb803cb423>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf7bc521-665b-48cd-ad12-aae6c5f7cb8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf7bc521-665b-48cd-ad12-aae6c5f7cb8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/b8be61ca7a95dbe82e9ac168bd3b18cb8c96a9b66ed380c91c4ab0bde2e84832/GetPublication?filename=BesluitenLijst_Raad%20voor%20maatschappelijk%20welzijn_31-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf7bc521-665b-48cd-ad12-aae6c5f7cb8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/04b8757b-80fe-42ea-b40f-5265e7fbc99c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04b8757b-80fe-42ea-b40f-5265e7fbc99c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/b8be61ca7a95dbe82e9ac168bd3b18cb8c96a9b66ed380c91c4ab0bde2e84832/GetPublication?filename=Uittreksels_30-06-2022_5751.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04b8757b-80fe-42ea-b40f-5265e7fbc99c>.
+    
+<http://data.lblod.info/id/remote-data-objects/032048d0-fa98-4960-b39f-b110af38d4f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "032048d0-fa98-4960-b39f-b110af38d4f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zuienkerke.be/LBLODWeb/Home/Overzicht/b8be61ca7a95dbe82e9ac168bd3b18cb8c96a9b66ed380c91c4ab0bde2e84832/GetPublication?filename=Uittreksels_30-12-2021_5268.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/032048d0-fa98-4960-b39f-b110af38d4f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9991c326-7ecb-4175-918e-f60250028487> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9991c326-7ecb-4175-918e-f60250028487";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Agenda_Gemeenteraad_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9991c326-7ecb-4175-918e-f60250028487>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6e31354-76f1-42fc-b32e-940611fe5857> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6e31354-76f1-42fc-b32e-940611fe5857";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Agenda_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6e31354-76f1-42fc-b32e-940611fe5857>.
+    
+<http://data.lblod.info/id/remote-data-objects/00311ea1-9554-43eb-bef0-883cdc42c3f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00311ea1-9554-43eb-bef0-883cdc42c3f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Agenda_Gemeenteraad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00311ea1-9554-43eb-bef0-883cdc42c3f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/449a6c88-9ce9-4ce6-af20-2f45fcef0b66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "449a6c88-9ce9-4ce6-af20-2f45fcef0b66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Agenda_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/449a6c88-9ce9-4ce6-af20-2f45fcef0b66>.
+    
+<http://data.lblod.info/id/remote-data-objects/01e7882e-ae74-4213-8214-d1e4e2ee467a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01e7882e-ae74-4213-8214-d1e4e2ee467a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Agenda_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01e7882e-ae74-4213-8214-d1e4e2ee467a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac1a6bfe-1558-4cb5-bd9d-88a206dd1526> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac1a6bfe-1558-4cb5-bd9d-88a206dd1526";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Agenda_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac1a6bfe-1558-4cb5-bd9d-88a206dd1526>.
+    
+<http://data.lblod.info/id/remote-data-objects/d907597b-9744-4844-a96f-fbf38128cc4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d907597b-9744-4844-a96f-fbf38128cc4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Agenda_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d907597b-9744-4844-a96f-fbf38128cc4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d1308ba-147b-492e-994a-dc542b8e3c14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d1308ba-147b-492e-994a-dc542b8e3c14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Agenda_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d1308ba-147b-492e-994a-dc542b8e3c14>.
+    
+<http://data.lblod.info/id/remote-data-objects/edbfbfa1-b2ea-4555-aea8-48cc1084e22f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edbfbfa1-b2ea-4555-aea8-48cc1084e22f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Agenda_Gemeenteraad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edbfbfa1-b2ea-4555-aea8-48cc1084e22f>.
+    
+<http://data.lblod.info/id/remote-data-objects/84153f17-8ae1-4bcb-8da4-2ccb7bf794be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84153f17-8ae1-4bcb-8da4-2ccb7bf794be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Agenda_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84153f17-8ae1-4bcb-8da4-2ccb7bf794be>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bf2e97c-b561-4178-b165-864678071a45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bf2e97c-b561-4178-b165-864678071a45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=BesluitenLijst_Gemeenteraad_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bf2e97c-b561-4178-b165-864678071a45>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7bb87d6-1320-4a4d-8ed5-528d984ca518> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7bb87d6-1320-4a4d-8ed5-528d984ca518";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=BesluitenLijst_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7bb87d6-1320-4a4d-8ed5-528d984ca518>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ed4857d-eb88-4bdc-8ac0-620e06063472> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ed4857d-eb88-4bdc-8ac0-620e06063472";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=BesluitenLijst_Gemeenteraad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ed4857d-eb88-4bdc-8ac0-620e06063472>.
+    
+<http://data.lblod.info/id/remote-data-objects/0188482f-9737-4363-b148-5914019f03a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0188482f-9737-4363-b148-5914019f03a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=BesluitenLijst_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0188482f-9737-4363-b148-5914019f03a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4ef76e1-d7b2-4c82-9040-f7cf2b9da2c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4ef76e1-d7b2-4c82-9040-f7cf2b9da2c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=BesluitenLijst_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4ef76e1-d7b2-4c82-9040-f7cf2b9da2c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f277a59-ae08-450c-97fa-4da6063b92ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f277a59-ae08-450c-97fa-4da6063b92ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f277a59-ae08-450c-97fa-4da6063b92ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/4db077d2-1912-47dd-924f-5be3ebc186e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4db077d2-1912-47dd-924f-5be3ebc186e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=BesluitenLijst_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4db077d2-1912-47dd-924f-5be3ebc186e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e2e54ce-40f3-4e52-8d5b-3c453516d693> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e2e54ce-40f3-4e52-8d5b-3c453516d693";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=BesluitenLijst_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e2e54ce-40f3-4e52-8d5b-3c453516d693>.
+    
+<http://data.lblod.info/id/remote-data-objects/1df8a7b8-bcd5-4a5f-9c00-d811878c0e5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1df8a7b8-bcd5-4a5f-9c00-d811878c0e5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1df8a7b8-bcd5-4a5f-9c00-d811878c0e5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/51c1aa34-e70a-4bf8-971d-3f97413f7ed0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51c1aa34-e70a-4bf8-971d-3f97413f7ed0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=BesluitenLijst_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51c1aa34-e70a-4bf8-971d-3f97413f7ed0>.
+    
+<http://data.lblod.info/id/remote-data-objects/78db53bc-2069-49e0-ac21-f386dfeecfcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78db53bc-2069-49e0-ac21-f386dfeecfcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Notulen_Gemeenteraad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78db53bc-2069-49e0-ac21-f386dfeecfcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/be8f3d6d-f1aa-4372-bbcb-92de971a6616> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be8f3d6d-f1aa-4372-bbcb-92de971a6616";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Notulen_Gemeenteraad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be8f3d6d-f1aa-4372-bbcb-92de971a6616>.
+    
+<http://data.lblod.info/id/remote-data-objects/6950baf6-8c09-41f5-bddc-b18a45c861e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6950baf6-8c09-41f5-bddc-b18a45c861e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Notulen_Gemeenteraad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6950baf6-8c09-41f5-bddc-b18a45c861e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/68bcccb6-c6a5-46e6-9f85-189e7283cb90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68bcccb6-c6a5-46e6-9f85-189e7283cb90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Notulen_Gemeenteraad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68bcccb6-c6a5-46e6-9f85-189e7283cb90>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb55b117-813b-45d0-9d38-ae86f06a5cb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb55b117-813b-45d0-9d38-ae86f06a5cb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Notulen_Gemeenteraad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb55b117-813b-45d0-9d38-ae86f06a5cb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad4188e7-b2ec-4274-8192-17bd313b7333> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad4188e7-b2ec-4274-8192-17bd313b7333";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Notulen_Gemeenteraad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad4188e7-b2ec-4274-8192-17bd313b7333>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fb7557d-9ad5-4723-a173-0ce71ebaa502> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fb7557d-9ad5-4723-a173-0ce71ebaa502";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Notulen_Gemeenteraad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fb7557d-9ad5-4723-a173-0ce71ebaa502>.
+    
+<http://data.lblod.info/id/remote-data-objects/82b4c898-444e-4c27-84b7-6bcb762a1f07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82b4c898-444e-4c27-84b7-6bcb762a1f07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Notulen_Gemeenteraad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82b4c898-444e-4c27-84b7-6bcb762a1f07>.
+    
+<http://data.lblod.info/id/remote-data-objects/08424e27-c477-4d5f-b7d7-14cec1a2df28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08424e27-c477-4d5f-b7d7-14cec1a2df28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Notulen_Gemeenteraad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08424e27-c477-4d5f-b7d7-14cec1a2df28>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fb795ba-abc5-489b-bbf5-c188513565f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fb795ba-abc5-489b-bbf5-c188513565f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_18-07-2022_58320.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fb795ba-abc5-489b-bbf5-c188513565f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a91ebcef-53bc-4ef7-95b6-ef256b769397> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a91ebcef-53bc-4ef7-95b6-ef256b769397";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_18-07-2022_58507.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a91ebcef-53bc-4ef7-95b6-ef256b769397>.
+    
+<http://data.lblod.info/id/remote-data-objects/811714e3-db15-4e0a-a7ba-bfe2dd509be8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "811714e3-db15-4e0a-a7ba-bfe2dd509be8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_18-07-2022_58508.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/811714e3-db15-4e0a-a7ba-bfe2dd509be8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8512f0f5-d459-49c8-94f7-1fc0d5006a33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8512f0f5-d459-49c8-94f7-1fc0d5006a33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_18-07-2022_58509.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8512f0f5-d459-49c8-94f7-1fc0d5006a33>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4260147-9b81-43ae-a1c9-f95968e9b296> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4260147-9b81-43ae-a1c9-f95968e9b296";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_18-07-2022_58532.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4260147-9b81-43ae-a1c9-f95968e9b296>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e184e64-4b41-42ab-aee2-9870fcec5f09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e184e64-4b41-42ab-aee2-9870fcec5f09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_20-12-2021_49573.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e184e64-4b41-42ab-aee2-9870fcec5f09>.
+    
+<http://data.lblod.info/id/remote-data-objects/6016d2a1-6f85-47b4-a918-67bf3e845f55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6016d2a1-6f85-47b4-a918-67bf3e845f55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_20-12-2021_51137.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6016d2a1-6f85-47b4-a918-67bf3e845f55>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf67f8ed-b588-40fc-bb29-ab9199c74c38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf67f8ed-b588-40fc-bb29-ab9199c74c38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_20-12-2021_51138.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf67f8ed-b588-40fc-bb29-ab9199c74c38>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b753bb0-075c-4a2f-be46-41cd62bd182d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b753bb0-075c-4a2f-be46-41cd62bd182d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_20-12-2021_51139.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a199ee6-4d30-40d0-87e0-623c7ef4bd49> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b753bb0-075c-4a2f-be46-41cd62bd182d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201812-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201812-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201812-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201812-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d90f2e27-80bf-4ec0-9841-9aba3e2b43dd> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d90f2e27-80bf-4ec0-9841-9aba3e2b43dd";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d9400cd3-823d-4742-a287-63f208ba93d9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/eb2f1ca7-d2ce-40ae-a4da-05507442c967> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "eb2f1ca7-d2ce-40ae-a4da-05507442c967";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9>.
+
+  <http://redpencil.data.gift/id/task/5aa73b5a-e285-4733-aa15-b3ab96e319f7> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5aa73b5a-e285-4733-aa15-b3ab96e319f7";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d90f2e27-80bf-4ec0-9841-9aba3e2b43dd>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/eb2f1ca7-d2ce-40ae-a4da-05507442c967>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/ee0712ea-0530-4a6e-835e-a04b27cff68e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee0712ea-0530-4a6e-835e-a04b27cff68e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_20-12-2021_55266.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee0712ea-0530-4a6e-835e-a04b27cff68e>.
+    
+<http://data.lblod.info/id/remote-data-objects/019ca58b-1619-4bd9-b1cc-7830e69535fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "019ca58b-1619-4bd9-b1cc-7830e69535fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_20-12-2021_55292.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/019ca58b-1619-4bd9-b1cc-7830e69535fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc3dd68c-5d13-463e-8ecc-65d7b640c6b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc3dd68c-5d13-463e-8ecc-65d7b640c6b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_20-12-2021_55417.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc3dd68c-5d13-463e-8ecc-65d7b640c6b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab37d96c-502b-455c-b1bf-7f9c4f24b819> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab37d96c-502b-455c-b1bf-7f9c4f24b819";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_20-12-2021_55418.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab37d96c-502b-455c-b1bf-7f9c4f24b819>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a87eabe-708e-4516-b9ca-a5f92572e096> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a87eabe-708e-4516-b9ca-a5f92572e096";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_22-11-2021_53616.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a87eabe-708e-4516-b9ca-a5f92572e096>.
+    
+<http://data.lblod.info/id/remote-data-objects/a00a77ca-b69c-46d4-ac7a-18db39f448bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a00a77ca-b69c-46d4-ac7a-18db39f448bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_22-11-2021_53623.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a00a77ca-b69c-46d4-ac7a-18db39f448bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fb887b9-0b7c-41ba-8be0-e585dc843a04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fb887b9-0b7c-41ba-8be0-e585dc843a04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_22-11-2021_53624.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fb887b9-0b7c-41ba-8be0-e585dc843a04>.
+    
+<http://data.lblod.info/id/remote-data-objects/d620ba5e-d382-40ab-a0d6-e080f67c88c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d620ba5e-d382-40ab-a0d6-e080f67c88c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_22-11-2021_53625.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d620ba5e-d382-40ab-a0d6-e080f67c88c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/416d590f-d7a6-4d80-b0b5-373e0d9c4fde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "416d590f-d7a6-4d80-b0b5-373e0d9c4fde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_22-11-2021_53649.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/416d590f-d7a6-4d80-b0b5-373e0d9c4fde>.
+    
+<http://data.lblod.info/id/remote-data-objects/6856100f-6a08-4ae5-b16e-e4f9d65715cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6856100f-6a08-4ae5-b16e-e4f9d65715cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_23-05-2022_57659.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6856100f-6a08-4ae5-b16e-e4f9d65715cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b7967e9-cc20-4624-adf9-b22adfaac3e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b7967e9-cc20-4624-adf9-b22adfaac3e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_23-05-2022_57792.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b7967e9-cc20-4624-adf9-b22adfaac3e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/acecf144-3406-4d72-82a7-4d19af8abfba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acecf144-3406-4d72-82a7-4d19af8abfba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_23-05-2022_57793.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acecf144-3406-4d72-82a7-4d19af8abfba>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f8a0cc2-3ee7-4b53-ad2b-ed8881448229> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f8a0cc2-3ee7-4b53-ad2b-ed8881448229";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_23-05-2022_57794.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f8a0cc2-3ee7-4b53-ad2b-ed8881448229>.
+    
+<http://data.lblod.info/id/remote-data-objects/84b4ca3a-a155-42b9-ab3f-465d69747880> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84b4ca3a-a155-42b9-ab3f-465d69747880";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_23-05-2022_57795.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84b4ca3a-a155-42b9-ab3f-465d69747880>.
+    
+<http://data.lblod.info/id/remote-data-objects/55027a51-f674-4359-84c7-70e12e6b2049> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55027a51-f674-4359-84c7-70e12e6b2049";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_24-01-2022_56190.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55027a51-f674-4359-84c7-70e12e6b2049>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0454e4f-828c-44eb-adcb-7f4a1d14cf67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0454e4f-828c-44eb-adcb-7f4a1d14cf67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_25-04-2022_57144.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0454e4f-828c-44eb-adcb-7f4a1d14cf67>.
+    
+<http://data.lblod.info/id/remote-data-objects/b11bcf41-6ec5-48df-bb6b-781622aea9c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b11bcf41-6ec5-48df-bb6b-781622aea9c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_25-04-2022_57269.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b11bcf41-6ec5-48df-bb6b-781622aea9c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/92b3d7c4-3273-4293-a15e-aa28cebcba08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92b3d7c4-3273-4293-a15e-aa28cebcba08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_25-04-2022_57323.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92b3d7c4-3273-4293-a15e-aa28cebcba08>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb494ffa-9724-43f6-895e-d4909f7ef0d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb494ffa-9724-43f6-895e-d4909f7ef0d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_27-06-2022_58189.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb494ffa-9724-43f6-895e-d4909f7ef0d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/affdf96b-d857-43cb-b6dd-c04d0643c6ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "affdf96b-d857-43cb-b6dd-c04d0643c6ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/23b5a629cb4b53d4c3b5f878410559eed5364e4178e4f3702adef831a0cfffe0/GetPublication?filename=Uittreksels_28-02-2022_55265.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/affdf96b-d857-43cb-b6dd-c04d0643c6ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2c032b6-307d-4ec3-9bcc-b073934b662a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2c032b6-307d-4ec3-9bcc-b073934b662a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2c032b6-307d-4ec3-9bcc-b073934b662a>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfde59e2-1856-4c12-99c8-588749901d54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfde59e2-1856-4c12-99c8-588749901d54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfde59e2-1856-4c12-99c8-588749901d54>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ea0e63a-75c5-45dd-9f02-671d8108a940> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ea0e63a-75c5-45dd-9f02-671d8108a940";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ea0e63a-75c5-45dd-9f02-671d8108a940>.
+    
+<http://data.lblod.info/id/remote-data-objects/178be36d-e0c3-4047-ae62-5fcc5d48b440> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "178be36d-e0c3-4047-ae62-5fcc5d48b440";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/178be36d-e0c3-4047-ae62-5fcc5d48b440>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dfa4f8b-7dcd-4a87-a34a-f2e07fb1554e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dfa4f8b-7dcd-4a87-a34a-f2e07fb1554e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dfa4f8b-7dcd-4a87-a34a-f2e07fb1554e>.
+    
+<http://data.lblod.info/id/remote-data-objects/53e6bd02-b6f5-4f9c-82a2-cb6ab282bf30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53e6bd02-b6f5-4f9c-82a2-cb6ab282bf30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53e6bd02-b6f5-4f9c-82a2-cb6ab282bf30>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e449247-c1d2-4c1f-ab14-32e8d53daf5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e449247-c1d2-4c1f-ab14-32e8d53daf5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e449247-c1d2-4c1f-ab14-32e8d53daf5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7065a30b-72a8-4ff6-9045-1c84b46262af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7065a30b-72a8-4ff6-9045-1c84b46262af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7065a30b-72a8-4ff6-9045-1c84b46262af>.
+    
+<http://data.lblod.info/id/remote-data-objects/3caf45da-13c8-4c5b-8b22-9680f7a61697> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3caf45da-13c8-4c5b-8b22-9680f7a61697";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3caf45da-13c8-4c5b-8b22-9680f7a61697>.
+    
+<http://data.lblod.info/id/remote-data-objects/24714638-e5d6-4c8c-a462-3d77537db5c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24714638-e5d6-4c8c-a462-3d77537db5c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24714638-e5d6-4c8c-a462-3d77537db5c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbc66c78-d9cc-44a3-90ca-e9c1b3580e29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbc66c78-d9cc-44a3-90ca-e9c1b3580e29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbc66c78-d9cc-44a3-90ca-e9c1b3580e29>.
+    
+<http://data.lblod.info/id/remote-data-objects/59244418-3b29-4a1c-af64-7d0637984a2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59244418-3b29-4a1c-af64-7d0637984a2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59244418-3b29-4a1c-af64-7d0637984a2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1147739d-4aa6-4984-a277-0b2121ea5ae2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1147739d-4aa6-4984-a277-0b2121ea5ae2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1147739d-4aa6-4984-a277-0b2121ea5ae2>.
+    
+<http://data.lblod.info/id/remote-data-objects/edf1ba85-6572-493c-8ac7-f51d77b58674> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edf1ba85-6572-493c-8ac7-f51d77b58674";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edf1ba85-6572-493c-8ac7-f51d77b58674>.
+    
+<http://data.lblod.info/id/remote-data-objects/898686b4-4422-4be0-af05-760181445f75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "898686b4-4422-4be0-af05-760181445f75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/898686b4-4422-4be0-af05-760181445f75>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e84e0e0-0134-4add-aa1e-1edbd1f1ff02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e84e0e0-0134-4add-aa1e-1edbd1f1ff02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e84e0e0-0134-4add-aa1e-1edbd1f1ff02>.
+    
+<http://data.lblod.info/id/remote-data-objects/b724212b-158a-4af2-93ca-cf5a4fcdf704> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b724212b-158a-4af2-93ca-cf5a4fcdf704";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b724212b-158a-4af2-93ca-cf5a4fcdf704>.
+    
+<http://data.lblod.info/id/remote-data-objects/8598bd5f-24eb-49a9-9c9b-ec9caf53ffba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8598bd5f-24eb-49a9-9c9b-ec9caf53ffba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8598bd5f-24eb-49a9-9c9b-ec9caf53ffba>.
+    
+<http://data.lblod.info/id/remote-data-objects/676b0707-57a1-42ff-bd93-17681fe3d81c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "676b0707-57a1-42ff-bd93-17681fe3d81c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/676b0707-57a1-42ff-bd93-17681fe3d81c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b9026ba-a3aa-488d-9ef2-bf594e273104> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b9026ba-a3aa-488d-9ef2-bf594e273104";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b9026ba-a3aa-488d-9ef2-bf594e273104>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff4b554c-c8aa-4fb3-b40b-a7ab6ad3fd0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff4b554c-c8aa-4fb3-b40b-a7ab6ad3fd0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff4b554c-c8aa-4fb3-b40b-a7ab6ad3fd0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6a5d5e3-b4a4-456d-ae6b-04981134215b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6a5d5e3-b4a4-456d-ae6b-04981134215b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6a5d5e3-b4a4-456d-ae6b-04981134215b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bd7efad-9d37-4162-befa-e4affc1870dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bd7efad-9d37-4162-befa-e4affc1870dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bd7efad-9d37-4162-befa-e4affc1870dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ed85c13-5558-40e5-acd1-3d4c2f3a73f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ed85c13-5558-40e5-acd1-3d4c2f3a73f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ed85c13-5558-40e5-acd1-3d4c2f3a73f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e8c52c7-d4e4-4f09-8a04-5e3968d5e8b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e8c52c7-d4e4-4f09-8a04-5e3968d5e8b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e8c52c7-d4e4-4f09-8a04-5e3968d5e8b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cc714e5-84c2-406a-8dd5-1f3bb21bf365> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cc714e5-84c2-406a-8dd5-1f3bb21bf365";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cc714e5-84c2-406a-8dd5-1f3bb21bf365>.
+    
+<http://data.lblod.info/id/remote-data-objects/c346a7f6-5144-4f17-9e0f-9070f2b4947a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c346a7f6-5144-4f17-9e0f-9070f2b4947a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c346a7f6-5144-4f17-9e0f-9070f2b4947a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0771402-4421-49ac-bc4d-1e3e79b230e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0771402-4421-49ac-bc4d-1e3e79b230e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0771402-4421-49ac-bc4d-1e3e79b230e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccd7a08f-328c-4ed2-8d03-bc1f74faa996> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccd7a08f-328c-4ed2-8d03-bc1f74faa996";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccd7a08f-328c-4ed2-8d03-bc1f74faa996>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa16bfb9-b652-4822-87ac-c32c12b2942d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa16bfb9-b652-4822-87ac-c32c12b2942d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d9400cd3-823d-4742-a287-63f208ba93d9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa16bfb9-b652-4822-87ac-c32c12b2942d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201813-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201813-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201813-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201813-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/421bb976-3802-48d9-8f99-9924189ec2b0> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "421bb976-3802-48d9-8f99-9924189ec2b0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5edf7cfd-38a9-4b14-95c9-da4173a7d914";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/de06be09-b6f3-4dc4-8254-180c49866952> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "de06be09-b6f3-4dc4-8254-180c49866952";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914>.
+
+  <http://redpencil.data.gift/id/task/627f8bc9-9d10-4304-a173-4cb84e336d4d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "627f8bc9-9d10-4304-a173-4cb84e336d4d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/421bb976-3802-48d9-8f99-9924189ec2b0>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/de06be09-b6f3-4dc4-8254-180c49866952>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/6f18fada-e7d2-4b18-a46e-c591dba0b1ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f18fada-e7d2-4b18-a46e-c591dba0b1ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f18fada-e7d2-4b18-a46e-c591dba0b1ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/0771d595-0150-4df3-b7a3-6f95551a5e48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0771d595-0150-4df3-b7a3-6f95551a5e48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0771d595-0150-4df3-b7a3-6f95551a5e48>.
+    
+<http://data.lblod.info/id/remote-data-objects/51025198-20de-460a-b7b7-5dc20ec7ed88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51025198-20de-460a-b7b7-5dc20ec7ed88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51025198-20de-460a-b7b7-5dc20ec7ed88>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d6a09af-f324-4f2c-b921-1e8b21dc17fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d6a09af-f324-4f2c-b921-1e8b21dc17fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d6a09af-f324-4f2c-b921-1e8b21dc17fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d348a673-d83a-4820-8555-782ad64c4984> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d348a673-d83a-4820-8555-782ad64c4984";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d348a673-d83a-4820-8555-782ad64c4984>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab3d0122-c504-4d00-8e44-bb1c5861cbba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab3d0122-c504-4d00-8e44-bb1c5861cbba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab3d0122-c504-4d00-8e44-bb1c5861cbba>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4efee4c-45d0-457b-a322-6df8f06325dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4efee4c-45d0-457b-a322-6df8f06325dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4efee4c-45d0-457b-a322-6df8f06325dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/66eb5911-9ad8-460d-9d2c-ac67a949196e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66eb5911-9ad8-460d-9d2c-ac67a949196e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66eb5911-9ad8-460d-9d2c-ac67a949196e>.
+    
+<http://data.lblod.info/id/remote-data-objects/945b5b0b-f2d3-49a2-a83d-1fe371ef2bc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "945b5b0b-f2d3-49a2-a83d-1fe371ef2bc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/945b5b0b-f2d3-49a2-a83d-1fe371ef2bc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e700e841-eed4-4847-a1b6-dc60d8ed35c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e700e841-eed4-4847-a1b6-dc60d8ed35c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/50188fcf82e54fbac848d06dad19dbe775e00331d93ff8ff583241d030d32253/GetPublication?filename=BesluitenLijst_Vast%20Bureau_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e700e841-eed4-4847-a1b6-dc60d8ed35c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/76826f3c-c5b3-4d33-9dd3-7c1d0912b2e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76826f3c-c5b3-4d33-9dd3-7c1d0912b2e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Agenda_OCMW-Raad_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76826f3c-c5b3-4d33-9dd3-7c1d0912b2e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff98b6ca-0de7-4be7-b745-1abb0a069040> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff98b6ca-0de7-4be7-b745-1abb0a069040";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Agenda_OCMW-Raad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff98b6ca-0de7-4be7-b745-1abb0a069040>.
+    
+<http://data.lblod.info/id/remote-data-objects/b594ebf8-4415-4ec1-83a3-3b70fa23d692> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b594ebf8-4415-4ec1-83a3-3b70fa23d692";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Agenda_OCMW-Raad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b594ebf8-4415-4ec1-83a3-3b70fa23d692>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf4ff4f2-e071-47f7-b80b-edbb85075e37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf4ff4f2-e071-47f7-b80b-edbb85075e37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Agenda_OCMW-Raad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf4ff4f2-e071-47f7-b80b-edbb85075e37>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e218bbf-4f70-4a39-af41-a071ac478a42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e218bbf-4f70-4a39-af41-a071ac478a42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Agenda_OCMW-Raad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e218bbf-4f70-4a39-af41-a071ac478a42>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c05c92a-6517-47c1-8648-48385f4c862e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c05c92a-6517-47c1-8648-48385f4c862e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Agenda_OCMW-Raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c05c92a-6517-47c1-8648-48385f4c862e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7621a88-4acf-470f-ae96-4fa6a99c8cb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7621a88-4acf-470f-ae96-4fa6a99c8cb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Agenda_OCMW-Raad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7621a88-4acf-470f-ae96-4fa6a99c8cb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5d4a772-3108-437f-beae-a24a1a67caa0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5d4a772-3108-437f-beae-a24a1a67caa0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Agenda_OCMW-Raad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5d4a772-3108-437f-beae-a24a1a67caa0>.
+    
+<http://data.lblod.info/id/remote-data-objects/41d86e18-a8de-461d-a5eb-2e16f2f74cb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41d86e18-a8de-461d-a5eb-2e16f2f74cb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Agenda_OCMW-Raad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41d86e18-a8de-461d-a5eb-2e16f2f74cb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a50e5aeb-d404-4bc0-b103-16d1a3228ed8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a50e5aeb-d404-4bc0-b103-16d1a3228ed8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Agenda_OCMW-Raad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a50e5aeb-d404-4bc0-b103-16d1a3228ed8>.
+    
+<http://data.lblod.info/id/remote-data-objects/50677c75-7f86-4eb1-a5cc-07092e4b89a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50677c75-7f86-4eb1-a5cc-07092e4b89a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=BesluitenLijst_OCMW-Raad_18-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50677c75-7f86-4eb1-a5cc-07092e4b89a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c306bff7-908c-481f-ba68-a1df26cafdaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c306bff7-908c-481f-ba68-a1df26cafdaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=BesluitenLijst_OCMW-Raad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c306bff7-908c-481f-ba68-a1df26cafdaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c2984ab-2c95-4b3b-a43c-afd27dd63652> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c2984ab-2c95-4b3b-a43c-afd27dd63652";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=BesluitenLijst_OCMW-Raad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c2984ab-2c95-4b3b-a43c-afd27dd63652>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c534973-855f-4edf-a559-daba6c59a77f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c534973-855f-4edf-a559-daba6c59a77f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=BesluitenLijst_OCMW-Raad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c534973-855f-4edf-a559-daba6c59a77f>.
+    
+<http://data.lblod.info/id/remote-data-objects/578d5845-5844-4c7e-871d-62e970ea8cdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "578d5845-5844-4c7e-871d-62e970ea8cdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=BesluitenLijst_OCMW-Raad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/578d5845-5844-4c7e-871d-62e970ea8cdf>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f3782f6-2168-433a-a7bb-fad4ef42d8a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f3782f6-2168-433a-a7bb-fad4ef42d8a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=BesluitenLijst_OCMW-Raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f3782f6-2168-433a-a7bb-fad4ef42d8a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a667c17-40e6-4fc6-a561-136487626236> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a667c17-40e6-4fc6-a561-136487626236";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=BesluitenLijst_OCMW-Raad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a667c17-40e6-4fc6-a561-136487626236>.
+    
+<http://data.lblod.info/id/remote-data-objects/f47c30ff-3257-4df1-9eaa-1400b8505f0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f47c30ff-3257-4df1-9eaa-1400b8505f0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=BesluitenLijst_OCMW-Raad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f47c30ff-3257-4df1-9eaa-1400b8505f0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2532c060-5e62-4197-aa62-8b705a30f29a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2532c060-5e62-4197-aa62-8b705a30f29a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=BesluitenLijst_OCMW-Raad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2532c060-5e62-4197-aa62-8b705a30f29a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fc1194d-036b-4e23-9a5a-1107a5269ee7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fc1194d-036b-4e23-9a5a-1107a5269ee7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=BesluitenLijst_OCMW-Raad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fc1194d-036b-4e23-9a5a-1107a5269ee7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c5b345c-2851-4687-bca8-d658444de339> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c5b345c-2851-4687-bca8-d658444de339";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Notulen_OCMW-Raad_20-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c5b345c-2851-4687-bca8-d658444de339>.
+    
+<http://data.lblod.info/id/remote-data-objects/09c97938-0541-4645-9db7-535fa4a8adda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09c97938-0541-4645-9db7-535fa4a8adda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Notulen_OCMW-Raad_22-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09c97938-0541-4645-9db7-535fa4a8adda>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f064b01-a15b-42cf-ba89-66a3bff2a662> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f064b01-a15b-42cf-ba89-66a3bff2a662";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Notulen_OCMW-Raad_23-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f064b01-a15b-42cf-ba89-66a3bff2a662>.
+    
+<http://data.lblod.info/id/remote-data-objects/910e46fc-d289-45b5-bb9b-3922e5285286> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "910e46fc-d289-45b5-bb9b-3922e5285286";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Notulen_OCMW-Raad_24-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/910e46fc-d289-45b5-bb9b-3922e5285286>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4479869-6842-432b-847b-e744966179c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4479869-6842-432b-847b-e744966179c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Notulen_OCMW-Raad_25-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4479869-6842-432b-847b-e744966179c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1dbe4e5a-18be-47af-9b62-3608f99a018f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1dbe4e5a-18be-47af-9b62-3608f99a018f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Notulen_OCMW-Raad_25-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1dbe4e5a-18be-47af-9b62-3608f99a018f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c10a5f99-3788-4668-b8cf-a912cc51a3c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c10a5f99-3788-4668-b8cf-a912cc51a3c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Notulen_OCMW-Raad_27-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c10a5f99-3788-4668-b8cf-a912cc51a3c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fa67234-4034-4cfa-a4e4-78195de8c779> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fa67234-4034-4cfa-a4e4-78195de8c779";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Notulen_OCMW-Raad_28-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fa67234-4034-4cfa-a4e4-78195de8c779>.
+    
+<http://data.lblod.info/id/remote-data-objects/77ef2b25-8e67-4f40-b8d5-6f21dd8af526> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77ef2b25-8e67-4f40-b8d5-6f21dd8af526";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Notulen_OCMW-Raad_28-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77ef2b25-8e67-4f40-b8d5-6f21dd8af526>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3d9a847-d153-4cf1-aa9f-a7dcbd77a13e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3d9a847-d153-4cf1-aa9f-a7dcbd77a13e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Uittreksels_22-11-2021_53621.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3d9a847-d153-4cf1-aa9f-a7dcbd77a13e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed55b9ad-56c1-487b-9fcd-7acf0c63eba2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed55b9ad-56c1-487b-9fcd-7acf0c63eba2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Uittreksels_23-05-2022_57796.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed55b9ad-56c1-487b-9fcd-7acf0c63eba2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9c5b77f-c7c3-44dd-a8cc-7e6b0cc6ce5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9c5b77f-c7c3-44dd-a8cc-7e6b0cc6ce5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/5a872bf5cd928e1dc79f6b3c6016311ce9cb054c26b026dd9554688d70aad3ef/GetPublication?filename=Uittreksels_27-06-2022_58186.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9c5b77f-c7c3-44dd-a8cc-7e6b0cc6ce5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b66a726-587d-4e58-ad04-ba7813c92c41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b66a726-587d-4e58-ad04-ba7813c92c41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b66a726-587d-4e58-ad04-ba7813c92c41>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b53720c-b995-4ced-988f-1127b80c55f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b53720c-b995-4ced-988f-1127b80c55f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b53720c-b995-4ced-988f-1127b80c55f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f3a530a-23b1-462a-b5de-e20f07ec2aed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f3a530a-23b1-462a-b5de-e20f07ec2aed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_05-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f3a530a-23b1-462a-b5de-e20f07ec2aed>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad116b4a-28b0-4cc8-9c06-bc897170374d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad116b4a-28b0-4cc8-9c06-bc897170374d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad116b4a-28b0-4cc8-9c06-bc897170374d>.
+    
+<http://data.lblod.info/id/remote-data-objects/75961377-90de-42ce-b8c1-f215b704c2dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75961377-90de-42ce-b8c1-f215b704c2dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75961377-90de-42ce-b8c1-f215b704c2dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d086e3a1-3608-4044-b194-40ab63569bdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d086e3a1-3608-4044-b194-40ab63569bdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_07-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d086e3a1-3608-4044-b194-40ab63569bdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/578b4c69-99eb-40b4-aa85-4ae359460a46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "578b4c69-99eb-40b4-aa85-4ae359460a46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/578b4c69-99eb-40b4-aa85-4ae359460a46>.
+    
+<http://data.lblod.info/id/remote-data-objects/89ef5baf-effb-4ca6-b8f1-64f42985c573> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89ef5baf-effb-4ca6-b8f1-64f42985c573";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:13.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5edf7cfd-38a9-4b14-95c9-da4173a7d914> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89ef5baf-effb-4ca6-b8f1-64f42985c573>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201815-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201815-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201815-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201815-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2b2f4a62-9f3c-45b7-8384-9ee0154db316> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2b2f4a62-9f3c-45b7-8384-9ee0154db316";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dbb90d94-7679-45ff-b6c9-c611801e9ce3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/3b2be2b3-a763-49cc-981b-766987526674> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3b2be2b3-a763-49cc-981b-766987526674";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3>.
+
+  <http://redpencil.data.gift/id/task/ead2c938-8908-442b-93af-97e9e9c14930> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ead2c938-8908-442b-93af-97e9e9c14930";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2b2f4a62-9f3c-45b7-8384-9ee0154db316>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/3b2be2b3-a763-49cc-981b-766987526674>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/79d6305d-910f-44de-9f7f-e92d731dd47a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79d6305d-910f-44de-9f7f-e92d731dd47a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_09-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79d6305d-910f-44de-9f7f-e92d731dd47a>.
+    
+<http://data.lblod.info/id/remote-data-objects/18508023-9987-4817-b4be-d8886a1c55be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18508023-9987-4817-b4be-d8886a1c55be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18508023-9987-4817-b4be-d8886a1c55be>.
+    
+<http://data.lblod.info/id/remote-data-objects/88e31ef9-f6ff-48e9-97b5-152f312a98cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88e31ef9-f6ff-48e9-97b5-152f312a98cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88e31ef9-f6ff-48e9-97b5-152f312a98cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3395d09-af58-4b9f-8156-44be151206c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3395d09-af58-4b9f-8156-44be151206c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_10-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3395d09-af58-4b9f-8156-44be151206c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a188a10-bc1d-4ecf-9ca6-1f17f305856f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a188a10-bc1d-4ecf-9ca6-1f17f305856f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a188a10-bc1d-4ecf-9ca6-1f17f305856f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0256b75-e5e9-4dfb-8dde-d491561cd2d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0256b75-e5e9-4dfb-8dde-d491561cd2d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0256b75-e5e9-4dfb-8dde-d491561cd2d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/be6768b7-e476-4496-8bea-bfaf75a4a00d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be6768b7-e476-4496-8bea-bfaf75a4a00d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_11-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be6768b7-e476-4496-8bea-bfaf75a4a00d>.
+    
+<http://data.lblod.info/id/remote-data-objects/44ff1336-d2ed-4c2c-8c01-a3b5ceca884e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44ff1336-d2ed-4c2c-8c01-a3b5ceca884e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44ff1336-d2ed-4c2c-8c01-a3b5ceca884e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7677ba11-b147-44b1-936d-a91f713a0343> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7677ba11-b147-44b1-936d-a91f713a0343";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7677ba11-b147-44b1-936d-a91f713a0343>.
+    
+<http://data.lblod.info/id/remote-data-objects/34540e36-c631-4833-9e9b-dfb1dde6c03e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34540e36-c631-4833-9e9b-dfb1dde6c03e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_12-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34540e36-c631-4833-9e9b-dfb1dde6c03e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab993787-5d39-482a-bb9a-6c854ccbc819> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab993787-5d39-482a-bb9a-6c854ccbc819";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab993787-5d39-482a-bb9a-6c854ccbc819>.
+    
+<http://data.lblod.info/id/remote-data-objects/dad8f552-42ee-4787-981b-210e443cbc95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dad8f552-42ee-4787-981b-210e443cbc95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dad8f552-42ee-4787-981b-210e443cbc95>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc374f56-54fd-4e6c-984b-82c441ed68ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc374f56-54fd-4e6c-984b-82c441ed68ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_12-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc374f56-54fd-4e6c-984b-82c441ed68ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b240898-1547-4eb8-a116-e12962c3cd1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b240898-1547-4eb8-a116-e12962c3cd1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b240898-1547-4eb8-a116-e12962c3cd1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bfe1f9e-d827-42d0-b967-f9e5a57b2ab8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bfe1f9e-d827-42d0-b967-f9e5a57b2ab8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bfe1f9e-d827-42d0-b967-f9e5a57b2ab8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d2aa116-7527-442a-bc56-c83659cab2a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d2aa116-7527-442a-bc56-c83659cab2a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_14-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d2aa116-7527-442a-bc56-c83659cab2a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ef50438-e90b-4897-84e4-80e1b5b5e410> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ef50438-e90b-4897-84e4-80e1b5b5e410";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ef50438-e90b-4897-84e4-80e1b5b5e410>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f3e5606-add0-4db7-8307-980c7160c885> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f3e5606-add0-4db7-8307-980c7160c885";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f3e5606-add0-4db7-8307-980c7160c885>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0a34b97-89db-44eb-b423-ebf47f410299> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0a34b97-89db-44eb-b423-ebf47f410299";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_15-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0a34b97-89db-44eb-b423-ebf47f410299>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bf301c3-722d-4ec2-8722-63160822fdb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bf301c3-722d-4ec2-8722-63160822fdb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bf301c3-722d-4ec2-8722-63160822fdb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e8ec04c-d0e8-4e79-be36-6cc096dcde29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e8ec04c-d0e8-4e79-be36-6cc096dcde29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e8ec04c-d0e8-4e79-be36-6cc096dcde29>.
+    
+<http://data.lblod.info/id/remote-data-objects/69137ac0-0e3f-4367-bb10-6d3b5762437a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69137ac0-0e3f-4367-bb10-6d3b5762437a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20-%20agenda%20gemeenteraad_15-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69137ac0-0e3f-4367-bb10-6d3b5762437a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b53cae54-2b33-4424-b2d1-6164b978e2fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b53cae54-2b33-4424-b2d1-6164b978e2fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_01-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b53cae54-2b33-4424-b2d1-6164b978e2fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a78920d-be9c-45d8-81ed-e8325f75d7f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a78920d-be9c-45d8-81ed-e8325f75d7f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_01-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a78920d-be9c-45d8-81ed-e8325f75d7f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/51a46a0d-207a-4bad-bc2a-c132b0205522> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51a46a0d-207a-4bad-bc2a-c132b0205522";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_03-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51a46a0d-207a-4bad-bc2a-c132b0205522>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e7924e1-0d1d-4b6f-8691-ee3c1de110f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e7924e1-0d1d-4b6f-8691-ee3c1de110f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_04-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e7924e1-0d1d-4b6f-8691-ee3c1de110f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c45fed10-d8f1-4c3e-acd9-a8dea008e42e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c45fed10-d8f1-4c3e-acd9-a8dea008e42e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c45fed10-d8f1-4c3e-acd9-a8dea008e42e>.
+    
+<http://data.lblod.info/id/remote-data-objects/79b6f5b4-8378-4ea5-a670-74362b3e1aaf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79b6f5b4-8378-4ea5-a670-74362b3e1aaf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_05-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79b6f5b4-8378-4ea5-a670-74362b3e1aaf>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed0c0c0d-9d5a-483b-a737-c6205d3e096d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed0c0c0d-9d5a-483b-a737-c6205d3e096d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_07-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed0c0c0d-9d5a-483b-a737-c6205d3e096d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d57e4e70-bae5-4f83-a72a-0bc2c9ef654e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d57e4e70-bae5-4f83-a72a-0bc2c9ef654e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_08-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d57e4e70-bae5-4f83-a72a-0bc2c9ef654e>.
+    
+<http://data.lblod.info/id/remote-data-objects/12d52500-941b-4514-96a6-842fab254a25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12d52500-941b-4514-96a6-842fab254a25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_08-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12d52500-941b-4514-96a6-842fab254a25>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dde3639-d706-4289-9f5a-2512d6432a93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dde3639-d706-4289-9f5a-2512d6432a93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_12-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dde3639-d706-4289-9f5a-2512d6432a93>.
+    
+<http://data.lblod.info/id/remote-data-objects/693e80b9-d347-46de-a372-9cf4c3c78aae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "693e80b9-d347-46de-a372-9cf4c3c78aae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_14-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/693e80b9-d347-46de-a372-9cf4c3c78aae>.
+    
+<http://data.lblod.info/id/remote-data-objects/231b1598-737f-45ac-b0a0-afdede640c4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "231b1598-737f-45ac-b0a0-afdede640c4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_16-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/231b1598-737f-45ac-b0a0-afdede640c4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc0ec225-714c-4121-adad-97631c8bd7d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc0ec225-714c-4121-adad-97631c8bd7d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_17-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc0ec225-714c-4121-adad-97631c8bd7d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/136f03fe-fe46-4cc0-b5c7-07f8312662ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "136f03fe-fe46-4cc0-b5c7-07f8312662ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_18-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/136f03fe-fe46-4cc0-b5c7-07f8312662ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ae43259-9256-418d-8887-17e5fd0fe844> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ae43259-9256-418d-8887-17e5fd0fe844";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ae43259-9256-418d-8887-17e5fd0fe844>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdbd5761-480e-4816-ac3d-d348aad0d4df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdbd5761-480e-4816-ac3d-d348aad0d4df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-07-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdbd5761-480e-4816-ac3d-d348aad0d4df>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd22ba66-a668-49fd-bbd1-e5db96306c40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd22ba66-a668-49fd-bbd1-e5db96306c40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_19-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd22ba66-a668-49fd-bbd1-e5db96306c40>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd52a8c5-c709-4bb6-aec6-51a1bb6511f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd52a8c5-c709-4bb6-aec6-51a1bb6511f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_20-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd52a8c5-c709-4bb6-aec6-51a1bb6511f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/20bf889d-ee44-427a-ac1c-510eee65179b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20bf889d-ee44-427a-ac1c-510eee65179b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_21-12-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20bf889d-ee44-427a-ac1c-510eee65179b>.
+    
+<http://data.lblod.info/id/remote-data-objects/255eda6b-4962-4224-9cb4-33289b3a7490> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "255eda6b-4962-4224-9cb4-33289b3a7490";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-02-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/255eda6b-4962-4224-9cb4-33289b3a7490>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2aee62e-8439-4653-97cd-f42fc670f30f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2aee62e-8439-4653-97cd-f42fc670f30f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_22-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2aee62e-8439-4653-97cd-f42fc670f30f>.
+    
+<http://data.lblod.info/id/remote-data-objects/eacc9df4-843f-4374-8731-c8d8c7d836ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eacc9df4-843f-4374-8731-c8d8c7d836ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_23-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eacc9df4-843f-4374-8731-c8d8c7d836ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/1da11656-20f2-4986-be31-b591cf2eb2f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1da11656-20f2-4986-be31-b591cf2eb2f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_24-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1da11656-20f2-4986-be31-b591cf2eb2f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e43785b-ebda-4b20-bb9a-0d79cd6221b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e43785b-ebda-4b20-bb9a-0d79cd6221b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_25-01-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e43785b-ebda-4b20-bb9a-0d79cd6221b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb0d3943-4894-4f7c-a4d4-901e5a2e1ed0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb0d3943-4894-4f7c-a4d4-901e5a2e1ed0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_26-04-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb0d3943-4894-4f7c-a4d4-901e5a2e1ed0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e927e8d4-88f5-447e-890a-a3d0e732fa9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e927e8d4-88f5-447e-890a-a3d0e732fa9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_26-10-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e927e8d4-88f5-447e-890a-a3d0e732fa9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0951beb8-69a7-4ac3-8018-0c5d9d0e8c02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0951beb8-69a7-4ac3-8018-0c5d9d0e8c02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_28-06-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0951beb8-69a7-4ac3-8018-0c5d9d0e8c02>.
+    
+<http://data.lblod.info/id/remote-data-objects/86cb68f9-c2e1-4b2c-9706-c10ce4766eb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86cb68f9-c2e1-4b2c-9706-c10ce4766eb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_29-03-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb90d94-7679-45ff-b6c9-c611801e9ce3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86cb68f9-c2e1-4b2c-9706-c10ce4766eb2>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201816-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201816-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201816-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201816-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/63087f29-2748-4d49-bfe0-ef889fd25450> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "63087f29-2748-4d49-bfe0-ef889fd25450";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1a27e9ce-ad67-4689-916d-9dc799960cc8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b7da1bb0-ef60-4e6d-a790-2459a5e9e8e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b7da1bb0-ef60-4e6d-a790-2459a5e9e8e2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8>.
+
+  <http://redpencil.data.gift/id/task/8219da5d-d71e-4f6f-a4ee-0607b64f7c46> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8219da5d-d71e-4f6f-a4ee-0607b64f7c46";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/63087f29-2748-4d49-bfe0-ef889fd25450>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b7da1bb0-ef60-4e6d-a790-2459a5e9e8e2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/dc867afe-7ca7-4e52-bff9-3d68d7eb67a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc867afe-7ca7-4e52-bff9-3d68d7eb67a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_30-11-2021.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc867afe-7ca7-4e52-bff9-3d68d7eb67a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/419f4113-b7e4-4714-8c0c-a7de445fed9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "419f4113-b7e4-4714-8c0c-a7de445fed9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=BesluitenLijst_College%20van%20burgemeester%20en%20schepenen_31-05-2022.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/419f4113-b7e4-4714-8c0c-a7de445fed9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bba0434-595b-433f-ad82-997d84d23bf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bba0434-595b-433f-ad82-997d84d23bf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_03-05-2022_57597.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bba0434-595b-433f-ad82-997d84d23bf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/cea3479b-f27b-4f5a-b2ab-fa8bc86601f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cea3479b-f27b-4f5a-b2ab-fa8bc86601f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_03-05-2022_57599.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cea3479b-f27b-4f5a-b2ab-fa8bc86601f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9ea9e65-deab-4786-9561-6e38d8ad3154> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9ea9e65-deab-4786-9561-6e38d8ad3154";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_05-04-2022_57118.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9ea9e65-deab-4786-9561-6e38d8ad3154>.
+    
+<http://data.lblod.info/id/remote-data-objects/663e47eb-788e-46e4-96c6-2ba67055ad2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "663e47eb-788e-46e4-96c6-2ba67055ad2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_05-04-2022_57126.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/663e47eb-788e-46e4-96c6-2ba67055ad2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbb9a123-bfa4-4d1c-bcaa-c3b2c319e52b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbb9a123-bfa4-4d1c-bcaa-c3b2c319e52b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_05-10-2021_52920.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbb9a123-bfa4-4d1c-bcaa-c3b2c319e52b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0139c07-cc39-4c2c-96e5-86e10a656513> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0139c07-cc39-4c2c-96e5-86e10a656513";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_07-06-2022_58065.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0139c07-cc39-4c2c-96e5-86e10a656513>.
+    
+<http://data.lblod.info/id/remote-data-objects/0069283c-1a39-4a4e-864a-79203d5c1383> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0069283c-1a39-4a4e-864a-79203d5c1383";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_07-06-2022_58078.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0069283c-1a39-4a4e-864a-79203d5c1383>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b4922cf-b559-4bfd-8a7c-d1bb8e88fb54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b4922cf-b559-4bfd-8a7c-d1bb8e88fb54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_07-06-2022_58080.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b4922cf-b559-4bfd-8a7c-d1bb8e88fb54>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a743f24-f1fa-4150-b22f-e1ec252a4eb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a743f24-f1fa-4150-b22f-e1ec252a4eb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_07-06-2022_58107.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a743f24-f1fa-4150-b22f-e1ec252a4eb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/8da03646-7227-466c-aa8a-990194c696fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8da03646-7227-466c-aa8a-990194c696fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_12-07-2022_58540.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8da03646-7227-466c-aa8a-990194c696fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ad28e81-8c12-4178-90be-1bf8055074d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ad28e81-8c12-4178-90be-1bf8055074d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_12-07-2022_58673.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ad28e81-8c12-4178-90be-1bf8055074d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9111a013-a907-4398-a163-cd4fb7fa59e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9111a013-a907-4398-a163-cd4fb7fa59e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_12-07-2022_58675.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9111a013-a907-4398-a163-cd4fb7fa59e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab5eb2c4-5df6-4093-b0a6-2ba6e76d66ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab5eb2c4-5df6-4093-b0a6-2ba6e76d66ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_12-07-2022_58676.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab5eb2c4-5df6-4093-b0a6-2ba6e76d66ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cf408ae-84ff-4083-b527-18fac2faa570> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cf408ae-84ff-4083-b527-18fac2faa570";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_12-07-2022_58684.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cf408ae-84ff-4083-b527-18fac2faa570>.
+    
+<http://data.lblod.info/id/remote-data-objects/4547a08c-4323-4b86-9bb3-aa6a208afde3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4547a08c-4323-4b86-9bb3-aa6a208afde3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_12-07-2022_58687.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4547a08c-4323-4b86-9bb3-aa6a208afde3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1609235e-cff5-45d8-9a05-6b11dca4e0ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1609235e-cff5-45d8-9a05-6b11dca4e0ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_12-07-2022_58716.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1609235e-cff5-45d8-9a05-6b11dca4e0ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/56066cb8-4a76-4270-8eab-8edd0433fb0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56066cb8-4a76-4270-8eab-8edd0433fb0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_12-07-2022_58720.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56066cb8-4a76-4270-8eab-8edd0433fb0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/73aa1f78-a041-404f-a48c-f58af3ba0f47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73aa1f78-a041-404f-a48c-f58af3ba0f47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_14-06-2022_58127.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73aa1f78-a041-404f-a48c-f58af3ba0f47>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5f444a8-0d9f-4596-9e35-d0541058f734> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5f444a8-0d9f-4596-9e35-d0541058f734";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_14-12-2021_55356.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5f444a8-0d9f-4596-9e35-d0541058f734>.
+    
+<http://data.lblod.info/id/remote-data-objects/af0632a4-070d-43ef-a315-68f692bf1314> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af0632a4-070d-43ef-a315-68f692bf1314";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_15-03-2022_56786.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af0632a4-070d-43ef-a315-68f692bf1314>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5ef294c-4b0e-4688-9ebd-9901ebfd938d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5ef294c-4b0e-4688-9ebd-9901ebfd938d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_16-11-2021_53399.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5ef294c-4b0e-4688-9ebd-9901ebfd938d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e18ee0d-7628-474a-b136-70eaf9b2c563> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e18ee0d-7628-474a-b136-70eaf9b2c563";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_17-05-2022_57634.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e18ee0d-7628-474a-b136-70eaf9b2c563>.
+    
+<http://data.lblod.info/id/remote-data-objects/a69070cf-4268-4613-8426-b65bee5c1c79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a69070cf-4268-4613-8426-b65bee5c1c79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_17-05-2022_57638.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a69070cf-4268-4613-8426-b65bee5c1c79>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbce3fc4-ed38-4574-906b-dcbd9beca735> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbce3fc4-ed38-4574-906b-dcbd9beca735";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_17-05-2022_57674.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbce3fc4-ed38-4574-906b-dcbd9beca735>.
+    
+<http://data.lblod.info/id/remote-data-objects/73fdc7fd-e369-4e07-8d7a-f344c1a65d33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73fdc7fd-e369-4e07-8d7a-f344c1a65d33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_17-05-2022_57815.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73fdc7fd-e369-4e07-8d7a-f344c1a65d33>.
+    
+<http://data.lblod.info/id/remote-data-objects/386d7b74-8a96-4187-99cd-0546700d8ca7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "386d7b74-8a96-4187-99cd-0546700d8ca7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_19-04-2022_57315.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/386d7b74-8a96-4187-99cd-0546700d8ca7>.
+    
+<http://data.lblod.info/id/remote-data-objects/97445b74-19bd-4677-a001-4c3f0c2572d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97445b74-19bd-4677-a001-4c3f0c2572d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_20-06-2022_58219.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97445b74-19bd-4677-a001-4c3f0c2572d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/eee57677-ff6b-4d75-904e-eb94477cb3cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eee57677-ff6b-4d75-904e-eb94477cb3cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_20-06-2022_58225.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eee57677-ff6b-4d75-904e-eb94477cb3cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/40b0a23d-fc80-487d-a07a-f070606cfb68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40b0a23d-fc80-487d-a07a-f070606cfb68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_22-02-2022_56423.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40b0a23d-fc80-487d-a07a-f070606cfb68>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfff4a9e-a524-4779-b34c-1e04c90d71a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfff4a9e-a524-4779-b34c-1e04c90d71a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_25-01-2022_56080.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfff4a9e-a524-4779-b34c-1e04c90d71a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/20367639-8622-4346-89fc-0fd1f8658660> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20367639-8622-4346-89fc-0fd1f8658660";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_26-04-2022_57466.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20367639-8622-4346-89fc-0fd1f8658660>.
+    
+<http://data.lblod.info/id/remote-data-objects/761259e3-9046-4193-8cae-bdf7c46616d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "761259e3-9046-4193-8cae-bdf7c46616d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_26-04-2022_57476.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/761259e3-9046-4193-8cae-bdf7c46616d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/11c0b15a-11f8-414d-8921-7038f4ceae39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11c0b15a-11f8-414d-8921-7038f4ceae39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_26-04-2022_57477.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11c0b15a-11f8-414d-8921-7038f4ceae39>.
+    
+<http://data.lblod.info/id/remote-data-objects/955f1689-488c-4b5c-ab14-1fcd0bad6a70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "955f1689-488c-4b5c-ab14-1fcd0bad6a70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_26-04-2022_57487.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/955f1689-488c-4b5c-ab14-1fcd0bad6a70>.
+    
+<http://data.lblod.info/id/remote-data-objects/17021b9b-572e-46d8-96a1-fe8c5cb70708> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17021b9b-572e-46d8-96a1-fe8c5cb70708";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_28-06-2022_58319.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17021b9b-572e-46d8-96a1-fe8c5cb70708>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab229854-cdee-44c4-a6ea-9e1e61301210> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab229854-cdee-44c4-a6ea-9e1e61301210";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_28-06-2022_58323.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab229854-cdee-44c4-a6ea-9e1e61301210>.
+    
+<http://data.lblod.info/id/remote-data-objects/a06defae-78be-48d0-850c-713250348565> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a06defae-78be-48d0-850c-713250348565";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_28-06-2022_58328.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a06defae-78be-48d0-850c-713250348565>.
+    
+<http://data.lblod.info/id/remote-data-objects/261a0684-9d6b-4ddf-ac0e-70275676e2bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "261a0684-9d6b-4ddf-ac0e-70275676e2bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_28-06-2022_58401.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/261a0684-9d6b-4ddf-ac0e-70275676e2bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/2646b5c7-2d9f-4ecc-8cff-ba876b8253db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2646b5c7-2d9f-4ecc-8cff-ba876b8253db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lblod.zwevegem.be/LBLODWeb/Home/Overzicht/b989ac6d-5c2a-4e46-9e9c-664d78158085/GetPublication?filename=Uittreksels_31-05-2022_57837.html>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2646b5c7-2d9f-4ecc-8cff-ba876b8253db>.
+    
+<http://data.lblod.info/id/remote-data-objects/520d784d-daaf-4f93-b832-a7c737119eec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "520d784d-daaf-4f93-b832-a7c737119eec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/0240fcf1-b3bd-433d-bd69-03327da9d59c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/520d784d-daaf-4f93-b832-a7c737119eec>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac148476-0d26-4cab-be2c-387e01a19f87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac148476-0d26-4cab-be2c-387e01a19f87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/02988db4-c176-48d4-934e-b7202c6ece89/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac148476-0d26-4cab-be2c-387e01a19f87>.
+    
+<http://data.lblod.info/id/remote-data-objects/953112b0-7a11-498f-8c15-8274a59c39f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "953112b0-7a11-498f-8c15-8274a59c39f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/034101b8-7300-4be9-8b53-77239552814f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/953112b0-7a11-498f-8c15-8274a59c39f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c8ae52a-9179-4d35-a1ca-6311e12faf4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c8ae52a-9179-4d35-a1ca-6311e12faf4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/057fceb1-3041-4069-b2a7-a3b43362df3e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c8ae52a-9179-4d35-a1ca-6311e12faf4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/af9d794b-d1a8-45a8-bda3-3371c76e6d7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af9d794b-d1a8-45a8-bda3-3371c76e6d7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/07550cc1-2038-46eb-9b3b-91556ffc111d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af9d794b-d1a8-45a8-bda3-3371c76e6d7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/af75ef05-6704-4409-847b-d7968c6eb6a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af75ef05-6704-4409-847b-d7968c6eb6a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/07d69509-01a0-4127-a40e-2e4fe3895400/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af75ef05-6704-4409-847b-d7968c6eb6a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/97b0b34e-885d-491a-8900-2b1b9a5e30e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97b0b34e-885d-491a-8900-2b1b9a5e30e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/0bbd4ef7-ea16-422c-913c-d2c0a45fea20/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97b0b34e-885d-491a-8900-2b1b9a5e30e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1198ed3-870f-4cd7-9b82-1a95eff5dbed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1198ed3-870f-4cd7-9b82-1a95eff5dbed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/0e5506fc-3002-4ff1-b740-73e02c2fd79c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1198ed3-870f-4cd7-9b82-1a95eff5dbed>.
+    
+<http://data.lblod.info/id/remote-data-objects/16711990-154d-48ba-b935-48d2120b370b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16711990-154d-48ba-b935-48d2120b370b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/0f28754b-42d5-4e4e-aef4-591b5130c28f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1a27e9ce-ad67-4689-916d-9dc799960cc8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16711990-154d-48ba-b935-48d2120b370b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201817-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201817-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201817-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201817-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/25cfd1fa-b834-48ce-b736-2eda907903b0> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "25cfd1fa-b834-48ce-b736-2eda907903b0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "eedbff0f-979d-4c93-a600-10dceac3cffa";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/206077bd-e066-4ddf-a89b-804e78168556> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "206077bd-e066-4ddf-a89b-804e78168556";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa>.
+
+  <http://redpencil.data.gift/id/task/4472fa3b-8d08-4069-b833-e5c0cc6395d8> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4472fa3b-8d08-4069-b833-e5c0cc6395d8";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/25cfd1fa-b834-48ce-b736-2eda907903b0>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/206077bd-e066-4ddf-a89b-804e78168556>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/79a80c3a-f5fe-4b03-a778-8ffc40bcdb4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79a80c3a-f5fe-4b03-a778-8ffc40bcdb4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/10221dc3-3244-4929-84c0-aa0ab5a87ef8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79a80c3a-f5fe-4b03-a778-8ffc40bcdb4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a63c9173-5833-424d-9dac-ab329c5322c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a63c9173-5833-424d-9dac-ab329c5322c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/102b928d-d902-4505-a8de-72ebbcc8ffc2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a63c9173-5833-424d-9dac-ab329c5322c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/cda9c6ee-2180-4aa5-af2b-a57024237d29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cda9c6ee-2180-4aa5-af2b-a57024237d29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/1047054f-de02-4b1d-b3c7-c96e45e10165/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cda9c6ee-2180-4aa5-af2b-a57024237d29>.
+    
+<http://data.lblod.info/id/remote-data-objects/e390c051-061e-49d0-bfc0-5c2b014ffc42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e390c051-061e-49d0-bfc0-5c2b014ffc42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/12dc0793-a802-4d01-acc0-fb749ecf95d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e390c051-061e-49d0-bfc0-5c2b014ffc42>.
+    
+<http://data.lblod.info/id/remote-data-objects/dff0b19c-584c-4988-a487-40f9c77efc47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dff0b19c-584c-4988-a487-40f9c77efc47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/134a41aa-4982-42b6-b173-b7e9c019b356/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dff0b19c-584c-4988-a487-40f9c77efc47>.
+    
+<http://data.lblod.info/id/remote-data-objects/6602762e-568c-4f66-9d89-dc6dc2fb33f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6602762e-568c-4f66-9d89-dc6dc2fb33f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/156d1f59-d843-44d8-ad7d-b06a92451d36/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6602762e-568c-4f66-9d89-dc6dc2fb33f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed835b4b-d9fa-47f8-9319-df17b902459f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed835b4b-d9fa-47f8-9319-df17b902459f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/157b7b61-4ccb-4bbf-97b3-c99ee68af221/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed835b4b-d9fa-47f8-9319-df17b902459f>.
+    
+<http://data.lblod.info/id/remote-data-objects/712d6558-b716-4ca7-9690-75b3436f89e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "712d6558-b716-4ca7-9690-75b3436f89e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/158a1a00-461d-4b75-aaea-a959a78c549f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/712d6558-b716-4ca7-9690-75b3436f89e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce685ae6-b3e6-41c8-b558-9703662fd2a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce685ae6-b3e6-41c8-b558-9703662fd2a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/16a49700-148b-48c2-bce6-cc4bf4c9db59/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce685ae6-b3e6-41c8-b558-9703662fd2a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5730afe1-f183-43bc-ae91-bc997fc9bf1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5730afe1-f183-43bc-ae91-bc997fc9bf1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/19840c8e-d1ec-4fe7-b176-2724ac5d1dfd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5730afe1-f183-43bc-ae91-bc997fc9bf1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/37d4ca78-94be-440e-8698-b2be37371c47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37d4ca78-94be-440e-8698-b2be37371c47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/19ac4492-8ff8-4656-b534-6a837ee56956/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37d4ca78-94be-440e-8698-b2be37371c47>.
+    
+<http://data.lblod.info/id/remote-data-objects/45e8dafa-1e9b-4be4-bd29-7723b2955f5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45e8dafa-1e9b-4be4-bd29-7723b2955f5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/19cee980-fcd9-443c-b68e-8c79d51520c2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45e8dafa-1e9b-4be4-bd29-7723b2955f5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2175318-6cb9-48f7-8bdf-00247f6d2c58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2175318-6cb9-48f7-8bdf-00247f6d2c58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/1b8dfd8b-15a0-4579-b7a6-5a868bd76a16/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2175318-6cb9-48f7-8bdf-00247f6d2c58>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f60a780-8392-4d79-a90e-fb14f7abb15f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f60a780-8392-4d79-a90e-fb14f7abb15f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/1ba99b7d-0bdf-4a81-acfe-e116a5ed8b24/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f60a780-8392-4d79-a90e-fb14f7abb15f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9c20bdf-e32e-4e7e-9d5f-958c8f443f4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9c20bdf-e32e-4e7e-9d5f-958c8f443f4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/1eb37f4b-9844-48f6-9d37-a833bd26f83c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9c20bdf-e32e-4e7e-9d5f-958c8f443f4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a74adce2-e684-4d7f-a378-c37ccb186458> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a74adce2-e684-4d7f-a378-c37ccb186458";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/1f9b097c-af5b-4c7a-bf1f-bb2816b21a8a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a74adce2-e684-4d7f-a378-c37ccb186458>.
+    
+<http://data.lblod.info/id/remote-data-objects/a09f340f-507f-4ebb-9745-626fa5a21ab5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a09f340f-507f-4ebb-9745-626fa5a21ab5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/20b69c85-384b-488a-a012-0a18686163d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a09f340f-507f-4ebb-9745-626fa5a21ab5>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ebc810d-061d-4f8d-8aed-5c6ccad5fc21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ebc810d-061d-4f8d-8aed-5c6ccad5fc21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/218dd886-8d27-446a-a36a-276f44a8687a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ebc810d-061d-4f8d-8aed-5c6ccad5fc21>.
+    
+<http://data.lblod.info/id/remote-data-objects/f75c3331-efa8-4503-bb47-2a2520c295af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f75c3331-efa8-4503-bb47-2a2520c295af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/21988861-18f0-4f14-9b98-47390b69c207/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f75c3331-efa8-4503-bb47-2a2520c295af>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5bcca5f-f601-4224-94f9-916dc82aba29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5bcca5f-f601-4224-94f9-916dc82aba29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/22d9f0a7-8f3e-498e-8996-b574affbb13c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5bcca5f-f601-4224-94f9-916dc82aba29>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5c67639-c5c3-4d97-8b42-383489589c48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5c67639-c5c3-4d97-8b42-383489589c48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/2414b5ea-bfec-4faa-9cb7-5ddc6f4a067d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5c67639-c5c3-4d97-8b42-383489589c48>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffb9a0b6-832b-43fb-96d8-c9635fd28969> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffb9a0b6-832b-43fb-96d8-c9635fd28969";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/244413c2-d702-4ef8-9ab9-1ce7abdd8d86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffb9a0b6-832b-43fb-96d8-c9635fd28969>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3cffabe-c6b2-4400-b615-0773adee24b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3cffabe-c6b2-4400-b615-0773adee24b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/250eee41-b63d-4340-8574-6892775ea41d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3cffabe-c6b2-4400-b615-0773adee24b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/708ecb0d-9152-421c-8aa1-b24b00637084> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "708ecb0d-9152-421c-8aa1-b24b00637084";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/26076fb2-a325-45b4-a08b-cdc5c34e3f9b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/708ecb0d-9152-421c-8aa1-b24b00637084>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9c3ed43-bbd4-4116-8f3b-084ad47887a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9c3ed43-bbd4-4116-8f3b-084ad47887a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/260da139-3c4a-4eef-9584-9ca5447c128b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9c3ed43-bbd4-4116-8f3b-084ad47887a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b56332c-dbda-4799-988d-89776dbb1af4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b56332c-dbda-4799-988d-89776dbb1af4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/2627eabd-14d9-4e39-9d8a-f8e9f9185922/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b56332c-dbda-4799-988d-89776dbb1af4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4957f973-67f8-4669-98bd-02c4b5e5fff4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4957f973-67f8-4669-98bd-02c4b5e5fff4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/26661797-1805-4b1b-a5cb-100c7441a2e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4957f973-67f8-4669-98bd-02c4b5e5fff4>.
+    
+<http://data.lblod.info/id/remote-data-objects/58d7b5da-da19-4d08-a486-fbc5d8a82031> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58d7b5da-da19-4d08-a486-fbc5d8a82031";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/27544199-28b2-41f4-b5cd-508e9e77c727/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58d7b5da-da19-4d08-a486-fbc5d8a82031>.
+    
+<http://data.lblod.info/id/remote-data-objects/98009071-8e69-40e4-ab85-de47b21148ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98009071-8e69-40e4-ab85-de47b21148ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/29851825-d0f5-4052-940f-7e3403bd9813/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98009071-8e69-40e4-ab85-de47b21148ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b6c2921-8fb2-4478-a126-fe2e6bb7de73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b6c2921-8fb2-4478-a126-fe2e6bb7de73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/29f68583-a02d-46fa-8851-e7f429aaf206/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b6c2921-8fb2-4478-a126-fe2e6bb7de73>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e2aa82e-61ea-457d-a15a-1c74d688fdd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e2aa82e-61ea-457d-a15a-1c74d688fdd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/2a003fcf-ce86-43a2-8c75-c910623cc244/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e2aa82e-61ea-457d-a15a-1c74d688fdd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/eea3ed8a-d8f6-4d0a-9a00-fbaf2ccb1a7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eea3ed8a-d8f6-4d0a-9a00-fbaf2ccb1a7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/2a3c0ba5-d3af-474b-bd35-63877010b454/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eea3ed8a-d8f6-4d0a-9a00-fbaf2ccb1a7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2338f3a-5894-4815-8d96-ca96c37fd80a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2338f3a-5894-4815-8d96-ca96c37fd80a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/2bf9d247-618d-4c1c-90f9-3cbacfeb3861/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2338f3a-5894-4815-8d96-ca96c37fd80a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bf04776-57de-48a7-9ed0-76d4917cc9b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bf04776-57de-48a7-9ed0-76d4917cc9b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/2ce627c2-8c54-4ce8-9dd8-5f23766163cc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bf04776-57de-48a7-9ed0-76d4917cc9b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9917ee6-46e5-4ce5-9f0a-46f0399a3b94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9917ee6-46e5-4ce5-9f0a-46f0399a3b94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/2d2b75fd-0f9d-452c-bb0e-ca61e5cfa8ce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9917ee6-46e5-4ce5-9f0a-46f0399a3b94>.
+    
+<http://data.lblod.info/id/remote-data-objects/48d25a2e-1f6b-4edd-aa0c-4e41ca93ace2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48d25a2e-1f6b-4edd-aa0c-4e41ca93ace2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/2e16cf81-c6cf-426f-a4a6-27c4b1747c9f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48d25a2e-1f6b-4edd-aa0c-4e41ca93ace2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fc090c0-b0a1-4787-9ff5-9721c101ab35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fc090c0-b0a1-4787-9ff5-9721c101ab35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/2eca7a0c-e0ee-420c-8a62-20e47196c029/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fc090c0-b0a1-4787-9ff5-9721c101ab35>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ac8ac54-eb5b-4728-b9b2-78c3cea1744c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ac8ac54-eb5b-4728-b9b2-78c3cea1744c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/2f1ba046-f939-4521-ba58-e6f6b1013e9d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ac8ac54-eb5b-4728-b9b2-78c3cea1744c>.
+    
+<http://data.lblod.info/id/remote-data-objects/02f65ad8-5311-4584-9eb4-e6d617347d70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02f65ad8-5311-4584-9eb4-e6d617347d70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/2f73ae07-4a3b-46e3-9c75-40a88c64358f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02f65ad8-5311-4584-9eb4-e6d617347d70>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3bc113f-f44c-4e07-b223-137f606e2b80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3bc113f-f44c-4e07-b223-137f606e2b80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/331a6d64-01da-41ef-aa6c-f9733d46d830/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3bc113f-f44c-4e07-b223-137f606e2b80>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c66479f-a6d8-456f-9273-733a4cb3d032> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c66479f-a6d8-456f-9273-733a4cb3d032";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/333f38a4-66ae-44dd-b3aa-2ccf7bf53649/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c66479f-a6d8-456f-9273-733a4cb3d032>.
+    
+<http://data.lblod.info/id/remote-data-objects/15e724ff-37fa-462c-8891-4e1bd8d2e807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15e724ff-37fa-462c-8891-4e1bd8d2e807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/3573a80b-95fb-45c2-9e85-fcc6cd8353fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15e724ff-37fa-462c-8891-4e1bd8d2e807>.
+    
+<http://data.lblod.info/id/remote-data-objects/672dce89-d17d-499c-bae3-8bb98b029889> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "672dce89-d17d-499c-bae3-8bb98b029889";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/357455a4-8741-467c-932c-af18554ef236/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/672dce89-d17d-499c-bae3-8bb98b029889>.
+    
+<http://data.lblod.info/id/remote-data-objects/272dc1ca-044d-4d0b-9a89-784e4785406a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "272dc1ca-044d-4d0b-9a89-784e4785406a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/35cf02e9-0fe0-4fab-af97-28bf102e45a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/272dc1ca-044d-4d0b-9a89-784e4785406a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cac1814-27b3-4427-bf21-e165266f38c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cac1814-27b3-4427-bf21-e165266f38c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/35d7712a-740a-4ba1-b298-da2ac89c6f27/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cac1814-27b3-4427-bf21-e165266f38c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d18b0eb-16ca-4ac1-b098-f213cbc3bb52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d18b0eb-16ca-4ac1-b098-f213cbc3bb52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/36f52229-c0ca-4edc-b7d4-ffb78014c4f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d18b0eb-16ca-4ac1-b098-f213cbc3bb52>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad08bc00-43b3-4f98-aa8f-d50aa6b6f50e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad08bc00-43b3-4f98-aa8f-d50aa6b6f50e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/37843656-b8ce-4c98-9827-25a22e397863/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad08bc00-43b3-4f98-aa8f-d50aa6b6f50e>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfc1d3c8-6668-4dab-bcae-bd2c94cbfe1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfc1d3c8-6668-4dab-bcae-bd2c94cbfe1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/3a573008-a195-4ab3-878c-918e1c266325/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfc1d3c8-6668-4dab-bcae-bd2c94cbfe1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/35b786bc-dd91-4296-9ab4-1e8a52e14307> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35b786bc-dd91-4296-9ab4-1e8a52e14307";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/3cbae7be-1a2f-4ea5-b8f9-219e95c9b104/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35b786bc-dd91-4296-9ab4-1e8a52e14307>.
+    
+<http://data.lblod.info/id/remote-data-objects/01da0c2c-7d6a-42a9-8718-5cb0a12f2652> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01da0c2c-7d6a-42a9-8718-5cb0a12f2652";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/3fd7f171-fd8b-4a1d-9cc2-16662e9c82c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/eedbff0f-979d-4c93-a600-10dceac3cffa> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01da0c2c-7d6a-42a9-8718-5cb0a12f2652>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201818-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201818-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201818-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201818-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/15710c92-f52b-4352-86a7-e0c8b51698d6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "15710c92-f52b-4352-86a7-e0c8b51698d6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "80833ef8-335f-4801-a721-2558c4848b3a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/368cfbda-db8a-419a-8701-7916078cbf8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "368cfbda-db8a-419a-8701-7916078cbf8d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a>.
+
+  <http://redpencil.data.gift/id/task/6e62f9ad-be29-4b49-aaa1-ff01cdfd857d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6e62f9ad-be29-4b49-aaa1-ff01cdfd857d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/15710c92-f52b-4352-86a7-e0c8b51698d6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/368cfbda-db8a-419a-8701-7916078cbf8d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/6bf23570-9256-4d93-893d-6af2ba257ba1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6bf23570-9256-4d93-893d-6af2ba257ba1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/42423bef-0875-47fc-afa4-826fdb783878/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6bf23570-9256-4d93-893d-6af2ba257ba1>.
+    
+<http://data.lblod.info/id/remote-data-objects/333c4594-c47e-475e-80f1-7384721eefd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "333c4594-c47e-475e-80f1-7384721eefd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/4349a710-bc06-43dd-9e3a-6d2cf4361c4f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/333c4594-c47e-475e-80f1-7384721eefd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/581f5f08-c2ef-4605-ba19-dd73446851f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "581f5f08-c2ef-4605-ba19-dd73446851f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/43c482cd-d47c-48d8-a5cb-a3633625d6ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/581f5f08-c2ef-4605-ba19-dd73446851f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/eedd890e-118e-473c-b42c-305e6ff5a13a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eedd890e-118e-473c-b42c-305e6ff5a13a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/45371eb9-f478-4d9b-bf75-49e208d01b0a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eedd890e-118e-473c-b42c-305e6ff5a13a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6200ee3e-9f27-4410-8135-a82c27d62bd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6200ee3e-9f27-4410-8135-a82c27d62bd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/45497034-de9e-44bb-9b88-3263e8e026ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6200ee3e-9f27-4410-8135-a82c27d62bd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7fd9ca5-be5c-4f34-9ec5-77b0d5fc77bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7fd9ca5-be5c-4f34-9ec5-77b0d5fc77bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/46f79b5d-78a8-451b-a3b2-3a1c8b0a5c3f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7fd9ca5-be5c-4f34-9ec5-77b0d5fc77bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/73a61f3e-8a62-4219-84ab-ffada3100c62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73a61f3e-8a62-4219-84ab-ffada3100c62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/46f7fd10-ea54-41ef-b07e-e47a00b9430c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73a61f3e-8a62-4219-84ab-ffada3100c62>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e62fa3e-3d8c-4996-9ad6-d249e598139c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e62fa3e-3d8c-4996-9ad6-d249e598139c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/47e7eead-c896-45f3-8962-a3b545500a31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e62fa3e-3d8c-4996-9ad6-d249e598139c>.
+    
+<http://data.lblod.info/id/remote-data-objects/17146550-d409-47ef-80fd-01146c05ef19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17146550-d409-47ef-80fd-01146c05ef19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/483cd1c1-87ac-43f5-b93b-7f07c50c1e07/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17146550-d409-47ef-80fd-01146c05ef19>.
+    
+<http://data.lblod.info/id/remote-data-objects/37e75bd7-70b8-4ac3-9876-c1c76f397322> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37e75bd7-70b8-4ac3-9876-c1c76f397322";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/4850bf1f-0250-4801-9f36-81b2c11a9e14/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37e75bd7-70b8-4ac3-9876-c1c76f397322>.
+    
+<http://data.lblod.info/id/remote-data-objects/56d2bb78-faf8-463d-9218-57f40c8ebe24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56d2bb78-faf8-463d-9218-57f40c8ebe24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/48624213-15f2-4733-94b5-e179a8535fca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56d2bb78-faf8-463d-9218-57f40c8ebe24>.
+    
+<http://data.lblod.info/id/remote-data-objects/73256825-da8f-4601-b0a7-2c37a82ded24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73256825-da8f-4601-b0a7-2c37a82ded24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/48f10c2f-94ee-4641-a5a6-eff990f6e413/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73256825-da8f-4601-b0a7-2c37a82ded24>.
+    
+<http://data.lblod.info/id/remote-data-objects/f000994d-28ba-4d64-9a0e-5adc982ccc13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f000994d-28ba-4d64-9a0e-5adc982ccc13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/4a241098-ac82-46c5-8559-6206455ff529/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f000994d-28ba-4d64-9a0e-5adc982ccc13>.
+    
+<http://data.lblod.info/id/remote-data-objects/12aaa500-455c-491b-bd19-7810d88d196e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12aaa500-455c-491b-bd19-7810d88d196e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/4b4b7b35-17da-46c2-9cc5-4c235cd54448/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12aaa500-455c-491b-bd19-7810d88d196e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6612c18-5981-4174-ae0d-4b9c6f433364> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6612c18-5981-4174-ae0d-4b9c6f433364";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/4b70c8dd-44cd-423b-a6be-332884dd2a74/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6612c18-5981-4174-ae0d-4b9c6f433364>.
+    
+<http://data.lblod.info/id/remote-data-objects/45ba6cf8-ac17-4a7e-8912-413a1f0c05c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45ba6cf8-ac17-4a7e-8912-413a1f0c05c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/4eaa34b5-24f4-4c1f-ae52-8e2889679348/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45ba6cf8-ac17-4a7e-8912-413a1f0c05c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccb60548-9fa1-428a-a055-b165594090b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccb60548-9fa1-428a-a055-b165594090b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/4f048050-044d-4951-9816-8fe16bc81d75/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccb60548-9fa1-428a-a055-b165594090b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/70dcdfc4-acba-43d6-b5d7-8716ced8bcfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70dcdfc4-acba-43d6-b5d7-8716ced8bcfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/50e7dc20-ca2f-47b2-94ca-8282a3e55ee1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70dcdfc4-acba-43d6-b5d7-8716ced8bcfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ded648d-8f41-40c1-aee4-eb147dd85800> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ded648d-8f41-40c1-aee4-eb147dd85800";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/516edd8e-3a69-4fdd-ab89-ae27548854a0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ded648d-8f41-40c1-aee4-eb147dd85800>.
+    
+<http://data.lblod.info/id/remote-data-objects/82ed862e-abbe-49ad-9ec2-db98eda2e7af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82ed862e-abbe-49ad-9ec2-db98eda2e7af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/51d3ad9b-6dfe-411e-bc69-8599ee0ae3ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82ed862e-abbe-49ad-9ec2-db98eda2e7af>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c222e55-a1f0-4542-af28-629b076e9afd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c222e55-a1f0-4542-af28-629b076e9afd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/522fedef-8365-4c15-b70f-14b601360244/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c222e55-a1f0-4542-af28-629b076e9afd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8698e38-dbd5-4946-bb3f-9eb64ee1e00d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8698e38-dbd5-4946-bb3f-9eb64ee1e00d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/53e785e3-a494-4d51-ae8a-e4d0f414c9b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8698e38-dbd5-4946-bb3f-9eb64ee1e00d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed4869b7-81fb-4e2a-8fde-278dba90e67b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed4869b7-81fb-4e2a-8fde-278dba90e67b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/57094d5c-ac95-41f8-8f1f-3007be2bf8d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed4869b7-81fb-4e2a-8fde-278dba90e67b>.
+    
+<http://data.lblod.info/id/remote-data-objects/52ba8ca4-004c-4675-b44a-4d317facd201> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52ba8ca4-004c-4675-b44a-4d317facd201";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/586c3942-98fb-4a0f-a675-e0bbe3cea484/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52ba8ca4-004c-4675-b44a-4d317facd201>.
+    
+<http://data.lblod.info/id/remote-data-objects/be38a38d-0209-4df3-89ec-dfb996aeca3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be38a38d-0209-4df3-89ec-dfb996aeca3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/5900959a-8e4f-4aa2-81cc-ff5a9c52f412/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be38a38d-0209-4df3-89ec-dfb996aeca3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/092e5c7a-2df5-4cf0-aa41-84db250966d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "092e5c7a-2df5-4cf0-aa41-84db250966d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/5aa5fa69-b41f-482a-8bfd-dada64a8c967/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/092e5c7a-2df5-4cf0-aa41-84db250966d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4849229f-bc9d-4ec8-b066-cdd4b40723f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4849229f-bc9d-4ec8-b066-cdd4b40723f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/5b8a6591-76d4-427d-b710-1a498b772fb7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4849229f-bc9d-4ec8-b066-cdd4b40723f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4a81d36-b704-42da-8fbb-19bae3a6344b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4a81d36-b704-42da-8fbb-19bae3a6344b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/5c2187f0-493c-492d-91b4-66bdb0931250/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4a81d36-b704-42da-8fbb-19bae3a6344b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e4977fa-b3a1-4f46-b70c-c9e3979d367c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e4977fa-b3a1-4f46-b70c-c9e3979d367c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/5da0edb3-f9ef-4374-95e6-a503692a6b70/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e4977fa-b3a1-4f46-b70c-c9e3979d367c>.
+    
+<http://data.lblod.info/id/remote-data-objects/20a7429a-827f-456d-ab05-8360037b1434> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20a7429a-827f-456d-ab05-8360037b1434";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/5ffb4016-7e45-43a6-ac3e-3070f8b6e441/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20a7429a-827f-456d-ab05-8360037b1434>.
+    
+<http://data.lblod.info/id/remote-data-objects/3403c216-ae4e-4c9e-a4af-ce2c8334ba28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3403c216-ae4e-4c9e-a4af-ce2c8334ba28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/61690d3e-22cd-4f91-854b-54abf0b4d9fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3403c216-ae4e-4c9e-a4af-ce2c8334ba28>.
+    
+<http://data.lblod.info/id/remote-data-objects/3435274c-fb33-4186-a0f9-47270c59e681> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3435274c-fb33-4186-a0f9-47270c59e681";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/62118a71-5022-4f21-be7f-e982a3204892/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3435274c-fb33-4186-a0f9-47270c59e681>.
+    
+<http://data.lblod.info/id/remote-data-objects/5db23c5a-6eee-465a-a2bb-610f05e1c3e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5db23c5a-6eee-465a-a2bb-610f05e1c3e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/625500c9-b51f-40c2-9616-423607bff6f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5db23c5a-6eee-465a-a2bb-610f05e1c3e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/477748e3-e936-4eca-bb90-1c60b59f9387> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "477748e3-e936-4eca-bb90-1c60b59f9387";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/6307b27a-acda-48a2-a0a5-6cdaf896903d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/477748e3-e936-4eca-bb90-1c60b59f9387>.
+    
+<http://data.lblod.info/id/remote-data-objects/91c60187-50a0-4f56-8708-4641d608a2de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91c60187-50a0-4f56-8708-4641d608a2de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/63aa7eb6-3d1b-49eb-a810-e81e44ddd7b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91c60187-50a0-4f56-8708-4641d608a2de>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb42e723-ab4d-43b9-a8a6-e1f86d3a3bea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb42e723-ab4d-43b9-a8a6-e1f86d3a3bea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/64a4fd11-0451-48f5-9fc6-886150ab6ab4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb42e723-ab4d-43b9-a8a6-e1f86d3a3bea>.
+    
+<http://data.lblod.info/id/remote-data-objects/30261621-24b3-49c4-a5fe-46768022a083> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30261621-24b3-49c4-a5fe-46768022a083";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/65a338f8-0596-4ebf-85c1-c1f2bb5ae9c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30261621-24b3-49c4-a5fe-46768022a083>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1949400-9b37-4945-bbe4-8f0683f8ff92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1949400-9b37-4945-bbe4-8f0683f8ff92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/65fa2ba9-91bb-46bf-a5c8-5c3fe814c91d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1949400-9b37-4945-bbe4-8f0683f8ff92>.
+    
+<http://data.lblod.info/id/remote-data-objects/377ada2d-3913-49f1-92da-f95f6c7edd4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "377ada2d-3913-49f1-92da-f95f6c7edd4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/66a6afab-d2b6-41b7-8cc6-420800d4e05f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/377ada2d-3913-49f1-92da-f95f6c7edd4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9d98c1b-e816-4b98-ba05-975e0f83c41a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9d98c1b-e816-4b98-ba05-975e0f83c41a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/670966df-59b1-46c0-93fd-14886c932bf1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9d98c1b-e816-4b98-ba05-975e0f83c41a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f635bca8-2a15-4c65-8dd1-01823e167a0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f635bca8-2a15-4c65-8dd1-01823e167a0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/6752c1b1-9b04-485b-bff5-42b9d4824e53/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f635bca8-2a15-4c65-8dd1-01823e167a0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3600a248-5615-4c76-9851-f385d86a2b62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3600a248-5615-4c76-9851-f385d86a2b62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/67933193-f43b-4c5e-9be6-c6e45a9fe380/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3600a248-5615-4c76-9851-f385d86a2b62>.
+    
+<http://data.lblod.info/id/remote-data-objects/22688c89-2598-48a3-bcb5-4374c55486f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22688c89-2598-48a3-bcb5-4374c55486f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/68cf4abb-7fb1-4ed5-a653-4c0799b37962/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22688c89-2598-48a3-bcb5-4374c55486f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f832564e-fc8f-45cc-b6f9-dcf295c3cf40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f832564e-fc8f-45cc-b6f9-dcf295c3cf40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/69f78dca-942b-4e0c-9cfa-f3d10a0635a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f832564e-fc8f-45cc-b6f9-dcf295c3cf40>.
+    
+<http://data.lblod.info/id/remote-data-objects/e73cb5c8-90e1-4eb7-872d-2d88f6feb57b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e73cb5c8-90e1-4eb7-872d-2d88f6feb57b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/6a6e30fa-7898-4480-92bc-b123abce9955/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e73cb5c8-90e1-4eb7-872d-2d88f6feb57b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea0c53bf-9ba7-4226-a83f-f3e8910728da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea0c53bf-9ba7-4226-a83f-f3e8910728da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/6b1010a0-0def-4f0f-834b-95d47a663cd5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea0c53bf-9ba7-4226-a83f-f3e8910728da>.
+    
+<http://data.lblod.info/id/remote-data-objects/65bcad7a-9a52-442c-a5fd-c42612391b52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65bcad7a-9a52-442c-a5fd-c42612391b52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/6bd064d2-1630-4905-9592-3b22768a7580/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65bcad7a-9a52-442c-a5fd-c42612391b52>.
+    
+<http://data.lblod.info/id/remote-data-objects/2022786e-9d52-42f6-90ee-f554fdfee785> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2022786e-9d52-42f6-90ee-f554fdfee785";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/6d985401-18ba-4843-9784-a8b602298db6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2022786e-9d52-42f6-90ee-f554fdfee785>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab32ce3a-496f-4c2a-a3c3-f865fbf2ec3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab32ce3a-496f-4c2a-a3c3-f865fbf2ec3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/6efef3d8-2c48-4f29-9658-2ce1a7fff4b8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab32ce3a-496f-4c2a-a3c3-f865fbf2ec3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b75a021-1b37-4839-bc47-fedd8fa38c11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b75a021-1b37-4839-bc47-fedd8fa38c11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/70d55e85-d5f5-49e5-ab8d-42d4411861e5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:18.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80833ef8-335f-4801-a721-2558c4848b3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b75a021-1b37-4839-bc47-fedd8fa38c11>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201820-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201820-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201820-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201820-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/57010f10-84c9-460e-b4a8-b93fd0cd2870> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "57010f10-84c9-460e-b4a8-b93fd0cd2870";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "092cbb0a-f9a3-438b-bcb9-09e2910069be";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/66f56dbf-223e-4236-b3bf-37c9ddce23a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "66f56dbf-223e-4236-b3bf-37c9ddce23a8";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be>.
+
+  <http://redpencil.data.gift/id/task/7ad77959-43f8-42d4-8431-e678ad8fbbe6> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7ad77959-43f8-42d4-8431-e678ad8fbbe6";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/57010f10-84c9-460e-b4a8-b93fd0cd2870>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/66f56dbf-223e-4236-b3bf-37c9ddce23a8>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5e6586c1-739e-4171-9dfe-8f206676f817> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e6586c1-739e-4171-9dfe-8f206676f817";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/71d50776-3c52-4ce8-be38-d78e14d0e17d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e6586c1-739e-4171-9dfe-8f206676f817>.
+    
+<http://data.lblod.info/id/remote-data-objects/256b189b-ad56-4b4b-9d17-c564f0c7d6f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "256b189b-ad56-4b4b-9d17-c564f0c7d6f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/743703ea-23ab-4c2b-bc96-d84ead193646/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/256b189b-ad56-4b4b-9d17-c564f0c7d6f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e50a528a-2029-450e-98c7-6d35aa918a3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e50a528a-2029-450e-98c7-6d35aa918a3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/74757492-daf9-46d7-8f6c-3ec5ed5041d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e50a528a-2029-450e-98c7-6d35aa918a3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fd66b61-db7b-45ac-9f76-2e5879fb2c71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fd66b61-db7b-45ac-9f76-2e5879fb2c71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/76d2f1da-6893-44ea-9c9c-c4b300174545/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fd66b61-db7b-45ac-9f76-2e5879fb2c71>.
+    
+<http://data.lblod.info/id/remote-data-objects/03c59ad1-1785-4aee-a344-207fe897f4df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03c59ad1-1785-4aee-a344-207fe897f4df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/7a506578-1c1d-4cba-ba85-9bbc391bafd3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03c59ad1-1785-4aee-a344-207fe897f4df>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9829534-b90e-4e29-94aa-0484a33f65d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9829534-b90e-4e29-94aa-0484a33f65d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/7d6689ad-275d-4263-a923-2eb342aca361/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9829534-b90e-4e29-94aa-0484a33f65d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/992dd5a4-f062-4de2-8a54-30a986c8c9cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "992dd5a4-f062-4de2-8a54-30a986c8c9cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/7f8750b7-df16-4dd3-ac8e-6834f5f21a4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/992dd5a4-f062-4de2-8a54-30a986c8c9cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7314d8d9-ac96-40ab-a6c1-cfc3c26d6981> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7314d8d9-ac96-40ab-a6c1-cfc3c26d6981";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/8147a4d2-8ae5-48ff-814b-2db6f5d0ff72/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7314d8d9-ac96-40ab-a6c1-cfc3c26d6981>.
+    
+<http://data.lblod.info/id/remote-data-objects/aae3ad5c-95ab-43b1-8d03-2da4523626e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aae3ad5c-95ab-43b1-8d03-2da4523626e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/8291b598-5966-4c61-959d-18d56075a5d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aae3ad5c-95ab-43b1-8d03-2da4523626e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7a77dea-4b06-4e9c-beb1-a802baa7a935> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7a77dea-4b06-4e9c-beb1-a802baa7a935";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/829927c3-f1fa-4255-b34a-dd6c58448af6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7a77dea-4b06-4e9c-beb1-a802baa7a935>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c15773f-cc16-4269-8ff3-a6aa1c6ef86f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c15773f-cc16-4269-8ff3-a6aa1c6ef86f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/838b72a5-4faf-4852-bfdb-605ebb101735/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c15773f-cc16-4269-8ff3-a6aa1c6ef86f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d6b0c55-6d87-45a5-9df2-2916df412a1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d6b0c55-6d87-45a5-9df2-2916df412a1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/8466244a-d170-40cc-9ba6-d06e45e82837/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d6b0c55-6d87-45a5-9df2-2916df412a1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9db993db-3e94-43c6-af71-c862732f8825> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9db993db-3e94-43c6-af71-c862732f8825";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/84ec05a9-b3df-4d80-96c2-a2e01b8f7c2d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9db993db-3e94-43c6-af71-c862732f8825>.
+    
+<http://data.lblod.info/id/remote-data-objects/19600244-3e20-4b94-b9c7-c5fcf37f7c02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19600244-3e20-4b94-b9c7-c5fcf37f7c02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/8539259f-2efb-443c-9905-8906803e568b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19600244-3e20-4b94-b9c7-c5fcf37f7c02>.
+    
+<http://data.lblod.info/id/remote-data-objects/958703c3-f221-4af3-9072-5b2d87c39310> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "958703c3-f221-4af3-9072-5b2d87c39310";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/8549be76-32a4-44e4-becd-eedde2396b7a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/958703c3-f221-4af3-9072-5b2d87c39310>.
+    
+<http://data.lblod.info/id/remote-data-objects/57525948-2b4c-4227-b669-3c9c5ed414e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57525948-2b4c-4227-b669-3c9c5ed414e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/898146ed-697d-407f-ae1e-52701ec2c17d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57525948-2b4c-4227-b669-3c9c5ed414e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/04fc7307-0687-437e-b217-c0cbcb908dc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04fc7307-0687-437e-b217-c0cbcb908dc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/8b8cdd3e-6829-4c02-abb0-9a7cd4def946/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04fc7307-0687-437e-b217-c0cbcb908dc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b06338b5-b82e-4483-a3d9-fa037117fc1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b06338b5-b82e-4483-a3d9-fa037117fc1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/8c4a45df-e226-40e5-9241-8df3a3a0172d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b06338b5-b82e-4483-a3d9-fa037117fc1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/772f2135-8563-44de-a326-704fe5e6e486> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "772f2135-8563-44de-a326-704fe5e6e486";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/8ca75acf-34d5-4084-a8da-36c8bd4c611e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/772f2135-8563-44de-a326-704fe5e6e486>.
+    
+<http://data.lblod.info/id/remote-data-objects/07295aea-b5f5-43c4-8217-75a99f2d7f0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07295aea-b5f5-43c4-8217-75a99f2d7f0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/8e320d1a-6de9-404d-b7fd-69c5b7d5651c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07295aea-b5f5-43c4-8217-75a99f2d7f0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4624262-eea6-4562-86af-262278bd593c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4624262-eea6-4562-86af-262278bd593c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/8ecd61b8-9e80-413c-b08d-a220f0f0c3f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4624262-eea6-4562-86af-262278bd593c>.
+    
+<http://data.lblod.info/id/remote-data-objects/aea50000-78ac-4d02-adbd-3991bb5c491f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aea50000-78ac-4d02-adbd-3991bb5c491f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/8f402fc0-add9-4be3-b4b2-54a57415857b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aea50000-78ac-4d02-adbd-3991bb5c491f>.
+    
+<http://data.lblod.info/id/remote-data-objects/601f9308-cadf-40c3-93e7-320827e8c75f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "601f9308-cadf-40c3-93e7-320827e8c75f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/916ab422-070f-47d9-ba6e-7f09cfeb04d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/601f9308-cadf-40c3-93e7-320827e8c75f>.
+    
+<http://data.lblod.info/id/remote-data-objects/923c86da-ab59-4e45-a92a-ed6eb2a4e5fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "923c86da-ab59-4e45-a92a-ed6eb2a4e5fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/932adc5f-a913-4f9a-8e3a-ab8a871dc0e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/923c86da-ab59-4e45-a92a-ed6eb2a4e5fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/605db1db-c43f-4b87-94f2-78faf0e649a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "605db1db-c43f-4b87-94f2-78faf0e649a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/93929d45-e467-4c81-bd65-f8acd8952cdf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/605db1db-c43f-4b87-94f2-78faf0e649a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c33f335e-524d-429d-ad93-7b6f251b02c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c33f335e-524d-429d-ad93-7b6f251b02c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/93f51699-c39f-40fd-9354-92077abb1e5d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c33f335e-524d-429d-ad93-7b6f251b02c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8416995d-635f-47db-9dfc-9ac521d6acce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8416995d-635f-47db-9dfc-9ac521d6acce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/95da2006-c4b6-47b8-9ef7-fc389f00456f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8416995d-635f-47db-9dfc-9ac521d6acce>.
+    
+<http://data.lblod.info/id/remote-data-objects/18eeba83-015a-41c0-b908-ce3dd0bb1e98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18eeba83-015a-41c0-b908-ce3dd0bb1e98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/95fe1db8-3bfb-45b2-9eed-05267789aeb5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18eeba83-015a-41c0-b908-ce3dd0bb1e98>.
+    
+<http://data.lblod.info/id/remote-data-objects/faf1f454-bb5e-4cb1-bfb6-80bd81569111> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "faf1f454-bb5e-4cb1-bfb6-80bd81569111";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/96921a2d-fc24-40ad-9b66-c7f9e15e4bec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/faf1f454-bb5e-4cb1-bfb6-80bd81569111>.
+    
+<http://data.lblod.info/id/remote-data-objects/16f5ebf6-de65-4b2a-b2d8-05ed5baf574b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16f5ebf6-de65-4b2a-b2d8-05ed5baf574b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/9724cad0-dbef-45bf-bbe5-f9d9aeec2ae2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16f5ebf6-de65-4b2a-b2d8-05ed5baf574b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc0df554-1fd3-4b3f-a381-f616e621e211> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc0df554-1fd3-4b3f-a381-f616e621e211";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/97f381d2-6cc1-4f33-8662-a3448dc9182e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc0df554-1fd3-4b3f-a381-f616e621e211>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f572749-d293-42ff-a26a-81c211d6ca03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f572749-d293-42ff-a26a-81c211d6ca03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/9be20bb6-551c-41db-8284-5a08fbc0db53/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f572749-d293-42ff-a26a-81c211d6ca03>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d06e3d5-218a-4572-bf7e-8d3b28e79b14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d06e3d5-218a-4572-bf7e-8d3b28e79b14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/9c972e41-2354-4d86-a331-033dde6a0b71/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d06e3d5-218a-4572-bf7e-8d3b28e79b14>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1904de3-bd3f-46f6-ba07-015c9932ac85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1904de3-bd3f-46f6-ba07-015c9932ac85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/9cab0a14-216a-4584-b438-4967a2995b76/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1904de3-bd3f-46f6-ba07-015c9932ac85>.
+    
+<http://data.lblod.info/id/remote-data-objects/e349b409-c3dd-4c51-83fd-85c62097f54b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e349b409-c3dd-4c51-83fd-85c62097f54b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/9e837a87-9279-4fb1-9a30-7aed216f579b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e349b409-c3dd-4c51-83fd-85c62097f54b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d9655ef-5029-4e99-a5b0-10175006275d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d9655ef-5029-4e99-a5b0-10175006275d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/a201308e-e600-4d67-8cef-9e7b57bef184/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d9655ef-5029-4e99-a5b0-10175006275d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f482556-2e69-4442-bf40-ea6033234690> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f482556-2e69-4442-bf40-ea6033234690";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/a2419af0-56b1-47a0-88e7-4d11938419ca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f482556-2e69-4442-bf40-ea6033234690>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dac1d9e-da53-4b75-811d-aad2d7caa11d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dac1d9e-da53-4b75-811d-aad2d7caa11d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/a43bb269-9341-4846-a408-9eb880658028/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dac1d9e-da53-4b75-811d-aad2d7caa11d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c802a39b-e517-41fc-a6d1-86ecade8b2a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c802a39b-e517-41fc-a6d1-86ecade8b2a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/a449f5b0-4201-458a-a7d7-e2266db27296/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c802a39b-e517-41fc-a6d1-86ecade8b2a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/449e769e-7a39-4647-bc29-69945608b9c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "449e769e-7a39-4647-bc29-69945608b9c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/a68a9f3f-47fc-4052-af1a-1f821c1599b8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/449e769e-7a39-4647-bc29-69945608b9c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bb842d7-eb39-4b4e-9134-428444e7f7f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bb842d7-eb39-4b4e-9134-428444e7f7f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/a692efdd-8cd3-4637-8b27-11aa4d2c8895/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bb842d7-eb39-4b4e-9134-428444e7f7f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ccf8030-bf1d-4fc9-84fe-4224968b03e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ccf8030-bf1d-4fc9-84fe-4224968b03e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/a8e771c7-5b2e-4b2e-97d1-213739724b14/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ccf8030-bf1d-4fc9-84fe-4224968b03e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e93a5e34-53d7-443f-8ca4-536bf61fa00e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e93a5e34-53d7-443f-8ca4-536bf61fa00e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/a90eff4f-a7bf-47a6-93cf-fda0147ef03e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e93a5e34-53d7-443f-8ca4-536bf61fa00e>.
+    
+<http://data.lblod.info/id/remote-data-objects/aace4b7a-dbec-4de9-8a46-0b6dc6137d7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aace4b7a-dbec-4de9-8a46-0b6dc6137d7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/a9637281-ba91-4c0e-b47f-32c6ba203f1d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aace4b7a-dbec-4de9-8a46-0b6dc6137d7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0e75319-29d0-4567-a3de-21d34e76fdde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0e75319-29d0-4567-a3de-21d34e76fdde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/a98be9f3-385d-4958-9d6a-5b2f9614241b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0e75319-29d0-4567-a3de-21d34e76fdde>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef7da95f-b6bc-41d6-b8d3-196d2f5e245e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef7da95f-b6bc-41d6-b8d3-196d2f5e245e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/aa83a203-47c3-40f4-8b96-a0b020be29bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef7da95f-b6bc-41d6-b8d3-196d2f5e245e>.
+    
+<http://data.lblod.info/id/remote-data-objects/97cdce07-f04b-4c51-ab35-a29716f3fc5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97cdce07-f04b-4c51-ab35-a29716f3fc5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/ab39773e-6043-4c99-afc7-59ce8e3b20c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97cdce07-f04b-4c51-ab35-a29716f3fc5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/43b98aa2-eb1e-4f47-aed8-736c58a06c1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43b98aa2-eb1e-4f47-aed8-736c58a06c1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/ac1e0263-fc3d-4217-ba18-2be1ba730508/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43b98aa2-eb1e-4f47-aed8-736c58a06c1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbfb3ea3-7e7f-4fd7-baff-30bd91868206> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbfb3ea3-7e7f-4fd7-baff-30bd91868206";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/accae030-02bf-4a9f-a430-73be0a9ee721/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbfb3ea3-7e7f-4fd7-baff-30bd91868206>.
+    
+<http://data.lblod.info/id/remote-data-objects/e99fc9ce-96d8-4263-ba09-bed4157bac00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e99fc9ce-96d8-4263-ba09-bed4157bac00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/add9296a-322d-4c5a-8119-69be13cc033b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/092cbb0a-f9a3-438b-bcb9-09e2910069be> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e99fc9ce-96d8-4263-ba09-bed4157bac00>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201821-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201821-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201821-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201821-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/14c60df7-51eb-4342-937b-e01d2e8b45bd> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "14c60df7-51eb-4342-937b-e01d2e8b45bd";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1bbe464f-60da-4584-8b1b-117037138fe9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c9125697-768b-44f6-b976-5cb3b054f1ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c9125697-768b-44f6-b976-5cb3b054f1ed";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9>.
+
+  <http://redpencil.data.gift/id/task/bc4305c6-3cf4-4ae8-a0ea-361a5f674118> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bc4305c6-3cf4-4ae8-a0ea-361a5f674118";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/14c60df7-51eb-4342-937b-e01d2e8b45bd>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c9125697-768b-44f6-b976-5cb3b054f1ed>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e75eaadc-8943-43cd-865f-839a8a6a25e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e75eaadc-8943-43cd-865f-839a8a6a25e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/ae086ce0-2531-4876-b917-62a6eebf7f73/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e75eaadc-8943-43cd-865f-839a8a6a25e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb615d0a-3861-4a6d-b527-874c8a38bc28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb615d0a-3861-4a6d-b527-874c8a38bc28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/b2487cd7-08e0-4fec-bb54-2ee2c55803c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb615d0a-3861-4a6d-b527-874c8a38bc28>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c19cb1f-48b8-40a8-b394-3763768152ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c19cb1f-48b8-40a8-b394-3763768152ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/b2c30fcd-bc1b-4b62-b194-cbddc4c7814a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c19cb1f-48b8-40a8-b394-3763768152ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/07587fa0-e617-43c6-9aa3-dcccf9f8de19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07587fa0-e617-43c6-9aa3-dcccf9f8de19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/b6485602-ae00-4c72-b427-91c22ad81083/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07587fa0-e617-43c6-9aa3-dcccf9f8de19>.
+    
+<http://data.lblod.info/id/remote-data-objects/04051d5e-ee80-4668-a4c4-1c38c70ff64f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04051d5e-ee80-4668-a4c4-1c38c70ff64f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/b73922b2-cdab-4ca2-aa13-13f4772915ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04051d5e-ee80-4668-a4c4-1c38c70ff64f>.
+    
+<http://data.lblod.info/id/remote-data-objects/98de8ad5-516e-4eaa-9a24-5976c296043f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98de8ad5-516e-4eaa-9a24-5976c296043f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/b74ed6c3-5f7c-49e8-93e2-f8fb87720a51/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98de8ad5-516e-4eaa-9a24-5976c296043f>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb5f803a-0889-4fde-9e81-0fb6a7497325> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb5f803a-0889-4fde-9e81-0fb6a7497325";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/b7c40170-a895-47af-8090-ac66e2b9428a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb5f803a-0889-4fde-9e81-0fb6a7497325>.
+    
+<http://data.lblod.info/id/remote-data-objects/55dd78e7-b093-4403-aaa1-1e1fb07765a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55dd78e7-b093-4403-aaa1-1e1fb07765a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/ba455829-2366-4dd4-9a80-b59ab252f014/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55dd78e7-b093-4403-aaa1-1e1fb07765a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/46d2c23d-0be5-492c-84cb-9389eacfbf39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46d2c23d-0be5-492c-84cb-9389eacfbf39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/bc3ab41b-30a6-4f58-abeb-cae72b5d2d95/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46d2c23d-0be5-492c-84cb-9389eacfbf39>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6143fa9-5de5-4cf3-8b70-7fdf0aad667a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6143fa9-5de5-4cf3-8b70-7fdf0aad667a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/befd19ea-b519-4c5a-970d-784749c366c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6143fa9-5de5-4cf3-8b70-7fdf0aad667a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef992344-3cc5-410b-a6ee-a8b322c7fa5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef992344-3cc5-410b-a6ee-a8b322c7fa5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/bf8580c4-651b-4acc-a5e7-925de2732097/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef992344-3cc5-410b-a6ee-a8b322c7fa5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d8e03f1-8186-4436-a935-7188c675a4a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d8e03f1-8186-4436-a935-7188c675a4a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/c0add3ae-a4b6-479c-b95e-15109169bdf9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d8e03f1-8186-4436-a935-7188c675a4a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/97ba5121-dc83-4d3d-a611-cc0112ee3ec8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97ba5121-dc83-4d3d-a611-cc0112ee3ec8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/c0e0f73b-1b80-42a7-b85c-d043c1351341/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97ba5121-dc83-4d3d-a611-cc0112ee3ec8>.
+    
+<http://data.lblod.info/id/remote-data-objects/50f9a79f-0134-4519-80b5-9d78fe55ddb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50f9a79f-0134-4519-80b5-9d78fe55ddb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/c1bb5f3d-9705-44ea-8ada-a2bf8cbd9df0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50f9a79f-0134-4519-80b5-9d78fe55ddb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c265753-a00d-4d26-ac27-fdab06f74bd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c265753-a00d-4d26-ac27-fdab06f74bd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/c77bc123-9bb4-4ba0-b4ca-3c79b01a9b04/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c265753-a00d-4d26-ac27-fdab06f74bd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/28d16eb0-d650-48f6-bb10-4fffd3e1f9f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28d16eb0-d650-48f6-bb10-4fffd3e1f9f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/c80d2535-09f5-49b8-85e7-af6702f01d51/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28d16eb0-d650-48f6-bb10-4fffd3e1f9f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c61c360-885f-4b60-b65a-cf0c35268e43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c61c360-885f-4b60-b65a-cf0c35268e43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/c94bf08e-d33a-4d77-9fc0-c6b4aa098a15/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c61c360-885f-4b60-b65a-cf0c35268e43>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cee240d-0d7c-4b52-b777-1bb87de59d58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cee240d-0d7c-4b52-b777-1bb87de59d58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/ca8dee8d-2b13-42be-b817-d0310b51f036/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cee240d-0d7c-4b52-b777-1bb87de59d58>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bde05ff-27fb-4517-82d1-7173f4930b6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bde05ff-27fb-4517-82d1-7173f4930b6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/cb0abe9c-eaf4-41a5-b08b-625f8809e458/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bde05ff-27fb-4517-82d1-7173f4930b6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/349f2171-4e97-4eb1-8f83-1cd1b573b1c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "349f2171-4e97-4eb1-8f83-1cd1b573b1c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/ce21a057-7fae-495c-8955-c14c7ff27b7f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/349f2171-4e97-4eb1-8f83-1cd1b573b1c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/700b5e18-8c3c-4188-9931-ee1665067503> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "700b5e18-8c3c-4188-9931-ee1665067503";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/d07cdf60-ede7-4ed2-9395-fc670413ca82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/700b5e18-8c3c-4188-9931-ee1665067503>.
+    
+<http://data.lblod.info/id/remote-data-objects/17b16a9a-85f1-48d3-8209-d9e7e4c0f57f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17b16a9a-85f1-48d3-8209-d9e7e4c0f57f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/d0b3e270-6139-44e4-8629-e0254418c171/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17b16a9a-85f1-48d3-8209-d9e7e4c0f57f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d50c7f61-c3e1-42ff-bb22-136def8d662e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d50c7f61-c3e1-42ff-bb22-136def8d662e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/d171553b-0870-4a2e-b3c5-8e1e6208c4b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d50c7f61-c3e1-42ff-bb22-136def8d662e>.
+    
+<http://data.lblod.info/id/remote-data-objects/171cc838-da86-4bb9-b2ed-bc4ce6035168> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "171cc838-da86-4bb9-b2ed-bc4ce6035168";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/d2300f81-c107-4cdd-9c9e-0abc5cf8e37d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/171cc838-da86-4bb9-b2ed-bc4ce6035168>.
+    
+<http://data.lblod.info/id/remote-data-objects/8400e5f9-319d-480f-a623-b2b48d86e141> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8400e5f9-319d-480f-a623-b2b48d86e141";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/d24f8387-3dad-4e88-9dde-c07dcdae886e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8400e5f9-319d-480f-a623-b2b48d86e141>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d87ef51-115c-4e7b-8ec1-a0339b224cdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d87ef51-115c-4e7b-8ec1-a0339b224cdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/d3c97600-642b-4007-a809-e503def339c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d87ef51-115c-4e7b-8ec1-a0339b224cdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d46a0f9-cc05-4f52-b5be-4bf817a0b056> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d46a0f9-cc05-4f52-b5be-4bf817a0b056";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/da153004-2da2-4670-a10f-065d5d457ce0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d46a0f9-cc05-4f52-b5be-4bf817a0b056>.
+    
+<http://data.lblod.info/id/remote-data-objects/238af8bd-8424-4067-8572-19b591b09d7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "238af8bd-8424-4067-8572-19b591b09d7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/da2537d4-de3d-4c1d-88cd-ff9a39609bb4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/238af8bd-8424-4067-8572-19b591b09d7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0fe7e86-2769-4925-b1c9-6b16eb5519fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0fe7e86-2769-4925-b1c9-6b16eb5519fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/dcb9c170-81f2-44bb-a7d0-1504c7dd69ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0fe7e86-2769-4925-b1c9-6b16eb5519fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a2f0a52-2985-4602-9d10-fd6d1ef3f78d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a2f0a52-2985-4602-9d10-fd6d1ef3f78d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/de7f5948-dcef-49b8-833a-99728325ab2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a2f0a52-2985-4602-9d10-fd6d1ef3f78d>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bcf440d-716d-4dca-bd73-c03447f3fc20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bcf440d-716d-4dca-bd73-c03447f3fc20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/e1c73d1f-9507-4380-89fe-d3960bc08916/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bcf440d-716d-4dca-bd73-c03447f3fc20>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc61d6c5-f608-4802-b91f-52f98143dfb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc61d6c5-f608-4802-b91f-52f98143dfb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/e2166851-01d4-4305-872f-e93de28a4efd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc61d6c5-f608-4802-b91f-52f98143dfb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a71f7f14-70cf-4a15-9be2-bf5a19b9959b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a71f7f14-70cf-4a15-9be2-bf5a19b9959b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/e23fe3cc-5428-4d5c-9f71-7d1f1e540660/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a71f7f14-70cf-4a15-9be2-bf5a19b9959b>.
+    
+<http://data.lblod.info/id/remote-data-objects/64adc50a-7d7f-4760-a0dc-ef01e57a4d1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64adc50a-7d7f-4760-a0dc-ef01e57a4d1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/e554c97d-e598-4419-82a7-cd1160e97e85/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64adc50a-7d7f-4760-a0dc-ef01e57a4d1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dd74b01-92ea-429a-be3e-613a136c929e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dd74b01-92ea-429a-be3e-613a136c929e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/e8316827-0e1e-4d12-a613-d98b3050363b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dd74b01-92ea-429a-be3e-613a136c929e>.
+    
+<http://data.lblod.info/id/remote-data-objects/86764ead-3cac-4eac-9c2c-586d2d7c6b40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86764ead-3cac-4eac-9c2c-586d2d7c6b40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/e8cac9a1-0e76-4c34-9104-537a99b9f84c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86764ead-3cac-4eac-9c2c-586d2d7c6b40>.
+    
+<http://data.lblod.info/id/remote-data-objects/772cc09a-0c7c-4ed3-8539-57d853ffbae3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "772cc09a-0c7c-4ed3-8539-57d853ffbae3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/e9af38ed-7879-40a4-8c6d-9a92968dbb4f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/772cc09a-0c7c-4ed3-8539-57d853ffbae3>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf6aad1b-ece7-4449-a70b-f8fccbddb3b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf6aad1b-ece7-4449-a70b-f8fccbddb3b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/ec1ef083-5f63-48f8-a26d-6a3824d9c6e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf6aad1b-ece7-4449-a70b-f8fccbddb3b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/90f7e561-4336-455f-a632-34243c90d70d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90f7e561-4336-455f-a632-34243c90d70d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/ec304fb6-15d4-458d-954b-0142332a0fe2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90f7e561-4336-455f-a632-34243c90d70d>.
+    
+<http://data.lblod.info/id/remote-data-objects/98139e82-39a4-4877-9781-21021851371b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98139e82-39a4-4877-9781-21021851371b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/ec3c46ea-41c1-49ba-997b-6b1ab10c89e6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98139e82-39a4-4877-9781-21021851371b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d76fb6af-e98b-4c2e-bfb1-74c7c6e20546> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d76fb6af-e98b-4c2e-bfb1-74c7c6e20546";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/ed555220-0e23-4553-90b5-c2a1e64a33cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d76fb6af-e98b-4c2e-bfb1-74c7c6e20546>.
+    
+<http://data.lblod.info/id/remote-data-objects/76d4fb92-07a1-44ad-97d4-8c5c4324123c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76d4fb92-07a1-44ad-97d4-8c5c4324123c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/ee95f46d-14fa-4737-85d1-18e91cd52f3e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76d4fb92-07a1-44ad-97d4-8c5c4324123c>.
+    
+<http://data.lblod.info/id/remote-data-objects/17798652-713c-43b9-8fd7-65e543f76866> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17798652-713c-43b9-8fd7-65e543f76866";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/eea72916-e428-467f-a8ab-84c130537f56/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17798652-713c-43b9-8fd7-65e543f76866>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3a73da1-ec10-400c-ab0e-6998f2d49172> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3a73da1-ec10-400c-ab0e-6998f2d49172";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/eef9d46c-fa3a-4013-858c-66d86a1fb481/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3a73da1-ec10-400c-ab0e-6998f2d49172>.
+    
+<http://data.lblod.info/id/remote-data-objects/59994fa1-417b-4730-8b17-073a640a2abb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59994fa1-417b-4730-8b17-073a640a2abb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/ef859ac6-6fc3-464d-9788-dd3fb6a2740c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59994fa1-417b-4730-8b17-073a640a2abb>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d82a04a-3336-45ff-936d-52d3de645192> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d82a04a-3336-45ff-936d-52d3de645192";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/effb3ca5-28cc-4b2b-8a69-941c53a27a8c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d82a04a-3336-45ff-936d-52d3de645192>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4227fb7-b219-463e-85a2-eaf2d2c688ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4227fb7-b219-463e-85a2-eaf2d2c688ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/f142bce7-ce78-40a9-9e3d-a739b1036334/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4227fb7-b219-463e-85a2-eaf2d2c688ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/670199c2-9907-43d7-b1ba-f895cfd23abe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "670199c2-9907-43d7-b1ba-f895cfd23abe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/f3274092-6687-49cb-b767-a308bf3052aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/670199c2-9907-43d7-b1ba-f895cfd23abe>.
+    
+<http://data.lblod.info/id/remote-data-objects/6564dcb6-dea0-4223-9217-756bd34986d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6564dcb6-dea0-4223-9217-756bd34986d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/f85d79cc-c292-4bd3-b18d-b843bfaff66e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6564dcb6-dea0-4223-9217-756bd34986d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/686b8996-5c35-49a5-97ec-0ba544ca0a9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "686b8996-5c35-49a5-97ec-0ba544ca0a9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/fabebe0b-5174-436c-a3c8-618f58289f13/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bbe464f-60da-4584-8b1b-117037138fe9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/686b8996-5c35-49a5-97ec-0ba544ca0a9b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201822-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201822-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201822-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201822-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f095fece-679f-42e0-bb1c-29db42a41997> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f095fece-679f-42e0-bb1c-29db42a41997";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8ba095fc-080f-420e-8f5e-06101ce3c6c3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/aa78b769-ac45-4960-a3a0-1ec942bcbeed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "aa78b769-ac45-4960-a3a0-1ec942bcbeed";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3>.
+
+  <http://redpencil.data.gift/id/task/a3283a63-dbf7-4a8d-a656-b04755dbd3e1> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a3283a63-dbf7-4a8d-a656-b04755dbd3e1";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f095fece-679f-42e0-bb1c-29db42a41997>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/aa78b769-ac45-4960-a3a0-1ec942bcbeed>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/12d0e41c-b7d8-4a9d-ab4c-0f3ba85feb8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12d0e41c-b7d8-4a9d-ab4c-0f3ba85feb8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/fcca6ef8-3658-45cd-9602-d4da93ecfe00/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12d0e41c-b7d8-4a9d-ab4c-0f3ba85feb8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a20aeae-428d-4c76-8c76-1d224352a292> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a20aeae-428d-4c76-8c76-1d224352a292";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/cbs/fd535bf8-1faa-4b90-b20a-63b4c3913525/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a20aeae-428d-4c76-8c76-1d224352a292>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a7f776f-674f-487f-b26c-61a3073df091> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a7f776f-674f-487f-b26c-61a3073df091";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/086e48f3-9efc-414f-836a-853d92deada7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a7f776f-674f-487f-b26c-61a3073df091>.
+    
+<http://data.lblod.info/id/remote-data-objects/297f67da-5b74-46fa-bc34-8b72a677c88a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "297f67da-5b74-46fa-bc34-8b72a677c88a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/086e48f3-9efc-414f-836a-853d92deada7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/297f67da-5b74-46fa-bc34-8b72a677c88a>.
+    
+<http://data.lblod.info/id/remote-data-objects/87787f47-53fd-43a5-afb0-9e3f331b4e06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87787f47-53fd-43a5-afb0-9e3f331b4e06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/086e48f3-9efc-414f-836a-853d92deada7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87787f47-53fd-43a5-afb0-9e3f331b4e06>.
+    
+<http://data.lblod.info/id/remote-data-objects/d59f3813-d4e2-430a-99b2-85a6bbfac73b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d59f3813-d4e2-430a-99b2-85a6bbfac73b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/08c39aa8-ee0e-4916-a588-7db2632a53d2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d59f3813-d4e2-430a-99b2-85a6bbfac73b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3568182b-ff5d-4303-8a3e-e872adb0650e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3568182b-ff5d-4303-8a3e-e872adb0650e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/08c39aa8-ee0e-4916-a588-7db2632a53d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3568182b-ff5d-4303-8a3e-e872adb0650e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a8fed2c-4aa0-44db-96dc-9ba0cdae2ab2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a8fed2c-4aa0-44db-96dc-9ba0cdae2ab2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/08c39aa8-ee0e-4916-a588-7db2632a53d2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a8fed2c-4aa0-44db-96dc-9ba0cdae2ab2>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb46dc9d-fa89-466f-9f7a-6dd9521e1282> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb46dc9d-fa89-466f-9f7a-6dd9521e1282";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/1585e7a0-76c9-47e1-9fc9-f597b1fc0114/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb46dc9d-fa89-466f-9f7a-6dd9521e1282>.
+    
+<http://data.lblod.info/id/remote-data-objects/27ea61a2-cdc3-4222-ab19-db30685e12d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27ea61a2-cdc3-4222-ab19-db30685e12d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/1585e7a0-76c9-47e1-9fc9-f597b1fc0114/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27ea61a2-cdc3-4222-ab19-db30685e12d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/529884ea-d225-42e5-9a36-fa37f525430a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "529884ea-d225-42e5-9a36-fa37f525430a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/1585e7a0-76c9-47e1-9fc9-f597b1fc0114/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/529884ea-d225-42e5-9a36-fa37f525430a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c610749-93a7-4513-944f-f72020535c69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c610749-93a7-4513-944f-f72020535c69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/191e342e-b280-4ba0-8425-61613ef0f46b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c610749-93a7-4513-944f-f72020535c69>.
+    
+<http://data.lblod.info/id/remote-data-objects/264b4db7-df54-4f07-aee2-08f51fd5198b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "264b4db7-df54-4f07-aee2-08f51fd5198b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/191e342e-b280-4ba0-8425-61613ef0f46b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/264b4db7-df54-4f07-aee2-08f51fd5198b>.
+    
+<http://data.lblod.info/id/remote-data-objects/54fa68cf-23a4-4a4c-bdc5-00470fc86078> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54fa68cf-23a4-4a4c-bdc5-00470fc86078";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/191e342e-b280-4ba0-8425-61613ef0f46b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54fa68cf-23a4-4a4c-bdc5-00470fc86078>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e3f3494-4e23-40ff-81b3-e9fb7b827447> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e3f3494-4e23-40ff-81b3-e9fb7b827447";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/24ffdd31-cb6b-4494-be10-7dc20bcd8566/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e3f3494-4e23-40ff-81b3-e9fb7b827447>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5973e23-babf-4cf8-ac40-18971804749e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5973e23-babf-4cf8-ac40-18971804749e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/24ffdd31-cb6b-4494-be10-7dc20bcd8566/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5973e23-babf-4cf8-ac40-18971804749e>.
+    
+<http://data.lblod.info/id/remote-data-objects/24d8d9e0-7393-4e53-93f0-020dc553263c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24d8d9e0-7393-4e53-93f0-020dc553263c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/273c98a4-ab61-448c-ae3f-9b2c6493d077/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24d8d9e0-7393-4e53-93f0-020dc553263c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b66a06ab-2e16-4ca8-829e-ab3f423fc3a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b66a06ab-2e16-4ca8-829e-ab3f423fc3a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/273c98a4-ab61-448c-ae3f-9b2c6493d077/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b66a06ab-2e16-4ca8-829e-ab3f423fc3a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/266147f5-985d-4895-969e-2bc11eb892b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "266147f5-985d-4895-969e-2bc11eb892b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/273c98a4-ab61-448c-ae3f-9b2c6493d077/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/266147f5-985d-4895-969e-2bc11eb892b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a8b7107-70b1-4986-a9d9-11efbbe8f696> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a8b7107-70b1-4986-a9d9-11efbbe8f696";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/31c0ee77-89ba-4c52-a3f6-10559143ae77/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a8b7107-70b1-4986-a9d9-11efbbe8f696>.
+    
+<http://data.lblod.info/id/remote-data-objects/9632bff5-6112-46a9-98af-87d48d1f6065> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9632bff5-6112-46a9-98af-87d48d1f6065";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/31c0ee77-89ba-4c52-a3f6-10559143ae77/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9632bff5-6112-46a9-98af-87d48d1f6065>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e7a3cb9-c357-4ed0-8cb0-3034404880ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e7a3cb9-c357-4ed0-8cb0-3034404880ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/31c0ee77-89ba-4c52-a3f6-10559143ae77/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e7a3cb9-c357-4ed0-8cb0-3034404880ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/777bda7e-5ad8-4bdd-a640-e9a8d264e0fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "777bda7e-5ad8-4bdd-a640-e9a8d264e0fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/329a01e9-a572-4403-a328-87922123f730/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/777bda7e-5ad8-4bdd-a640-e9a8d264e0fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c092522-8674-48b6-95d2-31b33cb992e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c092522-8674-48b6-95d2-31b33cb992e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/329a01e9-a572-4403-a328-87922123f730/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c092522-8674-48b6-95d2-31b33cb992e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/27b721b4-029c-4995-bd01-069cd6d38b16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27b721b4-029c-4995-bd01-069cd6d38b16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/329a01e9-a572-4403-a328-87922123f730/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27b721b4-029c-4995-bd01-069cd6d38b16>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4a4c28c-746e-429d-86cb-6b3faa56404b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4a4c28c-746e-429d-86cb-6b3faa56404b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/374bc9dd-6929-4c35-b595-8f3252b05195/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4a4c28c-746e-429d-86cb-6b3faa56404b>.
+    
+<http://data.lblod.info/id/remote-data-objects/74985f15-0da0-4c04-a928-d9f324af3473> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74985f15-0da0-4c04-a928-d9f324af3473";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/374bc9dd-6929-4c35-b595-8f3252b05195/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74985f15-0da0-4c04-a928-d9f324af3473>.
+    
+<http://data.lblod.info/id/remote-data-objects/79b81f4d-c5d7-4459-8561-15ee6e897b0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79b81f4d-c5d7-4459-8561-15ee6e897b0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/374bc9dd-6929-4c35-b595-8f3252b05195/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79b81f4d-c5d7-4459-8561-15ee6e897b0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/90022385-a2fb-4f65-bf16-d6a4bd81f75a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90022385-a2fb-4f65-bf16-d6a4bd81f75a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/3ee85abe-c69c-4e74-a3e1-e1a4cf5d1426/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90022385-a2fb-4f65-bf16-d6a4bd81f75a>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa437394-0a9d-48cb-bea3-6895a9c18ccc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa437394-0a9d-48cb-bea3-6895a9c18ccc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/3ee85abe-c69c-4e74-a3e1-e1a4cf5d1426/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa437394-0a9d-48cb-bea3-6895a9c18ccc>.
+    
+<http://data.lblod.info/id/remote-data-objects/072cc461-49f9-4ba4-ae30-78234881a12c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "072cc461-49f9-4ba4-ae30-78234881a12c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/3ee85abe-c69c-4e74-a3e1-e1a4cf5d1426/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/072cc461-49f9-4ba4-ae30-78234881a12c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bbd403b-feae-4316-b6a0-20606eacc326> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bbd403b-feae-4316-b6a0-20606eacc326";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/4b3d18e7-a34f-4c0a-aef3-7c4de40013a0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bbd403b-feae-4316-b6a0-20606eacc326>.
+    
+<http://data.lblod.info/id/remote-data-objects/d033078a-3690-4c00-8c43-e62e8601b308> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d033078a-3690-4c00-8c43-e62e8601b308";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/4b3d18e7-a34f-4c0a-aef3-7c4de40013a0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d033078a-3690-4c00-8c43-e62e8601b308>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1f78505-1feb-4ed4-8130-293406202033> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1f78505-1feb-4ed4-8130-293406202033";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/4b3d18e7-a34f-4c0a-aef3-7c4de40013a0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1f78505-1feb-4ed4-8130-293406202033>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2971029-98d6-4c39-be32-1171f20a26d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2971029-98d6-4c39-be32-1171f20a26d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/53b9e77c-01fe-4354-b562-77a98dd7997b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2971029-98d6-4c39-be32-1171f20a26d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/33be38d8-aeb3-4373-a8b0-59eb29e47575> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33be38d8-aeb3-4373-a8b0-59eb29e47575";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/53b9e77c-01fe-4354-b562-77a98dd7997b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33be38d8-aeb3-4373-a8b0-59eb29e47575>.
+    
+<http://data.lblod.info/id/remote-data-objects/9636dadb-ea64-487b-8715-d9842c888200> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9636dadb-ea64-487b-8715-d9842c888200";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/53b9e77c-01fe-4354-b562-77a98dd7997b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9636dadb-ea64-487b-8715-d9842c888200>.
+    
+<http://data.lblod.info/id/remote-data-objects/51eb1a7b-53c9-42c0-bb13-24b98015d906> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51eb1a7b-53c9-42c0-bb13-24b98015d906";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/55cd8668-c7ab-4e46-8ff1-42735e1bf1c6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51eb1a7b-53c9-42c0-bb13-24b98015d906>.
+    
+<http://data.lblod.info/id/remote-data-objects/d13f2172-78f3-4148-84c6-994766bd32ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d13f2172-78f3-4148-84c6-994766bd32ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/55cd8668-c7ab-4e46-8ff1-42735e1bf1c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d13f2172-78f3-4148-84c6-994766bd32ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/b55c535e-0ac3-45b2-bd49-6b4b4aec0f39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b55c535e-0ac3-45b2-bd49-6b4b4aec0f39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/55cd8668-c7ab-4e46-8ff1-42735e1bf1c6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b55c535e-0ac3-45b2-bd49-6b4b4aec0f39>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d52b39e-7da2-42b7-9822-685dcff7887b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d52b39e-7da2-42b7-9822-685dcff7887b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/69d44797-72d7-4afc-88d8-b67d86779ebc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d52b39e-7da2-42b7-9822-685dcff7887b>.
+    
+<http://data.lblod.info/id/remote-data-objects/378f98d9-9abf-4c6b-bb69-e019839f3e1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "378f98d9-9abf-4c6b-bb69-e019839f3e1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/69d44797-72d7-4afc-88d8-b67d86779ebc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/378f98d9-9abf-4c6b-bb69-e019839f3e1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9759817-2eee-4681-9b60-11e2e2924330> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9759817-2eee-4681-9b60-11e2e2924330";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/69d44797-72d7-4afc-88d8-b67d86779ebc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9759817-2eee-4681-9b60-11e2e2924330>.
+    
+<http://data.lblod.info/id/remote-data-objects/02f8cb70-5516-4686-b064-c9b7fc521d68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02f8cb70-5516-4686-b064-c9b7fc521d68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/7953e35e-1f7a-4a18-b5dc-dfdceeda641c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02f8cb70-5516-4686-b064-c9b7fc521d68>.
+    
+<http://data.lblod.info/id/remote-data-objects/03cb1cbc-58a2-4ef0-a7cd-638c51223465> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03cb1cbc-58a2-4ef0-a7cd-638c51223465";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/7953e35e-1f7a-4a18-b5dc-dfdceeda641c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03cb1cbc-58a2-4ef0-a7cd-638c51223465>.
+    
+<http://data.lblod.info/id/remote-data-objects/26f6088c-3e4f-4767-9814-94d766d2cc33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26f6088c-3e4f-4767-9814-94d766d2cc33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/7953e35e-1f7a-4a18-b5dc-dfdceeda641c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26f6088c-3e4f-4767-9814-94d766d2cc33>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcd1ef5c-71ae-4417-902b-59c31bf30170> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcd1ef5c-71ae-4417-902b-59c31bf30170";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/7fc7a124-6f8b-49b3-929c-9e9f03f9bd9b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcd1ef5c-71ae-4417-902b-59c31bf30170>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bbd380a-9e9d-4030-9793-a15022339f8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bbd380a-9e9d-4030-9793-a15022339f8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/7fc7a124-6f8b-49b3-929c-9e9f03f9bd9b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bbd380a-9e9d-4030-9793-a15022339f8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a250293-7a70-4a11-8fc2-976f53eefe2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a250293-7a70-4a11-8fc2-976f53eefe2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/7fc7a124-6f8b-49b3-929c-9e9f03f9bd9b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a250293-7a70-4a11-8fc2-976f53eefe2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bde7337-1029-4893-93ca-53a9a63b8bdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bde7337-1029-4893-93ca-53a9a63b8bdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/8d2f843b-d381-45b6-8275-81e406347d4f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8ba095fc-080f-420e-8f5e-06101ce3c6c3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bde7337-1029-4893-93ca-53a9a63b8bdb>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201823-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201823-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201823-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201823-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/302b4216-ba47-4199-b01c-71f65b36b437> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "302b4216-ba47-4199-b01c-71f65b36b437";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "59edaf50-032e-4966-b8ff-36fba449eb2b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/15a0c48e-b699-4361-ad58-aa0a0662d968> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "15a0c48e-b699-4361-ad58-aa0a0662d968";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b>.
+
+  <http://redpencil.data.gift/id/task/3ab5e05c-fa1f-425d-b523-141924e88f03> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3ab5e05c-fa1f-425d-b523-141924e88f03";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/302b4216-ba47-4199-b01c-71f65b36b437>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/15a0c48e-b699-4361-ad58-aa0a0662d968>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7ebd5857-4971-4008-80d8-282c02ad1840> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ebd5857-4971-4008-80d8-282c02ad1840";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/8d2f843b-d381-45b6-8275-81e406347d4f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ebd5857-4971-4008-80d8-282c02ad1840>.
+    
+<http://data.lblod.info/id/remote-data-objects/d500455a-e82d-4f15-bb8a-90eebb025d10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d500455a-e82d-4f15-bb8a-90eebb025d10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/8d2f843b-d381-45b6-8275-81e406347d4f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d500455a-e82d-4f15-bb8a-90eebb025d10>.
+    
+<http://data.lblod.info/id/remote-data-objects/afc00ea9-4978-4177-9b26-10c699fcd783> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "afc00ea9-4978-4177-9b26-10c699fcd783";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/93636aaf-4489-411a-9dcf-f59dac2beaa0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/afc00ea9-4978-4177-9b26-10c699fcd783>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c39d20c-f045-48d9-bed4-870dfa0026b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c39d20c-f045-48d9-bed4-870dfa0026b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/93636aaf-4489-411a-9dcf-f59dac2beaa0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c39d20c-f045-48d9-bed4-870dfa0026b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca2f9d03-671d-4773-b0a0-cf4b9e9ec989> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca2f9d03-671d-4773-b0a0-cf4b9e9ec989";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/93636aaf-4489-411a-9dcf-f59dac2beaa0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca2f9d03-671d-4773-b0a0-cf4b9e9ec989>.
+    
+<http://data.lblod.info/id/remote-data-objects/26f1000e-dbde-4933-874d-edb9f0da80a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26f1000e-dbde-4933-874d-edb9f0da80a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/9bef0719-dd8e-411c-befa-19dcc28be246/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26f1000e-dbde-4933-874d-edb9f0da80a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf94071e-e8ec-4e2b-978d-e661512db027> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf94071e-e8ec-4e2b-978d-e661512db027";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/9bef0719-dd8e-411c-befa-19dcc28be246/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf94071e-e8ec-4e2b-978d-e661512db027>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fae4b8e-eb1b-4876-b8c0-8bc3a6ba6681> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fae4b8e-eb1b-4876-b8c0-8bc3a6ba6681";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/a85e83b4-cd4b-428e-b5d3-d9b0fd9c687e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fae4b8e-eb1b-4876-b8c0-8bc3a6ba6681>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f00cfe4-f3ac-44fd-a7d9-43affa7a2ef2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f00cfe4-f3ac-44fd-a7d9-43affa7a2ef2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/a85e83b4-cd4b-428e-b5d3-d9b0fd9c687e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f00cfe4-f3ac-44fd-a7d9-43affa7a2ef2>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd7dcf4f-1a5c-4e9e-9e29-3beba9160c71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd7dcf4f-1a5c-4e9e-9e29-3beba9160c71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/a85e83b4-cd4b-428e-b5d3-d9b0fd9c687e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd7dcf4f-1a5c-4e9e-9e29-3beba9160c71>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5bc6ed5-11a7-4514-8fb7-eb55870f9636> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5bc6ed5-11a7-4514-8fb7-eb55870f9636";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/bca74318-f5c2-485b-bbad-4becfe3e49a6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5bc6ed5-11a7-4514-8fb7-eb55870f9636>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f03606f-7135-4c0f-9ee3-0c36d3ccaca4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f03606f-7135-4c0f-9ee3-0c36d3ccaca4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/bca74318-f5c2-485b-bbad-4becfe3e49a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f03606f-7135-4c0f-9ee3-0c36d3ccaca4>.
+    
+<http://data.lblod.info/id/remote-data-objects/072ace2d-fee6-4b85-a652-538577742c58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "072ace2d-fee6-4b85-a652-538577742c58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/bca74318-f5c2-485b-bbad-4becfe3e49a6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/072ace2d-fee6-4b85-a652-538577742c58>.
+    
+<http://data.lblod.info/id/remote-data-objects/66c9a43c-6457-411a-aea3-a98f3c0166c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66c9a43c-6457-411a-aea3-a98f3c0166c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/c571daf5-ee85-4dc8-85db-6b75c463f79b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66c9a43c-6457-411a-aea3-a98f3c0166c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/59ae1dad-36af-4243-a2e7-3bc4ae2ce636> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59ae1dad-36af-4243-a2e7-3bc4ae2ce636";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/c571daf5-ee85-4dc8-85db-6b75c463f79b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59ae1dad-36af-4243-a2e7-3bc4ae2ce636>.
+    
+<http://data.lblod.info/id/remote-data-objects/05bb4433-b0fb-4b94-a661-9e3409f7bde1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05bb4433-b0fb-4b94-a661-9e3409f7bde1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/c571daf5-ee85-4dc8-85db-6b75c463f79b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05bb4433-b0fb-4b94-a661-9e3409f7bde1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f68aa7f1-7d3d-413c-9dc9-7bd9d4abbfbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f68aa7f1-7d3d-413c-9dc9-7bd9d4abbfbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/cb5f37c2-d79d-4806-b0da-8968a29334ec/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f68aa7f1-7d3d-413c-9dc9-7bd9d4abbfbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/800d48f9-9695-4cd2-883a-d62e39631de1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "800d48f9-9695-4cd2-883a-d62e39631de1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/cb5f37c2-d79d-4806-b0da-8968a29334ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/800d48f9-9695-4cd2-883a-d62e39631de1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f27e624-31bd-4aa9-a842-eac21736a8b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f27e624-31bd-4aa9-a842-eac21736a8b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/cb5f37c2-d79d-4806-b0da-8968a29334ec/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f27e624-31bd-4aa9-a842-eac21736a8b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd435590-01f7-43fe-94e8-28c20be48438> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd435590-01f7-43fe-94e8-28c20be48438";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/dc10f3c1-a907-4d17-bd03-c5a232d2b4de/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd435590-01f7-43fe-94e8-28c20be48438>.
+    
+<http://data.lblod.info/id/remote-data-objects/7918d88a-281a-48ce-9993-350d51439bb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7918d88a-281a-48ce-9993-350d51439bb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/dc10f3c1-a907-4d17-bd03-c5a232d2b4de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7918d88a-281a-48ce-9993-350d51439bb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f292164-e95d-407a-a891-e84dd5773dfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f292164-e95d-407a-a891-e84dd5773dfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/dc10f3c1-a907-4d17-bd03-c5a232d2b4de/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f292164-e95d-407a-a891-e84dd5773dfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc4ac86b-1551-4586-8476-937bb023ef66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc4ac86b-1551-4586-8476-937bb023ef66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/dcec958d-ad25-4867-8206-001ce2ab272e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc4ac86b-1551-4586-8476-937bb023ef66>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb4907d7-23c5-4f51-84df-bdb13374b3b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb4907d7-23c5-4f51-84df-bdb13374b3b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/dcec958d-ad25-4867-8206-001ce2ab272e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb4907d7-23c5-4f51-84df-bdb13374b3b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/3de31b0b-8480-4969-a8b7-bd027b957737> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3de31b0b-8480-4969-a8b7-bd027b957737";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/dcec958d-ad25-4867-8206-001ce2ab272e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3de31b0b-8480-4969-a8b7-bd027b957737>.
+    
+<http://data.lblod.info/id/remote-data-objects/f92c93dc-e95d-4847-ad28-6b315ff23034> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f92c93dc-e95d-4847-ad28-6b315ff23034";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/ddaaa9ee-43e6-428d-a215-b90fb91eb052/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f92c93dc-e95d-4847-ad28-6b315ff23034>.
+    
+<http://data.lblod.info/id/remote-data-objects/6677f256-be0f-43a6-8863-ed564addc3ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6677f256-be0f-43a6-8863-ed564addc3ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/ddaaa9ee-43e6-428d-a215-b90fb91eb052/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6677f256-be0f-43a6-8863-ed564addc3ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad697d81-e589-486d-8619-ed8afe76a82e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad697d81-e589-486d-8619-ed8afe76a82e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/ddaaa9ee-43e6-428d-a215-b90fb91eb052/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad697d81-e589-486d-8619-ed8afe76a82e>.
+    
+<http://data.lblod.info/id/remote-data-objects/093080e3-9adf-4e7d-b97a-3944b90dd070> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "093080e3-9adf-4e7d-b97a-3944b90dd070";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/ea386f69-6cf6-4b07-833e-a0c39bcdf9a5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/093080e3-9adf-4e7d-b97a-3944b90dd070>.
+    
+<http://data.lblod.info/id/remote-data-objects/65b82a3c-892c-4057-9ebc-382a05f6d4e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65b82a3c-892c-4057-9ebc-382a05f6d4e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/ea386f69-6cf6-4b07-833e-a0c39bcdf9a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65b82a3c-892c-4057-9ebc-382a05f6d4e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/490a270a-6456-4a96-8a35-0889dbe459e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "490a270a-6456-4a96-8a35-0889dbe459e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/ea386f69-6cf6-4b07-833e-a0c39bcdf9a5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/490a270a-6456-4a96-8a35-0889dbe459e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1eaef900-a27c-43cf-bbe4-ec39134296eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1eaef900-a27c-43cf-bbe4-ec39134296eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/eb2ed734-f0be-4e5d-a58e-56b2ea7b190d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1eaef900-a27c-43cf-bbe4-ec39134296eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/18400794-9e1e-43b6-8d52-d9bf0dd62748> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18400794-9e1e-43b6-8d52-d9bf0dd62748";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/eb2ed734-f0be-4e5d-a58e-56b2ea7b190d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18400794-9e1e-43b6-8d52-d9bf0dd62748>.
+    
+<http://data.lblod.info/id/remote-data-objects/f55b1794-977a-48dd-9b67-6f1b9caa6278> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f55b1794-977a-48dd-9b67-6f1b9caa6278";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/eb2ed734-f0be-4e5d-a58e-56b2ea7b190d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f55b1794-977a-48dd-9b67-6f1b9caa6278>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8615bf2-faac-411b-a441-a313d6ea79ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8615bf2-faac-411b-a441-a313d6ea79ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/f3814244-7bd9-4103-b6e8-26500ca1dfc8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8615bf2-faac-411b-a441-a313d6ea79ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/c764c214-aab1-4af9-9a0d-17bc4df93015> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c764c214-aab1-4af9-9a0d-17bc4df93015";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/f3814244-7bd9-4103-b6e8-26500ca1dfc8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c764c214-aab1-4af9-9a0d-17bc4df93015>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa7a5077-a879-43d5-8fbc-f23c61e8aeb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa7a5077-a879-43d5-8fbc-f23c61e8aeb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/f3814244-7bd9-4103-b6e8-26500ca1dfc8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa7a5077-a879-43d5-8fbc-f23c61e8aeb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5e5dce5-b5b9-4410-9cfd-3b68e91371d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5e5dce5-b5b9-4410-9cfd-3b68e91371d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/f51ecdde-29fe-4cd1-ba2e-0eda8632b6b9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5e5dce5-b5b9-4410-9cfd-3b68e91371d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9c6cd19-72ca-46fe-8c5a-be045a7adbed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9c6cd19-72ca-46fe-8c5a-be045a7adbed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/f51ecdde-29fe-4cd1-ba2e-0eda8632b6b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9c6cd19-72ca-46fe-8c5a-be045a7adbed>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cbd466c-97b1-468d-bf93-47d468903f27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cbd466c-97b1-468d-bf93-47d468903f27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://lier.meetingburger.net/gr/f51ecdde-29fe-4cd1-ba2e-0eda8632b6b9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cbd466c-97b1-468d-bf93-47d468903f27>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfd73162-9ea2-4968-afc9-6b9acc2e5a85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfd73162-9ea2-4968-afc9-6b9acc2e5a85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/053041f7-3184-4314-a3b9-fd82738abe4a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfd73162-9ea2-4968-afc9-6b9acc2e5a85>.
+    
+<http://data.lblod.info/id/remote-data-objects/cda0a918-d7f7-4d88-b05f-8f10734a034c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cda0a918-d7f7-4d88-b05f-8f10734a034c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/11aa6e40-81e6-414d-abb9-6350ad887af4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cda0a918-d7f7-4d88-b05f-8f10734a034c>.
+    
+<http://data.lblod.info/id/remote-data-objects/71488b0e-dda2-4e73-abde-7fbff78e089b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71488b0e-dda2-4e73-abde-7fbff78e089b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/1812217a-0a12-42bb-9dbe-8acd37373280/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71488b0e-dda2-4e73-abde-7fbff78e089b>.
+    
+<http://data.lblod.info/id/remote-data-objects/43a8f8ac-c17b-457e-a91d-43987a8b8cb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43a8f8ac-c17b-457e-a91d-43987a8b8cb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/1cac5b91-261d-487b-a1a6-3f59ed549174/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43a8f8ac-c17b-457e-a91d-43987a8b8cb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/8de1c355-deac-49b2-bc24-c24726ee2743> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8de1c355-deac-49b2-bc24-c24726ee2743";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/24e12177-7284-4321-96f4-94f8f8339147/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8de1c355-deac-49b2-bc24-c24726ee2743>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5f31035-cbfa-4353-8b1b-e33fdca99b3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5f31035-cbfa-4353-8b1b-e33fdca99b3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/3779a88a-7130-4b95-9a22-0b80a444d1b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5f31035-cbfa-4353-8b1b-e33fdca99b3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f71f1ab-171c-4aee-893d-d98fd9f560b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f71f1ab-171c-4aee-893d-d98fd9f560b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/3834b11e-abbe-4f0c-96a3-82248ef3839c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f71f1ab-171c-4aee-893d-d98fd9f560b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b926069-6b49-41a9-a988-3ab5644583a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b926069-6b49-41a9-a988-3ab5644583a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/4b9f5060-40a4-48a7-8f5f-bb68d2f29196/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b926069-6b49-41a9-a988-3ab5644583a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/d82c0b56-b73f-4263-a28a-c1f3976be1c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d82c0b56-b73f-4263-a28a-c1f3976be1c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/660e0853-2cc0-4040-a7e7-691e94bf1d3a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d82c0b56-b73f-4263-a28a-c1f3976be1c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c56cbcd-065c-4a94-b437-11cd51c37fdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c56cbcd-065c-4a94-b437-11cd51c37fdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/6954b4dc-47fc-45e1-872d-48f282ca4b10/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:23.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59edaf50-032e-4966-b8ff-36fba449eb2b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c56cbcd-065c-4a94-b437-11cd51c37fdf>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201825-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201825-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201825-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201825-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c100759b-03f8-43fe-a579-7a4765b24614> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c100759b-03f8-43fe-a579-7a4765b24614";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "08c5889a-c536-4a5e-a198-7604723b31c1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/94c826fb-d5a1-4e3f-b1b7-cc651c5d630a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "94c826fb-d5a1-4e3f-b1b7-cc651c5d630a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1>.
+
+  <http://redpencil.data.gift/id/task/57204067-84e1-45d6-8a3b-fc21d9248f88> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "57204067-84e1-45d6-8a3b-fc21d9248f88";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c100759b-03f8-43fe-a579-7a4765b24614>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/94c826fb-d5a1-4e3f-b1b7-cc651c5d630a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b63b11a8-da17-4fa6-8b1e-f664ad85a5cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b63b11a8-da17-4fa6-8b1e-f664ad85a5cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/6eb9b89a-cc8a-4d4c-8551-226d9c7dcf64/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b63b11a8-da17-4fa6-8b1e-f664ad85a5cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/2853166d-f403-40de-95f7-6f581041c945> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2853166d-f403-40de-95f7-6f581041c945";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/6f3f8d31-9c05-4746-8f4b-9ee6727414d8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2853166d-f403-40de-95f7-6f581041c945>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4d1b43b-321f-4f20-8f3f-fa97fe1faecf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4d1b43b-321f-4f20-8f3f-fa97fe1faecf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/7290dedd-9d51-4208-ba47-c651dcec1d07/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4d1b43b-321f-4f20-8f3f-fa97fe1faecf>.
+    
+<http://data.lblod.info/id/remote-data-objects/2865db3e-a0a6-41b2-a070-1fc38eb3015b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2865db3e-a0a6-41b2-a070-1fc38eb3015b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/88accee3-8242-42b5-a4ea-6ade3e485ace/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2865db3e-a0a6-41b2-a070-1fc38eb3015b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9569780-1774-4066-9c13-88d3ff47d16d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9569780-1774-4066-9c13-88d3ff47d16d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/9631a175-21b5-474b-9b11-a7706065c6b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9569780-1774-4066-9c13-88d3ff47d16d>.
+    
+<http://data.lblod.info/id/remote-data-objects/15723b03-90b6-4b72-b1ec-8a0e783ddf1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15723b03-90b6-4b72-b1ec-8a0e783ddf1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/ae3cb0ac-38da-4f06-83fd-190fd153e8c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15723b03-90b6-4b72-b1ec-8a0e783ddf1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f66d7f1c-c207-4928-8939-df7b7b9125e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f66d7f1c-c207-4928-8939-df7b7b9125e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/af2fc636-7f73-4bfc-a21c-b2af830df52b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f66d7f1c-c207-4928-8939-df7b7b9125e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc823538-954a-4475-96c5-2bc6273cfa52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc823538-954a-4475-96c5-2bc6273cfa52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/b7489dd1-4897-4fdd-9fdd-4555bbaa74f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc823538-954a-4475-96c5-2bc6273cfa52>.
+    
+<http://data.lblod.info/id/remote-data-objects/700e76da-3f08-49a3-96aa-742d3cb86c5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "700e76da-3f08-49a3-96aa-742d3cb86c5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/be421bdd-aaf2-4e48-805e-8cfbdf6d4796/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/700e76da-3f08-49a3-96aa-742d3cb86c5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5abff243-75b5-47db-aa5e-417395f1cfda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5abff243-75b5-47db-aa5e-417395f1cfda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/c32692e9-0a7b-467f-80f1-794a31cdcde9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5abff243-75b5-47db-aa5e-417395f1cfda>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f9189e1-8bd1-4547-a7eb-fb97aafc9cd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f9189e1-8bd1-4547-a7eb-fb97aafc9cd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/c41f9386-36ff-46ff-8207-19638e41a95d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f9189e1-8bd1-4547-a7eb-fb97aafc9cd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c548da7-77ed-4d31-b1e1-5c7ae540c69d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c548da7-77ed-4d31-b1e1-5c7ae540c69d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/c72f4c00-3082-4be0-ace2-161de1e12923/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c548da7-77ed-4d31-b1e1-5c7ae540c69d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6333df9d-4a79-4ee2-9a67-67dddb6266b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6333df9d-4a79-4ee2-9a67-67dddb6266b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/c98293cb-a030-40b1-bb36-a79aec75e145/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6333df9d-4a79-4ee2-9a67-67dddb6266b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/9649be62-6a9d-4207-8e77-2270f3a7295e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9649be62-6a9d-4207-8e77-2270f3a7295e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/ccc5a3e3-83fb-4cda-a182-8f8367ad81b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9649be62-6a9d-4207-8e77-2270f3a7295e>.
+    
+<http://data.lblod.info/id/remote-data-objects/58d74fe0-1034-48cf-9635-ec74e7ccfaf0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58d74fe0-1034-48cf-9635-ec74e7ccfaf0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/db637624-2e16-4c6d-9e22-6c8945c78649/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58d74fe0-1034-48cf-9635-ec74e7ccfaf0>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb5f7ba3-ac81-4aca-b1c5-45c1366e32ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb5f7ba3-ac81-4aca-b1c5-45c1366e32ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/e5f00e8f-1b62-44a7-8946-9720241025a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb5f7ba3-ac81-4aca-b1c5-45c1366e32ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/4461ed98-639a-4256-a64a-7d9d97f6b250> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4461ed98-639a-4256-a64a-7d9d97f6b250";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/e97b2672-8807-4333-a811-ef7c304b33e6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4461ed98-639a-4256-a64a-7d9d97f6b250>.
+    
+<http://data.lblod.info/id/remote-data-objects/58a568b9-5e85-473b-91c2-d1d9d2e7b57c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58a568b9-5e85-473b-91c2-d1d9d2e7b57c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/f1e5cd35-1aee-4664-9e04-008f15524251/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58a568b9-5e85-473b-91c2-d1d9d2e7b57c>.
+    
+<http://data.lblod.info/id/remote-data-objects/426deb36-8cb2-4adb-be1e-0423066b1f3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "426deb36-8cb2-4adb-be1e-0423066b1f3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/bb/f437cdde-336e-4a64-8481-56387a7649d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/426deb36-8cb2-4adb-be1e-0423066b1f3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d73fa86-eef7-42a8-a75d-583e998bedc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d73fa86-eef7-42a8-a75d-583e998bedc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/02f9eb18-d88b-471d-ab12-6c6ba78e4bde/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d73fa86-eef7-42a8-a75d-583e998bedc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e1eab22-db80-401d-869f-dd67be71fc6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e1eab22-db80-401d-869f-dd67be71fc6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/07a73f54-68b7-415f-8329-248ca1f74a1f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e1eab22-db80-401d-869f-dd67be71fc6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/02d8379a-461a-4f91-9414-0ec74ee8df1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02d8379a-461a-4f91-9414-0ec74ee8df1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/0945dda3-3228-4f28-ba4c-cdfaff7f5915/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02d8379a-461a-4f91-9414-0ec74ee8df1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0f31491-d68d-4a8c-bf2f-f84c0e83e0a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0f31491-d68d-4a8c-bf2f-f84c0e83e0a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/0d940a97-09d7-4c6d-a8fe-faaf776325a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0f31491-d68d-4a8c-bf2f-f84c0e83e0a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b475101-bb54-4c96-9a29-424d5719502c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b475101-bb54-4c96-9a29-424d5719502c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/0eef8ec9-80ea-448e-b174-387fea9d8e01/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b475101-bb54-4c96-9a29-424d5719502c>.
+    
+<http://data.lblod.info/id/remote-data-objects/4df6baff-1a97-4cd4-ac31-8ae33b6a822b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4df6baff-1a97-4cd4-ac31-8ae33b6a822b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/0fb8a68c-f641-4c8b-ae0f-62209fc9d98f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4df6baff-1a97-4cd4-ac31-8ae33b6a822b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c4bd5a7-8f40-45ee-bc95-0653d36bffde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c4bd5a7-8f40-45ee-bc95-0653d36bffde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/146b103d-df13-4897-b798-c2f9af4a0749/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c4bd5a7-8f40-45ee-bc95-0653d36bffde>.
+    
+<http://data.lblod.info/id/remote-data-objects/0073323c-e7a8-4509-a07d-1bd16afab291> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0073323c-e7a8-4509-a07d-1bd16afab291";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/167ed9fc-6656-4788-a09f-dfa3d51520c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0073323c-e7a8-4509-a07d-1bd16afab291>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8e103c7-b0ec-44dc-b76f-926860a45a17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8e103c7-b0ec-44dc-b76f-926860a45a17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/17716d21-6b07-4e2a-bcd0-98208482fcfd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8e103c7-b0ec-44dc-b76f-926860a45a17>.
+    
+<http://data.lblod.info/id/remote-data-objects/61271f05-15b6-4a25-83a2-305e361b9a63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61271f05-15b6-4a25-83a2-305e361b9a63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/17e86d11-3837-42d2-bba4-85137a2e3d68/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61271f05-15b6-4a25-83a2-305e361b9a63>.
+    
+<http://data.lblod.info/id/remote-data-objects/89ab18c6-8c4c-4f73-8a82-bc0d1349c251> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89ab18c6-8c4c-4f73-8a82-bc0d1349c251";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/1894b863-6f37-4b6a-9099-cc68d4d5c019/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89ab18c6-8c4c-4f73-8a82-bc0d1349c251>.
+    
+<http://data.lblod.info/id/remote-data-objects/499ed132-a920-4de8-b374-9571ae6e7d5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "499ed132-a920-4de8-b374-9571ae6e7d5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/18c5c57c-4bb2-423e-a73e-6f88195d7431/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/499ed132-a920-4de8-b374-9571ae6e7d5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6db1fb3d-6a04-4bec-8a54-c5d21466210a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6db1fb3d-6a04-4bec-8a54-c5d21466210a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/1b5a64bb-1a81-4a97-8a50-f202e3d8f86a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6db1fb3d-6a04-4bec-8a54-c5d21466210a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7bbfdfd-819b-4a5c-8d23-28c71b547c1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7bbfdfd-819b-4a5c-8d23-28c71b547c1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/1fd3adc9-bcde-4375-8b6d-54396b95405b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7bbfdfd-819b-4a5c-8d23-28c71b547c1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/12a494d3-9e7a-4909-b304-af814dbcefef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12a494d3-9e7a-4909-b304-af814dbcefef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/20485d3d-0ae4-4174-badd-4cf6aa10d799/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12a494d3-9e7a-4909-b304-af814dbcefef>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ce10947-8b06-4cfe-b2c1-fcf3a96a341e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ce10947-8b06-4cfe-b2c1-fcf3a96a341e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/20ff82ff-5603-41db-bdf2-7aed76302ecd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ce10947-8b06-4cfe-b2c1-fcf3a96a341e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f248d09-6198-470e-825f-0168c384e3f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f248d09-6198-470e-825f-0168c384e3f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/2633f5d1-3e23-4b94-95b4-8780e4f79fda/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f248d09-6198-470e-825f-0168c384e3f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ac6f7aa-6d34-4cbd-a3f1-6730fda8d7ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ac6f7aa-6d34-4cbd-a3f1-6730fda8d7ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/2954a579-40e7-4ef7-91d0-b95ae4f0b3f0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ac6f7aa-6d34-4cbd-a3f1-6730fda8d7ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/127ffd17-3037-4eab-86ba-1aa47b31d494> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "127ffd17-3037-4eab-86ba-1aa47b31d494";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/2fb90e8a-7e1e-4c64-97f0-55f2e75670ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/127ffd17-3037-4eab-86ba-1aa47b31d494>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cfac938-8104-442b-a2db-a284438adcf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cfac938-8104-442b-a2db-a284438adcf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/2fe9f64c-5b0f-4c36-8013-299cec063484/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cfac938-8104-442b-a2db-a284438adcf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a416e8b-a3e1-4f44-9b9f-50caa1bc281f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a416e8b-a3e1-4f44-9b9f-50caa1bc281f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/35fd26c2-e846-4b20-bca7-608c0c78367e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a416e8b-a3e1-4f44-9b9f-50caa1bc281f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8a01db9-a59e-4d09-b278-e084880812a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8a01db9-a59e-4d09-b278-e084880812a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/39045c66-277e-4169-9ce2-9f45c90177a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8a01db9-a59e-4d09-b278-e084880812a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/633c3753-5cfe-45e3-9223-a0cfcf4eaa5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "633c3753-5cfe-45e3-9223-a0cfcf4eaa5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/3ef6741b-6f35-47a9-a160-ad06d35ac749/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/633c3753-5cfe-45e3-9223-a0cfcf4eaa5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d18b20f-dc85-4939-9de8-6471de2e0286> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d18b20f-dc85-4939-9de8-6471de2e0286";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/421368d8-68db-4f7e-936f-66912b3ed857/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d18b20f-dc85-4939-9de8-6471de2e0286>.
+    
+<http://data.lblod.info/id/remote-data-objects/626e4b62-dce6-4e93-89e1-b66f2489cf70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "626e4b62-dce6-4e93-89e1-b66f2489cf70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/486ee7b9-3045-43f2-a950-dcb62863e166/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/626e4b62-dce6-4e93-89e1-b66f2489cf70>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb8bc8b9-efec-44ee-a2b7-02e6a11d5fd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb8bc8b9-efec-44ee-a2b7-02e6a11d5fd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/48e9e574-1785-47eb-9f5a-28a241f0f5f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb8bc8b9-efec-44ee-a2b7-02e6a11d5fd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0de58ceb-d1d2-4926-ae74-23dab37b6e78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0de58ceb-d1d2-4926-ae74-23dab37b6e78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/4949a4db-8080-4ca5-8b1d-53931387c5e8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0de58ceb-d1d2-4926-ae74-23dab37b6e78>.
+    
+<http://data.lblod.info/id/remote-data-objects/036fbf9f-085a-452f-8d5d-69e9c54e8bcb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "036fbf9f-085a-452f-8d5d-69e9c54e8bcb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/499145ff-4487-4982-aa31-72d2e7af42f5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/036fbf9f-085a-452f-8d5d-69e9c54e8bcb>.
+    
+<http://data.lblod.info/id/remote-data-objects/11fcae5f-c9fc-4125-baf8-fbbea9e985f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11fcae5f-c9fc-4125-baf8-fbbea9e985f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/56d1846b-174d-4774-91f5-4c0b0f8f189d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11fcae5f-c9fc-4125-baf8-fbbea9e985f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/615668ef-0ecf-4485-a3ce-3ebe8b7fae11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "615668ef-0ecf-4485-a3ce-3ebe8b7fae11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/5715664c-f728-45ec-af77-bae5717e529b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/615668ef-0ecf-4485-a3ce-3ebe8b7fae11>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef15de5a-56db-417b-84ec-e159e40e9f39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef15de5a-56db-417b-84ec-e159e40e9f39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/595adcf1-0909-4912-8758-659de24069ad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08c5889a-c536-4a5e-a198-7604723b31c1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef15de5a-56db-417b-84ec-e159e40e9f39>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201826-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201826-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201826-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201826-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a70d3573-4e85-41ea-80bf-e53c48f0ea5e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a70d3573-4e85-41ea-80bf-e53c48f0ea5e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "852adf8c-96ed-40c5-bc89-66e05c762745";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/67e601fe-0f1d-421d-a2b0-b2841a0788de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "67e601fe-0f1d-421d-a2b0-b2841a0788de";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745>.
+
+  <http://redpencil.data.gift/id/task/c1c19dae-8809-4935-be67-d511ba948458> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c1c19dae-8809-4935-be67-d511ba948458";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a70d3573-4e85-41ea-80bf-e53c48f0ea5e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/67e601fe-0f1d-421d-a2b0-b2841a0788de>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/24135eee-9a90-46a2-a4f1-b045cac1bb05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24135eee-9a90-46a2-a4f1-b045cac1bb05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/5d8df553-7d5b-4ab8-903e-ca7958118707/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24135eee-9a90-46a2-a4f1-b045cac1bb05>.
+    
+<http://data.lblod.info/id/remote-data-objects/59fee6bd-2d01-48ed-be69-0250d03583f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59fee6bd-2d01-48ed-be69-0250d03583f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/60e7dfad-debd-446e-b93b-bb84ad20ce0c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59fee6bd-2d01-48ed-be69-0250d03583f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/16777380-0a3f-4412-ba31-31b88126f527> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16777380-0a3f-4412-ba31-31b88126f527";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/6590b786-38c4-4b97-9d36-3b4e970a4a91/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16777380-0a3f-4412-ba31-31b88126f527>.
+    
+<http://data.lblod.info/id/remote-data-objects/88569f2f-5be4-47f5-8904-3b5002e30b2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88569f2f-5be4-47f5-8904-3b5002e30b2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/65fbd55e-d99b-4978-a602-98489380778f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88569f2f-5be4-47f5-8904-3b5002e30b2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/09de22ba-8cb6-493c-8312-0d1af5831ea1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09de22ba-8cb6-493c-8312-0d1af5831ea1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/6ae3b3ba-20ed-4cca-af17-57912d3ca3a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09de22ba-8cb6-493c-8312-0d1af5831ea1>.
+    
+<http://data.lblod.info/id/remote-data-objects/85d85f65-b186-4298-8ced-aa7e065e3643> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85d85f65-b186-4298-8ced-aa7e065e3643";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/6d1467c9-85fe-4946-a4b8-c854139c2593/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85d85f65-b186-4298-8ced-aa7e065e3643>.
+    
+<http://data.lblod.info/id/remote-data-objects/09ceb6f7-98ec-45ec-85d2-8775ec4cd2fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09ceb6f7-98ec-45ec-85d2-8775ec4cd2fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/6ddd50ef-c28c-4e0d-8dbd-8d66cd97d5f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09ceb6f7-98ec-45ec-85d2-8775ec4cd2fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/dec3a776-8d6d-4262-9f30-8a763e8c41d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dec3a776-8d6d-4262-9f30-8a763e8c41d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/7a39bd95-be04-4423-85b3-f1f89b234821/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dec3a776-8d6d-4262-9f30-8a763e8c41d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/baae0ffa-d4e8-4b52-b64e-4fc73b586ca9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "baae0ffa-d4e8-4b52-b64e-4fc73b586ca9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/7c17b93d-b9f6-448c-ae7b-f25d083e6413/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/baae0ffa-d4e8-4b52-b64e-4fc73b586ca9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7e3152d-c16f-40a6-8f33-7539a64c6e0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7e3152d-c16f-40a6-8f33-7539a64c6e0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/7c6e4279-c7a4-4350-b82d-4a73152acd2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7e3152d-c16f-40a6-8f33-7539a64c6e0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6626711e-6fec-49e6-a1c0-3aa507ef7bb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6626711e-6fec-49e6-a1c0-3aa507ef7bb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/7d347dec-5cf3-44ae-8a4e-42176a5fb226/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6626711e-6fec-49e6-a1c0-3aa507ef7bb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1638c761-bba7-409f-91e4-be2a9e909180> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1638c761-bba7-409f-91e4-be2a9e909180";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/7e5952e3-146d-405c-82ee-de710c878f8b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1638c761-bba7-409f-91e4-be2a9e909180>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e7125bf-6234-4b95-b296-3b4cbb077469> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e7125bf-6234-4b95-b296-3b4cbb077469";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/8022d9b8-f29f-4060-8845-bd846a9f12fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e7125bf-6234-4b95-b296-3b4cbb077469>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b6fc848-6885-4345-adff-ea9ad98c884b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b6fc848-6885-4345-adff-ea9ad98c884b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/848750ad-dca4-4b73-9609-cd3004c79594/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b6fc848-6885-4345-adff-ea9ad98c884b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9854c114-c86b-4d12-afcd-8e3f56aaf856> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9854c114-c86b-4d12-afcd-8e3f56aaf856";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/84c98745-ef35-4ca2-88ab-fcf4e28c69dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9854c114-c86b-4d12-afcd-8e3f56aaf856>.
+    
+<http://data.lblod.info/id/remote-data-objects/3be0360b-bafb-47e5-94d7-c4137c1adb23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3be0360b-bafb-47e5-94d7-c4137c1adb23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/8dd22fba-f539-4bf6-b2ef-a0a9ff5b9d1d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3be0360b-bafb-47e5-94d7-c4137c1adb23>.
+    
+<http://data.lblod.info/id/remote-data-objects/a53a2d84-a852-4c47-b5a5-e667aa9bf9eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a53a2d84-a852-4c47-b5a5-e667aa9bf9eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/9847daaa-0c24-411c-9885-89f582450288/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a53a2d84-a852-4c47-b5a5-e667aa9bf9eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/37cdbc58-3ccb-44d9-bf33-1b6bc6e33f95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37cdbc58-3ccb-44d9-bf33-1b6bc6e33f95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/9b18e545-25c1-43ba-a3ae-cead9ff6c472/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37cdbc58-3ccb-44d9-bf33-1b6bc6e33f95>.
+    
+<http://data.lblod.info/id/remote-data-objects/36a257e7-0186-4aef-93b4-764684cc681e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36a257e7-0186-4aef-93b4-764684cc681e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/9d43e8d9-6042-46d9-bbc3-35b4294346ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36a257e7-0186-4aef-93b4-764684cc681e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f5ddf5c-2031-4110-abef-d4a02bec3d3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f5ddf5c-2031-4110-abef-d4a02bec3d3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/9ec332f1-30de-452b-9b21-a46d9a0eed55/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f5ddf5c-2031-4110-abef-d4a02bec3d3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ed9f589-cda2-496a-a19c-bd3e49ac33d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ed9f589-cda2-496a-a19c-bd3e49ac33d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/a6d985d6-7ce6-45fd-bf67-cc2dafd5bd92/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ed9f589-cda2-496a-a19c-bd3e49ac33d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b242bb57-d904-49d0-a96e-91b1b62cfb81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b242bb57-d904-49d0-a96e-91b1b62cfb81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/a89acc7f-49a8-4a0d-8859-b64a35b5e6bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b242bb57-d904-49d0-a96e-91b1b62cfb81>.
+    
+<http://data.lblod.info/id/remote-data-objects/11cffc46-4478-4d09-b041-5d205b8403ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11cffc46-4478-4d09-b041-5d205b8403ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/a89cf906-0709-4b77-98fb-dae2ffca68ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11cffc46-4478-4d09-b041-5d205b8403ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b656753-210f-47d7-88e9-0b8a4341a3c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b656753-210f-47d7-88e9-0b8a4341a3c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/aabf5afb-a8c8-43e1-989a-4eb048b3975d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b656753-210f-47d7-88e9-0b8a4341a3c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2d13b09-7a47-4a93-ac47-969fb38cb6a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2d13b09-7a47-4a93-ac47-969fb38cb6a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/adb81f06-b406-494a-8a41-aaa0f527d6d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2d13b09-7a47-4a93-ac47-969fb38cb6a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/aca28d91-14e3-4f9b-a089-87e12abd9eb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aca28d91-14e3-4f9b-a089-87e12abd9eb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/af196e5c-2be3-4300-9ad2-bd2b2b0043b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aca28d91-14e3-4f9b-a089-87e12abd9eb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b168aa1b-c33a-43f3-b9e0-9056ae0e0c5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b168aa1b-c33a-43f3-b9e0-9056ae0e0c5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/af22a94d-1763-40f4-b368-49611c67182b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b168aa1b-c33a-43f3-b9e0-9056ae0e0c5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/063b349e-5987-48bf-8262-e32a736958a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "063b349e-5987-48bf-8262-e32a736958a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/af8a3659-8d14-4c83-9a75-53986fbb731b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/063b349e-5987-48bf-8262-e32a736958a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e183f60-2d1c-4d28-af40-377dd1668cce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e183f60-2d1c-4d28-af40-377dd1668cce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/bf748c2d-e01f-479a-b77e-7db0375ec16c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e183f60-2d1c-4d28-af40-377dd1668cce>.
+    
+<http://data.lblod.info/id/remote-data-objects/be640d31-9284-4036-af52-9b27d119462e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be640d31-9284-4036-af52-9b27d119462e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/c14af1da-b0af-485f-ba1c-5e945ab8121d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be640d31-9284-4036-af52-9b27d119462e>.
+    
+<http://data.lblod.info/id/remote-data-objects/da81bd3d-7e2e-4699-83c8-09490ec95e99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da81bd3d-7e2e-4699-83c8-09490ec95e99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/c3e23c53-9cf2-4259-b526-6b1c2e0934e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da81bd3d-7e2e-4699-83c8-09490ec95e99>.
+    
+<http://data.lblod.info/id/remote-data-objects/72a69c37-a033-41c4-812e-f3753bba9168> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72a69c37-a033-41c4-812e-f3753bba9168";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/c462ba30-be31-4a58-bf7d-cc76a1cc4a76/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72a69c37-a033-41c4-812e-f3753bba9168>.
+    
+<http://data.lblod.info/id/remote-data-objects/416e1767-ac4a-4ad9-891c-6a1b67b851b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "416e1767-ac4a-4ad9-891c-6a1b67b851b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/c6eedbef-3343-4ef6-bb46-5c583197db1e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/416e1767-ac4a-4ad9-891c-6a1b67b851b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/59c87ecf-0547-4b97-9631-27d915ce78b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59c87ecf-0547-4b97-9631-27d915ce78b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/c94b21be-a082-415a-95f9-081c301b7ba3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59c87ecf-0547-4b97-9631-27d915ce78b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/32435940-d01e-47ef-83f5-c55d54c2fb0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32435940-d01e-47ef-83f5-c55d54c2fb0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/c9990d3c-50cd-42c5-8bb5-eb2f022578d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32435940-d01e-47ef-83f5-c55d54c2fb0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb5c87af-708b-46b8-a8f8-baa4bac60b52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb5c87af-708b-46b8-a8f8-baa4bac60b52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/ccc30f3a-0cdc-4d99-8ac4-80553b1d684c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb5c87af-708b-46b8-a8f8-baa4bac60b52>.
+    
+<http://data.lblod.info/id/remote-data-objects/321d2fdb-3d04-4d20-baac-dfe9fa216729> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "321d2fdb-3d04-4d20-baac-dfe9fa216729";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/d3e88a43-e75a-4b34-b133-4441d2210a54/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/321d2fdb-3d04-4d20-baac-dfe9fa216729>.
+    
+<http://data.lblod.info/id/remote-data-objects/79c9acc1-374a-4755-a8ab-7d20ded2cc69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79c9acc1-374a-4755-a8ab-7d20ded2cc69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/d5c72e5a-8132-4ee0-9cf8-f70ac5fa9e74/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79c9acc1-374a-4755-a8ab-7d20ded2cc69>.
+    
+<http://data.lblod.info/id/remote-data-objects/094d2684-623a-4ce0-8087-2d92537dcb8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "094d2684-623a-4ce0-8087-2d92537dcb8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/e007f5f2-4f5a-48ba-9b77-79c4d50d310d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/094d2684-623a-4ce0-8087-2d92537dcb8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/aac09427-aaf3-4428-a594-a5b281be651c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aac09427-aaf3-4428-a594-a5b281be651c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/e20681ce-c892-4ad9-90aa-9b4c5b785ba4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aac09427-aaf3-4428-a594-a5b281be651c>.
+    
+<http://data.lblod.info/id/remote-data-objects/74535f71-0ed3-432b-be91-af39482e1778> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74535f71-0ed3-432b-be91-af39482e1778";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/e605b54d-65d1-4d63-9567-85ee87ed42dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74535f71-0ed3-432b-be91-af39482e1778>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ea5b3c6-aa0d-4075-815d-eada05c99233> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ea5b3c6-aa0d-4075-815d-eada05c99233";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/e6fdcd8f-2117-4ec7-b2e9-4fc9149c0fba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ea5b3c6-aa0d-4075-815d-eada05c99233>.
+    
+<http://data.lblod.info/id/remote-data-objects/029387cb-b2ea-4d0a-991a-64b9c553449f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "029387cb-b2ea-4d0a-991a-64b9c553449f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/f4c34f47-dac5-411d-8f60-63dfb0118f23/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/029387cb-b2ea-4d0a-991a-64b9c553449f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0813d7cb-1767-41f2-a12b-7f759c07ccc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0813d7cb-1767-41f2-a12b-7f759c07ccc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/f8653798-15a1-437a-bc64-6845222e7c41/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0813d7cb-1767-41f2-a12b-7f759c07ccc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/3259b2f2-d737-40b5-a266-c9a8290bd2c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3259b2f2-d737-40b5-a266-c9a8290bd2c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/fa1dd72b-702e-4b9a-b310-77a1d143b90f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3259b2f2-d737-40b5-a266-c9a8290bd2c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/320fb9bc-2be4-4a2a-8f69-cc71216fc134> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "320fb9bc-2be4-4a2a-8f69-cc71216fc134";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/cbs/fe1ca4d3-fbaa-402b-ad1a-2ed3f685eb00/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/320fb9bc-2be4-4a2a-8f69-cc71216fc134>.
+    
+<http://data.lblod.info/id/remote-data-objects/1008cea2-b038-4e6a-8b2f-a309424c68eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1008cea2-b038-4e6a-8b2f-a309424c68eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/29b4ca7f-3cbc-4fce-bd26-1fdc77fe41c4/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1008cea2-b038-4e6a-8b2f-a309424c68eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc0177d5-e6c6-44db-97f1-0b61a9a91d42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc0177d5-e6c6-44db-97f1-0b61a9a91d42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/29b4ca7f-3cbc-4fce-bd26-1fdc77fe41c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc0177d5-e6c6-44db-97f1-0b61a9a91d42>.
+    
+<http://data.lblod.info/id/remote-data-objects/e596b5ee-2257-40e4-8e43-6731a967c240> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e596b5ee-2257-40e4-8e43-6731a967c240";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/29b4ca7f-3cbc-4fce-bd26-1fdc77fe41c4/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e596b5ee-2257-40e4-8e43-6731a967c240>.
+    
+<http://data.lblod.info/id/remote-data-objects/819481a5-b6db-403b-a533-0213dc3f2fac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "819481a5-b6db-403b-a533-0213dc3f2fac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/2d245dfd-7742-440d-bbd3-266178075bc8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/852adf8c-96ed-40c5-bc89-66e05c762745> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/819481a5-b6db-403b-a533-0213dc3f2fac>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201827-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201827-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201827-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201827-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/23ab3961-90b2-419b-aef1-b6e5eaacf639> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "23ab3961-90b2-419b-aef1-b6e5eaacf639";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7a5b6294-da4e-4b22-bb1c-2fdc867404f8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e4ab82b7-4ec2-4b73-895c-2d5e7d06ba7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e4ab82b7-4ec2-4b73-895c-2d5e7d06ba7c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8>.
+
+  <http://redpencil.data.gift/id/task/aefb8232-e0fa-4285-a953-5adc7621d78c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "aefb8232-e0fa-4285-a953-5adc7621d78c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/23ab3961-90b2-419b-aef1-b6e5eaacf639>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e4ab82b7-4ec2-4b73-895c-2d5e7d06ba7c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/f6098a35-115c-4eaa-adad-73f1856b39c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6098a35-115c-4eaa-adad-73f1856b39c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/2d245dfd-7742-440d-bbd3-266178075bc8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6098a35-115c-4eaa-adad-73f1856b39c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/64535d66-6d35-43c8-bc04-8a2dba37203f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64535d66-6d35-43c8-bc04-8a2dba37203f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/2d245dfd-7742-440d-bbd3-266178075bc8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64535d66-6d35-43c8-bc04-8a2dba37203f>.
+    
+<http://data.lblod.info/id/remote-data-objects/76b4ce2a-2875-4562-9422-9b6a9bd33230> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76b4ce2a-2875-4562-9422-9b6a9bd33230";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/2e1d367c-189d-4146-b32c-bc25d3ad8706/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76b4ce2a-2875-4562-9422-9b6a9bd33230>.
+    
+<http://data.lblod.info/id/remote-data-objects/2066f5fb-4f83-4cd0-ba3d-8816775712a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2066f5fb-4f83-4cd0-ba3d-8816775712a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/2e1d367c-189d-4146-b32c-bc25d3ad8706/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2066f5fb-4f83-4cd0-ba3d-8816775712a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/74611ed5-fa42-4218-9fd6-3d188718f4f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74611ed5-fa42-4218-9fd6-3d188718f4f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/2e1d367c-189d-4146-b32c-bc25d3ad8706/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74611ed5-fa42-4218-9fd6-3d188718f4f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c633de63-c75d-4e11-b54d-7fd31bf125ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c633de63-c75d-4e11-b54d-7fd31bf125ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/55ce3934-21be-49cd-9c50-865bbba5cf56/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c633de63-c75d-4e11-b54d-7fd31bf125ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/17e570e2-928d-4090-ad7a-bacc3b29d814> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17e570e2-928d-4090-ad7a-bacc3b29d814";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/55ce3934-21be-49cd-9c50-865bbba5cf56/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17e570e2-928d-4090-ad7a-bacc3b29d814>.
+    
+<http://data.lblod.info/id/remote-data-objects/65a324f6-466c-44df-bf80-ac30fb1e285c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65a324f6-466c-44df-bf80-ac30fb1e285c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/55ce3934-21be-49cd-9c50-865bbba5cf56/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65a324f6-466c-44df-bf80-ac30fb1e285c>.
+    
+<http://data.lblod.info/id/remote-data-objects/df547011-9c57-4400-bc40-1473972c88e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df547011-9c57-4400-bc40-1473972c88e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/77c2826d-f8ec-415a-9774-f0919db73f2b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df547011-9c57-4400-bc40-1473972c88e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f4dfaad-d3ec-4e95-8c06-6da155f3936e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f4dfaad-d3ec-4e95-8c06-6da155f3936e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/77c2826d-f8ec-415a-9774-f0919db73f2b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f4dfaad-d3ec-4e95-8c06-6da155f3936e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c0ca8e8-dbcb-4eb5-af4b-052fccf6af62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c0ca8e8-dbcb-4eb5-af4b-052fccf6af62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/77c2826d-f8ec-415a-9774-f0919db73f2b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c0ca8e8-dbcb-4eb5-af4b-052fccf6af62>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fd3ed96-166e-4153-9453-9c65e3c9bf91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fd3ed96-166e-4153-9453-9c65e3c9bf91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/89033031-db4d-44fe-af4e-29616c674068/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fd3ed96-166e-4153-9453-9c65e3c9bf91>.
+    
+<http://data.lblod.info/id/remote-data-objects/af6a8d40-b0af-432e-aff9-cd632729011c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af6a8d40-b0af-432e-aff9-cd632729011c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/89033031-db4d-44fe-af4e-29616c674068/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af6a8d40-b0af-432e-aff9-cd632729011c>.
+    
+<http://data.lblod.info/id/remote-data-objects/21374dcf-63d2-4700-b06a-75f73824f9e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21374dcf-63d2-4700-b06a-75f73824f9e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/89033031-db4d-44fe-af4e-29616c674068/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21374dcf-63d2-4700-b06a-75f73824f9e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/cadf6f55-29e2-4c84-9fca-803b8780b59c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cadf6f55-29e2-4c84-9fca-803b8780b59c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/9187da16-85dc-4cd6-bf0f-88d01b053026/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cadf6f55-29e2-4c84-9fca-803b8780b59c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1c3736e-1b02-42f9-a731-3efceb7c6bc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1c3736e-1b02-42f9-a731-3efceb7c6bc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/9187da16-85dc-4cd6-bf0f-88d01b053026/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1c3736e-1b02-42f9-a731-3efceb7c6bc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/34c42d9c-2ba6-4f2c-a1a1-8e37c5ab58b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34c42d9c-2ba6-4f2c-a1a1-8e37c5ab58b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/9187da16-85dc-4cd6-bf0f-88d01b053026/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34c42d9c-2ba6-4f2c-a1a1-8e37c5ab58b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ddb25b5-8924-4997-905b-8d95c3dca9b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ddb25b5-8924-4997-905b-8d95c3dca9b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/9925970a-be4a-40bb-be6c-57938c178946/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ddb25b5-8924-4997-905b-8d95c3dca9b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b52ac710-9c37-4d90-aeba-809e1fc678b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b52ac710-9c37-4d90-aeba-809e1fc678b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/9925970a-be4a-40bb-be6c-57938c178946/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b52ac710-9c37-4d90-aeba-809e1fc678b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/225dce9d-4725-45ef-92e9-906ba4a1d116> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "225dce9d-4725-45ef-92e9-906ba4a1d116";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/9925970a-be4a-40bb-be6c-57938c178946/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/225dce9d-4725-45ef-92e9-906ba4a1d116>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8c8eb58-52d3-4640-a6d9-baaf68b2c8c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8c8eb58-52d3-4640-a6d9-baaf68b2c8c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/bc2503ba-af7a-4d13-aba7-e919f744e73a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8c8eb58-52d3-4640-a6d9-baaf68b2c8c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5560164-e5ca-479b-bbc2-0a75a3972893> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5560164-e5ca-479b-bbc2-0a75a3972893";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/bc2503ba-af7a-4d13-aba7-e919f744e73a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5560164-e5ca-479b-bbc2-0a75a3972893>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cd816df-6b99-43dd-9c68-a829e1cf3bae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cd816df-6b99-43dd-9c68-a829e1cf3bae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/be3715b8-4ea4-4797-9b24-bdaf431d3f9d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cd816df-6b99-43dd-9c68-a829e1cf3bae>.
+    
+<http://data.lblod.info/id/remote-data-objects/0781df86-a235-4b8d-bd11-97f692fecdbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0781df86-a235-4b8d-bd11-97f692fecdbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/be3715b8-4ea4-4797-9b24-bdaf431d3f9d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0781df86-a235-4b8d-bd11-97f692fecdbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d4c8323-28a6-411e-aa02-404584b9a0e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d4c8323-28a6-411e-aa02-404584b9a0e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/be3715b8-4ea4-4797-9b24-bdaf431d3f9d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d4c8323-28a6-411e-aa02-404584b9a0e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/eaad3158-7d46-4eab-b456-366afba8b541> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eaad3158-7d46-4eab-b456-366afba8b541";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/cb7146b9-b753-4208-9aeb-68c3b51b4921/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eaad3158-7d46-4eab-b456-366afba8b541>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f2ccd37-3ae3-42af-bd12-b9cf256bb787> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f2ccd37-3ae3-42af-bd12-b9cf256bb787";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/cb7146b9-b753-4208-9aeb-68c3b51b4921/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f2ccd37-3ae3-42af-bd12-b9cf256bb787>.
+    
+<http://data.lblod.info/id/remote-data-objects/f05befec-d7a3-4ec4-a66b-e30f3279b466> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f05befec-d7a3-4ec4-a66b-e30f3279b466";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/cb7146b9-b753-4208-9aeb-68c3b51b4921/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f05befec-d7a3-4ec4-a66b-e30f3279b466>.
+    
+<http://data.lblod.info/id/remote-data-objects/81a06d74-26d7-4771-b3da-8cff08bba2b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81a06d74-26d7-4771-b3da-8cff08bba2b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/cd848431-373a-47db-ad82-c2e7a148583f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81a06d74-26d7-4771-b3da-8cff08bba2b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a4251db-5f35-4ebd-8310-5b56676a92dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a4251db-5f35-4ebd-8310-5b56676a92dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/cd848431-373a-47db-ad82-c2e7a148583f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a4251db-5f35-4ebd-8310-5b56676a92dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/41fe6f43-21cd-4c57-9a24-b0d11209e80f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41fe6f43-21cd-4c57-9a24-b0d11209e80f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/cd848431-373a-47db-ad82-c2e7a148583f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41fe6f43-21cd-4c57-9a24-b0d11209e80f>.
+    
+<http://data.lblod.info/id/remote-data-objects/01bfef7b-6fe5-41aa-8d13-015648c17702> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01bfef7b-6fe5-41aa-8d13-015648c17702";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/e3848e5c-2d2a-4843-97e6-397c823d2d77/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01bfef7b-6fe5-41aa-8d13-015648c17702>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9625afe-815d-49d0-96ce-0c1dc6347c45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9625afe-815d-49d0-96ce-0c1dc6347c45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/e3848e5c-2d2a-4843-97e6-397c823d2d77/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9625afe-815d-49d0-96ce-0c1dc6347c45>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad2f350d-61ee-4be3-bbb6-c690d8b24f39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad2f350d-61ee-4be3-bbb6-c690d8b24f39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/e3848e5c-2d2a-4843-97e6-397c823d2d77/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad2f350d-61ee-4be3-bbb6-c690d8b24f39>.
+    
+<http://data.lblod.info/id/remote-data-objects/a41428a3-3a71-4fd0-917e-0be80b5f3727> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a41428a3-3a71-4fd0-917e-0be80b5f3727";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/e3c46ae5-d962-4c57-aaad-016cedcdead6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a41428a3-3a71-4fd0-917e-0be80b5f3727>.
+    
+<http://data.lblod.info/id/remote-data-objects/787a454b-ee7a-4e12-ae84-80bdab49cc3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "787a454b-ee7a-4e12-ae84-80bdab49cc3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/e3c46ae5-d962-4c57-aaad-016cedcdead6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/787a454b-ee7a-4e12-ae84-80bdab49cc3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9265d5a-82f1-4402-a757-cd70b7a39910> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9265d5a-82f1-4402-a757-cd70b7a39910";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/e3c46ae5-d962-4c57-aaad-016cedcdead6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9265d5a-82f1-4402-a757-cd70b7a39910>.
+    
+<http://data.lblod.info/id/remote-data-objects/57d3fb8f-100d-47df-a3d0-552ea3fe4357> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57d3fb8f-100d-47df-a3d0-552ea3fe4357";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/f22689de-9f85-4c6f-a6b1-49e4bc5beb3e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57d3fb8f-100d-47df-a3d0-552ea3fe4357>.
+    
+<http://data.lblod.info/id/remote-data-objects/8873c42e-6254-4bda-b201-80e0847a5ff2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8873c42e-6254-4bda-b201-80e0847a5ff2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/f22689de-9f85-4c6f-a6b1-49e4bc5beb3e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8873c42e-6254-4bda-b201-80e0847a5ff2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fb5b121-4931-4a77-8241-1ed7f3641c6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fb5b121-4931-4a77-8241-1ed7f3641c6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/gr/f22689de-9f85-4c6f-a6b1-49e4bc5beb3e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fb5b121-4931-4a77-8241-1ed7f3641c6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/baec0ccc-0193-4e59-a418-a732ef08aa80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "baec0ccc-0193-4e59-a418-a732ef08aa80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/3350ecba-e4ae-4ffb-a228-9ea3519b186a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/baec0ccc-0193-4e59-a418-a732ef08aa80>.
+    
+<http://data.lblod.info/id/remote-data-objects/0067a9b9-97a0-454f-9ecd-3249b462e66a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0067a9b9-97a0-454f-9ecd-3249b462e66a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/3350ecba-e4ae-4ffb-a228-9ea3519b186a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0067a9b9-97a0-454f-9ecd-3249b462e66a>.
+    
+<http://data.lblod.info/id/remote-data-objects/239ea61c-980f-48d6-9ace-031df3fc1ee0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "239ea61c-980f-48d6-9ace-031df3fc1ee0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/3350ecba-e4ae-4ffb-a228-9ea3519b186a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/239ea61c-980f-48d6-9ace-031df3fc1ee0>.
+    
+<http://data.lblod.info/id/remote-data-objects/0060c134-b15e-4ee8-8c5b-3d420a10714a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0060c134-b15e-4ee8-8c5b-3d420a10714a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/40dc3ee7-ddec-4c2e-add7-aba1ac7b5850/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0060c134-b15e-4ee8-8c5b-3d420a10714a>.
+    
+<http://data.lblod.info/id/remote-data-objects/49ba04d9-b3c5-45f9-86ef-d8783d8e50c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49ba04d9-b3c5-45f9-86ef-d8783d8e50c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/40dc3ee7-ddec-4c2e-add7-aba1ac7b5850/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49ba04d9-b3c5-45f9-86ef-d8783d8e50c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6b7ca69-7257-4f53-9e3f-51f90dbd07d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6b7ca69-7257-4f53-9e3f-51f90dbd07d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/40dc3ee7-ddec-4c2e-add7-aba1ac7b5850/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6b7ca69-7257-4f53-9e3f-51f90dbd07d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/686a1c50-3f86-4532-92c4-97a3c93679fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "686a1c50-3f86-4532-92c4-97a3c93679fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/45286068-b491-42b9-9b99-4f424d0bc9fe/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/686a1c50-3f86-4532-92c4-97a3c93679fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f79f388-70a9-40a1-90e7-47fe181520b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f79f388-70a9-40a1-90e7-47fe181520b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/45286068-b491-42b9-9b99-4f424d0bc9fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f79f388-70a9-40a1-90e7-47fe181520b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bbb3cd3-f9dd-4ef6-b9a9-7f9039a54459> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bbb3cd3-f9dd-4ef6-b9a9-7f9039a54459";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/45286068-b491-42b9-9b99-4f424d0bc9fe/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bbb3cd3-f9dd-4ef6-b9a9-7f9039a54459>.
+    
+<http://data.lblod.info/id/remote-data-objects/de745cb1-b642-4c43-b0cf-e36de118d1b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de745cb1-b642-4c43-b0cf-e36de118d1b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/61e7d6b1-3fb3-41b2-9749-05acb857790a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7a5b6294-da4e-4b22-bb1c-2fdc867404f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de745cb1-b642-4c43-b0cf-e36de118d1b2>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201828-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201828-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201828-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201828-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e6c7640a-388c-49d2-9183-6da1a7db43b8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e6c7640a-388c-49d2-9183-6da1a7db43b8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b13c82e9-36e2-418f-b844-76824e46448b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b13c82e9-36e2-418f-b844-76824e46448b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8>.
+
+  <http://redpencil.data.gift/id/task/2fa399c9-214b-47b6-a770-d2067faa2b92> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2fa399c9-214b-47b6-a770-d2067faa2b92";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e6c7640a-388c-49d2-9183-6da1a7db43b8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b13c82e9-36e2-418f-b844-76824e46448b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b686cb59-c86f-49d6-9f7a-212167d55c7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b686cb59-c86f-49d6-9f7a-212167d55c7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/61e7d6b1-3fb3-41b2-9749-05acb857790a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b686cb59-c86f-49d6-9f7a-212167d55c7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad8166a0-4a3d-4d22-9370-0c477ee2f032> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad8166a0-4a3d-4d22-9370-0c477ee2f032";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/61e7d6b1-3fb3-41b2-9749-05acb857790a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad8166a0-4a3d-4d22-9370-0c477ee2f032>.
+    
+<http://data.lblod.info/id/remote-data-objects/39ead376-0a33-4047-a37f-963c2d7a7791> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39ead376-0a33-4047-a37f-963c2d7a7791";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/6989c913-4efd-493d-825f-e60b0e81dd7b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39ead376-0a33-4047-a37f-963c2d7a7791>.
+    
+<http://data.lblod.info/id/remote-data-objects/656334b6-6d5c-4257-b0ed-2b0bb0f5873c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "656334b6-6d5c-4257-b0ed-2b0bb0f5873c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/6989c913-4efd-493d-825f-e60b0e81dd7b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/656334b6-6d5c-4257-b0ed-2b0bb0f5873c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c0440e0-cdb3-4598-ad48-9abe3f505fe7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c0440e0-cdb3-4598-ad48-9abe3f505fe7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/6989c913-4efd-493d-825f-e60b0e81dd7b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c0440e0-cdb3-4598-ad48-9abe3f505fe7>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d12651b-9011-4e5f-b6a1-428cc85b3b49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d12651b-9011-4e5f-b6a1-428cc85b3b49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/7d392177-984e-4b1a-a38d-65491c87fe46/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d12651b-9011-4e5f-b6a1-428cc85b3b49>.
+    
+<http://data.lblod.info/id/remote-data-objects/e11a8307-681e-4ab1-be0a-c1b2e08b160c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e11a8307-681e-4ab1-be0a-c1b2e08b160c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/7d392177-984e-4b1a-a38d-65491c87fe46/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e11a8307-681e-4ab1-be0a-c1b2e08b160c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea5661fc-7b93-42d4-9551-69ab8faa0b84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea5661fc-7b93-42d4-9551-69ab8faa0b84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/7d392177-984e-4b1a-a38d-65491c87fe46/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea5661fc-7b93-42d4-9551-69ab8faa0b84>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2b0777f-a114-465c-add2-d035c4b40f01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2b0777f-a114-465c-add2-d035c4b40f01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/8383d465-aab6-4c89-a242-85fe4aee5923/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2b0777f-a114-465c-add2-d035c4b40f01>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd95a78a-ecaf-4232-9709-644626cda1ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd95a78a-ecaf-4232-9709-644626cda1ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/8383d465-aab6-4c89-a242-85fe4aee5923/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd95a78a-ecaf-4232-9709-644626cda1ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec5640c9-5307-4cd9-8ae9-63f102fc20d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec5640c9-5307-4cd9-8ae9-63f102fc20d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/8383d465-aab6-4c89-a242-85fe4aee5923/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec5640c9-5307-4cd9-8ae9-63f102fc20d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1b84a89-509e-417c-9d71-1189615d7910> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1b84a89-509e-417c-9d71-1189615d7910";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/85ebae07-408a-4917-a4cb-3b886390a582/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1b84a89-509e-417c-9d71-1189615d7910>.
+    
+<http://data.lblod.info/id/remote-data-objects/70f6bcea-fe0e-4755-9bfb-8c63d0f22b32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70f6bcea-fe0e-4755-9bfb-8c63d0f22b32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/85ebae07-408a-4917-a4cb-3b886390a582/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70f6bcea-fe0e-4755-9bfb-8c63d0f22b32>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc109230-7464-4ae1-81bc-69f866247375> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc109230-7464-4ae1-81bc-69f866247375";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/85ebae07-408a-4917-a4cb-3b886390a582/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc109230-7464-4ae1-81bc-69f866247375>.
+    
+<http://data.lblod.info/id/remote-data-objects/c51710be-61a8-42de-be4f-982f7d044cad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c51710be-61a8-42de-be4f-982f7d044cad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/a6fdc051-0fdf-452f-ad87-d3d52ee7c39b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c51710be-61a8-42de-be4f-982f7d044cad>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8c73651-ca7b-4db9-8ba9-6d59a25a2eb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8c73651-ca7b-4db9-8ba9-6d59a25a2eb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/a6fdc051-0fdf-452f-ad87-d3d52ee7c39b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8c73651-ca7b-4db9-8ba9-6d59a25a2eb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/3531da54-abf3-45e6-a391-13d3c463fa7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3531da54-abf3-45e6-a391-13d3c463fa7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/a6fdc051-0fdf-452f-ad87-d3d52ee7c39b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3531da54-abf3-45e6-a391-13d3c463fa7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5db3c730-434c-40d9-a1c5-39850fdf1957> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5db3c730-434c-40d9-a1c5-39850fdf1957";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/b76fd085-b417-427d-93ad-a932f6106793/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5db3c730-434c-40d9-a1c5-39850fdf1957>.
+    
+<http://data.lblod.info/id/remote-data-objects/624186ab-4261-4b52-ad79-570a7c96a4d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "624186ab-4261-4b52-ad79-570a7c96a4d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/b76fd085-b417-427d-93ad-a932f6106793/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/624186ab-4261-4b52-ad79-570a7c96a4d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/145a01cc-4235-4bb5-b798-91ee42f53e79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "145a01cc-4235-4bb5-b798-91ee42f53e79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/b76fd085-b417-427d-93ad-a932f6106793/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/145a01cc-4235-4bb5-b798-91ee42f53e79>.
+    
+<http://data.lblod.info/id/remote-data-objects/eeec42c2-9974-4802-a2a6-492b55b109ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eeec42c2-9974-4802-a2a6-492b55b109ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/ced50f60-764c-4984-94b0-03b00f3ed2be/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eeec42c2-9974-4802-a2a6-492b55b109ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec39dc47-8cf9-4591-91b7-062fde0ab264> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec39dc47-8cf9-4591-91b7-062fde0ab264";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/ced50f60-764c-4984-94b0-03b00f3ed2be/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec39dc47-8cf9-4591-91b7-062fde0ab264>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb793374-3877-48a9-b659-9653ae945d46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb793374-3877-48a9-b659-9653ae945d46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/ced50f60-764c-4984-94b0-03b00f3ed2be/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb793374-3877-48a9-b659-9653ae945d46>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd1cc45a-3631-48b6-9eed-51093525525f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd1cc45a-3631-48b6-9eed-51093525525f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/ea29ab7d-85d6-41b3-b1db-d6650e9ca129/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd1cc45a-3631-48b6-9eed-51093525525f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4962a5a-27a0-4ab3-a7a3-59904a534841> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4962a5a-27a0-4ab3-a7a3-59904a534841";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/ea29ab7d-85d6-41b3-b1db-d6650e9ca129/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4962a5a-27a0-4ab3-a7a3-59904a534841>.
+    
+<http://data.lblod.info/id/remote-data-objects/13e740d4-c729-4c32-910c-32ade084e047> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13e740d4-c729-4c32-910c-32ade084e047";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/ea29ab7d-85d6-41b3-b1db-d6650e9ca129/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13e740d4-c729-4c32-910c-32ade084e047>.
+    
+<http://data.lblod.info/id/remote-data-objects/def1f16e-41be-4a55-88ac-226c9b785c95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "def1f16e-41be-4a55-88ac-226c9b785c95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/fa2f008b-e709-4b10-ba1a-ced2d299f1f7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/def1f16e-41be-4a55-88ac-226c9b785c95>.
+    
+<http://data.lblod.info/id/remote-data-objects/06cc6457-9347-498c-8ca9-d46165e41b2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06cc6457-9347-498c-8ca9-d46165e41b2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/fa2f008b-e709-4b10-ba1a-ced2d299f1f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06cc6457-9347-498c-8ca9-d46165e41b2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8b23789-29e2-4576-828b-55941f88c410> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8b23789-29e2-4576-828b-55941f88c410";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/fa7947c3-90a4-4367-bfdd-7460f1eaa507/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8b23789-29e2-4576-828b-55941f88c410>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc999dc0-0b80-4eee-a256-f0604cc6ad2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc999dc0-0b80-4eee-a256-f0604cc6ad2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/fa7947c3-90a4-4367-bfdd-7460f1eaa507/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc999dc0-0b80-4eee-a256-f0604cc6ad2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b7a30c4-91c9-4fa6-aac6-d3dcb9ad4d51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b7a30c4-91c9-4fa6-aac6-d3dcb9ad4d51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/fa7947c3-90a4-4367-bfdd-7460f1eaa507/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b7a30c4-91c9-4fa6-aac6-d3dcb9ad4d51>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cb7d30b-6d56-4f74-99b1-220d827ebdd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cb7d30b-6d56-4f74-99b1-220d827ebdd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/fd480dd1-c0dc-4c12-8b82-7202f4da59b7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cb7d30b-6d56-4f74-99b1-220d827ebdd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c558139e-a0e9-4ce2-859e-b754f3013975> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c558139e-a0e9-4ce2-859e-b754f3013975";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/fd480dd1-c0dc-4c12-8b82-7202f4da59b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c558139e-a0e9-4ce2-859e-b754f3013975>.
+    
+<http://data.lblod.info/id/remote-data-objects/b40e833f-6976-47e5-ae3b-029d60856c8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b40e833f-6976-47e5-ae3b-029d60856c8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/rmw/fd480dd1-c0dc-4c12-8b82-7202f4da59b7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b40e833f-6976-47e5-ae3b-029d60856c8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a97e87a9-c8f4-4b77-bd28-f79db91c4295> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a97e87a9-c8f4-4b77-bd28-f79db91c4295";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/0289472a-5cbe-4d8b-8038-934f5a56b7d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a97e87a9-c8f4-4b77-bd28-f79db91c4295>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f1352ab-3f54-4b18-9a5b-3b3128b113b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f1352ab-3f54-4b18-9a5b-3b3128b113b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/03684f69-e7ec-4697-bbbd-46c645f9847f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f1352ab-3f54-4b18-9a5b-3b3128b113b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4879dbd-bbe3-4ffa-a0d5-79bf75563519> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4879dbd-bbe3-4ffa-a0d5-79bf75563519";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/045f48c1-c2de-4950-95cb-93fe17b5d1ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4879dbd-bbe3-4ffa-a0d5-79bf75563519>.
+    
+<http://data.lblod.info/id/remote-data-objects/8dacb2cd-5c6d-4ab2-8f24-c98b96df0064> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8dacb2cd-5c6d-4ab2-8f24-c98b96df0064";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/14c7dfc5-f20f-438a-a4c5-47df56787c02/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8dacb2cd-5c6d-4ab2-8f24-c98b96df0064>.
+    
+<http://data.lblod.info/id/remote-data-objects/11727ab2-c0fe-48f2-a408-94fdbcc87746> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11727ab2-c0fe-48f2-a408-94fdbcc87746";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/248ce287-8c43-45b8-bced-830e28f3f1ca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11727ab2-c0fe-48f2-a408-94fdbcc87746>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ecfe2b9-752c-46bf-9006-3d18b880db45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ecfe2b9-752c-46bf-9006-3d18b880db45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/26e7460f-9ce0-426d-830d-2612e475c591/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ecfe2b9-752c-46bf-9006-3d18b880db45>.
+    
+<http://data.lblod.info/id/remote-data-objects/faa53a72-dab8-4982-a10f-d431396cf80d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "faa53a72-dab8-4982-a10f-d431396cf80d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/3666c0b5-cfa4-4192-96c9-6e018d99a698/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/faa53a72-dab8-4982-a10f-d431396cf80d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5836c6e-904b-4e9d-b111-ab101e48eae4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5836c6e-904b-4e9d-b111-ab101e48eae4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/3db62b54-5ac8-4d2b-b3b0-566fb3cf451d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5836c6e-904b-4e9d-b111-ab101e48eae4>.
+    
+<http://data.lblod.info/id/remote-data-objects/40e8e02e-ac07-4502-9ddd-faf1da7a9c09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40e8e02e-ac07-4502-9ddd-faf1da7a9c09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/4164fdd2-640d-4203-af4c-97d3353f8554/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40e8e02e-ac07-4502-9ddd-faf1da7a9c09>.
+    
+<http://data.lblod.info/id/remote-data-objects/8efa02f6-e89b-47d5-adad-762d4f2ed2f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8efa02f6-e89b-47d5-adad-762d4f2ed2f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/46040722-adc7-45e8-a00e-022b823ade81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8efa02f6-e89b-47d5-adad-762d4f2ed2f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f88843ec-bce0-4832-99c7-7f6238af253f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f88843ec-bce0-4832-99c7-7f6238af253f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/54fcfc59-afeb-4075-a8dd-b7ef5715ab08/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f88843ec-bce0-4832-99c7-7f6238af253f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1477edf4-12ad-4783-be00-a03ffbf218ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1477edf4-12ad-4783-be00-a03ffbf218ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/5cbab058-d30c-4d83-bd39-1e5f343dc657/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1477edf4-12ad-4783-be00-a03ffbf218ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2f4d134-a106-41c2-818c-284938b9a048> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2f4d134-a106-41c2-818c-284938b9a048";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/65b1ec01-7ecb-49ec-b6f2-86a12479e306/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2f4d134-a106-41c2-818c-284938b9a048>.
+    
+<http://data.lblod.info/id/remote-data-objects/409347c1-76b1-4486-812f-be9ade4f1579> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "409347c1-76b1-4486-812f-be9ade4f1579";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/67096c80-1380-4f27-a065-78e5642f041d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/409347c1-76b1-4486-812f-be9ade4f1579>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff46a366-4c7f-4f10-a6a2-bf0b0f35ecb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff46a366-4c7f-4f10-a6a2-bf0b0f35ecb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/6ff5bfac-6081-4042-a45e-cab7a3195fec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff46a366-4c7f-4f10-a6a2-bf0b0f35ecb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d28a3fbf-6ec5-4358-bab6-d02e39bb8246> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d28a3fbf-6ec5-4358-bab6-d02e39bb8246";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/71af771f-58a3-4ffe-925b-4fa466832230/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74a537c8-c1f9-4c01-a77c-f57fcc6f2ac8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d28a3fbf-6ec5-4358-bab6-d02e39bb8246>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201829-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201829-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201829-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201829-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/6c9b322e-77a0-4cfb-b647-ccb00c0e7c21> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6c9b322e-77a0-4cfb-b647-ccb00c0e7c21";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f9467694-b130-4d9e-9d67-7327b89e903c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4660c762-09bf-46d8-a986-1e65dbeee7ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4660c762-09bf-46d8-a986-1e65dbeee7ef";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c>.
+
+  <http://redpencil.data.gift/id/task/8042b986-0a08-43f5-8623-b74101717c30> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8042b986-0a08-43f5-8623-b74101717c30";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/6c9b322e-77a0-4cfb-b647-ccb00c0e7c21>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4660c762-09bf-46d8-a986-1e65dbeee7ef>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/198dca27-7a07-4c4a-b583-d81447527d60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "198dca27-7a07-4c4a-b583-d81447527d60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/7d32b211-7c97-4bfa-b4f5-165feeedfb9a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/198dca27-7a07-4c4a-b583-d81447527d60>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd467120-553e-409b-9fcb-039cef02b624> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd467120-553e-409b-9fcb-039cef02b624";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/85147227-e358-4500-8124-bcd0b5093c7d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd467120-553e-409b-9fcb-039cef02b624>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd62d41c-6b3d-4ad9-b03e-b8ca88c59e84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd62d41c-6b3d-4ad9-b03e-b8ca88c59e84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/8596b2f9-3506-40c1-8a0b-726b486df801/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd62d41c-6b3d-4ad9-b03e-b8ca88c59e84>.
+    
+<http://data.lblod.info/id/remote-data-objects/6814cf05-468b-415e-88e6-1ae1fcbd22de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6814cf05-468b-415e-88e6-1ae1fcbd22de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/87e38024-65da-4d34-943b-8511c97ed363/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6814cf05-468b-415e-88e6-1ae1fcbd22de>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8b6adb6-9576-4aa7-99b7-76ddc3e36dbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8b6adb6-9576-4aa7-99b7-76ddc3e36dbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/89491a01-c0b6-4a8f-b039-83c372762f0e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8b6adb6-9576-4aa7-99b7-76ddc3e36dbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/5951c1c6-72a4-4b48-bd70-02164787eaf7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5951c1c6-72a4-4b48-bd70-02164787eaf7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/8b5b6c7d-bd9c-4912-b78a-86536fc7e90e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5951c1c6-72a4-4b48-bd70-02164787eaf7>.
+    
+<http://data.lblod.info/id/remote-data-objects/8189659f-fe87-4bb7-9212-43a4f677d200> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8189659f-fe87-4bb7-9212-43a4f677d200";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/8ddb0a3d-d334-42b0-bcf5-dfa025d56120/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8189659f-fe87-4bb7-9212-43a4f677d200>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ad52774-3dd0-47cc-93e4-c82a769b0021> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ad52774-3dd0-47cc-93e4-c82a769b0021";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/912c8f88-097c-4500-a96a-0b2ec674cd3d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ad52774-3dd0-47cc-93e4-c82a769b0021>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2cd9684-1302-4240-8880-10a11108f96b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2cd9684-1302-4240-8880-10a11108f96b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/969cfa0f-228a-402a-aa77-739cd425c07c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2cd9684-1302-4240-8880-10a11108f96b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d510a274-604f-4d06-8255-344b37ea43bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d510a274-604f-4d06-8255-344b37ea43bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/9af5abde-69f7-44bb-87ad-1875073c9490/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d510a274-604f-4d06-8255-344b37ea43bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a36104b-20a1-4b20-9071-24e5425b8815> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a36104b-20a1-4b20-9071-24e5425b8815";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/a803eccf-0d98-4f19-b6ca-15c8a26d26bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a36104b-20a1-4b20-9071-24e5425b8815>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bda591d-65af-4381-8225-6351ccccef70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bda591d-65af-4381-8225-6351ccccef70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/b48f5aa7-b20b-4a3d-ad29-68921e8740be/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bda591d-65af-4381-8225-6351ccccef70>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fd465dd-dffe-44bb-a4e4-24391b627479> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fd465dd-dffe-44bb-a4e4-24391b627479";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/b517b96c-10f9-49b0-9999-96571c19b01d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fd465dd-dffe-44bb-a4e4-24391b627479>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c31e1ed-5658-4257-a85b-20677276e30c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c31e1ed-5658-4257-a85b-20677276e30c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/b604b4bf-093c-4e3d-b9e9-b3909d025499/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c31e1ed-5658-4257-a85b-20677276e30c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2058cc99-6945-46fc-a707-1e57cb0e0ba9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2058cc99-6945-46fc-a707-1e57cb0e0ba9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/b7e1bf25-f95e-4bb2-92ed-0a079f697572/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2058cc99-6945-46fc-a707-1e57cb0e0ba9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1b9f2ee-ef3a-4123-8493-5beb997e408e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1b9f2ee-ef3a-4123-8493-5beb997e408e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/c02e3db7-b190-4232-957c-84e1af104ddc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1b9f2ee-ef3a-4123-8493-5beb997e408e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2523a3fb-968f-4fe6-88dc-6f2eabec61b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2523a3fb-968f-4fe6-88dc-6f2eabec61b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/d28e51b4-967c-4478-9176-3b120b1cea20/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2523a3fb-968f-4fe6-88dc-6f2eabec61b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae336851-af34-4de9-a248-242a096e984e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae336851-af34-4de9-a248-242a096e984e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/d9e47cce-03c0-4ebc-af7d-cb5f44727840/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae336851-af34-4de9-a248-242a096e984e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cd37729-99c3-4679-a4b5-337dfdb8d95f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cd37729-99c3-4679-a4b5-337dfdb8d95f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/e225293e-30d4-4115-9789-7e13f007a11c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cd37729-99c3-4679-a4b5-337dfdb8d95f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a2e187a-57b8-411a-a5a6-c78aa72d45fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a2e187a-57b8-411a-a5a6-c78aa72d45fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/e6852810-e367-487f-9b63-473403875108/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a2e187a-57b8-411a-a5a6-c78aa72d45fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/90692cba-4d32-4b4c-b7fa-a1e10539d0e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90692cba-4d32-4b4c-b7fa-a1e10539d0e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/f75708f3-c767-488c-88af-416fee12e8e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90692cba-4d32-4b4c-b7fa-a1e10539d0e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/949549e8-e4e9-405b-9ec9-f39244fb5947> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "949549e8-e4e9-405b-9ec9-f39244fb5947";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/fb2939e5-be63-458d-88bf-bad99077c560/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/949549e8-e4e9-405b-9ec9-f39244fb5947>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8d38b3c-810d-4eb0-b2e5-534e0a50694e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8d38b3c-810d-4eb0-b2e5-534e0a50694e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://maldegem.meetingburger.net/vabu/fdeff4b0-158d-4961-a953-bb814557ea98/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8d38b3c-810d-4eb0-b2e5-534e0a50694e>.
+    
+<http://data.lblod.info/id/remote-data-objects/58b3b8d3-2f44-4595-8bbd-9aaa6303ddc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58b3b8d3-2f44-4595-8bbd-9aaa6303ddc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/13734a94-e85c-43ec-8134-4d7f333cbf62/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58b3b8d3-2f44-4595-8bbd-9aaa6303ddc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dd721a2-15ad-44c4-8c69-4a2ba027cef2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dd721a2-15ad-44c4-8c69-4a2ba027cef2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/158d79e7-e266-4d58-a2b8-621ee6905c42/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dd721a2-15ad-44c4-8c69-4a2ba027cef2>.
+    
+<http://data.lblod.info/id/remote-data-objects/07cf4df0-f464-4c95-81c0-d036995c3888> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07cf4df0-f464-4c95-81c0-d036995c3888";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/26cd4ed6-dd60-42a3-8482-30f1c2d48f3a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07cf4df0-f464-4c95-81c0-d036995c3888>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b68bcf8-d946-4337-8329-99e12be6b2e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b68bcf8-d946-4337-8329-99e12be6b2e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/28a0f131-58e0-4b18-bed7-e70cb051a02a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b68bcf8-d946-4337-8329-99e12be6b2e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e268fcc-dd2d-4daa-9210-39112d6f7ed5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e268fcc-dd2d-4daa-9210-39112d6f7ed5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/2b0991ee-3647-4139-8d35-e99bea828114/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e268fcc-dd2d-4daa-9210-39112d6f7ed5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c9ce9a0-8f19-47e8-a0d2-85a24e18083e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c9ce9a0-8f19-47e8-a0d2-85a24e18083e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/2ec79f9b-956e-4455-97b3-1d9820eaddef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c9ce9a0-8f19-47e8-a0d2-85a24e18083e>.
+    
+<http://data.lblod.info/id/remote-data-objects/adee1999-97a0-4f02-a37f-869c00b3d166> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "adee1999-97a0-4f02-a37f-869c00b3d166";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/3236646e-f3a0-41e4-bec4-26ec38ac213a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/adee1999-97a0-4f02-a37f-869c00b3d166>.
+    
+<http://data.lblod.info/id/remote-data-objects/71180723-a8b7-4e0b-8a74-e3445c76cadc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71180723-a8b7-4e0b-8a74-e3445c76cadc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/3b412dd1-d8f4-4179-9e54-f52a44c641b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71180723-a8b7-4e0b-8a74-e3445c76cadc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3ce4874-d8f2-4c06-9eaa-14d1a08bbed0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3ce4874-d8f2-4c06-9eaa-14d1a08bbed0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/3d7ebddf-8ec6-49ee-ab07-21fbfcafa5e4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3ce4874-d8f2-4c06-9eaa-14d1a08bbed0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1a0b643-4382-4945-8556-2768ef12f9fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1a0b643-4382-4945-8556-2768ef12f9fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/3e62ab71-59b9-4055-b855-e932af08a17e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1a0b643-4382-4945-8556-2768ef12f9fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7e8e4c8-2099-40cc-8eb8-12a742f7db3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7e8e4c8-2099-40cc-8eb8-12a742f7db3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/3f4ef913-bd60-455d-8240-e0ff97815dae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7e8e4c8-2099-40cc-8eb8-12a742f7db3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f949d4a-a9ac-412b-9ebe-7112cfca79ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f949d4a-a9ac-412b-9ebe-7112cfca79ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/3fc1d381-2d9e-49a6-9118-9c835d9630fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f949d4a-a9ac-412b-9ebe-7112cfca79ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/58b62cbc-9fca-456e-b680-2421aef02e7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58b62cbc-9fca-456e-b680-2421aef02e7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/424bd9d0-b76c-4d8b-97e8-77555de20574/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58b62cbc-9fca-456e-b680-2421aef02e7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/033cd629-8350-4d2b-8d1e-4207848f9dd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "033cd629-8350-4d2b-8d1e-4207848f9dd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/42dbf7f3-7f60-4fc2-86fe-eb654067246e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/033cd629-8350-4d2b-8d1e-4207848f9dd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/db1de99d-3dca-4bed-9a0c-2ff7bc0fa4b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db1de99d-3dca-4bed-9a0c-2ff7bc0fa4b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/4863b617-2d30-4487-b5cd-01a2e3b30064/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db1de99d-3dca-4bed-9a0c-2ff7bc0fa4b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/62962f4f-883c-4c6f-9b58-4cc9d69545d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62962f4f-883c-4c6f-9b58-4cc9d69545d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/4ac490cc-9ca7-44cd-87f0-712a08c2f681/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62962f4f-883c-4c6f-9b58-4cc9d69545d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ff986ef-ce42-4106-8f6a-eac2aca5eeb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ff986ef-ce42-4106-8f6a-eac2aca5eeb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/4b71c211-13aa-4f18-bbe5-117047b3ed08/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ff986ef-ce42-4106-8f6a-eac2aca5eeb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0180658e-0205-48d9-81bd-d6e99eada558> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0180658e-0205-48d9-81bd-d6e99eada558";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/4c7bfcbf-bdb1-42e9-8faa-10d0cd6c1fe5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0180658e-0205-48d9-81bd-d6e99eada558>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a5d06f7-9dcb-43c2-9c76-e9245f4fffa2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a5d06f7-9dcb-43c2-9c76-e9245f4fffa2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/4dd6a393-e052-411b-8eef-940ebd727710/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a5d06f7-9dcb-43c2-9c76-e9245f4fffa2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c19e7e2e-d966-426d-9f28-f936f7b476fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c19e7e2e-d966-426d-9f28-f936f7b476fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/50e065ad-1d84-4125-933d-da9ab2b0c2d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c19e7e2e-d966-426d-9f28-f936f7b476fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0ab9034-0cea-4310-bca3-565d4774458f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0ab9034-0cea-4310-bca3-565d4774458f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/56be48ff-2aac-4851-8fcf-c31c640e55d8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0ab9034-0cea-4310-bca3-565d4774458f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a97a630-2481-4320-9bf3-e98234e6fc50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a97a630-2481-4320-9bf3-e98234e6fc50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/6565e6e3-f1c9-483d-9566-3deeead0b280/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a97a630-2481-4320-9bf3-e98234e6fc50>.
+    
+<http://data.lblod.info/id/remote-data-objects/b37569ea-8045-4376-993b-8bc58fc897fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b37569ea-8045-4376-993b-8bc58fc897fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/7122f77f-41ce-4393-9671-ff671f133c68/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b37569ea-8045-4376-993b-8bc58fc897fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d7a46ea-d5b8-46d5-8068-8a7cbe980fa2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d7a46ea-d5b8-46d5-8068-8a7cbe980fa2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/74bc4e47-b368-4989-80d0-fdb34304f3fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d7a46ea-d5b8-46d5-8068-8a7cbe980fa2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b31ab7bf-5ec2-4957-bf45-cac6d54bbf9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b31ab7bf-5ec2-4957-bf45-cac6d54bbf9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/7a32568d-748d-47af-bf36-02b8cde1f53e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b31ab7bf-5ec2-4957-bf45-cac6d54bbf9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1520af8f-35df-4ac8-98ae-90548539bf6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1520af8f-35df-4ac8-98ae-90548539bf6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/7c408485-30cf-403b-b18f-54651b572631/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1520af8f-35df-4ac8-98ae-90548539bf6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/40230515-8359-4618-b9b0-358e0792cf2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40230515-8359-4618-b9b0-358e0792cf2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/81c70afe-d879-49d6-a453-378c563a1bb2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:29.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f9467694-b130-4d9e-9d67-7327b89e903c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40230515-8359-4618-b9b0-358e0792cf2d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201831-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201831-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201831-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201831-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c192010f-260a-4c0a-862b-e31e6541f86d> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c192010f-260a-4c0a-862b-e31e6541f86d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8432ed5e-ec71-49ba-a0a8-a11de5de8a88";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/55fed61a-880c-4b85-b1de-0d5891a7259d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "55fed61a-880c-4b85-b1de-0d5891a7259d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88>.
+
+  <http://redpencil.data.gift/id/task/704068f9-0f93-4fea-b615-57268ce407f2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "704068f9-0f93-4fea-b615-57268ce407f2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c192010f-260a-4c0a-862b-e31e6541f86d>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/55fed61a-880c-4b85-b1de-0d5891a7259d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/8e511ccb-1ef3-4a15-8137-eeb1f999f7a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e511ccb-1ef3-4a15-8137-eeb1f999f7a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/90ff0dac-6f64-4aef-aac2-f08dcb6c2110/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e511ccb-1ef3-4a15-8137-eeb1f999f7a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/945f7a8a-8a15-42b4-b465-a95d244b293b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "945f7a8a-8a15-42b4-b465-a95d244b293b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/9fabcd5e-6b01-4ac4-a390-a3db1f165379/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/945f7a8a-8a15-42b4-b465-a95d244b293b>.
+    
+<http://data.lblod.info/id/remote-data-objects/934b9abd-a721-4d08-b88c-bfdccb517a60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "934b9abd-a721-4d08-b88c-bfdccb517a60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/a8ff3de4-e942-4c80-b168-a55c50106784/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/934b9abd-a721-4d08-b88c-bfdccb517a60>.
+    
+<http://data.lblod.info/id/remote-data-objects/e233fd96-8985-45b6-97b9-2cd55ee427fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e233fd96-8985-45b6-97b9-2cd55ee427fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/b174386d-4b86-4bf1-8eed-f9ab9a6267c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e233fd96-8985-45b6-97b9-2cd55ee427fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e29f6c7-0da4-442b-bf1b-45ebd0dd3738> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e29f6c7-0da4-442b-bf1b-45ebd0dd3738";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/bb5585bb-2b34-4769-b10b-fe344c1f4c07/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e29f6c7-0da4-442b-bf1b-45ebd0dd3738>.
+    
+<http://data.lblod.info/id/remote-data-objects/277fb6ed-76dd-4f9f-b664-2885218ae008> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "277fb6ed-76dd-4f9f-b664-2885218ae008";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/be0b58cb-13a0-43d4-8979-0ea0de48b88f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/277fb6ed-76dd-4f9f-b664-2885218ae008>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cb58a19-ac5c-499d-8ca5-8ceaa1cceb34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cb58a19-ac5c-499d-8ca5-8ceaa1cceb34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/c4586aba-00de-4584-80aa-4ac01ee8f900/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cb58a19-ac5c-499d-8ca5-8ceaa1cceb34>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bbacdbc-252a-4090-a8bb-bb9e32a8793e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bbacdbc-252a-4090-a8bb-bb9e32a8793e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/c8509a86-07d6-4bbf-8077-fb2e8d75a71e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bbacdbc-252a-4090-a8bb-bb9e32a8793e>.
+    
+<http://data.lblod.info/id/remote-data-objects/33c95c8d-400c-44f2-ba98-9e254a772669> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33c95c8d-400c-44f2-ba98-9e254a772669";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/cc0324a2-d396-4cb6-8618-3e8142830535/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33c95c8d-400c-44f2-ba98-9e254a772669>.
+    
+<http://data.lblod.info/id/remote-data-objects/548982a6-167b-4e16-8847-928c629893e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "548982a6-167b-4e16-8847-928c629893e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/ea7e8602-3790-47a3-a95d-dfc4bd3fc329/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/548982a6-167b-4e16-8847-928c629893e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/29bfc921-fb77-4dd4-87d5-782c39e0d1c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29bfc921-fb77-4dd4-87d5-782c39e0d1c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/ed60a5ee-e36f-4ea5-a52d-18bc646a37dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29bfc921-fb77-4dd4-87d5-782c39e0d1c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/885c7923-0522-4aea-9f1f-1a6442a1bb12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "885c7923-0522-4aea-9f1f-1a6442a1bb12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/ee7ccc92-b2df-4974-886e-f24c1534e557/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/885c7923-0522-4aea-9f1f-1a6442a1bb12>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e0a2af8-5b1c-4c94-9d22-5b2b52b70989> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e0a2af8-5b1c-4c94-9d22-5b2b52b70989";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/f0fcf8c8-2c6e-477d-8ec8-da07eb803910/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e0a2af8-5b1c-4c94-9d22-5b2b52b70989>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf93acb1-7efc-4134-acb5-f04fc25b0666> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf93acb1-7efc-4134-acb5-f04fc25b0666";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/f3058b64-80a1-4529-af66-ed3f8c0b9682/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf93acb1-7efc-4134-acb5-f04fc25b0666>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd641ebb-e5d8-413b-83ec-c68acdcf46c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd641ebb-e5d8-413b-83ec-c68acdcf46c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/f63a7b1d-e9f2-413c-9f10-18589815037c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd641ebb-e5d8-413b-83ec-c68acdcf46c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f18cbb6f-35ec-464a-8211-f503399e4ad2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f18cbb6f-35ec-464a-8211-f503399e4ad2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/f6a61e28-384c-45d5-87c8-9360a2791cad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f18cbb6f-35ec-464a-8211-f503399e4ad2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f26a135b-8e57-43c5-a65f-3c5840d0810b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f26a135b-8e57-43c5-a65f-3c5840d0810b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/fd1bbff8-9d13-40a5-ae3e-dad82cb22659/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f26a135b-8e57-43c5-a65f-3c5840d0810b>.
+    
+<http://data.lblod.info/id/remote-data-objects/49519b77-cd87-4d11-b658-01e27877b188> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49519b77-cd87-4d11-b658-01e27877b188";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/fd86528c-1984-43c7-a392-8096f11ec95d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49519b77-cd87-4d11-b658-01e27877b188>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf1e0860-9a80-4aeb-83f1-d24340bca8a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf1e0860-9a80-4aeb-83f1-d24340bca8a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/bb/fe408d85-e09f-4d10-9e0f-fc271ff6b7d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf1e0860-9a80-4aeb-83f1-d24340bca8a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f744d2c-065b-40d2-be8f-bf950d4e4b49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f744d2c-065b-40d2-be8f-bf950d4e4b49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/001a54f6-6389-46d4-b79b-dd348adcd55e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f744d2c-065b-40d2-be8f-bf950d4e4b49>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c826880-aacd-4495-b161-dffd021cefb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c826880-aacd-4495-b161-dffd021cefb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/013f6f5d-8869-4523-947b-3c1fea8c71d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c826880-aacd-4495-b161-dffd021cefb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/890d4549-df13-413f-810f-54efe3a80420> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "890d4549-df13-413f-810f-54efe3a80420";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/068258bb-c7b3-4bf4-bfca-388000f5bc78/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/890d4549-df13-413f-810f-54efe3a80420>.
+    
+<http://data.lblod.info/id/remote-data-objects/89b82fde-5562-424c-b6cc-30e951b2e7ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89b82fde-5562-424c-b6cc-30e951b2e7ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/07063d18-09f7-4405-92dc-a1afaa6e5f5c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89b82fde-5562-424c-b6cc-30e951b2e7ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9768d32-f56d-4f9d-9b7d-e25c0e6534d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9768d32-f56d-4f9d-9b7d-e25c0e6534d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/08a9d150-52b2-42d6-993c-74125ca8e57f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9768d32-f56d-4f9d-9b7d-e25c0e6534d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4481502d-cc74-4389-8d10-8bd5d670786a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4481502d-cc74-4389-8d10-8bd5d670786a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/0c87ee00-6df9-4da4-bd12-f971bce1f04a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4481502d-cc74-4389-8d10-8bd5d670786a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7000bef-b471-4ab8-b902-86d531a4e66a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7000bef-b471-4ab8-b902-86d531a4e66a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/0f225e84-6532-4fee-acbd-5a314c62779d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7000bef-b471-4ab8-b902-86d531a4e66a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b256b738-608e-491f-9f4c-482268f0b678> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b256b738-608e-491f-9f4c-482268f0b678";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/10baaa3f-c399-47ec-9f27-699286b2a7b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b256b738-608e-491f-9f4c-482268f0b678>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b7b5237-5af5-491c-a74b-707687a9a6e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b7b5237-5af5-491c-a74b-707687a9a6e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/12663231-753a-4502-880a-3fda03bf60ce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b7b5237-5af5-491c-a74b-707687a9a6e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/64648d84-4bf8-48bd-aad7-85a4b61f6517> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64648d84-4bf8-48bd-aad7-85a4b61f6517";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/1449b85a-515a-4eb9-90e7-b761525f4301/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64648d84-4bf8-48bd-aad7-85a4b61f6517>.
+    
+<http://data.lblod.info/id/remote-data-objects/78d1388c-9b55-44d2-866f-6e9dcdb24456> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78d1388c-9b55-44d2-866f-6e9dcdb24456";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/14af057b-edf8-4fe9-98d5-98d525d9276a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78d1388c-9b55-44d2-866f-6e9dcdb24456>.
+    
+<http://data.lblod.info/id/remote-data-objects/c489349d-3b51-4086-8822-4314f7809da5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c489349d-3b51-4086-8822-4314f7809da5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/17874774-02e2-4a2c-a802-5a9980b555fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c489349d-3b51-4086-8822-4314f7809da5>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc910684-c507-4eaa-888f-c8462ecf1910> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc910684-c507-4eaa-888f-c8462ecf1910";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/1d247ff1-394d-4d78-b456-a9eb2f4fc1c0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc910684-c507-4eaa-888f-c8462ecf1910>.
+    
+<http://data.lblod.info/id/remote-data-objects/a735d663-a60c-4500-9b1f-77791178e436> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a735d663-a60c-4500-9b1f-77791178e436";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/1d673ff2-8510-4d21-8517-5caf165ec6ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a735d663-a60c-4500-9b1f-77791178e436>.
+    
+<http://data.lblod.info/id/remote-data-objects/3eca4c0a-0828-46c6-9675-3cb80ff4700d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3eca4c0a-0828-46c6-9675-3cb80ff4700d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/281a4ffc-1a99-4d1f-97de-6bf9a2195c22/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3eca4c0a-0828-46c6-9675-3cb80ff4700d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f24985e-fa26-405c-a216-113d0a6f8856> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f24985e-fa26-405c-a216-113d0a6f8856";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/29a58fed-62ca-4650-bfe0-1e05ebd420a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f24985e-fa26-405c-a216-113d0a6f8856>.
+    
+<http://data.lblod.info/id/remote-data-objects/65a896b9-f4fc-4d3d-89f5-900fcba8d8cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65a896b9-f4fc-4d3d-89f5-900fcba8d8cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/2abf7bbf-88d0-43b2-ba8b-ff641a7e4050/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65a896b9-f4fc-4d3d-89f5-900fcba8d8cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/8790a57a-f58d-4e36-bd23-2275f9cea0fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8790a57a-f58d-4e36-bd23-2275f9cea0fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/2b5d45ab-5ae5-47bc-880d-8f2acf64bb0e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8790a57a-f58d-4e36-bd23-2275f9cea0fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/549a5db6-3e25-48bc-9aac-9e690bff284a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "549a5db6-3e25-48bc-9aac-9e690bff284a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/3271db4e-74b6-4167-880c-d1a3f2ccd235/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/549a5db6-3e25-48bc-9aac-9e690bff284a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f86bedcb-8432-407f-9d5a-fcd95c1b5f2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f86bedcb-8432-407f-9d5a-fcd95c1b5f2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/3363f5c1-9428-4041-aac1-78a839d8650a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f86bedcb-8432-407f-9d5a-fcd95c1b5f2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d885309-feaf-407f-bb4a-a0b2757349ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d885309-feaf-407f-bb4a-a0b2757349ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/3d132ea4-7c3e-4f5b-ba06-80a61a9c89e6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d885309-feaf-407f-bb4a-a0b2757349ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/51717608-8814-4b60-86eb-aa53ee8f41c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51717608-8814-4b60-86eb-aa53ee8f41c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/3e106726-9701-4fc9-b85c-f741ab892631/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51717608-8814-4b60-86eb-aa53ee8f41c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d05b2d7-1b83-4a68-9e16-475b7771ce9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d05b2d7-1b83-4a68-9e16-475b7771ce9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/3f18cd4b-0e60-4cc4-87a3-478117023039/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d05b2d7-1b83-4a68-9e16-475b7771ce9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2adf1e3c-07a7-418a-947a-e26a19573c9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2adf1e3c-07a7-418a-947a-e26a19573c9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/42d35808-fc22-4959-9fec-e49957678ac4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2adf1e3c-07a7-418a-947a-e26a19573c9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/65a4803e-a0d7-490f-b16d-976ed6da278b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65a4803e-a0d7-490f-b16d-976ed6da278b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/44ac2d82-5442-4bee-a827-3db852447e76/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65a4803e-a0d7-490f-b16d-976ed6da278b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e3d6809-8cc9-4c4f-bf01-febde479a24b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e3d6809-8cc9-4c4f-bf01-febde479a24b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/481b8b8d-d968-489a-95bc-18733e997551/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e3d6809-8cc9-4c4f-bf01-febde479a24b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e184e5c6-0ae5-4932-ae9e-a947fe631e3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e184e5c6-0ae5-4932-ae9e-a947fe631e3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/4bd30ad2-c7bd-4875-8556-11300fd9e41c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e184e5c6-0ae5-4932-ae9e-a947fe631e3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b22a91c-f5fc-4a61-a654-08f5851933c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b22a91c-f5fc-4a61-a654-08f5851933c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/5395c663-b8aa-409a-b544-36bbcd9641ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b22a91c-f5fc-4a61-a654-08f5851933c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/34f02a11-9542-4fe9-b164-d4a8cfbd3892> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34f02a11-9542-4fe9-b164-d4a8cfbd3892";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/5bd70b13-0224-49e2-afaf-d3ecbbc55559/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34f02a11-9542-4fe9-b164-d4a8cfbd3892>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6ab1192-b422-4d96-bd76-2f37e62536a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6ab1192-b422-4d96-bd76-2f37e62536a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/5ea75039-c642-4f00-9325-16e116f514ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6ab1192-b422-4d96-bd76-2f37e62536a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/acb0f751-37f8-43c4-a917-0cacb7063736> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acb0f751-37f8-43c4-a917-0cacb7063736";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/606bf3f6-c130-4b9c-ab50-26ae99cac1a2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8432ed5e-ec71-49ba-a0a8-a11de5de8a88> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acb0f751-37f8-43c4-a917-0cacb7063736>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201832-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201832-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201832-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201832-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/36172afe-e509-433b-a940-5e22bb155f44> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "36172afe-e509-433b-a940-5e22bb155f44";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "76eda2d4-a211-4d97-b44c-870dbb15ab96";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/eadeecc3-0f94-40f6-8903-e318b1c20f1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "eadeecc3-0f94-40f6-8903-e318b1c20f1c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96>.
+
+  <http://redpencil.data.gift/id/task/2b9b6951-5d5d-4f4f-a5f9-de7c4b007fd2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2b9b6951-5d5d-4f4f-a5f9-de7c4b007fd2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/36172afe-e509-433b-a940-5e22bb155f44>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/eadeecc3-0f94-40f6-8903-e318b1c20f1c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/70f29e80-d96d-4108-865c-b7485fa27cc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70f29e80-d96d-4108-865c-b7485fa27cc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/64b6a614-0189-4a6c-a046-219b2c1e2245/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70f29e80-d96d-4108-865c-b7485fa27cc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/57d5a3e3-7d2b-4fdc-9c3e-776918a5dd20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57d5a3e3-7d2b-4fdc-9c3e-776918a5dd20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/7197d5e0-8df1-4063-99c4-499bc85bc1aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57d5a3e3-7d2b-4fdc-9c3e-776918a5dd20>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8b451b6-fbed-449b-a259-a3c2a6fdd95a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8b451b6-fbed-449b-a259-a3c2a6fdd95a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/73e041a6-8424-45ea-9b7f-9bf5d7897e6f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8b451b6-fbed-449b-a259-a3c2a6fdd95a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b43c752-a8eb-4174-a8bd-668dd11eceb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b43c752-a8eb-4174-a8bd-668dd11eceb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/7412435b-74c4-4e7c-88ac-d257df880be9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b43c752-a8eb-4174-a8bd-668dd11eceb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f479fbd-4774-47d2-9ed3-121b5e1bd94b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f479fbd-4774-47d2-9ed3-121b5e1bd94b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/769cfcdb-6d8e-40f8-986d-a65727407ff8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f479fbd-4774-47d2-9ed3-121b5e1bd94b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f01feee-faab-4ee4-baa9-b4841a13eb43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f01feee-faab-4ee4-baa9-b4841a13eb43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/774a5ded-5b5e-44de-a6f0-a478644a6082/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f01feee-faab-4ee4-baa9-b4841a13eb43>.
+    
+<http://data.lblod.info/id/remote-data-objects/71c8e094-07e0-4cb8-95cc-018d96e08a39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71c8e094-07e0-4cb8-95cc-018d96e08a39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/78a3974a-c75b-42f2-816f-c85e309c6eaa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71c8e094-07e0-4cb8-95cc-018d96e08a39>.
+    
+<http://data.lblod.info/id/remote-data-objects/181fbef6-3de0-428f-9423-da2e5a69726f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "181fbef6-3de0-428f-9423-da2e5a69726f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/79581856-49d8-4073-9170-0b8213de9177/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/181fbef6-3de0-428f-9423-da2e5a69726f>.
+    
+<http://data.lblod.info/id/remote-data-objects/36fb51ed-6c40-4f9e-9edb-490e856b31b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36fb51ed-6c40-4f9e-9edb-490e856b31b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/7eb99e43-3534-4f1d-986e-8670ab1a38bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36fb51ed-6c40-4f9e-9edb-490e856b31b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef63b23f-773a-4318-9820-32910998b7ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef63b23f-773a-4318-9820-32910998b7ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/829b4b14-22f4-4cb5-b0c4-a50faec26076/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef63b23f-773a-4318-9820-32910998b7ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3448d48-7a31-4c49-a84c-02377eb48186> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3448d48-7a31-4c49-a84c-02377eb48186";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/84bb3cbc-03ee-4393-86cd-a0afbe586a76/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3448d48-7a31-4c49-a84c-02377eb48186>.
+    
+<http://data.lblod.info/id/remote-data-objects/957c5c19-ef3e-48e9-9459-20bd98f5d833> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "957c5c19-ef3e-48e9-9459-20bd98f5d833";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/85d0301b-c911-45ec-b1d6-54719416c983/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/957c5c19-ef3e-48e9-9459-20bd98f5d833>.
+    
+<http://data.lblod.info/id/remote-data-objects/93e58440-3f1d-4c5b-9b66-b389e2d45887> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93e58440-3f1d-4c5b-9b66-b389e2d45887";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/865fffb6-8470-41b4-a49c-4679f4aeae13/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93e58440-3f1d-4c5b-9b66-b389e2d45887>.
+    
+<http://data.lblod.info/id/remote-data-objects/f854328b-fb1d-4e00-903f-75f70dbaf9a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f854328b-fb1d-4e00-903f-75f70dbaf9a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/8b082181-338b-4eac-9661-95d92c4f9a2a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f854328b-fb1d-4e00-903f-75f70dbaf9a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/2658ffbc-1c57-441d-a2aa-8da98f23faf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2658ffbc-1c57-441d-a2aa-8da98f23faf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/91a6470c-19bb-4874-b163-9f1557031f2a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2658ffbc-1c57-441d-a2aa-8da98f23faf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/923a9d44-d682-41d4-ad42-1d26647ef8db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "923a9d44-d682-41d4-ad42-1d26647ef8db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/91e7f0b2-cbeb-48ba-aee5-2a696c6ba7ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/923a9d44-d682-41d4-ad42-1d26647ef8db>.
+    
+<http://data.lblod.info/id/remote-data-objects/995055e9-0d61-41d6-a98c-8ac945084dde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "995055e9-0d61-41d6-a98c-8ac945084dde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/947fb9d3-f231-477b-975e-ad005454f2c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/995055e9-0d61-41d6-a98c-8ac945084dde>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9ae56de-180e-45b8-8acd-c3b850eb06c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9ae56de-180e-45b8-8acd-c3b850eb06c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/95397829-e53e-45db-814a-ef9f248c3de0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9ae56de-180e-45b8-8acd-c3b850eb06c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cf13239-cb9a-4faf-98d1-008bca166d07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cf13239-cb9a-4faf-98d1-008bca166d07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/9c27723c-e7e5-4bc2-85f2-449165751235/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cf13239-cb9a-4faf-98d1-008bca166d07>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f0677d4-36a5-44b4-8e5b-57e004c7aaf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f0677d4-36a5-44b4-8e5b-57e004c7aaf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/a41e7d25-961e-4733-9e07-f418c79741c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f0677d4-36a5-44b4-8e5b-57e004c7aaf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0933c14-2ed6-4323-9fca-a902b4aa2fa7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0933c14-2ed6-4323-9fca-a902b4aa2fa7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/a4bd3fdd-0cd5-473b-a9c2-b08204cf6350/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0933c14-2ed6-4323-9fca-a902b4aa2fa7>.
+    
+<http://data.lblod.info/id/remote-data-objects/72db145e-58f2-4a32-988a-d661cc8c456f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72db145e-58f2-4a32-988a-d661cc8c456f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/a5dc5410-6ec6-47bc-b8a0-27fcc441860c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72db145e-58f2-4a32-988a-d661cc8c456f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa6c9906-8af6-4de8-a2a4-9eeb9d2711b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa6c9906-8af6-4de8-a2a4-9eeb9d2711b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/af2b8bf7-89db-47e1-bd3c-7b325259259a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa6c9906-8af6-4de8-a2a4-9eeb9d2711b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a9b7638-0086-4c96-964f-fcf973f5e68c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a9b7638-0086-4c96-964f-fcf973f5e68c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/b38b9e76-9240-4d73-8cdc-e9ad2553dfd6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a9b7638-0086-4c96-964f-fcf973f5e68c>.
+    
+<http://data.lblod.info/id/remote-data-objects/32922735-b745-413d-ad61-4cba2394da97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32922735-b745-413d-ad61-4cba2394da97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/b38fd9eb-b22f-42f2-953a-1a03626f0d32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32922735-b745-413d-ad61-4cba2394da97>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c76e576-a46b-42b4-9f5b-9b2fc987ccb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c76e576-a46b-42b4-9f5b-9b2fc987ccb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/bab721b8-ab15-4d59-a1c4-11763e367531/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c76e576-a46b-42b4-9f5b-9b2fc987ccb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d38696c-3531-41b3-a172-37d2f7c2eaf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d38696c-3531-41b3-a172-37d2f7c2eaf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/bd008318-1547-4e67-8509-cab54e6b2390/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d38696c-3531-41b3-a172-37d2f7c2eaf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec13f07f-8d83-44f4-8703-df78e9153094> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec13f07f-8d83-44f4-8703-df78e9153094";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/beb632c1-dcec-435a-a702-f203763dacc7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec13f07f-8d83-44f4-8703-df78e9153094>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b8a9a6a-572b-4566-8dda-135b3e858b47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b8a9a6a-572b-4566-8dda-135b3e858b47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/bf8a2896-f66c-4a9c-9797-a41f2d0d97f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b8a9a6a-572b-4566-8dda-135b3e858b47>.
+    
+<http://data.lblod.info/id/remote-data-objects/9479d433-a128-447d-8d98-74d5064cda54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9479d433-a128-447d-8d98-74d5064cda54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/c3afab37-06d3-4083-b7cd-5c517ae5cfa8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9479d433-a128-447d-8d98-74d5064cda54>.
+    
+<http://data.lblod.info/id/remote-data-objects/3673f1c8-8f28-4d5b-b9d0-aa50c6f6e7de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3673f1c8-8f28-4d5b-b9d0-aa50c6f6e7de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/d2a3a4fb-3c71-4fbc-80bf-e909f3abe2bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3673f1c8-8f28-4d5b-b9d0-aa50c6f6e7de>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7a18128-0fd6-4a8d-9cb3-6b5f66228ce1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7a18128-0fd6-4a8d-9cb3-6b5f66228ce1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/d401fcfd-6fa6-4829-a1e8-8b9a1eb50e9e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7a18128-0fd6-4a8d-9cb3-6b5f66228ce1>.
+    
+<http://data.lblod.info/id/remote-data-objects/822e4505-3efd-4050-b213-a91f0b189755> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "822e4505-3efd-4050-b213-a91f0b189755";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/dbbe8c2f-0e22-417b-bad1-9d876b47f249/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/822e4505-3efd-4050-b213-a91f0b189755>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cc1a09c-dd5b-4319-bc4d-df40bef18958> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cc1a09c-dd5b-4319-bc4d-df40bef18958";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/defa211f-874d-48f0-8f2d-ee2af6d6d2c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cc1a09c-dd5b-4319-bc4d-df40bef18958>.
+    
+<http://data.lblod.info/id/remote-data-objects/769fa89e-414a-4560-9e0e-cc65d57a0c24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "769fa89e-414a-4560-9e0e-cc65d57a0c24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/e30be5ff-6af5-45d8-a472-3d85494345a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/769fa89e-414a-4560-9e0e-cc65d57a0c24>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e7295ec-d4c7-4973-ab43-69076ffe0194> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e7295ec-d4c7-4973-ab43-69076ffe0194";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/e61bb966-7a6c-4595-bbf0-e601dd7fa35e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e7295ec-d4c7-4973-ab43-69076ffe0194>.
+    
+<http://data.lblod.info/id/remote-data-objects/089b554c-c537-499d-b1fa-d7d6001924b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "089b554c-c537-499d-b1fa-d7d6001924b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/eefe2be5-65a0-433b-8e74-137f65985e68/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/089b554c-c537-499d-b1fa-d7d6001924b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/22e46c95-4bf1-4c3f-be96-aa2de4119043> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22e46c95-4bf1-4c3f-be96-aa2de4119043";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/cbs/f52006be-3977-4986-99e2-ee48ff09f156/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22e46c95-4bf1-4c3f-be96-aa2de4119043>.
+    
+<http://data.lblod.info/id/remote-data-objects/c97f4830-f1e3-4f00-abbb-5a390df0eab8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c97f4830-f1e3-4f00-abbb-5a390df0eab8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/0df7a00f-8d73-4354-86f8-28155d162ccc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c97f4830-f1e3-4f00-abbb-5a390df0eab8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e19c2255-e679-4cbf-b2aa-f1a12a4fa133> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e19c2255-e679-4cbf-b2aa-f1a12a4fa133";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/0df7a00f-8d73-4354-86f8-28155d162ccc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e19c2255-e679-4cbf-b2aa-f1a12a4fa133>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffe9141d-c40f-4784-9065-7273304e1e1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffe9141d-c40f-4784-9065-7273304e1e1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/0df7a00f-8d73-4354-86f8-28155d162ccc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffe9141d-c40f-4784-9065-7273304e1e1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/39d868e6-33d3-4384-8cbf-b2760636febf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39d868e6-33d3-4384-8cbf-b2760636febf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/1d9233e4-d8d6-4ea8-9818-dc16b960f7b9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39d868e6-33d3-4384-8cbf-b2760636febf>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c61eecc-5fcd-41da-91b7-b832404ee9f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c61eecc-5fcd-41da-91b7-b832404ee9f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/1d9233e4-d8d6-4ea8-9818-dc16b960f7b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c61eecc-5fcd-41da-91b7-b832404ee9f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cd3cfa9-f34e-43eb-b698-350e5a408590> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cd3cfa9-f34e-43eb-b698-350e5a408590";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/1d9233e4-d8d6-4ea8-9818-dc16b960f7b9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cd3cfa9-f34e-43eb-b698-350e5a408590>.
+    
+<http://data.lblod.info/id/remote-data-objects/18e38fe7-0f97-4789-985c-b7a4d7d9c6b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18e38fe7-0f97-4789-985c-b7a4d7d9c6b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/233a8884-bbbb-4a3b-a302-ca32b8a26d49/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18e38fe7-0f97-4789-985c-b7a4d7d9c6b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0122586-f0aa-4dd8-811e-b2ba73adfb1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0122586-f0aa-4dd8-811e-b2ba73adfb1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/233a8884-bbbb-4a3b-a302-ca32b8a26d49/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0122586-f0aa-4dd8-811e-b2ba73adfb1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/36b4e862-81af-4b32-99c1-61d6592e1219> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36b4e862-81af-4b32-99c1-61d6592e1219";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/233a8884-bbbb-4a3b-a302-ca32b8a26d49/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36b4e862-81af-4b32-99c1-61d6592e1219>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8ba6cf6-c6c9-4f7f-b23c-84ae942ee8e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8ba6cf6-c6c9-4f7f-b23c-84ae942ee8e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/54d3331c-51ca-4e29-a867-653ebadc8eb7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8ba6cf6-c6c9-4f7f-b23c-84ae942ee8e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/90d19c8c-2e00-4de6-abae-04c9d468dcae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90d19c8c-2e00-4de6-abae-04c9d468dcae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/54d3331c-51ca-4e29-a867-653ebadc8eb7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90d19c8c-2e00-4de6-abae-04c9d468dcae>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bd591de-7cc8-4003-b122-3c3b33d3017e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bd591de-7cc8-4003-b122-3c3b33d3017e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/54d3331c-51ca-4e29-a867-653ebadc8eb7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/76eda2d4-a211-4d97-b44c-870dbb15ab96> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bd591de-7cc8-4003-b122-3c3b33d3017e>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201833-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201833-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201833-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201833-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/444e728c-d165-4761-b3b6-8ed42f89fbd1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "444e728c-d165-4761-b3b6-8ed42f89fbd1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d6e83365-ac75-4bc6-9459-c35f8238c16f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/92d8aa40-cb82-4afd-ad71-aac6ceaed081> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "92d8aa40-cb82-4afd-ad71-aac6ceaed081";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f>.
+
+  <http://redpencil.data.gift/id/task/3f4828c1-ca50-4904-931e-a1636f436abf> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3f4828c1-ca50-4904-931e-a1636f436abf";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/444e728c-d165-4761-b3b6-8ed42f89fbd1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/92d8aa40-cb82-4afd-ad71-aac6ceaed081>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/391c8fe2-c7ce-4a6c-ad2c-ddeded81adee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "391c8fe2-c7ce-4a6c-ad2c-ddeded81adee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/5756d2c6-3fb2-441b-a876-f4e1e5d33a36/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/391c8fe2-c7ce-4a6c-ad2c-ddeded81adee>.
+    
+<http://data.lblod.info/id/remote-data-objects/36db9f6d-ddcf-411b-9971-3264850dd695> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36db9f6d-ddcf-411b-9971-3264850dd695";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/5756d2c6-3fb2-441b-a876-f4e1e5d33a36/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36db9f6d-ddcf-411b-9971-3264850dd695>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ac56ade-8801-4af2-97d2-358cc48e874f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ac56ade-8801-4af2-97d2-358cc48e874f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/5756d2c6-3fb2-441b-a876-f4e1e5d33a36/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ac56ade-8801-4af2-97d2-358cc48e874f>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfcf82b2-80ff-4c10-977b-dc81b9d27606> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfcf82b2-80ff-4c10-977b-dc81b9d27606";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/63cd4d27-e200-48cb-9bc9-046f9eefa955/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfcf82b2-80ff-4c10-977b-dc81b9d27606>.
+    
+<http://data.lblod.info/id/remote-data-objects/1285d333-5399-4579-a20a-82cbbd71dca1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1285d333-5399-4579-a20a-82cbbd71dca1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/63cd4d27-e200-48cb-9bc9-046f9eefa955/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1285d333-5399-4579-a20a-82cbbd71dca1>.
+    
+<http://data.lblod.info/id/remote-data-objects/4316c35a-0105-4cc9-be31-56025a925a3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4316c35a-0105-4cc9-be31-56025a925a3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/63cd4d27-e200-48cb-9bc9-046f9eefa955/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4316c35a-0105-4cc9-be31-56025a925a3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/865086e5-ef67-4747-806a-b779fbc1948e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "865086e5-ef67-4747-806a-b779fbc1948e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/6bd70c0c-1549-4bb0-a9c2-a380c627a2e9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/865086e5-ef67-4747-806a-b779fbc1948e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f00d11fc-06e0-4ab0-848a-b05d2c4e8df4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f00d11fc-06e0-4ab0-848a-b05d2c4e8df4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/6bd70c0c-1549-4bb0-a9c2-a380c627a2e9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f00d11fc-06e0-4ab0-848a-b05d2c4e8df4>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcd4958c-f463-4f09-9111-a9d176b30c94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcd4958c-f463-4f09-9111-a9d176b30c94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/6bd70c0c-1549-4bb0-a9c2-a380c627a2e9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcd4958c-f463-4f09-9111-a9d176b30c94>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d0e2d29-049a-4416-bdef-c035f6460f5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d0e2d29-049a-4416-bdef-c035f6460f5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/6d1e9c25-2733-4dba-bdf1-c031aa30a348/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d0e2d29-049a-4416-bdef-c035f6460f5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9efe9b49-dc12-4f17-b071-4722e62e90fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9efe9b49-dc12-4f17-b071-4722e62e90fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/6d1e9c25-2733-4dba-bdf1-c031aa30a348/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9efe9b49-dc12-4f17-b071-4722e62e90fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/46d77ff4-f357-43bc-b09a-71278cab1cb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46d77ff4-f357-43bc-b09a-71278cab1cb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/6d1e9c25-2733-4dba-bdf1-c031aa30a348/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46d77ff4-f357-43bc-b09a-71278cab1cb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/539cbbd0-b32e-4f16-af92-cdb27c40e458> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "539cbbd0-b32e-4f16-af92-cdb27c40e458";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/8f7b0ac3-025f-4c90-aeb9-cc49e354d66c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/539cbbd0-b32e-4f16-af92-cdb27c40e458>.
+    
+<http://data.lblod.info/id/remote-data-objects/93f304ec-5255-4214-9e6f-af569f1b0f70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93f304ec-5255-4214-9e6f-af569f1b0f70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/8f7b0ac3-025f-4c90-aeb9-cc49e354d66c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93f304ec-5255-4214-9e6f-af569f1b0f70>.
+    
+<http://data.lblod.info/id/remote-data-objects/16d75166-1cf5-4219-9143-e3dd5884bd71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16d75166-1cf5-4219-9143-e3dd5884bd71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/91da726f-b6e4-450c-8dfe-acbe65b87bab/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16d75166-1cf5-4219-9143-e3dd5884bd71>.
+    
+<http://data.lblod.info/id/remote-data-objects/5238412e-8344-4330-9bb5-2d59e6eef54a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5238412e-8344-4330-9bb5-2d59e6eef54a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/91da726f-b6e4-450c-8dfe-acbe65b87bab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5238412e-8344-4330-9bb5-2d59e6eef54a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef00b441-f39d-4a82-8e79-fc61f44a8d23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef00b441-f39d-4a82-8e79-fc61f44a8d23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/91da726f-b6e4-450c-8dfe-acbe65b87bab/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef00b441-f39d-4a82-8e79-fc61f44a8d23>.
+    
+<http://data.lblod.info/id/remote-data-objects/11e28a09-cb8c-4b06-b34e-f00a70a8af23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11e28a09-cb8c-4b06-b34e-f00a70a8af23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/943a326d-bef8-4ef6-9a9e-622ceb791690/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11e28a09-cb8c-4b06-b34e-f00a70a8af23>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3d310c0-adb3-4ae1-a273-80d03f96e66c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3d310c0-adb3-4ae1-a273-80d03f96e66c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/943a326d-bef8-4ef6-9a9e-622ceb791690/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3d310c0-adb3-4ae1-a273-80d03f96e66c>.
+    
+<http://data.lblod.info/id/remote-data-objects/623bf8dd-5d6b-48ef-aae7-453f942a065a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "623bf8dd-5d6b-48ef-aae7-453f942a065a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/943a326d-bef8-4ef6-9a9e-622ceb791690/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/623bf8dd-5d6b-48ef-aae7-453f942a065a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5279d412-0a8d-454f-8bdb-d08a5b9582df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5279d412-0a8d-454f-8bdb-d08a5b9582df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/c0c90d30-2cbc-4298-b344-bf02f1ed0111/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5279d412-0a8d-454f-8bdb-d08a5b9582df>.
+    
+<http://data.lblod.info/id/remote-data-objects/f35ec909-718a-4b31-8313-fae1358fbbe7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f35ec909-718a-4b31-8313-fae1358fbbe7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/c0c90d30-2cbc-4298-b344-bf02f1ed0111/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f35ec909-718a-4b31-8313-fae1358fbbe7>.
+    
+<http://data.lblod.info/id/remote-data-objects/099ee799-c163-4464-889f-a22bd7507129> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "099ee799-c163-4464-889f-a22bd7507129";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/c0c90d30-2cbc-4298-b344-bf02f1ed0111/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/099ee799-c163-4464-889f-a22bd7507129>.
+    
+<http://data.lblod.info/id/remote-data-objects/a922ae8b-aeb2-4fd7-ae66-eb6568fe50ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a922ae8b-aeb2-4fd7-ae66-eb6568fe50ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/cbb513d5-bd38-4184-8459-db0141653abd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a922ae8b-aeb2-4fd7-ae66-eb6568fe50ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/38a6cea2-67f2-45ac-913a-f20d913b1a67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38a6cea2-67f2-45ac-913a-f20d913b1a67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/cbb513d5-bd38-4184-8459-db0141653abd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38a6cea2-67f2-45ac-913a-f20d913b1a67>.
+    
+<http://data.lblod.info/id/remote-data-objects/3da9e3fa-f958-40ac-96e2-c280f201baf3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3da9e3fa-f958-40ac-96e2-c280f201baf3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/cbb513d5-bd38-4184-8459-db0141653abd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3da9e3fa-f958-40ac-96e2-c280f201baf3>.
+    
+<http://data.lblod.info/id/remote-data-objects/18ab7df2-4dbd-467f-9bf5-21889187e861> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18ab7df2-4dbd-467f-9bf5-21889187e861";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/cd9c2124-12da-44a8-97a9-85f9ef44835e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18ab7df2-4dbd-467f-9bf5-21889187e861>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e49c55e-13bb-42a3-88dc-dc011c372980> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e49c55e-13bb-42a3-88dc-dc011c372980";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/cd9c2124-12da-44a8-97a9-85f9ef44835e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e49c55e-13bb-42a3-88dc-dc011c372980>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a4f8fca-0054-42a7-b64e-9bb2d546d336> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a4f8fca-0054-42a7-b64e-9bb2d546d336";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/cd9c2124-12da-44a8-97a9-85f9ef44835e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a4f8fca-0054-42a7-b64e-9bb2d546d336>.
+    
+<http://data.lblod.info/id/remote-data-objects/233e07a3-39e6-456e-b5ba-c499dde1b19e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "233e07a3-39e6-456e-b5ba-c499dde1b19e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/daab9b24-bf52-495c-9873-926d091f1934/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/233e07a3-39e6-456e-b5ba-c499dde1b19e>.
+    
+<http://data.lblod.info/id/remote-data-objects/29fbc02b-4135-4381-9080-c002d4c5c2b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29fbc02b-4135-4381-9080-c002d4c5c2b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/daab9b24-bf52-495c-9873-926d091f1934/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29fbc02b-4135-4381-9080-c002d4c5c2b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc80e8db-3aa4-4781-a55c-0aa253fd04cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc80e8db-3aa4-4781-a55c-0aa253fd04cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/gr/daab9b24-bf52-495c-9873-926d091f1934/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc80e8db-3aa4-4781-a55c-0aa253fd04cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d2c642b-c95f-42a8-b69f-2472c4487438> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d2c642b-c95f-42a8-b69f-2472c4487438";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/13104fe4-e17d-436f-bc75-ff1cb776fcf7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d2c642b-c95f-42a8-b69f-2472c4487438>.
+    
+<http://data.lblod.info/id/remote-data-objects/97945154-0f52-497e-a2bd-127abdf04f35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97945154-0f52-497e-a2bd-127abdf04f35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/13104fe4-e17d-436f-bc75-ff1cb776fcf7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97945154-0f52-497e-a2bd-127abdf04f35>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf2a032b-cc04-4232-9de7-ccdb8ecb10cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf2a032b-cc04-4232-9de7-ccdb8ecb10cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/13104fe4-e17d-436f-bc75-ff1cb776fcf7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf2a032b-cc04-4232-9de7-ccdb8ecb10cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/572233e9-14fb-4a6b-af31-58bb51c8da9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "572233e9-14fb-4a6b-af31-58bb51c8da9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/1bc82f32-b34b-4427-8838-e27274e901db/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/572233e9-14fb-4a6b-af31-58bb51c8da9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dfe1ce4-410d-4425-8175-6ccfd208d7dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dfe1ce4-410d-4425-8175-6ccfd208d7dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/1bc82f32-b34b-4427-8838-e27274e901db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dfe1ce4-410d-4425-8175-6ccfd208d7dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/91ce72fb-2008-424d-b7f4-dde57ed482ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91ce72fb-2008-424d-b7f4-dde57ed482ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/1bc82f32-b34b-4427-8838-e27274e901db/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91ce72fb-2008-424d-b7f4-dde57ed482ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b9c213e-e4f8-4a60-b7fc-add5c66ede7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b9c213e-e4f8-4a60-b7fc-add5c66ede7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/4575d07b-9f1a-49c1-9859-21ca67d5e9f1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b9c213e-e4f8-4a60-b7fc-add5c66ede7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/17c49375-0943-4fdf-926e-7b0bdd5e9a39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17c49375-0943-4fdf-926e-7b0bdd5e9a39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/4575d07b-9f1a-49c1-9859-21ca67d5e9f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17c49375-0943-4fdf-926e-7b0bdd5e9a39>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d4394bf-f2e0-4b59-b594-9478396849c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d4394bf-f2e0-4b59-b594-9478396849c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/4575d07b-9f1a-49c1-9859-21ca67d5e9f1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d4394bf-f2e0-4b59-b594-9478396849c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/edc30d01-eff5-4488-ad81-e86b46df65dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edc30d01-eff5-4488-ad81-e86b46df65dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/56629be9-d878-413c-ac70-f3db5c0d1250/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edc30d01-eff5-4488-ad81-e86b46df65dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca09538a-f6f0-4f06-8215-929d265204ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca09538a-f6f0-4f06-8215-929d265204ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/56629be9-d878-413c-ac70-f3db5c0d1250/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca09538a-f6f0-4f06-8215-929d265204ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e7242ef-f055-474b-86d0-0d5e355c4e4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e7242ef-f055-474b-86d0-0d5e355c4e4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/56629be9-d878-413c-ac70-f3db5c0d1250/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e7242ef-f055-474b-86d0-0d5e355c4e4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/261670bf-a6da-49f1-b36b-2d4f9819c085> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "261670bf-a6da-49f1-b36b-2d4f9819c085";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/56bdc6f1-1245-4b68-b7b8-e4d4920e6b89/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/261670bf-a6da-49f1-b36b-2d4f9819c085>.
+    
+<http://data.lblod.info/id/remote-data-objects/25928c1e-71d7-4b3e-bda9-30f53cc8d05f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25928c1e-71d7-4b3e-bda9-30f53cc8d05f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/56bdc6f1-1245-4b68-b7b8-e4d4920e6b89/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25928c1e-71d7-4b3e-bda9-30f53cc8d05f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d952ab9-e6fc-48ce-bcc8-7e36d10eb323> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d952ab9-e6fc-48ce-bcc8-7e36d10eb323";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/56bdc6f1-1245-4b68-b7b8-e4d4920e6b89/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d952ab9-e6fc-48ce-bcc8-7e36d10eb323>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e889c4e-62b0-4e58-9607-327afab53ba2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e889c4e-62b0-4e58-9607-327afab53ba2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/5e6a1508-86e9-44ba-af88-d2d6779a1bd5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e889c4e-62b0-4e58-9607-327afab53ba2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a887f82b-abde-4dd3-85e7-5b851b2c14ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a887f82b-abde-4dd3-85e7-5b851b2c14ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/5e6a1508-86e9-44ba-af88-d2d6779a1bd5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a887f82b-abde-4dd3-85e7-5b851b2c14ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/291a9f16-a2ab-4e23-a9f2-41a99ec1ef29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "291a9f16-a2ab-4e23-a9f2-41a99ec1ef29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/5e6a1508-86e9-44ba-af88-d2d6779a1bd5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d6e83365-ac75-4bc6-9459-c35f8238c16f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/291a9f16-a2ab-4e23-a9f2-41a99ec1ef29>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201834-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201834-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201834-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201834-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a947508d-3923-401d-92c1-7f73f7c4ec48> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a947508d-3923-401d-92c1-7f73f7c4ec48";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "41c6b46e-928e-46ca-a5ad-076c478b75a0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/7e201e52-b8cc-49f0-b3b1-313ba531dac1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7e201e52-b8cc-49f0-b3b1-313ba531dac1";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0>.
+
+  <http://redpencil.data.gift/id/task/5045c784-3234-4bda-9c0c-7e16248cce17> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5045c784-3234-4bda-9c0c-7e16248cce17";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a947508d-3923-401d-92c1-7f73f7c4ec48>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/7e201e52-b8cc-49f0-b3b1-313ba531dac1>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/ecafe3ab-6b2f-49e7-b027-c624012d8060> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecafe3ab-6b2f-49e7-b027-c624012d8060";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/73f1919c-e527-4b9f-8d15-ccd48b686d86/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecafe3ab-6b2f-49e7-b027-c624012d8060>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f15675a-abe7-4727-898a-95f1e1475f8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f15675a-abe7-4727-898a-95f1e1475f8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/73f1919c-e527-4b9f-8d15-ccd48b686d86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f15675a-abe7-4727-898a-95f1e1475f8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a36b288a-1078-46c5-8bb3-acbb507f9acb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a36b288a-1078-46c5-8bb3-acbb507f9acb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/73f1919c-e527-4b9f-8d15-ccd48b686d86/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a36b288a-1078-46c5-8bb3-acbb507f9acb>.
+    
+<http://data.lblod.info/id/remote-data-objects/016dcde5-c00e-4a1d-979c-6559526e4f6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "016dcde5-c00e-4a1d-979c-6559526e4f6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/75f3be3b-2bcf-4701-8d3c-8db6d5a16dbc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/016dcde5-c00e-4a1d-979c-6559526e4f6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfec88c5-4c40-4799-ae86-fa43f099b636> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfec88c5-4c40-4799-ae86-fa43f099b636";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/75f3be3b-2bcf-4701-8d3c-8db6d5a16dbc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfec88c5-4c40-4799-ae86-fa43f099b636>.
+    
+<http://data.lblod.info/id/remote-data-objects/66c2a2aa-c8c7-4c56-96bc-216b4cbb28b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66c2a2aa-c8c7-4c56-96bc-216b4cbb28b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/75f3be3b-2bcf-4701-8d3c-8db6d5a16dbc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66c2a2aa-c8c7-4c56-96bc-216b4cbb28b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f1c9151-cb0f-4652-8286-a7ef086e1c8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f1c9151-cb0f-4652-8286-a7ef086e1c8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/7e35f668-27cd-4719-860e-f1495e751ea8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f1c9151-cb0f-4652-8286-a7ef086e1c8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b668788d-8bd7-4490-88c8-40b000ed11a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b668788d-8bd7-4490-88c8-40b000ed11a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/7e35f668-27cd-4719-860e-f1495e751ea8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b668788d-8bd7-4490-88c8-40b000ed11a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/abaed1a0-b24c-40ef-b81f-b541c87d7fbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abaed1a0-b24c-40ef-b81f-b541c87d7fbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/7e35f668-27cd-4719-860e-f1495e751ea8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abaed1a0-b24c-40ef-b81f-b541c87d7fbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/1372cd80-6a03-4a24-9296-108a35cb26ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1372cd80-6a03-4a24-9296-108a35cb26ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/818c43d1-1845-4dc7-a5b8-d031222fe948/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1372cd80-6a03-4a24-9296-108a35cb26ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a06bb6f-24fd-4b1c-b12d-172b49824755> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a06bb6f-24fd-4b1c-b12d-172b49824755";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/818c43d1-1845-4dc7-a5b8-d031222fe948/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a06bb6f-24fd-4b1c-b12d-172b49824755>.
+    
+<http://data.lblod.info/id/remote-data-objects/f50f222a-949c-4d71-bf00-8621eb70aa3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f50f222a-949c-4d71-bf00-8621eb70aa3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/a7b0018d-0d80-4749-a6c4-92a9d2b21962/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f50f222a-949c-4d71-bf00-8621eb70aa3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e261aaf-02ea-4a83-9d41-6e309f1d1182> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e261aaf-02ea-4a83-9d41-6e309f1d1182";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/a7b0018d-0d80-4749-a6c4-92a9d2b21962/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e261aaf-02ea-4a83-9d41-6e309f1d1182>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b0bac4f-39d3-490e-b9bd-95eb319cf229> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b0bac4f-39d3-490e-b9bd-95eb319cf229";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/a7b0018d-0d80-4749-a6c4-92a9d2b21962/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b0bac4f-39d3-490e-b9bd-95eb319cf229>.
+    
+<http://data.lblod.info/id/remote-data-objects/12ba4a2e-982e-4b37-8823-3916fdf32863> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12ba4a2e-982e-4b37-8823-3916fdf32863";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/c77b62d3-ddcd-46b2-963a-9a86a0029884/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12ba4a2e-982e-4b37-8823-3916fdf32863>.
+    
+<http://data.lblod.info/id/remote-data-objects/c299fe6d-3a2b-44ad-a5c2-52e5ecea1c29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c299fe6d-3a2b-44ad-a5c2-52e5ecea1c29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/c77b62d3-ddcd-46b2-963a-9a86a0029884/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c299fe6d-3a2b-44ad-a5c2-52e5ecea1c29>.
+    
+<http://data.lblod.info/id/remote-data-objects/6af6b609-97d6-40bc-a527-b900c5c0dccc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6af6b609-97d6-40bc-a527-b900c5c0dccc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/c77b62d3-ddcd-46b2-963a-9a86a0029884/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6af6b609-97d6-40bc-a527-b900c5c0dccc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c95e30df-3bd3-40ad-b472-60eac5a989a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c95e30df-3bd3-40ad-b472-60eac5a989a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/f4ef3fad-4f30-473b-a05c-a350c64f3736/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c95e30df-3bd3-40ad-b472-60eac5a989a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0159386-57e4-4787-aa58-6464b5edfd9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0159386-57e4-4787-aa58-6464b5edfd9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/f4ef3fad-4f30-473b-a05c-a350c64f3736/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0159386-57e4-4787-aa58-6464b5edfd9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/32a062fd-9c06-4fd4-b32e-d664a0809f99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32a062fd-9c06-4fd4-b32e-d664a0809f99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/fbc08337-e66e-43d2-824e-15aea19738bd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32a062fd-9c06-4fd4-b32e-d664a0809f99>.
+    
+<http://data.lblod.info/id/remote-data-objects/810fd109-481f-4800-b8eb-1f5ed62ab881> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "810fd109-481f-4800-b8eb-1f5ed62ab881";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/fbc08337-e66e-43d2-824e-15aea19738bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/810fd109-481f-4800-b8eb-1f5ed62ab881>.
+    
+<http://data.lblod.info/id/remote-data-objects/d352c405-0951-4448-9df3-c6d1169bec5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d352c405-0951-4448-9df3-c6d1169bec5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/fbc08337-e66e-43d2-824e-15aea19738bd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d352c405-0951-4448-9df3-c6d1169bec5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ba2fc28-1e87-4ca5-8fd4-92a1926ac1bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ba2fc28-1e87-4ca5-8fd4-92a1926ac1bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/fe6bc3da-bfd1-4347-87cb-191ff4783f64/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ba2fc28-1e87-4ca5-8fd4-92a1926ac1bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/8421e797-d7a6-4df8-8ae1-9023c4ede4d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8421e797-d7a6-4df8-8ae1-9023c4ede4d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/fe6bc3da-bfd1-4347-87cb-191ff4783f64/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8421e797-d7a6-4df8-8ae1-9023c4ede4d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/08259765-5523-4259-81c5-591691db816a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08259765-5523-4259-81c5-591691db816a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/rmw/fe6bc3da-bfd1-4347-87cb-191ff4783f64/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08259765-5523-4259-81c5-591691db816a>.
+    
+<http://data.lblod.info/id/remote-data-objects/44ea803d-635b-4336-befd-2c1af0c035f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44ea803d-635b-4336-befd-2c1af0c035f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/0108c952-59bd-40ed-ba72-3928d8f9a7aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44ea803d-635b-4336-befd-2c1af0c035f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/89a19568-94b2-4666-8ce1-19b6f611f8ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89a19568-94b2-4666-8ce1-19b6f611f8ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/0127c181-e768-4f35-819d-c1f1bd49ba46/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89a19568-94b2-4666-8ce1-19b6f611f8ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1e6f493-dc2a-485f-a02c-137d5c05c43b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1e6f493-dc2a-485f-a02c-137d5c05c43b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/03507234-5a4c-4c94-90cf-aa4517e477df/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1e6f493-dc2a-485f-a02c-137d5c05c43b>.
+    
+<http://data.lblod.info/id/remote-data-objects/284681db-4c66-4bb0-93aa-e525b7c537c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "284681db-4c66-4bb0-93aa-e525b7c537c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/05f8f9bd-cbcc-470e-8811-96194998b06a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/284681db-4c66-4bb0-93aa-e525b7c537c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3f0cc36-c320-442d-a5a4-f55f089c4c18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3f0cc36-c320-442d-a5a4-f55f089c4c18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/060e24fb-4f48-44a7-b62c-d8c82f038c25/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3f0cc36-c320-442d-a5a4-f55f089c4c18>.
+    
+<http://data.lblod.info/id/remote-data-objects/62ad6a3b-01e6-4651-a51c-b8a7b6e5018d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62ad6a3b-01e6-4651-a51c-b8a7b6e5018d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/065cdaf0-4bfa-4f6c-aef1-6a01c9d57e98/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62ad6a3b-01e6-4651-a51c-b8a7b6e5018d>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc7d5adc-2f34-44f6-bfac-239a1c697a57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc7d5adc-2f34-44f6-bfac-239a1c697a57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/075b152e-922f-4ef2-ac13-c1ad8329a69e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc7d5adc-2f34-44f6-bfac-239a1c697a57>.
+    
+<http://data.lblod.info/id/remote-data-objects/65f2e4d5-22f5-436b-9783-a196f42c46d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65f2e4d5-22f5-436b-9783-a196f42c46d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/0a921ab0-b2f3-4d91-9859-66b4dc255a97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65f2e4d5-22f5-436b-9783-a196f42c46d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7e75f4f-f430-4fa8-8bb4-ae9a47132aed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7e75f4f-f430-4fa8-8bb4-ae9a47132aed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/0d1ae58a-e32a-45e1-9e03-21545610e334/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7e75f4f-f430-4fa8-8bb4-ae9a47132aed>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a2e133d-77ab-474f-85ce-275856fae7e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a2e133d-77ab-474f-85ce-275856fae7e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/0fbad9d4-e904-41f7-b8ad-8b43a9263898/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a2e133d-77ab-474f-85ce-275856fae7e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/759a5ec6-97a7-4352-af52-7b5ca519f0ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "759a5ec6-97a7-4352-af52-7b5ca519f0ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/187baf39-e48e-416c-9704-4a57561f09d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/759a5ec6-97a7-4352-af52-7b5ca519f0ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/75ed064e-cb40-4ac2-b06a-f37fbda1f7d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75ed064e-cb40-4ac2-b06a-f37fbda1f7d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/18e43855-c62a-4fe7-8264-dd99eaf9387a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75ed064e-cb40-4ac2-b06a-f37fbda1f7d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d5a0f87-5ee8-4788-843b-bf6b5b6fa815> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d5a0f87-5ee8-4788-843b-bf6b5b6fa815";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/1e49b818-3e84-4c3f-84a1-df1b44f4a834/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d5a0f87-5ee8-4788-843b-bf6b5b6fa815>.
+    
+<http://data.lblod.info/id/remote-data-objects/494ba9d0-5e3a-4cb4-9114-baf5f20328db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "494ba9d0-5e3a-4cb4-9114-baf5f20328db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/27658e30-ccc2-4b71-990d-875650bca837/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/494ba9d0-5e3a-4cb4-9114-baf5f20328db>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b03adf0-5823-4590-afbb-e94d7280eef3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b03adf0-5823-4590-afbb-e94d7280eef3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/2a89b661-171b-47b2-9c97-39bc6acb8c7f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b03adf0-5823-4590-afbb-e94d7280eef3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9ab6a0d-5e9f-4bd4-adc6-fd6597de9b15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9ab6a0d-5e9f-4bd4-adc6-fd6597de9b15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/2d5c8309-02ec-42fd-a539-1e022c317adc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9ab6a0d-5e9f-4bd4-adc6-fd6597de9b15>.
+    
+<http://data.lblod.info/id/remote-data-objects/be1cce6e-0494-49e9-988d-89a1b7003648> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be1cce6e-0494-49e9-988d-89a1b7003648";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/3475e8a9-b874-48eb-8b30-2713bf0a5df6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be1cce6e-0494-49e9-988d-89a1b7003648>.
+    
+<http://data.lblod.info/id/remote-data-objects/925d56a3-7667-4730-a7ec-599bae3a866f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "925d56a3-7667-4730-a7ec-599bae3a866f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/396f6162-8ed6-4ba0-b259-78a7b61e5467/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/925d56a3-7667-4730-a7ec-599bae3a866f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1ed393d-a4b2-4df7-9c0e-e0814368f950> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1ed393d-a4b2-4df7-9c0e-e0814368f950";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/3a5bf40d-1b07-41ab-ac3f-76af16fbb65b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1ed393d-a4b2-4df7-9c0e-e0814368f950>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c5b0f6c-abcd-42f9-8ea8-bdc1d501ffdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c5b0f6c-abcd-42f9-8ea8-bdc1d501ffdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/3d3b3dcf-38d8-425f-96f2-91348ed98a32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c5b0f6c-abcd-42f9-8ea8-bdc1d501ffdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b90ede8-9afa-4404-9596-6a56b23cfc6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b90ede8-9afa-4404-9596-6a56b23cfc6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/3dfb5bd1-5d62-44bb-a29c-2ba9eeb16ef9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b90ede8-9afa-4404-9596-6a56b23cfc6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fe6ad96-acd5-4705-909c-06f275594f6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fe6ad96-acd5-4705-909c-06f275594f6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/40fb2a5d-14dc-4f0b-81b6-8d25e162329f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fe6ad96-acd5-4705-909c-06f275594f6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4b339a4-2fed-4644-9af4-0b2c9acac52a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4b339a4-2fed-4644-9af4-0b2c9acac52a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/41e00525-ea8b-4ffb-9c86-d6651984a614/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4b339a4-2fed-4644-9af4-0b2c9acac52a>.
+    
+<http://data.lblod.info/id/remote-data-objects/61502b33-3b03-4f60-afdb-60f4feab7b9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61502b33-3b03-4f60-afdb-60f4feab7b9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/4fb0942c-35f3-4db8-aad4-60b7be8dc5d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61502b33-3b03-4f60-afdb-60f4feab7b9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6718147e-ad0a-467c-bf89-bd6f4154eee9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6718147e-ad0a-467c-bf89-bd6f4154eee9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/5436cf4c-3b9b-400c-b826-4114849cafd2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:34.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/41c6b46e-928e-46ca-a5ad-076c478b75a0> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6718147e-ad0a-467c-bf89-bd6f4154eee9>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201836-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201836-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201836-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201836-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/55bd7de5-c311-4358-b544-12eb5dc02ae9> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "55bd7de5-c311-4358-b544-12eb5dc02ae9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "639ac19e-9616-4ac4-abe7-399e31ae2639";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/6c956731-a1e8-4cff-95df-f2e7edebcc91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6c956731-a1e8-4cff-95df-f2e7edebcc91";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639>.
+
+  <http://redpencil.data.gift/id/task/195acf94-0a0a-41bd-9e2a-c13fe008772a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "195acf94-0a0a-41bd-9e2a-c13fe008772a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/55bd7de5-c311-4358-b544-12eb5dc02ae9>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/6c956731-a1e8-4cff-95df-f2e7edebcc91>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/89da5c60-7adb-4b13-8112-c1959c8544a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89da5c60-7adb-4b13-8112-c1959c8544a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/58912780-dc2f-4996-8acf-b8114ffaa34a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89da5c60-7adb-4b13-8112-c1959c8544a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/092470d7-1dab-41f2-b217-9fb821b77bd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "092470d7-1dab-41f2-b217-9fb821b77bd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/5b883512-d92b-4cb5-bd3c-3a58e0d84e2b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/092470d7-1dab-41f2-b217-9fb821b77bd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/120b8b6b-5668-4e18-9b03-cf7d885ce24d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "120b8b6b-5668-4e18-9b03-cf7d885ce24d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/5ba852ae-4a2d-4fb8-9608-d0c225d7b0b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/120b8b6b-5668-4e18-9b03-cf7d885ce24d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed73dbd0-5787-47ad-a8d1-54d446d94aac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed73dbd0-5787-47ad-a8d1-54d446d94aac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/5f3b5dda-89e1-4a35-ab28-0e788aec5425/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed73dbd0-5787-47ad-a8d1-54d446d94aac>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d94ea4b-42c3-4eca-9f2d-388adb5d875b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d94ea4b-42c3-4eca-9f2d-388adb5d875b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/61e997d5-7490-4844-a6da-1e216b63187c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d94ea4b-42c3-4eca-9f2d-388adb5d875b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bdb22cd-31fd-47cc-8e16-66b127278505> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bdb22cd-31fd-47cc-8e16-66b127278505";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/62da3a0c-5e1f-4767-9d45-3455f830fa50/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bdb22cd-31fd-47cc-8e16-66b127278505>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec130374-1ffa-4537-af8a-d355a93d3140> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec130374-1ffa-4537-af8a-d355a93d3140";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/6442c3af-d4e6-4c8f-9838-f834852128f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec130374-1ffa-4537-af8a-d355a93d3140>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d141d10-415c-4804-b573-da09f6cc5648> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d141d10-415c-4804-b573-da09f6cc5648";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/6604dabb-4376-4546-907d-085779db1bd6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d141d10-415c-4804-b573-da09f6cc5648>.
+    
+<http://data.lblod.info/id/remote-data-objects/3940c1c0-233f-46b6-ab16-2ae17ebf3a12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3940c1c0-233f-46b6-ab16-2ae17ebf3a12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/6b311824-b015-4132-98cf-17a4523d0482/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3940c1c0-233f-46b6-ab16-2ae17ebf3a12>.
+    
+<http://data.lblod.info/id/remote-data-objects/95974471-0c73-407d-b84d-ab88b5984f5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95974471-0c73-407d-b84d-ab88b5984f5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/72811e8d-2ce8-437b-b515-8062757cbe4a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95974471-0c73-407d-b84d-ab88b5984f5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8eb82616-8bb4-4899-8be0-1549448d2e35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8eb82616-8bb4-4899-8be0-1549448d2e35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/73be57d4-ad8f-453a-b0aa-a5afdd1d0ed0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8eb82616-8bb4-4899-8be0-1549448d2e35>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd954028-d91c-4a7d-8dc8-6fa5037f268d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd954028-d91c-4a7d-8dc8-6fa5037f268d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/74b2a41f-a38f-49fa-9a0a-986738e8142e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd954028-d91c-4a7d-8dc8-6fa5037f268d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec54113c-8d88-4193-9537-b166487eb471> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec54113c-8d88-4193-9537-b166487eb471";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/768c2445-9598-426e-b306-0ff5473ea596/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec54113c-8d88-4193-9537-b166487eb471>.
+    
+<http://data.lblod.info/id/remote-data-objects/b050fc49-e4b6-477b-9b8f-66b2a258ecb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b050fc49-e4b6-477b-9b8f-66b2a258ecb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/7a4717ec-7b0c-4d15-846d-c36acae686d9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b050fc49-e4b6-477b-9b8f-66b2a258ecb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fca41e6-b7de-48b3-87b9-5a6dbe550726> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fca41e6-b7de-48b3-87b9-5a6dbe550726";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/83dab20d-7d7e-41d0-bfba-f3c8b7ee7fd1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fca41e6-b7de-48b3-87b9-5a6dbe550726>.
+    
+<http://data.lblod.info/id/remote-data-objects/90cc47d5-1f27-416e-839e-c428997dfcad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90cc47d5-1f27-416e-839e-c428997dfcad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/8a43ce49-6456-4e55-af5f-beb0922ad726/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90cc47d5-1f27-416e-839e-c428997dfcad>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b08d0ff-50bb-4c19-bf2c-73b35f4dbebf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b08d0ff-50bb-4c19-bf2c-73b35f4dbebf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/8ffa7eb6-413d-4d68-8f0f-448b82bd35ad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b08d0ff-50bb-4c19-bf2c-73b35f4dbebf>.
+    
+<http://data.lblod.info/id/remote-data-objects/b66260da-ba39-4b06-8ec2-bed65d5fa47e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b66260da-ba39-4b06-8ec2-bed65d5fa47e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/9133bb1c-6711-42f6-95c0-dc2e974bcc0e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b66260da-ba39-4b06-8ec2-bed65d5fa47e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8f953a6-d40a-4e38-82c0-d410b464f1b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8f953a6-d40a-4e38-82c0-d410b464f1b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/93116b7c-b747-4c6d-b142-b3f9822edf56/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8f953a6-d40a-4e38-82c0-d410b464f1b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/40f92828-3044-49de-8aa6-7fd1c8450ad8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40f92828-3044-49de-8aa6-7fd1c8450ad8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/9ab0031d-0489-456c-b3f7-1282a4ac1aa8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40f92828-3044-49de-8aa6-7fd1c8450ad8>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b8a6d4a-95ed-40b8-afa1-b2d8d1a86c61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b8a6d4a-95ed-40b8-afa1-b2d8d1a86c61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/a2f2eb27-020f-4625-b6b2-62593306e1a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b8a6d4a-95ed-40b8-afa1-b2d8d1a86c61>.
+    
+<http://data.lblod.info/id/remote-data-objects/1408fe3c-6379-4d1b-bbd2-80c1588085fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1408fe3c-6379-4d1b-bbd2-80c1588085fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/a488e420-a10b-4226-89d2-94ad9249b8e9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1408fe3c-6379-4d1b-bbd2-80c1588085fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/60c9afa8-a621-47a5-a2b2-8fbb27551e81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60c9afa8-a621-47a5-a2b2-8fbb27551e81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/a52533a0-9234-4c6c-850b-fb499ad4084b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60c9afa8-a621-47a5-a2b2-8fbb27551e81>.
+    
+<http://data.lblod.info/id/remote-data-objects/684e3e49-4827-4ff2-9965-55c9a010935a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "684e3e49-4827-4ff2-9965-55c9a010935a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/a6d52a53-2f12-4b68-ac34-832c7707a8aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/684e3e49-4827-4ff2-9965-55c9a010935a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fa61db3-5e89-46e2-a42e-11300c00b481> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fa61db3-5e89-46e2-a42e-11300c00b481";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/a8140349-13bb-452e-b7c7-7d160578a47f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fa61db3-5e89-46e2-a42e-11300c00b481>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3560677-e992-4630-beb8-42df97a54540> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3560677-e992-4630-beb8-42df97a54540";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/b2317fed-15ec-4172-9784-b12acef46396/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3560677-e992-4630-beb8-42df97a54540>.
+    
+<http://data.lblod.info/id/remote-data-objects/db5b3cb6-e3b7-494d-b370-59ce4781ccee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db5b3cb6-e3b7-494d-b370-59ce4781ccee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/b275b242-904e-4bfd-b6a7-d9352109782a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db5b3cb6-e3b7-494d-b370-59ce4781ccee>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad917eed-9a2a-4296-aa04-c8faab48c652> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad917eed-9a2a-4296-aa04-c8faab48c652";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/b9b0b150-ac3b-46fc-bb90-1dce7a3f188f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad917eed-9a2a-4296-aa04-c8faab48c652>.
+    
+<http://data.lblod.info/id/remote-data-objects/aaac9755-2a9f-4a4f-a5fb-c3db4efe84de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aaac9755-2a9f-4a4f-a5fb-c3db4efe84de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/bc632d41-2a9c-43d2-bf51-8a6c81851fbc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aaac9755-2a9f-4a4f-a5fb-c3db4efe84de>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0a80451-77a8-4fa4-a05b-53127b41babb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0a80451-77a8-4fa4-a05b-53127b41babb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/c4ec33a3-e098-468a-bb0a-3a91371b5cb2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0a80451-77a8-4fa4-a05b-53127b41babb>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9283c0d-94c7-4315-8531-0918d28e2bb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9283c0d-94c7-4315-8531-0918d28e2bb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/c695a557-5f7b-45dc-ab3a-0e047169ba30/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9283c0d-94c7-4315-8531-0918d28e2bb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/066e352f-5b5b-4dba-9ed2-72a96f680508> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "066e352f-5b5b-4dba-9ed2-72a96f680508";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/c717e759-ca4d-4dbc-9336-4b91fb8d1f0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/066e352f-5b5b-4dba-9ed2-72a96f680508>.
+    
+<http://data.lblod.info/id/remote-data-objects/767476ba-8993-4378-8ad6-c26bdaa587c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "767476ba-8993-4378-8ad6-c26bdaa587c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/cc85681d-d37f-4110-9d50-3700b51ad456/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/767476ba-8993-4378-8ad6-c26bdaa587c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/956b881d-322e-4d46-8956-cab0b000ab7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "956b881d-322e-4d46-8956-cab0b000ab7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/d03adf95-b9cd-4e03-972b-83e00fadcaf4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/956b881d-322e-4d46-8956-cab0b000ab7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9da0c7cd-be55-483a-b409-494e1e73add1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9da0c7cd-be55-483a-b409-494e1e73add1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/d2d8593e-77d8-48a4-998c-ca46f64749e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9da0c7cd-be55-483a-b409-494e1e73add1>.
+    
+<http://data.lblod.info/id/remote-data-objects/368aaa30-16c4-4069-9f7c-edee6d133cb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "368aaa30-16c4-4069-9f7c-edee6d133cb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/d2f31b82-fd44-4980-947d-08da896db2f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/368aaa30-16c4-4069-9f7c-edee6d133cb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/87832e7b-2da5-40de-9c5e-d8bcd2d44eea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87832e7b-2da5-40de-9c5e-d8bcd2d44eea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/dcbf466c-5e5d-4396-9b20-474855f2d48a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87832e7b-2da5-40de-9c5e-d8bcd2d44eea>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbfc42a4-1103-432a-87aa-fafbac3154a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbfc42a4-1103-432a-87aa-fafbac3154a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/ec542f72-936f-4d56-b500-fcc533551104/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbfc42a4-1103-432a-87aa-fafbac3154a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/d987f4bb-4b34-4a3a-98e9-9a7d8d60529e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d987f4bb-4b34-4a3a-98e9-9a7d8d60529e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/ef808792-b63f-4ca5-a669-8e07e072ed0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d987f4bb-4b34-4a3a-98e9-9a7d8d60529e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0348e082-7fe3-4b5f-823a-225264c07846> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0348e082-7fe3-4b5f-823a-225264c07846";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/ef9586d2-95ae-4411-ab6b-78e4a269b660/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0348e082-7fe3-4b5f-823a-225264c07846>.
+    
+<http://data.lblod.info/id/remote-data-objects/17a99d60-1dcb-403b-bf5e-67bb2ef14591> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17a99d60-1dcb-403b-bf5e-67bb2ef14591";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/f3d8ee8a-b944-4891-929a-7d1ab54b0013/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17a99d60-1dcb-403b-bf5e-67bb2ef14591>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5d0b18b-d2ef-476c-95d1-9d093dbaa4b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5d0b18b-d2ef-476c-95d1-9d093dbaa4b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/fa00e13a-c827-440b-bfa2-0811473654a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5d0b18b-d2ef-476c-95d1-9d093dbaa4b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/b881f2c8-8d4a-41d3-a218-edb6be1092a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b881f2c8-8d4a-41d3-a218-edb6be1092a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/fb1439a9-f9ce-4a3d-9e81-ee75116951d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b881f2c8-8d4a-41d3-a218-edb6be1092a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/572b544c-850b-4414-b399-bd45028f7933> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "572b544c-850b-4414-b399-bd45028f7933";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/fbf383f5-ca73-48e5-8317-3584e68d84fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/572b544c-850b-4414-b399-bd45028f7933>.
+    
+<http://data.lblod.info/id/remote-data-objects/090b5d8d-f51f-4cf0-bb9d-379177095d1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "090b5d8d-f51f-4cf0-bb9d-379177095d1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://malle.meetingburger.net/vabu/fcdf7a93-e475-4985-a296-46961b1291a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/090b5d8d-f51f-4cf0-bb9d-379177095d1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae0aefaf-caa9-4986-8aa9-4dab26a5bba3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae0aefaf-caa9-4986-8aa9-4dab26a5bba3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/1e0a4892-1413-43ec-98e8-d5628b0fde73/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae0aefaf-caa9-4986-8aa9-4dab26a5bba3>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a4c2267-4a9d-4ab3-8c0b-877a9d905d72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a4c2267-4a9d-4ab3-8c0b-877a9d905d72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/201cf3bd-f955-4fba-94f3-e5418b6daf05/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a4c2267-4a9d-4ab3-8c0b-877a9d905d72>.
+    
+<http://data.lblod.info/id/remote-data-objects/aba4acfa-cd7e-4d8a-9f50-d9162d0c9037> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aba4acfa-cd7e-4d8a-9f50-d9162d0c9037";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/219b453a-2ae1-4327-b277-e24f7599813d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aba4acfa-cd7e-4d8a-9f50-d9162d0c9037>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c0eb105-f051-453f-a0b7-01e415b6ce93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c0eb105-f051-453f-a0b7-01e415b6ce93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/41d68e3c-227b-4a61-9271-bd618161f891/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c0eb105-f051-453f-a0b7-01e415b6ce93>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5f6fa04-db09-49fe-8a97-0cb60e0902e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5f6fa04-db09-49fe-8a97-0cb60e0902e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/5e350657-7577-4123-8bc5-002102bf4ad5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/639ac19e-9616-4ac4-abe7-399e31ae2639> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5f6fa04-db09-49fe-8a97-0cb60e0902e6>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201837-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201837-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201837-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201837-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/46ae29aa-3f39-4ad1-8055-d814ddd8e586> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "46ae29aa-3f39-4ad1-8055-d814ddd8e586";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fbda5f20-456e-4504-932c-9e8c5e1744af";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4d66c3dc-90bc-446e-8bfb-3a61440df38a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4d66c3dc-90bc-446e-8bfb-3a61440df38a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af>.
+
+  <http://redpencil.data.gift/id/task/3b0a46e4-6078-410c-aafb-f8e18278df0c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3b0a46e4-6078-410c-aafb-f8e18278df0c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/46ae29aa-3f39-4ad1-8055-d814ddd8e586>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4d66c3dc-90bc-446e-8bfb-3a61440df38a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/1a1dd30a-0450-4293-954b-6c37fcbc5289> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a1dd30a-0450-4293-954b-6c37fcbc5289";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/6cd24da6-b1f6-4023-a9e3-2c42ce5daa02/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a1dd30a-0450-4293-954b-6c37fcbc5289>.
+    
+<http://data.lblod.info/id/remote-data-objects/3727ffb4-8db0-4bd7-9d86-3519d5ca40c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3727ffb4-8db0-4bd7-9d86-3519d5ca40c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/70a41fad-beca-4e7a-bd1d-9799c76ba680/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3727ffb4-8db0-4bd7-9d86-3519d5ca40c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f37fc63e-6e5a-47db-a47b-d7dafa182f82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f37fc63e-6e5a-47db-a47b-d7dafa182f82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/72101600-1133-4bb4-a42c-a1e5df8a1293/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f37fc63e-6e5a-47db-a47b-d7dafa182f82>.
+    
+<http://data.lblod.info/id/remote-data-objects/b15e862d-6003-4317-ae93-70e17f06d480> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b15e862d-6003-4317-ae93-70e17f06d480";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/7449d5d9-76f0-45fa-a5a2-2313f13cc054/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b15e862d-6003-4317-ae93-70e17f06d480>.
+    
+<http://data.lblod.info/id/remote-data-objects/f810dfc0-8c3e-45af-b92a-5a526c14eb2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f810dfc0-8c3e-45af-b92a-5a526c14eb2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/879eee46-ed8b-49f8-9284-d6df3f537677/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f810dfc0-8c3e-45af-b92a-5a526c14eb2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/30a50bc0-51f1-4087-9774-de92d7aa838d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30a50bc0-51f1-4087-9774-de92d7aa838d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/8d5fea1a-1a63-4968-ab98-ba0035052719/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30a50bc0-51f1-4087-9774-de92d7aa838d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5393c6c9-003f-43fb-ade4-ae53ad728afd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5393c6c9-003f-43fb-ade4-ae53ad728afd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/a0d6059a-cf3e-469e-b876-b02f458c730d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5393c6c9-003f-43fb-ade4-ae53ad728afd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba580d6f-a644-4fbe-bb39-f46597e58580> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba580d6f-a644-4fbe-bb39-f46597e58580";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/bd5b1798-e9c9-4eb9-ba3d-f90914b930f0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba580d6f-a644-4fbe-bb39-f46597e58580>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a0bbfe8-6677-4c6d-a584-d7530147a585> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a0bbfe8-6677-4c6d-a584-d7530147a585";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/d58477ca-3966-4ac7-bc9f-5138bc007e64/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a0bbfe8-6677-4c6d-a584-d7530147a585>.
+    
+<http://data.lblod.info/id/remote-data-objects/66ffcccb-8ead-47d7-9c18-82e7de7c4644> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66ffcccb-8ead-47d7-9c18-82e7de7c4644";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/d721b834-63da-493a-bbd2-d9bc84f3d30b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66ffcccb-8ead-47d7-9c18-82e7de7c4644>.
+    
+<http://data.lblod.info/id/remote-data-objects/9523d65b-bbc8-41d1-a4c0-62e42c20a871> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9523d65b-bbc8-41d1-a4c0-62e42c20a871";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/ee21de83-3fae-4cc5-a2e9-105b16ea4ade/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9523d65b-bbc8-41d1-a4c0-62e42c20a871>.
+    
+<http://data.lblod.info/id/remote-data-objects/41ceaecf-9e6b-40d1-83cc-37cdf8a2dac4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41ceaecf-9e6b-40d1-83cc-37cdf8a2dac4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/f5971dd0-39ce-4c03-9807-c6e1e73398ca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41ceaecf-9e6b-40d1-83cc-37cdf8a2dac4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c4c23e0-8d9d-4b9d-b1de-15603be5b981> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c4c23e0-8d9d-4b9d-b1de-15603be5b981";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/bb/feafd0f2-2b8c-4e1b-97a4-fd21f2ae1440/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c4c23e0-8d9d-4b9d-b1de-15603be5b981>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4979794-bec3-43e6-ba93-929fb4f8c65b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4979794-bec3-43e6-ba93-929fb4f8c65b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/02130fac-f7e0-4d6a-922e-305aeda43ea6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4979794-bec3-43e6-ba93-929fb4f8c65b>.
+    
+<http://data.lblod.info/id/remote-data-objects/16bfe51a-6042-4353-903c-948f61bb1602> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16bfe51a-6042-4353-903c-948f61bb1602";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/033126fd-5d8c-4704-ac6a-a4b0459fcb38/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16bfe51a-6042-4353-903c-948f61bb1602>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fbc82be-0003-44b9-8af9-e7abc4d1cf0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fbc82be-0003-44b9-8af9-e7abc4d1cf0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/09146efd-050c-4c54-9cd4-6d103cd474e4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fbc82be-0003-44b9-8af9-e7abc4d1cf0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ec3972b-2d7b-4e98-a95e-accb084c18f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ec3972b-2d7b-4e98-a95e-accb084c18f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/0dc94afb-588a-4988-b04d-26740dcfa40d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ec3972b-2d7b-4e98-a95e-accb084c18f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc4af4e8-0984-4c24-a732-f4ec57c77c4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc4af4e8-0984-4c24-a732-f4ec57c77c4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/0e9ed728-b13d-482d-ab1c-debc8d6a7629/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc4af4e8-0984-4c24-a732-f4ec57c77c4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/38c997b2-96f3-4155-85da-89c1b528b0b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38c997b2-96f3-4155-85da-89c1b528b0b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/0ed57c2b-d1a7-40a5-b7ae-ed6b79f17159/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38c997b2-96f3-4155-85da-89c1b528b0b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c743b87-ec3e-4536-afec-abbc362ffc87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c743b87-ec3e-4536-afec-abbc362ffc87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/0ef879c2-c9e9-4a24-9ea9-e0cbe92f591e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c743b87-ec3e-4536-afec-abbc362ffc87>.
+    
+<http://data.lblod.info/id/remote-data-objects/fde6ce12-9e57-4706-8e8e-ed47a9081241> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fde6ce12-9e57-4706-8e8e-ed47a9081241";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/0f180779-8daa-4d22-a30a-321f1ae5d46c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fde6ce12-9e57-4706-8e8e-ed47a9081241>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf0e29a9-7cd7-4df4-bed6-b8793625f1b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf0e29a9-7cd7-4df4-bed6-b8793625f1b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/1afefaeb-7a62-42ed-9e6b-5fdc005ba743/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf0e29a9-7cd7-4df4-bed6-b8793625f1b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/389b61ed-55ca-429a-8ae1-eff42d9f2b0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "389b61ed-55ca-429a-8ae1-eff42d9f2b0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/1ce7b320-6c05-464e-a2f0-203bbf8f8003/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/389b61ed-55ca-429a-8ae1-eff42d9f2b0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff973e4a-f1f2-42f1-a019-77cb9dada084> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff973e4a-f1f2-42f1-a019-77cb9dada084";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/25254f6c-f3e1-4505-895b-328a76c986d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff973e4a-f1f2-42f1-a019-77cb9dada084>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd692012-22c9-4a68-b193-4317517a20a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd692012-22c9-4a68-b193-4317517a20a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/2ed72ade-9550-44b1-a1e0-38df280e9ecf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd692012-22c9-4a68-b193-4317517a20a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba2da617-3ba6-43c4-8196-0a9b0dda31ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba2da617-3ba6-43c4-8196-0a9b0dda31ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/314e2ef8-ff4b-4011-885c-9a6a2f0ce755/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba2da617-3ba6-43c4-8196-0a9b0dda31ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/61a0d0b6-596b-4665-bf3d-c0478e413bf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61a0d0b6-596b-4665-bf3d-c0478e413bf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/33794448-5192-441e-849c-65503bf93970/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61a0d0b6-596b-4665-bf3d-c0478e413bf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a569551-b256-4f3a-8fd0-8a5306377d27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a569551-b256-4f3a-8fd0-8a5306377d27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/34ae4f72-fd22-466a-ad8f-8c75f0e9a730/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a569551-b256-4f3a-8fd0-8a5306377d27>.
+    
+<http://data.lblod.info/id/remote-data-objects/45f1cc80-442e-43f5-909d-e52b414b4473> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45f1cc80-442e-43f5-909d-e52b414b4473";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/3771fbbc-f47e-475c-9586-df862233d4ed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45f1cc80-442e-43f5-909d-e52b414b4473>.
+    
+<http://data.lblod.info/id/remote-data-objects/eda8d9fa-8397-471e-b327-618f50f156a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eda8d9fa-8397-471e-b327-618f50f156a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/3adbe022-caf7-4082-a842-19d8254cada5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eda8d9fa-8397-471e-b327-618f50f156a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cf9d168-3161-4416-9781-cace719b6357> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cf9d168-3161-4416-9781-cace719b6357";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/446a9a1e-68ef-4aa3-809a-05a900ca531a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cf9d168-3161-4416-9781-cace719b6357>.
+    
+<http://data.lblod.info/id/remote-data-objects/493941ef-80c2-4a2f-93b1-fe1c96a5cb88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "493941ef-80c2-4a2f-93b1-fe1c96a5cb88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/4992a2ef-d13c-4904-b6c6-a8c1d78d9147/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/493941ef-80c2-4a2f-93b1-fe1c96a5cb88>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ccfb33c-3ffd-42da-910f-8210653bd706> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ccfb33c-3ffd-42da-910f-8210653bd706";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/4a3ff4e7-308f-4686-ac7d-8e6c5bbc63bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ccfb33c-3ffd-42da-910f-8210653bd706>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fda7669-0091-4822-a355-d29c2d763410> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fda7669-0091-4822-a355-d29c2d763410";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/5108a10f-1ecb-41b9-ae02-b36920ed27be/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fda7669-0091-4822-a355-d29c2d763410>.
+    
+<http://data.lblod.info/id/remote-data-objects/80140e01-b5cd-42d7-a265-c477863914c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80140e01-b5cd-42d7-a265-c477863914c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/53bbfe39-72e8-44ea-877b-df674dc7137b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80140e01-b5cd-42d7-a265-c477863914c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae305018-4231-4eef-85e1-dbf29f755716> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae305018-4231-4eef-85e1-dbf29f755716";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/57152b76-2cfe-4635-91ae-2fa70c4d068c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae305018-4231-4eef-85e1-dbf29f755716>.
+    
+<http://data.lblod.info/id/remote-data-objects/85e54c48-f691-4445-8009-f91eedb722d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85e54c48-f691-4445-8009-f91eedb722d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/579fb36e-d4f5-4da2-bb76-6fdb33f19b78/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85e54c48-f691-4445-8009-f91eedb722d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/38c279b2-81f7-4d5b-b37e-d57fd99c01f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38c279b2-81f7-4d5b-b37e-d57fd99c01f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/5e7ebd0f-40f9-483f-866b-ded0fa685048/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38c279b2-81f7-4d5b-b37e-d57fd99c01f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/376b5af4-567f-4a3f-aaaa-22dc3fc6b505> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "376b5af4-567f-4a3f-aaaa-22dc3fc6b505";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/67535141-5d19-49af-af45-d93a1ae29076/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/376b5af4-567f-4a3f-aaaa-22dc3fc6b505>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1c246de-81cb-4e4d-a0b6-b25b383bda63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1c246de-81cb-4e4d-a0b6-b25b383bda63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/6fa3a04e-1727-4542-b83c-a9a39976e99d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1c246de-81cb-4e4d-a0b6-b25b383bda63>.
+    
+<http://data.lblod.info/id/remote-data-objects/75a38f38-bd49-4790-9491-d2f7eb12e90a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75a38f38-bd49-4790-9491-d2f7eb12e90a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/751bfd3c-7383-40ee-b25f-8fd775c16423/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75a38f38-bd49-4790-9491-d2f7eb12e90a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec79b422-dedc-439f-afac-48f41b7d8602> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec79b422-dedc-439f-afac-48f41b7d8602";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/753ee045-367a-439d-bd46-8b9bd394cbcf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec79b422-dedc-439f-afac-48f41b7d8602>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce35a610-53dc-4bbc-a766-5e7e36e2ac60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce35a610-53dc-4bbc-a766-5e7e36e2ac60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/7a291080-22c9-44fc-a024-e74992f67abe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce35a610-53dc-4bbc-a766-5e7e36e2ac60>.
+    
+<http://data.lblod.info/id/remote-data-objects/3329d3d8-55d4-4fbb-9d01-b328ba0eb0ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3329d3d8-55d4-4fbb-9d01-b328ba0eb0ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/80eb6a7e-964f-4f3f-b92e-154a67c30cc1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3329d3d8-55d4-4fbb-9d01-b328ba0eb0ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/73db26d4-0a3f-4ad1-8c98-c76604b47ee6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73db26d4-0a3f-4ad1-8c98-c76604b47ee6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/81104c38-e025-405a-93cb-e7fa6845f357/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73db26d4-0a3f-4ad1-8c98-c76604b47ee6>.
+    
+<http://data.lblod.info/id/remote-data-objects/11d2bdf7-4f41-4d5e-8b02-3decc4041530> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11d2bdf7-4f41-4d5e-8b02-3decc4041530";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/8178bd38-7379-4ac5-b7d9-859f8774f466/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11d2bdf7-4f41-4d5e-8b02-3decc4041530>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5773368-531b-4b24-a21f-de1ccfd4e127> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5773368-531b-4b24-a21f-de1ccfd4e127";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/8402d0bd-1e02-4777-8475-b078f550b348/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5773368-531b-4b24-a21f-de1ccfd4e127>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fe6a261-8217-4df8-8ad7-0496532e7a2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fe6a261-8217-4df8-8ad7-0496532e7a2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/87929873-d161-4757-95d8-cd409a45f0ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fe6a261-8217-4df8-8ad7-0496532e7a2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/95a2af85-843d-459d-9dfb-0c7ac675cf14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95a2af85-843d-459d-9dfb-0c7ac675cf14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/8887fa3f-6caf-4432-935e-d0dc5aa58a7c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95a2af85-843d-459d-9dfb-0c7ac675cf14>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfc757d9-f0ea-405f-b32b-8fb5de953f6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfc757d9-f0ea-405f-b32b-8fb5de953f6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/90293a62-eacd-4203-bf8a-f922619fcbfd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/fbda5f20-456e-4504-932c-9e8c5e1744af> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfc757d9-f0ea-405f-b32b-8fb5de953f6f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201838-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201838-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201838-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201838-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2e272b7c-9ef8-443b-ac45-481730a71a28> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2e272b7c-9ef8-443b-ac45-481730a71a28";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6a0e8611-2a58-4b0b-bbec-ec09723e4970";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c5cc3e7c-58bb-4c18-a039-7bf3ed02293b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c5cc3e7c-58bb-4c18-a039-7bf3ed02293b";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970>.
+
+  <http://redpencil.data.gift/id/task/948d9866-efc1-4f07-9e75-5aa9a0cadcdb> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "948d9866-efc1-4f07-9e75-5aa9a0cadcdb";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2e272b7c-9ef8-443b-ac45-481730a71a28>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c5cc3e7c-58bb-4c18-a039-7bf3ed02293b>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a10cca79-bb15-4a09-920e-9a080d2c7b8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a10cca79-bb15-4a09-920e-9a080d2c7b8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/9cc5e860-7c70-4234-aa64-34362e1480a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a10cca79-bb15-4a09-920e-9a080d2c7b8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1de58f4c-2dbb-4985-8827-322759de7822> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1de58f4c-2dbb-4985-8827-322759de7822";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/9ffe22fb-6d03-42f1-b27f-386bd70ac79f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1de58f4c-2dbb-4985-8827-322759de7822>.
+    
+<http://data.lblod.info/id/remote-data-objects/b857464d-e874-4dfb-843f-3436281bf3ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b857464d-e874-4dfb-843f-3436281bf3ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/a49b821b-3ad6-48c9-b2bd-692c221fbaac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b857464d-e874-4dfb-843f-3436281bf3ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/90a4bc24-0bbf-42b8-aa67-2d851b10085c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90a4bc24-0bbf-42b8-aa67-2d851b10085c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/aa94f030-655b-4c9e-a790-d5d796c9a9a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90a4bc24-0bbf-42b8-aa67-2d851b10085c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d859ab64-1dc4-4c4d-b101-3cc6ea4243cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d859ab64-1dc4-4c4d-b101-3cc6ea4243cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/b8d518b2-1019-4d31-ab30-cc1cf995fb07/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d859ab64-1dc4-4c4d-b101-3cc6ea4243cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffbac3d1-1331-4ec0-8a23-3bfe62d729ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffbac3d1-1331-4ec0-8a23-3bfe62d729ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/d2564d96-e1a3-46db-b927-2d0b1e1bbbb6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffbac3d1-1331-4ec0-8a23-3bfe62d729ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/5879ae4b-ce95-4042-a90c-e621e10032e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5879ae4b-ce95-4042-a90c-e621e10032e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/d67d9069-98ca-4a7d-9e99-049516fd10f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5879ae4b-ce95-4042-a90c-e621e10032e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a218755f-e94b-4316-92ec-2e574124fed9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a218755f-e94b-4316-92ec-2e574124fed9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/d89917d0-025c-4a6f-9036-0040fe196386/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a218755f-e94b-4316-92ec-2e574124fed9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a50d1344-417c-4243-84c0-d3f88ef6cf85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a50d1344-417c-4243-84c0-d3f88ef6cf85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/ddcea047-fd2f-457b-8c88-0d9c56b5b5d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a50d1344-417c-4243-84c0-d3f88ef6cf85>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa541313-cd0e-4fdd-90b9-c0b6d0c3fe91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa541313-cd0e-4fdd-90b9-c0b6d0c3fe91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/e90fc34b-7116-47dc-8d56-3e61bdc8d1ca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa541313-cd0e-4fdd-90b9-c0b6d0c3fe91>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4dc55ea-6c88-44ad-9b48-98a31844f144> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4dc55ea-6c88-44ad-9b48-98a31844f144";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/e9d03042-af77-4e68-bf08-99dccd932387/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4dc55ea-6c88-44ad-9b48-98a31844f144>.
+    
+<http://data.lblod.info/id/remote-data-objects/e14af069-f6fd-4d1d-bb40-54ed22b64316> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e14af069-f6fd-4d1d-bb40-54ed22b64316";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/ec3333d3-4412-4181-8273-62b98e29085e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e14af069-f6fd-4d1d-bb40-54ed22b64316>.
+    
+<http://data.lblod.info/id/remote-data-objects/01901d67-99bd-4278-986a-cdfd73bf3447> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01901d67-99bd-4278-986a-cdfd73bf3447";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/f1e7c886-04a4-4b35-a6dc-2d4640f428a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01901d67-99bd-4278-986a-cdfd73bf3447>.
+    
+<http://data.lblod.info/id/remote-data-objects/79e9504d-4db3-4378-8428-3aad1f82e654> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79e9504d-4db3-4378-8428-3aad1f82e654";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/fa34df0a-3b7d-4180-ab32-49cb1a178d26/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79e9504d-4db3-4378-8428-3aad1f82e654>.
+    
+<http://data.lblod.info/id/remote-data-objects/36277b77-9c85-42d0-9ca0-dd679246aff1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36277b77-9c85-42d0-9ca0-dd679246aff1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/cbs/fe455753-e323-4a3e-9319-2e9ad0f0f67e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36277b77-9c85-42d0-9ca0-dd679246aff1>.
+    
+<http://data.lblod.info/id/remote-data-objects/c75c5aef-7ba1-45ca-a07c-6975a68acdb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c75c5aef-7ba1-45ca-a07c-6975a68acdb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/14f4b020-e06d-4521-88e1-4313f2335aeb/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c75c5aef-7ba1-45ca-a07c-6975a68acdb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/28475ad6-041d-47da-96ad-a064df08b09f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28475ad6-041d-47da-96ad-a064df08b09f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/14f4b020-e06d-4521-88e1-4313f2335aeb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28475ad6-041d-47da-96ad-a064df08b09f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d43c1fab-fe3b-4cce-b24a-2aa745fc2d50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d43c1fab-fe3b-4cce-b24a-2aa745fc2d50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/14f4b020-e06d-4521-88e1-4313f2335aeb/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d43c1fab-fe3b-4cce-b24a-2aa745fc2d50>.
+    
+<http://data.lblod.info/id/remote-data-objects/c228ce52-b527-42ac-b36c-7d7311c0b9e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c228ce52-b527-42ac-b36c-7d7311c0b9e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/232a176d-1222-4008-a0b2-471c25625a0b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c228ce52-b527-42ac-b36c-7d7311c0b9e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce2552a3-d357-4da8-b2a9-4acf2bd6de91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce2552a3-d357-4da8-b2a9-4acf2bd6de91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/232a176d-1222-4008-a0b2-471c25625a0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce2552a3-d357-4da8-b2a9-4acf2bd6de91>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc8ec060-c207-456e-8bfb-2e660e3b003a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc8ec060-c207-456e-8bfb-2e660e3b003a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/232a176d-1222-4008-a0b2-471c25625a0b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc8ec060-c207-456e-8bfb-2e660e3b003a>.
+    
+<http://data.lblod.info/id/remote-data-objects/77d3dbe2-8cd6-46b3-a4ff-8e2d8524dbcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77d3dbe2-8cd6-46b3-a4ff-8e2d8524dbcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/35cab22a-a3ad-4c8d-b786-5d07ddf13a1a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77d3dbe2-8cd6-46b3-a4ff-8e2d8524dbcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/988c7518-6e66-43bd-87bc-c7399dcda363> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "988c7518-6e66-43bd-87bc-c7399dcda363";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/35cab22a-a3ad-4c8d-b786-5d07ddf13a1a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/988c7518-6e66-43bd-87bc-c7399dcda363>.
+    
+<http://data.lblod.info/id/remote-data-objects/46f7b8ac-2e05-4498-ae1f-08ba676e9f46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46f7b8ac-2e05-4498-ae1f-08ba676e9f46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/35cab22a-a3ad-4c8d-b786-5d07ddf13a1a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46f7b8ac-2e05-4498-ae1f-08ba676e9f46>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8a83b4b-3bc0-4996-8382-76b9bc039bd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8a83b4b-3bc0-4996-8382-76b9bc039bd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/5112147b-745a-43e2-8e75-67f2e2988098/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8a83b4b-3bc0-4996-8382-76b9bc039bd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/97ca2b77-c4cc-4944-97a4-efabdbbf81df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97ca2b77-c4cc-4944-97a4-efabdbbf81df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/5112147b-745a-43e2-8e75-67f2e2988098/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97ca2b77-c4cc-4944-97a4-efabdbbf81df>.
+    
+<http://data.lblod.info/id/remote-data-objects/6919e708-91f4-4565-8656-11da4596b931> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6919e708-91f4-4565-8656-11da4596b931";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/5112147b-745a-43e2-8e75-67f2e2988098/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6919e708-91f4-4565-8656-11da4596b931>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c19461d-1f3a-445d-94c3-e14314f2ca39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c19461d-1f3a-445d-94c3-e14314f2ca39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/540c400a-8ad2-4294-89d7-78f9432e429a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c19461d-1f3a-445d-94c3-e14314f2ca39>.
+    
+<http://data.lblod.info/id/remote-data-objects/005cc56f-b16d-4914-9a89-b2c83fe86be4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "005cc56f-b16d-4914-9a89-b2c83fe86be4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/540c400a-8ad2-4294-89d7-78f9432e429a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/005cc56f-b16d-4914-9a89-b2c83fe86be4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1480adb-d276-4b5b-a170-2599e94b633b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1480adb-d276-4b5b-a170-2599e94b633b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/5f94d9cf-6f92-4ab3-b6b4-eadbe87aff63/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1480adb-d276-4b5b-a170-2599e94b633b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dfa753e-d191-434e-9128-7cd4014a9a7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dfa753e-d191-434e-9128-7cd4014a9a7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/5f94d9cf-6f92-4ab3-b6b4-eadbe87aff63/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dfa753e-d191-434e-9128-7cd4014a9a7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f06897ec-d60f-4d16-9581-109ffba1b864> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f06897ec-d60f-4d16-9581-109ffba1b864";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/5f94d9cf-6f92-4ab3-b6b4-eadbe87aff63/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f06897ec-d60f-4d16-9581-109ffba1b864>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f8a1f7d-8522-495f-bbaa-76fa6e41d1f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f8a1f7d-8522-495f-bbaa-76fa6e41d1f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/63e1ef7c-83d5-425f-95ba-a013d3022af3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f8a1f7d-8522-495f-bbaa-76fa6e41d1f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/380a4eee-bc05-4cb8-8a49-486b7f17fa62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "380a4eee-bc05-4cb8-8a49-486b7f17fa62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/63e1ef7c-83d5-425f-95ba-a013d3022af3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/380a4eee-bc05-4cb8-8a49-486b7f17fa62>.
+    
+<http://data.lblod.info/id/remote-data-objects/0dca7cc7-61ed-4fcb-9d11-67914da5b112> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0dca7cc7-61ed-4fcb-9d11-67914da5b112";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/63e1ef7c-83d5-425f-95ba-a013d3022af3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0dca7cc7-61ed-4fcb-9d11-67914da5b112>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ac08cf1-0bed-4778-a631-a2b566484f5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ac08cf1-0bed-4778-a631-a2b566484f5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/c0c467e9-3005-40b2-bd12-5686bbda5ef8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ac08cf1-0bed-4778-a631-a2b566484f5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/82ff0a86-6d9d-4c63-a65e-43a37bd4d1b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82ff0a86-6d9d-4c63-a65e-43a37bd4d1b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/c0c467e9-3005-40b2-bd12-5686bbda5ef8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82ff0a86-6d9d-4c63-a65e-43a37bd4d1b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2dbe35c-4151-4529-b526-461f48a50d86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2dbe35c-4151-4529-b526-461f48a50d86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/c0c467e9-3005-40b2-bd12-5686bbda5ef8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2dbe35c-4151-4529-b526-461f48a50d86>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bea2270-6b39-44eb-b801-1639a184024a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bea2270-6b39-44eb-b801-1639a184024a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/c7c9f98d-a99c-4762-a9aa-055a08ba0e67/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bea2270-6b39-44eb-b801-1639a184024a>.
+    
+<http://data.lblod.info/id/remote-data-objects/70388372-cbae-48e8-b758-8bb2a29a44ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70388372-cbae-48e8-b758-8bb2a29a44ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/c7c9f98d-a99c-4762-a9aa-055a08ba0e67/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70388372-cbae-48e8-b758-8bb2a29a44ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9355fc4-822b-419d-b21d-34adef6cace0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9355fc4-822b-419d-b21d-34adef6cace0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/c7c9f98d-a99c-4762-a9aa-055a08ba0e67/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9355fc4-822b-419d-b21d-34adef6cace0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1908a64a-e36a-470a-9e67-3461e85d02ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1908a64a-e36a-470a-9e67-3461e85d02ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/d40375dc-6b8e-4dc3-a8a4-dcd84d54935d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1908a64a-e36a-470a-9e67-3461e85d02ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/b22a449a-27a8-48e6-a9d3-8421e1f47219> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b22a449a-27a8-48e6-a9d3-8421e1f47219";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/d40375dc-6b8e-4dc3-a8a4-dcd84d54935d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b22a449a-27a8-48e6-a9d3-8421e1f47219>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cd3e27d-eb22-4071-89ff-b03872f16931> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cd3e27d-eb22-4071-89ff-b03872f16931";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/d40375dc-6b8e-4dc3-a8a4-dcd84d54935d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cd3e27d-eb22-4071-89ff-b03872f16931>.
+    
+<http://data.lblod.info/id/remote-data-objects/f303d08b-a5da-4d6e-a30b-f3e50b34395a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f303d08b-a5da-4d6e-a30b-f3e50b34395a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/e1547497-f825-4da4-9610-496affda6785/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f303d08b-a5da-4d6e-a30b-f3e50b34395a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba8c73eb-bed9-48db-9d62-059dd7e26b4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba8c73eb-bed9-48db-9d62-059dd7e26b4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/e1547497-f825-4da4-9610-496affda6785/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba8c73eb-bed9-48db-9d62-059dd7e26b4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7857bb6c-990c-45cc-9231-b60e7f351b8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7857bb6c-990c-45cc-9231-b60e7f351b8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/gr/e1547497-f825-4da4-9610-496affda6785/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7857bb6c-990c-45cc-9231-b60e7f351b8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bb91e6c-a87c-47b0-bde3-7b7840e49d05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bb91e6c-a87c-47b0-bde3-7b7840e49d05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/03c3289f-1434-4dae-9e65-ab75faba9514/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bb91e6c-a87c-47b0-bde3-7b7840e49d05>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae184994-cb62-479c-896c-a75313c03c7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae184994-cb62-479c-896c-a75313c03c7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/03c3289f-1434-4dae-9e65-ab75faba9514/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae184994-cb62-479c-896c-a75313c03c7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e0cecc4-db90-45aa-b905-1d91663a611c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e0cecc4-db90-45aa-b905-1d91663a611c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/03c3289f-1434-4dae-9e65-ab75faba9514/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a0e8611-2a58-4b0b-bbec-ec09723e4970> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e0cecc4-db90-45aa-b905-1d91663a611c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201839-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201839-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201839-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201839-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3f710d1c-67c7-442d-a51f-2bfed8272692> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3f710d1c-67c7-442d-a51f-2bfed8272692";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ae46d6f9-74dc-413b-ab66-d88946ca6a79";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/824ab114-7fe5-4181-818a-6d3db11b93bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "824ab114-7fe5-4181-818a-6d3db11b93bf";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79>.
+
+  <http://redpencil.data.gift/id/task/5f41f642-378e-4749-a7ff-21ef2ea72588> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5f41f642-378e-4749-a7ff-21ef2ea72588";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3f710d1c-67c7-442d-a51f-2bfed8272692>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/824ab114-7fe5-4181-818a-6d3db11b93bf>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/85bd7ecc-d9d0-4f15-94c5-e4d57b43a696> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85bd7ecc-d9d0-4f15-94c5-e4d57b43a696";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/083b0709-993c-497d-8cae-87e01725e540/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85bd7ecc-d9d0-4f15-94c5-e4d57b43a696>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa8a9642-eb12-4132-9eb2-d4f66ec5c051> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa8a9642-eb12-4132-9eb2-d4f66ec5c051";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/083b0709-993c-497d-8cae-87e01725e540/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa8a9642-eb12-4132-9eb2-d4f66ec5c051>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ed4bb12-da79-4ff3-89f0-5ce7824c0124> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ed4bb12-da79-4ff3-89f0-5ce7824c0124";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/083b0709-993c-497d-8cae-87e01725e540/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ed4bb12-da79-4ff3-89f0-5ce7824c0124>.
+    
+<http://data.lblod.info/id/remote-data-objects/5573ece4-354f-421b-b05f-4e2cdf51af0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5573ece4-354f-421b-b05f-4e2cdf51af0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/1d760555-d324-40cb-8369-dd41bf990eee/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5573ece4-354f-421b-b05f-4e2cdf51af0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee2b6632-c596-4ca9-881f-422d68961ea6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee2b6632-c596-4ca9-881f-422d68961ea6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/1d760555-d324-40cb-8369-dd41bf990eee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee2b6632-c596-4ca9-881f-422d68961ea6>.
+    
+<http://data.lblod.info/id/remote-data-objects/498f922d-6d31-4f59-ae3d-5ef7d45c7569> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "498f922d-6d31-4f59-ae3d-5ef7d45c7569";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/1d760555-d324-40cb-8369-dd41bf990eee/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/498f922d-6d31-4f59-ae3d-5ef7d45c7569>.
+    
+<http://data.lblod.info/id/remote-data-objects/31a82295-9d56-427b-8c7a-6f12e429d437> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31a82295-9d56-427b-8c7a-6f12e429d437";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/4ee5d3d9-2a9f-45c6-8474-c7e03c059d4d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31a82295-9d56-427b-8c7a-6f12e429d437>.
+    
+<http://data.lblod.info/id/remote-data-objects/8eb75f66-9495-491f-9608-b0e7d5275351> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8eb75f66-9495-491f-9608-b0e7d5275351";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/4ee5d3d9-2a9f-45c6-8474-c7e03c059d4d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8eb75f66-9495-491f-9608-b0e7d5275351>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb906d88-4309-494e-abbb-d4082892d7fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb906d88-4309-494e-abbb-d4082892d7fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/4ee5d3d9-2a9f-45c6-8474-c7e03c059d4d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb906d88-4309-494e-abbb-d4082892d7fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/a69667f8-fd79-4720-93a7-ebf1fe6e5c44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a69667f8-fd79-4720-93a7-ebf1fe6e5c44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/56a04940-a5e7-4ec2-ac96-c23017d39528/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a69667f8-fd79-4720-93a7-ebf1fe6e5c44>.
+    
+<http://data.lblod.info/id/remote-data-objects/acfc0b60-56b0-43b7-bf49-c0e21abee019> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acfc0b60-56b0-43b7-bf49-c0e21abee019";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/56a04940-a5e7-4ec2-ac96-c23017d39528/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acfc0b60-56b0-43b7-bf49-c0e21abee019>.
+    
+<http://data.lblod.info/id/remote-data-objects/24961e00-775b-45a6-9820-84ed9ba48734> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24961e00-775b-45a6-9820-84ed9ba48734";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/56a04940-a5e7-4ec2-ac96-c23017d39528/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24961e00-775b-45a6-9820-84ed9ba48734>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0a9d9ad-76e4-44eb-879c-9ae38ab58b85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0a9d9ad-76e4-44eb-879c-9ae38ab58b85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/5ec36020-4f28-4a14-a561-08c6f28dd527/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0a9d9ad-76e4-44eb-879c-9ae38ab58b85>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd79373f-28e0-4edd-8ad6-62e55168d676> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd79373f-28e0-4edd-8ad6-62e55168d676";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/5ec36020-4f28-4a14-a561-08c6f28dd527/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd79373f-28e0-4edd-8ad6-62e55168d676>.
+    
+<http://data.lblod.info/id/remote-data-objects/d911a9ec-c4b3-4921-b6f4-925641ec4c18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d911a9ec-c4b3-4921-b6f4-925641ec4c18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/5ec36020-4f28-4a14-a561-08c6f28dd527/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d911a9ec-c4b3-4921-b6f4-925641ec4c18>.
+    
+<http://data.lblod.info/id/remote-data-objects/85f630ac-7f49-4c01-b8af-3d222c8c825b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85f630ac-7f49-4c01-b8af-3d222c8c825b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/d0a37fec-b39d-4f21-8cec-839c57481e70/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85f630ac-7f49-4c01-b8af-3d222c8c825b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ab85b63-1d9f-42e8-84a9-8da48499a30f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ab85b63-1d9f-42e8-84a9-8da48499a30f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/d0a37fec-b39d-4f21-8cec-839c57481e70/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ab85b63-1d9f-42e8-84a9-8da48499a30f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b118e01a-5f5f-4d89-9768-769c4bb71913> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b118e01a-5f5f-4d89-9768-769c4bb71913";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/d0a37fec-b39d-4f21-8cec-839c57481e70/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b118e01a-5f5f-4d89-9768-769c4bb71913>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cbbab2d-5e6f-4673-8169-323d3934939f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cbbab2d-5e6f-4673-8169-323d3934939f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/e0ec32c8-dd39-4e9e-8d27-d26d64ac90d1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cbbab2d-5e6f-4673-8169-323d3934939f>.
+    
+<http://data.lblod.info/id/remote-data-objects/03bbd28d-db0a-4daf-949c-b799dd5f50c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03bbd28d-db0a-4daf-949c-b799dd5f50c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/e0ec32c8-dd39-4e9e-8d27-d26d64ac90d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03bbd28d-db0a-4daf-949c-b799dd5f50c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d459a725-0295-4e90-a3fa-6ef7a527bfcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d459a725-0295-4e90-a3fa-6ef7a527bfcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/e0ec32c8-dd39-4e9e-8d27-d26d64ac90d1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d459a725-0295-4e90-a3fa-6ef7a527bfcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7df8fee-b18f-410e-b457-1dedd2e6aa9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7df8fee-b18f-410e-b457-1dedd2e6aa9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/e61c942d-6e33-46a2-aad8-87281dd24ace/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7df8fee-b18f-410e-b457-1dedd2e6aa9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3d5cac2-51ff-40ad-b262-a0b92a294af0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3d5cac2-51ff-40ad-b262-a0b92a294af0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/e61c942d-6e33-46a2-aad8-87281dd24ace/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3d5cac2-51ff-40ad-b262-a0b92a294af0>.
+    
+<http://data.lblod.info/id/remote-data-objects/38784fcf-0f93-44a7-8a0e-e84cfa929f1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38784fcf-0f93-44a7-8a0e-e84cfa929f1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/e9a89f31-3d37-42b8-a0bc-72f97cfdd38f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38784fcf-0f93-44a7-8a0e-e84cfa929f1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1eba9c67-1c8b-4f9d-a9e6-5ef33fef281e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1eba9c67-1c8b-4f9d-a9e6-5ef33fef281e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/e9a89f31-3d37-42b8-a0bc-72f97cfdd38f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1eba9c67-1c8b-4f9d-a9e6-5ef33fef281e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c5e8ce7-6622-4c5a-af53-cad2807cf768> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c5e8ce7-6622-4c5a-af53-cad2807cf768";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/rmw/e9a89f31-3d37-42b8-a0bc-72f97cfdd38f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c5e8ce7-6622-4c5a-af53-cad2807cf768>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c478102-f64f-4415-b11c-54ad1b534b05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c478102-f64f-4415-b11c-54ad1b534b05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/0d4cc848-2789-420c-9b10-4f64ce7860b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c478102-f64f-4415-b11c-54ad1b534b05>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cd331fb-0949-422a-83ad-7b49d942a68d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cd331fb-0949-422a-83ad-7b49d942a68d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/105721b6-1fe7-43e5-a054-67bada207748/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cd331fb-0949-422a-83ad-7b49d942a68d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c8691ed-842f-431b-875a-6e08cec8de2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c8691ed-842f-431b-875a-6e08cec8de2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/17ef2d01-fb99-4b01-9eea-6790059fd867/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c8691ed-842f-431b-875a-6e08cec8de2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/303ae26c-50c9-4e84-bcbf-e4033e84b204> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "303ae26c-50c9-4e84-bcbf-e4033e84b204";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/1c3d0a61-8e71-4233-a4cf-0acf4337f166/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/303ae26c-50c9-4e84-bcbf-e4033e84b204>.
+    
+<http://data.lblod.info/id/remote-data-objects/f533c9b2-b31e-41f2-bde3-e3bcfdbcb0ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f533c9b2-b31e-41f2-bde3-e3bcfdbcb0ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/274bc5c1-a2ab-45fb-b238-ce0c548c6f2b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f533c9b2-b31e-41f2-bde3-e3bcfdbcb0ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a2b2a8e-cb91-4320-96c4-8e303ddb836b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a2b2a8e-cb91-4320-96c4-8e303ddb836b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/33086eef-01ea-434c-9fe1-8ef16e63bbb9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a2b2a8e-cb91-4320-96c4-8e303ddb836b>.
+    
+<http://data.lblod.info/id/remote-data-objects/eac21e38-5ce0-4108-9da6-c31d4efdcbdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eac21e38-5ce0-4108-9da6-c31d4efdcbdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/350b388e-8729-4c98-b42b-aaaa4d4a674b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eac21e38-5ce0-4108-9da6-c31d4efdcbdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c35a152a-e3ac-4f00-9c02-153de2b4db69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c35a152a-e3ac-4f00-9c02-153de2b4db69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/38da46a8-4ebb-4ae7-917c-7bffc178e7a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c35a152a-e3ac-4f00-9c02-153de2b4db69>.
+    
+<http://data.lblod.info/id/remote-data-objects/18fd01c6-e595-4793-aed1-8a04221bbfa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18fd01c6-e595-4793-aed1-8a04221bbfa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/3a6ff492-5f8c-480b-8b73-9d67a4e1c107/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18fd01c6-e595-4793-aed1-8a04221bbfa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbb931b2-a6b4-437e-b9af-3f643de563dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbb931b2-a6b4-437e-b9af-3f643de563dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/3ac67c6e-3547-48bf-b6af-7885e6115623/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbb931b2-a6b4-437e-b9af-3f643de563dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/62a484f2-34dd-412c-8c02-2fac35cc9e57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62a484f2-34dd-412c-8c02-2fac35cc9e57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/45119886-5fdb-4a75-bd0b-afadae5dd7ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62a484f2-34dd-412c-8c02-2fac35cc9e57>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e13f45b-486a-41c9-9308-2361c7d2fcb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e13f45b-486a-41c9-9308-2361c7d2fcb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/5e363f4c-6608-4d06-99f1-13ea9e96baa0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e13f45b-486a-41c9-9308-2361c7d2fcb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e40bbfc9-8af9-4242-b859-8e8875a7f427> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e40bbfc9-8af9-4242-b859-8e8875a7f427";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/66df4f4a-617a-41a8-98ef-3a18e988af92/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e40bbfc9-8af9-4242-b859-8e8875a7f427>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4b76f21-8187-4421-98fa-5a31f5e6e054> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4b76f21-8187-4421-98fa-5a31f5e6e054";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/6dcce046-1e92-44b2-afba-01bba2fef2d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4b76f21-8187-4421-98fa-5a31f5e6e054>.
+    
+<http://data.lblod.info/id/remote-data-objects/29a7b359-0ea1-46a7-b42c-bcadb42a2ce2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29a7b359-0ea1-46a7-b42c-bcadb42a2ce2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/70570606-b909-4e03-8bc4-17e476970011/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29a7b359-0ea1-46a7-b42c-bcadb42a2ce2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b5a1471-2c60-4a4a-8ecf-0b38909a8489> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b5a1471-2c60-4a4a-8ecf-0b38909a8489";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/757f445a-1d0f-425e-85e8-b47e201654a2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b5a1471-2c60-4a4a-8ecf-0b38909a8489>.
+    
+<http://data.lblod.info/id/remote-data-objects/518fb079-99b6-4457-be7d-cbec199a49f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "518fb079-99b6-4457-be7d-cbec199a49f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/80e60558-b8b5-4ca0-b89f-507e728cf8d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/518fb079-99b6-4457-be7d-cbec199a49f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9293676-608f-4176-aa00-56f8bff025e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9293676-608f-4176-aa00-56f8bff025e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/83a149f7-fe9f-4518-82f6-df94a091548e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9293676-608f-4176-aa00-56f8bff025e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/927e1ae0-ac62-4727-9869-516dd58f2758> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "927e1ae0-ac62-4727-9869-516dd58f2758";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/899c1f80-80d2-4cad-bad2-5bf7a0e873bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/927e1ae0-ac62-4727-9869-516dd58f2758>.
+    
+<http://data.lblod.info/id/remote-data-objects/08fd8bc9-5663-4c87-b3b5-fd249049acf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08fd8bc9-5663-4c87-b3b5-fd249049acf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/8be4b400-946f-476c-b604-1bc585259647/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08fd8bc9-5663-4c87-b3b5-fd249049acf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/20dd4097-7b2a-45b2-95f4-0af3c189b9f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20dd4097-7b2a-45b2-95f4-0af3c189b9f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/a03f4b1a-cced-41bd-a89b-5de7ceb0e4aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20dd4097-7b2a-45b2-95f4-0af3c189b9f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/83ef95b2-2d31-40fc-9482-d32d7eab8e48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83ef95b2-2d31-40fc-9482-d32d7eab8e48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/aa624147-1b69-40b5-a74c-84e6e7670aac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83ef95b2-2d31-40fc-9482-d32d7eab8e48>.
+    
+<http://data.lblod.info/id/remote-data-objects/db240ab0-2928-4166-b339-60aa0522f55d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db240ab0-2928-4166-b339-60aa0522f55d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/c6ff3dff-dfb6-4263-8025-a46bf30dd57c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db240ab0-2928-4166-b339-60aa0522f55d>.
+    
+<http://data.lblod.info/id/remote-data-objects/49ced5f8-bf69-442e-8d37-b28d5fd2246d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49ced5f8-bf69-442e-8d37-b28d5fd2246d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/dc8643b3-4d83-4754-9042-44b14b203c00/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:39.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ae46d6f9-74dc-413b-ab66-d88946ca6a79> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49ced5f8-bf69-442e-8d37-b28d5fd2246d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201841-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201841-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201841-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201841-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/36aafeb3-a8fa-473d-acfb-089d78637a27> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "36aafeb3-a8fa-473d-acfb-089d78637a27";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "80133f57-0c71-4afb-9d91-70db3612c296";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/5c53a084-ae61-4dd7-9f8a-5624fb03d3c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5c53a084-ae61-4dd7-9f8a-5624fb03d3c8";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296>.
+
+  <http://redpencil.data.gift/id/task/c106b10a-2526-4f99-8682-096fa684e9ad> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c106b10a-2526-4f99-8682-096fa684e9ad";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/36aafeb3-a8fa-473d-acfb-089d78637a27>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/5c53a084-ae61-4dd7-9f8a-5624fb03d3c8>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/42624add-4a30-4ae6-96e8-408fe00cad79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42624add-4a30-4ae6-96e8-408fe00cad79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/ec7db1d3-5d12-4698-babc-21790492367a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42624add-4a30-4ae6-96e8-408fe00cad79>.
+    
+<http://data.lblod.info/id/remote-data-objects/0429ffb2-2f40-4601-b7ec-8d777403d97f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0429ffb2-2f40-4601-b7ec-8d777403d97f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/f1535079-5422-4a82-9a2b-af52cf6db5e9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0429ffb2-2f40-4601-b7ec-8d777403d97f>.
+    
+<http://data.lblod.info/id/remote-data-objects/48efca9a-fda3-44b0-8bee-989ae27b2d0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48efca9a-fda3-44b0-8bee-989ae27b2d0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meerhout.meetingburger.net/vb/fdc53862-bf39-41f9-86b4-385da76eb584/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48efca9a-fda3-44b0-8bee-989ae27b2d0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0052f19b-c824-4863-8556-e336c8b62ab5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0052f19b-c824-4863-8556-e336c8b62ab5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/02aed406-8b06-4eff-9626-2ceb07c6afa7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0052f19b-c824-4863-8556-e336c8b62ab5>.
+    
+<http://data.lblod.info/id/remote-data-objects/94a6714e-17ce-454c-8ae2-92596c0ac3aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94a6714e-17ce-454c-8ae2-92596c0ac3aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/0b302c1c-b63e-4bf1-b8d9-c8e9130500d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94a6714e-17ce-454c-8ae2-92596c0ac3aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0f19879-d37c-4c03-b720-52e37ba9c2c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0f19879-d37c-4c03-b720-52e37ba9c2c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/0fcefb62-915d-436c-bba3-782794621525/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0f19879-d37c-4c03-b720-52e37ba9c2c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/82101eed-26c5-4b03-b49c-43c67a4557b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82101eed-26c5-4b03-b49c-43c67a4557b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/116a3167-01ab-4f83-8eb8-12773db078ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82101eed-26c5-4b03-b49c-43c67a4557b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/76711b01-363a-45ca-80b1-60b38421572b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76711b01-363a-45ca-80b1-60b38421572b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/144735ca-86ad-4db3-be39-f41bdd7e85fb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76711b01-363a-45ca-80b1-60b38421572b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a834f6b-5ba0-4be1-89b0-43cfd6ddd261> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a834f6b-5ba0-4be1-89b0-43cfd6ddd261";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/176a9758-5f49-43cf-b038-b0b6f5f61f7a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a834f6b-5ba0-4be1-89b0-43cfd6ddd261>.
+    
+<http://data.lblod.info/id/remote-data-objects/160ff4c2-3d11-4ae7-a0f3-0f40d07da1f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "160ff4c2-3d11-4ae7-a0f3-0f40d07da1f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/1b88e9d6-229d-494f-a02f-fef8e51cc2e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/160ff4c2-3d11-4ae7-a0f3-0f40d07da1f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/303246d8-839c-4d0e-aa50-f8f3e494291f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "303246d8-839c-4d0e-aa50-f8f3e494291f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/1ba1166b-22a0-4de6-b0d1-64fad4d804ba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/303246d8-839c-4d0e-aa50-f8f3e494291f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2d669f2-fea9-4820-bef8-83e8932f04c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2d669f2-fea9-4820-bef8-83e8932f04c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/1d571f4d-b417-477e-b987-240ceb2f111a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2d669f2-fea9-4820-bef8-83e8932f04c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/02986d27-273d-43ad-b284-1fc3aa6746f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02986d27-273d-43ad-b284-1fc3aa6746f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/1f386519-9eee-4026-90b4-7ff99c181c77/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02986d27-273d-43ad-b284-1fc3aa6746f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4125631-8473-4ca1-aeed-9eb93a367416> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4125631-8473-4ca1-aeed-9eb93a367416";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/23e1173a-450b-48a8-a07d-1b6f113404fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4125631-8473-4ca1-aeed-9eb93a367416>.
+    
+<http://data.lblod.info/id/remote-data-objects/10ea7cd8-7bc0-48a1-afb4-a50738663087> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10ea7cd8-7bc0-48a1-afb4-a50738663087";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/2430d5b3-159f-4266-ad1e-6747cb69a702/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10ea7cd8-7bc0-48a1-afb4-a50738663087>.
+    
+<http://data.lblod.info/id/remote-data-objects/378bbbfa-37f6-4e96-8262-6e9964f987be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "378bbbfa-37f6-4e96-8262-6e9964f987be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/2afc03a2-d65a-413b-a5ce-c8833796a547/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/378bbbfa-37f6-4e96-8262-6e9964f987be>.
+    
+<http://data.lblod.info/id/remote-data-objects/14f386d1-4eb2-459c-97e4-dc42765d5c1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14f386d1-4eb2-459c-97e4-dc42765d5c1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/310320f4-6db9-4e87-8e94-02cc9ab0e082/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14f386d1-4eb2-459c-97e4-dc42765d5c1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5034b249-49ad-46b3-ab63-a7725bccbb9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5034b249-49ad-46b3-ab63-a7725bccbb9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/32d43b42-482c-455a-989f-75bcc9ffdeed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5034b249-49ad-46b3-ab63-a7725bccbb9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5800ce01-28e0-4ec1-a415-ef4dba60100b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5800ce01-28e0-4ec1-a415-ef4dba60100b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/3bad7360-1ce0-472c-a37f-84bc4b1e5d75/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5800ce01-28e0-4ec1-a415-ef4dba60100b>.
+    
+<http://data.lblod.info/id/remote-data-objects/79861f14-cf94-479f-9e13-0eb69abc5f17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79861f14-cf94-479f-9e13-0eb69abc5f17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/3e436328-47c8-445c-8797-e913fa875890/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79861f14-cf94-479f-9e13-0eb69abc5f17>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a63c905-6ee5-4832-85e9-c1a6d3ee0dd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a63c905-6ee5-4832-85e9-c1a6d3ee0dd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/41658576-0651-457e-a28e-2d07519ac962/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a63c905-6ee5-4832-85e9-c1a6d3ee0dd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/855ba21c-9ecf-4779-81f6-23af33b833a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "855ba21c-9ecf-4779-81f6-23af33b833a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/5509ac08-04af-4c3a-a4f9-697dc6eb5c0c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/855ba21c-9ecf-4779-81f6-23af33b833a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/61abcd77-d56a-4859-817a-e1125488b6fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61abcd77-d56a-4859-817a-e1125488b6fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/55c4785e-73b0-4815-9894-35ed44728da3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61abcd77-d56a-4859-817a-e1125488b6fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/605b47fc-d946-42f2-9062-60952e9bfaf1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "605b47fc-d946-42f2-9062-60952e9bfaf1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/5ca38898-faa2-430d-adf3-edf6e619d080/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/605b47fc-d946-42f2-9062-60952e9bfaf1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a78fe768-9319-4fab-b005-18a686211f46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a78fe768-9319-4fab-b005-18a686211f46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/5cad7e37-7021-4e0a-bd07-31a552c839f6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a78fe768-9319-4fab-b005-18a686211f46>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea241482-6663-4b1b-a548-856d142e1913> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea241482-6663-4b1b-a548-856d142e1913";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/5e975a92-a678-4df8-9248-20a7d18257f0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea241482-6663-4b1b-a548-856d142e1913>.
+    
+<http://data.lblod.info/id/remote-data-objects/5616bf4d-6775-4359-922b-bbebbbe5b21c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5616bf4d-6775-4359-922b-bbebbbe5b21c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/707063fc-a2e1-4cfd-9de1-49e6b27dd96f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5616bf4d-6775-4359-922b-bbebbbe5b21c>.
+    
+<http://data.lblod.info/id/remote-data-objects/63afa1cb-f279-4c17-b019-4786b5add218> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63afa1cb-f279-4c17-b019-4786b5add218";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/710a08b0-255e-497b-8b5c-09e4363a9d87/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63afa1cb-f279-4c17-b019-4786b5add218>.
+    
+<http://data.lblod.info/id/remote-data-objects/5aecdd3f-fb96-4196-9d26-e56235e34d42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5aecdd3f-fb96-4196-9d26-e56235e34d42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/73ddc95c-3ac7-475d-94b9-07c0d774707e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5aecdd3f-fb96-4196-9d26-e56235e34d42>.
+    
+<http://data.lblod.info/id/remote-data-objects/61639e15-1f81-491d-b253-333e0a1e570d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61639e15-1f81-491d-b253-333e0a1e570d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/747aa40b-c32d-4a1f-ae3c-77a46f3786b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61639e15-1f81-491d-b253-333e0a1e570d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bd2e8b0-fa8d-47ec-96cc-c90686fa977e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bd2e8b0-fa8d-47ec-96cc-c90686fa977e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/74cf9fbc-9abc-4b31-89d1-0f0be5a9195b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bd2e8b0-fa8d-47ec-96cc-c90686fa977e>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd201dc1-5be8-4576-8cb0-012f0c67bb51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd201dc1-5be8-4576-8cb0-012f0c67bb51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/838eee33-bc8f-4bfa-8f66-26e24cf4ce34/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd201dc1-5be8-4576-8cb0-012f0c67bb51>.
+    
+<http://data.lblod.info/id/remote-data-objects/0fa955ca-9cf5-4a8f-8a4f-f3867b7fe3cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0fa955ca-9cf5-4a8f-8a4f-f3867b7fe3cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/89ae6791-8b0f-4ce1-8f01-c254564fc6d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0fa955ca-9cf5-4a8f-8a4f-f3867b7fe3cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd9d1187-7ff4-4cee-9fb6-daa41ccb9adf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd9d1187-7ff4-4cee-9fb6-daa41ccb9adf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/99d35c81-954f-445a-866e-4935456b9752/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd9d1187-7ff4-4cee-9fb6-daa41ccb9adf>.
+    
+<http://data.lblod.info/id/remote-data-objects/750f0be2-fbc3-4a75-be9b-e6b23053f4ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "750f0be2-fbc3-4a75-be9b-e6b23053f4ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/a14318a4-1e99-4be9-9db8-124e685d9444/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/750f0be2-fbc3-4a75-be9b-e6b23053f4ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c0b86f1-0797-496c-86e8-3175a1a7c217> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c0b86f1-0797-496c-86e8-3175a1a7c217";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/a58402ff-ccda-471d-afa0-baa4678c8be5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c0b86f1-0797-496c-86e8-3175a1a7c217>.
+    
+<http://data.lblod.info/id/remote-data-objects/28a0d203-0cd5-4778-baed-4fb0d24d9202> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28a0d203-0cd5-4778-baed-4fb0d24d9202";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/a7cbbfbc-4adb-47ec-9d80-eb0de099a805/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28a0d203-0cd5-4778-baed-4fb0d24d9202>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f5af3ae-7e60-4d60-b394-31997b0401cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f5af3ae-7e60-4d60-b394-31997b0401cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/a8fa54bb-c028-4feb-b6ff-2ceebefa4da5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f5af3ae-7e60-4d60-b394-31997b0401cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/18505a3d-b006-48a9-aa79-125a8dd6f971> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18505a3d-b006-48a9-aa79-125a8dd6f971";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/a9538059-938a-473a-ada3-f07fd7b89b0e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18505a3d-b006-48a9-aa79-125a8dd6f971>.
+    
+<http://data.lblod.info/id/remote-data-objects/78554506-2558-47d8-8f14-2891c7e24eb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78554506-2558-47d8-8f14-2891c7e24eb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/ab6c11d6-47db-4e52-85f7-71ed5ec7ca04/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78554506-2558-47d8-8f14-2891c7e24eb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb1e136b-41f3-48d2-a768-c03bfaa69652> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb1e136b-41f3-48d2-a768-c03bfaa69652";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/aee14bb5-1213-41b8-8266-e0bd880bfa39/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb1e136b-41f3-48d2-a768-c03bfaa69652>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d096066-e980-488c-aa62-e59a1634fd40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d096066-e980-488c-aa62-e59a1634fd40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/b78ecb85-1577-4675-a6b0-e82dbdc789ca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d096066-e980-488c-aa62-e59a1634fd40>.
+    
+<http://data.lblod.info/id/remote-data-objects/c313b996-e05a-469a-a85e-a0a454aa0af8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c313b996-e05a-469a-a85e-a0a454aa0af8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/ba58313e-0bff-47f1-8589-24bda1f03b61/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c313b996-e05a-469a-a85e-a0a454aa0af8>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3727959-fb29-4f95-b151-3e2b1cd41c78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3727959-fb29-4f95-b151-3e2b1cd41c78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/ba6f4249-f1ba-4d5a-81be-4d87c7e93ee1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3727959-fb29-4f95-b151-3e2b1cd41c78>.
+    
+<http://data.lblod.info/id/remote-data-objects/9610cb75-16ca-48ce-93c5-64d6d0c84e2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9610cb75-16ca-48ce-93c5-64d6d0c84e2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/bf92c1ea-2ddb-46ee-b9e8-e1d0857d7ff3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9610cb75-16ca-48ce-93c5-64d6d0c84e2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a45e0b3-4881-4a1a-8cca-433a73257a20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a45e0b3-4881-4a1a-8cca-433a73257a20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/c0e8fd30-aee4-43d0-a9c5-36ed4d48c7d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a45e0b3-4881-4a1a-8cca-433a73257a20>.
+    
+<http://data.lblod.info/id/remote-data-objects/b282f2a9-c1e0-4319-8080-58fb8a09e21f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b282f2a9-c1e0-4319-8080-58fb8a09e21f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/c2058d32-67fe-4150-97bc-d4b5c1b0a404/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b282f2a9-c1e0-4319-8080-58fb8a09e21f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cf97581-07df-4ac1-b124-5a36ae4a5ef6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cf97581-07df-4ac1-b124-5a36ae4a5ef6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/c26d9826-a8db-4545-9c99-6b879a03dea4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cf97581-07df-4ac1-b124-5a36ae4a5ef6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e520a1d7-32df-4d5b-a800-e6b6b3bdd9a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e520a1d7-32df-4d5b-a800-e6b6b3bdd9a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/ce96fdbc-c099-4d7e-b6e7-3be6cead40f0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e520a1d7-32df-4d5b-a800-e6b6b3bdd9a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/62cea1fb-d498-429e-a7a7-db579bd9ef60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62cea1fb-d498-429e-a7a7-db579bd9ef60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/cfca32fb-e3aa-41e1-bc8e-e569417a0d97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/80133f57-0c71-4afb-9d91-70db3612c296> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62cea1fb-d498-429e-a7a7-db579bd9ef60>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201842-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201842-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201842-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201842-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/8683a3a9-22b8-43ef-8431-4c8278cffe99> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8683a3a9-22b8-43ef-8431-4c8278cffe99";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0299f693-27b5-4564-8107-da7d35fb6e30";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/02b0139d-6697-4137-acad-3de0ca555b54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "02b0139d-6697-4137-acad-3de0ca555b54";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30>.
+
+  <http://redpencil.data.gift/id/task/3dcea652-070b-4da7-8a96-fd9b530c454a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3dcea652-070b-4da7-8a96-fd9b530c454a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/8683a3a9-22b8-43ef-8431-4c8278cffe99>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/02b0139d-6697-4137-acad-3de0ca555b54>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/ff5e2d00-cef2-43bf-9ae1-d6c5f1021f1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff5e2d00-cef2-43bf-9ae1-d6c5f1021f1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/da17e892-6a88-438a-b38b-99f4bc630c3c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff5e2d00-cef2-43bf-9ae1-d6c5f1021f1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef910aec-faf2-4ded-900b-9233874e7e46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef910aec-faf2-4ded-900b-9233874e7e46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/db3363d7-e201-41f9-ab01-0965060cb828/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef910aec-faf2-4ded-900b-9233874e7e46>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5135bbf-fc7c-4613-9b45-2ee1cb988081> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5135bbf-fc7c-4613-9b45-2ee1cb988081";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/e1d39e01-69a5-4417-9a36-0b9a12d69d12/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5135bbf-fc7c-4613-9b45-2ee1cb988081>.
+    
+<http://data.lblod.info/id/remote-data-objects/5914ebd5-a55b-4393-b7de-bb78854d6437> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5914ebd5-a55b-4393-b7de-bb78854d6437";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/e3fb1686-f3e1-4504-8923-56952c2ec231/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5914ebd5-a55b-4393-b7de-bb78854d6437>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6f88dd3-5ce9-43d8-9583-09ccaaee4b7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6f88dd3-5ce9-43d8-9583-09ccaaee4b7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/e5d4c940-c92c-4859-a04c-001178be85fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6f88dd3-5ce9-43d8-9583-09ccaaee4b7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/40480df4-4d0a-4906-b4d5-241798a4593e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40480df4-4d0a-4906-b4d5-241798a4593e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/e9359d31-2e7b-41ed-8589-dcc93581fd8f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40480df4-4d0a-4906-b4d5-241798a4593e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4722c40c-9fc9-41f6-a32a-778cd0bdd5c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4722c40c-9fc9-41f6-a32a-778cd0bdd5c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/f0d86ea6-fdd6-407c-9abd-07b2cd669303/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4722c40c-9fc9-41f6-a32a-778cd0bdd5c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b470a6e-d380-4f0e-b75d-9d09675ccac4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b470a6e-d380-4f0e-b75d-9d09675ccac4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/f2c697d0-e50e-4363-b1c3-b6bb953463c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b470a6e-d380-4f0e-b75d-9d09675ccac4>.
+    
+<http://data.lblod.info/id/remote-data-objects/098ce144-9385-46c6-b25c-fe12ece3bb73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "098ce144-9385-46c6-b25c-fe12ece3bb73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/bb/f5408bb8-7e72-44f8-b34a-ae66e70b8400/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/098ce144-9385-46c6-b25c-fe12ece3bb73>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2a7fe57-69ac-4a0c-9573-be749f2ec578> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2a7fe57-69ac-4a0c-9573-be749f2ec578";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/003f540c-d0c5-40d1-ac66-cd190f21c35e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2a7fe57-69ac-4a0c-9573-be749f2ec578>.
+    
+<http://data.lblod.info/id/remote-data-objects/aeed08ff-aa26-4d59-a764-1800157bc615> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aeed08ff-aa26-4d59-a764-1800157bc615";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/032f5a25-f8a3-4258-b4ce-b99e598116ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aeed08ff-aa26-4d59-a764-1800157bc615>.
+    
+<http://data.lblod.info/id/remote-data-objects/3aace498-488f-498a-81f0-3cf7e7178036> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3aace498-488f-498a-81f0-3cf7e7178036";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/079ce810-b78c-43a1-b2ed-41b2e8196b8e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3aace498-488f-498a-81f0-3cf7e7178036>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c145198-d5b5-4145-bccf-9005e37ad96e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c145198-d5b5-4145-bccf-9005e37ad96e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/08009de0-d916-497d-b2fa-9b280dc92b5e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c145198-d5b5-4145-bccf-9005e37ad96e>.
+    
+<http://data.lblod.info/id/remote-data-objects/95be304e-b326-4d5b-8c64-b1c634c68a8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95be304e-b326-4d5b-8c64-b1c634c68a8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/091410f0-3fbb-441a-b762-38b41e824aac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95be304e-b326-4d5b-8c64-b1c634c68a8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9979d51-8a14-4008-a05d-be8f582b2003> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9979d51-8a14-4008-a05d-be8f582b2003";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/09bc7dc9-b398-4253-8795-16df64ddcf03/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9979d51-8a14-4008-a05d-be8f582b2003>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee4b65fc-8c38-4d9e-b334-0bf0085ce0de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee4b65fc-8c38-4d9e-b334-0bf0085ce0de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/0bbcdd58-8de2-4592-822b-4ad9f298adb5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee4b65fc-8c38-4d9e-b334-0bf0085ce0de>.
+    
+<http://data.lblod.info/id/remote-data-objects/eae07272-2905-4b32-b68a-e2a09ffdf10f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eae07272-2905-4b32-b68a-e2a09ffdf10f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/0f1087f8-7b10-46f7-a590-363f276326df/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eae07272-2905-4b32-b68a-e2a09ffdf10f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce19b8b2-9898-48b3-a55a-677370f1104a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce19b8b2-9898-48b3-a55a-677370f1104a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/0fe53c11-2ac5-4036-b498-9db0de617956/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce19b8b2-9898-48b3-a55a-677370f1104a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3683a0b2-839d-483d-b50b-e478b9cb4320> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3683a0b2-839d-483d-b50b-e478b9cb4320";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/17cd0d9b-afcc-425c-af79-e67a8f04acec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3683a0b2-839d-483d-b50b-e478b9cb4320>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7b354c1-4de9-4651-a302-61c7661332bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7b354c1-4de9-4651-a302-61c7661332bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/1904c023-631d-470f-be26-a489b3be8c52/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7b354c1-4de9-4651-a302-61c7661332bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/8caee7ff-c298-4617-9f3e-f06a9b56a741> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8caee7ff-c298-4617-9f3e-f06a9b56a741";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/1a6d20c9-41f2-40f8-ae20-d0ebc2df85a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8caee7ff-c298-4617-9f3e-f06a9b56a741>.
+    
+<http://data.lblod.info/id/remote-data-objects/97efefae-fe26-4bb7-b6d6-db8add903a40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97efefae-fe26-4bb7-b6d6-db8add903a40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/1aa1599d-d8c9-4fcd-81db-d4d0c100483a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97efefae-fe26-4bb7-b6d6-db8add903a40>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4c4f7b4-3bcd-48dd-9e3f-965fb0214810> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4c4f7b4-3bcd-48dd-9e3f-965fb0214810";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/1aef8496-9667-4518-b7ea-1bc1872486a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4c4f7b4-3bcd-48dd-9e3f-965fb0214810>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fd41910-cb0a-4893-9ec0-902879d46cf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fd41910-cb0a-4893-9ec0-902879d46cf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/1cb2d711-0e2d-4d09-8bee-237d3ce06699/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fd41910-cb0a-4893-9ec0-902879d46cf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/98130b83-8d96-425c-b6b3-0e6e242554ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98130b83-8d96-425c-b6b3-0e6e242554ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/1cc57d8b-8352-4fa9-818d-9eadffec9b3c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98130b83-8d96-425c-b6b3-0e6e242554ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b7765af-49f0-4733-9f70-56f5f5ff3459> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b7765af-49f0-4733-9f70-56f5f5ff3459";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/227864db-6543-43e7-9947-3280b1ddd917/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b7765af-49f0-4733-9f70-56f5f5ff3459>.
+    
+<http://data.lblod.info/id/remote-data-objects/17615a8e-5f22-4c72-ad69-5f138d963732> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17615a8e-5f22-4c72-ad69-5f138d963732";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/3b261555-ac9c-4aab-bc03-6fb2b3ffb977/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17615a8e-5f22-4c72-ad69-5f138d963732>.
+    
+<http://data.lblod.info/id/remote-data-objects/e611cfb7-3b67-4e50-9df8-f3aeb5ba1ea7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e611cfb7-3b67-4e50-9df8-f3aeb5ba1ea7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/4006f1f9-b453-4f24-84d3-4c798d61996e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e611cfb7-3b67-4e50-9df8-f3aeb5ba1ea7>.
+    
+<http://data.lblod.info/id/remote-data-objects/5694d8bc-208e-4928-840d-f8ac33355a2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5694d8bc-208e-4928-840d-f8ac33355a2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/4072faa9-956a-4360-a867-ba04dddd4f7c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5694d8bc-208e-4928-840d-f8ac33355a2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d09c0204-75b5-4170-9a8c-e5fc87f048b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d09c0204-75b5-4170-9a8c-e5fc87f048b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/4431a571-6d55-4e7a-875b-09497d93841e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d09c0204-75b5-4170-9a8c-e5fc87f048b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c6dd800-0220-4ab4-a592-d06e16402df5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c6dd800-0220-4ab4-a592-d06e16402df5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/47865554-2184-48da-b844-55465fc42b2d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c6dd800-0220-4ab4-a592-d06e16402df5>.
+    
+<http://data.lblod.info/id/remote-data-objects/67c25a0c-17f5-485c-994d-fd1d2892fa3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67c25a0c-17f5-485c-994d-fd1d2892fa3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/4c6a3c9a-4dfa-4f32-bd3c-3e61cf77dada/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67c25a0c-17f5-485c-994d-fd1d2892fa3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d832969c-ed54-42d1-8fbc-9fc01a278949> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d832969c-ed54-42d1-8fbc-9fc01a278949";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/550a475a-ead1-4b6d-8071-88162d7b52b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d832969c-ed54-42d1-8fbc-9fc01a278949>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae3871d8-261e-428a-985f-8510bb092619> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae3871d8-261e-428a-985f-8510bb092619";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/55fa0ca7-5799-4fba-ac0b-be02ad089eb3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae3871d8-261e-428a-985f-8510bb092619>.
+    
+<http://data.lblod.info/id/remote-data-objects/59a60bf1-9d11-4a2a-b15f-3e0bf996ef3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59a60bf1-9d11-4a2a-b15f-3e0bf996ef3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/58f3eb64-cb7a-4d61-ae1f-9e2e79bd6ac1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59a60bf1-9d11-4a2a-b15f-3e0bf996ef3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/515fb480-24e3-4f50-b58f-fb78a74f30fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "515fb480-24e3-4f50-b58f-fb78a74f30fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/60d676e5-bd30-4619-9abf-43f606325316/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/515fb480-24e3-4f50-b58f-fb78a74f30fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcb6ecf8-b80e-4fa5-8ab8-af15ac21b93c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcb6ecf8-b80e-4fa5-8ab8-af15ac21b93c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/617c6da1-f25d-43ad-ae38-de9fcc27be11/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcb6ecf8-b80e-4fa5-8ab8-af15ac21b93c>.
+    
+<http://data.lblod.info/id/remote-data-objects/197fe013-4927-4c20-a9b6-791547729389> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "197fe013-4927-4c20-a9b6-791547729389";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/62bad452-ea06-47db-82f6-1d3105a88f26/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/197fe013-4927-4c20-a9b6-791547729389>.
+    
+<http://data.lblod.info/id/remote-data-objects/2887090e-fd46-4560-a7f3-ac09dd777407> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2887090e-fd46-4560-a7f3-ac09dd777407";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/6364e375-c297-49e0-a437-caf7135db6d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2887090e-fd46-4560-a7f3-ac09dd777407>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7f8036b-ef83-4636-8735-9a82e0a41690> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7f8036b-ef83-4636-8735-9a82e0a41690";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/642ce7ee-1a12-4581-bc93-bcaceb3abe12/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7f8036b-ef83-4636-8735-9a82e0a41690>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd098fb3-bf18-429e-8d88-5f74994dbe2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd098fb3-bf18-429e-8d88-5f74994dbe2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/65019763-c3e7-460d-a57b-dfb8c255d599/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd098fb3-bf18-429e-8d88-5f74994dbe2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/65f213c1-5d66-42f3-a039-d86427817114> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65f213c1-5d66-42f3-a039-d86427817114";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/6a08b0c1-0a0c-49d3-8374-5a7e43cfaad5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65f213c1-5d66-42f3-a039-d86427817114>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2c4fb40-7613-41e7-9b81-6fe273712d8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2c4fb40-7613-41e7-9b81-6fe273712d8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/6ba93cdc-d59c-4783-8239-869200755cc7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2c4fb40-7613-41e7-9b81-6fe273712d8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/08ad7ee4-4998-48cf-b2de-ecd6833d6bde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08ad7ee4-4998-48cf-b2de-ecd6833d6bde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/6bf1d803-f54a-4658-8835-5909617b3083/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08ad7ee4-4998-48cf-b2de-ecd6833d6bde>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cdbd5e2-e828-46f8-80ba-a17f74cf9a9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cdbd5e2-e828-46f8-80ba-a17f74cf9a9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/6d98f982-4b3d-44a2-8071-016e8bc90dca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cdbd5e2-e828-46f8-80ba-a17f74cf9a9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f00cadfc-1b20-4439-aea9-5059d8e48b28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f00cadfc-1b20-4439-aea9-5059d8e48b28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/72416e7e-2153-48c9-aa35-bc56b7020f39/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f00cadfc-1b20-4439-aea9-5059d8e48b28>.
+    
+<http://data.lblod.info/id/remote-data-objects/6edc6bb7-41cb-4f48-9699-bec490630cca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6edc6bb7-41cb-4f48-9699-bec490630cca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/78422ee2-a378-4b85-a9c7-15d033223483/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6edc6bb7-41cb-4f48-9699-bec490630cca>.
+    
+<http://data.lblod.info/id/remote-data-objects/b66d05bc-5a1f-4dec-9584-d77cc9276941> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b66d05bc-5a1f-4dec-9584-d77cc9276941";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/7ad57cdd-8639-495d-bed0-bb1aaa28c10b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b66d05bc-5a1f-4dec-9584-d77cc9276941>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa6cd393-c21f-4938-b4ca-daa70b02470c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa6cd393-c21f-4938-b4ca-daa70b02470c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/845b0363-bc1b-43b1-88b7-fcfe4334cc9a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa6cd393-c21f-4938-b4ca-daa70b02470c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2eeaae05-39b6-4ab7-8fa6-dc7db2dc7e2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2eeaae05-39b6-4ab7-8fa6-dc7db2dc7e2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/89cb1e56-8508-48d3-9f63-dc61a6a1cdb1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/0299f693-27b5-4564-8107-da7d35fb6e30> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2eeaae05-39b6-4ab7-8fa6-dc7db2dc7e2b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201843-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201843-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201843-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201843-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a50c58da-b6c2-4dd5-93d7-513be9b7994b> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a50c58da-b6c2-4dd5-93d7-513be9b7994b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "10aead0a-a661-415a-a548-c92bb055495a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d8afd5dc-e4b2-4faa-b4a7-279f95623f2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d8afd5dc-e4b2-4faa-b4a7-279f95623f2c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a>.
+
+  <http://redpencil.data.gift/id/task/a9ea514e-0320-414e-b76b-3eaa051c8957> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a9ea514e-0320-414e-b76b-3eaa051c8957";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a50c58da-b6c2-4dd5-93d7-513be9b7994b>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d8afd5dc-e4b2-4faa-b4a7-279f95623f2c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/cbaa9ec6-49da-44fa-b0fb-a5ab13969d00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbaa9ec6-49da-44fa-b0fb-a5ab13969d00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/8cb087b0-3917-43b5-be45-64f55173f603/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbaa9ec6-49da-44fa-b0fb-a5ab13969d00>.
+    
+<http://data.lblod.info/id/remote-data-objects/08493e2b-ce75-4123-b0bf-8f76c93fa502> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08493e2b-ce75-4123-b0bf-8f76c93fa502";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/916c48fe-76ea-4230-a94d-0f372f4f8556/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08493e2b-ce75-4123-b0bf-8f76c93fa502>.
+    
+<http://data.lblod.info/id/remote-data-objects/96e711d9-5f16-4ae9-80d5-2527808968d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96e711d9-5f16-4ae9-80d5-2527808968d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/9c90a7d6-0c3c-42b4-9d21-97913dea9ec8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96e711d9-5f16-4ae9-80d5-2527808968d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/bce32af3-6d49-4fa2-82d5-7fc4447c6de3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bce32af3-6d49-4fa2-82d5-7fc4447c6de3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/a5653d4f-a282-4948-bec1-ee018b9510c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bce32af3-6d49-4fa2-82d5-7fc4447c6de3>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ac7ca78-1ce3-4661-a3a5-661f4983aade> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ac7ca78-1ce3-4661-a3a5-661f4983aade";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/a9cdb23f-c5d0-4bed-956a-6aafc52ee166/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ac7ca78-1ce3-4661-a3a5-661f4983aade>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fe2b9fd-1043-4906-9597-f286dcf7777d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fe2b9fd-1043-4906-9597-f286dcf7777d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/ab7c04ba-93d8-4f78-9810-43be969252fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fe2b9fd-1043-4906-9597-f286dcf7777d>.
+    
+<http://data.lblod.info/id/remote-data-objects/021d29df-7a07-4f3e-80d8-acd400866a11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "021d29df-7a07-4f3e-80d8-acd400866a11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/ae2a324c-1b9e-46a8-ab69-463b84e241d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/021d29df-7a07-4f3e-80d8-acd400866a11>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d3c4ad4-5a3c-47f9-bd31-1a30cf76f8fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d3c4ad4-5a3c-47f9-bd31-1a30cf76f8fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/b14012bc-8244-46b9-bdfc-6053580a98fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d3c4ad4-5a3c-47f9-bd31-1a30cf76f8fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/1aac5139-a37f-4b02-bfdc-2b991f6fdea3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1aac5139-a37f-4b02-bfdc-2b991f6fdea3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/b86bd1a7-eb79-483b-aa00-8af893c3f01f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1aac5139-a37f-4b02-bfdc-2b991f6fdea3>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcabc70d-ad4f-426d-980d-93675391fad6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcabc70d-ad4f-426d-980d-93675391fad6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/b98b14b0-e606-462e-b4a5-c007f17083a0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcabc70d-ad4f-426d-980d-93675391fad6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9382feaf-c0cb-418a-bb80-00d687949141> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9382feaf-c0cb-418a-bb80-00d687949141";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/bd72f7f6-f0f2-4534-974c-e1be8d88e7bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9382feaf-c0cb-418a-bb80-00d687949141>.
+    
+<http://data.lblod.info/id/remote-data-objects/be6e2474-2983-45d7-bffd-f870ae9037b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be6e2474-2983-45d7-bffd-f870ae9037b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/c01e4c78-9675-4bc6-8d30-40e0f8558b17/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be6e2474-2983-45d7-bffd-f870ae9037b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/93be4075-52ea-4a2b-aa67-fe6653e87c91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93be4075-52ea-4a2b-aa67-fe6653e87c91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/c0741003-f0da-4236-ae80-6b9af16d1965/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93be4075-52ea-4a2b-aa67-fe6653e87c91>.
+    
+<http://data.lblod.info/id/remote-data-objects/960e4ccf-59bb-4f6f-bd97-4f12ede36b80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "960e4ccf-59bb-4f6f-bd97-4f12ede36b80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/c24b048a-490b-4abf-b4c5-cedb436934c0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/960e4ccf-59bb-4f6f-bd97-4f12ede36b80>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba9ce268-7f04-45f4-8c75-e2f71b34a35b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba9ce268-7f04-45f4-8c75-e2f71b34a35b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/c70bd3c0-1639-41a3-832a-eac46c217649/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba9ce268-7f04-45f4-8c75-e2f71b34a35b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb79b344-4f8a-4496-9517-13d31e621d38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb79b344-4f8a-4496-9517-13d31e621d38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/c89d472d-360e-4c93-bc8c-e3fc14236bc9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb79b344-4f8a-4496-9517-13d31e621d38>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b45b9e1-8666-452b-9562-62f804146510> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b45b9e1-8666-452b-9562-62f804146510";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/ce4e63e7-a7b0-49b2-b621-dd36fa3b3c01/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b45b9e1-8666-452b-9562-62f804146510>.
+    
+<http://data.lblod.info/id/remote-data-objects/93bae08c-8a68-433c-aa66-c2c7691586f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93bae08c-8a68-433c-aa66-c2c7691586f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/d17fe7c7-e365-4568-b86b-8438ce106aa0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93bae08c-8a68-433c-aa66-c2c7691586f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/83bc53e2-02ec-44e9-a5c3-387f11a96fe7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83bc53e2-02ec-44e9-a5c3-387f11a96fe7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/de00c5a8-0fa1-4283-b968-a3e42c17611a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83bc53e2-02ec-44e9-a5c3-387f11a96fe7>.
+    
+<http://data.lblod.info/id/remote-data-objects/08b956ed-d1c2-4957-a22c-7f9c1e0e90f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08b956ed-d1c2-4957-a22c-7f9c1e0e90f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/e341df14-8ddc-4bce-9d93-cc2cf62b0b0a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08b956ed-d1c2-4957-a22c-7f9c1e0e90f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/54a6b7f9-24c0-433b-b7eb-b661104ca561> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54a6b7f9-24c0-433b-b7eb-b661104ca561";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/f1500f6e-4933-4584-be79-8a2233e46307/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54a6b7f9-24c0-433b-b7eb-b661104ca561>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1455b0c-b393-48ad-b5af-836170e8ef45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1455b0c-b393-48ad-b5af-836170e8ef45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/f2941313-0f1e-4748-827f-a3e4c03f128a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1455b0c-b393-48ad-b5af-836170e8ef45>.
+    
+<http://data.lblod.info/id/remote-data-objects/b22043a2-6d1f-4b5c-b3c0-5ee9ebf79790> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b22043a2-6d1f-4b5c-b3c0-5ee9ebf79790";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/f4d86cb7-833b-4052-8567-8e0e0908d694/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b22043a2-6d1f-4b5c-b3c0-5ee9ebf79790>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc4ece49-beeb-4230-ad4c-c8bee32189b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc4ece49-beeb-4230-ad4c-c8bee32189b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/f9c09a23-288b-4977-bc10-549edc35f955/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc4ece49-beeb-4230-ad4c-c8bee32189b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/226f5790-5819-4bd9-b9ba-2bf142e022ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "226f5790-5819-4bd9-b9ba-2bf142e022ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/cbs/fa12bf6d-1000-490a-82e4-4e99be7d05cc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/226f5790-5819-4bd9-b9ba-2bf142e022ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/140a1a61-eb25-4a45-a623-8c5afdc24650> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "140a1a61-eb25-4a45-a623-8c5afdc24650";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/08ecb525-009a-4a9a-9036-1c25957a51ac/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/140a1a61-eb25-4a45-a623-8c5afdc24650>.
+    
+<http://data.lblod.info/id/remote-data-objects/99f7e9b7-e26a-49f4-ac9b-0446a11aca27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99f7e9b7-e26a-49f4-ac9b-0446a11aca27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/08ecb525-009a-4a9a-9036-1c25957a51ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99f7e9b7-e26a-49f4-ac9b-0446a11aca27>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cfd65e0-784c-4ea9-bb00-379fe55d68d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cfd65e0-784c-4ea9-bb00-379fe55d68d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/08ecb525-009a-4a9a-9036-1c25957a51ac/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cfd65e0-784c-4ea9-bb00-379fe55d68d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/d02ac628-bd8c-4213-b2b2-5ccfc80f123c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d02ac628-bd8c-4213-b2b2-5ccfc80f123c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/2492e70a-cf2b-4c54-affc-ad2eb9d1228a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d02ac628-bd8c-4213-b2b2-5ccfc80f123c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6594f905-b019-454d-bf35-db02b340370f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6594f905-b019-454d-bf35-db02b340370f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/2492e70a-cf2b-4c54-affc-ad2eb9d1228a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6594f905-b019-454d-bf35-db02b340370f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b878bfa0-7733-4259-a438-d8245942bfc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b878bfa0-7733-4259-a438-d8245942bfc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/2492e70a-cf2b-4c54-affc-ad2eb9d1228a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b878bfa0-7733-4259-a438-d8245942bfc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/14369b2e-003e-4764-9770-8d7b234a972d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14369b2e-003e-4764-9770-8d7b234a972d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/2760a440-de17-4096-b912-ea7b06d1d920/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14369b2e-003e-4764-9770-8d7b234a972d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a04f8614-2127-4e8b-bf61-ea964db0d2b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a04f8614-2127-4e8b-bf61-ea964db0d2b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/2760a440-de17-4096-b912-ea7b06d1d920/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a04f8614-2127-4e8b-bf61-ea964db0d2b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e79ea03-5fce-46d0-bb77-80eeddfd398d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e79ea03-5fce-46d0-bb77-80eeddfd398d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/2760a440-de17-4096-b912-ea7b06d1d920/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e79ea03-5fce-46d0-bb77-80eeddfd398d>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf3a1a47-a19c-420c-adc5-df3271504208> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf3a1a47-a19c-420c-adc5-df3271504208";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/2d86abfe-f604-47b4-99e2-17113512ed3a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf3a1a47-a19c-420c-adc5-df3271504208>.
+    
+<http://data.lblod.info/id/remote-data-objects/30e58058-c5fc-4d04-ad53-3ce9fe867589> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30e58058-c5fc-4d04-ad53-3ce9fe867589";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/2d86abfe-f604-47b4-99e2-17113512ed3a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30e58058-c5fc-4d04-ad53-3ce9fe867589>.
+    
+<http://data.lblod.info/id/remote-data-objects/513a1c73-5982-424a-ae7d-51e6698f1b9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "513a1c73-5982-424a-ae7d-51e6698f1b9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/2d86abfe-f604-47b4-99e2-17113512ed3a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/513a1c73-5982-424a-ae7d-51e6698f1b9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3276b179-4a9c-40a8-8121-1adc1e107d60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3276b179-4a9c-40a8-8121-1adc1e107d60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/3c54a51c-0f2d-49bf-b62a-832b68132d54/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3276b179-4a9c-40a8-8121-1adc1e107d60>.
+    
+<http://data.lblod.info/id/remote-data-objects/58ec9503-a2ea-4654-be63-44a78b4c6b67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58ec9503-a2ea-4654-be63-44a78b4c6b67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/3c54a51c-0f2d-49bf-b62a-832b68132d54/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58ec9503-a2ea-4654-be63-44a78b4c6b67>.
+    
+<http://data.lblod.info/id/remote-data-objects/d91f5083-8529-478e-8d8c-190e52322df1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d91f5083-8529-478e-8d8c-190e52322df1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/3c54a51c-0f2d-49bf-b62a-832b68132d54/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d91f5083-8529-478e-8d8c-190e52322df1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b485e1eb-82e6-49f1-aa49-1c2b8308746b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b485e1eb-82e6-49f1-aa49-1c2b8308746b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/3e4f2b53-fe07-4182-b734-e0902282fe55/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b485e1eb-82e6-49f1-aa49-1c2b8308746b>.
+    
+<http://data.lblod.info/id/remote-data-objects/975b7f5d-28ef-4e76-8e82-e3994bebef1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "975b7f5d-28ef-4e76-8e82-e3994bebef1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/3e4f2b53-fe07-4182-b734-e0902282fe55/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/975b7f5d-28ef-4e76-8e82-e3994bebef1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c6d54a7-1b54-400f-b0df-3baa7173c8e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c6d54a7-1b54-400f-b0df-3baa7173c8e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/3e4f2b53-fe07-4182-b734-e0902282fe55/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c6d54a7-1b54-400f-b0df-3baa7173c8e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7da297f5-62be-4553-aae2-becb668fd07a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7da297f5-62be-4553-aae2-becb668fd07a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/405b2993-6996-459c-9907-b52aa49f6049/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7da297f5-62be-4553-aae2-becb668fd07a>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc499c60-9c84-41c3-af58-981773fa8349> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc499c60-9c84-41c3-af58-981773fa8349";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/405b2993-6996-459c-9907-b52aa49f6049/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc499c60-9c84-41c3-af58-981773fa8349>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f32f5e0-3640-4603-b25b-4197e3f1b7b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f32f5e0-3640-4603-b25b-4197e3f1b7b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/405b2993-6996-459c-9907-b52aa49f6049/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f32f5e0-3640-4603-b25b-4197e3f1b7b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/84215753-4753-4fd8-b66c-e143e1d6e4e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84215753-4753-4fd8-b66c-e143e1d6e4e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/58d45dbb-da7f-4d70-bc38-2288a5604acf/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84215753-4753-4fd8-b66c-e143e1d6e4e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/15c65d18-854a-48c9-ac6a-b641fca8b27b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15c65d18-854a-48c9-ac6a-b641fca8b27b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/58d45dbb-da7f-4d70-bc38-2288a5604acf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15c65d18-854a-48c9-ac6a-b641fca8b27b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a32008ec-3635-4ac0-9262-9c968e242ff1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a32008ec-3635-4ac0-9262-9c968e242ff1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/58d45dbb-da7f-4d70-bc38-2288a5604acf/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a32008ec-3635-4ac0-9262-9c968e242ff1>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c8db5ef-8b03-4d4f-aa2b-67c9592ab2a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c8db5ef-8b03-4d4f-aa2b-67c9592ab2a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/5d000953-1df2-4b4b-8b82-beb798263a87/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/10aead0a-a661-415a-a548-c92bb055495a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c8db5ef-8b03-4d4f-aa2b-67c9592ab2a8>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201844-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201844-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201844-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201844-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/23a9b28a-a95a-4902-b6bf-47fc0480eea0> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "23a9b28a-a95a-4902-b6bf-47fc0480eea0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "532eeca5-2317-43cc-b8bd-67bb3c7638cd";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/74c7ae7e-b800-4afa-97dd-1bca59bb3679> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "74c7ae7e-b800-4afa-97dd-1bca59bb3679";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd>.
+
+  <http://redpencil.data.gift/id/task/a193c302-3c33-43eb-8436-11b70d35b1b4> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a193c302-3c33-43eb-8436-11b70d35b1b4";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/23a9b28a-a95a-4902-b6bf-47fc0480eea0>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/74c7ae7e-b800-4afa-97dd-1bca59bb3679>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5827c49f-ceca-4073-b8cf-b5bcf5ad6dd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5827c49f-ceca-4073-b8cf-b5bcf5ad6dd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/5d000953-1df2-4b4b-8b82-beb798263a87/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5827c49f-ceca-4073-b8cf-b5bcf5ad6dd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/61018bca-3f51-448d-ad47-ad16da11eac4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61018bca-3f51-448d-ad47-ad16da11eac4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/5d000953-1df2-4b4b-8b82-beb798263a87/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61018bca-3f51-448d-ad47-ad16da11eac4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3eac4f75-9427-43d0-90dc-ef3fb09eef70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3eac4f75-9427-43d0-90dc-ef3fb09eef70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/72e8f79a-2681-4e30-85b2-166d4c41cf96/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3eac4f75-9427-43d0-90dc-ef3fb09eef70>.
+    
+<http://data.lblod.info/id/remote-data-objects/13dccf9b-e281-4c75-9138-0b8941f83d56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13dccf9b-e281-4c75-9138-0b8941f83d56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/72e8f79a-2681-4e30-85b2-166d4c41cf96/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13dccf9b-e281-4c75-9138-0b8941f83d56>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e33d4c6-4287-45a1-9f60-f5e46017326f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e33d4c6-4287-45a1-9f60-f5e46017326f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/72e8f79a-2681-4e30-85b2-166d4c41cf96/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e33d4c6-4287-45a1-9f60-f5e46017326f>.
+    
+<http://data.lblod.info/id/remote-data-objects/17d333eb-8cbb-4315-8cc3-2dada63e48eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17d333eb-8cbb-4315-8cc3-2dada63e48eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/79ca43e7-33e9-429c-bb8b-5e958e4e2d2d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17d333eb-8cbb-4315-8cc3-2dada63e48eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/e01f8f2a-bb3c-4dbd-8ccf-3ed9a7c972de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e01f8f2a-bb3c-4dbd-8ccf-3ed9a7c972de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/79ca43e7-33e9-429c-bb8b-5e958e4e2d2d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e01f8f2a-bb3c-4dbd-8ccf-3ed9a7c972de>.
+    
+<http://data.lblod.info/id/remote-data-objects/564ddd83-1895-49b6-8200-ae1e01441123> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "564ddd83-1895-49b6-8200-ae1e01441123";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/79ca43e7-33e9-429c-bb8b-5e958e4e2d2d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/564ddd83-1895-49b6-8200-ae1e01441123>.
+    
+<http://data.lblod.info/id/remote-data-objects/66e20d26-7b8e-4fdd-8f5e-3528c0ea9114> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66e20d26-7b8e-4fdd-8f5e-3528c0ea9114";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/9353a123-ff88-4015-8836-08a764bf77bc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66e20d26-7b8e-4fdd-8f5e-3528c0ea9114>.
+    
+<http://data.lblod.info/id/remote-data-objects/45b62382-6b23-4537-a237-731df9b43ca0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45b62382-6b23-4537-a237-731df9b43ca0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/9353a123-ff88-4015-8836-08a764bf77bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45b62382-6b23-4537-a237-731df9b43ca0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e0b4d35-0211-4ec2-88a3-9fa8f940de00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e0b4d35-0211-4ec2-88a3-9fa8f940de00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/9353a123-ff88-4015-8836-08a764bf77bc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e0b4d35-0211-4ec2-88a3-9fa8f940de00>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a47c12f-f7f0-4d07-ae66-4aaf02f7801f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a47c12f-f7f0-4d07-ae66-4aaf02f7801f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/9d22b149-8e46-485f-b03c-71729283b294/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a47c12f-f7f0-4d07-ae66-4aaf02f7801f>.
+    
+<http://data.lblod.info/id/remote-data-objects/641ad9e0-21d3-4f39-87b5-2c7683bfb7da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "641ad9e0-21d3-4f39-87b5-2c7683bfb7da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/9d22b149-8e46-485f-b03c-71729283b294/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/641ad9e0-21d3-4f39-87b5-2c7683bfb7da>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ef99be4-5153-4fcf-88a7-afa392172a4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ef99be4-5153-4fcf-88a7-afa392172a4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/a603ff53-f78b-43a5-a714-5e50a8fa3c15/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ef99be4-5153-4fcf-88a7-afa392172a4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/eef546d1-4512-4b9a-975d-924bf8d857f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eef546d1-4512-4b9a-975d-924bf8d857f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/a603ff53-f78b-43a5-a714-5e50a8fa3c15/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eef546d1-4512-4b9a-975d-924bf8d857f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/024b1ca1-e990-4f82-93a6-16c251a5e857> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "024b1ca1-e990-4f82-93a6-16c251a5e857";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/a603ff53-f78b-43a5-a714-5e50a8fa3c15/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/024b1ca1-e990-4f82-93a6-16c251a5e857>.
+    
+<http://data.lblod.info/id/remote-data-objects/208756e3-75af-479f-a3b4-de43d3cc3da4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "208756e3-75af-479f-a3b4-de43d3cc3da4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/d9bf0035-bbee-4e99-a605-a293fd1181b3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/208756e3-75af-479f-a3b4-de43d3cc3da4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c54e0473-babf-44ea-bb46-3324214aa005> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c54e0473-babf-44ea-bb46-3324214aa005";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/d9bf0035-bbee-4e99-a605-a293fd1181b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c54e0473-babf-44ea-bb46-3324214aa005>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5ada9d7-2cc0-47d6-9873-c4bba9a9171b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5ada9d7-2cc0-47d6-9873-c4bba9a9171b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/d9bf0035-bbee-4e99-a605-a293fd1181b3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5ada9d7-2cc0-47d6-9873-c4bba9a9171b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2db14c24-6030-4fd6-8b33-45fe83e22443> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2db14c24-6030-4fd6-8b33-45fe83e22443";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/e05a149c-c58a-4923-8f67-21180114b5ce/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2db14c24-6030-4fd6-8b33-45fe83e22443>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc8a9a43-5e8b-45d0-95fd-3f0218c8010b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc8a9a43-5e8b-45d0-95fd-3f0218c8010b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/e05a149c-c58a-4923-8f67-21180114b5ce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc8a9a43-5e8b-45d0-95fd-3f0218c8010b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb912da8-3d9e-4839-b047-c2bb1a0c6e7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb912da8-3d9e-4839-b047-c2bb1a0c6e7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/e05a149c-c58a-4923-8f67-21180114b5ce/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb912da8-3d9e-4839-b047-c2bb1a0c6e7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1ddb965-6889-49cd-90eb-6bc5cb64d7ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1ddb965-6889-49cd-90eb-6bc5cb64d7ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/e6f6dd51-7115-4c9e-86ca-a08f0820acda/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1ddb965-6889-49cd-90eb-6bc5cb64d7ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/82ee7e71-ac9d-4267-920c-a99b8f0edd20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82ee7e71-ac9d-4267-920c-a99b8f0edd20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/e6f6dd51-7115-4c9e-86ca-a08f0820acda/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82ee7e71-ac9d-4267-920c-a99b8f0edd20>.
+    
+<http://data.lblod.info/id/remote-data-objects/c009bc1c-87c2-4e61-b229-97bb2c9c29f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c009bc1c-87c2-4e61-b229-97bb2c9c29f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/gr/e6f6dd51-7115-4c9e-86ca-a08f0820acda/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c009bc1c-87c2-4e61-b229-97bb2c9c29f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/79d3d318-e69c-4010-a628-9c913b711c40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79d3d318-e69c-4010-a628-9c913b711c40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/0b2396b2-e1ef-4e77-89fa-82f2037a991b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79d3d318-e69c-4010-a628-9c913b711c40>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f0813a2-976a-47b5-a1f2-b69bee0c01c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f0813a2-976a-47b5-a1f2-b69bee0c01c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/0b2396b2-e1ef-4e77-89fa-82f2037a991b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f0813a2-976a-47b5-a1f2-b69bee0c01c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ef2abc3-d7c3-48fa-a520-cb4c7ed9a145> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ef2abc3-d7c3-48fa-a520-cb4c7ed9a145";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/0b2396b2-e1ef-4e77-89fa-82f2037a991b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ef2abc3-d7c3-48fa-a520-cb4c7ed9a145>.
+    
+<http://data.lblod.info/id/remote-data-objects/c38387a8-11b4-4caf-8f63-d53c66ba0039> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c38387a8-11b4-4caf-8f63-d53c66ba0039";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/0d867f49-291a-4a90-9642-09f384c2d487/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c38387a8-11b4-4caf-8f63-d53c66ba0039>.
+    
+<http://data.lblod.info/id/remote-data-objects/719b46fe-9d4c-4736-b51b-9831cc91ca5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "719b46fe-9d4c-4736-b51b-9831cc91ca5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/0d867f49-291a-4a90-9642-09f384c2d487/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/719b46fe-9d4c-4736-b51b-9831cc91ca5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fc74a8d-77bb-4eb6-b8f4-99d97298bcb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fc74a8d-77bb-4eb6-b8f4-99d97298bcb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/0d867f49-291a-4a90-9642-09f384c2d487/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fc74a8d-77bb-4eb6-b8f4-99d97298bcb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/1389cc8c-1c64-434d-932c-87dcf4c212cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1389cc8c-1c64-434d-932c-87dcf4c212cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/14a28ddc-cf58-4820-be07-583c07e2b62e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1389cc8c-1c64-434d-932c-87dcf4c212cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/a92dd6de-08a8-4fce-b620-d0747f6e6ff7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a92dd6de-08a8-4fce-b620-d0747f6e6ff7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/14a28ddc-cf58-4820-be07-583c07e2b62e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a92dd6de-08a8-4fce-b620-d0747f6e6ff7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f07e97a9-b628-4128-aeae-e6206283266e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f07e97a9-b628-4128-aeae-e6206283266e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/14a28ddc-cf58-4820-be07-583c07e2b62e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f07e97a9-b628-4128-aeae-e6206283266e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a64f807c-1c35-4d76-bb69-08bfb37d3d57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a64f807c-1c35-4d76-bb69-08bfb37d3d57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/2084d2a2-c6d5-48b6-a5df-5735ea06a33d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a64f807c-1c35-4d76-bb69-08bfb37d3d57>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6dd29b7-22d2-4e6b-9851-7e79930d01e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6dd29b7-22d2-4e6b-9851-7e79930d01e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/2084d2a2-c6d5-48b6-a5df-5735ea06a33d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6dd29b7-22d2-4e6b-9851-7e79930d01e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c800f44-d5cb-4873-b632-0ee65ff28ed4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c800f44-d5cb-4873-b632-0ee65ff28ed4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/2084d2a2-c6d5-48b6-a5df-5735ea06a33d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c800f44-d5cb-4873-b632-0ee65ff28ed4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bf8c047-b04f-48ea-83bd-afb5cc5ee89b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bf8c047-b04f-48ea-83bd-afb5cc5ee89b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/43acb34f-0605-43e9-90a0-a36984f3fbb8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bf8c047-b04f-48ea-83bd-afb5cc5ee89b>.
+    
+<http://data.lblod.info/id/remote-data-objects/66d8d33b-c5f5-406a-a42e-37ba900f50cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66d8d33b-c5f5-406a-a42e-37ba900f50cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/43acb34f-0605-43e9-90a0-a36984f3fbb8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66d8d33b-c5f5-406a-a42e-37ba900f50cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/30c7995c-6004-41e6-b147-1671d1e77de6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30c7995c-6004-41e6-b147-1671d1e77de6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/43acb34f-0605-43e9-90a0-a36984f3fbb8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30c7995c-6004-41e6-b147-1671d1e77de6>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf7f2ad1-07c8-414a-bfc1-ce27d09e21a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf7f2ad1-07c8-414a-bfc1-ce27d09e21a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/46ed4dfc-8299-4ccf-a2f6-c5df0de4a083/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf7f2ad1-07c8-414a-bfc1-ce27d09e21a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a5a1e26-d84a-4e5e-b425-35ca1480cbe0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a5a1e26-d84a-4e5e-b425-35ca1480cbe0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/46ed4dfc-8299-4ccf-a2f6-c5df0de4a083/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a5a1e26-d84a-4e5e-b425-35ca1480cbe0>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb3830fe-37de-41dc-830b-166d4e1b6a62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb3830fe-37de-41dc-830b-166d4e1b6a62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/46ed4dfc-8299-4ccf-a2f6-c5df0de4a083/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb3830fe-37de-41dc-830b-166d4e1b6a62>.
+    
+<http://data.lblod.info/id/remote-data-objects/f52aa3cf-91b9-408e-926e-ca4f417f7914> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f52aa3cf-91b9-408e-926e-ca4f417f7914";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/4b7ddd93-0545-4ddc-b3d3-66d21d0b03a2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f52aa3cf-91b9-408e-926e-ca4f417f7914>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0823ca8-c4a2-446e-9198-d59fb33e5a66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0823ca8-c4a2-446e-9198-d59fb33e5a66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/4b7ddd93-0545-4ddc-b3d3-66d21d0b03a2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0823ca8-c4a2-446e-9198-d59fb33e5a66>.
+    
+<http://data.lblod.info/id/remote-data-objects/05881802-affe-4962-a20c-128be076c004> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05881802-affe-4962-a20c-128be076c004";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/4bcdfde2-c361-4db8-b8d1-261c6bc64741/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05881802-affe-4962-a20c-128be076c004>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8fd5a4d-3778-4fc4-b7a8-cb47f078d0b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8fd5a4d-3778-4fc4-b7a8-cb47f078d0b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/4bcdfde2-c361-4db8-b8d1-261c6bc64741/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8fd5a4d-3778-4fc4-b7a8-cb47f078d0b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdfa2a5d-7f1c-4e00-b664-eda3097b94cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdfa2a5d-7f1c-4e00-b664-eda3097b94cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/4bcdfde2-c361-4db8-b8d1-261c6bc64741/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdfa2a5d-7f1c-4e00-b664-eda3097b94cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8291a94-7ee8-4fde-89f9-e9ec864bbbb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8291a94-7ee8-4fde-89f9-e9ec864bbbb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/589fa0bc-fc66-43c7-b808-a81e1a38a604/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8291a94-7ee8-4fde-89f9-e9ec864bbbb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3940a1d-84bd-4774-82a4-33ab1e9d9290> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3940a1d-84bd-4774-82a4-33ab1e9d9290";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/589fa0bc-fc66-43c7-b808-a81e1a38a604/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/532eeca5-2317-43cc-b8bd-67bb3c7638cd> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3940a1d-84bd-4774-82a4-33ab1e9d9290>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201845-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201845-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201845-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201845-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/4e2e07f6-f794-4886-a888-cacf6d148790> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4e2e07f6-f794-4886-a888-cacf6d148790";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "71e27cda-758c-409a-a2e4-6eef65a752d6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/eceae31b-734e-4245-afb1-da088abad5fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "eceae31b-734e-4245-afb1-da088abad5fe";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6>.
+
+  <http://redpencil.data.gift/id/task/ee3f1629-9d02-492f-a680-092bbf414618> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ee3f1629-9d02-492f-a680-092bbf414618";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/4e2e07f6-f794-4886-a888-cacf6d148790>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/eceae31b-734e-4245-afb1-da088abad5fe>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/bec1a2c7-a581-427f-a952-516ae0ebb356> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bec1a2c7-a581-427f-a952-516ae0ebb356";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/589fa0bc-fc66-43c7-b808-a81e1a38a604/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bec1a2c7-a581-427f-a952-516ae0ebb356>.
+    
+<http://data.lblod.info/id/remote-data-objects/2423c8e9-f502-45e6-a3f7-6031e85231cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2423c8e9-f502-45e6-a3f7-6031e85231cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/5d46c3a4-be24-4f9e-bd28-b782a8c01c76/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2423c8e9-f502-45e6-a3f7-6031e85231cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/80a12297-8b51-4f8b-8b3d-473b7903dac3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80a12297-8b51-4f8b-8b3d-473b7903dac3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/5d46c3a4-be24-4f9e-bd28-b782a8c01c76/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80a12297-8b51-4f8b-8b3d-473b7903dac3>.
+    
+<http://data.lblod.info/id/remote-data-objects/56ce74ed-eb1d-4751-8ac6-4835ab2edf0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56ce74ed-eb1d-4751-8ac6-4835ab2edf0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/5d46c3a4-be24-4f9e-bd28-b782a8c01c76/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56ce74ed-eb1d-4751-8ac6-4835ab2edf0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bbce1c6-738c-461a-a24a-d67fe21b77c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bbce1c6-738c-461a-a24a-d67fe21b77c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/6dbf6d92-8deb-4b5d-9552-819e868199ca/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bbce1c6-738c-461a-a24a-d67fe21b77c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ba1c3fa-ab57-4d6f-86df-3aaec7beef46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ba1c3fa-ab57-4d6f-86df-3aaec7beef46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/6dbf6d92-8deb-4b5d-9552-819e868199ca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ba1c3fa-ab57-4d6f-86df-3aaec7beef46>.
+    
+<http://data.lblod.info/id/remote-data-objects/db52e408-b679-47a4-86cf-3aa0000bc4cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db52e408-b679-47a4-86cf-3aa0000bc4cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/6dbf6d92-8deb-4b5d-9552-819e868199ca/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db52e408-b679-47a4-86cf-3aa0000bc4cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/608ed72d-2607-4ab7-a71e-68e7fe7a7f1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "608ed72d-2607-4ab7-a71e-68e7fe7a7f1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/99c72959-5da0-48fb-8477-2e35ece1dac7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/608ed72d-2607-4ab7-a71e-68e7fe7a7f1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7094f12-90dc-472a-87c7-3d4fbba1772a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7094f12-90dc-472a-87c7-3d4fbba1772a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/99c72959-5da0-48fb-8477-2e35ece1dac7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7094f12-90dc-472a-87c7-3d4fbba1772a>.
+    
+<http://data.lblod.info/id/remote-data-objects/571f6410-c626-427f-808a-f79d709aa98c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "571f6410-c626-427f-808a-f79d709aa98c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/99c72959-5da0-48fb-8477-2e35ece1dac7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/571f6410-c626-427f-808a-f79d709aa98c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d8c7263-94ea-4df5-b828-efe8d806005e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d8c7263-94ea-4df5-b828-efe8d806005e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/99cee452-5e50-44eb-8263-f2ee6d0b9fbd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d8c7263-94ea-4df5-b828-efe8d806005e>.
+    
+<http://data.lblod.info/id/remote-data-objects/28b85dd7-5578-4220-bcf1-f3e221d46147> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28b85dd7-5578-4220-bcf1-f3e221d46147";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/99cee452-5e50-44eb-8263-f2ee6d0b9fbd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28b85dd7-5578-4220-bcf1-f3e221d46147>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3176b4a-d0bb-4419-88ec-2e9a9b9e01e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3176b4a-d0bb-4419-88ec-2e9a9b9e01e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/99cee452-5e50-44eb-8263-f2ee6d0b9fbd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3176b4a-d0bb-4419-88ec-2e9a9b9e01e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca93d3a8-c2c4-4a67-b9b5-362ce8d616e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca93d3a8-c2c4-4a67-b9b5-362ce8d616e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/ab2a8e57-d226-4170-b3a9-85e9438247c1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca93d3a8-c2c4-4a67-b9b5-362ce8d616e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d3def56-2d13-4c52-92f2-da92af354d6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d3def56-2d13-4c52-92f2-da92af354d6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/ab2a8e57-d226-4170-b3a9-85e9438247c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d3def56-2d13-4c52-92f2-da92af354d6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/45409e27-aa12-49d5-814f-ea3f301dda2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45409e27-aa12-49d5-814f-ea3f301dda2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/ab2a8e57-d226-4170-b3a9-85e9438247c1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45409e27-aa12-49d5-814f-ea3f301dda2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccb65698-88bd-48a8-b66a-0368afbe5ac9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccb65698-88bd-48a8-b66a-0368afbe5ac9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/bf393242-8939-4951-a8c4-38258a5289f6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccb65698-88bd-48a8-b66a-0368afbe5ac9>.
+    
+<http://data.lblod.info/id/remote-data-objects/916b0256-830c-4578-b1ea-897c64ca15a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "916b0256-830c-4578-b1ea-897c64ca15a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/bf393242-8939-4951-a8c4-38258a5289f6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/916b0256-830c-4578-b1ea-897c64ca15a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/84cb27a1-7888-4474-87d2-bad6318e3a60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84cb27a1-7888-4474-87d2-bad6318e3a60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/bf393242-8939-4951-a8c4-38258a5289f6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84cb27a1-7888-4474-87d2-bad6318e3a60>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dbae27d-4e4a-4b8a-889e-795e11577275> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dbae27d-4e4a-4b8a-889e-795e11577275";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/d2920b79-6110-4d4a-9bf2-64a0f30714cd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dbae27d-4e4a-4b8a-889e-795e11577275>.
+    
+<http://data.lblod.info/id/remote-data-objects/48c36e57-9c66-4daf-9f6c-76cc69a89b0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48c36e57-9c66-4daf-9f6c-76cc69a89b0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/d2920b79-6110-4d4a-9bf2-64a0f30714cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48c36e57-9c66-4daf-9f6c-76cc69a89b0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b226e27c-c45b-41a8-8762-786e94da946c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b226e27c-c45b-41a8-8762-786e94da946c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/d2920b79-6110-4d4a-9bf2-64a0f30714cd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b226e27c-c45b-41a8-8762-786e94da946c>.
+    
+<http://data.lblod.info/id/remote-data-objects/124fe08a-02fa-4d61-b512-c498b6fffde3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "124fe08a-02fa-4d61-b512-c498b6fffde3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/e98fa0d1-4810-4482-a249-f6affc7fe582/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/124fe08a-02fa-4d61-b512-c498b6fffde3>.
+    
+<http://data.lblod.info/id/remote-data-objects/4aaebc2d-6d7c-4886-9ac0-e27a020e1865> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4aaebc2d-6d7c-4886-9ac0-e27a020e1865";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/e98fa0d1-4810-4482-a249-f6affc7fe582/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4aaebc2d-6d7c-4886-9ac0-e27a020e1865>.
+    
+<http://data.lblod.info/id/remote-data-objects/09e8d7b0-5c4c-45d1-aa97-792247a00333> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09e8d7b0-5c4c-45d1-aa97-792247a00333";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/rmw/e98fa0d1-4810-4482-a249-f6affc7fe582/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09e8d7b0-5c4c-45d1-aa97-792247a00333>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6a22ac3-b9e4-4902-85c9-1e8b61f02f23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6a22ac3-b9e4-4902-85c9-1e8b61f02f23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/011527f0-a1e1-4c3d-9b35-cbbd15182863/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6a22ac3-b9e4-4902-85c9-1e8b61f02f23>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3c76175-1a30-4aca-a58e-30d2397f1575> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3c76175-1a30-4aca-a58e-30d2397f1575";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/0649a07e-e462-4e74-a8f1-ba7cf6bb1e85/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3c76175-1a30-4aca-a58e-30d2397f1575>.
+    
+<http://data.lblod.info/id/remote-data-objects/5920b2ad-0637-4c6b-9123-787ff1eac864> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5920b2ad-0637-4c6b-9123-787ff1eac864";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/077770de-5a67-4e1a-a630-605a4743bd53/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5920b2ad-0637-4c6b-9123-787ff1eac864>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2a8d150-b991-44cd-8692-b41edd6b37d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2a8d150-b991-44cd-8692-b41edd6b37d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/12b3ea69-b0dd-4acd-b1ed-9feaab93bc53/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2a8d150-b991-44cd-8692-b41edd6b37d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6625ef2-ff07-4d62-b9c7-e1876b6a60cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6625ef2-ff07-4d62-b9c7-e1876b6a60cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/14e7e790-e7b8-46ea-9b19-41c848149859/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6625ef2-ff07-4d62-b9c7-e1876b6a60cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed0f3dda-43ad-4b6d-9956-7d4a5ee95a0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed0f3dda-43ad-4b6d-9956-7d4a5ee95a0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/1583f4c6-2dc0-4373-94ae-9193f0a0f2cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed0f3dda-43ad-4b6d-9956-7d4a5ee95a0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/822a666b-2c8b-42f2-9605-baad1b227e2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "822a666b-2c8b-42f2-9605-baad1b227e2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/192e0528-83b6-4cfd-8712-fecc6d7664c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/822a666b-2c8b-42f2-9605-baad1b227e2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f951e25b-0a2e-4c57-98d4-a9ae46ed8299> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f951e25b-0a2e-4c57-98d4-a9ae46ed8299";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/1b3da75d-a58f-476b-a0f9-3b82a04d9110/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f951e25b-0a2e-4c57-98d4-a9ae46ed8299>.
+    
+<http://data.lblod.info/id/remote-data-objects/affec507-78fe-4d3f-9178-959e3602cc27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "affec507-78fe-4d3f-9178-959e3602cc27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/1c8c9a9b-6f15-4118-96ec-cf9c54e11c0f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/affec507-78fe-4d3f-9178-959e3602cc27>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd850077-2c1f-47fa-a220-b437df70d21b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd850077-2c1f-47fa-a220-b437df70d21b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/1cc37317-f9d9-4d6d-8b15-61af223a5048/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd850077-2c1f-47fa-a220-b437df70d21b>.
+    
+<http://data.lblod.info/id/remote-data-objects/317a56d8-b062-4478-acf7-00c77a4f9786> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "317a56d8-b062-4478-acf7-00c77a4f9786";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/1f5a3ea8-a743-4bb6-b4fe-b14b36d96c7f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/317a56d8-b062-4478-acf7-00c77a4f9786>.
+    
+<http://data.lblod.info/id/remote-data-objects/2849d47e-8c9f-478a-9519-cfcfe4af3977> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2849d47e-8c9f-478a-9519-cfcfe4af3977";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/20a624ff-52be-4f1d-bef8-06ea4d200d28/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2849d47e-8c9f-478a-9519-cfcfe4af3977>.
+    
+<http://data.lblod.info/id/remote-data-objects/367bfb26-ecda-415d-b70c-0fd0aa54bdf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "367bfb26-ecda-415d-b70c-0fd0aa54bdf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/22a851e3-9960-4e36-93b3-a65562353fd1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/367bfb26-ecda-415d-b70c-0fd0aa54bdf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f1c0ab5-cdca-4a3b-bc4b-f0b6ebc120d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f1c0ab5-cdca-4a3b-bc4b-f0b6ebc120d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/28ccfcfe-044b-437c-b6ae-7cab2f25e9b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f1c0ab5-cdca-4a3b-bc4b-f0b6ebc120d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/152b2627-8274-448b-af4c-3e2eac570161> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "152b2627-8274-448b-af4c-3e2eac570161";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/28dbe595-3e30-47a7-a598-8290b29346e2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/152b2627-8274-448b-af4c-3e2eac570161>.
+    
+<http://data.lblod.info/id/remote-data-objects/0105c6f7-88c4-4b3f-adca-6fc329ef50c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0105c6f7-88c4-4b3f-adca-6fc329ef50c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/34dafc52-3cd3-4d36-abc8-11c72528637e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0105c6f7-88c4-4b3f-adca-6fc329ef50c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b84106d-04ea-4a7f-925d-bf1dc92350a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b84106d-04ea-4a7f-925d-bf1dc92350a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/39bc4da6-a14e-45cb-b8f1-8a41ed1b21ad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b84106d-04ea-4a7f-925d-bf1dc92350a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e48540b8-114a-43ab-a96b-4037b51362d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e48540b8-114a-43ab-a96b-4037b51362d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/3e2b4d87-2c1e-4fa7-a7a1-6a84c004054d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e48540b8-114a-43ab-a96b-4037b51362d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f852d6c3-27f7-4b2c-9e1c-eb8e49a859dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f852d6c3-27f7-4b2c-9e1c-eb8e49a859dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/40423802-f9e2-43f5-abb5-d07c016c94d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f852d6c3-27f7-4b2c-9e1c-eb8e49a859dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcdb7ab7-e178-4a33-92eb-20d3b51e5bed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcdb7ab7-e178-4a33-92eb-20d3b51e5bed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/4804214a-71b5-48d8-8443-20dfb4a183c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcdb7ab7-e178-4a33-92eb-20d3b51e5bed>.
+    
+<http://data.lblod.info/id/remote-data-objects/471c72ac-1882-4669-9944-6436423ccd75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "471c72ac-1882-4669-9944-6436423ccd75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/48bb0860-5e62-486f-9319-ba8e400c86e4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/471c72ac-1882-4669-9944-6436423ccd75>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a312297-d296-488a-895e-a9cc880225b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a312297-d296-488a-895e-a9cc880225b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/4d871edb-da38-4988-8493-f7749784246a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a312297-d296-488a-895e-a9cc880225b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/06132f41-f7b8-43ca-b350-51e6ce12cacd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06132f41-f7b8-43ca-b350-51e6ce12cacd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/53b32f4b-6b7f-4e2d-b366-7332797af6a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06132f41-f7b8-43ca-b350-51e6ce12cacd>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e791a7f-8772-4724-adee-bfc85d8f26f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e791a7f-8772-4724-adee-bfc85d8f26f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/5bc8baba-e4bd-4a2a-8107-a81fcfa36356/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e791a7f-8772-4724-adee-bfc85d8f26f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd81a956-ffb6-4824-9716-772d6bd7ead4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd81a956-ffb6-4824-9716-772d6bd7ead4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/5e523f8d-0a27-427c-939b-1fb8f0d84c26/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:45.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71e27cda-758c-409a-a2e4-6eef65a752d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd81a956-ffb6-4824-9716-772d6bd7ead4>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201847-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201847-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201847-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201847-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/ed78dcda-86bc-42de-8020-a43d8efc709b> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ed78dcda-86bc-42de-8020-a43d8efc709b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "59507b9a-082d-4144-906a-5c04eba3ac3a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b4e6836c-4c1a-4595-b5d3-8a98aa594542> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b4e6836c-4c1a-4595-b5d3-8a98aa594542";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a>.
+
+  <http://redpencil.data.gift/id/task/07a1ad94-edc0-488d-b076-c1be90d97c50> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "07a1ad94-edc0-488d-b076-c1be90d97c50";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/ed78dcda-86bc-42de-8020-a43d8efc709b>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b4e6836c-4c1a-4595-b5d3-8a98aa594542>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/0372555c-8ceb-4633-b085-22f61be70504> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0372555c-8ceb-4633-b085-22f61be70504";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/5eb9a253-f32f-45da-b86a-dad71438c558/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0372555c-8ceb-4633-b085-22f61be70504>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a2d0ec7-ea08-453c-9861-c84e1dfda2df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a2d0ec7-ea08-453c-9861-c84e1dfda2df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/60cdf1d1-df05-4825-a617-5bda03b5d97b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a2d0ec7-ea08-453c-9861-c84e1dfda2df>.
+    
+<http://data.lblod.info/id/remote-data-objects/9489916e-24eb-4af1-8850-14e0b6c841fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9489916e-24eb-4af1-8850-14e0b6c841fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/64fe9aec-f1c4-44d2-af03-379842549097/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9489916e-24eb-4af1-8850-14e0b6c841fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/cef05a0f-f2c3-4fa7-8c12-67e01169a1dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cef05a0f-f2c3-4fa7-8c12-67e01169a1dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/6612d161-570c-4483-941e-8f85065c4067/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cef05a0f-f2c3-4fa7-8c12-67e01169a1dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/506ed58e-1bda-4c42-9172-2e3f50848123> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "506ed58e-1bda-4c42-9172-2e3f50848123";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/6fc378ae-47c4-478b-8933-e7279e9cbb5e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/506ed58e-1bda-4c42-9172-2e3f50848123>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2b323c8-2a92-4add-a1da-a3c0f8b6dd4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2b323c8-2a92-4add-a1da-a3c0f8b6dd4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/704d5a6c-1fcd-413e-9597-220497d2e483/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2b323c8-2a92-4add-a1da-a3c0f8b6dd4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d63ff6fe-3ad7-4451-bf36-d2a3485610e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d63ff6fe-3ad7-4451-bf36-d2a3485610e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/73349a3f-f704-4380-a0af-5f40b3e43450/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d63ff6fe-3ad7-4451-bf36-d2a3485610e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cb8bc1d-851b-47f7-b714-35e881cf2c0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cb8bc1d-851b-47f7-b714-35e881cf2c0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/76946712-6c40-4a77-8f4b-146274828603/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cb8bc1d-851b-47f7-b714-35e881cf2c0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d9a3230-7b50-491c-a976-31decc71720d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d9a3230-7b50-491c-a976-31decc71720d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/77e66751-7c82-4664-9499-82fa8b234de8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d9a3230-7b50-491c-a976-31decc71720d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b225a7de-fbe5-4b90-82d7-2f937d8902e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b225a7de-fbe5-4b90-82d7-2f937d8902e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/7829f730-0fd5-49b9-b185-d7e5bf0f3eb9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b225a7de-fbe5-4b90-82d7-2f937d8902e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7404fd3-620b-44a0-bcb4-0f4af9f7b004> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7404fd3-620b-44a0-bcb4-0f4af9f7b004";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/78ff3094-123b-49ed-87ef-0a4f943e82d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7404fd3-620b-44a0-bcb4-0f4af9f7b004>.
+    
+<http://data.lblod.info/id/remote-data-objects/11c98306-8c39-4bc6-a35d-61cb32c4928a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11c98306-8c39-4bc6-a35d-61cb32c4928a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/7af61d57-c0b4-4026-b66b-70f1714d7778/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11c98306-8c39-4bc6-a35d-61cb32c4928a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9e8720e-64f3-406e-9937-d154cedb6691> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9e8720e-64f3-406e-9937-d154cedb6691";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/81d0c6ea-e0e1-4aa3-badd-ab9c7302d32f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9e8720e-64f3-406e-9937-d154cedb6691>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5b5156a-be9f-4ecf-8d1b-759f7444bafa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5b5156a-be9f-4ecf-8d1b-759f7444bafa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/82fdb113-d98f-4692-b717-4c6a85d26068/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5b5156a-be9f-4ecf-8d1b-759f7444bafa>.
+    
+<http://data.lblod.info/id/remote-data-objects/eac28497-6874-4bab-8fe6-e8de2d3adade> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eac28497-6874-4bab-8fe6-e8de2d3adade";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/984f2ff8-425d-4b95-b582-f3a95064d8d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eac28497-6874-4bab-8fe6-e8de2d3adade>.
+    
+<http://data.lblod.info/id/remote-data-objects/d43e2a6c-5387-4b7e-82c5-3b85ccae83c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d43e2a6c-5387-4b7e-82c5-3b85ccae83c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/ae7b0e4d-e224-45d4-afe1-89fee2f2486c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d43e2a6c-5387-4b7e-82c5-3b85ccae83c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec1a87c8-f59b-402e-860a-68e7a5d5f7af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec1a87c8-f59b-402e-860a-68e7a5d5f7af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/aeb96806-c3cd-41c5-97de-adb2ff130add/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec1a87c8-f59b-402e-860a-68e7a5d5f7af>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb9981f6-dbbf-4a12-8812-c55c209b46a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb9981f6-dbbf-4a12-8812-c55c209b46a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/b1ca3187-3b11-444c-9f08-73eae03ab721/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb9981f6-dbbf-4a12-8812-c55c209b46a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/70e8aef6-03c5-4f63-a060-2fbb52001d8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70e8aef6-03c5-4f63-a060-2fbb52001d8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/b4c70ca4-fb69-4d7b-943b-923a1099d345/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70e8aef6-03c5-4f63-a060-2fbb52001d8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2efa354a-be77-4585-a6b6-b267da1c5f9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2efa354a-be77-4585-a6b6-b267da1c5f9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/bc1f9fb1-932b-4d5b-aa37-6b7ad73ae6c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2efa354a-be77-4585-a6b6-b267da1c5f9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/11997bf0-f6b9-44d3-847c-2f50a8efba4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11997bf0-f6b9-44d3-847c-2f50a8efba4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/c3dd3285-b328-4366-8c32-9baf383b658d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11997bf0-f6b9-44d3-847c-2f50a8efba4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4e65c93-8b0b-481d-ab15-d8f7b5a31171> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4e65c93-8b0b-481d-ab15-d8f7b5a31171";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/cf311f69-5d92-4a45-b8c8-199f86faaa5d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4e65c93-8b0b-481d-ab15-d8f7b5a31171>.
+    
+<http://data.lblod.info/id/remote-data-objects/51b0d5dc-d8d9-416d-afd6-79823b83aa46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51b0d5dc-d8d9-416d-afd6-79823b83aa46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/d20077d5-3fbc-4b8e-a32e-1aad50adf5aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51b0d5dc-d8d9-416d-afd6-79823b83aa46>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab1a1d59-3e13-4805-b310-c384a788a0c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab1a1d59-3e13-4805-b310-c384a788a0c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/d293c22b-f5de-4da9-8b81-9d47acadfe16/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab1a1d59-3e13-4805-b310-c384a788a0c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c918a387-93ab-4578-bba1-5b9dd3ff0e15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c918a387-93ab-4578-bba1-5b9dd3ff0e15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/e24a30cd-ca80-42fb-8a81-5d9e1bc6df82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c918a387-93ab-4578-bba1-5b9dd3ff0e15>.
+    
+<http://data.lblod.info/id/remote-data-objects/696ca64c-7efd-46d9-bafd-4b2931f77b66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "696ca64c-7efd-46d9-bafd-4b2931f77b66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/e2f6c6dc-3a92-4c1b-9c17-23f5034635bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/696ca64c-7efd-46d9-bafd-4b2931f77b66>.
+    
+<http://data.lblod.info/id/remote-data-objects/00b9ae7d-170c-440c-8cab-d7052fb348a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00b9ae7d-170c-440c-8cab-d7052fb348a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/ea3da7d7-ed4c-4c6c-b496-94257e2c9e75/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00b9ae7d-170c-440c-8cab-d7052fb348a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfbe7154-bd85-4551-a6f1-109738cadd16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfbe7154-bd85-4551-a6f1-109738cadd16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/ec1baa36-731f-422a-bc67-29578a538fd4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfbe7154-bd85-4551-a6f1-109738cadd16>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f246b26-10b4-4e0b-ab40-f5be0c07de44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f246b26-10b4-4e0b-ab40-f5be0c07de44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/f2afb721-6be7-4050-8011-a793bb24e4bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f246b26-10b4-4e0b-ab40-f5be0c07de44>.
+    
+<http://data.lblod.info/id/remote-data-objects/a64a4304-6e4d-4784-847f-8f7e4bda9833> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a64a4304-6e4d-4784-847f-8f7e4bda9833";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/f33c7d04-f92f-4321-b062-e827c086791b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a64a4304-6e4d-4784-847f-8f7e4bda9833>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e82b146-cfd7-462c-a977-85d3c4f3330d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e82b146-cfd7-462c-a977-85d3c4f3330d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/fefe547c-e08b-411e-8b4c-8a7ca469ecc2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e82b146-cfd7-462c-a977-85d3c4f3330d>.
+    
+<http://data.lblod.info/id/remote-data-objects/25b4b612-e179-48b3-95e6-95a6dbbfd286> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25b4b612-e179-48b3-95e6-95a6dbbfd286";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://meise.meetingburger.net/vabu/ff8daff0-3b72-415b-abe7-2c9cbb01c476/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25b4b612-e179-48b3-95e6-95a6dbbfd286>.
+    
+<http://data.lblod.info/id/remote-data-objects/11bdb2a7-cee1-471b-940a-7942744eebd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11bdb2a7-cee1-471b-940a-7942744eebd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/00c45d2d-bf45-4e4f-86ed-2b7b281d704a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11bdb2a7-cee1-471b-940a-7942744eebd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/55e85dfd-fbc2-48b5-a937-57c6a19978a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55e85dfd-fbc2-48b5-a937-57c6a19978a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/010f0cb6-d58e-4094-9f91-e8fca97c4a4f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55e85dfd-fbc2-48b5-a937-57c6a19978a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/3019a807-faec-449d-accc-5d9e8117f3f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3019a807-faec-449d-accc-5d9e8117f3f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/0ee51f73-9dd4-414e-a716-68140818c507/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3019a807-faec-449d-accc-5d9e8117f3f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/684633c2-bfe3-4b2e-b5b8-22ff83439be5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "684633c2-bfe3-4b2e-b5b8-22ff83439be5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/189c3f25-662b-4af6-9e1b-53620eee5d04/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/684633c2-bfe3-4b2e-b5b8-22ff83439be5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1639863e-34eb-45f6-b878-010255c70f0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1639863e-34eb-45f6-b878-010255c70f0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/1ad9321d-98f8-42e9-9892-dd4f0a2de3b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1639863e-34eb-45f6-b878-010255c70f0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/05b6c0bd-9198-4a5e-9caa-554dfe6ee69c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05b6c0bd-9198-4a5e-9caa-554dfe6ee69c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/1aed9203-1074-4cb8-b012-7b97a8457700/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05b6c0bd-9198-4a5e-9caa-554dfe6ee69c>.
+    
+<http://data.lblod.info/id/remote-data-objects/61793494-1f4e-400b-9880-7c60a37f6fe3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61793494-1f4e-400b-9880-7c60a37f6fe3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/1b30aaa9-738b-44fa-ba86-f769c25b123b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61793494-1f4e-400b-9880-7c60a37f6fe3>.
+    
+<http://data.lblod.info/id/remote-data-objects/245e18ca-0183-48b4-b97f-b43260b852b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "245e18ca-0183-48b4-b97f-b43260b852b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/1cec2082-025f-45ff-8cae-678713df35f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/245e18ca-0183-48b4-b97f-b43260b852b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/49ca95ad-963f-4c8f-ab4f-d5d05f228b35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49ca95ad-963f-4c8f-ab4f-d5d05f228b35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/1d124e98-0c0f-4426-aa85-78850d9028a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49ca95ad-963f-4c8f-ab4f-d5d05f228b35>.
+    
+<http://data.lblod.info/id/remote-data-objects/892ab04d-71ab-4e6a-8b43-46e427dc4a17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "892ab04d-71ab-4e6a-8b43-46e427dc4a17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/1e643256-2040-4ed0-b859-13017690788d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/892ab04d-71ab-4e6a-8b43-46e427dc4a17>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa977d4f-775a-4f5d-95b1-970fca378728> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa977d4f-775a-4f5d-95b1-970fca378728";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/1f5f1ae3-5b27-44d6-907b-87600213d4f0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa977d4f-775a-4f5d-95b1-970fca378728>.
+    
+<http://data.lblod.info/id/remote-data-objects/d81e1524-6cc6-4afe-88ee-d83027020628> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d81e1524-6cc6-4afe-88ee-d83027020628";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/23b2251d-f2fc-4555-8147-1269f109a131/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d81e1524-6cc6-4afe-88ee-d83027020628>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a453131-5d71-4259-809d-9a4340632425> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a453131-5d71-4259-809d-9a4340632425";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/2f086ebb-74de-42b6-ad95-224551231a92/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a453131-5d71-4259-809d-9a4340632425>.
+    
+<http://data.lblod.info/id/remote-data-objects/4afd09d5-747e-481a-822c-325af30ea807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4afd09d5-747e-481a-822c-325af30ea807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/34dac4f6-b849-4e21-9e25-d79cab36b990/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4afd09d5-747e-481a-822c-325af30ea807>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9cb309b-2978-43b1-8a48-f2faa3c4f356> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9cb309b-2978-43b1-8a48-f2faa3c4f356";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/3720b8eb-69a8-4c26-a418-4c04f8f8cd09/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9cb309b-2978-43b1-8a48-f2faa3c4f356>.
+    
+<http://data.lblod.info/id/remote-data-objects/b04aec24-0134-47f1-95ee-a711ecedbd17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b04aec24-0134-47f1-95ee-a711ecedbd17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/3c0d5d14-1af4-4f7b-aff0-83260120ee59/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b04aec24-0134-47f1-95ee-a711ecedbd17>.
+    
+<http://data.lblod.info/id/remote-data-objects/aed4c012-ec43-4cdf-9d58-1e10080f80b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aed4c012-ec43-4cdf-9d58-1e10080f80b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/46d6e3cf-b65f-4e97-8f18-20552d5d38b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aed4c012-ec43-4cdf-9d58-1e10080f80b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c551a54-b602-41ad-8857-b2c82ade4ffc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c551a54-b602-41ad-8857-b2c82ade4ffc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/4908e29e-53c1-4405-8c9b-eb5f7948fab4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59507b9a-082d-4144-906a-5c04eba3ac3a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c551a54-b602-41ad-8857-b2c82ade4ffc>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201848-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201848-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201848-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201848-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a308bf40-76ce-4849-9d7a-b4b74fb306d1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a308bf40-76ce-4849-9d7a-b4b74fb306d1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b912b235-c21e-4ad5-9f6e-af6ba28acce6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f90ed3bf-10f4-4886-a353-0daece5674f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f90ed3bf-10f4-4886-a353-0daece5674f3";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6>.
+
+  <http://redpencil.data.gift/id/task/7ecd10d7-f43c-4a19-bf85-b9a46d0b2b2c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7ecd10d7-f43c-4a19-bf85-b9a46d0b2b2c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a308bf40-76ce-4849-9d7a-b4b74fb306d1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f90ed3bf-10f4-4886-a353-0daece5674f3>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/ba27e346-13db-41c2-83bf-a7291e84bf82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba27e346-13db-41c2-83bf-a7291e84bf82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/50238677-221c-4b7e-81f0-c8466471dd0a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba27e346-13db-41c2-83bf-a7291e84bf82>.
+    
+<http://data.lblod.info/id/remote-data-objects/32cb48d4-4013-46b8-926e-6f5fc45036b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32cb48d4-4013-46b8-926e-6f5fc45036b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/51ff2397-799b-4266-9220-1a16de8fb837/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32cb48d4-4013-46b8-926e-6f5fc45036b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1b62ce8-9385-4d3b-9a92-59d87d4fdf14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1b62ce8-9385-4d3b-9a92-59d87d4fdf14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/54c29476-9575-4ee8-b229-e5f5b55567cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1b62ce8-9385-4d3b-9a92-59d87d4fdf14>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a449e33-314f-45b9-a89d-29fc765bfded> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a449e33-314f-45b9-a89d-29fc765bfded";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/56ff864e-268c-469a-80bc-81169de21531/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a449e33-314f-45b9-a89d-29fc765bfded>.
+    
+<http://data.lblod.info/id/remote-data-objects/10dbde20-2c52-49b5-98a4-679b97fbd7e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10dbde20-2c52-49b5-98a4-679b97fbd7e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/57c02110-4c5a-49db-b8be-410f53a90c79/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10dbde20-2c52-49b5-98a4-679b97fbd7e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dc13a62-f1ae-4ebe-8ef4-33bda0c3471b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dc13a62-f1ae-4ebe-8ef4-33bda0c3471b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/5a28e595-752f-4a8d-b7e7-c3c0408d4e2b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dc13a62-f1ae-4ebe-8ef4-33bda0c3471b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d153f1b-f119-44b4-a257-33756b6e9eff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d153f1b-f119-44b4-a257-33756b6e9eff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/5d3b4781-f1c2-4df1-ba3f-2275a8630de8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d153f1b-f119-44b4-a257-33756b6e9eff>.
+    
+<http://data.lblod.info/id/remote-data-objects/230a3b7f-f1f1-4edd-97b9-d9ae6a8cba38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "230a3b7f-f1f1-4edd-97b9-d9ae6a8cba38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/5d63cfbd-311a-4aa3-905e-4265cf8b3e6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/230a3b7f-f1f1-4edd-97b9-d9ae6a8cba38>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4a955d8-2702-4e5d-b561-529bea48eefd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4a955d8-2702-4e5d-b561-529bea48eefd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/643f4c97-df1d-4026-a440-d203760f3255/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4a955d8-2702-4e5d-b561-529bea48eefd>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c24fd45-16b4-44da-87c1-8585b65c1044> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c24fd45-16b4-44da-87c1-8585b65c1044";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/6a6abf53-6004-4cfe-b58e-c81a202ff6f6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c24fd45-16b4-44da-87c1-8585b65c1044>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9cb5669-621e-4635-ab04-4603d0a625e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9cb5669-621e-4635-ab04-4603d0a625e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/722179a1-3791-48d6-a985-7875f23b3aa0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9cb5669-621e-4635-ab04-4603d0a625e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d998b394-9b1b-42b2-b24b-e70caa57567a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d998b394-9b1b-42b2-b24b-e70caa57567a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/78e85d3a-7b9c-473e-bdd3-23942608b4f5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d998b394-9b1b-42b2-b24b-e70caa57567a>.
+    
+<http://data.lblod.info/id/remote-data-objects/347c13ae-f148-4471-87db-48ff7b1df0b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "347c13ae-f148-4471-87db-48ff7b1df0b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/7d22b678-a778-40e4-8ecb-40aecd59e872/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/347c13ae-f148-4471-87db-48ff7b1df0b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/da890b57-7683-479d-af4e-fbd96708926c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da890b57-7683-479d-af4e-fbd96708926c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/85a31c1b-b81b-45ad-a6d6-597557bd883a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da890b57-7683-479d-af4e-fbd96708926c>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfa1f370-9ba5-4d30-b7c5-3a18dc4c0bb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfa1f370-9ba5-4d30-b7c5-3a18dc4c0bb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/8773d4bb-b4d7-41f8-90ae-29365d0fc768/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfa1f370-9ba5-4d30-b7c5-3a18dc4c0bb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/91e441b0-54b5-4a55-82e5-91e0dbdb130a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91e441b0-54b5-4a55-82e5-91e0dbdb130a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/87dfc2a6-dcf2-41ec-b04c-11b0dfa9df76/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91e441b0-54b5-4a55-82e5-91e0dbdb130a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d2e3e5f-8823-4415-818c-0fd7f9b21166> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d2e3e5f-8823-4415-818c-0fd7f9b21166";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/8b39378c-66b1-4551-9dbd-485c3c07108c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d2e3e5f-8823-4415-818c-0fd7f9b21166>.
+    
+<http://data.lblod.info/id/remote-data-objects/178443f8-5b9c-4958-a2df-a73974d75967> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "178443f8-5b9c-4958-a2df-a73974d75967";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/8be2ca7b-2de1-49af-8b44-24c94b3816cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/178443f8-5b9c-4958-a2df-a73974d75967>.
+    
+<http://data.lblod.info/id/remote-data-objects/e20e6e9b-3210-45b2-9c9c-92f071133fbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e20e6e9b-3210-45b2-9c9c-92f071133fbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/90bf45f4-6072-4d15-b733-44649b830937/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e20e6e9b-3210-45b2-9c9c-92f071133fbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e0a99c2-d4c8-403e-9be4-e45172a34a02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e0a99c2-d4c8-403e-9be4-e45172a34a02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/91a0b9d5-53da-4b25-9b9d-e2bce07b0b03/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e0a99c2-d4c8-403e-9be4-e45172a34a02>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5a7da6d-0981-4708-8517-ae77e267b1ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5a7da6d-0981-4708-8517-ae77e267b1ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/91aa120f-2c3e-4423-af9f-7369eea2367c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5a7da6d-0981-4708-8517-ae77e267b1ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e2da3d3-28bb-4b2b-b294-20ee96537b27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e2da3d3-28bb-4b2b-b294-20ee96537b27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/94414877-2fc7-42a0-81ba-49bba007dc5e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e2da3d3-28bb-4b2b-b294-20ee96537b27>.
+    
+<http://data.lblod.info/id/remote-data-objects/8aee358b-e294-4f8a-a4bf-685c6826e1dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8aee358b-e294-4f8a-a4bf-685c6826e1dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/97a0a01d-36cc-40bf-b43b-734eee8517b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8aee358b-e294-4f8a-a4bf-685c6826e1dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/43be5e57-621d-441d-b47d-4eab30b823f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43be5e57-621d-441d-b47d-4eab30b823f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/a391d548-f251-43b6-9b54-e40b1f483653/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43be5e57-621d-441d-b47d-4eab30b823f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ff9b7f3-93e7-4ea1-8fac-8c86f373f640> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ff9b7f3-93e7-4ea1-8fac-8c86f373f640";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/a7fc8628-d9cb-4c00-8b83-e2cc3b647aaa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ff9b7f3-93e7-4ea1-8fac-8c86f373f640>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c20d0c1-45e9-4cd3-a8bd-fcf987714607> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c20d0c1-45e9-4cd3-a8bd-fcf987714607";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/ab4c87c5-7066-4252-905a-5f0eb60adb12/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c20d0c1-45e9-4cd3-a8bd-fcf987714607>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cda0b8a-5882-47ee-995d-d792fdaf3546> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cda0b8a-5882-47ee-995d-d792fdaf3546";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/ab773dc5-a190-4164-8161-c2e4317ceb35/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cda0b8a-5882-47ee-995d-d792fdaf3546>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a2651ee-fae4-4871-bb01-2bdfc5f16bd6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a2651ee-fae4-4871-bb01-2bdfc5f16bd6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/ae998e12-7219-4262-879e-c5de96426e46/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a2651ee-fae4-4871-bb01-2bdfc5f16bd6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7b1ee60-3af8-44c7-80d6-6b7dbb31bb4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7b1ee60-3af8-44c7-80d6-6b7dbb31bb4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/b4e8f282-6db5-4950-ade8-a92371f0a139/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7b1ee60-3af8-44c7-80d6-6b7dbb31bb4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2df10ed-4172-4bdc-9bde-69615465e923> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2df10ed-4172-4bdc-9bde-69615465e923";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/b4f41392-1a9e-45c9-bec5-d436a2320631/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2df10ed-4172-4bdc-9bde-69615465e923>.
+    
+<http://data.lblod.info/id/remote-data-objects/60af38f9-761d-44a4-b17e-20b69e430271> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60af38f9-761d-44a4-b17e-20b69e430271";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/b544852a-e9e2-4101-9f9b-c07d07bed612/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60af38f9-761d-44a4-b17e-20b69e430271>.
+    
+<http://data.lblod.info/id/remote-data-objects/145b3661-a380-41c1-ada1-846aab6733f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "145b3661-a380-41c1-ada1-846aab6733f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/b5ffb840-5a3d-47f9-8ad9-c4b578de1633/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/145b3661-a380-41c1-ada1-846aab6733f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/6df69a6e-6a57-4ed5-a13c-15015a04b0a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6df69a6e-6a57-4ed5-a13c-15015a04b0a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/b75781d0-73f2-4444-9a41-a820d201acf1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6df69a6e-6a57-4ed5-a13c-15015a04b0a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/250faf55-4349-44b8-bec7-76fbfd1d243e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "250faf55-4349-44b8-bec7-76fbfd1d243e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/b779c0c9-f78a-44aa-94c6-805949177243/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/250faf55-4349-44b8-bec7-76fbfd1d243e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f45c5fd5-dc2f-41c8-9305-5e17cad0eb64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f45c5fd5-dc2f-41c8-9305-5e17cad0eb64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/bdafc4b4-264e-4d66-8c77-27c4e35ab8de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f45c5fd5-dc2f-41c8-9305-5e17cad0eb64>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbf1b267-c2ec-4e43-825b-8c0f449d7741> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbf1b267-c2ec-4e43-825b-8c0f449d7741";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/bdc5674b-1f95-418b-b790-d2ffe711e2ad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbf1b267-c2ec-4e43-825b-8c0f449d7741>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b703c84-23f7-44f6-a445-6813d9ffe148> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b703c84-23f7-44f6-a445-6813d9ffe148";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/c29ffb5e-a79d-4013-9335-af2f3de85ec7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b703c84-23f7-44f6-a445-6813d9ffe148>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b4e0d2a-260c-436f-8545-15068da15b5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b4e0d2a-260c-436f-8545-15068da15b5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/c31dc733-6136-47cb-bff0-0d480b088f35/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b4e0d2a-260c-436f-8545-15068da15b5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/930fc389-adf1-4554-b03f-41dfb484bb11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "930fc389-adf1-4554-b03f-41dfb484bb11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/c499ad1c-1cd5-44bb-a71b-f1a20e9d49f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/930fc389-adf1-4554-b03f-41dfb484bb11>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3cba465-93ee-4c9a-8172-bda81c0d1ca5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3cba465-93ee-4c9a-8172-bda81c0d1ca5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/c79f29c2-7246-4499-ba1d-78ca5589156e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3cba465-93ee-4c9a-8172-bda81c0d1ca5>.
+    
+<http://data.lblod.info/id/remote-data-objects/00cd4402-0c42-493a-ad50-18fc1f57b5d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00cd4402-0c42-493a-ad50-18fc1f57b5d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/cb72ab07-f45a-4eb8-8d89-b84a5828b199/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00cd4402-0c42-493a-ad50-18fc1f57b5d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b19d8d1a-3fcf-4530-93cf-88d389ca26b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b19d8d1a-3fcf-4530-93cf-88d389ca26b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/cf73828e-3bbd-4177-84ae-66d2ce337177/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b19d8d1a-3fcf-4530-93cf-88d389ca26b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/934cf306-94d2-4140-989f-21ec54e7928c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "934cf306-94d2-4140-989f-21ec54e7928c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/d1ddfb77-ad97-4662-abd2-03c5212e3164/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/934cf306-94d2-4140-989f-21ec54e7928c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b52effeb-9fd5-459c-a241-3352ccf6a222> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b52effeb-9fd5-459c-a241-3352ccf6a222";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/d2434abf-305a-4d7a-9472-117bfc34fa6b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b52effeb-9fd5-459c-a241-3352ccf6a222>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fe2725c-77af-4667-a7e5-0e125b60325f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fe2725c-77af-4667-a7e5-0e125b60325f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/d5987f64-0c29-4b89-bb93-3ffc4e1254f8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fe2725c-77af-4667-a7e5-0e125b60325f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ac4db8a-7d2a-4566-8ec6-0cff25f95385> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ac4db8a-7d2a-4566-8ec6-0cff25f95385";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/dcbd43ce-75b5-451f-8b5a-d0aacbf280f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ac4db8a-7d2a-4566-8ec6-0cff25f95385>.
+    
+<http://data.lblod.info/id/remote-data-objects/06406cf0-6d25-4e3d-a17f-d420bc07ee93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06406cf0-6d25-4e3d-a17f-d420bc07ee93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/e03fae11-ec7e-40f6-b338-0fc232ad7fce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06406cf0-6d25-4e3d-a17f-d420bc07ee93>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ecf51f9-6fae-413f-86d5-61f3a2cd9d62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ecf51f9-6fae-413f-86d5-61f3a2cd9d62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/e151f52e-2d7e-4110-81b4-3a1db40ed0ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ecf51f9-6fae-413f-86d5-61f3a2cd9d62>.
+    
+<http://data.lblod.info/id/remote-data-objects/aeebb23e-9a28-42da-b8cc-0fc210c04f0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aeebb23e-9a28-42da-b8cc-0fc210c04f0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/e307b876-a853-48dc-8af7-5463a2b9d15b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aeebb23e-9a28-42da-b8cc-0fc210c04f0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/baa58bd4-977c-49e3-9cd7-f3333430fa32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "baa58bd4-977c-49e3-9cd7-f3333430fa32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/f9e9aea8-3ceb-4c3a-8e19-cb9d32f23c59/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b912b235-c21e-4ad5-9f6e-af6ba28acce6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/baa58bd4-977c-49e3-9cd7-f3333430fa32>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201849-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201849-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201849-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201849-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/14e99bbd-b4a6-4368-9302-178e659b42fa> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "14e99bbd-b4a6-4368-9302-178e659b42fa";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a89688e2-7ad3-4871-84a2-eac2516da02d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/0db37a0c-12ba-4c4d-80c4-e8bd6055cc3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0db37a0c-12ba-4c4d-80c4-e8bd6055cc3f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d>.
+
+  <http://redpencil.data.gift/id/task/58c0ff47-f9f2-41c2-bae1-bfa466594ed4> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "58c0ff47-f9f2-41c2-bae1-bfa466594ed4";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/14e99bbd-b4a6-4368-9302-178e659b42fa>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/0db37a0c-12ba-4c4d-80c4-e8bd6055cc3f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/ab07e669-f892-48ca-99c3-f7664a8dd583> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab07e669-f892-48ca-99c3-f7664a8dd583";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/fab1c906-8e0f-45f8-bcac-d467990c98db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab07e669-f892-48ca-99c3-f7664a8dd583>.
+    
+<http://data.lblod.info/id/remote-data-objects/68fb655f-fca8-4b66-9568-3e6de07512f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68fb655f-fca8-4b66-9568-3e6de07512f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/fb2ea79e-0587-4904-bc54-82b2dc59ebcf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68fb655f-fca8-4b66-9568-3e6de07512f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9921a380-f465-4570-998d-4105205a6324> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9921a380-f465-4570-998d-4105205a6324";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/fd3c77bd-6f78-48ee-a2b0-cd33eb8fb84f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9921a380-f465-4570-998d-4105205a6324>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdd52a8a-9f9c-4605-9578-edb0cb9ac060> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdd52a8a-9f9c-4605-9578-edb0cb9ac060";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/bb/ffccbefe-e458-467b-94ae-fdb08d1d39d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdd52a8a-9f9c-4605-9578-edb0cb9ac060>.
+    
+<http://data.lblod.info/id/remote-data-objects/6766c405-7c86-4dd9-b5dc-908645e3a70b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6766c405-7c86-4dd9-b5dc-908645e3a70b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/0633449e-6f8d-4c1d-a2c6-3307e78fbfe2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6766c405-7c86-4dd9-b5dc-908645e3a70b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4cec3b5-2fd2-4fae-83b0-261cb6ade93c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4cec3b5-2fd2-4fae-83b0-261cb6ade93c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/08c90e24-aa44-4127-a472-242da65d516f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4cec3b5-2fd2-4fae-83b0-261cb6ade93c>.
+    
+<http://data.lblod.info/id/remote-data-objects/34e28565-f95a-48c2-9a00-9d47bd199959> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34e28565-f95a-48c2-9a00-9d47bd199959";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/0b04f10a-3b67-432e-9c75-651a4134cbc0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34e28565-f95a-48c2-9a00-9d47bd199959>.
+    
+<http://data.lblod.info/id/remote-data-objects/79c49cb2-92ff-4910-92dd-e3edb7f61acd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79c49cb2-92ff-4910-92dd-e3edb7f61acd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/0e2537b7-92cc-4451-a7ed-32c6f05ee0ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79c49cb2-92ff-4910-92dd-e3edb7f61acd>.
+    
+<http://data.lblod.info/id/remote-data-objects/92ce80d0-b7ec-45de-b5fc-7f2c4684c73c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92ce80d0-b7ec-45de-b5fc-7f2c4684c73c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/0f26f33c-0a16-47cf-a9ef-c801ef2e27a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92ce80d0-b7ec-45de-b5fc-7f2c4684c73c>.
+    
+<http://data.lblod.info/id/remote-data-objects/94fb81ca-9ef9-430c-bf41-c8dc50bc548e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94fb81ca-9ef9-430c-bf41-c8dc50bc548e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/15b9e4e8-be59-4f0f-972b-d388066058c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94fb81ca-9ef9-430c-bf41-c8dc50bc548e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3c4ded5-c686-46d8-b91b-446eb0cdb8a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3c4ded5-c686-46d8-b91b-446eb0cdb8a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/1f336760-53c4-4ac9-9c8e-8acc4a63cddc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3c4ded5-c686-46d8-b91b-446eb0cdb8a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/67df3615-97f7-4428-9a8d-a4b601238755> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67df3615-97f7-4428-9a8d-a4b601238755";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/26698f9a-247a-4d11-a897-de6d260a15c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67df3615-97f7-4428-9a8d-a4b601238755>.
+    
+<http://data.lblod.info/id/remote-data-objects/950e6ac7-de77-47aa-9728-e97f28b33bde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "950e6ac7-de77-47aa-9728-e97f28b33bde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/2b32cba7-f224-4ea6-bd2b-67716ab5be6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/950e6ac7-de77-47aa-9728-e97f28b33bde>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f20a457-045b-439c-9b7c-6477121c2a23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f20a457-045b-439c-9b7c-6477121c2a23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/31f0fd7d-cfb5-4362-aaf2-6d7fc328a5cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f20a457-045b-439c-9b7c-6477121c2a23>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcabd633-8dcb-4ef7-9e1b-c957b7323c20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcabd633-8dcb-4ef7-9e1b-c957b7323c20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/3772ea15-b694-4c41-98ce-c2286d878252/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcabd633-8dcb-4ef7-9e1b-c957b7323c20>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b9a78b4-b740-4154-825a-0c86bc257b84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b9a78b4-b740-4154-825a-0c86bc257b84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/38868484-c1a2-4168-98c8-98684950e350/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b9a78b4-b740-4154-825a-0c86bc257b84>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f51c831-304c-4280-a40a-7843f613d311> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f51c831-304c-4280-a40a-7843f613d311";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/3b46949b-d800-4482-8235-862df571a16f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f51c831-304c-4280-a40a-7843f613d311>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b0118ba-1852-4b12-b5d2-1f742a44383e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b0118ba-1852-4b12-b5d2-1f742a44383e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/3b8fe966-209f-4617-a062-ab1b802b407d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b0118ba-1852-4b12-b5d2-1f742a44383e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5452ffcf-c805-49bb-b971-031fa6db5521> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5452ffcf-c805-49bb-b971-031fa6db5521";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/4934744d-0f0e-464f-827b-1cd17f46dbc0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5452ffcf-c805-49bb-b971-031fa6db5521>.
+    
+<http://data.lblod.info/id/remote-data-objects/1eed8551-5731-4a8f-9e16-0304c8cb71f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1eed8551-5731-4a8f-9e16-0304c8cb71f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/4bc99580-df80-4918-a3e8-6571f8b4633f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1eed8551-5731-4a8f-9e16-0304c8cb71f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecb3596c-16d3-4e2e-9d7a-4bab7cc51838> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecb3596c-16d3-4e2e-9d7a-4bab7cc51838";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/5257aa61-2061-4634-b160-63a334ccbd51/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecb3596c-16d3-4e2e-9d7a-4bab7cc51838>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc5e59f9-2a5c-43be-81b9-b4933db96174> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc5e59f9-2a5c-43be-81b9-b4933db96174";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/684798e0-6aa3-4871-abb2-f6974e9d4b09/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc5e59f9-2a5c-43be-81b9-b4933db96174>.
+    
+<http://data.lblod.info/id/remote-data-objects/80a5aea7-3446-4d6b-aa9a-c1a52163b847> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80a5aea7-3446-4d6b-aa9a-c1a52163b847";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/6a9a7e33-9732-48e2-8ff0-e77c97f8abf8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80a5aea7-3446-4d6b-aa9a-c1a52163b847>.
+    
+<http://data.lblod.info/id/remote-data-objects/6164118b-2891-4b06-ad71-5f144f513ce7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6164118b-2891-4b06-ad71-5f144f513ce7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/6b006677-3a41-45bd-bd89-70d830493b0f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6164118b-2891-4b06-ad71-5f144f513ce7>.
+    
+<http://data.lblod.info/id/remote-data-objects/32bc6ce2-8d1c-42e3-ada1-e817a4170827> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32bc6ce2-8d1c-42e3-ada1-e817a4170827";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/6d2d959a-bac1-44bb-9632-c6a413ede8ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32bc6ce2-8d1c-42e3-ada1-e817a4170827>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c91fdba-695d-4e16-9bd5-92d4c581a933> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c91fdba-695d-4e16-9bd5-92d4c581a933";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/6fc86f95-bef1-4404-965f-11ac6c6bdf2a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c91fdba-695d-4e16-9bd5-92d4c581a933>.
+    
+<http://data.lblod.info/id/remote-data-objects/52a4d77f-3526-4d62-96e0-8cd092c76108> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52a4d77f-3526-4d62-96e0-8cd092c76108";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/707bfb6f-0363-4f12-8fc0-3d8aeecbe24c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52a4d77f-3526-4d62-96e0-8cd092c76108>.
+    
+<http://data.lblod.info/id/remote-data-objects/32cf9ead-5ffd-4591-82dc-227e3e2f435b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32cf9ead-5ffd-4591-82dc-227e3e2f435b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/72167e84-02ce-40ae-8be7-71351901e6df/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32cf9ead-5ffd-4591-82dc-227e3e2f435b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6688d247-12da-4aa7-a4ad-33f2d9ea62ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6688d247-12da-4aa7-a4ad-33f2d9ea62ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/73b15de4-378e-45a8-856c-2c2807dfe8bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6688d247-12da-4aa7-a4ad-33f2d9ea62ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/01e6fb9b-a8fc-489b-bf88-c7e7e9c59915> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01e6fb9b-a8fc-489b-bf88-c7e7e9c59915";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/759d04ef-ebe4-4c0a-b228-9816d97978aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01e6fb9b-a8fc-489b-bf88-c7e7e9c59915>.
+    
+<http://data.lblod.info/id/remote-data-objects/cca5b96c-a938-4267-9ee1-428f45fcc493> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cca5b96c-a938-4267-9ee1-428f45fcc493";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/76cca3a2-e219-4680-be20-81902cf9aa2b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cca5b96c-a938-4267-9ee1-428f45fcc493>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca10bb52-e12e-4723-85ec-f42073c23c6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca10bb52-e12e-4723-85ec-f42073c23c6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/79d5f89b-885a-436d-9311-d514f6b7c14f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca10bb52-e12e-4723-85ec-f42073c23c6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0075132e-675c-4fcc-9bdb-f14b4af0387d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0075132e-675c-4fcc-9bdb-f14b4af0387d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/7a5544ab-4eba-46fc-b44a-1b60a8f50039/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0075132e-675c-4fcc-9bdb-f14b4af0387d>.
+    
+<http://data.lblod.info/id/remote-data-objects/118268e5-5701-408d-b58c-7c62cceffe9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "118268e5-5701-408d-b58c-7c62cceffe9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/7f01d641-46a1-483b-9573-886a504e6d16/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/118268e5-5701-408d-b58c-7c62cceffe9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/376a61a8-af1d-4971-8d51-619511cddc4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "376a61a8-af1d-4971-8d51-619511cddc4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/85b01720-dcd7-4d65-9ca3-672f54644e49/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/376a61a8-af1d-4971-8d51-619511cddc4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/df25c196-02c5-4c4b-b754-159906942675> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df25c196-02c5-4c4b-b754-159906942675";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/89081dfe-9b7c-420a-a017-d1ef4d7d055c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df25c196-02c5-4c4b-b754-159906942675>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee13727d-8799-4ae9-9059-d7b64c7da7fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee13727d-8799-4ae9-9059-d7b64c7da7fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/89fe2883-04f7-41da-9782-9a820189d742/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee13727d-8799-4ae9-9059-d7b64c7da7fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/e675e84c-7bba-4387-a594-8a5bd91785f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e675e84c-7bba-4387-a594-8a5bd91785f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/8a5febd9-b7f0-4137-bee0-0e68dca6dcec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e675e84c-7bba-4387-a594-8a5bd91785f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3456c03-b68b-4bb9-999b-c9330e76f822> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3456c03-b68b-4bb9-999b-c9330e76f822";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/8aff40e6-451f-415a-bb9d-cf2209ebc9c2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3456c03-b68b-4bb9-999b-c9330e76f822>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a6d77b8-79ea-4008-a692-2b97a07150bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a6d77b8-79ea-4008-a692-2b97a07150bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/91cfd582-1206-4054-817e-ad8ccccee5fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a6d77b8-79ea-4008-a692-2b97a07150bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/3319eb12-a413-4e2b-96de-963a76cb900e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3319eb12-a413-4e2b-96de-963a76cb900e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/94315e9d-d38a-426a-8736-7a6fa5d5ea88/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3319eb12-a413-4e2b-96de-963a76cb900e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2dc38737-4b4c-4a95-8bd1-3ec56cde6de7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2dc38737-4b4c-4a95-8bd1-3ec56cde6de7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/94371d0b-ade1-4ef7-b451-e67b59b250a0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2dc38737-4b4c-4a95-8bd1-3ec56cde6de7>.
+    
+<http://data.lblod.info/id/remote-data-objects/277e6c4b-1f80-41ad-aaaf-448aa59503ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "277e6c4b-1f80-41ad-aaaf-448aa59503ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/98cc1cef-9e1a-4b75-9aa2-6e0f8b70fe08/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/277e6c4b-1f80-41ad-aaaf-448aa59503ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/23b901fd-cc08-43ed-8db9-b3b73d5c204c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23b901fd-cc08-43ed-8db9-b3b73d5c204c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/999190c3-0ddd-425c-ac7e-394578212081/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23b901fd-cc08-43ed-8db9-b3b73d5c204c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9816896c-c1f0-4211-8f68-d855f35ed379> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9816896c-c1f0-4211-8f68-d855f35ed379";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/9e071632-784c-43f7-b9c4-4cf63e59f52b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9816896c-c1f0-4211-8f68-d855f35ed379>.
+    
+<http://data.lblod.info/id/remote-data-objects/0726cef1-f1ec-4595-938b-66be475c1b93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0726cef1-f1ec-4595-938b-66be475c1b93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/a25236f5-51f5-4c8e-9e87-18b8d0d21029/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0726cef1-f1ec-4595-938b-66be475c1b93>.
+    
+<http://data.lblod.info/id/remote-data-objects/a165a50d-b504-4a4d-9e19-eeda06dd3b4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a165a50d-b504-4a4d-9e19-eeda06dd3b4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/a58f9b6f-54dc-4f36-8fbf-a196df9d7d81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a165a50d-b504-4a4d-9e19-eeda06dd3b4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ecd9112-51ef-42b4-ab96-d6d64be8ffb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ecd9112-51ef-42b4-ab96-d6d64be8ffb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/a63de83d-fbc7-4711-a883-2b5fc0ca18b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ecd9112-51ef-42b4-ab96-d6d64be8ffb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ed404df-601e-4e6a-b4dd-4e66d0c4b1e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ed404df-601e-4e6a-b4dd-4e66d0c4b1e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/a8235e43-6d23-467b-886d-393faaef8ef8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ed404df-601e-4e6a-b4dd-4e66d0c4b1e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/efacb90c-fa7a-4319-800e-86dae2964405> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efacb90c-fa7a-4319-800e-86dae2964405";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/a91adfce-9489-44f1-b5dd-30286c9ba0a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a89688e2-7ad3-4871-84a2-eac2516da02d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efacb90c-fa7a-4319-800e-86dae2964405>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201850-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201850-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201850-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201850-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f0280d2d-ca01-4415-8d78-e4e7a9ee8fca> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f0280d2d-ca01-4415-8d78-e4e7a9ee8fca";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b71363f7-86dd-4e5c-a549-d0c36612c7d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b71363f7-86dd-4e5c-a549-d0c36612c7d0";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a>.
+
+  <http://redpencil.data.gift/id/task/0761eda3-4532-408c-822e-7819f04e1260> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0761eda3-4532-408c-822e-7819f04e1260";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f0280d2d-ca01-4415-8d78-e4e7a9ee8fca>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b71363f7-86dd-4e5c-a549-d0c36612c7d0>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/0127916c-eb2e-43d7-82fc-c01d8bdabe75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0127916c-eb2e-43d7-82fc-c01d8bdabe75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/aa798e22-d0aa-4d07-a38f-d23d2a50d4fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0127916c-eb2e-43d7-82fc-c01d8bdabe75>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8e476df-114e-4639-a9a3-be9f09f55869> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8e476df-114e-4639-a9a3-be9f09f55869";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/afad47ce-4852-4a6e-9c05-a4d93d2a0d13/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8e476df-114e-4639-a9a3-be9f09f55869>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe155178-3058-4549-aede-d5d34974f78f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe155178-3058-4549-aede-d5d34974f78f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/b48b9bf9-6d0a-4d5a-b1e5-3fe00ef23534/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe155178-3058-4549-aede-d5d34974f78f>.
+    
+<http://data.lblod.info/id/remote-data-objects/809ec719-adcc-4363-a06f-0a7bac4156a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "809ec719-adcc-4363-a06f-0a7bac4156a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/b604389c-876e-40a4-b033-844a502e6e58/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/809ec719-adcc-4363-a06f-0a7bac4156a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9481b442-e646-4c16-a1a7-192ba534e09c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9481b442-e646-4c16-a1a7-192ba534e09c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/b6d000cb-35fe-4512-bc45-210e8badb223/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9481b442-e646-4c16-a1a7-192ba534e09c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d801707-09ac-47ac-b914-5c8b7cbbaa8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d801707-09ac-47ac-b914-5c8b7cbbaa8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/b95e6b08-921f-44cc-aee7-988bc0124381/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d801707-09ac-47ac-b914-5c8b7cbbaa8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/136d1e0b-d0b6-4bd1-a9cc-20c949213173> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "136d1e0b-d0b6-4bd1-a9cc-20c949213173";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/b9ef5ee5-b89f-4614-ba1e-944e6aeb68be/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/136d1e0b-d0b6-4bd1-a9cc-20c949213173>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc22cee7-b7e7-452f-ac63-addd44245bf4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc22cee7-b7e7-452f-ac63-addd44245bf4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/bdf744c1-6e2c-47d8-9fa7-8ccfec5947e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc22cee7-b7e7-452f-ac63-addd44245bf4>.
+    
+<http://data.lblod.info/id/remote-data-objects/58089573-89fb-4519-a006-d382f1824a30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58089573-89fb-4519-a006-d382f1824a30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/c0db118b-5db0-4d60-b834-af501c58c248/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58089573-89fb-4519-a006-d382f1824a30>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a0e61e9-5b5c-4ce5-8bdd-c06b38ce4a87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a0e61e9-5b5c-4ce5-8bdd-c06b38ce4a87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/c560c1e3-d745-46dd-ad3d-b1826e503eb2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a0e61e9-5b5c-4ce5-8bdd-c06b38ce4a87>.
+    
+<http://data.lblod.info/id/remote-data-objects/5308ab70-fa40-4a24-883c-0c9583342f8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5308ab70-fa40-4a24-883c-0c9583342f8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/c593f8dc-9db7-43b7-80e8-701d1758fa46/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5308ab70-fa40-4a24-883c-0c9583342f8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c1a1c3f-5dee-4d40-83ad-39c5c8d0afb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c1a1c3f-5dee-4d40-83ad-39c5c8d0afb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/c8b2bab2-948d-49af-bbbe-ceb40e5b19e2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c1a1c3f-5dee-4d40-83ad-39c5c8d0afb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/73dd176a-df5e-4a6a-a8e9-7b462a3c2b99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73dd176a-df5e-4a6a-a8e9-7b462a3c2b99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/d1f74962-3d2b-4d05-9eea-829b01ce2866/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73dd176a-df5e-4a6a-a8e9-7b462a3c2b99>.
+    
+<http://data.lblod.info/id/remote-data-objects/04318b04-6c0f-4522-8a3a-839627defe04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04318b04-6c0f-4522-8a3a-839627defe04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/d3e1481e-2d7c-4061-9ef7-621fdc332183/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04318b04-6c0f-4522-8a3a-839627defe04>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcc838a7-7b17-484d-be5d-cf71ebf5bf7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcc838a7-7b17-484d-be5d-cf71ebf5bf7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/d7df72af-6283-4210-8b31-d429f80cdc04/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcc838a7-7b17-484d-be5d-cf71ebf5bf7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/16b077de-89eb-4550-a6bf-84fc04aaba39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16b077de-89eb-4550-a6bf-84fc04aaba39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/dcac32a3-a994-4de7-bacf-3d54a93399d9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16b077de-89eb-4550-a6bf-84fc04aaba39>.
+    
+<http://data.lblod.info/id/remote-data-objects/7724c8d2-9b84-48fa-910c-587c732f1baa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7724c8d2-9b84-48fa-910c-587c732f1baa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/e3b1209b-e62a-468b-bcd2-3fd77ca60138/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7724c8d2-9b84-48fa-910c-587c732f1baa>.
+    
+<http://data.lblod.info/id/remote-data-objects/2769d659-3797-4aa7-a324-36aa74ef07eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2769d659-3797-4aa7-a324-36aa74ef07eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/e5f1ab46-2120-46c1-830f-1833de884fa5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2769d659-3797-4aa7-a324-36aa74ef07eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa1bedd3-7de5-4d3a-a236-ffea9afd6f3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa1bedd3-7de5-4d3a-a236-ffea9afd6f3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/e864c7fd-14aa-4248-87e2-768696468ed4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa1bedd3-7de5-4d3a-a236-ffea9afd6f3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1666a666-f7f7-4327-ba94-dcfe66513317> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1666a666-f7f7-4327-ba94-dcfe66513317";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/e9c5d685-8c26-4e9c-bf84-88c5ab4ccb58/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1666a666-f7f7-4327-ba94-dcfe66513317>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef4008d1-40ab-49ac-952a-f87cf427793a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef4008d1-40ab-49ac-952a-f87cf427793a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/f1b066e2-5262-49c2-bdff-523106b1187c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef4008d1-40ab-49ac-952a-f87cf427793a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bdc4b1d-065d-4ff2-b38a-cd4bd00b69f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bdc4b1d-065d-4ff2-b38a-cd4bd00b69f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/f502cb59-248e-42c2-b4cc-acb4ed88681d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bdc4b1d-065d-4ff2-b38a-cd4bd00b69f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1db32785-cbf1-43b8-bf30-83b04b7ae642> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1db32785-cbf1-43b8-bf30-83b04b7ae642";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/f7387113-59b8-4df7-b5af-c586836ee4fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1db32785-cbf1-43b8-bf30-83b04b7ae642>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a2152fa-1b46-45c8-9cd3-c039d11b0d5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a2152fa-1b46-45c8-9cd3-c039d11b0d5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/f99f5877-e784-4e3b-91f9-256e2550e2da/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a2152fa-1b46-45c8-9cd3-c039d11b0d5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/271ac58b-c843-405d-aa9f-7a54b7d17f7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "271ac58b-c843-405d-aa9f-7a54b7d17f7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/fae33d2f-1149-4810-979e-57c4401d7ff2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/271ac58b-c843-405d-aa9f-7a54b7d17f7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9e7fb71-856e-441a-b667-6268e505f44c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9e7fb71-856e-441a-b667-6268e505f44c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/fd286255-dbc7-435c-9e95-3af901c3c339/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9e7fb71-856e-441a-b667-6268e505f44c>.
+    
+<http://data.lblod.info/id/remote-data-objects/04c53ffd-0ec2-4348-9d01-f6acb7870e7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04c53ffd-0ec2-4348-9d01-f6acb7870e7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/fd2a078b-6b6b-405b-9732-bd2c10ccb9c0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04c53ffd-0ec2-4348-9d01-f6acb7870e7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c46e900-7e1b-4c7f-99e9-7b7923fe872f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c46e900-7e1b-4c7f-99e9-7b7923fe872f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/cbs/fe2c5627-ebe7-4fac-b6f5-e8f31d971ea1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c46e900-7e1b-4c7f-99e9-7b7923fe872f>.
+    
+<http://data.lblod.info/id/remote-data-objects/90c5361a-bf73-43e8-8fa5-315ac1ee8b62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90c5361a-bf73-43e8-8fa5-315ac1ee8b62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/eva-vzw-cultuurcentrum-mol-av/2150b151-09bc-4ff0-833e-048fa2f2f049/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90c5361a-bf73-43e8-8fa5-315ac1ee8b62>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c9cd719-5706-4f0d-be77-a7e496824598> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c9cd719-5706-4f0d-be77-a7e496824598";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/eva-vzw-cultuurcentrum-mol-rvb/12d0c34c-fd83-4c31-bf81-0f03e3dcb00f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c9cd719-5706-4f0d-be77-a7e496824598>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf1ee420-5c13-4575-a718-4008ed737fd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf1ee420-5c13-4575-a718-4008ed737fd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/eva-vzw-cultuurcentrum-mol-rvb/252b0e46-7c45-49bd-b400-144c2499b6fc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf1ee420-5c13-4575-a718-4008ed737fd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/85317e3d-1ebc-42f3-b6cf-0610370baf8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85317e3d-1ebc-42f3-b6cf-0610370baf8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/eva-vzw-cultuurcentrum-mol-rvb/ba11701d-a1f7-4d31-a56b-074c350ce62a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85317e3d-1ebc-42f3-b6cf-0610370baf8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7c5796a-7e02-4595-aa6a-19aca38f6122> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7c5796a-7e02-4595-aa6a-19aca38f6122";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/eva-vzw-kinderdagverblijf-molleke-av/7fd9bc12-7898-4529-8461-35f0754a5de1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7c5796a-7e02-4595-aa6a-19aca38f6122>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6cfc7be-573b-4b0f-9107-ddcf14b5ef03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6cfc7be-573b-4b0f-9107-ddcf14b5ef03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/05186689-2e8d-481d-bec8-59a6ef996261/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6cfc7be-573b-4b0f-9107-ddcf14b5ef03>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d04c8f4-ec20-4a2b-8807-66ca2005f57d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d04c8f4-ec20-4a2b-8807-66ca2005f57d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/05186689-2e8d-481d-bec8-59a6ef996261/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d04c8f4-ec20-4a2b-8807-66ca2005f57d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a526c1f9-cd94-40a4-9013-1d2f5e4dfa1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a526c1f9-cd94-40a4-9013-1d2f5e4dfa1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/05186689-2e8d-481d-bec8-59a6ef996261/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a526c1f9-cd94-40a4-9013-1d2f5e4dfa1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a634540-7daa-43a2-8a1a-8a97114f86bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a634540-7daa-43a2-8a1a-8a97114f86bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/0564a380-b1aa-4bb0-98a5-082e7a047bb2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a634540-7daa-43a2-8a1a-8a97114f86bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/8756520c-02de-4bca-9b7a-bff3993c3610> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8756520c-02de-4bca-9b7a-bff3993c3610";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/0564a380-b1aa-4bb0-98a5-082e7a047bb2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8756520c-02de-4bca-9b7a-bff3993c3610>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ee571b5-700c-4308-bbe1-ca6395ec07d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ee571b5-700c-4308-bbe1-ca6395ec07d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/0564a380-b1aa-4bb0-98a5-082e7a047bb2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ee571b5-700c-4308-bbe1-ca6395ec07d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/06709f38-b3cf-4b4f-a3a1-037745f53523> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06709f38-b3cf-4b4f-a3a1-037745f53523";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/086f8c36-5efa-4f74-bece-f975551e1196/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06709f38-b3cf-4b4f-a3a1-037745f53523>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd69b18a-0a4f-4062-bc74-4c673d561d6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd69b18a-0a4f-4062-bc74-4c673d561d6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/086f8c36-5efa-4f74-bece-f975551e1196/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd69b18a-0a4f-4062-bc74-4c673d561d6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c2f8aaa-1814-4f77-a51d-6b991a981696> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c2f8aaa-1814-4f77-a51d-6b991a981696";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/086f8c36-5efa-4f74-bece-f975551e1196/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c2f8aaa-1814-4f77-a51d-6b991a981696>.
+    
+<http://data.lblod.info/id/remote-data-objects/19ad1c49-d7ba-4435-b4dd-b24256d73ff5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19ad1c49-d7ba-4435-b4dd-b24256d73ff5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/1c14c4a4-b638-4e39-bbbf-233adda7e055/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19ad1c49-d7ba-4435-b4dd-b24256d73ff5>.
+    
+<http://data.lblod.info/id/remote-data-objects/93439df7-c99a-4313-9327-1eeada418e1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93439df7-c99a-4313-9327-1eeada418e1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/1c14c4a4-b638-4e39-bbbf-233adda7e055/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93439df7-c99a-4313-9327-1eeada418e1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/84d08cf5-a5ac-4135-8d56-083172aaddb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84d08cf5-a5ac-4135-8d56-083172aaddb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/1c14c4a4-b638-4e39-bbbf-233adda7e055/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84d08cf5-a5ac-4135-8d56-083172aaddb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d735c32-cc13-4e95-8317-c00aee899801> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d735c32-cc13-4e95-8317-c00aee899801";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/42e3d5f8-ec01-48a2-9c62-9a7961221fd7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d735c32-cc13-4e95-8317-c00aee899801>.
+    
+<http://data.lblod.info/id/remote-data-objects/519ed97f-34de-4368-9c4d-9bf451c89960> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "519ed97f-34de-4368-9c4d-9bf451c89960";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/42e3d5f8-ec01-48a2-9c62-9a7961221fd7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/519ed97f-34de-4368-9c4d-9bf451c89960>.
+    
+<http://data.lblod.info/id/remote-data-objects/a86642a6-f0d4-44d5-b4d3-c5c2575204a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a86642a6-f0d4-44d5-b4d3-c5c2575204a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/42e3d5f8-ec01-48a2-9c62-9a7961221fd7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a86642a6-f0d4-44d5-b4d3-c5c2575204a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/3460411d-ce76-42b5-b31d-146364b050c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3460411d-ce76-42b5-b31d-146364b050c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/6add300c-96f0-4ad6-9e06-d88d25ca9a9f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3460411d-ce76-42b5-b31d-146364b050c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5bb5ef8-3b39-44d1-acf4-8a345feabb37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5bb5ef8-3b39-44d1-acf4-8a345feabb37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/6add300c-96f0-4ad6-9e06-d88d25ca9a9f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:50.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/08b8b5e7-1953-4e1c-9ec2-b30af06e4e7a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5bb5ef8-3b39-44d1-acf4-8a345feabb37>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201852-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201852-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201852-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201852-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/7d9b3709-fa73-4e3f-96e9-aea5a7965344> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7d9b3709-fa73-4e3f-96e9-aea5a7965344";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6f197801-f433-4f8e-9dd0-6787f8c7ac2d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/bbdece16-2e80-4e4d-8df7-deb1eae6b27a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bbdece16-2e80-4e4d-8df7-deb1eae6b27a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d>.
+
+  <http://redpencil.data.gift/id/task/709eea02-d0c4-4a4c-a0ea-30557b277a75> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "709eea02-d0c4-4a4c-a0ea-30557b277a75";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/7d9b3709-fa73-4e3f-96e9-aea5a7965344>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/bbdece16-2e80-4e4d-8df7-deb1eae6b27a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/2cfebdfa-16df-4e38-894b-f3fda894ac40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cfebdfa-16df-4e38-894b-f3fda894ac40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/6add300c-96f0-4ad6-9e06-d88d25ca9a9f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cfebdfa-16df-4e38-894b-f3fda894ac40>.
+    
+<http://data.lblod.info/id/remote-data-objects/22f6e8bf-b066-4070-b9fb-24e3d02502c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22f6e8bf-b066-4070-b9fb-24e3d02502c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/761d16cb-8a45-4f07-badd-909346949112/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22f6e8bf-b066-4070-b9fb-24e3d02502c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7b69186-4723-4335-97c9-5fcd4c6c50c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7b69186-4723-4335-97c9-5fcd4c6c50c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/761d16cb-8a45-4f07-badd-909346949112/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7b69186-4723-4335-97c9-5fcd4c6c50c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd8fc554-0d9f-494a-9bc5-d0ba4e6af557> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd8fc554-0d9f-494a-9bc5-d0ba4e6af557";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/761d16cb-8a45-4f07-badd-909346949112/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd8fc554-0d9f-494a-9bc5-d0ba4e6af557>.
+    
+<http://data.lblod.info/id/remote-data-objects/f027c208-4ad8-45e1-a6eb-efb0018b5500> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f027c208-4ad8-45e1-a6eb-efb0018b5500";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/7ff34ddf-41f6-42cf-a345-985fa6e1c0b1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f027c208-4ad8-45e1-a6eb-efb0018b5500>.
+    
+<http://data.lblod.info/id/remote-data-objects/d723527b-6f23-4dcf-ae0c-6bb7a6a5af25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d723527b-6f23-4dcf-ae0c-6bb7a6a5af25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/7ff34ddf-41f6-42cf-a345-985fa6e1c0b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d723527b-6f23-4dcf-ae0c-6bb7a6a5af25>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff7edd3d-e238-4a04-afe3-ca6f58298512> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff7edd3d-e238-4a04-afe3-ca6f58298512";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/7ff34ddf-41f6-42cf-a345-985fa6e1c0b1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff7edd3d-e238-4a04-afe3-ca6f58298512>.
+    
+<http://data.lblod.info/id/remote-data-objects/9438614a-5a40-4ae1-9ee4-8cafb6aca743> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9438614a-5a40-4ae1-9ee4-8cafb6aca743";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/8625a0ac-9a50-4ec1-b9ca-cfeadcba07c6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9438614a-5a40-4ae1-9ee4-8cafb6aca743>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f5d9630-33a9-4d91-8a76-2d585fc7a643> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f5d9630-33a9-4d91-8a76-2d585fc7a643";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/8625a0ac-9a50-4ec1-b9ca-cfeadcba07c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f5d9630-33a9-4d91-8a76-2d585fc7a643>.
+    
+<http://data.lblod.info/id/remote-data-objects/60c4d428-5628-4104-a8db-777b3943cb55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60c4d428-5628-4104-a8db-777b3943cb55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/8625a0ac-9a50-4ec1-b9ca-cfeadcba07c6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60c4d428-5628-4104-a8db-777b3943cb55>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cee0884-826d-4e28-bad6-85e44e2c75d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cee0884-826d-4e28-bad6-85e44e2c75d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/97f0f70f-30f6-4c7b-ad34-4ca95f5fec68/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cee0884-826d-4e28-bad6-85e44e2c75d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/79740862-f94a-4f36-a105-c1b81e11b363> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79740862-f94a-4f36-a105-c1b81e11b363";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/97f0f70f-30f6-4c7b-ad34-4ca95f5fec68/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79740862-f94a-4f36-a105-c1b81e11b363>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac24106f-df34-401c-992b-fe993f4cfeef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac24106f-df34-401c-992b-fe993f4cfeef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/97f0f70f-30f6-4c7b-ad34-4ca95f5fec68/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac24106f-df34-401c-992b-fe993f4cfeef>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c49b255-5174-4c9e-8bb6-01b7058dd912> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c49b255-5174-4c9e-8bb6-01b7058dd912";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/9a0b9c2e-fe47-41f2-a6ea-dffbb8197b2c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c49b255-5174-4c9e-8bb6-01b7058dd912>.
+    
+<http://data.lblod.info/id/remote-data-objects/50be0d0a-162d-4a84-b4bd-dad9ce6e9861> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50be0d0a-162d-4a84-b4bd-dad9ce6e9861";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/9a0b9c2e-fe47-41f2-a6ea-dffbb8197b2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50be0d0a-162d-4a84-b4bd-dad9ce6e9861>.
+    
+<http://data.lblod.info/id/remote-data-objects/a404b7b7-8d46-4d74-b49a-534b4550cc79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a404b7b7-8d46-4d74-b49a-534b4550cc79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/9a0b9c2e-fe47-41f2-a6ea-dffbb8197b2c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a404b7b7-8d46-4d74-b49a-534b4550cc79>.
+    
+<http://data.lblod.info/id/remote-data-objects/52b22626-63b5-4ca2-89ac-76c06f32ca73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52b22626-63b5-4ca2-89ac-76c06f32ca73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/a3272eba-664a-4ab7-9a85-b9b8cfa15d07/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52b22626-63b5-4ca2-89ac-76c06f32ca73>.
+    
+<http://data.lblod.info/id/remote-data-objects/a199caa3-52c2-4192-8689-8ec9c0de18b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a199caa3-52c2-4192-8689-8ec9c0de18b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/a3272eba-664a-4ab7-9a85-b9b8cfa15d07/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a199caa3-52c2-4192-8689-8ec9c0de18b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cac055c-a7ac-4e35-9e6c-2416fa9f47ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cac055c-a7ac-4e35-9e6c-2416fa9f47ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/a3272eba-664a-4ab7-9a85-b9b8cfa15d07/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cac055c-a7ac-4e35-9e6c-2416fa9f47ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6efea56-d835-4b00-be6a-0509df9104e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6efea56-d835-4b00-be6a-0509df9104e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/b027c317-a420-47c8-a556-72bc49330df6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6efea56-d835-4b00-be6a-0509df9104e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecf519f6-263c-49cb-a6fb-a2229ae2d89f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecf519f6-263c-49cb-a6fb-a2229ae2d89f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/b027c317-a420-47c8-a556-72bc49330df6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecf519f6-263c-49cb-a6fb-a2229ae2d89f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7c0ab3c-6c5c-4651-9983-f485d54bf60f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7c0ab3c-6c5c-4651-9983-f485d54bf60f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/b027c317-a420-47c8-a556-72bc49330df6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7c0ab3c-6c5c-4651-9983-f485d54bf60f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7dd81ba-2e78-496d-b806-e492b574f95e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7dd81ba-2e78-496d-b806-e492b574f95e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/c75b8a15-5622-4c61-8fbe-9c07b929eaed/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7dd81ba-2e78-496d-b806-e492b574f95e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ac2c157-550a-40e0-b722-078b8cfbdc6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ac2c157-550a-40e0-b722-078b8cfbdc6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/c75b8a15-5622-4c61-8fbe-9c07b929eaed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ac2c157-550a-40e0-b722-078b8cfbdc6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/790fe094-6210-473d-a9b9-1a180ec73010> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "790fe094-6210-473d-a9b9-1a180ec73010";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/fa865d27-ed3f-42e9-801f-18bd7704012b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/790fe094-6210-473d-a9b9-1a180ec73010>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e2d0176-dd4b-4dae-92c3-cdddd57b94bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e2d0176-dd4b-4dae-92c3-cdddd57b94bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/fa865d27-ed3f-42e9-801f-18bd7704012b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e2d0176-dd4b-4dae-92c3-cdddd57b94bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/0054b854-f822-4e55-9019-7685ac12408a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0054b854-f822-4e55-9019-7685ac12408a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/gr/fa865d27-ed3f-42e9-801f-18bd7704012b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0054b854-f822-4e55-9019-7685ac12408a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f89eef5b-bda4-4db2-94b1-119b3468218f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f89eef5b-bda4-4db2-94b1-119b3468218f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/059c8546-7156-4e54-aae5-14b692d80d8d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f89eef5b-bda4-4db2-94b1-119b3468218f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a75487e4-515e-4ec0-ad3e-cb5ed4297659> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a75487e4-515e-4ec0-ad3e-cb5ed4297659";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/059c8546-7156-4e54-aae5-14b692d80d8d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a75487e4-515e-4ec0-ad3e-cb5ed4297659>.
+    
+<http://data.lblod.info/id/remote-data-objects/a47d2fdb-538a-47fa-8e26-b71d450fdab5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a47d2fdb-538a-47fa-8e26-b71d450fdab5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/059c8546-7156-4e54-aae5-14b692d80d8d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a47d2fdb-538a-47fa-8e26-b71d450fdab5>.
+    
+<http://data.lblod.info/id/remote-data-objects/d98e5a31-eb16-4559-b18e-82c357573939> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d98e5a31-eb16-4559-b18e-82c357573939";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/1e16a609-41c7-465f-901d-800e33dcba25/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d98e5a31-eb16-4559-b18e-82c357573939>.
+    
+<http://data.lblod.info/id/remote-data-objects/d750c22b-79ad-4b32-b3e5-d350a3dc480d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d750c22b-79ad-4b32-b3e5-d350a3dc480d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/1e16a609-41c7-465f-901d-800e33dcba25/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d750c22b-79ad-4b32-b3e5-d350a3dc480d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ebe7371-8826-4c75-8af8-860d2b5d0d7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ebe7371-8826-4c75-8af8-860d2b5d0d7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/1e16a609-41c7-465f-901d-800e33dcba25/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ebe7371-8826-4c75-8af8-860d2b5d0d7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ade5e81f-2e07-4f36-887a-d1cb5c66557d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ade5e81f-2e07-4f36-887a-d1cb5c66557d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/34be171d-8c03-4151-8918-d421d2586026/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ade5e81f-2e07-4f36-887a-d1cb5c66557d>.
+    
+<http://data.lblod.info/id/remote-data-objects/89b2eb23-44e3-4adc-aca0-37cb807300f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89b2eb23-44e3-4adc-aca0-37cb807300f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/34be171d-8c03-4151-8918-d421d2586026/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89b2eb23-44e3-4adc-aca0-37cb807300f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f6e42b8-53ef-4af8-ab91-15274449040c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f6e42b8-53ef-4af8-ab91-15274449040c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/34be171d-8c03-4151-8918-d421d2586026/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f6e42b8-53ef-4af8-ab91-15274449040c>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc571e74-8f0c-457f-a7d2-01b3eee4aabf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc571e74-8f0c-457f-a7d2-01b3eee4aabf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/355fb55d-020a-4557-a4ce-d4cdf7df1ac1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc571e74-8f0c-457f-a7d2-01b3eee4aabf>.
+    
+<http://data.lblod.info/id/remote-data-objects/f104b23f-a406-454a-9538-07c04ceb2966> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f104b23f-a406-454a-9538-07c04ceb2966";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/355fb55d-020a-4557-a4ce-d4cdf7df1ac1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f104b23f-a406-454a-9538-07c04ceb2966>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fd73c2d-b637-4cf6-bbee-b37838fe89d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fd73c2d-b637-4cf6-bbee-b37838fe89d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/355fb55d-020a-4557-a4ce-d4cdf7df1ac1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fd73c2d-b637-4cf6-bbee-b37838fe89d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/878da1c9-83dd-4155-a4eb-987d704a035c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "878da1c9-83dd-4155-a4eb-987d704a035c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/3986e960-ac7a-468a-9e4a-d63e666b17db/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/878da1c9-83dd-4155-a4eb-987d704a035c>.
+    
+<http://data.lblod.info/id/remote-data-objects/075a6b75-286c-4d2e-aaed-595cf03c883f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "075a6b75-286c-4d2e-aaed-595cf03c883f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/3986e960-ac7a-468a-9e4a-d63e666b17db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/075a6b75-286c-4d2e-aaed-595cf03c883f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f21644fe-9a62-4ab8-938b-a39a9cb58285> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f21644fe-9a62-4ab8-938b-a39a9cb58285";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/3986e960-ac7a-468a-9e4a-d63e666b17db/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f21644fe-9a62-4ab8-938b-a39a9cb58285>.
+    
+<http://data.lblod.info/id/remote-data-objects/9209a574-409a-4004-b307-ac27ce07b1bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9209a574-409a-4004-b307-ac27ce07b1bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/6e9ffbfb-52bd-478b-aef4-a9e3c38165ee/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9209a574-409a-4004-b307-ac27ce07b1bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/3100d6c7-2e4c-4ca2-996c-37f5869871b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3100d6c7-2e4c-4ca2-996c-37f5869871b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/6e9ffbfb-52bd-478b-aef4-a9e3c38165ee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3100d6c7-2e4c-4ca2-996c-37f5869871b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bba8423-ac12-489d-bba3-cadabd914bfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bba8423-ac12-489d-bba3-cadabd914bfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/6e9ffbfb-52bd-478b-aef4-a9e3c38165ee/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bba8423-ac12-489d-bba3-cadabd914bfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/da2c16d8-379f-434e-a00e-3e381111f7f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da2c16d8-379f-434e-a00e-3e381111f7f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/82763099-760b-4688-9c6e-b472598dc09a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da2c16d8-379f-434e-a00e-3e381111f7f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4eec2f09-5a3c-4deb-a91d-7a105ae28fe9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4eec2f09-5a3c-4deb-a91d-7a105ae28fe9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/82763099-760b-4688-9c6e-b472598dc09a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4eec2f09-5a3c-4deb-a91d-7a105ae28fe9>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc1cbbea-28d6-4540-af9a-d8c333458360> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc1cbbea-28d6-4540-af9a-d8c333458360";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/82763099-760b-4688-9c6e-b472598dc09a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc1cbbea-28d6-4540-af9a-d8c333458360>.
+    
+<http://data.lblod.info/id/remote-data-objects/f46c771f-4190-4281-a4d2-1a67d11c1e7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f46c771f-4190-4281-a4d2-1a67d11c1e7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/82a44685-6076-429e-8f07-112936711578/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f46c771f-4190-4281-a4d2-1a67d11c1e7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1eb34e23-d879-4a50-a702-1a48310b4089> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1eb34e23-d879-4a50-a702-1a48310b4089";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/82a44685-6076-429e-8f07-112936711578/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6f197801-f433-4f8e-9dd0-6787f8c7ac2d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1eb34e23-d879-4a50-a702-1a48310b4089>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201853-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201853-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201853-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201853-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/1378f9cc-e727-4c51-87db-d098a378093f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1378f9cc-e727-4c51-87db-d098a378093f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a4e9f083-e958-4826-9c46-eec35de0f54c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/e620ff88-ca89-4d0a-84ab-061ba9feb1b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e620ff88-ca89-4d0a-84ab-061ba9feb1b8";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c>.
+
+  <http://redpencil.data.gift/id/task/142804bc-fb09-44f0-873a-3aac68cff880> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "142804bc-fb09-44f0-873a-3aac68cff880";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/1378f9cc-e727-4c51-87db-d098a378093f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/e620ff88-ca89-4d0a-84ab-061ba9feb1b8>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/fbe692ff-a3fe-4dcd-9969-3aae8e93ac4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbe692ff-a3fe-4dcd-9969-3aae8e93ac4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/82a44685-6076-429e-8f07-112936711578/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbe692ff-a3fe-4dcd-9969-3aae8e93ac4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/76983991-1f53-45cb-8494-9f2c016eeddd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76983991-1f53-45cb-8494-9f2c016eeddd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/8d7ad867-497a-4f0d-87ad-3f740c53f550/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76983991-1f53-45cb-8494-9f2c016eeddd>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b57a1e2-67bc-4ad5-9cce-a5245321a0b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b57a1e2-67bc-4ad5-9cce-a5245321a0b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/8d7ad867-497a-4f0d-87ad-3f740c53f550/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b57a1e2-67bc-4ad5-9cce-a5245321a0b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce0fa2eb-0b70-4642-be0f-6bde63d71819> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce0fa2eb-0b70-4642-be0f-6bde63d71819";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/8d7ad867-497a-4f0d-87ad-3f740c53f550/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce0fa2eb-0b70-4642-be0f-6bde63d71819>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6493c1c-1300-44cc-9369-ede288cff89c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6493c1c-1300-44cc-9369-ede288cff89c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/a7d57e03-193b-4af3-8000-43092ef4e599/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6493c1c-1300-44cc-9369-ede288cff89c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5676627-b217-408f-85be-ceb70e2c051f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5676627-b217-408f-85be-ceb70e2c051f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/a7d57e03-193b-4af3-8000-43092ef4e599/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5676627-b217-408f-85be-ceb70e2c051f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b89cba07-78e6-425c-9e04-79083f9df2d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b89cba07-78e6-425c-9e04-79083f9df2d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/a7d57e03-193b-4af3-8000-43092ef4e599/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b89cba07-78e6-425c-9e04-79083f9df2d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/87450655-2ce7-4b0b-9297-ad34205b43ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87450655-2ce7-4b0b-9297-ad34205b43ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/adabfd5e-e1bf-4b5f-a866-6a2bf772570a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87450655-2ce7-4b0b-9297-ad34205b43ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/acf63777-9633-44a6-8485-97d1f9f62bd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acf63777-9633-44a6-8485-97d1f9f62bd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/adabfd5e-e1bf-4b5f-a866-6a2bf772570a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acf63777-9633-44a6-8485-97d1f9f62bd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c508b606-4e60-4ae3-aa2f-928e8d96f9f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c508b606-4e60-4ae3-aa2f-928e8d96f9f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/b0993e14-bd3e-4479-aecf-c9cb2f79b068/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c508b606-4e60-4ae3-aa2f-928e8d96f9f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/5dc8edfd-aa7d-4739-90af-e95f7889fea5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5dc8edfd-aa7d-4739-90af-e95f7889fea5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/b0993e14-bd3e-4479-aecf-c9cb2f79b068/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5dc8edfd-aa7d-4739-90af-e95f7889fea5>.
+    
+<http://data.lblod.info/id/remote-data-objects/af3b7a5b-b5fd-4a85-93d9-67c4c268e4c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af3b7a5b-b5fd-4a85-93d9-67c4c268e4c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/b0993e14-bd3e-4479-aecf-c9cb2f79b068/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af3b7a5b-b5fd-4a85-93d9-67c4c268e4c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6b546eb-dc6d-445f-bde5-ccf8a02dde50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6b546eb-dc6d-445f-bde5-ccf8a02dde50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/b6880744-fcb7-45e9-b949-d2e9f5394e43/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6b546eb-dc6d-445f-bde5-ccf8a02dde50>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebe94ab6-7ed9-4cb1-a512-20508ede97c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebe94ab6-7ed9-4cb1-a512-20508ede97c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/b6880744-fcb7-45e9-b949-d2e9f5394e43/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebe94ab6-7ed9-4cb1-a512-20508ede97c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1a08f61-e1a8-42fe-9f75-94ee7327b5f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1a08f61-e1a8-42fe-9f75-94ee7327b5f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/b6880744-fcb7-45e9-b949-d2e9f5394e43/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1a08f61-e1a8-42fe-9f75-94ee7327b5f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/8515cf9c-2634-4455-ac20-9b7ca12a08b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8515cf9c-2634-4455-ac20-9b7ca12a08b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/cd36c2d2-69c5-4691-9e1c-fd88b1361ac7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8515cf9c-2634-4455-ac20-9b7ca12a08b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9927f6a-8d7e-49a7-96fe-41043908ac55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9927f6a-8d7e-49a7-96fe-41043908ac55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/cd36c2d2-69c5-4691-9e1c-fd88b1361ac7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9927f6a-8d7e-49a7-96fe-41043908ac55>.
+    
+<http://data.lblod.info/id/remote-data-objects/89b56c26-455e-4a30-b4f8-e517ca35447c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89b56c26-455e-4a30-b4f8-e517ca35447c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/cd36c2d2-69c5-4691-9e1c-fd88b1361ac7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89b56c26-455e-4a30-b4f8-e517ca35447c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5329f127-acda-471d-ac29-b2f0164562b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5329f127-acda-471d-ac29-b2f0164562b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/faf7eaae-73ed-46cc-b9b2-2a4eaccedaae/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5329f127-acda-471d-ac29-b2f0164562b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/b887bbcd-fe48-42c3-80cc-fb7042cf5bdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b887bbcd-fe48-42c3-80cc-fb7042cf5bdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/faf7eaae-73ed-46cc-b9b2-2a4eaccedaae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b887bbcd-fe48-42c3-80cc-fb7042cf5bdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/333a0c8c-bf45-43b5-80b7-2f9adae0c558> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "333a0c8c-bf45-43b5-80b7-2f9adae0c558";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/or/faf7eaae-73ed-46cc-b9b2-2a4eaccedaae/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/333a0c8c-bf45-43b5-80b7-2f9adae0c558>.
+    
+<http://data.lblod.info/id/remote-data-objects/b53c89c9-b251-4a81-ab10-a85620927e15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b53c89c9-b251-4a81-ab10-a85620927e15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/05e037a5-e0ba-4bc4-919d-66583d0675e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b53c89c9-b251-4a81-ab10-a85620927e15>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b9b1a9d-bff1-4234-ae4b-6b3e542f0d7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b9b1a9d-bff1-4234-ae4b-6b3e542f0d7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/0670c5db-f323-446b-9a17-96998967abc7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b9b1a9d-bff1-4234-ae4b-6b3e542f0d7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/dca5518a-94fb-4587-9283-45810a809e6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dca5518a-94fb-4587-9283-45810a809e6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/0a3f2945-5e82-42c3-b768-75f40eb85b28/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dca5518a-94fb-4587-9283-45810a809e6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/58ef3bbf-a71d-4f6e-a598-ddcdcf29af15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58ef3bbf-a71d-4f6e-a598-ddcdcf29af15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/15a77e55-2971-4d24-a353-8442d549c6c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58ef3bbf-a71d-4f6e-a598-ddcdcf29af15>.
+    
+<http://data.lblod.info/id/remote-data-objects/170c491b-04b7-4911-b485-f8764c9ac280> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "170c491b-04b7-4911-b485-f8764c9ac280";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/16856e5c-abbc-4f2f-bf65-1faa1e49e38b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/170c491b-04b7-4911-b485-f8764c9ac280>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4dbf594-bb4d-44f9-98f7-36eeac1fa383> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4dbf594-bb4d-44f9-98f7-36eeac1fa383";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/1744f91a-5bbc-448a-8ec6-d9d7802d2f8f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4dbf594-bb4d-44f9-98f7-36eeac1fa383>.
+    
+<http://data.lblod.info/id/remote-data-objects/87177e99-112f-4274-8e3b-35f51150eb7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87177e99-112f-4274-8e3b-35f51150eb7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/1ef2ec7a-04e7-47a3-bfb9-8ce534aa140e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87177e99-112f-4274-8e3b-35f51150eb7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e089125e-caa0-41e3-91de-5d707992b0a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e089125e-caa0-41e3-91de-5d707992b0a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/1facb76e-10ac-4540-9817-b74059573b6f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e089125e-caa0-41e3-91de-5d707992b0a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b07a0b4-8835-4e90-9afc-47dd49ec8123> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b07a0b4-8835-4e90-9afc-47dd49ec8123";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/2098253f-8bf7-4ec4-a25f-1e714bdbce59/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b07a0b4-8835-4e90-9afc-47dd49ec8123>.
+    
+<http://data.lblod.info/id/remote-data-objects/4adf0e96-d408-431d-8731-3dd229a73be9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4adf0e96-d408-431d-8731-3dd229a73be9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/22299d20-094b-4f89-a178-38ecf8b378dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4adf0e96-d408-431d-8731-3dd229a73be9>.
+    
+<http://data.lblod.info/id/remote-data-objects/23841961-84f9-4c2b-a31e-36bd10364084> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23841961-84f9-4c2b-a31e-36bd10364084";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/24491f5d-2b3f-4e5a-a99f-bef2e3fe7d5f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23841961-84f9-4c2b-a31e-36bd10364084>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce2120dd-5f0a-45de-a842-0f0c77baa743> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce2120dd-5f0a-45de-a842-0f0c77baa743";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/25c37c5e-776b-4bb0-ad91-0e3b87e02ac9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce2120dd-5f0a-45de-a842-0f0c77baa743>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4b819c7-74c6-4c00-8443-d3697ca72c85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4b819c7-74c6-4c00-8443-d3697ca72c85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/28f3f104-489f-4fa9-ad07-3edf0f356a78/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4b819c7-74c6-4c00-8443-d3697ca72c85>.
+    
+<http://data.lblod.info/id/remote-data-objects/944fb70e-2b0d-48c0-9749-b82679f52c02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "944fb70e-2b0d-48c0-9749-b82679f52c02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/299157fd-ac73-4321-8ceb-05d95f0a3ce8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/944fb70e-2b0d-48c0-9749-b82679f52c02>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fe489b8-efc0-4b30-8970-7ffe4208e31d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fe489b8-efc0-4b30-8970-7ffe4208e31d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/2a259ddf-bf28-44ca-82cf-6488c867db9c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fe489b8-efc0-4b30-8970-7ffe4208e31d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8caf87b-a76c-46fb-b0af-c75c981b0a5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8caf87b-a76c-46fb-b0af-c75c981b0a5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/2a2bbe9f-9290-42d6-88a5-ec793c99fa95/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8caf87b-a76c-46fb-b0af-c75c981b0a5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ea1c559-c2b0-4991-a860-b2fdd5355832> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ea1c559-c2b0-4991-a860-b2fdd5355832";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/304aafc6-15e7-4732-90b6-320144bccc70/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ea1c559-c2b0-4991-a860-b2fdd5355832>.
+    
+<http://data.lblod.info/id/remote-data-objects/d235c30c-2fdf-4e72-872e-950b5bb9aa49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d235c30c-2fdf-4e72-872e-950b5bb9aa49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/320748fd-4dd3-46aa-b891-2b8bb8a321c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d235c30c-2fdf-4e72-872e-950b5bb9aa49>.
+    
+<http://data.lblod.info/id/remote-data-objects/4afe2689-b75f-4036-a51b-543750d1605b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4afe2689-b75f-4036-a51b-543750d1605b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/32ac5c86-0f93-4889-8ae4-941f58482bb0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4afe2689-b75f-4036-a51b-543750d1605b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d16bd64b-7e36-4504-8661-3b2f5fc9813b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d16bd64b-7e36-4504-8661-3b2f5fc9813b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/37ac6d09-a758-47a7-9cb2-7545a36567da/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d16bd64b-7e36-4504-8661-3b2f5fc9813b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4a7a06c-5fb8-4721-afab-ab97d2353a5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4a7a06c-5fb8-4721-afab-ab97d2353a5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/37d47a61-d4c3-4c3f-a28f-1be52f409fd8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4a7a06c-5fb8-4721-afab-ab97d2353a5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/af3c93a0-a6d6-4601-8cc5-a4f06771260e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af3c93a0-a6d6-4601-8cc5-a4f06771260e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/3d0969ee-98fd-4c77-8eab-7c9e9501b84f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af3c93a0-a6d6-4601-8cc5-a4f06771260e>.
+    
+<http://data.lblod.info/id/remote-data-objects/169b2072-b6f7-4b42-8e3a-3a4bf83983cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "169b2072-b6f7-4b42-8e3a-3a4bf83983cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/405af0c4-6d09-4232-ab6b-c28d6c80e6dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/169b2072-b6f7-4b42-8e3a-3a4bf83983cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/586e57d8-1b1b-4df9-b198-53ea259c59d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "586e57d8-1b1b-4df9-b198-53ea259c59d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/485cd0a0-7986-46ac-b195-660bce2976ba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/586e57d8-1b1b-4df9-b198-53ea259c59d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f979e86-3638-4e71-bde2-0f91ac994157> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f979e86-3638-4e71-bde2-0f91ac994157";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/49b90030-261a-492d-aa50-288eac7a8dae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f979e86-3638-4e71-bde2-0f91ac994157>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b6a9abd-53ab-4673-9dd8-ac87fe0f6b1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b6a9abd-53ab-4673-9dd8-ac87fe0f6b1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/4eca5aab-39b3-4e46-913b-47b29f7ea81c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b6a9abd-53ab-4673-9dd8-ac87fe0f6b1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/132d6972-9356-4def-be70-913bb04d63b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "132d6972-9356-4def-be70-913bb04d63b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/4fc0c1c8-638b-46d0-aa90-788e3ea12421/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/132d6972-9356-4def-be70-913bb04d63b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7db57c13-fcb8-4c75-947e-a35ed3892aac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7db57c13-fcb8-4c75-947e-a35ed3892aac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/52c38223-00b4-4b5d-b0d7-99beedd65607/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7db57c13-fcb8-4c75-947e-a35ed3892aac>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc5ef6ef-bbaa-403b-bfd0-b778723e90da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc5ef6ef-bbaa-403b-bfd0-b778723e90da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/5934c488-e1cf-4e83-8621-b6bdde5f2891/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/a4e9f083-e958-4826-9c46-eec35de0f54c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc5ef6ef-bbaa-403b-bfd0-b778723e90da>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201854-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201854-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201854-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201854-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/def6c455-1061-46dd-9a2a-5a86e94c1288> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "def6c455-1061-46dd-9a2a-5a86e94c1288";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6a064528-2af2-4574-b9fa-b214da88bbcf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/0a69f114-5757-4f7c-ab79-59ad7a46c6e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0a69f114-5757-4f7c-ab79-59ad7a46c6e6";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf>.
+
+  <http://redpencil.data.gift/id/task/e56590ba-2dfe-4feb-a5c6-0e598b5d38b9> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e56590ba-2dfe-4feb-a5c6-0e598b5d38b9";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/def6c455-1061-46dd-9a2a-5a86e94c1288>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/0a69f114-5757-4f7c-ab79-59ad7a46c6e6>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d3503f3b-14f8-4e05-b893-497c0f292e23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3503f3b-14f8-4e05-b893-497c0f292e23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/61c6fcbf-0aee-4177-a0b1-9eab1730f286/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3503f3b-14f8-4e05-b893-497c0f292e23>.
+    
+<http://data.lblod.info/id/remote-data-objects/2415f5bb-eb15-49c8-9145-2f5f9471ff90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2415f5bb-eb15-49c8-9145-2f5f9471ff90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/62620720-68da-4267-8e65-fd4f37f83143/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2415f5bb-eb15-49c8-9145-2f5f9471ff90>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee613968-1e48-4678-9d87-b5980519a7ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee613968-1e48-4678-9d87-b5980519a7ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/6be285b4-f66a-4444-a8d0-c9cb696d6f59/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee613968-1e48-4678-9d87-b5980519a7ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b57fbee-9457-4875-9f85-168e3472522f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b57fbee-9457-4875-9f85-168e3472522f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/6e4c236e-63b3-415c-8602-a98c4a15465a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b57fbee-9457-4875-9f85-168e3472522f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f426042-f20f-481c-a305-436f62c65e5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f426042-f20f-481c-a305-436f62c65e5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/6e7d5399-6ea3-4c87-9ec5-69445b492386/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f426042-f20f-481c-a305-436f62c65e5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/70a6acdd-13cb-4d83-8871-eb06f92eb1a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70a6acdd-13cb-4d83-8871-eb06f92eb1a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/6f23825b-4929-4366-a9be-e07075a44673/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70a6acdd-13cb-4d83-8871-eb06f92eb1a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/86c58c0b-b26c-4f16-9e42-a27b01478b7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86c58c0b-b26c-4f16-9e42-a27b01478b7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/70eeac5c-4784-4701-bac0-1be9f95d3e40/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86c58c0b-b26c-4f16-9e42-a27b01478b7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0f51614-8c92-4e46-a259-10ff5a30f6a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0f51614-8c92-4e46-a259-10ff5a30f6a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/72fc813b-7597-4252-977b-8d76ba50b57a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0f51614-8c92-4e46-a259-10ff5a30f6a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5d5387f-3bda-4c27-a953-a315c22d0300> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5d5387f-3bda-4c27-a953-a315c22d0300";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/78c7fe9b-e383-4b19-8226-069bef40cad3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5d5387f-3bda-4c27-a953-a315c22d0300>.
+    
+<http://data.lblod.info/id/remote-data-objects/62747857-9182-4cb6-80cc-f918da828b8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62747857-9182-4cb6-80cc-f918da828b8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/82b9f274-d62c-4366-82dd-c5e03136d387/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62747857-9182-4cb6-80cc-f918da828b8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/eebbabcc-be0f-47da-9a7f-fb5acb81b681> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eebbabcc-be0f-47da-9a7f-fb5acb81b681";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/83e1ea27-8a43-4fd9-8b8b-092b760270f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eebbabcc-be0f-47da-9a7f-fb5acb81b681>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6b46eae-e6d1-4ac5-9372-a6ccef0b2bd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6b46eae-e6d1-4ac5-9372-a6ccef0b2bd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/8658faa3-f911-4da8-9ed9-6e3af08125a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6b46eae-e6d1-4ac5-9372-a6ccef0b2bd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee27e7cc-a35e-44a2-be04-fede9e220c77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee27e7cc-a35e-44a2-be04-fede9e220c77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/8b4ecda0-90b1-476a-98ce-f094fdc4f489/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee27e7cc-a35e-44a2-be04-fede9e220c77>.
+    
+<http://data.lblod.info/id/remote-data-objects/a04844a2-1be9-45c4-a203-39d0fff6d787> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a04844a2-1be9-45c4-a203-39d0fff6d787";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/989ed5be-90b6-40a2-9723-215db6ad51a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a04844a2-1be9-45c4-a203-39d0fff6d787>.
+    
+<http://data.lblod.info/id/remote-data-objects/a16e5fa3-2313-4f6c-9237-1013126855bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a16e5fa3-2313-4f6c-9237-1013126855bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/997b3dd2-90fb-449c-8071-59a927629711/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a16e5fa3-2313-4f6c-9237-1013126855bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc7ccb77-7726-40c4-b5cf-1321324fb9ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc7ccb77-7726-40c4-b5cf-1321324fb9ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/a1d402b0-99c0-4eef-bc8f-49fa48182637/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc7ccb77-7726-40c4-b5cf-1321324fb9ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/fddd3a76-5074-45f7-869e-37e88231a417> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fddd3a76-5074-45f7-869e-37e88231a417";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/a6f98a48-cf6f-43a8-bb7b-a61cb4c88f38/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fddd3a76-5074-45f7-869e-37e88231a417>.
+    
+<http://data.lblod.info/id/remote-data-objects/c01a38da-5c05-48ec-aefa-0612ee9b68b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c01a38da-5c05-48ec-aefa-0612ee9b68b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/a910d68a-4907-4aec-b7e0-58a58f7384a0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c01a38da-5c05-48ec-aefa-0612ee9b68b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/eec630a7-6bc7-4384-895d-34f4b590342c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eec630a7-6bc7-4384-895d-34f4b590342c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/ab29a71d-c047-4181-bc5c-781e6e2925e2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eec630a7-6bc7-4384-895d-34f4b590342c>.
+    
+<http://data.lblod.info/id/remote-data-objects/066cd307-c021-4858-a0da-dd99f08b3f30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "066cd307-c021-4858-a0da-dd99f08b3f30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/ad767640-9c39-490a-b909-733e05efd145/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/066cd307-c021-4858-a0da-dd99f08b3f30>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef0eab45-36d1-4eee-825e-7876a9110a20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef0eab45-36d1-4eee-825e-7876a9110a20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/b10a2e3f-4487-4991-b7f5-a1bf96873e55/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef0eab45-36d1-4eee-825e-7876a9110a20>.
+    
+<http://data.lblod.info/id/remote-data-objects/704e62b4-a8f3-45a3-b78e-360052d46452> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "704e62b4-a8f3-45a3-b78e-360052d46452";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/b83d07b7-0821-45ca-a996-9e6183a3dd82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/704e62b4-a8f3-45a3-b78e-360052d46452>.
+    
+<http://data.lblod.info/id/remote-data-objects/53635bab-1d12-4b4b-8890-d1e12871f0a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53635bab-1d12-4b4b-8890-d1e12871f0a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/b8c539cd-6bd7-42c0-9c1f-2073cba0f849/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53635bab-1d12-4b4b-8890-d1e12871f0a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/54165bbd-6fd7-47e6-83a1-e61cb3e91ba5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54165bbd-6fd7-47e6-83a1-e61cb3e91ba5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/c0c7862a-aa21-4659-9cee-dac0f3dafd6d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54165bbd-6fd7-47e6-83a1-e61cb3e91ba5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e2491e7-e6a2-49a8-bbb2-0b90ebfeee70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e2491e7-e6a2-49a8-bbb2-0b90ebfeee70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/c5a06375-3811-4b33-ad1b-16409d49bbd1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e2491e7-e6a2-49a8-bbb2-0b90ebfeee70>.
+    
+<http://data.lblod.info/id/remote-data-objects/ebf9c822-f431-48f0-b2fd-c5262373f6c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ebf9c822-f431-48f0-b2fd-c5262373f6c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/c5c2828e-daa8-4246-b38b-089cb2572589/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ebf9c822-f431-48f0-b2fd-c5262373f6c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d164afbf-813c-4485-b332-003da295a99f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d164afbf-813c-4485-b332-003da295a99f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/ca63e795-ba28-47c3-af65-f117704a78bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d164afbf-813c-4485-b332-003da295a99f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d035b52f-ff54-4ee8-baec-4c94fdfbf1fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d035b52f-ff54-4ee8-baec-4c94fdfbf1fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/cbe74b48-4a20-4fc3-9574-d5603a0ef883/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d035b52f-ff54-4ee8-baec-4c94fdfbf1fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/81e465f4-cb31-4b78-b12b-a94b477d361b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81e465f4-cb31-4b78-b12b-a94b477d361b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/d22e7764-908a-497e-8de9-98ba0d843985/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81e465f4-cb31-4b78-b12b-a94b477d361b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3d97150-c16d-4c47-bfe2-71a63440a06c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3d97150-c16d-4c47-bfe2-71a63440a06c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/d24e0322-c8e9-4b42-a3ef-d6e938a411b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3d97150-c16d-4c47-bfe2-71a63440a06c>.
+    
+<http://data.lblod.info/id/remote-data-objects/70e0eada-8554-411e-9fea-3cfdbaf5f32f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70e0eada-8554-411e-9fea-3cfdbaf5f32f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/e43143b8-fb3a-46f2-9908-d66ab5106ca8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70e0eada-8554-411e-9fea-3cfdbaf5f32f>.
+    
+<http://data.lblod.info/id/remote-data-objects/926540e7-8afd-4d2c-af34-672791350642> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "926540e7-8afd-4d2c-af34-672791350642";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/e5224163-62ec-4119-9dd4-e5d53c025024/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/926540e7-8afd-4d2c-af34-672791350642>.
+    
+<http://data.lblod.info/id/remote-data-objects/e497dc23-4038-4396-a800-4d75993c5c02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e497dc23-4038-4396-a800-4d75993c5c02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/e5227db2-adda-4cf7-b358-0b43e2e3c848/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e497dc23-4038-4396-a800-4d75993c5c02>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2649d9f-60f1-4983-8c34-12b475ceef73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2649d9f-60f1-4983-8c34-12b475ceef73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/e52c2694-604b-4cb3-97b7-8e0c3073eb48/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2649d9f-60f1-4983-8c34-12b475ceef73>.
+    
+<http://data.lblod.info/id/remote-data-objects/247c9935-c675-4de0-8b4c-6c3d24f55a7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "247c9935-c675-4de0-8b4c-6c3d24f55a7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/e56d2c32-d462-4e9f-b585-0a979ddac6f6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/247c9935-c675-4de0-8b4c-6c3d24f55a7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/018fca60-3f05-4be5-b16d-a4c5214b42da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "018fca60-3f05-4be5-b16d-a4c5214b42da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/f2047719-bfd7-492d-a2e4-022efaa25b26/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/018fca60-3f05-4be5-b16d-a4c5214b42da>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c4381eb-3cb7-479d-b7ed-0e12c92c848c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c4381eb-3cb7-479d-b7ed-0e12c92c848c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/f5ffbe0b-f91d-43dc-bf7b-55aaec7e7ce6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c4381eb-3cb7-479d-b7ed-0e12c92c848c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c53d2540-7304-4363-950a-78688f3aebd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c53d2540-7304-4363-950a-78688f3aebd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/f8c797e0-1ce1-46dd-a0e2-d90b8293ba2e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c53d2540-7304-4363-950a-78688f3aebd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1094cfc-8fe2-4ffe-a42b-99a34f99d0b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1094cfc-8fe2-4ffe-a42b-99a34f99d0b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://mol.meetingburger.net/vabu/f94ac505-3734-4a42-8b52-abe41bcb6998/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1094cfc-8fe2-4ffe-a42b-99a34f99d0b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/17e4514f-ea97-4327-a3f2-b34aa7ee0464> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17e4514f-ea97-4327-a3f2-b34aa7ee0464";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/0104e143-462d-41ee-bef3-c63532971b22/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17e4514f-ea97-4327-a3f2-b34aa7ee0464>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dc5825b-3d80-496a-a978-a728accf6e1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dc5825b-3d80-496a-a978-a728accf6e1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/038e851d-71e3-42b6-8b17-a9f85762427e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dc5825b-3d80-496a-a978-a728accf6e1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b978942-d435-40b5-8e35-fbb989a6942f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b978942-d435-40b5-8e35-fbb989a6942f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/0494c463-b057-4731-9b34-21d42b98ac20/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b978942-d435-40b5-8e35-fbb989a6942f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2473f0a0-28cb-4071-9186-c1f10f012f59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2473f0a0-28cb-4071-9186-c1f10f012f59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/08012307-408b-460b-a656-2f2f9256a36c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2473f0a0-28cb-4071-9186-c1f10f012f59>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e31cf9f-f525-4b9f-a303-dcfabc1c4ee9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e31cf9f-f525-4b9f-a303-dcfabc1c4ee9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/0a70bcbb-b73b-4afd-8439-79922664cbcc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e31cf9f-f525-4b9f-a303-dcfabc1c4ee9>.
+    
+<http://data.lblod.info/id/remote-data-objects/667e11d2-d075-4497-aedc-dc7edb25176f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "667e11d2-d075-4497-aedc-dc7edb25176f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/0a94ca96-66e1-45eb-9070-b22475d1e823/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/667e11d2-d075-4497-aedc-dc7edb25176f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cdb0c06-5795-463d-ac88-93cb19980447> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cdb0c06-5795-463d-ac88-93cb19980447";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/0b237b2b-2982-489b-9221-e0c01524e761/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cdb0c06-5795-463d-ac88-93cb19980447>.
+    
+<http://data.lblod.info/id/remote-data-objects/8486c784-ee1a-4432-a78c-5d6dd03daa28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8486c784-ee1a-4432-a78c-5d6dd03daa28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/0c67efbc-c701-4198-8779-d0ca2e4429b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8486c784-ee1a-4432-a78c-5d6dd03daa28>.
+    
+<http://data.lblod.info/id/remote-data-objects/61a2dea1-1d49-40cf-aa29-577a9a0dcb70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61a2dea1-1d49-40cf-aa29-577a9a0dcb70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/0cdd691f-8e35-4ece-b4bc-026ea04eaa6f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61a2dea1-1d49-40cf-aa29-577a9a0dcb70>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea6ba042-76e0-4af3-ae11-9ed70baec53a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea6ba042-76e0-4af3-ae11-9ed70baec53a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/0e040ab3-c370-40f9-845e-4e120be79eea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea6ba042-76e0-4af3-ae11-9ed70baec53a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7ee3fd3-4d04-4499-a2e3-f837d07acffa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7ee3fd3-4d04-4499-a2e3-f837d07acffa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/115adf46-aba7-4f44-a2e2-bfcb13f01df2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6a064528-2af2-4574-b9fa-b214da88bbcf> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7ee3fd3-4d04-4499-a2e3-f837d07acffa>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201855-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201855-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201855-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201855-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/faef90bb-db0c-4a34-9443-d19edfcd54cf> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "faef90bb-db0c-4a34-9443-d19edfcd54cf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7cdc730e-c204-4dec-8096-f6c95736d43a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/12d0d7cb-422e-48a5-992b-d45a3a9ff01e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "12d0d7cb-422e-48a5-992b-d45a3a9ff01e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a>.
+
+  <http://redpencil.data.gift/id/task/59fafce9-1c4b-467d-bc68-7d5f53f6c5b9> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "59fafce9-1c4b-467d-bc68-7d5f53f6c5b9";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/faef90bb-db0c-4a34-9443-d19edfcd54cf>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/12d0d7cb-422e-48a5-992b-d45a3a9ff01e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/8533fe04-e615-445b-ada7-c46f4e58d54e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8533fe04-e615-445b-ada7-c46f4e58d54e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/1519f49b-ae48-4ba6-becf-63b7d8a45b24/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8533fe04-e615-445b-ada7-c46f4e58d54e>.
+    
+<http://data.lblod.info/id/remote-data-objects/46303b18-f186-44d9-93b3-3f15ea4231db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46303b18-f186-44d9-93b3-3f15ea4231db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/18514aa5-5dd6-4364-bf92-be9c1a6e8367/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46303b18-f186-44d9-93b3-3f15ea4231db>.
+    
+<http://data.lblod.info/id/remote-data-objects/55e71a37-5a0b-4158-b98c-afbe283ba29c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55e71a37-5a0b-4158-b98c-afbe283ba29c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/193df719-3ac1-4aa8-9b79-07f4fdff4df7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55e71a37-5a0b-4158-b98c-afbe283ba29c>.
+    
+<http://data.lblod.info/id/remote-data-objects/82db0ed0-7538-4f67-97db-f7fb40f2a102> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82db0ed0-7538-4f67-97db-f7fb40f2a102";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/1c0a2f1d-6a42-4d4f-bc49-a53317309387/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82db0ed0-7538-4f67-97db-f7fb40f2a102>.
+    
+<http://data.lblod.info/id/remote-data-objects/29c0cd4a-d946-4bef-85c6-43b9590c57bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29c0cd4a-d946-4bef-85c6-43b9590c57bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/1cb56c46-258c-4d58-821b-55f53ad5fa36/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29c0cd4a-d946-4bef-85c6-43b9590c57bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/703c47ee-ef4e-43fa-85a0-09f365029704> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "703c47ee-ef4e-43fa-85a0-09f365029704";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/1f17750e-7682-418f-894b-0864260fded2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/703c47ee-ef4e-43fa-85a0-09f365029704>.
+    
+<http://data.lblod.info/id/remote-data-objects/21398283-1ca1-45ed-a918-bdd93e5683ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21398283-1ca1-45ed-a918-bdd93e5683ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/21d0c712-683d-41de-8bdb-2ee3fdfb3a8c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21398283-1ca1-45ed-a918-bdd93e5683ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8f1599d-af80-4f0a-9187-dbffbb3bc30e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8f1599d-af80-4f0a-9187-dbffbb3bc30e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/278043ef-60cb-4622-8773-02b3ef4c392c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8f1599d-af80-4f0a-9187-dbffbb3bc30e>.
+    
+<http://data.lblod.info/id/remote-data-objects/53400995-f132-4efe-a7b1-4cf6b2e1293e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53400995-f132-4efe-a7b1-4cf6b2e1293e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/295d0e8a-cf99-4f90-91a3-d618b8fc30ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53400995-f132-4efe-a7b1-4cf6b2e1293e>.
+    
+<http://data.lblod.info/id/remote-data-objects/671cbf96-dcc2-4122-b7b6-52b0ab0a8725> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "671cbf96-dcc2-4122-b7b6-52b0ab0a8725";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/2a0c8c5f-2dea-4039-9fce-393bd78c875c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/671cbf96-dcc2-4122-b7b6-52b0ab0a8725>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7816e5f-6b03-4ebb-94c3-4501323690cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7816e5f-6b03-4ebb-94c3-4501323690cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/2cae459c-5373-4f33-8b2d-0ae5051f2f6c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7816e5f-6b03-4ebb-94c3-4501323690cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/9fe028af-d706-4330-a581-71d06e081e84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fe028af-d706-4330-a581-71d06e081e84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/2d445718-94cd-4c28-ab51-9164447ebc27/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9fe028af-d706-4330-a581-71d06e081e84>.
+    
+<http://data.lblod.info/id/remote-data-objects/0abed917-3eff-4884-82c7-94449f267fa9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0abed917-3eff-4884-82c7-94449f267fa9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/2faa54f9-ea72-4c57-9c2b-98d8730fd9cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0abed917-3eff-4884-82c7-94449f267fa9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba5af10c-698a-4646-a4ca-3bbe156d2a2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba5af10c-698a-4646-a4ca-3bbe156d2a2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/340c2efe-65a9-4f0a-ae7e-e7f205ac256b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba5af10c-698a-4646-a4ca-3bbe156d2a2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/92173f14-3e94-42d6-99ca-1cac081d657e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92173f14-3e94-42d6-99ca-1cac081d657e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/3410873f-ad75-4b6e-b6d8-cc615ca9f0a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92173f14-3e94-42d6-99ca-1cac081d657e>.
+    
+<http://data.lblod.info/id/remote-data-objects/88eb2f23-8d5d-4042-bff0-bb218cf9e40d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88eb2f23-8d5d-4042-bff0-bb218cf9e40d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/387e9bfe-8873-45d3-a327-be11eaef4067/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88eb2f23-8d5d-4042-bff0-bb218cf9e40d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec05fd52-0298-4fe9-b770-1199b79ea62d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec05fd52-0298-4fe9-b770-1199b79ea62d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/3e486896-0fa5-48d5-8303-ace0541c6142/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec05fd52-0298-4fe9-b770-1199b79ea62d>.
+    
+<http://data.lblod.info/id/remote-data-objects/10d7f943-211d-4994-962d-2b6f19fb1d31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10d7f943-211d-4994-962d-2b6f19fb1d31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/43f5b357-d67a-4219-ad32-90d175f8a08a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10d7f943-211d-4994-962d-2b6f19fb1d31>.
+    
+<http://data.lblod.info/id/remote-data-objects/9825b9c5-542f-4527-9fe6-a36d9fd89f8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9825b9c5-542f-4527-9fe6-a36d9fd89f8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/44f87e0b-dbf6-4572-b509-841f81fffda2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9825b9c5-542f-4527-9fe6-a36d9fd89f8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad982ff1-923d-4f9d-b39f-bef779a8b664> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad982ff1-923d-4f9d-b39f-bef779a8b664";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/4aada6e0-4b00-4c30-8b46-79697ef5a11b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad982ff1-923d-4f9d-b39f-bef779a8b664>.
+    
+<http://data.lblod.info/id/remote-data-objects/686e31e4-3e84-4c79-9b0c-36cd5d3d56a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "686e31e4-3e84-4c79-9b0c-36cd5d3d56a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/4fe59889-adb7-4684-9321-b0afd525f6c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/686e31e4-3e84-4c79-9b0c-36cd5d3d56a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4910f78-53eb-4535-ba44-af8ee1314203> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4910f78-53eb-4535-ba44-af8ee1314203";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/5169465c-d6db-4031-821f-1b8572baac49/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4910f78-53eb-4535-ba44-af8ee1314203>.
+    
+<http://data.lblod.info/id/remote-data-objects/d83af56d-60ae-41bc-a952-a7b0943e1679> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d83af56d-60ae-41bc-a952-a7b0943e1679";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/54cab06e-87ea-46a7-a9fc-118f6c2554ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d83af56d-60ae-41bc-a952-a7b0943e1679>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3d7456b-cc37-424d-9189-46a9debb6b5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3d7456b-cc37-424d-9189-46a9debb6b5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/5868104e-825b-4f44-9b2e-290dcf4233c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3d7456b-cc37-424d-9189-46a9debb6b5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/090ab166-f22e-43a1-8ba5-d6f4c61b34c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "090ab166-f22e-43a1-8ba5-d6f4c61b34c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/58b2abe5-bd2d-4cd1-a647-58ef4aa1229b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/090ab166-f22e-43a1-8ba5-d6f4c61b34c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/605ea2b8-b32d-4a7b-a868-ae2cf4d82c96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "605ea2b8-b32d-4a7b-a868-ae2cf4d82c96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/59c6bbfc-1bd7-4b74-89f8-3166b25a6b14/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/605ea2b8-b32d-4a7b-a868-ae2cf4d82c96>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a7d38f0-5517-44e8-b1c1-fd47c0d676c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a7d38f0-5517-44e8-b1c1-fd47c0d676c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/5c92c600-d569-4798-90eb-2a5704524bc7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a7d38f0-5517-44e8-b1c1-fd47c0d676c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f910a82f-0b43-4572-b2a2-96a2a3cc579a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f910a82f-0b43-4572-b2a2-96a2a3cc579a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/5f48ad23-87d6-4ac0-9c53-27d3e702c5c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f910a82f-0b43-4572-b2a2-96a2a3cc579a>.
+    
+<http://data.lblod.info/id/remote-data-objects/0bcc3a8f-6f85-4e86-be1d-39bf4cca6367> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0bcc3a8f-6f85-4e86-be1d-39bf4cca6367";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/611d4e55-29a5-4875-9205-f04a3440f637/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0bcc3a8f-6f85-4e86-be1d-39bf4cca6367>.
+    
+<http://data.lblod.info/id/remote-data-objects/8383b499-271c-4fb8-963a-cb35f3225341> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8383b499-271c-4fb8-963a-cb35f3225341";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/6317f708-c4f0-455a-a67e-4748306da3b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8383b499-271c-4fb8-963a-cb35f3225341>.
+    
+<http://data.lblod.info/id/remote-data-objects/97c9d030-6c98-4664-80a0-62d2cf395012> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97c9d030-6c98-4664-80a0-62d2cf395012";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/6a3c8ed7-4db4-4595-9cdc-0f3f18d87544/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97c9d030-6c98-4664-80a0-62d2cf395012>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e949caf-769d-44cb-b53d-3d126242669d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e949caf-769d-44cb-b53d-3d126242669d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/70f1f976-0f04-4190-b587-24b58b631e86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e949caf-769d-44cb-b53d-3d126242669d>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc942b4c-efb7-445b-b226-a5890fe101fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc942b4c-efb7-445b-b226-a5890fe101fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/791b0632-6412-4165-bcaa-682e10561df0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc942b4c-efb7-445b-b226-a5890fe101fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e681363-220b-4c2a-8237-f1c40f285394> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e681363-220b-4c2a-8237-f1c40f285394";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/7f9d2c5a-0d72-4d3c-8884-f7b6e538ffc5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e681363-220b-4c2a-8237-f1c40f285394>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fabc683-215a-475f-b67f-00fecdd01701> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fabc683-215a-475f-b67f-00fecdd01701";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/89fb9de6-0b3e-4989-b406-3b549e17d57d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fabc683-215a-475f-b67f-00fecdd01701>.
+    
+<http://data.lblod.info/id/remote-data-objects/af1210c9-5866-4bdd-a193-e7d0c6e31fbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af1210c9-5866-4bdd-a193-e7d0c6e31fbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/8b0f24b5-ea4b-4f9d-a550-60d652cd30db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af1210c9-5866-4bdd-a193-e7d0c6e31fbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/de8b1996-eae4-4b9e-9ce7-ea8b1de82795> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de8b1996-eae4-4b9e-9ce7-ea8b1de82795";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/920f861f-22c6-408f-a55c-494a9c39d951/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de8b1996-eae4-4b9e-9ce7-ea8b1de82795>.
+    
+<http://data.lblod.info/id/remote-data-objects/775ac42d-1e2d-4caa-9a19-11e1f643b542> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "775ac42d-1e2d-4caa-9a19-11e1f643b542";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/9ec156ff-cc1a-4389-9299-5e1bc0385fac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/775ac42d-1e2d-4caa-9a19-11e1f643b542>.
+    
+<http://data.lblod.info/id/remote-data-objects/e75c0043-0c64-446c-93c5-f2794618e73e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e75c0043-0c64-446c-93c5-f2794618e73e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/a4524dbd-a494-46b5-885d-01c217dfb260/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e75c0043-0c64-446c-93c5-f2794618e73e>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd7f393d-6a44-47c5-9614-580b5b672dc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd7f393d-6a44-47c5-9614-580b5b672dc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/a49d53c7-141d-4ad8-b12a-783a71f54e84/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd7f393d-6a44-47c5-9614-580b5b672dc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6d9a6b5-7e19-4534-8390-cfd275418c6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6d9a6b5-7e19-4534-8390-cfd275418c6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/a52c9753-66cc-42fd-b4a5-1878294d0673/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6d9a6b5-7e19-4534-8390-cfd275418c6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b807f3a-8df6-415d-a678-03cb525ed4ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b807f3a-8df6-415d-a678-03cb525ed4ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/aae962d6-e933-4528-8f81-92ad4ce8f8fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b807f3a-8df6-415d-a678-03cb525ed4ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/9551f91a-13ba-40cd-84a2-7d4f48c28cec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9551f91a-13ba-40cd-84a2-7d4f48c28cec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/ad67e824-246e-44fb-8789-ef206ac5e6b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9551f91a-13ba-40cd-84a2-7d4f48c28cec>.
+    
+<http://data.lblod.info/id/remote-data-objects/057bfe48-173f-478f-93d3-95200c119fee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "057bfe48-173f-478f-93d3-95200c119fee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/b26f2f62-6f5e-42d8-8995-4c894399d740/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/057bfe48-173f-478f-93d3-95200c119fee>.
+    
+<http://data.lblod.info/id/remote-data-objects/45a8570a-63d7-4515-9210-0b0c84d1a053> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45a8570a-63d7-4515-9210-0b0c84d1a053";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/b5a0a82a-8c3b-4f69-be6b-fbd1c291127d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45a8570a-63d7-4515-9210-0b0c84d1a053>.
+    
+<http://data.lblod.info/id/remote-data-objects/78081228-e5da-45fa-9075-3b5cf5a93612> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78081228-e5da-45fa-9075-3b5cf5a93612";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/b77888df-3b80-458f-8de4-fb4faf1075ba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78081228-e5da-45fa-9075-3b5cf5a93612>.
+    
+<http://data.lblod.info/id/remote-data-objects/183d7c51-b58a-41e4-9cba-45ca1badcbe6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "183d7c51-b58a-41e4-9cba-45ca1badcbe6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/c15194fd-cbf2-4e86-b05b-1fc3d0b0f876/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/183d7c51-b58a-41e4-9cba-45ca1badcbe6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea8533bf-54b0-4f19-a162-a10c2547bbf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea8533bf-54b0-4f19-a162-a10c2547bbf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/cea60c58-5513-427e-8eed-dbdbdbc2c795/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea8533bf-54b0-4f19-a162-a10c2547bbf9>.
+    
+<http://data.lblod.info/id/remote-data-objects/891c623e-ca98-4fa4-9080-aa0418fe1a35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "891c623e-ca98-4fa4-9080-aa0418fe1a35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/d0aa983a-5fd7-41df-bb8f-32ecdc1b1bb1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/891c623e-ca98-4fa4-9080-aa0418fe1a35>.
+    
+<http://data.lblod.info/id/remote-data-objects/455e7259-b3d9-43ac-8270-c5f7d37035bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "455e7259-b3d9-43ac-8270-c5f7d37035bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/d0d7bd41-5779-4b15-88c1-a6f195385af1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:55.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/7cdc730e-c204-4dec-8096-f6c95736d43a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/455e7259-b3d9-43ac-8270-c5f7d37035bd>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201857-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201857-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201857-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201857-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/44b8573c-242e-4019-90d3-77e6a545dd4c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "44b8573c-242e-4019-90d3-77e6a545dd4c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4fd22fd2-67f8-419e-80b6-ee23b0d3a25d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b6bcc1e6-d568-4330-9881-f372ae2ec836> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b6bcc1e6-d568-4330-9881-f372ae2ec836";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d>.
+
+  <http://redpencil.data.gift/id/task/beb3eb69-b6f7-4f82-9eae-2d96d3d375fb> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "beb3eb69-b6f7-4f82-9eae-2d96d3d375fb";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/44b8573c-242e-4019-90d3-77e6a545dd4c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b6bcc1e6-d568-4330-9881-f372ae2ec836>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/55942e3c-bf08-4aca-bba1-b9db89874a03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55942e3c-bf08-4aca-bba1-b9db89874a03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/d0f6c205-917d-45f1-aa4e-8d8d3263b2b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55942e3c-bf08-4aca-bba1-b9db89874a03>.
+    
+<http://data.lblod.info/id/remote-data-objects/420229f2-ba36-49b0-bbfc-f125bc1f9f04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "420229f2-ba36-49b0-bbfc-f125bc1f9f04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/d285a36e-2484-420f-ba14-6fceee742b75/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/420229f2-ba36-49b0-bbfc-f125bc1f9f04>.
+    
+<http://data.lblod.info/id/remote-data-objects/25fb21ef-09a8-487c-bf10-84734b836323> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25fb21ef-09a8-487c-bf10-84734b836323";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/d6b57634-34d3-46fa-8d3c-2600025bdbc3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25fb21ef-09a8-487c-bf10-84734b836323>.
+    
+<http://data.lblod.info/id/remote-data-objects/f141f88e-8c95-436f-ae82-d037f2e48ac4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f141f88e-8c95-436f-ae82-d037f2e48ac4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/d8ff285a-3766-4169-93bf-c6d804ff7a91/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f141f88e-8c95-436f-ae82-d037f2e48ac4>.
+    
+<http://data.lblod.info/id/remote-data-objects/018304e6-9236-47b0-aa36-adc7ad3ca3cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "018304e6-9236-47b0-aa36-adc7ad3ca3cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/d9cef58d-751d-4f26-832e-181bff32b015/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/018304e6-9236-47b0-aa36-adc7ad3ca3cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/baba450c-aef2-478a-a287-810a78c3c475> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "baba450c-aef2-478a-a287-810a78c3c475";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/da645634-8bed-4ab1-adc7-2233d0988cff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/baba450c-aef2-478a-a287-810a78c3c475>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cfa472c-b39f-4151-ab7f-def69885dd1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cfa472c-b39f-4151-ab7f-def69885dd1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/dcfb1705-66dd-417e-8d64-ed3bea4ca113/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cfa472c-b39f-4151-ab7f-def69885dd1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9a5950c-02d2-4153-b649-614697a13412> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9a5950c-02d2-4153-b649-614697a13412";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/dfa870bf-fd94-48bf-a3f6-be6cdf03b8a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9a5950c-02d2-4153-b649-614697a13412>.
+    
+<http://data.lblod.info/id/remote-data-objects/f18e167b-0a91-4393-ba3f-7bd015a3069a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f18e167b-0a91-4393-ba3f-7bd015a3069a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/e994d146-8c11-4006-a87a-6f3c1080da75/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f18e167b-0a91-4393-ba3f-7bd015a3069a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8a7179c-799e-4ba5-8f64-38942d79df05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8a7179c-799e-4ba5-8f64-38942d79df05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/ede5b056-e5d4-4a17-a7f6-c7ef5849dd97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8a7179c-799e-4ba5-8f64-38942d79df05>.
+    
+<http://data.lblod.info/id/remote-data-objects/295f65a0-ba43-4896-9c35-a3ca2ffdd592> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "295f65a0-ba43-4896-9c35-a3ca2ffdd592";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/ef2faa93-aff9-4dd0-9f78-7fe7d8477d5b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/295f65a0-ba43-4896-9c35-a3ca2ffdd592>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb569f61-f80d-4e68-acd4-b276dec92381> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb569f61-f80d-4e68-acd4-b276dec92381";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/bb/f3875573-c176-4f01-a58e-860998cedc29/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb569f61-f80d-4e68-acd4-b276dec92381>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c6cfe2f-80ec-466a-9b1d-7a50ed38ef7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c6cfe2f-80ec-466a-9b1d-7a50ed38ef7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/061b64d3-d4c7-441b-9e19-b959d9792d9d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c6cfe2f-80ec-466a-9b1d-7a50ed38ef7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5d3efbb-8412-47a9-8bd8-4f121254c1f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5d3efbb-8412-47a9-8bd8-4f121254c1f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/0894fe62-14be-4089-b086-4a9ebd7fed7c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5d3efbb-8412-47a9-8bd8-4f121254c1f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/53b6d0f2-3ca3-48e1-87a2-d701180fb2bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53b6d0f2-3ca3-48e1-87a2-d701180fb2bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/113e2451-b1af-4a5b-8676-f7ed91d68a46/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53b6d0f2-3ca3-48e1-87a2-d701180fb2bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/57e6a904-72e3-4328-8634-b6e84693f642> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57e6a904-72e3-4328-8634-b6e84693f642";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/142e23ce-0fd7-4af6-ba1f-96f6f260b8df/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57e6a904-72e3-4328-8634-b6e84693f642>.
+    
+<http://data.lblod.info/id/remote-data-objects/b360b462-df6a-4d78-8f9e-6fe6a459421a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b360b462-df6a-4d78-8f9e-6fe6a459421a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/14348f81-eb66-459f-b89b-59f8c5b3ca4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b360b462-df6a-4d78-8f9e-6fe6a459421a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c795f13-5516-4140-af70-7fc09518fd7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c795f13-5516-4140-af70-7fc09518fd7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/1496f322-f0e8-49aa-9b6b-98bf6c9e8eaa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c795f13-5516-4140-af70-7fc09518fd7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecae75c4-a6f9-4f4d-9a1c-3f3a755de9bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecae75c4-a6f9-4f4d-9a1c-3f3a755de9bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/1b8a472d-7814-44e5-95d8-e26ceffa4f67/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecae75c4-a6f9-4f4d-9a1c-3f3a755de9bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/362c1e90-0247-45d6-bd16-95b9393eb8be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "362c1e90-0247-45d6-bd16-95b9393eb8be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/1ba6e5da-91c9-41cd-8cf7-3afee2889869/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/362c1e90-0247-45d6-bd16-95b9393eb8be>.
+    
+<http://data.lblod.info/id/remote-data-objects/18629a21-de6e-4a28-ac95-bdda3e278dce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18629a21-de6e-4a28-ac95-bdda3e278dce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/207a0479-c2c9-4c86-a041-bd1a396344e2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18629a21-de6e-4a28-ac95-bdda3e278dce>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f95b1d2-dae4-45e4-9f5d-5477e9b27f1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f95b1d2-dae4-45e4-9f5d-5477e9b27f1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/20d1e4ae-131d-48ad-a993-4056e748516d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f95b1d2-dae4-45e4-9f5d-5477e9b27f1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb8f7216-dd01-41a2-8e7e-7d0960bfbb1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb8f7216-dd01-41a2-8e7e-7d0960bfbb1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/21cefc02-426b-43f3-8804-818ffb869c32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb8f7216-dd01-41a2-8e7e-7d0960bfbb1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d90c4c9-2bfb-4568-8ff2-10744bb9390d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d90c4c9-2bfb-4568-8ff2-10744bb9390d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/23adc03d-11f4-42e7-b294-3dff9c7a8d8f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d90c4c9-2bfb-4568-8ff2-10744bb9390d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e54a38cd-84b8-40ec-b479-b810c4608882> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e54a38cd-84b8-40ec-b479-b810c4608882";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/25edcec5-ac90-4278-a1d6-ede405d28c19/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e54a38cd-84b8-40ec-b479-b810c4608882>.
+    
+<http://data.lblod.info/id/remote-data-objects/09ee2855-9311-467c-8fc4-5fb7766d11a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09ee2855-9311-467c-8fc4-5fb7766d11a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/26372099-374d-4c7a-8aec-ed93872e5b6f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09ee2855-9311-467c-8fc4-5fb7766d11a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/da61488d-6901-4637-95cc-1f0c7d8a6426> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da61488d-6901-4637-95cc-1f0c7d8a6426";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/2859c5f5-bf34-4d1b-b747-16a4962ba435/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da61488d-6901-4637-95cc-1f0c7d8a6426>.
+    
+<http://data.lblod.info/id/remote-data-objects/e48f9798-5789-4e31-ae89-d4ed337423b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e48f9798-5789-4e31-ae89-d4ed337423b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/30e0050b-dacc-4be6-9114-3cf8029bc611/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e48f9798-5789-4e31-ae89-d4ed337423b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/63b553f3-95e1-4886-b195-247be6a445d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63b553f3-95e1-4886-b195-247be6a445d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/334fef72-f021-4a3b-89f3-b0918b23a44b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63b553f3-95e1-4886-b195-247be6a445d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3ffaf5a-2d8d-4407-ac1a-557837d91a35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3ffaf5a-2d8d-4407-ac1a-557837d91a35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/3af037cb-a6c7-4137-ab0f-c1cdd59ff0fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3ffaf5a-2d8d-4407-ac1a-557837d91a35>.
+    
+<http://data.lblod.info/id/remote-data-objects/79d69a11-16d9-4f6b-8c7f-923c408c0b29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79d69a11-16d9-4f6b-8c7f-923c408c0b29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/3cd0c140-71e4-4c6f-b07a-f143c4dbc23d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79d69a11-16d9-4f6b-8c7f-923c408c0b29>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a51046a-7ee8-4a2c-bedf-4796b97d75df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a51046a-7ee8-4a2c-bedf-4796b97d75df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/3fb5beb3-0b58-4e3d-a56c-15aab3104361/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a51046a-7ee8-4a2c-bedf-4796b97d75df>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b424c5d-fbe2-42be-8514-2b7ec600aeb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b424c5d-fbe2-42be-8514-2b7ec600aeb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/471d58f3-fa57-4879-8456-41dd4b9f9082/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b424c5d-fbe2-42be-8514-2b7ec600aeb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9cfc43b-4317-44c6-88a4-f0687b1ed045> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9cfc43b-4317-44c6-88a4-f0687b1ed045";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/49fa0f3e-cdea-453d-b177-09db363c6d54/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9cfc43b-4317-44c6-88a4-f0687b1ed045>.
+    
+<http://data.lblod.info/id/remote-data-objects/3699635d-cf31-4605-a966-cc791b0c5574> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3699635d-cf31-4605-a966-cc791b0c5574";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/4bc00f61-60e8-4be1-872d-bfc09524abcd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3699635d-cf31-4605-a966-cc791b0c5574>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ea9fcfb-8599-4e04-b50f-dbf88e899cc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ea9fcfb-8599-4e04-b50f-dbf88e899cc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/4e3a1eb9-f2a3-4d1b-b66a-7aa69831dccb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ea9fcfb-8599-4e04-b50f-dbf88e899cc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5b9ce12-cc60-4a16-8d70-dbfb4565090c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5b9ce12-cc60-4a16-8d70-dbfb4565090c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/50ddf523-23b2-4e67-9f57-5a95168557e2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5b9ce12-cc60-4a16-8d70-dbfb4565090c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3015b6c-d654-4173-bafd-3e83f98e5944> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3015b6c-d654-4173-bafd-3e83f98e5944";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/51cb889d-e451-40e5-b96d-f429dd1b2ab7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3015b6c-d654-4173-bafd-3e83f98e5944>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dbe1999-dedd-4029-8ad9-926a0780e006> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dbe1999-dedd-4029-8ad9-926a0780e006";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/52d8b84c-6198-4d4a-a861-67b5c0d39ace/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dbe1999-dedd-4029-8ad9-926a0780e006>.
+    
+<http://data.lblod.info/id/remote-data-objects/f845c333-a2ab-41f2-a389-9780b5c86246> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f845c333-a2ab-41f2-a389-9780b5c86246";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/56c2ef7f-b894-4ce3-a1d2-59a9c2123c64/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f845c333-a2ab-41f2-a389-9780b5c86246>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5a157ba-3abc-4aab-9d90-729c6d8edbac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5a157ba-3abc-4aab-9d90-729c6d8edbac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/62a99e37-9e58-4e96-83d7-5a3b2449b455/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5a157ba-3abc-4aab-9d90-729c6d8edbac>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6572053-96f4-4cd6-b79b-7465d6cf419c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6572053-96f4-4cd6-b79b-7465d6cf419c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/68aee641-933f-43cb-b430-147cc887e6ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6572053-96f4-4cd6-b79b-7465d6cf419c>.
+    
+<http://data.lblod.info/id/remote-data-objects/842cd73a-9425-45b1-a39f-62e6dbe34627> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "842cd73a-9425-45b1-a39f-62e6dbe34627";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/6a0a82aa-967a-4866-989b-3433e660d45c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/842cd73a-9425-45b1-a39f-62e6dbe34627>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd6fc30d-c429-4f7e-8f5f-0b62048e6024> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd6fc30d-c429-4f7e-8f5f-0b62048e6024";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/6ae9309e-0143-4d22-989b-c91da1a6ce12/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd6fc30d-c429-4f7e-8f5f-0b62048e6024>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf4e8dad-ddd9-4109-97a7-db1bbd4efa26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf4e8dad-ddd9-4109-97a7-db1bbd4efa26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/6d711439-7c8a-4d0e-a9d3-12dbded49805/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf4e8dad-ddd9-4109-97a7-db1bbd4efa26>.
+    
+<http://data.lblod.info/id/remote-data-objects/96f043f2-5d3b-422a-a3a9-0071912cf1b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96f043f2-5d3b-422a-a3a9-0071912cf1b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/6e164a81-227b-4833-9b72-ec9234fa41a0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96f043f2-5d3b-422a-a3a9-0071912cf1b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/51433f09-b8fa-4183-9928-e4696b8ba9fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51433f09-b8fa-4183-9928-e4696b8ba9fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/7f8904e8-40da-4064-818c-fe522d03f85d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51433f09-b8fa-4183-9928-e4696b8ba9fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e8445ef-f73e-4e0b-961c-aa5caf472e73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e8445ef-f73e-4e0b-961c-aa5caf472e73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/80da8b47-4c1f-4767-b61d-c7daca94e7ad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e8445ef-f73e-4e0b-961c-aa5caf472e73>.
+    
+<http://data.lblod.info/id/remote-data-objects/525e7c3a-70f3-4cd2-ba9e-1bab724af58f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "525e7c3a-70f3-4cd2-ba9e-1bab724af58f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/8903e397-976e-4131-a72d-f4c560283cdc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/525e7c3a-70f3-4cd2-ba9e-1bab724af58f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cce8bc4-9dbe-486d-a8ee-2fbe3d00835f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cce8bc4-9dbe-486d-a8ee-2fbe3d00835f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/8c1a66de-2845-4234-a97f-e77e475b6197/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4fd22fd2-67f8-419e-80b6-ee23b0d3a25d> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cce8bc4-9dbe-486d-a8ee-2fbe3d00835f>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201858-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201858-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201858-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201858-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/30b807f0-6c01-48b7-968b-69f6410ff300> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "30b807f0-6c01-48b7-968b-69f6410ff300";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ab808d6e-c74f-4054-a3f1-9e34b1998576";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ebebbe36-82e3-4e72-850e-e68dea4e28c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ebebbe36-82e3-4e72-850e-e68dea4e28c2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576>.
+
+  <http://redpencil.data.gift/id/task/320187ac-3e13-470a-bc27-7190a885319c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "320187ac-3e13-470a-bc27-7190a885319c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/30b807f0-6c01-48b7-968b-69f6410ff300>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ebebbe36-82e3-4e72-850e-e68dea4e28c2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/458570e5-d774-4469-a488-b829c11fb5df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "458570e5-d774-4469-a488-b829c11fb5df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/8e59fa8b-262c-4c6f-aad5-d0b20316516e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/458570e5-d774-4469-a488-b829c11fb5df>.
+    
+<http://data.lblod.info/id/remote-data-objects/e071fb8e-344f-4d1d-8c8d-a443f7424d88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e071fb8e-344f-4d1d-8c8d-a443f7424d88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/96ecc785-5714-4153-8486-a27136b2f884/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e071fb8e-344f-4d1d-8c8d-a443f7424d88>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3d40aaf-a28a-40db-b068-9db3c7a9af9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3d40aaf-a28a-40db-b068-9db3c7a9af9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/9874483b-7ade-4e57-a0ab-76dd2bd0ab90/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3d40aaf-a28a-40db-b068-9db3c7a9af9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/43b24637-72cb-4e1f-9507-f1014c0fb220> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43b24637-72cb-4e1f-9507-f1014c0fb220";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/9f965fea-4bbc-4a6c-a600-370b72507f6c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43b24637-72cb-4e1f-9507-f1014c0fb220>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6f5eae6-dcf5-4892-bd96-1302d886d286> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6f5eae6-dcf5-4892-bd96-1302d886d286";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/aa0f011a-a0ba-458c-9392-cb7b4bbafbd6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6f5eae6-dcf5-4892-bd96-1302d886d286>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b85d211-4ec1-46e9-9c60-a535fa8294ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b85d211-4ec1-46e9-9c60-a535fa8294ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/abd27493-c6e3-4013-8d17-41c1846f232a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b85d211-4ec1-46e9-9c60-a535fa8294ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/c939ed37-bb4b-45e9-8bb4-389ee4af9801> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c939ed37-bb4b-45e9-8bb4-389ee4af9801";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/b45bff20-965b-4c39-ae31-91cd4128e2e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c939ed37-bb4b-45e9-8bb4-389ee4af9801>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3a4c897-1159-4898-92ab-bc54f985dda8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3a4c897-1159-4898-92ab-bc54f985dda8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/b85a2499-7a40-4d49-a001-a04c53eda129/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3a4c897-1159-4898-92ab-bc54f985dda8>.
+    
+<http://data.lblod.info/id/remote-data-objects/6efbbf81-24d4-4bb1-a7cc-1170be20ede2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6efbbf81-24d4-4bb1-a7cc-1170be20ede2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/b8f64527-33ad-499b-84e7-360ca056b5d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6efbbf81-24d4-4bb1-a7cc-1170be20ede2>.
+    
+<http://data.lblod.info/id/remote-data-objects/90a100bc-794b-4bc0-a2ba-8c754055cc55> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90a100bc-794b-4bc0-a2ba-8c754055cc55";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/b98d113d-3e40-47be-9d13-1512d0016b9b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90a100bc-794b-4bc0-a2ba-8c754055cc55>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcc719b9-1f19-4eac-9854-04246d438a4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcc719b9-1f19-4eac-9854-04246d438a4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/bc614a33-04be-405c-b0bb-1fd12ad7ada9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcc719b9-1f19-4eac-9854-04246d438a4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/40a46464-4cb5-433b-aa69-9a0c05c86adc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40a46464-4cb5-433b-aa69-9a0c05c86adc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/c94ba03c-b71a-4b22-9007-039579003b80/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40a46464-4cb5-433b-aa69-9a0c05c86adc>.
+    
+<http://data.lblod.info/id/remote-data-objects/41a89131-9766-4d83-aa81-115f446cfa0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41a89131-9766-4d83-aa81-115f446cfa0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/cbafa7b8-c8a6-4b3f-a06c-7e3c6072060a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41a89131-9766-4d83-aa81-115f446cfa0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d79d112-bc1f-4a61-a397-fe4d69d72e37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d79d112-bc1f-4a61-a397-fe4d69d72e37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/d017d8f1-dcbf-4550-8895-0538524db90c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d79d112-bc1f-4a61-a397-fe4d69d72e37>.
+    
+<http://data.lblod.info/id/remote-data-objects/749579b2-f8d4-44c5-8482-13b64f82d4c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "749579b2-f8d4-44c5-8482-13b64f82d4c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/d29c995c-11ee-4479-b662-10553623b666/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/749579b2-f8d4-44c5-8482-13b64f82d4c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd4ecd97-decd-4270-886a-cbefc2cc7dcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd4ecd97-decd-4270-886a-cbefc2cc7dcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/d3a12d07-225e-4055-ac76-c24661187e20/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd4ecd97-decd-4270-886a-cbefc2cc7dcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/4efd4944-0b41-4354-9862-600d3dcfd1e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4efd4944-0b41-4354-9862-600d3dcfd1e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/d4e3910e-3d86-4829-adab-7c9f2f959265/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4efd4944-0b41-4354-9862-600d3dcfd1e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f8a07a6-7adc-48db-9e96-a592391f1666> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f8a07a6-7adc-48db-9e96-a592391f1666";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/d5969ba6-55c2-470c-8751-fba6a2b9c20d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f8a07a6-7adc-48db-9e96-a592391f1666>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c4887e0-3a8a-4ea9-9cf5-843ee7869010> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c4887e0-3a8a-4ea9-9cf5-843ee7869010";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/d6ae86ac-1a3f-4719-952f-26ef3f923a8b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c4887e0-3a8a-4ea9-9cf5-843ee7869010>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ac55d05-80fe-4e2d-a149-c9fa43fe38df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ac55d05-80fe-4e2d-a149-c9fa43fe38df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/d7521362-0399-4a8b-b4f9-5a02837bb69b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ac55d05-80fe-4e2d-a149-c9fa43fe38df>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae761953-5249-4a57-adf9-6c91375c1498> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae761953-5249-4a57-adf9-6c91375c1498";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/d855b27a-66ce-46f5-be3e-58398cc394cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae761953-5249-4a57-adf9-6c91375c1498>.
+    
+<http://data.lblod.info/id/remote-data-objects/633bab9c-6684-4263-b048-ec8643836dc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "633bab9c-6684-4263-b048-ec8643836dc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/d86c7ce9-56d5-431b-ba4a-dbcfdc0ff075/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/633bab9c-6684-4263-b048-ec8643836dc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/68aabee5-92ac-41df-940b-7c72213fbcc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68aabee5-92ac-41df-940b-7c72213fbcc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/dcf60165-5d3d-468c-abdd-8b43bd0070ad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68aabee5-92ac-41df-940b-7c72213fbcc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/403c9132-6468-4346-916c-02dc0de5d822> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "403c9132-6468-4346-916c-02dc0de5d822";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/dd50d0b1-a084-449c-aa67-2f1b9583fb17/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/403c9132-6468-4346-916c-02dc0de5d822>.
+    
+<http://data.lblod.info/id/remote-data-objects/df6128e9-452e-400b-a4a7-be7521fb993d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df6128e9-452e-400b-a4a7-be7521fb993d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/de56dc31-6284-4282-83c1-16ef8f1c76ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df6128e9-452e-400b-a4a7-be7521fb993d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b7ee1f7-c8ce-4037-b30e-b65dff405147> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b7ee1f7-c8ce-4037-b30e-b65dff405147";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/e8a93b24-8d37-4c1a-9545-ad856b0082b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b7ee1f7-c8ce-4037-b30e-b65dff405147>.
+    
+<http://data.lblod.info/id/remote-data-objects/311062d3-2f04-46fc-b82c-05af80a5169e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "311062d3-2f04-46fc-b82c-05af80a5169e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/e92d8254-edc7-4ff2-a30b-b9695425ff3d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/311062d3-2f04-46fc-b82c-05af80a5169e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4b7cfbb-9c38-4a38-aea5-33e3e539c21e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4b7cfbb-9c38-4a38-aea5-33e3e539c21e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/ea5c102c-8d1f-4be4-8463-34898b86a85d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4b7cfbb-9c38-4a38-aea5-33e3e539c21e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f6d9b54-2cdb-4fc0-a15f-25ce1b8cd198> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f6d9b54-2cdb-4fc0-a15f-25ce1b8cd198";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/ee2d1c5c-20f7-4afa-8fa9-e53df6e86f9c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f6d9b54-2cdb-4fc0-a15f-25ce1b8cd198>.
+    
+<http://data.lblod.info/id/remote-data-objects/e680e0e6-9fce-4e38-b7fc-703a33492a18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e680e0e6-9fce-4e38-b7fc-703a33492a18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/ef99fcf8-a652-474b-b4ab-bb9d3a6a376f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e680e0e6-9fce-4e38-b7fc-703a33492a18>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8fd6442-a42e-448e-b7fd-8ef154bc0ce2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8fd6442-a42e-448e-b7fd-8ef154bc0ce2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/efb055d6-0225-41c7-9ed0-1700dd7d2417/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8fd6442-a42e-448e-b7fd-8ef154bc0ce2>.
+    
+<http://data.lblod.info/id/remote-data-objects/462beb24-baed-4851-a2c3-59e7cae81376> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "462beb24-baed-4851-a2c3-59e7cae81376";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/f6b730d0-91a4-42d1-886c-14f5c19c638b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/462beb24-baed-4851-a2c3-59e7cae81376>.
+    
+<http://data.lblod.info/id/remote-data-objects/12c7e4b6-f6fc-4662-bd60-a2e1956a7671> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12c7e4b6-f6fc-4662-bd60-a2e1956a7671";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/fa881611-af02-4afa-a28a-c1dc19c9fa95/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12c7e4b6-f6fc-4662-bd60-a2e1956a7671>.
+    
+<http://data.lblod.info/id/remote-data-objects/797e729a-e8d3-4859-8d6e-c2a69ccd4edf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "797e729a-e8d3-4859-8d6e-c2a69ccd4edf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/cbs/fd2a85ec-bbc0-4735-a4fb-d2a98cfdab3f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/797e729a-e8d3-4859-8d6e-c2a69ccd4edf>.
+    
+<http://data.lblod.info/id/remote-data-objects/e51061db-d26a-4b7e-b82b-da068e594023> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e51061db-d26a-4b7e-b82b-da068e594023";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/0ad24eae-6b9f-4858-8bd6-0e5205171fec/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e51061db-d26a-4b7e-b82b-da068e594023>.
+    
+<http://data.lblod.info/id/remote-data-objects/c77cff62-b130-4f9c-aaf6-00bdfde859e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c77cff62-b130-4f9c-aaf6-00bdfde859e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/0ad24eae-6b9f-4858-8bd6-0e5205171fec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c77cff62-b130-4f9c-aaf6-00bdfde859e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e11ec4b-8dc6-461a-9e24-dd78268456da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e11ec4b-8dc6-461a-9e24-dd78268456da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/0ad24eae-6b9f-4858-8bd6-0e5205171fec/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e11ec4b-8dc6-461a-9e24-dd78268456da>.
+    
+<http://data.lblod.info/id/remote-data-objects/b546043c-076a-4acc-9ff2-e4c9ea718213> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b546043c-076a-4acc-9ff2-e4c9ea718213";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/25a42dcc-490a-4f02-baca-3cce4dac8324/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b546043c-076a-4acc-9ff2-e4c9ea718213>.
+    
+<http://data.lblod.info/id/remote-data-objects/5218309b-f0f4-4429-9ac0-ca20707c9454> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5218309b-f0f4-4429-9ac0-ca20707c9454";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/25a42dcc-490a-4f02-baca-3cce4dac8324/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5218309b-f0f4-4429-9ac0-ca20707c9454>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c7bcaef-a306-4b6a-b10f-0c9b15eed728> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c7bcaef-a306-4b6a-b10f-0c9b15eed728";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/25a42dcc-490a-4f02-baca-3cce4dac8324/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c7bcaef-a306-4b6a-b10f-0c9b15eed728>.
+    
+<http://data.lblod.info/id/remote-data-objects/d746691b-d992-4c14-894c-ea1db5daf0c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d746691b-d992-4c14-894c-ea1db5daf0c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/3e384b6b-ad55-40d5-b4d4-681edc6a335e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d746691b-d992-4c14-894c-ea1db5daf0c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7197db0d-1174-4c4b-96f6-42f02aa898ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7197db0d-1174-4c4b-96f6-42f02aa898ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/3e384b6b-ad55-40d5-b4d4-681edc6a335e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7197db0d-1174-4c4b-96f6-42f02aa898ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9663275-71e9-42c1-86e0-d17ebf7e6f32> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9663275-71e9-42c1-86e0-d17ebf7e6f32";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/3e384b6b-ad55-40d5-b4d4-681edc6a335e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9663275-71e9-42c1-86e0-d17ebf7e6f32>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fa52dc1-5d4d-4824-b72b-94893bc2cbb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fa52dc1-5d4d-4824-b72b-94893bc2cbb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/40a0f736-9472-4f32-bb06-5ca4cb727710/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fa52dc1-5d4d-4824-b72b-94893bc2cbb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8f3d6bd-7dfb-4f4c-81fb-081fd07a53cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8f3d6bd-7dfb-4f4c-81fb-081fd07a53cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/40a0f736-9472-4f32-bb06-5ca4cb727710/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8f3d6bd-7dfb-4f4c-81fb-081fd07a53cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4934291-a2d9-4e02-8854-164d6f67bda3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4934291-a2d9-4e02-8854-164d6f67bda3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/40a0f736-9472-4f32-bb06-5ca4cb727710/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4934291-a2d9-4e02-8854-164d6f67bda3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f28ccba-be79-4034-91f5-a7f879f9d57c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f28ccba-be79-4034-91f5-a7f879f9d57c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/4773d50a-5282-4586-baf0-b266d5b4a308/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f28ccba-be79-4034-91f5-a7f879f9d57c>.
+    
+<http://data.lblod.info/id/remote-data-objects/31726a14-8dc9-439e-85f0-a2a506c78bf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31726a14-8dc9-439e-85f0-a2a506c78bf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/4773d50a-5282-4586-baf0-b266d5b4a308/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31726a14-8dc9-439e-85f0-a2a506c78bf9>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc81f771-9950-452a-ba76-bc4d5261097f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc81f771-9950-452a-ba76-bc4d5261097f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/4773d50a-5282-4586-baf0-b266d5b4a308/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc81f771-9950-452a-ba76-bc4d5261097f>.
+    
+<http://data.lblod.info/id/remote-data-objects/09613157-5373-48f8-a7aa-4e3d271f5c09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09613157-5373-48f8-a7aa-4e3d271f5c09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/65ae5bfd-616a-45a5-9092-2f2cdab3ce1d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ab808d6e-c74f-4054-a3f1-9e34b1998576> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09613157-5373-48f8-a7aa-4e3d271f5c09>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201859-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201859-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201859-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201859-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/cadf1682-e5aa-4a35-9819-5109db7c0156> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cadf1682-e5aa-4a35-9819-5109db7c0156";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "750d30ea-953e-44ac-bf1f-b3f19768b3ba";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b3edcda7-5cf6-4be4-be43-d87d303c11c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b3edcda7-5cf6-4be4-be43-d87d303c11c0";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba>.
+
+  <http://redpencil.data.gift/id/task/28c92003-384e-4f02-9a0d-d499dae678ff> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "28c92003-384e-4f02-9a0d-d499dae678ff";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/cadf1682-e5aa-4a35-9819-5109db7c0156>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b3edcda7-5cf6-4be4-be43-d87d303c11c0>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4eeed081-7125-4317-bb8d-3d07a8468d21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4eeed081-7125-4317-bb8d-3d07a8468d21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/65ae5bfd-616a-45a5-9092-2f2cdab3ce1d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4eeed081-7125-4317-bb8d-3d07a8468d21>.
+    
+<http://data.lblod.info/id/remote-data-objects/feff6d29-57be-481b-b4b9-172f68e6b06d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "feff6d29-57be-481b-b4b9-172f68e6b06d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/65ae5bfd-616a-45a5-9092-2f2cdab3ce1d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/feff6d29-57be-481b-b4b9-172f68e6b06d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f983f934-f919-4418-a99c-2013e6194f78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f983f934-f919-4418-a99c-2013e6194f78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/7a514f59-8f6f-40a2-9714-725dc1ed1125/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f983f934-f919-4418-a99c-2013e6194f78>.
+    
+<http://data.lblod.info/id/remote-data-objects/7847a8c7-1822-48e0-a5e7-77a7cc420aa1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7847a8c7-1822-48e0-a5e7-77a7cc420aa1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/7a514f59-8f6f-40a2-9714-725dc1ed1125/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7847a8c7-1822-48e0-a5e7-77a7cc420aa1>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ffc3e2d-7b1e-4a58-9428-9b842d75c9af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ffc3e2d-7b1e-4a58-9428-9b842d75c9af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/88b84ea6-7f2f-4a0c-813e-96fc97820396/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ffc3e2d-7b1e-4a58-9428-9b842d75c9af>.
+    
+<http://data.lblod.info/id/remote-data-objects/141b9ee4-9b3d-4d83-aaa1-06d79f4a66ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "141b9ee4-9b3d-4d83-aaa1-06d79f4a66ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/88b84ea6-7f2f-4a0c-813e-96fc97820396/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/141b9ee4-9b3d-4d83-aaa1-06d79f4a66ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/07791c9d-50e5-4f64-b992-eefcb4dfeffd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07791c9d-50e5-4f64-b992-eefcb4dfeffd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/88b84ea6-7f2f-4a0c-813e-96fc97820396/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07791c9d-50e5-4f64-b992-eefcb4dfeffd>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b0f138b-8373-4aa3-ad99-4e97d3c373b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b0f138b-8373-4aa3-ad99-4e97d3c373b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/8f753948-5fe0-4d4d-a8ff-ae2bb9a02573/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b0f138b-8373-4aa3-ad99-4e97d3c373b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/046aa3da-7688-4eba-bb4b-c6cc7488177f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "046aa3da-7688-4eba-bb4b-c6cc7488177f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/8f753948-5fe0-4d4d-a8ff-ae2bb9a02573/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/046aa3da-7688-4eba-bb4b-c6cc7488177f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d40b6c4-7c55-4602-b60c-c7c332b9ca11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d40b6c4-7c55-4602-b60c-c7c332b9ca11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/8f753948-5fe0-4d4d-a8ff-ae2bb9a02573/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d40b6c4-7c55-4602-b60c-c7c332b9ca11>.
+    
+<http://data.lblod.info/id/remote-data-objects/60c973e9-2480-42f9-81ac-df5e545cff8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60c973e9-2480-42f9-81ac-df5e545cff8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/a9bf803d-7a03-4860-8117-4cbaaf532b9b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60c973e9-2480-42f9-81ac-df5e545cff8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/604fae52-d730-4f78-bcdd-09ff2db40274> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "604fae52-d730-4f78-bcdd-09ff2db40274";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/a9bf803d-7a03-4860-8117-4cbaaf532b9b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/604fae52-d730-4f78-bcdd-09ff2db40274>.
+    
+<http://data.lblod.info/id/remote-data-objects/52b5924d-15ee-418a-9936-2abb02b520ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52b5924d-15ee-418a-9936-2abb02b520ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/a9bf803d-7a03-4860-8117-4cbaaf532b9b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52b5924d-15ee-418a-9936-2abb02b520ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f08b807-394f-4729-b0e7-1b3c766ef1b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f08b807-394f-4729-b0e7-1b3c766ef1b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/afb9799f-e864-4076-b935-4b2471a7f1cc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f08b807-394f-4729-b0e7-1b3c766ef1b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/1abaf08e-b3f3-420a-9b7a-039edf685ec1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1abaf08e-b3f3-420a-9b7a-039edf685ec1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/afb9799f-e864-4076-b935-4b2471a7f1cc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1abaf08e-b3f3-420a-9b7a-039edf685ec1>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf71a50a-c125-4a33-9e5b-a317b4b7d13f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf71a50a-c125-4a33-9e5b-a317b4b7d13f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/afb9799f-e864-4076-b935-4b2471a7f1cc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf71a50a-c125-4a33-9e5b-a317b4b7d13f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2d2c515-06e3-40c4-9e12-c9700b8d7194> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2d2c515-06e3-40c4-9e12-c9700b8d7194";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/be1e6563-c284-4965-a930-7cc54028262f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2d2c515-06e3-40c4-9e12-c9700b8d7194>.
+    
+<http://data.lblod.info/id/remote-data-objects/b30ab646-4ed1-42c1-89df-7c441d0c1cda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b30ab646-4ed1-42c1-89df-7c441d0c1cda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/be1e6563-c284-4965-a930-7cc54028262f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b30ab646-4ed1-42c1-89df-7c441d0c1cda>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e3a716c-1567-464a-ac79-85596bfd5e1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e3a716c-1567-464a-ac79-85596bfd5e1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/be1e6563-c284-4965-a930-7cc54028262f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e3a716c-1567-464a-ac79-85596bfd5e1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bfecec8-1169-4924-a87b-53823af61009> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bfecec8-1169-4924-a87b-53823af61009";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/c2b6acb3-fd36-4327-9df9-f7ac1939c611/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bfecec8-1169-4924-a87b-53823af61009>.
+    
+<http://data.lblod.info/id/remote-data-objects/6075fb1e-6c3e-4061-8675-5ce00d71cb58> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6075fb1e-6c3e-4061-8675-5ce00d71cb58";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/c2b6acb3-fd36-4327-9df9-f7ac1939c611/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6075fb1e-6c3e-4061-8675-5ce00d71cb58>.
+    
+<http://data.lblod.info/id/remote-data-objects/6adb7157-4213-438d-9eac-a2724237f9c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6adb7157-4213-438d-9eac-a2724237f9c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/c2b6acb3-fd36-4327-9df9-f7ac1939c611/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6adb7157-4213-438d-9eac-a2724237f9c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/330482f5-5ee8-470e-9e69-4ca92d439cee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "330482f5-5ee8-470e-9e69-4ca92d439cee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/e4ce9e00-a0e6-4147-bc4a-2c83aa7a4324/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/330482f5-5ee8-470e-9e69-4ca92d439cee>.
+    
+<http://data.lblod.info/id/remote-data-objects/03392c82-153c-459b-a71e-483ff3ea3849> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03392c82-153c-459b-a71e-483ff3ea3849";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/e4ce9e00-a0e6-4147-bc4a-2c83aa7a4324/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03392c82-153c-459b-a71e-483ff3ea3849>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b7aec93-2af9-4ae4-ba78-e16b077d8298> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b7aec93-2af9-4ae4-ba78-e16b077d8298";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/e4ce9e00-a0e6-4147-bc4a-2c83aa7a4324/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b7aec93-2af9-4ae4-ba78-e16b077d8298>.
+    
+<http://data.lblod.info/id/remote-data-objects/58171606-1e00-49e6-b79b-166c7860a2a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58171606-1e00-49e6-b79b-166c7860a2a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/ec35b500-ed36-45cb-8b41-b70b03e2ace2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58171606-1e00-49e6-b79b-166c7860a2a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/da937e9e-7d40-4f9a-aef2-5acdfb081e06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da937e9e-7d40-4f9a-aef2-5acdfb081e06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/ec35b500-ed36-45cb-8b41-b70b03e2ace2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da937e9e-7d40-4f9a-aef2-5acdfb081e06>.
+    
+<http://data.lblod.info/id/remote-data-objects/5731b7e4-e1a9-4a7e-9eab-871f37065ef0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5731b7e4-e1a9-4a7e-9eab-871f37065ef0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/ec35b500-ed36-45cb-8b41-b70b03e2ace2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5731b7e4-e1a9-4a7e-9eab-871f37065ef0>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe9fbaed-53bc-4683-9ee2-29e63fa34a5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe9fbaed-53bc-4683-9ee2-29e63fa34a5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/f1dabf0b-9347-485e-a01e-0361edcdadaa/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe9fbaed-53bc-4683-9ee2-29e63fa34a5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/02ab8052-6601-4a05-baa4-a66bbdb71ed0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02ab8052-6601-4a05-baa4-a66bbdb71ed0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/f1dabf0b-9347-485e-a01e-0361edcdadaa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02ab8052-6601-4a05-baa4-a66bbdb71ed0>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d81a249-0d68-4e29-bd95-2beba416fc29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d81a249-0d68-4e29-bd95-2beba416fc29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/f1dabf0b-9347-485e-a01e-0361edcdadaa/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d81a249-0d68-4e29-bd95-2beba416fc29>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5c0086e-0acb-4481-844a-d59190e1602a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5c0086e-0acb-4481-844a-d59190e1602a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/f4901fba-d044-4749-abc0-1a53d66a0de0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5c0086e-0acb-4481-844a-d59190e1602a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f77304d6-9985-49ab-befd-b45bfb3c42f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f77304d6-9985-49ab-befd-b45bfb3c42f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/f4901fba-d044-4749-abc0-1a53d66a0de0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f77304d6-9985-49ab-befd-b45bfb3c42f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6f995fd-a138-4fcb-b50b-7adb8bdc050f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6f995fd-a138-4fcb-b50b-7adb8bdc050f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/gr/f4901fba-d044-4749-abc0-1a53d66a0de0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6f995fd-a138-4fcb-b50b-7adb8bdc050f>.
+    
+<http://data.lblod.info/id/remote-data-objects/27bb7df7-b032-4c0d-b98f-f71e62503438> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27bb7df7-b032-4c0d-b98f-f71e62503438";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/0c3f604b-85e5-4036-9b65-ad554279efab/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27bb7df7-b032-4c0d-b98f-f71e62503438>.
+    
+<http://data.lblod.info/id/remote-data-objects/95341607-7ed7-41a6-b850-7142641428ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95341607-7ed7-41a6-b850-7142641428ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/0c3f604b-85e5-4036-9b65-ad554279efab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95341607-7ed7-41a6-b850-7142641428ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/8be665e5-e8be-4812-b506-c74ca5ad0306> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8be665e5-e8be-4812-b506-c74ca5ad0306";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/0c3f604b-85e5-4036-9b65-ad554279efab/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8be665e5-e8be-4812-b506-c74ca5ad0306>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c199999-5277-4feb-9fa7-1d3efb5e95d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c199999-5277-4feb-9fa7-1d3efb5e95d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/1134b9c2-ed10-4280-afbe-44cf46aaae72/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c199999-5277-4feb-9fa7-1d3efb5e95d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/09e580c8-8743-44aa-bc02-0c290a0e4b69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09e580c8-8743-44aa-bc02-0c290a0e4b69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/1134b9c2-ed10-4280-afbe-44cf46aaae72/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09e580c8-8743-44aa-bc02-0c290a0e4b69>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d1aa4cf-2e41-47ed-8600-74afdafa8faa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d1aa4cf-2e41-47ed-8600-74afdafa8faa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/1134b9c2-ed10-4280-afbe-44cf46aaae72/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d1aa4cf-2e41-47ed-8600-74afdafa8faa>.
+    
+<http://data.lblod.info/id/remote-data-objects/03deb5fb-17e9-4438-808f-6f2b7ecdacbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03deb5fb-17e9-4438-808f-6f2b7ecdacbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/310d9699-0add-4803-8afb-591f6ff9ff21/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03deb5fb-17e9-4438-808f-6f2b7ecdacbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/82113b11-349e-4322-81c0-5af1a26d3792> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82113b11-349e-4322-81c0-5af1a26d3792";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/310d9699-0add-4803-8afb-591f6ff9ff21/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82113b11-349e-4322-81c0-5af1a26d3792>.
+    
+<http://data.lblod.info/id/remote-data-objects/6370f921-a222-4eae-b310-6828ce59ae9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6370f921-a222-4eae-b310-6828ce59ae9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/310d9699-0add-4803-8afb-591f6ff9ff21/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6370f921-a222-4eae-b310-6828ce59ae9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3bb7726-b0a0-43f2-a70a-b31094b24191> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3bb7726-b0a0-43f2-a70a-b31094b24191";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/375cb84b-d15a-43c2-8e33-ea1b4f494f7e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3bb7726-b0a0-43f2-a70a-b31094b24191>.
+    
+<http://data.lblod.info/id/remote-data-objects/a787abab-81cf-4291-9d6b-a7b109a62569> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a787abab-81cf-4291-9d6b-a7b109a62569";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/375cb84b-d15a-43c2-8e33-ea1b4f494f7e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a787abab-81cf-4291-9d6b-a7b109a62569>.
+    
+<http://data.lblod.info/id/remote-data-objects/d274f93e-6958-46e1-bce6-c63ade8a0da2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d274f93e-6958-46e1-bce6-c63ade8a0da2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/375cb84b-d15a-43c2-8e33-ea1b4f494f7e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d274f93e-6958-46e1-bce6-c63ade8a0da2>.
+    
+<http://data.lblod.info/id/remote-data-objects/27d952ed-a3a3-4a70-80aa-908fe61b36ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27d952ed-a3a3-4a70-80aa-908fe61b36ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/3da94dd0-6220-45b5-a68d-3209c7945ff6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27d952ed-a3a3-4a70-80aa-908fe61b36ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/87b3d7b3-91f6-4647-a7a0-81abc004bac0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87b3d7b3-91f6-4647-a7a0-81abc004bac0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/3da94dd0-6220-45b5-a68d-3209c7945ff6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87b3d7b3-91f6-4647-a7a0-81abc004bac0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2851c67a-681a-4295-90f7-984c2636567f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2851c67a-681a-4295-90f7-984c2636567f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/3da94dd0-6220-45b5-a68d-3209c7945ff6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2851c67a-681a-4295-90f7-984c2636567f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3685d88-8f40-4699-b0da-ef6f6f387d23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3685d88-8f40-4699-b0da-ef6f6f387d23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/45194f30-3127-40b4-a36a-be5b52d1d139/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:18:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/750d30ea-953e-44ac-bf1f-b3f19768b3ba> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3685d88-8f40-4699-b0da-ef6f6f387d23>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201900-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201900-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201900-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201900-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/1d683b4a-a050-4e26-8209-204f10690e5e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1d683b4a-a050-4e26-8209-204f10690e5e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5cee38dc-d976-4f6e-8d29-5cc9189af2eb";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/552764bc-cff5-404b-b82d-3df2811cf89d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "552764bc-cff5-404b-b82d-3df2811cf89d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb>.
+
+  <http://redpencil.data.gift/id/task/ca1bec5e-607d-4891-be0d-461682b21ab1> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ca1bec5e-607d-4891-be0d-461682b21ab1";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/1d683b4a-a050-4e26-8209-204f10690e5e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/552764bc-cff5-404b-b82d-3df2811cf89d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/784586ce-4457-4c6f-a6a4-559aef590baf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "784586ce-4457-4c6f-a6a4-559aef590baf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/45194f30-3127-40b4-a36a-be5b52d1d139/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/784586ce-4457-4c6f-a6a4-559aef590baf>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbfeab14-c523-4459-aa40-3e89bdde0899> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbfeab14-c523-4459-aa40-3e89bdde0899";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/45194f30-3127-40b4-a36a-be5b52d1d139/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbfeab14-c523-4459-aa40-3e89bdde0899>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1d44348-1189-4c06-87df-ba193ff54c93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1d44348-1189-4c06-87df-ba193ff54c93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/457f6b59-61f8-4b48-9c56-2f136bcb0e31/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1d44348-1189-4c06-87df-ba193ff54c93>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcfa74b4-3a49-4dfc-9e3d-89cf3f0a5aa6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcfa74b4-3a49-4dfc-9e3d-89cf3f0a5aa6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/457f6b59-61f8-4b48-9c56-2f136bcb0e31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcfa74b4-3a49-4dfc-9e3d-89cf3f0a5aa6>.
+    
+<http://data.lblod.info/id/remote-data-objects/37563991-3e35-4467-ba4c-75d394aa33e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37563991-3e35-4467-ba4c-75d394aa33e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/457f6b59-61f8-4b48-9c56-2f136bcb0e31/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37563991-3e35-4467-ba4c-75d394aa33e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/22a470ef-f8e1-4aea-803f-12664014a97a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22a470ef-f8e1-4aea-803f-12664014a97a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/4ac387d3-9140-435b-a922-5e6a326afd76/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22a470ef-f8e1-4aea-803f-12664014a97a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4be52fd9-ae2b-42e2-8e4b-cc23b5d7f11e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4be52fd9-ae2b-42e2-8e4b-cc23b5d7f11e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/4ac387d3-9140-435b-a922-5e6a326afd76/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4be52fd9-ae2b-42e2-8e4b-cc23b5d7f11e>.
+    
+<http://data.lblod.info/id/remote-data-objects/400e972a-c0f8-405c-af8f-5dc33bf80a93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "400e972a-c0f8-405c-af8f-5dc33bf80a93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/4ac387d3-9140-435b-a922-5e6a326afd76/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/400e972a-c0f8-405c-af8f-5dc33bf80a93>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1389bdb-337c-48fa-9e21-a46937e3f6f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1389bdb-337c-48fa-9e21-a46937e3f6f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/4efada9f-b7cb-445b-82f7-de35f27d0c18/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1389bdb-337c-48fa-9e21-a46937e3f6f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad997c3d-b3ab-40e3-a9d4-29c46ff6777d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad997c3d-b3ab-40e3-a9d4-29c46ff6777d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/4efada9f-b7cb-445b-82f7-de35f27d0c18/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad997c3d-b3ab-40e3-a9d4-29c46ff6777d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3094017-3823-4eb8-bd74-6fb28da17b04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3094017-3823-4eb8-bd74-6fb28da17b04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/4efada9f-b7cb-445b-82f7-de35f27d0c18/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3094017-3823-4eb8-bd74-6fb28da17b04>.
+    
+<http://data.lblod.info/id/remote-data-objects/b073adff-bc28-4c3a-8d24-cf97ef1a2ab2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b073adff-bc28-4c3a-8d24-cf97ef1a2ab2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/562f74c9-4b13-4ef1-9fd7-defd7ccbdc6f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b073adff-bc28-4c3a-8d24-cf97ef1a2ab2>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf3a395c-d760-475c-8735-99a0ed428b8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf3a395c-d760-475c-8735-99a0ed428b8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/562f74c9-4b13-4ef1-9fd7-defd7ccbdc6f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf3a395c-d760-475c-8735-99a0ed428b8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/02e6294d-a087-4b21-8fa0-c9dce4858b16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "02e6294d-a087-4b21-8fa0-c9dce4858b16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/562f74c9-4b13-4ef1-9fd7-defd7ccbdc6f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/02e6294d-a087-4b21-8fa0-c9dce4858b16>.
+    
+<http://data.lblod.info/id/remote-data-objects/f17f80be-794b-424e-a9ae-76a39ff30461> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f17f80be-794b-424e-a9ae-76a39ff30461";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/6f90ad8b-fc84-42bf-8e7b-32aea8aee7a5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f17f80be-794b-424e-a9ae-76a39ff30461>.
+    
+<http://data.lblod.info/id/remote-data-objects/2311cf76-46de-4315-bede-cab271a26c30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2311cf76-46de-4315-bede-cab271a26c30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/6f90ad8b-fc84-42bf-8e7b-32aea8aee7a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2311cf76-46de-4315-bede-cab271a26c30>.
+    
+<http://data.lblod.info/id/remote-data-objects/698431cb-a10e-436d-bab0-a5bc4f579396> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "698431cb-a10e-436d-bab0-a5bc4f579396";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/6f90ad8b-fc84-42bf-8e7b-32aea8aee7a5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/698431cb-a10e-436d-bab0-a5bc4f579396>.
+    
+<http://data.lblod.info/id/remote-data-objects/efe0aad1-ba10-4134-a0f8-fbde527423a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efe0aad1-ba10-4134-a0f8-fbde527423a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/8ed61ef7-eda0-4cdb-a7be-d9e52e4fb323/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efe0aad1-ba10-4134-a0f8-fbde527423a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8c247ba-67f3-4cb9-bde6-251b99d08897> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8c247ba-67f3-4cb9-bde6-251b99d08897";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/8ed61ef7-eda0-4cdb-a7be-d9e52e4fb323/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8c247ba-67f3-4cb9-bde6-251b99d08897>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fccfb26-e85b-488a-8731-2680af61d466> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fccfb26-e85b-488a-8731-2680af61d466";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/8ed61ef7-eda0-4cdb-a7be-d9e52e4fb323/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fccfb26-e85b-488a-8731-2680af61d466>.
+    
+<http://data.lblod.info/id/remote-data-objects/32804d13-0ae0-490f-b39e-2a8a5918c9f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32804d13-0ae0-490f-b39e-2a8a5918c9f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/9bd51a05-b2e4-4257-9ff2-8f5d2c78d01e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32804d13-0ae0-490f-b39e-2a8a5918c9f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6dd8103-8f13-4849-83ad-9361a6243fcb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6dd8103-8f13-4849-83ad-9361a6243fcb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/9bd51a05-b2e4-4257-9ff2-8f5d2c78d01e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6dd8103-8f13-4849-83ad-9361a6243fcb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d167736e-8991-4706-b565-d05db53c4bc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d167736e-8991-4706-b565-d05db53c4bc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/aecc6746-a8e7-414a-b07e-e8c2699a3b48/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d167736e-8991-4706-b565-d05db53c4bc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/721ba44e-b7d5-423e-b22e-dd75e2700335> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "721ba44e-b7d5-423e-b22e-dd75e2700335";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/aecc6746-a8e7-414a-b07e-e8c2699a3b48/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/721ba44e-b7d5-423e-b22e-dd75e2700335>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ac3a997-315b-4d89-87fa-ac9e112bbc11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ac3a997-315b-4d89-87fa-ac9e112bbc11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/aecc6746-a8e7-414a-b07e-e8c2699a3b48/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ac3a997-315b-4d89-87fa-ac9e112bbc11>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5c9edfe-1190-4ae0-bedc-e0e33a482961> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5c9edfe-1190-4ae0-bedc-e0e33a482961";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/b66eb88f-67ce-41f9-bf29-b94a678c38ad/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5c9edfe-1190-4ae0-bedc-e0e33a482961>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9b89f64-c735-43a9-9729-fb9fc163f3a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9b89f64-c735-43a9-9729-fb9fc163f3a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/b66eb88f-67ce-41f9-bf29-b94a678c38ad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9b89f64-c735-43a9-9729-fb9fc163f3a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/14816fef-3c01-4bfe-9633-3d1674fe3ea9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14816fef-3c01-4bfe-9633-3d1674fe3ea9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/b66eb88f-67ce-41f9-bf29-b94a678c38ad/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14816fef-3c01-4bfe-9633-3d1674fe3ea9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e088cc7e-8073-4b6e-ad10-9e8c148781a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e088cc7e-8073-4b6e-ad10-9e8c148781a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/d56335c4-f0ff-4b45-a195-3bfec70139b4/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e088cc7e-8073-4b6e-ad10-9e8c148781a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dfae3b8-bf5c-4396-9aab-4cc48de0d55a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dfae3b8-bf5c-4396-9aab-4cc48de0d55a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/d56335c4-f0ff-4b45-a195-3bfec70139b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dfae3b8-bf5c-4396-9aab-4cc48de0d55a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d687f411-2990-4ff9-b509-1348148a58b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d687f411-2990-4ff9-b509-1348148a58b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/d56335c4-f0ff-4b45-a195-3bfec70139b4/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d687f411-2990-4ff9-b509-1348148a58b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/be1595a7-818b-4a82-9514-b9c03f0808c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be1595a7-818b-4a82-9514-b9c03f0808c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/fa5cced8-7c4d-40f7-bcaa-cf439e542f49/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be1595a7-818b-4a82-9514-b9c03f0808c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f70a48b5-d99d-4eaf-8e98-006be3a9e613> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f70a48b5-d99d-4eaf-8e98-006be3a9e613";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/fa5cced8-7c4d-40f7-bcaa-cf439e542f49/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f70a48b5-d99d-4eaf-8e98-006be3a9e613>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b96b9a0-769f-47fc-97df-fe93b7929b05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b96b9a0-769f-47fc-97df-fe93b7929b05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/rmw/fa5cced8-7c4d-40f7-bcaa-cf439e542f49/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b96b9a0-769f-47fc-97df-fe93b7929b05>.
+    
+<http://data.lblod.info/id/remote-data-objects/57887a23-5fe3-48cf-b9ab-624cfa3003d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57887a23-5fe3-48cf-b9ab-624cfa3003d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/010a265f-0fe2-42af-b1a2-7f10b6dc3496/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57887a23-5fe3-48cf-b9ab-624cfa3003d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/0aa4baf6-6cd5-462f-ab92-272b77bf1ad2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0aa4baf6-6cd5-462f-ab92-272b77bf1ad2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/039a1b06-172f-4654-bb28-243281cd379d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0aa4baf6-6cd5-462f-ab92-272b77bf1ad2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c91e70b8-4f34-45e7-8c5e-0ad39e4f49f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c91e70b8-4f34-45e7-8c5e-0ad39e4f49f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/03e5de9b-ce9b-4854-a17e-2e52267cb4dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c91e70b8-4f34-45e7-8c5e-0ad39e4f49f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3759218c-31e6-4bef-8d7f-7d4b7c6cfb48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3759218c-31e6-4bef-8d7f-7d4b7c6cfb48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/089bfe0f-7a82-4340-94c0-9fb9a44593d9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3759218c-31e6-4bef-8d7f-7d4b7c6cfb48>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb24b57f-0711-4380-b824-d353de864822> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb24b57f-0711-4380-b824-d353de864822";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/0f33c663-0e8d-48e9-8660-dfb71d4b9a61/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb24b57f-0711-4380-b824-d353de864822>.
+    
+<http://data.lblod.info/id/remote-data-objects/babe1c24-f505-4175-a8f3-64df117d1f60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "babe1c24-f505-4175-a8f3-64df117d1f60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/12ceb961-56d0-494b-a132-2285bd09d92b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/babe1c24-f505-4175-a8f3-64df117d1f60>.
+    
+<http://data.lblod.info/id/remote-data-objects/422418c3-cd49-4f0a-bc26-d555837a7b45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "422418c3-cd49-4f0a-bc26-d555837a7b45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/1504287b-3652-402f-bd25-fb4647768b04/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/422418c3-cd49-4f0a-bc26-d555837a7b45>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f84bbe6-e48a-4be2-841f-6d1d28e26eeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f84bbe6-e48a-4be2-841f-6d1d28e26eeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/1752a56e-ce74-4910-ad9c-07bb5eca3cf6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f84bbe6-e48a-4be2-841f-6d1d28e26eeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c97c9b79-fd9d-41d1-ae13-db74e5910bbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c97c9b79-fd9d-41d1-ae13-db74e5910bbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/1b6d516b-5fcb-4530-8677-e89b31a31976/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c97c9b79-fd9d-41d1-ae13-db74e5910bbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/3912b93e-b096-4a08-af9b-bdc0b017a000> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3912b93e-b096-4a08-af9b-bdc0b017a000";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/1d30c11e-2e49-47e4-aa05-f51c331d6817/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3912b93e-b096-4a08-af9b-bdc0b017a000>.
+    
+<http://data.lblod.info/id/remote-data-objects/c39fd0dd-8b98-4528-89f5-c31b7809624c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c39fd0dd-8b98-4528-89f5-c31b7809624c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/1d4f4ed6-a104-402a-997a-8239822e9b5a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c39fd0dd-8b98-4528-89f5-c31b7809624c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b390774-ad2c-47f1-96ca-9a289fd4b26c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b390774-ad2c-47f1-96ca-9a289fd4b26c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/220d3aae-89ae-4bd5-a3f0-b31e84b7a31a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b390774-ad2c-47f1-96ca-9a289fd4b26c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c7c85df-638c-4b2f-abf5-3767d50a7521> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c7c85df-638c-4b2f-abf5-3767d50a7521";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/22a9928e-2ef0-4df0-83a5-2dff31829c40/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c7c85df-638c-4b2f-abf5-3767d50a7521>.
+    
+<http://data.lblod.info/id/remote-data-objects/077a8063-6bd8-4aba-a074-4c6831440e0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "077a8063-6bd8-4aba-a074-4c6831440e0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/2b12b1b1-5023-47fe-b675-9309b025733d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/077a8063-6bd8-4aba-a074-4c6831440e0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/25f123c5-f452-48b1-99d5-2944882a2f70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25f123c5-f452-48b1-99d5-2944882a2f70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/2b989175-0f18-4aab-af71-3380a3997406/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25f123c5-f452-48b1-99d5-2944882a2f70>.
+    
+<http://data.lblod.info/id/remote-data-objects/50c2fd2a-941a-4540-8ac8-229ef9298f15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50c2fd2a-941a-4540-8ac8-229ef9298f15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/2c15a67b-7901-43a0-8652-f6c6f7b9428e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/5cee38dc-d976-4f6e-8d29-5cc9189af2eb> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50c2fd2a-941a-4540-8ac8-229ef9298f15>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201901-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201901-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201901-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201901-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/584deae3-cf38-4f42-a7b6-bddae0c0cfe2> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "584deae3-cf38-4f42-a7b6-bddae0c0cfe2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8f4627ef-8e67-4763-a107-d3bec00b255b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/dc8de2ff-5e34-4bc2-8d90-cdd5ebf588b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dc8de2ff-5e34-4bc2-8d90-cdd5ebf588b2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b>.
+
+  <http://redpencil.data.gift/id/task/086cc0a4-ca8e-4aab-8335-9bbe07aad1c2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "086cc0a4-ca8e-4aab-8335-9bbe07aad1c2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/584deae3-cf38-4f42-a7b6-bddae0c0cfe2>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/dc8de2ff-5e34-4bc2-8d90-cdd5ebf588b2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/ba4ebcc6-a6e1-4a61-afa3-26ee2a2393a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba4ebcc6-a6e1-4a61-afa3-26ee2a2393a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/2cac3b3c-a05b-4f43-823b-4ff9cd731a5e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba4ebcc6-a6e1-4a61-afa3-26ee2a2393a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/596b6929-3f99-44e2-aa56-9cdf67225ce6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "596b6929-3f99-44e2-aa56-9cdf67225ce6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/2d259238-e07f-466e-be02-16927d81fb62/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/596b6929-3f99-44e2-aa56-9cdf67225ce6>.
+    
+<http://data.lblod.info/id/remote-data-objects/649fdbf5-5bac-4ed8-a19f-d34ba6b8fe0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "649fdbf5-5bac-4ed8-a19f-d34ba6b8fe0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/31340569-4326-46e7-9059-664de83027d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/649fdbf5-5bac-4ed8-a19f-d34ba6b8fe0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4debac2c-e9ad-4ba1-99c9-69419569174b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4debac2c-e9ad-4ba1-99c9-69419569174b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/45dd6413-0ad8-4b0b-9e11-ddf46c88d27b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4debac2c-e9ad-4ba1-99c9-69419569174b>.
+    
+<http://data.lblod.info/id/remote-data-objects/d820b41d-2475-48e8-bee7-7422de917b9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d820b41d-2475-48e8-bee7-7422de917b9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/45e526b5-61e4-4900-9b29-500c71dcdcb2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d820b41d-2475-48e8-bee7-7422de917b9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/aad294b4-529b-434d-b0f5-ee635b9d7355> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aad294b4-529b-434d-b0f5-ee635b9d7355";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/47a768b6-c0ee-4cf2-9c7f-ba21d92a34bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aad294b4-529b-434d-b0f5-ee635b9d7355>.
+    
+<http://data.lblod.info/id/remote-data-objects/0120a9a4-6876-492c-8780-33f7389da7a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0120a9a4-6876-492c-8780-33f7389da7a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/4ba0a8cb-f80f-4b14-8d9b-da02aaf79662/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0120a9a4-6876-492c-8780-33f7389da7a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/bffe42d3-d075-4335-86cf-86edb60c586d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bffe42d3-d075-4335-86cf-86edb60c586d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/4c5c0554-35dc-466d-8c4c-5286b9d960ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bffe42d3-d075-4335-86cf-86edb60c586d>.
+    
+<http://data.lblod.info/id/remote-data-objects/129e0db3-97c4-4b6c-bd28-1515ea95f57d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "129e0db3-97c4-4b6c-bd28-1515ea95f57d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/4c73ca37-d6d4-4458-8b6d-9fe321b68418/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/129e0db3-97c4-4b6c-bd28-1515ea95f57d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6f21cb4-fbdc-4d7b-a252-2766e663bdba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6f21cb4-fbdc-4d7b-a252-2766e663bdba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/4ccbf304-835b-4e09-965d-8339fada9a6f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6f21cb4-fbdc-4d7b-a252-2766e663bdba>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6e3e332-a024-4c40-b3dd-e35d121b042b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6e3e332-a024-4c40-b3dd-e35d121b042b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/4fc11bbf-991a-4a17-908a-95964630fb24/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6e3e332-a024-4c40-b3dd-e35d121b042b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e02f5de-e13a-4943-b766-12dd3f0772e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e02f5de-e13a-4943-b766-12dd3f0772e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/58a2b91f-fe1b-4a6a-8b4e-319e2a7364e8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e02f5de-e13a-4943-b766-12dd3f0772e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ad8fcd8-aad5-442b-91d6-14caee9c6fa5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ad8fcd8-aad5-442b-91d6-14caee9c6fa5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/5ae59ce7-9ce0-4d6c-bc79-cc423185f75f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ad8fcd8-aad5-442b-91d6-14caee9c6fa5>.
+    
+<http://data.lblod.info/id/remote-data-objects/97509d18-9319-48c2-8ee0-412a9f070623> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97509d18-9319-48c2-8ee0-412a9f070623";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/60589efe-69be-4c29-870b-e44cd49150b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97509d18-9319-48c2-8ee0-412a9f070623>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e2a9d71-fad6-4a29-bfd8-912bd66876a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e2a9d71-fad6-4a29-bfd8-912bd66876a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/64d425b3-2d47-4724-ba8d-6a3fa0f7be89/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e2a9d71-fad6-4a29-bfd8-912bd66876a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ba81b0f-a673-4cb6-87da-c56b28b140bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ba81b0f-a673-4cb6-87da-c56b28b140bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/74680e15-affd-4fc0-af45-d09251283641/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ba81b0f-a673-4cb6-87da-c56b28b140bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c732774-1c9a-415a-894a-7ee46e5562b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c732774-1c9a-415a-894a-7ee46e5562b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/757692b1-d4f8-4100-bca2-41dfb718dba2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c732774-1c9a-415a-894a-7ee46e5562b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd5dca50-f91f-403c-a829-28f28d676407> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd5dca50-f91f-403c-a829-28f28d676407";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/7705dd30-c9d2-4340-9d18-d1f106c0f19c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd5dca50-f91f-403c-a829-28f28d676407>.
+    
+<http://data.lblod.info/id/remote-data-objects/9364834f-10aa-42e5-821d-eb4209651d10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9364834f-10aa-42e5-821d-eb4209651d10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/78647887-4aa7-4d88-907c-943bdb1d6f17/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9364834f-10aa-42e5-821d-eb4209651d10>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b675f3d-bbc8-459e-90c6-5c7c46170a16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b675f3d-bbc8-459e-90c6-5c7c46170a16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/794ae4b6-8082-49bc-bc41-48e3ed4012d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b675f3d-bbc8-459e-90c6-5c7c46170a16>.
+    
+<http://data.lblod.info/id/remote-data-objects/8aee3fca-6991-4e63-97e7-f19788b45018> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8aee3fca-6991-4e63-97e7-f19788b45018";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/7e7451a8-5401-436b-ab6d-b8175e1844aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8aee3fca-6991-4e63-97e7-f19788b45018>.
+    
+<http://data.lblod.info/id/remote-data-objects/be8373be-031d-4306-b6cf-d5f5f8def609> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be8373be-031d-4306-b6cf-d5f5f8def609";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/7ecdce10-08ac-4650-aac9-1b6e9b3d2c2b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be8373be-031d-4306-b6cf-d5f5f8def609>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a41bb0f-a76e-4410-aa9d-96a11e5a60ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a41bb0f-a76e-4410-aa9d-96a11e5a60ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/7ed23ecc-1d51-41eb-9ca9-e18c15ccb529/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a41bb0f-a76e-4410-aa9d-96a11e5a60ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/040ab48d-d6c0-4a68-bd40-584a02d3ce71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "040ab48d-d6c0-4a68-bd40-584a02d3ce71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/8039b395-cb29-4d6e-8715-4236f2dae233/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/040ab48d-d6c0-4a68-bd40-584a02d3ce71>.
+    
+<http://data.lblod.info/id/remote-data-objects/58e6a68c-cbf3-437e-b673-7ca3a4e58145> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58e6a68c-cbf3-437e-b673-7ca3a4e58145";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/81965cf9-ca4a-4766-bed0-bc1f2191d812/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58e6a68c-cbf3-437e-b673-7ca3a4e58145>.
+    
+<http://data.lblod.info/id/remote-data-objects/26f58959-5e04-43e4-a1a7-cc467f078af7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26f58959-5e04-43e4-a1a7-cc467f078af7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/87f89ffc-9fec-460f-9437-10dff7d19504/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26f58959-5e04-43e4-a1a7-cc467f078af7>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc04e5b0-1c77-4e5c-81d1-ab97bfe985bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc04e5b0-1c77-4e5c-81d1-ab97bfe985bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/950f9cdb-b868-4d5a-af48-0092333124cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc04e5b0-1c77-4e5c-81d1-ab97bfe985bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/993052f0-b33d-4433-a170-7e94ff4c95c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "993052f0-b33d-4433-a170-7e94ff4c95c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/975de519-be18-4e5f-aa04-fbf5f86c7902/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/993052f0-b33d-4433-a170-7e94ff4c95c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dca197d-ed5b-4a62-b1b8-25a8c6c71416> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dca197d-ed5b-4a62-b1b8-25a8c6c71416";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/9b0ad578-5b61-4801-a630-7c6592e4b33c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dca197d-ed5b-4a62-b1b8-25a8c6c71416>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fd0d534-d64d-4f7d-a2a6-b2e4ff9f9033> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fd0d534-d64d-4f7d-a2a6-b2e4ff9f9033";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/9f2c3146-8042-4dcb-86a6-24da6e17fca2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fd0d534-d64d-4f7d-a2a6-b2e4ff9f9033>.
+    
+<http://data.lblod.info/id/remote-data-objects/3dc983c5-3639-4188-a40b-2c298afad77a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3dc983c5-3639-4188-a40b-2c298afad77a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/a5097111-7b87-482c-a258-92d999479287/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3dc983c5-3639-4188-a40b-2c298afad77a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6fe68c37-b676-49a4-92a8-85c845df5558> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6fe68c37-b676-49a4-92a8-85c845df5558";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/a88a25c1-a718-4cab-ab00-2f30e775f3a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6fe68c37-b676-49a4-92a8-85c845df5558>.
+    
+<http://data.lblod.info/id/remote-data-objects/9131de68-fccc-47f1-999a-cef6706cb17d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9131de68-fccc-47f1-999a-cef6706cb17d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/a92d5f37-6cf6-4808-8962-1ce2ff8efe1b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9131de68-fccc-47f1-999a-cef6706cb17d>.
+    
+<http://data.lblod.info/id/remote-data-objects/704dbb9a-bbb7-45e4-9fdb-a09cef898a91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "704dbb9a-bbb7-45e4-9fdb-a09cef898a91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/ab2aa4f6-d2d6-472a-93be-745186f7d868/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/704dbb9a-bbb7-45e4-9fdb-a09cef898a91>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb4d2afa-b0dd-43b6-aff9-ed9ba059aedb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb4d2afa-b0dd-43b6-aff9-ed9ba059aedb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/ace73e1e-7ae3-4930-9051-a954e70a719b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb4d2afa-b0dd-43b6-aff9-ed9ba059aedb>.
+    
+<http://data.lblod.info/id/remote-data-objects/55d428eb-3c3b-4bc8-874f-f61593b89bc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55d428eb-3c3b-4bc8-874f-f61593b89bc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/ae24ea5d-7cff-45fa-92ee-bb9cffe06ae1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55d428eb-3c3b-4bc8-874f-f61593b89bc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc2fe172-3223-4415-b230-b973836ca9b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc2fe172-3223-4415-b230-b973836ca9b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/b44e67f1-248a-4875-92c3-0db84f3016a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc2fe172-3223-4415-b230-b973836ca9b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/60b1d89c-50e3-4ea4-8e20-8536ef4a215d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60b1d89c-50e3-4ea4-8e20-8536ef4a215d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/b5822395-9c22-417a-820d-305ed9dbd446/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60b1d89c-50e3-4ea4-8e20-8536ef4a215d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5dcfe9a5-501f-41b5-a7de-d31cb2aeae9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5dcfe9a5-501f-41b5-a7de-d31cb2aeae9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/b966b7f9-1580-448d-b072-283c299ea940/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5dcfe9a5-501f-41b5-a7de-d31cb2aeae9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d014a64-9a5d-4132-9a3d-9be7bf846d00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d014a64-9a5d-4132-9a3d-9be7bf846d00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/bde859b3-6574-4d21-b4a0-f39bf61dba18/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d014a64-9a5d-4132-9a3d-9be7bf846d00>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d508c3a-73d5-49a3-a0a7-12f33e6b7664> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d508c3a-73d5-49a3-a0a7-12f33e6b7664";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/c06537c5-7cbe-475f-9f9d-1d6db3f9ef6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d508c3a-73d5-49a3-a0a7-12f33e6b7664>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4006df8-179a-4f26-83c5-e0186546e0de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4006df8-179a-4f26-83c5-e0186546e0de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/c423f8ba-6cc8-477c-a25e-aacc9e0ac9fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4006df8-179a-4f26-83c5-e0186546e0de>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c508bc7-c128-4744-8341-de36f5654d11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c508bc7-c128-4744-8341-de36f5654d11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/c615528d-8997-4824-abe1-b6762cdd736c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c508bc7-c128-4744-8341-de36f5654d11>.
+    
+<http://data.lblod.info/id/remote-data-objects/6be64123-3e26-440b-9a49-ee5b0091d0ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6be64123-3e26-440b-9a49-ee5b0091d0ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/c6212663-9e65-47b1-b64e-cccdaa80bd97/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6be64123-3e26-440b-9a49-ee5b0091d0ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6e75563-fb10-470c-b2b2-25f695b28494> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6e75563-fb10-470c-b2b2-25f695b28494";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/ca369cca-f6de-4d16-ad59-6e81cae69226/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6e75563-fb10-470c-b2b2-25f695b28494>.
+    
+<http://data.lblod.info/id/remote-data-objects/d69ed7ce-a829-40b1-a61d-6bcaaeafffd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d69ed7ce-a829-40b1-a61d-6bcaaeafffd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/cbd01e28-ba92-4082-bccc-6622b8b4c45f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d69ed7ce-a829-40b1-a61d-6bcaaeafffd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6ac7bb1-857e-45fe-9e95-4c8f68b050e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6ac7bb1-857e-45fe-9e95-4c8f68b050e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/d0a73c6f-8fc2-46a1-837b-b375850234f6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6ac7bb1-857e-45fe-9e95-4c8f68b050e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/834f85de-85f9-4fda-b126-2a166f1bade5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "834f85de-85f9-4fda-b126-2a166f1bade5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/d14931ef-80e5-4526-b2a9-ba57329230a5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/834f85de-85f9-4fda-b126-2a166f1bade5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9104f9d7-8452-4615-a521-acf0afbf0c2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9104f9d7-8452-4615-a521-acf0afbf0c2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/d1d98033-6cc3-4f8a-b0a3-3af925ba676c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9104f9d7-8452-4615-a521-acf0afbf0c2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a1f3295-cba5-4414-82d2-d7c8ce4d454b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a1f3295-cba5-4414-82d2-d7c8ce4d454b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/d5aee26c-b4e8-4cf2-b064-2b9fa19e8184/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:01.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/8f4627ef-8e67-4763-a107-d3bec00b255b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a1f3295-cba5-4414-82d2-d7c8ce4d454b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201903-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201903-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201903-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201903-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/af5fa3c3-30c0-49d8-85b8-7ee0f63f60c3> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "af5fa3c3-30c0-49d8-85b8-7ee0f63f60c3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dbab2722-b8d9-49db-98e6-f9f8f5df12c8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/2e0e738a-ae82-4ff0-8c6d-e1048b0fdfe6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2e0e738a-ae82-4ff0-8c6d-e1048b0fdfe6";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8>.
+
+  <http://redpencil.data.gift/id/task/d51cfe12-a1c4-4b53-a377-eca92e96c350> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d51cfe12-a1c4-4b53-a377-eca92e96c350";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/af5fa3c3-30c0-49d8-85b8-7ee0f63f60c3>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/2e0e738a-ae82-4ff0-8c6d-e1048b0fdfe6>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/0093ab2f-c631-4f64-8d6f-d79a55e8e16c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0093ab2f-c631-4f64-8d6f-d79a55e8e16c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/db29851c-6018-4d3e-8774-9aaaf2700f95/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0093ab2f-c631-4f64-8d6f-d79a55e8e16c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b56371c7-ba0a-452a-9cf8-8218259b7ea5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b56371c7-ba0a-452a-9cf8-8218259b7ea5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/de126b26-6927-41ad-982f-983a2e06641b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b56371c7-ba0a-452a-9cf8-8218259b7ea5>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0b3a683-14f8-427e-af64-2756eb585071> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0b3a683-14f8-427e-af64-2756eb585071";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/e899cf1d-8569-4ce0-a8fa-334a6cdc147f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0b3a683-14f8-427e-af64-2756eb585071>.
+    
+<http://data.lblod.info/id/remote-data-objects/1732b415-7c29-4728-ba76-9e7bc0bf8de8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1732b415-7c29-4728-ba76-9e7bc0bf8de8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/ea69a5d8-75fd-43b6-bb7a-7417ef9f6d47/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1732b415-7c29-4728-ba76-9e7bc0bf8de8>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb8eca2a-2e56-485f-9ce7-5e576641756a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb8eca2a-2e56-485f-9ce7-5e576641756a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/fc0aca0c-d2e2-4269-a3b5-057b9cbd929c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb8eca2a-2e56-485f-9ce7-5e576641756a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b53ee23d-447a-45f2-ae17-62c34af18f8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b53ee23d-447a-45f2-ae17-62c34af18f8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://olen.meetingburger.net/vabu/fe3eccaf-11b0-4f7d-9864-055f27899b1c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b53ee23d-447a-45f2-ae17-62c34af18f8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/254fc5c2-628e-409b-84f2-b077dd6be4dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "254fc5c2-628e-409b-84f2-b077dd6be4dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/070ef6ae-7a90-419d-9471-9753cbf8a91a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/254fc5c2-628e-409b-84f2-b077dd6be4dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bf88390-9d92-4c1e-a1b7-9cec6d6ff7bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bf88390-9d92-4c1e-a1b7-9cec6d6ff7bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/38d7eeec-d17f-4a12-aa77-d6614a544b27/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bf88390-9d92-4c1e-a1b7-9cec6d6ff7bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0a69dd7-2e59-4eec-a288-03a53258c7bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0a69dd7-2e59-4eec-a288-03a53258c7bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/6c775701-cf66-49d8-bdc9-9b2938ae73da/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0a69dd7-2e59-4eec-a288-03a53258c7bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/e79fffbc-e3f5-480a-a360-c1e22e450cdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e79fffbc-e3f5-480a-a360-c1e22e450cdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/80701f06-f483-4d19-8386-4b71c352fde4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e79fffbc-e3f5-480a-a360-c1e22e450cdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/22b7a8d4-4977-42d5-8a59-7919a019686b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22b7a8d4-4977-42d5-8a59-7919a019686b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/860d0849-b5a3-41e1-907c-66f7095099d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22b7a8d4-4977-42d5-8a59-7919a019686b>.
+    
+<http://data.lblod.info/id/remote-data-objects/59cca4b9-8ed3-442c-997b-1f2a9d7e8047> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59cca4b9-8ed3-442c-997b-1f2a9d7e8047";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/885b2d4f-ba9e-4743-8853-de7ac4043339/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59cca4b9-8ed3-442c-997b-1f2a9d7e8047>.
+    
+<http://data.lblod.info/id/remote-data-objects/da49533b-54a2-4564-9c84-5d3fd7612ad9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da49533b-54a2-4564-9c84-5d3fd7612ad9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/8ada14dd-7e6e-4436-8678-b94a2a47f2b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da49533b-54a2-4564-9c84-5d3fd7612ad9>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa0fbd92-ddd5-4a96-9ebf-7413e363d6b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa0fbd92-ddd5-4a96-9ebf-7413e363d6b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/8f65db4a-cbf2-4707-8a1d-f747b2868bd7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa0fbd92-ddd5-4a96-9ebf-7413e363d6b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f85b2ea-f47e-48e4-88b5-f10442ae6563> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f85b2ea-f47e-48e4-88b5-f10442ae6563";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/9275d4c8-623f-4553-8ae8-7f539dbcb080/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f85b2ea-f47e-48e4-88b5-f10442ae6563>.
+    
+<http://data.lblod.info/id/remote-data-objects/fce35f06-c38f-4730-ac1a-1f34fa56e98c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fce35f06-c38f-4730-ac1a-1f34fa56e98c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/931460dc-c432-4ff3-b196-e687a7012ba2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fce35f06-c38f-4730-ac1a-1f34fa56e98c>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf913466-9bbb-4f8b-a3ff-b8d3bb8e9783> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf913466-9bbb-4f8b-a3ff-b8d3bb8e9783";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/b676ea72-d964-40b1-aa3d-ba5a1c7eb9b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf913466-9bbb-4f8b-a3ff-b8d3bb8e9783>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f8ce777-4499-4add-8044-40378c356a15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f8ce777-4499-4add-8044-40378c356a15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/b69192f4-a60a-4dd5-9a94-475401fa2e31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f8ce777-4499-4add-8044-40378c356a15>.
+    
+<http://data.lblod.info/id/remote-data-objects/0903a858-3b6b-4467-afd4-afefbf6b2fe8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0903a858-3b6b-4467-afd4-afefbf6b2fe8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/bdc17e53-2fcf-4286-b90b-e7541e4b36b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0903a858-3b6b-4467-afd4-afefbf6b2fe8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8b770f6-2a4f-45c6-9d74-bb18b1f26724> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8b770f6-2a4f-45c6-9d74-bb18b1f26724";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/cb495fd8-d5df-4941-a2ed-de950e626bf1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8b770f6-2a4f-45c6-9d74-bb18b1f26724>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc822294-b150-4e72-a409-611d3c50475b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc822294-b150-4e72-a409-611d3c50475b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/e9c77e81-e9f0-471e-b90f-6ef9d8c5771b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc822294-b150-4e72-a409-611d3c50475b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ef41bd4-5e5b-4f68-a27f-819259f5d56d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ef41bd4-5e5b-4f68-a27f-819259f5d56d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/ea3087c4-a094-456c-8c3c-91f61b61c516/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ef41bd4-5e5b-4f68-a27f-819259f5d56d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f82ad61e-61a5-436b-b11b-956744cc097c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f82ad61e-61a5-436b-b11b-956744cc097c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/ed4fe1bb-f3a8-4469-8622-ee644b9231cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f82ad61e-61a5-436b-b11b-956744cc097c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cd6c022-0c38-4b14-a262-4961cd530183> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cd6c022-0c38-4b14-a262-4961cd530183";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/fbc85876-eed9-4bc7-850e-216dd17a3726/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cd6c022-0c38-4b14-a262-4961cd530183>.
+    
+<http://data.lblod.info/id/remote-data-objects/18017320-741d-4dad-99ef-c7a7299b1028> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18017320-741d-4dad-99ef-c7a7299b1028";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/bb/ff4bf06a-fe2a-48d5-b36a-097d29b5fe94/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18017320-741d-4dad-99ef-c7a7299b1028>.
+    
+<http://data.lblod.info/id/remote-data-objects/098ae57c-d190-4825-84ff-246e8653cee3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "098ae57c-d190-4825-84ff-246e8653cee3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/09d842f2-5176-4a89-9201-9b691142f66e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/098ae57c-d190-4825-84ff-246e8653cee3>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6f14549-f7d3-41da-9e49-2676fc97dd63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6f14549-f7d3-41da-9e49-2676fc97dd63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/1023b640-47b5-4ae6-a1f9-4d0703741eac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6f14549-f7d3-41da-9e49-2676fc97dd63>.
+    
+<http://data.lblod.info/id/remote-data-objects/5119654c-efc0-479b-9efd-a05d45730dfb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5119654c-efc0-479b-9efd-a05d45730dfb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/3ccd51eb-3565-4a7f-a719-b139a4e65ce7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5119654c-efc0-479b-9efd-a05d45730dfb>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ed0beb0-d822-4ae1-ac6b-e1138fd8b201> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ed0beb0-d822-4ae1-ac6b-e1138fd8b201";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/3d4c7893-b4ce-49fc-8e7d-87c08ac58cc4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ed0beb0-d822-4ae1-ac6b-e1138fd8b201>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0ab83b9-cd49-4978-8e7c-65aec1c57760> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0ab83b9-cd49-4978-8e7c-65aec1c57760";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/47a590c2-2829-4f09-bb6f-91f17fc99506/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0ab83b9-cd49-4978-8e7c-65aec1c57760>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d08502d-d759-482e-8b2a-4640b67edb19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d08502d-d759-482e-8b2a-4640b67edb19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/4aae2164-da6f-4761-9cde-d359820a3e6d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d08502d-d759-482e-8b2a-4640b67edb19>.
+    
+<http://data.lblod.info/id/remote-data-objects/e82868fb-e09b-41ba-ab16-f3cd69f79dcb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e82868fb-e09b-41ba-ab16-f3cd69f79dcb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/5b5631d2-6afd-45e8-848a-c8d81f12786f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e82868fb-e09b-41ba-ab16-f3cd69f79dcb>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d3d7c84-273c-4761-9e17-f0ce23a8aebb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d3d7c84-273c-4761-9e17-f0ce23a8aebb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/653b632f-c4e6-4295-bb15-cd998c185643/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d3d7c84-273c-4761-9e17-f0ce23a8aebb>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b50d1da-2401-4829-8f0c-b9d75d64733e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b50d1da-2401-4829-8f0c-b9d75d64733e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/bb30e90a-936d-479d-9827-1e96cb6515de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b50d1da-2401-4829-8f0c-b9d75d64733e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6463b9fb-6c59-44ba-94b3-4e112b22e0db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6463b9fb-6c59-44ba-94b3-4e112b22e0db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/cd3ef4bc-509b-416c-9e4c-c2fd0f5463db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6463b9fb-6c59-44ba-94b3-4e112b22e0db>.
+    
+<http://data.lblod.info/id/remote-data-objects/765dae2d-26cb-4803-96c3-aed1e8ba698b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "765dae2d-26cb-4803-96c3-aed1e8ba698b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/d505e91a-89bc-4588-bc43-1bebb7d01189/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/765dae2d-26cb-4803-96c3-aed1e8ba698b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6aa8c7ad-810b-4d99-8637-b48906fca29c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6aa8c7ad-810b-4d99-8637-b48906fca29c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/d8c711e1-9924-4924-ae9a-2b1e0402ac68/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6aa8c7ad-810b-4d99-8637-b48906fca29c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2f6c5fd-97bf-4b83-8d56-47f153018093> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2f6c5fd-97bf-4b83-8d56-47f153018093";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/ddb18c4b-f155-44f6-8701-3cd283065a26/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2f6c5fd-97bf-4b83-8d56-47f153018093>.
+    
+<http://data.lblod.info/id/remote-data-objects/98f8106b-47c7-4a82-a602-651b6312a7c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98f8106b-47c7-4a82-a602-651b6312a7c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/e51fac1e-05e2-44e9-bbed-b70cd848240c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98f8106b-47c7-4a82-a602-651b6312a7c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb731076-69bc-4c64-bfec-3078aa1b490d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb731076-69bc-4c64-bfec-3078aa1b490d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/eca06f1f-a060-46c3-bbf4-44664c8b79ee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb731076-69bc-4c64-bfec-3078aa1b490d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d489cfa-0432-4b14-bfe6-c73d14ff66cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d489cfa-0432-4b14-bfe6-c73d14ff66cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/f13a2dd6-4835-4d5d-9ddd-014ddd1893bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d489cfa-0432-4b14-bfe6-c73d14ff66cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/406b5f03-6380-45ac-842c-1928d3d261fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "406b5f03-6380-45ac-842c-1928d3d261fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/f352f1c9-182f-4b82-989a-0a5d2ac6d05a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/406b5f03-6380-45ac-842c-1928d3d261fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/768093c6-dad3-4988-818e-c83778dbeaf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "768093c6-dad3-4988-818e-c83778dbeaf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/cbs/f50eb70b-b892-48e8-8305-bbae0a9a994b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/768093c6-dad3-4988-818e-c83778dbeaf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0d963d2-784b-409d-9836-9a1b94882635> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0d963d2-784b-409d-9836-9a1b94882635";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/04e647d7-1f1d-4926-9267-ce4f57ed31ed/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0d963d2-784b-409d-9836-9a1b94882635>.
+    
+<http://data.lblod.info/id/remote-data-objects/59b393bc-4ec2-4196-b24f-44a8e714e0ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59b393bc-4ec2-4196-b24f-44a8e714e0ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/04e647d7-1f1d-4926-9267-ce4f57ed31ed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59b393bc-4ec2-4196-b24f-44a8e714e0ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/3929e4b7-6f7f-44e3-bbc0-be96581f02df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3929e4b7-6f7f-44e3-bbc0-be96581f02df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/04e647d7-1f1d-4926-9267-ce4f57ed31ed/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3929e4b7-6f7f-44e3-bbc0-be96581f02df>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9132694-1735-4bc4-91ad-68dfb95cd2f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9132694-1735-4bc4-91ad-68dfb95cd2f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/19260eec-b2f7-4746-b87d-7e1cbca31ce7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9132694-1735-4bc4-91ad-68dfb95cd2f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/27818fc0-b2a5-436c-816e-ea57855ef529> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27818fc0-b2a5-436c-816e-ea57855ef529";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/19260eec-b2f7-4746-b87d-7e1cbca31ce7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27818fc0-b2a5-436c-816e-ea57855ef529>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c22d87c-d1d5-4f4e-ba9d-f19e45695123> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c22d87c-d1d5-4f4e-ba9d-f19e45695123";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/19260eec-b2f7-4746-b87d-7e1cbca31ce7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c22d87c-d1d5-4f4e-ba9d-f19e45695123>.
+    
+<http://data.lblod.info/id/remote-data-objects/e805f0d2-b01d-404a-8ffc-18f06233ccd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e805f0d2-b01d-404a-8ffc-18f06233ccd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/20631ed2-a70d-40c8-961e-6435abcc698c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbab2722-b8d9-49db-98e6-f9f8f5df12c8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e805f0d2-b01d-404a-8ffc-18f06233ccd2>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201904-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201904-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201904-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201904-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d601f2e4-fefb-450e-8bfa-75a1fd2178b9> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d601f2e4-fefb-450e-8bfa-75a1fd2178b9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1dcddc75-9137-4677-9a61-4534c9aeae5c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/019a64fb-4f43-46bd-a208-7a42a731d77c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "019a64fb-4f43-46bd-a208-7a42a731d77c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c>.
+
+  <http://redpencil.data.gift/id/task/0099d72f-497a-441d-b76d-4a3ab99ab87a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0099d72f-497a-441d-b76d-4a3ab99ab87a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d601f2e4-fefb-450e-8bfa-75a1fd2178b9>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/019a64fb-4f43-46bd-a208-7a42a731d77c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/1beb36ba-3a52-4cbd-bcc8-639a98dd8f2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1beb36ba-3a52-4cbd-bcc8-639a98dd8f2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/20631ed2-a70d-40c8-961e-6435abcc698c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1beb36ba-3a52-4cbd-bcc8-639a98dd8f2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb2fa115-fe28-44d6-97ce-9c4fbde18669> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb2fa115-fe28-44d6-97ce-9c4fbde18669";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/21122c61-a58b-4184-b81d-300ceb70ac09/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb2fa115-fe28-44d6-97ce-9c4fbde18669>.
+    
+<http://data.lblod.info/id/remote-data-objects/233cf9ba-9bc8-4e6a-b0a0-9a24627f9a0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "233cf9ba-9bc8-4e6a-b0a0-9a24627f9a0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/21122c61-a58b-4184-b81d-300ceb70ac09/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/233cf9ba-9bc8-4e6a-b0a0-9a24627f9a0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/107d3c21-fd51-4cc3-99f3-673e9f2ca581> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "107d3c21-fd51-4cc3-99f3-673e9f2ca581";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/21122c61-a58b-4184-b81d-300ceb70ac09/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/107d3c21-fd51-4cc3-99f3-673e9f2ca581>.
+    
+<http://data.lblod.info/id/remote-data-objects/edb4be08-5128-477a-804b-b3927df7481c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edb4be08-5128-477a-804b-b3927df7481c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/26eb1140-e249-48de-a00d-0495bf049f4d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edb4be08-5128-477a-804b-b3927df7481c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f73e46c7-400c-4ae8-ae3d-0a97c7772475> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f73e46c7-400c-4ae8-ae3d-0a97c7772475";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/26eb1140-e249-48de-a00d-0495bf049f4d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f73e46c7-400c-4ae8-ae3d-0a97c7772475>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdd6af2a-5e59-48de-8986-a23c4e73b4b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdd6af2a-5e59-48de-8986-a23c4e73b4b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/26eb1140-e249-48de-a00d-0495bf049f4d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdd6af2a-5e59-48de-8986-a23c4e73b4b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9301eff-3b86-42dd-850c-3d278204e1e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9301eff-3b86-42dd-850c-3d278204e1e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/2fd585e2-d150-441b-9bb9-507614f1224d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9301eff-3b86-42dd-850c-3d278204e1e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/37fb850a-2a82-42fb-80ce-178df561647d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37fb850a-2a82-42fb-80ce-178df561647d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/2fd585e2-d150-441b-9bb9-507614f1224d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37fb850a-2a82-42fb-80ce-178df561647d>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf197f37-dfc5-4b13-b804-3a245e2e7556> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf197f37-dfc5-4b13-b804-3a245e2e7556";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/2fd585e2-d150-441b-9bb9-507614f1224d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf197f37-dfc5-4b13-b804-3a245e2e7556>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c74becc-2fcb-4f2d-b91f-fce31d0dcd4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c74becc-2fcb-4f2d-b91f-fce31d0dcd4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/390bdab6-bd8f-4199-b4b4-d321c2f87d7d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c74becc-2fcb-4f2d-b91f-fce31d0dcd4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e6b3993-1ab4-4f06-859f-6520a6210932> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e6b3993-1ab4-4f06-859f-6520a6210932";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/390bdab6-bd8f-4199-b4b4-d321c2f87d7d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e6b3993-1ab4-4f06-859f-6520a6210932>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ee82ceb-c123-4212-a074-b5fb7090f54e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ee82ceb-c123-4212-a074-b5fb7090f54e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/390bdab6-bd8f-4199-b4b4-d321c2f87d7d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ee82ceb-c123-4212-a074-b5fb7090f54e>.
+    
+<http://data.lblod.info/id/remote-data-objects/65b6cbcd-4dd3-4b2e-8643-939fb3c4c50c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65b6cbcd-4dd3-4b2e-8643-939fb3c4c50c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/4d46163d-8055-42d1-ab0e-40aaad97d8cc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65b6cbcd-4dd3-4b2e-8643-939fb3c4c50c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2de583e2-520a-4708-a6fb-1374dae7f2a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2de583e2-520a-4708-a6fb-1374dae7f2a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/4d46163d-8055-42d1-ab0e-40aaad97d8cc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2de583e2-520a-4708-a6fb-1374dae7f2a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/88232677-e605-43ca-a068-120fb08d96be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88232677-e605-43ca-a068-120fb08d96be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/4d46163d-8055-42d1-ab0e-40aaad97d8cc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88232677-e605-43ca-a068-120fb08d96be>.
+    
+<http://data.lblod.info/id/remote-data-objects/c678140f-bc55-4ace-8dd4-d523319f8069> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c678140f-bc55-4ace-8dd4-d523319f8069";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/5449d94a-6b5b-4617-a316-0f4fb0d79093/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c678140f-bc55-4ace-8dd4-d523319f8069>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0545c49-dd8e-49df-9c17-cdcacfc3948f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0545c49-dd8e-49df-9c17-cdcacfc3948f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/5449d94a-6b5b-4617-a316-0f4fb0d79093/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0545c49-dd8e-49df-9c17-cdcacfc3948f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b02fb70f-4a57-423a-a275-284f3398e440> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b02fb70f-4a57-423a-a275-284f3398e440";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/5449d94a-6b5b-4617-a316-0f4fb0d79093/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b02fb70f-4a57-423a-a275-284f3398e440>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e3b61a1-bfdf-4f18-a82e-dead56ee629e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e3b61a1-bfdf-4f18-a82e-dead56ee629e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/5b74f1ad-923b-420b-80f1-f7c5fac566af/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e3b61a1-bfdf-4f18-a82e-dead56ee629e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2198a8b1-f9a7-462e-8596-e0a63a65553f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2198a8b1-f9a7-462e-8596-e0a63a65553f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/5b74f1ad-923b-420b-80f1-f7c5fac566af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2198a8b1-f9a7-462e-8596-e0a63a65553f>.
+    
+<http://data.lblod.info/id/remote-data-objects/be98b442-1904-4bb7-a759-531e500d2e3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be98b442-1904-4bb7-a759-531e500d2e3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/5b74f1ad-923b-420b-80f1-f7c5fac566af/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be98b442-1904-4bb7-a759-531e500d2e3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c5c2f6c-a89a-415f-bca5-734c598f72db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c5c2f6c-a89a-415f-bca5-734c598f72db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/62a923f7-4245-4c81-96d0-db9cc089a439/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c5c2f6c-a89a-415f-bca5-734c598f72db>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9205ca2-f157-4604-a6ab-5cde2ed1574d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9205ca2-f157-4604-a6ab-5cde2ed1574d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/62a923f7-4245-4c81-96d0-db9cc089a439/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9205ca2-f157-4604-a6ab-5cde2ed1574d>.
+    
+<http://data.lblod.info/id/remote-data-objects/99b3e35c-1c63-479e-bdd9-4e668c088352> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99b3e35c-1c63-479e-bdd9-4e668c088352";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/62a923f7-4245-4c81-96d0-db9cc089a439/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99b3e35c-1c63-479e-bdd9-4e668c088352>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1ceef21-6493-4e44-8cef-f8ccf84cec15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1ceef21-6493-4e44-8cef-f8ccf84cec15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/638b3b77-dd12-4a9c-8531-90ec20eed0a1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1ceef21-6493-4e44-8cef-f8ccf84cec15>.
+    
+<http://data.lblod.info/id/remote-data-objects/71d1c67a-8d18-44ee-a985-89b60ac66437> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71d1c67a-8d18-44ee-a985-89b60ac66437";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/638b3b77-dd12-4a9c-8531-90ec20eed0a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71d1c67a-8d18-44ee-a985-89b60ac66437>.
+    
+<http://data.lblod.info/id/remote-data-objects/90fb54d5-ccb3-4801-bbae-734f60b2a0e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90fb54d5-ccb3-4801-bbae-734f60b2a0e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/638b3b77-dd12-4a9c-8531-90ec20eed0a1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90fb54d5-ccb3-4801-bbae-734f60b2a0e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/124e38f6-ce2a-42e6-ba5a-e0efc20fcf69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "124e38f6-ce2a-42e6-ba5a-e0efc20fcf69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/995ddd80-3610-46da-a3f3-3646a27a5ece/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/124e38f6-ce2a-42e6-ba5a-e0efc20fcf69>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9defcee-e59f-43b8-a3ce-84ecb18a6b99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9defcee-e59f-43b8-a3ce-84ecb18a6b99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/995ddd80-3610-46da-a3f3-3646a27a5ece/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9defcee-e59f-43b8-a3ce-84ecb18a6b99>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e58c9a8-55ce-4b1c-9556-3aa792ba6371> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e58c9a8-55ce-4b1c-9556-3aa792ba6371";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/995ddd80-3610-46da-a3f3-3646a27a5ece/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e58c9a8-55ce-4b1c-9556-3aa792ba6371>.
+    
+<http://data.lblod.info/id/remote-data-objects/9aa1fb67-af91-45cd-9634-9f8e7874b57f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9aa1fb67-af91-45cd-9634-9f8e7874b57f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/9e209494-9da5-45a4-9e02-37a99741457e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9aa1fb67-af91-45cd-9634-9f8e7874b57f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0a28c94-05a5-4f6e-afe9-04419ea415f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0a28c94-05a5-4f6e-afe9-04419ea415f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/9e209494-9da5-45a4-9e02-37a99741457e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0a28c94-05a5-4f6e-afe9-04419ea415f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/01c6f887-fe00-4b54-90eb-9a75b0edf221> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01c6f887-fe00-4b54-90eb-9a75b0edf221";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/9e209494-9da5-45a4-9e02-37a99741457e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01c6f887-fe00-4b54-90eb-9a75b0edf221>.
+    
+<http://data.lblod.info/id/remote-data-objects/68d38547-1033-4e3f-a1ff-54869a23ff3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68d38547-1033-4e3f-a1ff-54869a23ff3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/af712eb3-1a37-43f8-b1b6-091d0a9fea46/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68d38547-1033-4e3f-a1ff-54869a23ff3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1515001-5530-4aac-add5-217eb1913953> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1515001-5530-4aac-add5-217eb1913953";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/af712eb3-1a37-43f8-b1b6-091d0a9fea46/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1515001-5530-4aac-add5-217eb1913953>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b9be608-4f8c-4692-b3e9-8a01205d32d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b9be608-4f8c-4692-b3e9-8a01205d32d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/af712eb3-1a37-43f8-b1b6-091d0a9fea46/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b9be608-4f8c-4692-b3e9-8a01205d32d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d3c3a56-e12c-486e-940b-9532ce63f2a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d3c3a56-e12c-486e-940b-9532ce63f2a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/f700403c-81d4-4df5-aa7a-e07a94bf7c7b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d3c3a56-e12c-486e-940b-9532ce63f2a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9338f537-af0d-4f9d-993f-c610b53ba149> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9338f537-af0d-4f9d-993f-c610b53ba149";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/f700403c-81d4-4df5-aa7a-e07a94bf7c7b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9338f537-af0d-4f9d-993f-c610b53ba149>.
+    
+<http://data.lblod.info/id/remote-data-objects/852ee543-901f-4958-9fa1-b7907603cf51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "852ee543-901f-4958-9fa1-b7907603cf51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/gr/f700403c-81d4-4df5-aa7a-e07a94bf7c7b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/852ee543-901f-4958-9fa1-b7907603cf51>.
+    
+<http://data.lblod.info/id/remote-data-objects/8adf5ced-7346-4a6a-b9e8-b73aa94a511f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8adf5ced-7346-4a6a-b9e8-b73aa94a511f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/09795852-b9a1-4389-b391-d4bac55627a0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8adf5ced-7346-4a6a-b9e8-b73aa94a511f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b3c1073-cc80-4d44-b23f-b3c18677a12b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b3c1073-cc80-4d44-b23f-b3c18677a12b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/09795852-b9a1-4389-b391-d4bac55627a0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b3c1073-cc80-4d44-b23f-b3c18677a12b>.
+    
+<http://data.lblod.info/id/remote-data-objects/063bc1e1-d7c4-4dff-844e-1d1035559484> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "063bc1e1-d7c4-4dff-844e-1d1035559484";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/09795852-b9a1-4389-b391-d4bac55627a0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/063bc1e1-d7c4-4dff-844e-1d1035559484>.
+    
+<http://data.lblod.info/id/remote-data-objects/7615fcf5-1fdb-4cca-b838-bb02fa603f1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7615fcf5-1fdb-4cca-b838-bb02fa603f1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/1066cf20-5e5e-4751-80e7-ca96564b6790/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7615fcf5-1fdb-4cca-b838-bb02fa603f1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a019af31-0c57-42e9-bf2d-60cf0f380e5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a019af31-0c57-42e9-bf2d-60cf0f380e5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/1066cf20-5e5e-4751-80e7-ca96564b6790/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a019af31-0c57-42e9-bf2d-60cf0f380e5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7bca77c-aaf0-4b48-8321-cd537e512584> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7bca77c-aaf0-4b48-8321-cd537e512584";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/1066cf20-5e5e-4751-80e7-ca96564b6790/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7bca77c-aaf0-4b48-8321-cd537e512584>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2cc1eb5-6b1b-41f0-80c8-acff597a5e06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2cc1eb5-6b1b-41f0-80c8-acff597a5e06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/11af86ca-527a-47b8-98ff-70985d9fbf0c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2cc1eb5-6b1b-41f0-80c8-acff597a5e06>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ca1f873-d878-4fa5-bf38-4edea4f99b94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ca1f873-d878-4fa5-bf38-4edea4f99b94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/11af86ca-527a-47b8-98ff-70985d9fbf0c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ca1f873-d878-4fa5-bf38-4edea4f99b94>.
+    
+<http://data.lblod.info/id/remote-data-objects/54dd0a7f-2ce4-4c81-a166-567536fd41f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54dd0a7f-2ce4-4c81-a166-567536fd41f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/11af86ca-527a-47b8-98ff-70985d9fbf0c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/54dd0a7f-2ce4-4c81-a166-567536fd41f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a045b8a7-8994-4771-8f11-0b3f9c63c4f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a045b8a7-8994-4771-8f11-0b3f9c63c4f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/140121e5-87ae-4684-b6ec-dbe6a8bd9db3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1dcddc75-9137-4677-9a61-4534c9aeae5c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a045b8a7-8994-4771-8f11-0b3f9c63c4f9>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201905-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201905-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201905-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201905-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/62e0cdd5-fbf3-4a07-9d2e-a0584ed34d5b> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "62e0cdd5-fbf3-4a07-9d2e-a0584ed34d5b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b786093d-1c52-4074-915b-f12ae8973e25";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/60c8478e-5ec3-4d8b-a973-059fd874cd68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "60c8478e-5ec3-4d8b-a973-059fd874cd68";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25>.
+
+  <http://redpencil.data.gift/id/task/a3f656bc-4946-4542-8b1d-5a7ee6a1f39f> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a3f656bc-4946-4542-8b1d-5a7ee6a1f39f";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/62e0cdd5-fbf3-4a07-9d2e-a0584ed34d5b>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/60c8478e-5ec3-4d8b-a973-059fd874cd68>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/38636d7a-67ca-43d5-80dd-97fb3f30f83c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38636d7a-67ca-43d5-80dd-97fb3f30f83c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/140121e5-87ae-4684-b6ec-dbe6a8bd9db3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38636d7a-67ca-43d5-80dd-97fb3f30f83c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5f41e0d-c153-45ed-82c7-3528e8f0efbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5f41e0d-c153-45ed-82c7-3528e8f0efbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/140121e5-87ae-4684-b6ec-dbe6a8bd9db3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5f41e0d-c153-45ed-82c7-3528e8f0efbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/d15b78e4-a8e0-40bf-8d71-009a39d0fbf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d15b78e4-a8e0-40bf-8d71-009a39d0fbf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/19218bfd-d410-48a2-b886-4bfc65f9cb40/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d15b78e4-a8e0-40bf-8d71-009a39d0fbf9>.
+    
+<http://data.lblod.info/id/remote-data-objects/91eb8fa4-5ce0-4471-8594-6779bb92371d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91eb8fa4-5ce0-4471-8594-6779bb92371d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/19218bfd-d410-48a2-b886-4bfc65f9cb40/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91eb8fa4-5ce0-4471-8594-6779bb92371d>.
+    
+<http://data.lblod.info/id/remote-data-objects/35cf20b7-21d8-4d65-bdde-b519c547114e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35cf20b7-21d8-4d65-bdde-b519c547114e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/19218bfd-d410-48a2-b886-4bfc65f9cb40/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35cf20b7-21d8-4d65-bdde-b519c547114e>.
+    
+<http://data.lblod.info/id/remote-data-objects/35e390ea-7935-4389-8cf0-7f0a70e7bd8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35e390ea-7935-4389-8cf0-7f0a70e7bd8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/1de7bd66-8db1-4c63-ad6f-1a9aeccf27a9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35e390ea-7935-4389-8cf0-7f0a70e7bd8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f46c5a18-4768-4386-8e28-30e0e215b6ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f46c5a18-4768-4386-8e28-30e0e215b6ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/1de7bd66-8db1-4c63-ad6f-1a9aeccf27a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f46c5a18-4768-4386-8e28-30e0e215b6ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/c502e357-4b5a-4a51-a24e-1c3fa905e100> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c502e357-4b5a-4a51-a24e-1c3fa905e100";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/1de7bd66-8db1-4c63-ad6f-1a9aeccf27a9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c502e357-4b5a-4a51-a24e-1c3fa905e100>.
+    
+<http://data.lblod.info/id/remote-data-objects/a34d4cc8-66cd-4498-8290-1fb55653d079> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a34d4cc8-66cd-4498-8290-1fb55653d079";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/43e130e0-0fce-4aae-ad3f-6488178288b7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a34d4cc8-66cd-4498-8290-1fb55653d079>.
+    
+<http://data.lblod.info/id/remote-data-objects/b308a762-d2a4-41d4-b2bd-75ad6d82dca4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b308a762-d2a4-41d4-b2bd-75ad6d82dca4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/43e130e0-0fce-4aae-ad3f-6488178288b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b308a762-d2a4-41d4-b2bd-75ad6d82dca4>.
+    
+<http://data.lblod.info/id/remote-data-objects/3124ecc0-5f24-4481-95c9-50f3aa77b952> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3124ecc0-5f24-4481-95c9-50f3aa77b952";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/43e130e0-0fce-4aae-ad3f-6488178288b7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3124ecc0-5f24-4481-95c9-50f3aa77b952>.
+    
+<http://data.lblod.info/id/remote-data-objects/e82d913b-1473-4b84-a661-92d43a9d89c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e82d913b-1473-4b84-a661-92d43a9d89c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/6c14d7ce-570c-47f1-8bea-864e2c20f19b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e82d913b-1473-4b84-a661-92d43a9d89c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5f10748-c9e7-455a-8fd9-56a422dbab8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5f10748-c9e7-455a-8fd9-56a422dbab8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/6c14d7ce-570c-47f1-8bea-864e2c20f19b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5f10748-c9e7-455a-8fd9-56a422dbab8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/24293fc3-a549-4cd3-8ab9-baff045dc3da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24293fc3-a549-4cd3-8ab9-baff045dc3da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/6c14d7ce-570c-47f1-8bea-864e2c20f19b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24293fc3-a549-4cd3-8ab9-baff045dc3da>.
+    
+<http://data.lblod.info/id/remote-data-objects/1795571b-fa94-433f-b47b-50d052d3f693> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1795571b-fa94-433f-b47b-50d052d3f693";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/6d4daee2-1828-498e-9c28-d6e1c39276bc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1795571b-fa94-433f-b47b-50d052d3f693>.
+    
+<http://data.lblod.info/id/remote-data-objects/95666948-c2de-46ca-8a46-3a12fc0b1f04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95666948-c2de-46ca-8a46-3a12fc0b1f04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/6d4daee2-1828-498e-9c28-d6e1c39276bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95666948-c2de-46ca-8a46-3a12fc0b1f04>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad47cb9e-5948-492c-8b5c-ccc4e2890a62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad47cb9e-5948-492c-8b5c-ccc4e2890a62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/6d4daee2-1828-498e-9c28-d6e1c39276bc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad47cb9e-5948-492c-8b5c-ccc4e2890a62>.
+    
+<http://data.lblod.info/id/remote-data-objects/a80212ee-d7ff-410c-950a-b1560678a3d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a80212ee-d7ff-410c-950a-b1560678a3d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/82bd1c24-357f-4149-939f-47c0a1099de9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a80212ee-d7ff-410c-950a-b1560678a3d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a56388c3-5052-4cc8-88f0-b261cd161e8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a56388c3-5052-4cc8-88f0-b261cd161e8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/82bd1c24-357f-4149-939f-47c0a1099de9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a56388c3-5052-4cc8-88f0-b261cd161e8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b31c6a45-fd34-4fbc-9536-a75c5e2bfd30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b31c6a45-fd34-4fbc-9536-a75c5e2bfd30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/82bd1c24-357f-4149-939f-47c0a1099de9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b31c6a45-fd34-4fbc-9536-a75c5e2bfd30>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc962f28-ba44-48dd-93e0-53685fed1bcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc962f28-ba44-48dd-93e0-53685fed1bcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/aa01903c-c727-4b42-9cb0-8836cc2d22cd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc962f28-ba44-48dd-93e0-53685fed1bcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b15e624-d0c6-4dfe-91f4-29c46cb0437e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b15e624-d0c6-4dfe-91f4-29c46cb0437e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/aa01903c-c727-4b42-9cb0-8836cc2d22cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b15e624-d0c6-4dfe-91f4-29c46cb0437e>.
+    
+<http://data.lblod.info/id/remote-data-objects/de64905e-42d4-4673-a8b2-4ffe4365649d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de64905e-42d4-4673-a8b2-4ffe4365649d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/aa01903c-c727-4b42-9cb0-8836cc2d22cd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de64905e-42d4-4673-a8b2-4ffe4365649d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e65b430-be68-4925-b3aa-3fcd0bcb853e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e65b430-be68-4925-b3aa-3fcd0bcb853e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/c39212eb-5131-4da4-a19b-743f3ee2be08/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e65b430-be68-4925-b3aa-3fcd0bcb853e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fcc8113-31de-473e-8791-7be6ad6127c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fcc8113-31de-473e-8791-7be6ad6127c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/c39212eb-5131-4da4-a19b-743f3ee2be08/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fcc8113-31de-473e-8791-7be6ad6127c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/660b549c-dfff-4a96-b8d2-952e980b7415> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "660b549c-dfff-4a96-b8d2-952e980b7415";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/da0c983d-bc61-47fb-98bc-b486e0ecd425/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/660b549c-dfff-4a96-b8d2-952e980b7415>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2f6120e-2c83-45d9-98ce-67e891d25e74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2f6120e-2c83-45d9-98ce-67e891d25e74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/da0c983d-bc61-47fb-98bc-b486e0ecd425/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2f6120e-2c83-45d9-98ce-67e891d25e74>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e6090d8-6442-4b15-b4e1-30c10d351a2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e6090d8-6442-4b15-b4e1-30c10d351a2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/da0c983d-bc61-47fb-98bc-b486e0ecd425/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e6090d8-6442-4b15-b4e1-30c10d351a2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2aa6f08-fd16-45ab-87c4-d685dff0984e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2aa6f08-fd16-45ab-87c4-d685dff0984e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/e8020ad5-3e05-4e14-a68c-a62565f39458/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2aa6f08-fd16-45ab-87c4-d685dff0984e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f959adc-1d74-4b4a-ba0b-d617c8666127> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f959adc-1d74-4b4a-ba0b-d617c8666127";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/e8020ad5-3e05-4e14-a68c-a62565f39458/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f959adc-1d74-4b4a-ba0b-d617c8666127>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d6e015c-fcec-494d-bb62-0f471f1d1b4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d6e015c-fcec-494d-bb62-0f471f1d1b4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/rmw/e8020ad5-3e05-4e14-a68c-a62565f39458/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d6e015c-fcec-494d-bb62-0f471f1d1b4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1025c7b8-3860-485e-a650-8e406d2f6067> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1025c7b8-3860-485e-a650-8e406d2f6067";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/0559e928-a02b-4a88-b309-7a1d03092db2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1025c7b8-3860-485e-a650-8e406d2f6067>.
+    
+<http://data.lblod.info/id/remote-data-objects/0327bc06-918f-46ca-ab8a-bb67b310baa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0327bc06-918f-46ca-ab8a-bb67b310baa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/0d431a01-c655-4176-89b6-ebaa75ef6827/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0327bc06-918f-46ca-ab8a-bb67b310baa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0afbe5a-56b7-4c43-8f4b-03e5a15464d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0afbe5a-56b7-4c43-8f4b-03e5a15464d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/159a1ea7-07ed-4083-a0c1-940230bfbc24/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0afbe5a-56b7-4c43-8f4b-03e5a15464d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/533e88e3-9ad6-48e9-b7f0-89953b41ec2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "533e88e3-9ad6-48e9-b7f0-89953b41ec2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/1734232f-ffed-4fbc-8bae-e98224ae130b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/533e88e3-9ad6-48e9-b7f0-89953b41ec2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f025cb35-764e-4dac-bae6-649f62159ef3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f025cb35-764e-4dac-bae6-649f62159ef3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/1d5f3f44-2834-4f36-88d0-bc83d5050b8c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f025cb35-764e-4dac-bae6-649f62159ef3>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4261f03-2646-4880-a43d-613a7c7c3587> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4261f03-2646-4880-a43d-613a7c7c3587";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/212f6205-5849-468a-82b8-3f6191f6711d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4261f03-2646-4880-a43d-613a7c7c3587>.
+    
+<http://data.lblod.info/id/remote-data-objects/34180681-59cc-4012-9979-d861ee77af94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34180681-59cc-4012-9979-d861ee77af94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/42b165c6-ed48-47fc-ab77-44332bb6ec66/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34180681-59cc-4012-9979-d861ee77af94>.
+    
+<http://data.lblod.info/id/remote-data-objects/8960eba8-436d-42aa-86dc-ce76ca6c5311> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8960eba8-436d-42aa-86dc-ce76ca6c5311";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/498f3b60-5bc0-4d75-84ed-a343876ced3a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8960eba8-436d-42aa-86dc-ce76ca6c5311>.
+    
+<http://data.lblod.info/id/remote-data-objects/5454d3b0-4b44-4c50-901d-0175d574e02a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5454d3b0-4b44-4c50-901d-0175d574e02a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/4b5cc6bc-3813-475f-a53b-69538b29d416/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5454d3b0-4b44-4c50-901d-0175d574e02a>.
+    
+<http://data.lblod.info/id/remote-data-objects/9929eead-3906-4a0f-bfb0-da6e0570a9d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9929eead-3906-4a0f-bfb0-da6e0570a9d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/7c99729c-9acf-46a4-a06d-1a0d74d3fba8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9929eead-3906-4a0f-bfb0-da6e0570a9d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb5e8a56-3b15-4bad-9eb3-144117d1c89c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb5e8a56-3b15-4bad-9eb3-144117d1c89c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/84084e5c-24e1-4379-8c1b-ca12df40ab3b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb5e8a56-3b15-4bad-9eb3-144117d1c89c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0048a407-27ff-461c-8784-6cbad09e493d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0048a407-27ff-461c-8784-6cbad09e493d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/84c2901d-7ddd-47ce-9424-9b09eff305dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0048a407-27ff-461c-8784-6cbad09e493d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0e1a4a8-5171-4656-8400-a0e72bca2c42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0e1a4a8-5171-4656-8400-a0e72bca2c42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/ad21393c-673b-40e9-908c-5be33fd4ac4a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0e1a4a8-5171-4656-8400-a0e72bca2c42>.
+    
+<http://data.lblod.info/id/remote-data-objects/3135519e-e163-4f18-a18c-97c67f1a98c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3135519e-e163-4f18-a18c-97c67f1a98c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/affe37df-aae2-40f8-b5e7-a1ce3e29752d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3135519e-e163-4f18-a18c-97c67f1a98c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8e9c62f-f44a-4f4f-ac7b-3c77c071b67e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8e9c62f-f44a-4f4f-ac7b-3c77c071b67e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/b85ca5e1-fa6f-4d71-a769-6882f6a8bf9e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8e9c62f-f44a-4f4f-ac7b-3c77c071b67e>.
+    
+<http://data.lblod.info/id/remote-data-objects/11b7e909-13a4-4ebe-bc6f-15f7649fe432> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11b7e909-13a4-4ebe-bc6f-15f7649fe432";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/ce77b1cd-ed17-4a21-920d-f7c3ccfafb50/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11b7e909-13a4-4ebe-bc6f-15f7649fe432>.
+    
+<http://data.lblod.info/id/remote-data-objects/75ce9e3f-2791-4fec-9da4-4d1113375583> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75ce9e3f-2791-4fec-9da4-4d1113375583";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/eff130cd-22b4-4434-8e91-c47574602806/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75ce9e3f-2791-4fec-9da4-4d1113375583>.
+    
+<http://data.lblod.info/id/remote-data-objects/50a6b3b9-267e-4644-871a-16b9b4ac7149> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50a6b3b9-267e-4644-871a-16b9b4ac7149";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ranst.meetingburger.net/vabu/ff3c9f69-19f6-4d8b-941d-b6e81de8f1a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50a6b3b9-267e-4644-871a-16b9b4ac7149>.
+    
+<http://data.lblod.info/id/remote-data-objects/61384c29-eead-4709-b7c4-5b7a4232d3b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61384c29-eead-4709-b7c4-5b7a4232d3b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/0ebd5750-3267-471a-a468-38dc21aea1ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/b786093d-1c52-4074-915b-f12ae8973e25> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61384c29-eead-4709-b7c4-5b7a4232d3b7>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201906-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201906-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201906-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201906-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d3079c08-1b32-48dc-b49b-cd27578f32a6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d3079c08-1b32-48dc-b49b-cd27578f32a6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2c86e30a-8fac-42d1-9c51-faa21976b732";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/255d834b-2b5c-413e-9e13-9303ab3e00a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "255d834b-2b5c-413e-9e13-9303ab3e00a2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732>.
+
+  <http://redpencil.data.gift/id/task/a0eae215-d1fe-4dbb-a44e-f4b027636476> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a0eae215-d1fe-4dbb-a44e-f4b027636476";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d3079c08-1b32-48dc-b49b-cd27578f32a6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/255d834b-2b5c-413e-9e13-9303ab3e00a2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b247f0d7-7622-4ee9-b920-5ee86fdb2d7f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b247f0d7-7622-4ee9-b920-5ee86fdb2d7f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/14666d4f-4097-4063-971b-53eaf514301c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b247f0d7-7622-4ee9-b920-5ee86fdb2d7f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef514309-3065-427d-9356-77569cf6177c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef514309-3065-427d-9356-77569cf6177c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/1670ce36-d5fd-4bbc-aa5b-a8b5e53dc23d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef514309-3065-427d-9356-77569cf6177c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7956506e-19f5-469c-b4c7-ff4c7c61f016> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7956506e-19f5-469c-b4c7-ff4c7c61f016";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/196f738a-1769-4545-89bf-548d7e1cd07b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7956506e-19f5-469c-b4c7-ff4c7c61f016>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb072d69-fcec-46a3-91b0-487f33f9c2eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb072d69-fcec-46a3-91b0-487f33f9c2eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/1ffb33d8-22c8-45d2-b1a3-af0da3541ef6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb072d69-fcec-46a3-91b0-487f33f9c2eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc9e558f-f4fa-4909-91b4-79ad9668ea02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc9e558f-f4fa-4909-91b4-79ad9668ea02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/237c5e4e-3e37-4850-85f9-f61db6c3a282/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc9e558f-f4fa-4909-91b4-79ad9668ea02>.
+    
+<http://data.lblod.info/id/remote-data-objects/a94e5d7e-575c-4d00-b3d1-6003d1322445> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a94e5d7e-575c-4d00-b3d1-6003d1322445";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/27d00140-beb9-4fd2-9ca4-e1986d7ab8d9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a94e5d7e-575c-4d00-b3d1-6003d1322445>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ab5986a-84ee-4618-b757-b0ce107cde34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ab5986a-84ee-4618-b757-b0ce107cde34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/2eba3ffb-8d2e-4d6d-a903-2e0214f35c8b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ab5986a-84ee-4618-b757-b0ce107cde34>.
+    
+<http://data.lblod.info/id/remote-data-objects/b762293d-5974-45cd-8c71-3146334b3e1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b762293d-5974-45cd-8c71-3146334b3e1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/32742684-de92-42d4-8c66-fc7050392b46/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b762293d-5974-45cd-8c71-3146334b3e1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/582acb75-2a41-4714-b299-3ecc757a15e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "582acb75-2a41-4714-b299-3ecc757a15e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/404675af-ead9-49e0-a421-26934112f7d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/582acb75-2a41-4714-b299-3ecc757a15e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4956d96a-d1e8-4a75-a314-a049334926d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4956d96a-d1e8-4a75-a314-a049334926d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/4a11632d-b3c4-431c-9870-7960505d9668/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4956d96a-d1e8-4a75-a314-a049334926d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/1310a4ee-4687-415f-8d9e-3bf75297cfa5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1310a4ee-4687-415f-8d9e-3bf75297cfa5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/4ed3dc47-17ce-4e15-9f7b-52d5b093e0d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1310a4ee-4687-415f-8d9e-3bf75297cfa5>.
+    
+<http://data.lblod.info/id/remote-data-objects/85bbfd50-e800-48f9-913c-dd21fdad0624> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85bbfd50-e800-48f9-913c-dd21fdad0624";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/51e0a6fd-a112-4cfa-bec7-eac298b5b32e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85bbfd50-e800-48f9-913c-dd21fdad0624>.
+    
+<http://data.lblod.info/id/remote-data-objects/23674a88-ee68-4574-a31b-f22e067b9b0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23674a88-ee68-4574-a31b-f22e067b9b0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/69a84d5c-7ff8-43e1-ae45-87c2048d03cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23674a88-ee68-4574-a31b-f22e067b9b0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/714aaed1-7439-40b9-b00f-883ed4964040> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "714aaed1-7439-40b9-b00f-883ed4964040";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/7049f961-2c7c-49af-a8bf-4a487f03b516/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/714aaed1-7439-40b9-b00f-883ed4964040>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8c683a5-93a9-4aae-aa93-ac71888c0d59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8c683a5-93a9-4aae-aa93-ac71888c0d59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/830f7be7-3d09-47a0-9824-31385eb34277/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8c683a5-93a9-4aae-aa93-ac71888c0d59>.
+    
+<http://data.lblod.info/id/remote-data-objects/11f5bf4d-5dd2-4f5b-8a8d-5c340f181ec7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11f5bf4d-5dd2-4f5b-8a8d-5c340f181ec7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/87660e97-b0bb-4fa2-8f65-75ad4f6b8e8d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11f5bf4d-5dd2-4f5b-8a8d-5c340f181ec7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b002644-e368-4d8b-8f28-a0b2ec49dae8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b002644-e368-4d8b-8f28-a0b2ec49dae8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/8bed2e02-e20e-4c58-bba2-168068fcdfed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b002644-e368-4d8b-8f28-a0b2ec49dae8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3f3cfa6-8471-4938-801f-d9dbc982ad3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3f3cfa6-8471-4938-801f-d9dbc982ad3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/9f46376c-f835-4de9-ad51-817e8af9bd96/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3f3cfa6-8471-4938-801f-d9dbc982ad3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e271b7f8-1350-4d5f-b18b-f8b5f65a142c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e271b7f8-1350-4d5f-b18b-f8b5f65a142c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/af9b3e1a-c440-4257-be38-dfc4ffa40d03/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e271b7f8-1350-4d5f-b18b-f8b5f65a142c>.
+    
+<http://data.lblod.info/id/remote-data-objects/72121318-96d5-4847-944d-f3cf54b269af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72121318-96d5-4847-944d-f3cf54b269af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/bc37b6db-b69f-4cd6-b504-5e9b9323c76b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72121318-96d5-4847-944d-f3cf54b269af>.
+    
+<http://data.lblod.info/id/remote-data-objects/e74acbd3-729d-4398-9347-d463713e95e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e74acbd3-729d-4398-9347-d463713e95e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/ca2d2c57-a002-4eb4-a038-b2f28c67a8eb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e74acbd3-729d-4398-9347-d463713e95e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/da4b6aa2-620d-421d-b8c8-6098c5b2bc26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da4b6aa2-620d-421d-b8c8-6098c5b2bc26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/d5badfcd-2246-4c4f-bfcb-88560688a77f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da4b6aa2-620d-421d-b8c8-6098c5b2bc26>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7873658-5fe9-4625-b98b-1444c3cc543b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7873658-5fe9-4625-b98b-1444c3cc543b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/d98658c2-773b-4243-a102-cb86357c06ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7873658-5fe9-4625-b98b-1444c3cc543b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7207686d-25e9-4564-977d-0676e693407f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7207686d-25e9-4564-977d-0676e693407f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/eba295be-4cc8-4a9c-870b-6ee668e5b137/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7207686d-25e9-4564-977d-0676e693407f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8632d7a-1b53-475a-96e9-14e534dee73f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8632d7a-1b53-475a-96e9-14e534dee73f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/bb/f4617695-1146-4106-846b-39e0d9c43387/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8632d7a-1b53-475a-96e9-14e534dee73f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e29de8b1-93ef-4451-961e-a758eb3000e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e29de8b1-93ef-4451-961e-a758eb3000e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/00621fa4-687f-4ee2-b1d8-eaa4792f2dd2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e29de8b1-93ef-4451-961e-a758eb3000e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ae494a9-2523-4bdf-9be2-2130cf8cdeca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ae494a9-2523-4bdf-9be2-2130cf8cdeca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/06ce6d24-642f-4c6e-8df1-e5ae5b8a8a0e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ae494a9-2523-4bdf-9be2-2130cf8cdeca>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cf3f012-fdb2-4ec4-b541-4afe4212baa7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cf3f012-fdb2-4ec4-b541-4afe4212baa7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/0b96ed79-37c6-46c5-9b77-89cc5784801e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cf3f012-fdb2-4ec4-b541-4afe4212baa7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0365986-daec-4364-84b7-78ed24ed9c22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0365986-daec-4364-84b7-78ed24ed9c22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/1d60ae6c-b874-4cc2-ae7b-1260ef85d0b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0365986-daec-4364-84b7-78ed24ed9c22>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed15e45a-6312-4508-a652-c2234be4b684> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed15e45a-6312-4508-a652-c2234be4b684";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/26e622a4-f274-4723-9960-e279ed289a2d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed15e45a-6312-4508-a652-c2234be4b684>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ca388ea-39dc-4c68-a308-ee9fda6f8a2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ca388ea-39dc-4c68-a308-ee9fda6f8a2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/292e7e0f-4810-459c-a23b-3a199de957f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ca388ea-39dc-4c68-a308-ee9fda6f8a2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/82e50059-c69f-4f0d-930e-2cdebd3faeab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82e50059-c69f-4f0d-930e-2cdebd3faeab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/362c7705-d9ad-41ea-b1b8-0ee9f46d53e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82e50059-c69f-4f0d-930e-2cdebd3faeab>.
+    
+<http://data.lblod.info/id/remote-data-objects/27a1d401-a29f-452c-85a6-ed24df58397b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27a1d401-a29f-452c-85a6-ed24df58397b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/36fc6a1a-586e-48ed-bb22-3b611ab70509/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27a1d401-a29f-452c-85a6-ed24df58397b>.
+    
+<http://data.lblod.info/id/remote-data-objects/aea243be-ca62-48d5-99c3-ff0204bb53e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aea243be-ca62-48d5-99c3-ff0204bb53e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/45038b78-b8f2-472f-a525-be7cea7265d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aea243be-ca62-48d5-99c3-ff0204bb53e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2adca3d2-3f1e-45be-9410-782bf5bb855e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2adca3d2-3f1e-45be-9410-782bf5bb855e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/46244301-e884-4e5f-b732-fae4c99c3af6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2adca3d2-3f1e-45be-9410-782bf5bb855e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e541c6e-e3e0-46ca-b7f6-5bbd12ac848f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e541c6e-e3e0-46ca-b7f6-5bbd12ac848f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/468e3e1b-e7f0-4402-bba1-e0f673bc0d1f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e541c6e-e3e0-46ca-b7f6-5bbd12ac848f>.
+    
+<http://data.lblod.info/id/remote-data-objects/43550b06-d783-4197-aa86-8c12cdf8e393> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43550b06-d783-4197-aa86-8c12cdf8e393";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/46a0de30-4f86-4422-9ced-5a0349343556/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43550b06-d783-4197-aa86-8c12cdf8e393>.
+    
+<http://data.lblod.info/id/remote-data-objects/df189e7d-b7cc-46d8-866a-b5cac38e4fd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df189e7d-b7cc-46d8-866a-b5cac38e4fd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/482d0521-5849-4e0b-acbd-45a452d3ca56/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df189e7d-b7cc-46d8-866a-b5cac38e4fd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8288532-7a3a-4840-8100-cb74f4b096be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8288532-7a3a-4840-8100-cb74f4b096be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/49bd6543-2a99-43b1-83c2-6cdd551085a2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8288532-7a3a-4840-8100-cb74f4b096be>.
+    
+<http://data.lblod.info/id/remote-data-objects/a368710e-7b60-47e7-b7cf-78f1f23d3ac5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a368710e-7b60-47e7-b7cf-78f1f23d3ac5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/4b0cd1c8-7609-4db9-b0e2-8a1d6f5ec3dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a368710e-7b60-47e7-b7cf-78f1f23d3ac5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0629a6f-a2c8-4442-a7cb-6e23916e4b5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0629a6f-a2c8-4442-a7cb-6e23916e4b5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/5ac6fe38-e905-4360-a6f4-97f6bdba17be/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0629a6f-a2c8-4442-a7cb-6e23916e4b5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e842e41-1f4e-4489-a404-d3c2aa6a66b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e842e41-1f4e-4489-a404-d3c2aa6a66b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/5d1994ba-7267-4c5c-9a04-e9ea9b253622/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e842e41-1f4e-4489-a404-d3c2aa6a66b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/958c350d-7158-4fa5-a6a9-4fa6dc2d0bf5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "958c350d-7158-4fa5-a6a9-4fa6dc2d0bf5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/629f4805-3cd6-449a-bf09-1db1efe71227/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/958c350d-7158-4fa5-a6a9-4fa6dc2d0bf5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d7f8979-d237-48a4-b775-fdaead3e3432> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d7f8979-d237-48a4-b775-fdaead3e3432";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/715be27e-17ed-4a0a-8583-b2478e5a4ffb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d7f8979-d237-48a4-b775-fdaead3e3432>.
+    
+<http://data.lblod.info/id/remote-data-objects/711df613-cf28-4fec-b60b-5b42b4a96c97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "711df613-cf28-4fec-b60b-5b42b4a96c97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/76958bfd-65f0-4eaa-bcc4-1634270ba631/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/711df613-cf28-4fec-b60b-5b42b4a96c97>.
+    
+<http://data.lblod.info/id/remote-data-objects/e929cd15-7adc-444f-9171-bce27a9a3ba2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e929cd15-7adc-444f-9171-bce27a9a3ba2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/7acb5e92-ba4a-4c9d-8c03-024d6cd2a298/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e929cd15-7adc-444f-9171-bce27a9a3ba2>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b29ee35-0b01-4b79-ace2-5737e7e46226> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b29ee35-0b01-4b79-ace2-5737e7e46226";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/81481975-08b6-448b-818b-f2d882a007f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b29ee35-0b01-4b79-ace2-5737e7e46226>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd1bd819-69dc-4610-8ea4-070c06061345> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd1bd819-69dc-4610-8ea4-070c06061345";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/83a2673b-e945-400e-9660-6b754686ec53/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd1bd819-69dc-4610-8ea4-070c06061345>.
+    
+<http://data.lblod.info/id/remote-data-objects/66e9dd55-94a8-4ec5-909d-f0bc5e02c2c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66e9dd55-94a8-4ec5-909d-f0bc5e02c2c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/866bc55a-cfd4-44c6-82ad-4867c6be1f81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66e9dd55-94a8-4ec5-909d-f0bc5e02c2c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/223f2893-f8b0-426a-9221-a759d219adbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "223f2893-f8b0-426a-9221-a759d219adbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/8a170b9c-489e-42de-bf0a-58a0559074e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:06.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2c86e30a-8fac-42d1-9c51-faa21976b732> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/223f2893-f8b0-426a-9221-a759d219adbc>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201908-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201908-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201908-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201908-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2e288441-58ba-4d15-80f4-8b89eb268198> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2e288441-58ba-4d15-80f4-8b89eb268198";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9660c981-7148-4736-b45d-bdc8ae0e831e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9660c981-7148-4736-b45d-bdc8ae0e831e";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1>.
+
+  <http://redpencil.data.gift/id/task/e9640675-3120-404d-9d21-5757def6edf4> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e9640675-3120-404d-9d21-5757def6edf4";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2e288441-58ba-4d15-80f4-8b89eb268198>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9660c981-7148-4736-b45d-bdc8ae0e831e>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c9202637-44c1-4cd1-974d-318ee6b939bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9202637-44c1-4cd1-974d-318ee6b939bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/8cd7bb29-b4b3-4bf1-8dfd-9ee67c01d057/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9202637-44c1-4cd1-974d-318ee6b939bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a5bab08-ed66-4ae4-896f-77e0eb5af62f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a5bab08-ed66-4ae4-896f-77e0eb5af62f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/8fab8873-24a6-40de-ae2e-487f7c14365b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a5bab08-ed66-4ae4-896f-77e0eb5af62f>.
+    
+<http://data.lblod.info/id/remote-data-objects/59c4a829-7e26-4f9d-9d6f-8a782f24a247> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59c4a829-7e26-4f9d-9d6f-8a782f24a247";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/98c23fa5-3895-4e14-a328-45dbb0880637/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59c4a829-7e26-4f9d-9d6f-8a782f24a247>.
+    
+<http://data.lblod.info/id/remote-data-objects/30327720-1f48-4a84-887b-f028337db4ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30327720-1f48-4a84-887b-f028337db4ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/995c565d-44aa-4614-be5f-5640b172630d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30327720-1f48-4a84-887b-f028337db4ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd1a0974-df0f-4ff7-ac4e-e03dc8e61469> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd1a0974-df0f-4ff7-ac4e-e03dc8e61469";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/9b9dcbe5-f177-4098-b1ac-f9fcda60578c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd1a0974-df0f-4ff7-ac4e-e03dc8e61469>.
+    
+<http://data.lblod.info/id/remote-data-objects/edb8f509-fc71-4498-8847-963c9138dfb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edb8f509-fc71-4498-8847-963c9138dfb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/9e96e69a-539f-4cd6-bdef-f0327ebb7ac0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edb8f509-fc71-4498-8847-963c9138dfb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ced407f3-dd6d-4ca4-9db8-dab9fb12e6ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ced407f3-dd6d-4ca4-9db8-dab9fb12e6ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/9f2d0fc9-f8ee-4237-b31d-21a95e1ca748/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ced407f3-dd6d-4ca4-9db8-dab9fb12e6ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cb12f39-3d5b-4c83-a677-a5907b354c02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cb12f39-3d5b-4c83-a677-a5907b354c02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/9fe5c518-de49-4ddd-a4c8-e56743e74180/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cb12f39-3d5b-4c83-a677-a5907b354c02>.
+    
+<http://data.lblod.info/id/remote-data-objects/71851eee-ad2f-4399-a732-c714e40aa4e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71851eee-ad2f-4399-a732-c714e40aa4e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/a06d6b83-ecfa-4f22-9be5-060eb6361066/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71851eee-ad2f-4399-a732-c714e40aa4e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a964232-2537-413d-8c21-cb5888145bbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a964232-2537-413d-8c21-cb5888145bbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/a27461c6-a899-47b5-a43b-41a697fcedb2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a964232-2537-413d-8c21-cb5888145bbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffef2aad-b3d7-4522-b0fd-31094e546457> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffef2aad-b3d7-4522-b0fd-31094e546457";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/a4c51cac-2189-403e-9601-aceb54ac53d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffef2aad-b3d7-4522-b0fd-31094e546457>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b71c081-0bf2-4576-bbc8-434c9403a501> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b71c081-0bf2-4576-bbc8-434c9403a501";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/a5352444-3f16-4bb2-bcc9-cf7c8cc344fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b71c081-0bf2-4576-bbc8-434c9403a501>.
+    
+<http://data.lblod.info/id/remote-data-objects/51b81ecf-a924-4356-997c-45ee896f4ef9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51b81ecf-a924-4356-997c-45ee896f4ef9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/a5acbe11-eeb7-4be6-8920-1ff5547e07af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51b81ecf-a924-4356-997c-45ee896f4ef9>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e80e1b1-d241-436a-96a5-69b3f7517abd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e80e1b1-d241-436a-96a5-69b3f7517abd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/ac136016-e47d-4a36-be00-8a3e55ef76cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e80e1b1-d241-436a-96a5-69b3f7517abd>.
+    
+<http://data.lblod.info/id/remote-data-objects/2848570a-f79b-4947-a763-7193c1482da8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2848570a-f79b-4947-a763-7193c1482da8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/b08a26ea-79dd-4076-b481-3625b033da07/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2848570a-f79b-4947-a763-7193c1482da8>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e4d4b78-071d-44f8-ae81-98e54e3b199b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e4d4b78-071d-44f8-ae81-98e54e3b199b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/b8d25a25-51ac-4d3e-b923-e15b6d69c140/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e4d4b78-071d-44f8-ae81-98e54e3b199b>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa7caee0-f5e1-4c15-bf50-48524a59aacd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa7caee0-f5e1-4c15-bf50-48524a59aacd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/bcbee4ba-1479-41a4-ba01-99cde5eab9f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa7caee0-f5e1-4c15-bf50-48524a59aacd>.
+    
+<http://data.lblod.info/id/remote-data-objects/25f5a159-6345-4f65-88a0-b990049cc0db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25f5a159-6345-4f65-88a0-b990049cc0db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/c0159a58-67df-4886-bfe7-010028745bf7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25f5a159-6345-4f65-88a0-b990049cc0db>.
+    
+<http://data.lblod.info/id/remote-data-objects/755ae5cc-6fc5-40da-834c-05a90f8cc5f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "755ae5cc-6fc5-40da-834c-05a90f8cc5f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/cbaad6e7-8e2c-4359-a895-0ed42a5e0998/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/755ae5cc-6fc5-40da-834c-05a90f8cc5f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea959884-0195-4ffd-ae25-b4b5c75d5086> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea959884-0195-4ffd-ae25-b4b5c75d5086";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/cbfa5a43-9e50-49fd-9a45-87b39977ef89/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea959884-0195-4ffd-ae25-b4b5c75d5086>.
+    
+<http://data.lblod.info/id/remote-data-objects/01a8f20f-1403-46b0-83ff-9861ce6c5019> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01a8f20f-1403-46b0-83ff-9861ce6c5019";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/cdffc431-5977-4b1e-b41c-203bfc7d55a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01a8f20f-1403-46b0-83ff-9861ce6c5019>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a6f1c69-cefa-458d-bb49-a68065e55593> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a6f1c69-cefa-458d-bb49-a68065e55593";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/ce3d8803-9450-4ab2-a96d-d3d042f31817/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a6f1c69-cefa-458d-bb49-a68065e55593>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdb71d6e-eb1e-41b0-b015-3ce9c964bea8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdb71d6e-eb1e-41b0-b015-3ce9c964bea8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/d0aa4f39-172e-451f-9b89-ac3bb8664e1c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdb71d6e-eb1e-41b0-b015-3ce9c964bea8>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd6a7f88-cab9-404c-9d07-fc6d8ce6d25a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd6a7f88-cab9-404c-9d07-fc6d8ce6d25a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/d28aa7f6-9731-48cd-a864-d4bc5f146de2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd6a7f88-cab9-404c-9d07-fc6d8ce6d25a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b311d4cc-cac8-43b3-ab08-a827560a42ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b311d4cc-cac8-43b3-ab08-a827560a42ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/e2f3c646-4bfc-46aa-9d7e-21402126fe61/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b311d4cc-cac8-43b3-ab08-a827560a42ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/c195ea82-b101-4b8e-913d-e41ed63541d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c195ea82-b101-4b8e-913d-e41ed63541d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/e82b6bd2-06c2-47de-ad1d-caca65286682/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c195ea82-b101-4b8e-913d-e41ed63541d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d22af9b1-cb9b-40cc-9ee9-d859c1540e44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d22af9b1-cb9b-40cc-9ee9-d859c1540e44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/ee76aef5-850b-43cf-a172-8725559b7bb1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d22af9b1-cb9b-40cc-9ee9-d859c1540e44>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cb6c795-aac6-41f3-9ce6-67388e598b21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cb6c795-aac6-41f3-9ce6-67388e598b21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/f65110b8-8192-4c95-ba88-c009c926381a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cb6c795-aac6-41f3-9ce6-67388e598b21>.
+    
+<http://data.lblod.info/id/remote-data-objects/e94d81cf-5f8c-46af-bc50-91df1cd090d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e94d81cf-5f8c-46af-bc50-91df1cd090d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/f77af704-676c-4804-a080-0fe9072b8d4d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e94d81cf-5f8c-46af-bc50-91df1cd090d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ef970cc-c8cd-4101-84e2-dbacefa5cd65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ef970cc-c8cd-4101-84e2-dbacefa5cd65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/f95a9937-28c9-4df4-af53-bc185ecb7fff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ef970cc-c8cd-4101-84e2-dbacefa5cd65>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cd4e732-7b64-4b8f-a533-d60779dd6a4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cd4e732-7b64-4b8f-a533-d60779dd6a4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/fb0d780d-4e28-4c26-9223-b4c562c7d8fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cd4e732-7b64-4b8f-a533-d60779dd6a4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c475ac1-2cb6-45df-865d-2d9937a18548> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c475ac1-2cb6-45df-865d-2d9937a18548";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/fd153478-af0d-41c6-9caf-13b3360e68a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c475ac1-2cb6-45df-865d-2d9937a18548>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2ae7f76-7b3d-4f1f-8f4b-cb97fa93b1e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2ae7f76-7b3d-4f1f-8f4b-cb97fa93b1e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/cbs/fefbfb4f-f9a3-4adb-88cd-5adb18c2fc7b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2ae7f76-7b3d-4f1f-8f4b-cb97fa93b1e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/115d3772-8f72-4807-ab4b-56109326e754> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "115d3772-8f72-4807-ab4b-56109326e754";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/0e08f303-9bc1-4092-a988-4b54a809a8c5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/115d3772-8f72-4807-ab4b-56109326e754>.
+    
+<http://data.lblod.info/id/remote-data-objects/2eaa1d61-ff25-48b2-8854-57d40e512231> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2eaa1d61-ff25-48b2-8854-57d40e512231";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/0e08f303-9bc1-4092-a988-4b54a809a8c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2eaa1d61-ff25-48b2-8854-57d40e512231>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b6223b4-ad24-44b7-b7a4-21dd817851f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b6223b4-ad24-44b7-b7a4-21dd817851f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/0e08f303-9bc1-4092-a988-4b54a809a8c5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b6223b4-ad24-44b7-b7a4-21dd817851f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/39af0243-b6be-47c1-9229-7489397b0055> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39af0243-b6be-47c1-9229-7489397b0055";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/10123878-e804-4a31-a7dd-7c9545d6aa77/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39af0243-b6be-47c1-9229-7489397b0055>.
+    
+<http://data.lblod.info/id/remote-data-objects/d124c631-8d79-496b-a9c2-9603c37d3725> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d124c631-8d79-496b-a9c2-9603c37d3725";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/10123878-e804-4a31-a7dd-7c9545d6aa77/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d124c631-8d79-496b-a9c2-9603c37d3725>.
+    
+<http://data.lblod.info/id/remote-data-objects/e186b28e-1757-43f8-acac-1744933ff174> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e186b28e-1757-43f8-acac-1744933ff174";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/10123878-e804-4a31-a7dd-7c9545d6aa77/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e186b28e-1757-43f8-acac-1744933ff174>.
+    
+<http://data.lblod.info/id/remote-data-objects/be3408ce-503e-404e-be92-a2935940b981> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be3408ce-503e-404e-be92-a2935940b981";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/18023faf-1877-4f55-a0c9-e1171bb7740f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be3408ce-503e-404e-be92-a2935940b981>.
+    
+<http://data.lblod.info/id/remote-data-objects/76a76999-9b7d-4acb-9cba-eb614ea43d9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76a76999-9b7d-4acb-9cba-eb614ea43d9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/18023faf-1877-4f55-a0c9-e1171bb7740f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76a76999-9b7d-4acb-9cba-eb614ea43d9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8fd932b-bba4-4010-bafd-76e11bc665c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8fd932b-bba4-4010-bafd-76e11bc665c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/18023faf-1877-4f55-a0c9-e1171bb7740f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8fd932b-bba4-4010-bafd-76e11bc665c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f778ba15-9d53-4361-97b8-222b28a3d354> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f778ba15-9d53-4361-97b8-222b28a3d354";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/288653c4-258f-4bcc-8ec6-68b237384251/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f778ba15-9d53-4361-97b8-222b28a3d354>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6782ad5-0d43-409d-b36b-f08470da96f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6782ad5-0d43-409d-b36b-f08470da96f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/288653c4-258f-4bcc-8ec6-68b237384251/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6782ad5-0d43-409d-b36b-f08470da96f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5aafa5cc-f978-40ae-ac7d-bf3c0fe0008f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5aafa5cc-f978-40ae-ac7d-bf3c0fe0008f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/288653c4-258f-4bcc-8ec6-68b237384251/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5aafa5cc-f978-40ae-ac7d-bf3c0fe0008f>.
+    
+<http://data.lblod.info/id/remote-data-objects/82fa21e5-6a1e-44c3-8f4b-5c03a0e9b807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82fa21e5-6a1e-44c3-8f4b-5c03a0e9b807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/2b721e72-c878-4a58-8845-448a3b1890cc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82fa21e5-6a1e-44c3-8f4b-5c03a0e9b807>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9e1578b-694b-4d1c-b8c3-bf5e1ee97c7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9e1578b-694b-4d1c-b8c3-bf5e1ee97c7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/2b721e72-c878-4a58-8845-448a3b1890cc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9e1578b-694b-4d1c-b8c3-bf5e1ee97c7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/11e9a6b9-e545-4a86-bccb-ba08ff785c2b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11e9a6b9-e545-4a86-bccb-ba08ff785c2b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/2b721e72-c878-4a58-8845-448a3b1890cc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11e9a6b9-e545-4a86-bccb-ba08ff785c2b>.
+    
+<http://data.lblod.info/id/remote-data-objects/adbe251b-f459-4d4e-b3c5-e05e904913c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "adbe251b-f459-4d4e-b3c5-e05e904913c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/2ea73675-0053-4206-8915-ac835c30fb6a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/adbe251b-f459-4d4e-b3c5-e05e904913c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/48ba5f1d-671e-4491-9d8b-4492ea1fedb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48ba5f1d-671e-4491-9d8b-4492ea1fedb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/2ea73675-0053-4206-8915-ac835c30fb6a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:08.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c6f6fd35-cdaa-4ea6-afdc-17af2ee1eee1> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48ba5f1d-671e-4491-9d8b-4492ea1fedb5>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201909-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201909-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201909-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201909-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2019629a-0c32-4128-872c-769ef7d8d8aa> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2019629a-0c32-4128-872c-769ef7d8d8aa";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2f08a582-4f9e-4ad2-89af-8f14edca10f4";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/5863a74d-af4d-4c7b-ba22-96ed777a9f09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5863a74d-af4d-4c7b-ba22-96ed777a9f09";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4>.
+
+  <http://redpencil.data.gift/id/task/bf28e207-e09e-4f52-9004-6ed46c667a86> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bf28e207-e09e-4f52-9004-6ed46c667a86";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2019629a-0c32-4128-872c-769ef7d8d8aa>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/5863a74d-af4d-4c7b-ba22-96ed777a9f09>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/37bee2e5-e76f-4a0a-9925-62b3e4ecd4b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37bee2e5-e76f-4a0a-9925-62b3e4ecd4b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/2ea73675-0053-4206-8915-ac835c30fb6a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37bee2e5-e76f-4a0a-9925-62b3e4ecd4b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2e14291-36d2-4f73-9885-5db8be09a180> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2e14291-36d2-4f73-9885-5db8be09a180";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/3caa16f6-4018-43e8-ad3c-12449ebae42d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2e14291-36d2-4f73-9885-5db8be09a180>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f925a7f-4514-402f-b30d-dfc2e51f0da8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f925a7f-4514-402f-b30d-dfc2e51f0da8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/3caa16f6-4018-43e8-ad3c-12449ebae42d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f925a7f-4514-402f-b30d-dfc2e51f0da8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9784943-d69c-4e65-8bc4-bcb307620f89> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9784943-d69c-4e65-8bc4-bcb307620f89";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/3caa16f6-4018-43e8-ad3c-12449ebae42d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9784943-d69c-4e65-8bc4-bcb307620f89>.
+    
+<http://data.lblod.info/id/remote-data-objects/e38d7665-f57e-42f1-990f-465c02699cca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e38d7665-f57e-42f1-990f-465c02699cca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/60e0c388-dd4f-4798-a863-e80f81b2c478/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e38d7665-f57e-42f1-990f-465c02699cca>.
+    
+<http://data.lblod.info/id/remote-data-objects/20f574e3-424d-45ac-8433-b34ae85029af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20f574e3-424d-45ac-8433-b34ae85029af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/60e0c388-dd4f-4798-a863-e80f81b2c478/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20f574e3-424d-45ac-8433-b34ae85029af>.
+    
+<http://data.lblod.info/id/remote-data-objects/64da01b3-928b-4d1f-ad11-bfc17a0c8cee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64da01b3-928b-4d1f-ad11-bfc17a0c8cee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/8e4931b9-b2a0-4916-8be7-12311bcfe36a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64da01b3-928b-4d1f-ad11-bfc17a0c8cee>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8551600-8b75-42b8-8e4a-e1d1c6061914> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8551600-8b75-42b8-8e4a-e1d1c6061914";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/8e4931b9-b2a0-4916-8be7-12311bcfe36a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8551600-8b75-42b8-8e4a-e1d1c6061914>.
+    
+<http://data.lblod.info/id/remote-data-objects/71dd3c0f-aa7b-422a-b6fd-414b9e9468be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71dd3c0f-aa7b-422a-b6fd-414b9e9468be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/8e4931b9-b2a0-4916-8be7-12311bcfe36a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71dd3c0f-aa7b-422a-b6fd-414b9e9468be>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb5be796-f4ac-447c-80b8-e025ae3f1673> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb5be796-f4ac-447c-80b8-e025ae3f1673";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/a13606eb-d964-45fe-95c5-cccb3a938274/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb5be796-f4ac-447c-80b8-e025ae3f1673>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfa2e6e4-9f5a-4499-9304-2b79d590f1e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfa2e6e4-9f5a-4499-9304-2b79d590f1e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/a13606eb-d964-45fe-95c5-cccb3a938274/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfa2e6e4-9f5a-4499-9304-2b79d590f1e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/17ba48cc-07b2-4b3b-8178-9c7dfc68b4c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17ba48cc-07b2-4b3b-8178-9c7dfc68b4c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/a13606eb-d964-45fe-95c5-cccb3a938274/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17ba48cc-07b2-4b3b-8178-9c7dfc68b4c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/5685ebc7-67ba-42da-9d78-9fc253d2967e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5685ebc7-67ba-42da-9d78-9fc253d2967e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/a750fdbd-ae58-46d1-a731-1be12d89ea32/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5685ebc7-67ba-42da-9d78-9fc253d2967e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d00bb534-0027-4b80-bb18-c35119312092> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d00bb534-0027-4b80-bb18-c35119312092";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/a750fdbd-ae58-46d1-a731-1be12d89ea32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d00bb534-0027-4b80-bb18-c35119312092>.
+    
+<http://data.lblod.info/id/remote-data-objects/144f8e58-3f99-4f88-84b1-4beb1bba20a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "144f8e58-3f99-4f88-84b1-4beb1bba20a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/a750fdbd-ae58-46d1-a731-1be12d89ea32/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/144f8e58-3f99-4f88-84b1-4beb1bba20a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbe865b0-9878-4333-9f20-b0a817e25868> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbe865b0-9878-4333-9f20-b0a817e25868";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/a97d74dc-495c-4190-9988-855e4e20022e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbe865b0-9878-4333-9f20-b0a817e25868>.
+    
+<http://data.lblod.info/id/remote-data-objects/091df6ae-39ca-4bd7-b01e-0498e2783c41> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "091df6ae-39ca-4bd7-b01e-0498e2783c41";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/a97d74dc-495c-4190-9988-855e4e20022e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/091df6ae-39ca-4bd7-b01e-0498e2783c41>.
+    
+<http://data.lblod.info/id/remote-data-objects/eccebcb5-0da3-4905-b728-54ad277e67b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eccebcb5-0da3-4905-b728-54ad277e67b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/a97d74dc-495c-4190-9988-855e4e20022e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eccebcb5-0da3-4905-b728-54ad277e67b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/f635efcb-543f-4b3f-930c-aa0f8d8d0402> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f635efcb-543f-4b3f-930c-aa0f8d8d0402";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/c332d825-a2f0-45a4-abcd-a3002d4539e5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f635efcb-543f-4b3f-930c-aa0f8d8d0402>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef9d6d8b-7a23-44e4-acda-cdf6ad5bca96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef9d6d8b-7a23-44e4-acda-cdf6ad5bca96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/c332d825-a2f0-45a4-abcd-a3002d4539e5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef9d6d8b-7a23-44e4-acda-cdf6ad5bca96>.
+    
+<http://data.lblod.info/id/remote-data-objects/25fbd02c-d1bd-493c-a037-20cab1b3f7c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25fbd02c-d1bd-493c-a037-20cab1b3f7c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/c332d825-a2f0-45a4-abcd-a3002d4539e5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25fbd02c-d1bd-493c-a037-20cab1b3f7c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1beed9b-3eca-4bdd-bf5c-7fed24ae76c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1beed9b-3eca-4bdd-bf5c-7fed24ae76c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/fa1da903-e03c-4f70-9e5f-02a266ad76d8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1beed9b-3eca-4bdd-bf5c-7fed24ae76c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6d94761-92a1-4b57-b297-b0d7db42bb67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6d94761-92a1-4b57-b297-b0d7db42bb67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/fa1da903-e03c-4f70-9e5f-02a266ad76d8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6d94761-92a1-4b57-b297-b0d7db42bb67>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2707f26-9227-49a8-aa91-ff6070b686b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2707f26-9227-49a8-aa91-ff6070b686b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/fa1da903-e03c-4f70-9e5f-02a266ad76d8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2707f26-9227-49a8-aa91-ff6070b686b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/87186983-8821-4350-9dd2-f2803b725bbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87186983-8821-4350-9dd2-f2803b725bbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/fd430bf2-3c8a-4a20-b76c-5dadc22c3a83/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87186983-8821-4350-9dd2-f2803b725bbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/589954b0-7e97-4d85-9c8a-d8a27aad0350> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "589954b0-7e97-4d85-9c8a-d8a27aad0350";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/fd430bf2-3c8a-4a20-b76c-5dadc22c3a83/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/589954b0-7e97-4d85-9c8a-d8a27aad0350>.
+    
+<http://data.lblod.info/id/remote-data-objects/1384e620-1350-4f97-9350-919748d44848> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1384e620-1350-4f97-9350-919748d44848";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/gr/fd430bf2-3c8a-4a20-b76c-5dadc22c3a83/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1384e620-1350-4f97-9350-919748d44848>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fd0c396-c3bb-4cf0-9429-35c05e89dc5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fd0c396-c3bb-4cf0-9429-35c05e89dc5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/029875d8-dd22-4924-ad65-6c5cd4f4dd60/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fd0c396-c3bb-4cf0-9429-35c05e89dc5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc42cf76-5663-4796-b1aa-b50b0000c8c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc42cf76-5663-4796-b1aa-b50b0000c8c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/029875d8-dd22-4924-ad65-6c5cd4f4dd60/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc42cf76-5663-4796-b1aa-b50b0000c8c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b4647b3-e63f-4c20-99b2-1e20397b30fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b4647b3-e63f-4c20-99b2-1e20397b30fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/029875d8-dd22-4924-ad65-6c5cd4f4dd60/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b4647b3-e63f-4c20-99b2-1e20397b30fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2c9fed7-f070-490b-ac13-cdd8f0bd19f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2c9fed7-f070-490b-ac13-cdd8f0bd19f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/074c149f-9253-46d9-b40d-1ac56d5c078d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2c9fed7-f070-490b-ac13-cdd8f0bd19f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/19943f9b-f8ed-4335-b323-fe9c0bc5a8ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19943f9b-f8ed-4335-b323-fe9c0bc5a8ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/074c149f-9253-46d9-b40d-1ac56d5c078d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19943f9b-f8ed-4335-b323-fe9c0bc5a8ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3c84863-8555-4a37-a71b-cab96a03a8f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3c84863-8555-4a37-a71b-cab96a03a8f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/074c149f-9253-46d9-b40d-1ac56d5c078d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3c84863-8555-4a37-a71b-cab96a03a8f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/0305245e-560a-4a7b-96ab-7dc19be97700> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0305245e-560a-4a7b-96ab-7dc19be97700";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/18297202-c595-496f-88c6-b6661e54eae6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0305245e-560a-4a7b-96ab-7dc19be97700>.
+    
+<http://data.lblod.info/id/remote-data-objects/85c3c1d0-b7fe-4f69-a739-d47e51535d8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85c3c1d0-b7fe-4f69-a739-d47e51535d8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/18297202-c595-496f-88c6-b6661e54eae6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85c3c1d0-b7fe-4f69-a739-d47e51535d8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e740e2e-19bc-4e6c-8ad2-31b0649b2178> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e740e2e-19bc-4e6c-8ad2-31b0649b2178";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/18297202-c595-496f-88c6-b6661e54eae6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e740e2e-19bc-4e6c-8ad2-31b0649b2178>.
+    
+<http://data.lblod.info/id/remote-data-objects/dddcffd9-363d-4f16-a262-83c05b1e6179> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dddcffd9-363d-4f16-a262-83c05b1e6179";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/1d89b76a-14b2-46a7-9bff-ab3ac6e5c98a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dddcffd9-363d-4f16-a262-83c05b1e6179>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a598032-4a11-46e8-a13b-37fb922dfc73> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a598032-4a11-46e8-a13b-37fb922dfc73";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/1d89b76a-14b2-46a7-9bff-ab3ac6e5c98a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a598032-4a11-46e8-a13b-37fb922dfc73>.
+    
+<http://data.lblod.info/id/remote-data-objects/17a96d16-e25d-4ba2-a4e8-86d0c9513c2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17a96d16-e25d-4ba2-a4e8-86d0c9513c2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/1d89b76a-14b2-46a7-9bff-ab3ac6e5c98a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17a96d16-e25d-4ba2-a4e8-86d0c9513c2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c7815ba-caae-4a1f-bc46-a61dca213204> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c7815ba-caae-4a1f-bc46-a61dca213204";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/433e6bc0-87c6-4136-865b-dac6b126bcd8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c7815ba-caae-4a1f-bc46-a61dca213204>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1339477-5338-41ba-a727-f9736e247b36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1339477-5338-41ba-a727-f9736e247b36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/433e6bc0-87c6-4136-865b-dac6b126bcd8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1339477-5338-41ba-a727-f9736e247b36>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbee4296-8289-49fb-9b26-338252a63b96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbee4296-8289-49fb-9b26-338252a63b96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/433e6bc0-87c6-4136-865b-dac6b126bcd8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbee4296-8289-49fb-9b26-338252a63b96>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe0952ad-1742-4b95-ba7e-17863b3e8594> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe0952ad-1742-4b95-ba7e-17863b3e8594";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/6b728615-56c5-4bb6-981e-63598dd870d6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe0952ad-1742-4b95-ba7e-17863b3e8594>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3583ba0-6540-48e5-8089-37ee9132429f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3583ba0-6540-48e5-8089-37ee9132429f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/6b728615-56c5-4bb6-981e-63598dd870d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3583ba0-6540-48e5-8089-37ee9132429f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7981951f-9d16-45c9-b7d6-4e29cc80574f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7981951f-9d16-45c9-b7d6-4e29cc80574f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/76bce5ba-3a2f-4949-ae29-33b6c5c82184/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7981951f-9d16-45c9-b7d6-4e29cc80574f>.
+    
+<http://data.lblod.info/id/remote-data-objects/18ecf5ff-edbd-4092-b13d-c8bcf4249162> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18ecf5ff-edbd-4092-b13d-c8bcf4249162";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/76bce5ba-3a2f-4949-ae29-33b6c5c82184/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18ecf5ff-edbd-4092-b13d-c8bcf4249162>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2d63ad0-aa73-431b-8825-5958f8d8d3cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2d63ad0-aa73-431b-8825-5958f8d8d3cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/76bce5ba-3a2f-4949-ae29-33b6c5c82184/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2d63ad0-aa73-431b-8825-5958f8d8d3cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/e92ca007-a2a2-469f-99f0-2a00d57e27c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e92ca007-a2a2-469f-99f0-2a00d57e27c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/78ee860e-c1d1-44a8-9b6f-f7236c33f513/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e92ca007-a2a2-469f-99f0-2a00d57e27c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/cce61799-4a36-49d7-96b6-3e8dc246b9cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cce61799-4a36-49d7-96b6-3e8dc246b9cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/78ee860e-c1d1-44a8-9b6f-f7236c33f513/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cce61799-4a36-49d7-96b6-3e8dc246b9cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b474a53-f503-40b0-aebd-fb2581cb4cb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b474a53-f503-40b0-aebd-fb2581cb4cb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/78ee860e-c1d1-44a8-9b6f-f7236c33f513/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:09.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f08a582-4f9e-4ad2-89af-8f14edca10f4> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b474a53-f503-40b0-aebd-fb2581cb4cb5>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201910-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201910-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201910-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201910-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b8475dd1-1871-4eeb-9586-d320689264a5> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b8475dd1-1871-4eeb-9586-d320689264a5";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/650bca58-1ecf-4f21-98af-dcbc0e3d6fd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "650bca58-1ecf-4f21-98af-dcbc0e3d6fd5";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76>.
+
+  <http://redpencil.data.gift/id/task/79a20fbb-3e18-406c-b1f0-b336b5b937f7> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "79a20fbb-3e18-406c-b1f0-b336b5b937f7";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b8475dd1-1871-4eeb-9586-d320689264a5>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/650bca58-1ecf-4f21-98af-dcbc0e3d6fd5>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/118ac449-faa6-4def-a1da-54a1c7daef3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "118ac449-faa6-4def-a1da-54a1c7daef3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/7b422630-d4b6-432c-965f-d19cc4fd49a8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/118ac449-faa6-4def-a1da-54a1c7daef3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/62f0e314-c443-4a16-9f51-052afd188ee6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62f0e314-c443-4a16-9f51-052afd188ee6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/7b422630-d4b6-432c-965f-d19cc4fd49a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62f0e314-c443-4a16-9f51-052afd188ee6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9c72d9b-3616-4c8c-b880-a00ea2b402f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9c72d9b-3616-4c8c-b880-a00ea2b402f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/7b422630-d4b6-432c-965f-d19cc4fd49a8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9c72d9b-3616-4c8c-b880-a00ea2b402f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e7993ad-efb4-4ed9-a4de-590345d88036> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e7993ad-efb4-4ed9-a4de-590345d88036";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/9dfc1c68-1960-4da6-b105-6172dfb23c3b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e7993ad-efb4-4ed9-a4de-590345d88036>.
+    
+<http://data.lblod.info/id/remote-data-objects/39ec3882-6d9f-4cd0-8375-73254d298b60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39ec3882-6d9f-4cd0-8375-73254d298b60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/9dfc1c68-1960-4da6-b105-6172dfb23c3b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39ec3882-6d9f-4cd0-8375-73254d298b60>.
+    
+<http://data.lblod.info/id/remote-data-objects/01ac590c-80d9-47b8-a4ed-fa51a277765f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01ac590c-80d9-47b8-a4ed-fa51a277765f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/a5100030-e400-4b37-a88c-0c26f47cc690/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01ac590c-80d9-47b8-a4ed-fa51a277765f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7c65579-eb8d-460a-a4ab-ff303abe1d22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7c65579-eb8d-460a-a4ab-ff303abe1d22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/a5100030-e400-4b37-a88c-0c26f47cc690/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7c65579-eb8d-460a-a4ab-ff303abe1d22>.
+    
+<http://data.lblod.info/id/remote-data-objects/03fe8a7d-796a-4afb-924e-4bff9bb171cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03fe8a7d-796a-4afb-924e-4bff9bb171cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/a72a2e7b-fe8b-4498-a1fa-e1d5a45e4866/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03fe8a7d-796a-4afb-924e-4bff9bb171cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e1a268a-3b78-4ea7-8784-d4b23a1f245f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e1a268a-3b78-4ea7-8784-d4b23a1f245f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/a72a2e7b-fe8b-4498-a1fa-e1d5a45e4866/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e1a268a-3b78-4ea7-8784-d4b23a1f245f>.
+    
+<http://data.lblod.info/id/remote-data-objects/811fc412-3c36-4aea-ae1f-75fccb9b9744> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "811fc412-3c36-4aea-ae1f-75fccb9b9744";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/e0a09450-735f-4e3b-9a65-e7a1c303632b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/811fc412-3c36-4aea-ae1f-75fccb9b9744>.
+    
+<http://data.lblod.info/id/remote-data-objects/b900be7c-cdbe-417e-b6ba-0fb1049e49b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b900be7c-cdbe-417e-b6ba-0fb1049e49b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/e0a09450-735f-4e3b-9a65-e7a1c303632b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b900be7c-cdbe-417e-b6ba-0fb1049e49b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/594230e4-9516-4f28-8c35-837be70fd118> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "594230e4-9516-4f28-8c35-837be70fd118";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/e0a09450-735f-4e3b-9a65-e7a1c303632b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/594230e4-9516-4f28-8c35-837be70fd118>.
+    
+<http://data.lblod.info/id/remote-data-objects/82d4477a-1130-4a00-b0f5-5d6df3b8f5f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82d4477a-1130-4a00-b0f5-5d6df3b8f5f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/f6d4ab87-be8b-4054-b62d-1ecaa1343691/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82d4477a-1130-4a00-b0f5-5d6df3b8f5f7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5e0e50c-da3e-4358-8fbb-2cf1a373cbe6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5e0e50c-da3e-4358-8fbb-2cf1a373cbe6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/f6d4ab87-be8b-4054-b62d-1ecaa1343691/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5e0e50c-da3e-4358-8fbb-2cf1a373cbe6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9114efdd-c000-440b-88c2-5f5d732ba4a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9114efdd-c000-440b-88c2-5f5d732ba4a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/f6d4ab87-be8b-4054-b62d-1ecaa1343691/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9114efdd-c000-440b-88c2-5f5d732ba4a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6aeeddfe-76f6-45c5-9513-ae311b6423df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6aeeddfe-76f6-45c5-9513-ae311b6423df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/f76eec17-075b-496f-9404-9a71a6890a10/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6aeeddfe-76f6-45c5-9513-ae311b6423df>.
+    
+<http://data.lblod.info/id/remote-data-objects/991d4abf-e261-4cde-9674-537591adfb7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "991d4abf-e261-4cde-9674-537591adfb7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/f76eec17-075b-496f-9404-9a71a6890a10/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/991d4abf-e261-4cde-9674-537591adfb7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/370d0bc6-c335-4a67-8db5-8105cbcd6623> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "370d0bc6-c335-4a67-8db5-8105cbcd6623";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/rmw/f76eec17-075b-496f-9404-9a71a6890a10/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/370d0bc6-c335-4a67-8db5-8105cbcd6623>.
+    
+<http://data.lblod.info/id/remote-data-objects/e25a1cb7-22fe-4dab-813a-203b45ffa510> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e25a1cb7-22fe-4dab-813a-203b45ffa510";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/00319dec-b11d-4b38-9597-679730549efd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e25a1cb7-22fe-4dab-813a-203b45ffa510>.
+    
+<http://data.lblod.info/id/remote-data-objects/f48536dd-d652-4549-a6a4-f742d1a3bd0e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f48536dd-d652-4549-a6a4-f742d1a3bd0e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/0209b815-9050-4063-95f7-4b8712a67438/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f48536dd-d652-4549-a6a4-f742d1a3bd0e>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb00c9d5-9167-4110-b376-c5927fdebbcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb00c9d5-9167-4110-b376-c5927fdebbcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/020d7227-112d-4104-9881-887468c7c23f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb00c9d5-9167-4110-b376-c5927fdebbcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/320e97bd-5dfc-4587-b5b1-0fa1ef3aab77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "320e97bd-5dfc-4587-b5b1-0fa1ef3aab77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/0333f857-72a8-4987-be06-dad45412b8c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/320e97bd-5dfc-4587-b5b1-0fa1ef3aab77>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f48a480-6ade-493f-bfb0-070a58621175> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f48a480-6ade-493f-bfb0-070a58621175";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/04e061ac-7c82-461b-adbc-05aaf0e07d2d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f48a480-6ade-493f-bfb0-070a58621175>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf09386a-6cec-4d89-812f-afe3d6696a53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf09386a-6cec-4d89-812f-afe3d6696a53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/1102a860-08c2-4670-9beb-b769e8acd8b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf09386a-6cec-4d89-812f-afe3d6696a53>.
+    
+<http://data.lblod.info/id/remote-data-objects/358fc408-0332-486f-8a1b-d7d16c57b224> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "358fc408-0332-486f-8a1b-d7d16c57b224";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/17345bcd-96aa-4abe-a33e-2d78a0047a08/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/358fc408-0332-486f-8a1b-d7d16c57b224>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1fe5270-2f57-4819-a2ea-9ffb9773714d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1fe5270-2f57-4819-a2ea-9ffb9773714d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/1902c480-707b-4641-b9fe-0c7ae4c3edd6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1fe5270-2f57-4819-a2ea-9ffb9773714d>.
+    
+<http://data.lblod.info/id/remote-data-objects/74066ab6-d86d-4a11-abfa-6f47068a06f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74066ab6-d86d-4a11-abfa-6f47068a06f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/26e8215c-a98d-46dd-8f5f-98ce26a1166a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74066ab6-d86d-4a11-abfa-6f47068a06f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ed72f64-7868-4ec9-8bdd-8951e50484a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ed72f64-7868-4ec9-8bdd-8951e50484a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/308772b7-bbf4-4584-86fe-f7e5929c222e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ed72f64-7868-4ec9-8bdd-8951e50484a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e2c44af-9ad4-4525-ab85-a40924a78a88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e2c44af-9ad4-4525-ab85-a40924a78a88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/3139342f-6871-49b4-bc8c-b9a10e4d3954/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e2c44af-9ad4-4525-ab85-a40924a78a88>.
+    
+<http://data.lblod.info/id/remote-data-objects/091d095d-7e88-41b9-ac02-4694aec5f7ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "091d095d-7e88-41b9-ac02-4694aec5f7ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/3187ac17-ddc3-4e59-ac83-672492482ecd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/091d095d-7e88-41b9-ac02-4694aec5f7ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fdd1f24-2406-4df2-badf-764b61515127> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fdd1f24-2406-4df2-badf-764b61515127";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/3afe5fa6-59d6-406f-9bb0-b5e4d4f7e0e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fdd1f24-2406-4df2-badf-764b61515127>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f734420-a242-49eb-8f4f-233a2190968b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f734420-a242-49eb-8f4f-233a2190968b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/3d28b4dd-5acf-4bc7-a994-ea3dcce7f946/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f734420-a242-49eb-8f4f-233a2190968b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7566811a-349d-4498-a084-1f54120c3653> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7566811a-349d-4498-a084-1f54120c3653";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/4631ee8a-669d-44c7-a52b-8b8d2bbb22da/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7566811a-349d-4498-a084-1f54120c3653>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c6e5de4-dd58-43d9-b0a6-a129fb2bd425> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c6e5de4-dd58-43d9-b0a6-a129fb2bd425";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/47badd0d-5b8d-42e8-b04c-fb65ccbfa98e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c6e5de4-dd58-43d9-b0a6-a129fb2bd425>.
+    
+<http://data.lblod.info/id/remote-data-objects/db4f19a2-8c6c-47c4-bd85-4d9453381472> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db4f19a2-8c6c-47c4-bd85-4d9453381472";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/4c06990e-8b72-4045-bc60-46370f45606b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db4f19a2-8c6c-47c4-bd85-4d9453381472>.
+    
+<http://data.lblod.info/id/remote-data-objects/17c9a8d9-6dd5-4fa0-869b-db3ca34047cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17c9a8d9-6dd5-4fa0-869b-db3ca34047cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/4e162cc7-319b-42e0-bffc-b8062cee3d66/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17c9a8d9-6dd5-4fa0-869b-db3ca34047cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7795dd6-8d40-43ff-b2fe-985ea7abb728> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7795dd6-8d40-43ff-b2fe-985ea7abb728";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/5b826ac2-ace4-4d3b-b07e-a5e7bf56727d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7795dd6-8d40-43ff-b2fe-985ea7abb728>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5bb7456-db7d-4de8-be23-362ae69eee03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5bb7456-db7d-4de8-be23-362ae69eee03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/5cf1dfb2-a151-464c-bc5a-e4ee24058ff0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5bb7456-db7d-4de8-be23-362ae69eee03>.
+    
+<http://data.lblod.info/id/remote-data-objects/eae62e54-9770-402a-b041-fff99d459481> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eae62e54-9770-402a-b041-fff99d459481";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/5fe63517-9936-452d-a46d-b3c94e085e22/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eae62e54-9770-402a-b041-fff99d459481>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e37b1d2-b032-4685-b748-bffde38c8919> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e37b1d2-b032-4685-b748-bffde38c8919";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/6162c930-ee42-4fbc-ade7-a1822d038e2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e37b1d2-b032-4685-b748-bffde38c8919>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c449abe-0db6-4ba9-9c8c-6ffc355e36a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c449abe-0db6-4ba9-9c8c-6ffc355e36a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/6380fa61-8012-4dcd-bf3e-817936f07b9d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c449abe-0db6-4ba9-9c8c-6ffc355e36a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/943a89d0-7cc7-4fcd-bae2-be2d1f665644> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "943a89d0-7cc7-4fcd-bae2-be2d1f665644";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/63d1343c-83a5-4dfd-ad01-08199f66b29f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/943a89d0-7cc7-4fcd-bae2-be2d1f665644>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddebc38f-2b4e-4599-b4b3-f62ec8b07fc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddebc38f-2b4e-4599-b4b3-f62ec8b07fc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/64b0cdab-f0db-40f4-89c8-4fefeaa69edc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddebc38f-2b4e-4599-b4b3-f62ec8b07fc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/93444c92-0569-4e48-a557-a50d51fef58b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93444c92-0569-4e48-a557-a50d51fef58b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/659fa2ca-fed8-461d-854a-febeded9d900/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93444c92-0569-4e48-a557-a50d51fef58b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3be381e-61c8-4c64-ad39-d9439293da75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3be381e-61c8-4c64-ad39-d9439293da75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/6634d222-c8c2-43d9-b0dd-bbd2cf4c92db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3be381e-61c8-4c64-ad39-d9439293da75>.
+    
+<http://data.lblod.info/id/remote-data-objects/70fac5f1-8427-4bd2-ba76-45a388f9956a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70fac5f1-8427-4bd2-ba76-45a388f9956a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/67d35a96-feb7-455d-9930-80856e9457ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70fac5f1-8427-4bd2-ba76-45a388f9956a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f65673e2-330a-4b94-871a-9d2774025500> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f65673e2-330a-4b94-871a-9d2774025500";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/67dfc88c-4be4-4079-b9a0-6ec955b811cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f65673e2-330a-4b94-871a-9d2774025500>.
+    
+<http://data.lblod.info/id/remote-data-objects/87049807-57f1-4493-b643-b5ca99d9efdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87049807-57f1-4493-b643-b5ca99d9efdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/786d5f85-ea70-4c3f-8256-33423edb5c08/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87049807-57f1-4493-b643-b5ca99d9efdf>.
+    
+<http://data.lblod.info/id/remote-data-objects/6879e4aa-d4a6-4cf1-9b65-c41615accebb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6879e4aa-d4a6-4cf1-9b65-c41615accebb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/817bd7a1-6405-441b-b093-2321689cd99f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6879e4aa-d4a6-4cf1-9b65-c41615accebb>.
+    
+<http://data.lblod.info/id/remote-data-objects/d24937b4-932c-4425-8b5e-484c47d85cdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d24937b4-932c-4425-8b5e-484c47d85cdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/8737c88c-0175-4ce8-a741-cce374217924/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:10.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/f87c2b13-2f42-44c4-bf6e-2afc2a6b3b76> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d24937b4-932c-4425-8b5e-484c47d85cdd>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201911-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201911-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201911-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201911-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a5ff9f4e-3ddb-40e5-833c-a0f3185060cf> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a5ff9f4e-3ddb-40e5-833c-a0f3185060cf";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e4024428-9aab-46f6-a282-012f46b63a63";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/aa926731-9a5f-4f29-827a-0670e364a51d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "aa926731-9a5f-4f29-827a-0670e364a51d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63>.
+
+  <http://redpencil.data.gift/id/task/0b3fdee2-5afc-4d2d-b824-166d799e126d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0b3fdee2-5afc-4d2d-b824-166d799e126d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a5ff9f4e-3ddb-40e5-833c-a0f3185060cf>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/aa926731-9a5f-4f29-827a-0670e364a51d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4dc1b8ea-cde1-47b6-bc42-b180ab130d64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dc1b8ea-cde1-47b6-bc42-b180ab130d64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/8c839f8b-ce39-4cf2-91ef-b78ab44d4678/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dc1b8ea-cde1-47b6-bc42-b180ab130d64>.
+    
+<http://data.lblod.info/id/remote-data-objects/851c0773-1fc1-40a4-a16f-773723596d27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "851c0773-1fc1-40a4-a16f-773723596d27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/9390749c-d536-43fb-873e-1a057cfef980/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/851c0773-1fc1-40a4-a16f-773723596d27>.
+    
+<http://data.lblod.info/id/remote-data-objects/214e45bb-0a88-4d86-bc81-ddc606cf09d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "214e45bb-0a88-4d86-bc81-ddc606cf09d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/9eb8847a-42e8-4ff9-bb13-56caf3761483/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/214e45bb-0a88-4d86-bc81-ddc606cf09d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c974aba1-6ef4-464d-9051-9362783f6e63> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c974aba1-6ef4-464d-9051-9362783f6e63";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/a09fcb87-1139-4f73-b88a-102a25018b29/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c974aba1-6ef4-464d-9051-9362783f6e63>.
+    
+<http://data.lblod.info/id/remote-data-objects/11d1e6ea-9d63-4503-bda9-808bfc68aa3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11d1e6ea-9d63-4503-bda9-808bfc68aa3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/a9062ca5-3269-499c-ac40-b1c2643ff5f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11d1e6ea-9d63-4503-bda9-808bfc68aa3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/57a7ac2c-e8c5-401d-a895-ff61ed1593ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57a7ac2c-e8c5-401d-a895-ff61ed1593ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/abf4a2ab-08fa-4121-9a9c-c9c463bffe50/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57a7ac2c-e8c5-401d-a895-ff61ed1593ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/40f180f0-163b-4b41-8bed-92cd87ca0cc3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40f180f0-163b-4b41-8bed-92cd87ca0cc3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/aecc6bc8-ac39-4bdb-95d2-8fa0a45417ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40f180f0-163b-4b41-8bed-92cd87ca0cc3>.
+    
+<http://data.lblod.info/id/remote-data-objects/978056a2-17c1-4b38-91cb-a3404645e00c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "978056a2-17c1-4b38-91cb-a3404645e00c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/af1660db-67a2-4055-b2f8-00c4026b0402/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/978056a2-17c1-4b38-91cb-a3404645e00c>.
+    
+<http://data.lblod.info/id/remote-data-objects/20307a6e-4d6f-4cd0-94ad-fab65a0bdcf4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20307a6e-4d6f-4cd0-94ad-fab65a0bdcf4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/b459021a-d6b3-4cc8-a001-9f94e6e6b4dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20307a6e-4d6f-4cd0-94ad-fab65a0bdcf4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e7026e0-b2f5-4066-b09e-bcf54f5d9f9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e7026e0-b2f5-4066-b09e-bcf54f5d9f9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/b5a35b3f-2695-46df-8eb9-460ae00353ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e7026e0-b2f5-4066-b09e-bcf54f5d9f9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3e74a5b-67b4-43aa-8a0d-1024cc098d50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3e74a5b-67b4-43aa-8a0d-1024cc098d50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/b820ff33-a4c6-47b7-93ab-f649e8edd212/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3e74a5b-67b4-43aa-8a0d-1024cc098d50>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed5bc4ee-5bc7-49bb-9d07-06d17b66b9e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed5bc4ee-5bc7-49bb-9d07-06d17b66b9e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/c11698fa-7ed5-419d-a3dc-7e657c7cc90d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed5bc4ee-5bc7-49bb-9d07-06d17b66b9e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/2796220f-19d8-47c5-9950-2219f9111afc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2796220f-19d8-47c5-9950-2219f9111afc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/c7f7960b-5e7d-4f28-a1f7-0fb9852c1645/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2796220f-19d8-47c5-9950-2219f9111afc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4003d75-35f6-4cdc-a4e7-d268c72b894e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4003d75-35f6-4cdc-a4e7-d268c72b894e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/c9e5af1f-d5de-40b0-abd8-7a6cbdb1cc68/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4003d75-35f6-4cdc-a4e7-d268c72b894e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fb4cff0-d766-4e7e-910d-a1522f9b55f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fb4cff0-d766-4e7e-910d-a1522f9b55f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/c9ffc16b-d938-4601-8e54-622a7ad4f5b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fb4cff0-d766-4e7e-910d-a1522f9b55f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5434e441-039b-49d2-aec0-3f3d11539fa5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5434e441-039b-49d2-aec0-3f3d11539fa5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/cfde10ab-66eb-4c80-b4ea-590a5431596c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5434e441-039b-49d2-aec0-3f3d11539fa5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ecca13e-8acb-4ff4-8755-43947c05b4ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ecca13e-8acb-4ff4-8755-43947c05b4ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/cff5f4b8-0cec-42cb-8447-7bd48a1899bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ecca13e-8acb-4ff4-8755-43947c05b4ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1424741-64ff-48a0-a5fb-2cfb14be01bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1424741-64ff-48a0-a5fb-2cfb14be01bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/d0ed1cfb-2f19-4701-a051-389a2b649f20/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1424741-64ff-48a0-a5fb-2cfb14be01bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c4d0419-14a6-41e8-90db-14260e6f0ffb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c4d0419-14a6-41e8-90db-14260e6f0ffb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/d16070ee-ba45-4dd8-aec8-978cd035533a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c4d0419-14a6-41e8-90db-14260e6f0ffb>.
+    
+<http://data.lblod.info/id/remote-data-objects/598b2da8-faab-4846-9e61-adc0c056904f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "598b2da8-faab-4846-9e61-adc0c056904f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/d16cdc75-bc57-43ab-bbd0-2296b7a25cfb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/598b2da8-faab-4846-9e61-adc0c056904f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f525ed90-2085-42a3-b611-b9363dc20a3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f525ed90-2085-42a3-b611-b9363dc20a3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/e7f31283-e3be-41ae-9d2d-dbb3242c75f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f525ed90-2085-42a3-b611-b9363dc20a3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7de2e40e-c4cb-4496-b1b4-c2f7269cd8de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7de2e40e-c4cb-4496-b1b4-c2f7269cd8de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/ec4050a0-a8bf-49f3-8945-eeee94da60a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7de2e40e-c4cb-4496-b1b4-c2f7269cd8de>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f71fa7f-3dad-4d06-b7fc-e9845c07c104> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f71fa7f-3dad-4d06-b7fc-e9845c07c104";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/ece707ac-6561-43e6-8921-b287a7ee5ac3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f71fa7f-3dad-4d06-b7fc-e9845c07c104>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e28b110-e327-446d-8d14-1ba8f4d329ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e28b110-e327-446d-8d14-1ba8f4d329ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://riemst.meetingburger.net/vabu/f10aef90-bbcd-4ee8-a156-5f6504e3d8dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e28b110-e327-446d-8d14-1ba8f4d329ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/57f8875a-460c-498f-9019-5421c7113160> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57f8875a-460c-498f-9019-5421c7113160";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/17de02ab-5681-4776-a7a4-795cf87736e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57f8875a-460c-498f-9019-5421c7113160>.
+    
+<http://data.lblod.info/id/remote-data-objects/df1efe3c-9abe-40df-8f66-45bd3a7e3137> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df1efe3c-9abe-40df-8f66-45bd3a7e3137";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/1d46d2af-d2b2-4548-893d-3bfe73095401/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df1efe3c-9abe-40df-8f66-45bd3a7e3137>.
+    
+<http://data.lblod.info/id/remote-data-objects/225f2dff-bb44-4200-baa3-6c7376d600ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "225f2dff-bb44-4200-baa3-6c7376d600ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/252141c3-15a2-4e18-a42d-61ba5ec5a978/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/225f2dff-bb44-4200-baa3-6c7376d600ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/3aa3091a-1fc9-4488-bf81-7a3a30a823b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3aa3091a-1fc9-4488-bf81-7a3a30a823b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/36beed44-7704-48c1-92d2-dfbc0a618720/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3aa3091a-1fc9-4488-bf81-7a3a30a823b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/a04f7b00-0c05-4c44-9b0c-61b331bd7242> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a04f7b00-0c05-4c44-9b0c-61b331bd7242";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/4b2d895c-4d8a-429b-91d0-58c84879ef44/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a04f7b00-0c05-4c44-9b0c-61b331bd7242>.
+    
+<http://data.lblod.info/id/remote-data-objects/574fc54d-30e3-4d68-8092-89060840ca33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "574fc54d-30e3-4d68-8092-89060840ca33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/610a033d-5a92-4175-9af8-aa93d309ee64/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/574fc54d-30e3-4d68-8092-89060840ca33>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b62b604-09dd-4c6b-a7d7-455ca12c333e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b62b604-09dd-4c6b-a7d7-455ca12c333e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/7466e412-0ba5-4b8b-bc94-5a51f06c12ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b62b604-09dd-4c6b-a7d7-455ca12c333e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b16d9f11-378b-4ce9-b260-0cfb27cfa5cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b16d9f11-378b-4ce9-b260-0cfb27cfa5cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/7cca20e0-10b3-44ac-a139-ff48c2b9a07f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b16d9f11-378b-4ce9-b260-0cfb27cfa5cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f8f431f-df18-4416-b9aa-649e7355708a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f8f431f-df18-4416-b9aa-649e7355708a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/7cf1f02b-f8d1-4e0a-b90e-8fde62c58af1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f8f431f-df18-4416-b9aa-649e7355708a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e61623d-6be6-4414-8c67-0a294ca4f68d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e61623d-6be6-4414-8c67-0a294ca4f68d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/ad79b36a-01d6-4385-9be4-f5e626823604/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e61623d-6be6-4414-8c67-0a294ca4f68d>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b1c2e1f-cf36-44b9-a652-bbdb9cd3ae1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b1c2e1f-cf36-44b9-a652-bbdb9cd3ae1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/b080faaf-0a29-45a5-a3fe-3986063538d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b1c2e1f-cf36-44b9-a652-bbdb9cd3ae1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff998dc3-f6f0-47bf-a926-71d330ea9014> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff998dc3-f6f0-47bf-a926-71d330ea9014";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/c6e1cf13-fb93-40f8-90eb-6a55c9e3f5f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff998dc3-f6f0-47bf-a926-71d330ea9014>.
+    
+<http://data.lblod.info/id/remote-data-objects/8197a7a9-5bd0-443f-9c1d-8ab759fdcb3b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8197a7a9-5bd0-443f-9c1d-8ab759fdcb3b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/e254c859-0b42-4933-a4f0-b7245632e9bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8197a7a9-5bd0-443f-9c1d-8ab759fdcb3b>.
+    
+<http://data.lblod.info/id/remote-data-objects/46197393-e4ca-4936-86da-d9d3d5af4247> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46197393-e4ca-4936-86da-d9d3d5af4247";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/e91dc163-75a3-41b1-a8f8-6dcca2c1d525/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46197393-e4ca-4936-86da-d9d3d5af4247>.
+    
+<http://data.lblod.info/id/remote-data-objects/37c5f85e-e463-457d-bc16-45b33f303265> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37c5f85e-e463-457d-bc16-45b33f303265";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/f3244b0b-be67-44e0-aedb-3fe0b77af0e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37c5f85e-e463-457d-bc16-45b33f303265>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d56564c-8f8a-4bd9-8397-1a4ace2228e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d56564c-8f8a-4bd9-8397-1a4ace2228e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/f77252f9-2a02-4c24-b031-02f226cfdfbe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d56564c-8f8a-4bd9-8397-1a4ace2228e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad4087b4-cb52-4723-a314-1d426103e644> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad4087b4-cb52-4723-a314-1d426103e644";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/fb18788a-06ba-4cfe-825b-9c9d6f4b7ab8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad4087b4-cb52-4723-a314-1d426103e644>.
+    
+<http://data.lblod.info/id/remote-data-objects/39c28b04-3070-4213-86db-61811ec93265> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39c28b04-3070-4213-86db-61811ec93265";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/bb/fc25bb25-0b46-4210-9af3-a7d384b07731/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39c28b04-3070-4213-86db-61811ec93265>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5e25290-4005-467d-9f84-c57915aa28f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5e25290-4005-467d-9f84-c57915aa28f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/0064e1c5-3040-409a-b8ed-505e45066e88/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5e25290-4005-467d-9f84-c57915aa28f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/64e4fa27-349d-43bc-8ea8-bf777bc02f0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64e4fa27-349d-43bc-8ea8-bf777bc02f0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/0064e1c5-3040-409a-b8ed-505e45066e88/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64e4fa27-349d-43bc-8ea8-bf777bc02f0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb33ac05-7f6b-4f64-98b1-e31bb61f34f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb33ac05-7f6b-4f64-98b1-e31bb61f34f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/0064e1c5-3040-409a-b8ed-505e45066e88/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb33ac05-7f6b-4f64-98b1-e31bb61f34f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/94180e31-68bc-4b2a-bbd3-a8d3e81d9910> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94180e31-68bc-4b2a-bbd3-a8d3e81d9910";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/08a3da89-f5ab-45a3-91fc-fbe93b39d14d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94180e31-68bc-4b2a-bbd3-a8d3e81d9910>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a6986ff-76fb-4681-a15e-9e9028284318> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a6986ff-76fb-4681-a15e-9e9028284318";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/08a3da89-f5ab-45a3-91fc-fbe93b39d14d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a6986ff-76fb-4681-a15e-9e9028284318>.
+    
+<http://data.lblod.info/id/remote-data-objects/707842f8-446c-4250-a778-18198ebfa778> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "707842f8-446c-4250-a778-18198ebfa778";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/08a3da89-f5ab-45a3-91fc-fbe93b39d14d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/707842f8-446c-4250-a778-18198ebfa778>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a1f5419-1dbf-4e81-a96e-fb9ca6831539> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a1f5419-1dbf-4e81-a96e-fb9ca6831539";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/0ae98f04-f2c9-4391-9557-01d83a6857a5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a1f5419-1dbf-4e81-a96e-fb9ca6831539>.
+    
+<http://data.lblod.info/id/remote-data-objects/84fd8d85-1031-4137-a065-1500150616ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84fd8d85-1031-4137-a065-1500150616ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/143b20e6-985f-4420-9b85-0bc317e0915b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:11.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e4024428-9aab-46f6-a282-012f46b63a63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84fd8d85-1031-4137-a065-1500150616ab>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201912-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201912-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201912-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201912-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d73a1035-33d9-44a7-9377-c7384667859a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d73a1035-33d9-44a7-9377-c7384667859a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "74641aab-0ff9-46f1-ae9f-5745693d0f71";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/977acad8-ef25-444a-ad6a-c62c04456c80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "977acad8-ef25-444a-ad6a-c62c04456c80";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71>.
+
+  <http://redpencil.data.gift/id/task/dd8f742b-b49f-4bca-80ae-188843a7ea73> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dd8f742b-b49f-4bca-80ae-188843a7ea73";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d73a1035-33d9-44a7-9377-c7384667859a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/977acad8-ef25-444a-ad6a-c62c04456c80>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7faae005-dfb6-42dd-8f41-66386169304a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7faae005-dfb6-42dd-8f41-66386169304a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/143b20e6-985f-4420-9b85-0bc317e0915b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7faae005-dfb6-42dd-8f41-66386169304a>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a0cb0c6-8c7b-4b7f-b44f-b748a9e6ebc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a0cb0c6-8c7b-4b7f-b44f-b748a9e6ebc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/143b20e6-985f-4420-9b85-0bc317e0915b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a0cb0c6-8c7b-4b7f-b44f-b748a9e6ebc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c2fab41-a24d-4e4f-a8da-8cf8af592afd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c2fab41-a24d-4e4f-a8da-8cf8af592afd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/27fc98f5-4ef1-4212-a9e6-db6a83946ce9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c2fab41-a24d-4e4f-a8da-8cf8af592afd>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc18cb84-3046-48d7-90fc-c02c784ca0e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc18cb84-3046-48d7-90fc-c02c784ca0e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/27fc98f5-4ef1-4212-a9e6-db6a83946ce9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc18cb84-3046-48d7-90fc-c02c784ca0e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e8153ef-17c5-4705-bb67-969ec75c516e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e8153ef-17c5-4705-bb67-969ec75c516e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/3196212f-b49d-4e3f-8ee5-cb298753912d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e8153ef-17c5-4705-bb67-969ec75c516e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3d50233-57ce-4ec5-ad03-59d21485471b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3d50233-57ce-4ec5-ad03-59d21485471b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/3196212f-b49d-4e3f-8ee5-cb298753912d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3d50233-57ce-4ec5-ad03-59d21485471b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ad3e64a4-3f8b-4d74-8087-696c40fb0f01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad3e64a4-3f8b-4d74-8087-696c40fb0f01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/3196212f-b49d-4e3f-8ee5-cb298753912d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ad3e64a4-3f8b-4d74-8087-696c40fb0f01>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e5c3ab6-1e3d-4ce0-a5d4-effa8ae4afcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e5c3ab6-1e3d-4ce0-a5d4-effa8ae4afcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/3708fcfe-d206-4ecf-8f59-0fe7d3e5d7a8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e5c3ab6-1e3d-4ce0-a5d4-effa8ae4afcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d5332e6-57c9-41ae-8305-05dfd8ff886d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d5332e6-57c9-41ae-8305-05dfd8ff886d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/3708fcfe-d206-4ecf-8f59-0fe7d3e5d7a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d5332e6-57c9-41ae-8305-05dfd8ff886d>.
+    
+<http://data.lblod.info/id/remote-data-objects/27412688-914e-45f1-8db2-cae06efbb859> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27412688-914e-45f1-8db2-cae06efbb859";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/3708fcfe-d206-4ecf-8f59-0fe7d3e5d7a8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27412688-914e-45f1-8db2-cae06efbb859>.
+    
+<http://data.lblod.info/id/remote-data-objects/15a67952-68e1-4f7d-8c2c-80a8be86b635> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15a67952-68e1-4f7d-8c2c-80a8be86b635";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/41ffefc2-87bd-4f32-8aa2-e2fba73a12c4/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15a67952-68e1-4f7d-8c2c-80a8be86b635>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfb693ab-10be-4ff5-941f-bf19e8825a06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfb693ab-10be-4ff5-941f-bf19e8825a06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/41ffefc2-87bd-4f32-8aa2-e2fba73a12c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfb693ab-10be-4ff5-941f-bf19e8825a06>.
+    
+<http://data.lblod.info/id/remote-data-objects/7555c9bd-45df-4996-bcda-d4bdbb757417> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7555c9bd-45df-4996-bcda-d4bdbb757417";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/41ffefc2-87bd-4f32-8aa2-e2fba73a12c4/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7555c9bd-45df-4996-bcda-d4bdbb757417>.
+    
+<http://data.lblod.info/id/remote-data-objects/df99ba2d-bfab-4eb5-a29d-6484756ddd38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df99ba2d-bfab-4eb5-a29d-6484756ddd38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/86d0f38c-c94d-4a84-bf7b-3155edd73d3e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df99ba2d-bfab-4eb5-a29d-6484756ddd38>.
+    
+<http://data.lblod.info/id/remote-data-objects/87b27870-2dee-4ff2-93fa-87130da028ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87b27870-2dee-4ff2-93fa-87130da028ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/86d0f38c-c94d-4a84-bf7b-3155edd73d3e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87b27870-2dee-4ff2-93fa-87130da028ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0a277eb-f440-427a-b9a7-85df6d83758f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0a277eb-f440-427a-b9a7-85df6d83758f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/86d0f38c-c94d-4a84-bf7b-3155edd73d3e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0a277eb-f440-427a-b9a7-85df6d83758f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a0c60d9-f36b-4289-9452-9b00ea59c960> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a0c60d9-f36b-4289-9452-9b00ea59c960";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/95d3c493-4238-47e9-8efc-71a2da9c032d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a0c60d9-f36b-4289-9452-9b00ea59c960>.
+    
+<http://data.lblod.info/id/remote-data-objects/39468be7-637c-4b9d-bb14-269188339488> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39468be7-637c-4b9d-bb14-269188339488";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/95d3c493-4238-47e9-8efc-71a2da9c032d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39468be7-637c-4b9d-bb14-269188339488>.
+    
+<http://data.lblod.info/id/remote-data-objects/159607ee-2dbf-423f-9bfa-4cfe7a13cf75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "159607ee-2dbf-423f-9bfa-4cfe7a13cf75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/95d3c493-4238-47e9-8efc-71a2da9c032d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/159607ee-2dbf-423f-9bfa-4cfe7a13cf75>.
+    
+<http://data.lblod.info/id/remote-data-objects/538e7b48-33d8-4ebc-ada9-7002a9c2ec92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "538e7b48-33d8-4ebc-ada9-7002a9c2ec92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/b8204ccf-6cf3-4159-977d-ecca8afb3d66/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/538e7b48-33d8-4ebc-ada9-7002a9c2ec92>.
+    
+<http://data.lblod.info/id/remote-data-objects/2774ae67-2d74-468b-88bb-c6e335e91f6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2774ae67-2d74-468b-88bb-c6e335e91f6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/b8204ccf-6cf3-4159-977d-ecca8afb3d66/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2774ae67-2d74-468b-88bb-c6e335e91f6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/805b7a1b-2d7a-4245-bdcd-4d16bf948852> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "805b7a1b-2d7a-4245-bdcd-4d16bf948852";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/b8204ccf-6cf3-4159-977d-ecca8afb3d66/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/805b7a1b-2d7a-4245-bdcd-4d16bf948852>.
+    
+<http://data.lblod.info/id/remote-data-objects/8596ac04-72ce-41b4-a960-80c2e523e165> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8596ac04-72ce-41b4-a960-80c2e523e165";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/c23274d9-33c7-47e6-a056-2018d12be56e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8596ac04-72ce-41b4-a960-80c2e523e165>.
+    
+<http://data.lblod.info/id/remote-data-objects/25c606fd-9665-421e-a073-f5a8e289d7eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25c606fd-9665-421e-a073-f5a8e289d7eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/c23274d9-33c7-47e6-a056-2018d12be56e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25c606fd-9665-421e-a073-f5a8e289d7eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/10043081-a655-41f3-a22b-c26b92247ae6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10043081-a655-41f3-a22b-c26b92247ae6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/c23274d9-33c7-47e6-a056-2018d12be56e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10043081-a655-41f3-a22b-c26b92247ae6>.
+    
+<http://data.lblod.info/id/remote-data-objects/91230833-9b87-48f7-99c3-fa5b90f02304> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91230833-9b87-48f7-99c3-fa5b90f02304";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/c25cedd1-3006-4442-8a0f-246b6493b806/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91230833-9b87-48f7-99c3-fa5b90f02304>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8e5fedd-e7cf-45dd-9e21-f4b556dcacfe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8e5fedd-e7cf-45dd-9e21-f4b556dcacfe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/c25cedd1-3006-4442-8a0f-246b6493b806/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8e5fedd-e7cf-45dd-9e21-f4b556dcacfe>.
+    
+<http://data.lblod.info/id/remote-data-objects/143348a1-1202-4183-867d-0e342d6bc775> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "143348a1-1202-4183-867d-0e342d6bc775";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/c25cedd1-3006-4442-8a0f-246b6493b806/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/143348a1-1202-4183-867d-0e342d6bc775>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ad4c287-3e3f-40eb-a472-ad3bbbb75f96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ad4c287-3e3f-40eb-a472-ad3bbbb75f96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/cb922178-1bb9-47a8-a1ae-4bc367e4cd8c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ad4c287-3e3f-40eb-a472-ad3bbbb75f96>.
+    
+<http://data.lblod.info/id/remote-data-objects/31fb7187-d8d7-4f91-b62a-4755cf34af23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31fb7187-d8d7-4f91-b62a-4755cf34af23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/cb922178-1bb9-47a8-a1ae-4bc367e4cd8c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31fb7187-d8d7-4f91-b62a-4755cf34af23>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae186164-d62b-4415-95a9-d26eb03b9e45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae186164-d62b-4415-95a9-d26eb03b9e45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/cb922178-1bb9-47a8-a1ae-4bc367e4cd8c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae186164-d62b-4415-95a9-d26eb03b9e45>.
+    
+<http://data.lblod.info/id/remote-data-objects/f25141a6-9fcb-4f5e-86cd-8d274cc69347> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f25141a6-9fcb-4f5e-86cd-8d274cc69347";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/ec9f7a8f-fca5-4979-87b1-10bcfce2b4b7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f25141a6-9fcb-4f5e-86cd-8d274cc69347>.
+    
+<http://data.lblod.info/id/remote-data-objects/374c19d7-b4fd-4287-8074-5860409c6fe6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "374c19d7-b4fd-4287-8074-5860409c6fe6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/ec9f7a8f-fca5-4979-87b1-10bcfce2b4b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/374c19d7-b4fd-4287-8074-5860409c6fe6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d8c7149-904f-4ad9-bbdd-5629cc209a86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d8c7149-904f-4ad9-bbdd-5629cc209a86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/ec9f7a8f-fca5-4979-87b1-10bcfce2b4b7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d8c7149-904f-4ad9-bbdd-5629cc209a86>.
+    
+<http://data.lblod.info/id/remote-data-objects/03afc194-2a7d-489b-8716-2b6c0fab9060> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03afc194-2a7d-489b-8716-2b6c0fab9060";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/f14f4416-d545-47ce-9dbe-ef294c45e7f6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03afc194-2a7d-489b-8716-2b6c0fab9060>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b5cd6a5-d0ce-406e-a22a-87b5cc7a559d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b5cd6a5-d0ce-406e-a22a-87b5cc7a559d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/f14f4416-d545-47ce-9dbe-ef294c45e7f6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b5cd6a5-d0ce-406e-a22a-87b5cc7a559d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a962d41b-c2bc-4adc-9ba4-576bb025f57d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a962d41b-c2bc-4adc-9ba4-576bb025f57d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/gr/f14f4416-d545-47ce-9dbe-ef294c45e7f6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a962d41b-c2bc-4adc-9ba4-576bb025f57d>.
+    
+<http://data.lblod.info/id/remote-data-objects/94657993-010f-4e95-85db-b2fd8dc3802e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94657993-010f-4e95-85db-b2fd8dc3802e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/101fb7ee-856a-47a3-a0ac-0f512acbbff7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94657993-010f-4e95-85db-b2fd8dc3802e>.
+    
+<http://data.lblod.info/id/remote-data-objects/002198a4-4867-47b6-8a14-4284f39139be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "002198a4-4867-47b6-8a14-4284f39139be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/101fb7ee-856a-47a3-a0ac-0f512acbbff7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/002198a4-4867-47b6-8a14-4284f39139be>.
+    
+<http://data.lblod.info/id/remote-data-objects/d338fb8d-9c21-4470-9656-9ccb2c0d1a40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d338fb8d-9c21-4470-9656-9ccb2c0d1a40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/165f9aba-29c9-4eaa-95ab-97e3c857908e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d338fb8d-9c21-4470-9656-9ccb2c0d1a40>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc83368e-91ab-451a-ada6-0c1512567b14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc83368e-91ab-451a-ada6-0c1512567b14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/165f9aba-29c9-4eaa-95ab-97e3c857908e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc83368e-91ab-451a-ada6-0c1512567b14>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfe35407-58e8-4b2a-ba88-77a0c01ec135> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfe35407-58e8-4b2a-ba88-77a0c01ec135";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/165f9aba-29c9-4eaa-95ab-97e3c857908e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfe35407-58e8-4b2a-ba88-77a0c01ec135>.
+    
+<http://data.lblod.info/id/remote-data-objects/515e39b4-cf84-4b8c-b692-12f4edbdf26c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "515e39b4-cf84-4b8c-b692-12f4edbdf26c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/20024c4e-3e32-4555-be2d-e8d4919ecc90/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/515e39b4-cf84-4b8c-b692-12f4edbdf26c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c24dc16d-93a4-44df-8fe5-1120b749333e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c24dc16d-93a4-44df-8fe5-1120b749333e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/20024c4e-3e32-4555-be2d-e8d4919ecc90/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c24dc16d-93a4-44df-8fe5-1120b749333e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e1a41dd-b836-4b84-92ed-b7656af683ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e1a41dd-b836-4b84-92ed-b7656af683ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/20024c4e-3e32-4555-be2d-e8d4919ecc90/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e1a41dd-b836-4b84-92ed-b7656af683ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d0b9bd6-760d-46b5-a1e3-786ebb41a182> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d0b9bd6-760d-46b5-a1e3-786ebb41a182";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/45b069c7-d323-49eb-aa28-66ca067a1181/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d0b9bd6-760d-46b5-a1e3-786ebb41a182>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae1c725d-57ff-472d-b0a9-9bc105508813> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae1c725d-57ff-472d-b0a9-9bc105508813";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/45b069c7-d323-49eb-aa28-66ca067a1181/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae1c725d-57ff-472d-b0a9-9bc105508813>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8760043-5266-44ea-b21f-c5b7a939e81f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8760043-5266-44ea-b21f-c5b7a939e81f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/45b069c7-d323-49eb-aa28-66ca067a1181/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8760043-5266-44ea-b21f-c5b7a939e81f>.
+    
+<http://data.lblod.info/id/remote-data-objects/972fc471-3b12-4cac-9b05-5a5be2b12181> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "972fc471-3b12-4cac-9b05-5a5be2b12181";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/4e50d25f-39c9-42af-b9cd-458ad5185f69/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/972fc471-3b12-4cac-9b05-5a5be2b12181>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2fb4744-2932-42c3-bbe4-3f8893171fb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2fb4744-2932-42c3-bbe4-3f8893171fb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/4e50d25f-39c9-42af-b9cd-458ad5185f69/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:12.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/74641aab-0ff9-46f1-ae9f-5745693d0f71> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2fb4744-2932-42c3-bbe4-3f8893171fb3>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201914-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201914-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201914-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201914-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/e87f4cc1-7e05-44f2-8e08-55d2db151e72> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e87f4cc1-7e05-44f2-8e08-55d2db151e72";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "965203a7-a62c-4fcd-82aa-8ac4895c0855";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/2e291024-0de4-4608-9637-872a19fcac0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2e291024-0de4-4608-9637-872a19fcac0a";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855>.
+
+  <http://redpencil.data.gift/id/task/8d38c975-c9e4-48ca-912b-ac60881a33a2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8d38c975-c9e4-48ca-912b-ac60881a33a2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e87f4cc1-7e05-44f2-8e08-55d2db151e72>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/2e291024-0de4-4608-9637-872a19fcac0a>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/09fd30ec-5b48-4f26-91f6-68cb92db459e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09fd30ec-5b48-4f26-91f6-68cb92db459e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/4e50d25f-39c9-42af-b9cd-458ad5185f69/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09fd30ec-5b48-4f26-91f6-68cb92db459e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f4a4f39-a7f6-499e-b3df-803f677b19b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f4a4f39-a7f6-499e-b3df-803f677b19b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/5796ad44-316a-445a-a6b3-ffed58fe6f2c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f4a4f39-a7f6-499e-b3df-803f677b19b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b7f3b1e-d77e-4d69-8a4f-3fce7f182700> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b7f3b1e-d77e-4d69-8a4f-3fce7f182700";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/5796ad44-316a-445a-a6b3-ffed58fe6f2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b7f3b1e-d77e-4d69-8a4f-3fce7f182700>.
+    
+<http://data.lblod.info/id/remote-data-objects/92ca0e6a-866f-4446-977f-f557f5bade2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92ca0e6a-866f-4446-977f-f557f5bade2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/5796ad44-316a-445a-a6b3-ffed58fe6f2c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92ca0e6a-866f-4446-977f-f557f5bade2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/71761f0b-1ac9-44ec-93ae-2729b0ea4007> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71761f0b-1ac9-44ec-93ae-2729b0ea4007";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/69bd6bb3-6e57-43ae-986d-bf6c6bf8f711/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71761f0b-1ac9-44ec-93ae-2729b0ea4007>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e91e8e4-075a-4724-a261-9f1793341c0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e91e8e4-075a-4724-a261-9f1793341c0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/69bd6bb3-6e57-43ae-986d-bf6c6bf8f711/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e91e8e4-075a-4724-a261-9f1793341c0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/99a4d273-18d1-4d73-bbbb-fb8e439f886c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99a4d273-18d1-4d73-bbbb-fb8e439f886c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/69bd6bb3-6e57-43ae-986d-bf6c6bf8f711/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99a4d273-18d1-4d73-bbbb-fb8e439f886c>.
+    
+<http://data.lblod.info/id/remote-data-objects/13524e32-0162-4163-ae16-31e039a143ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13524e32-0162-4163-ae16-31e039a143ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/71263d05-e0a7-4ee5-94a9-c8ffe9bc116e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13524e32-0162-4163-ae16-31e039a143ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/772ebb24-026e-4651-b44d-51ea151f2878> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "772ebb24-026e-4651-b44d-51ea151f2878";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/71263d05-e0a7-4ee5-94a9-c8ffe9bc116e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/772ebb24-026e-4651-b44d-51ea151f2878>.
+    
+<http://data.lblod.info/id/remote-data-objects/13bfb98d-fb4b-4578-a089-84b4c7c39809> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13bfb98d-fb4b-4578-a089-84b4c7c39809";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/71263d05-e0a7-4ee5-94a9-c8ffe9bc116e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13bfb98d-fb4b-4578-a089-84b4c7c39809>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2e96db2-5f6d-4db1-95d8-92f50ea1ab0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2e96db2-5f6d-4db1-95d8-92f50ea1ab0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/73c0603b-9d92-4ffc-bbca-2af073174b31/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2e96db2-5f6d-4db1-95d8-92f50ea1ab0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c79e6ef6-2704-4b27-93a4-73629c8fbdb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c79e6ef6-2704-4b27-93a4-73629c8fbdb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/73c0603b-9d92-4ffc-bbca-2af073174b31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c79e6ef6-2704-4b27-93a4-73629c8fbdb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/262e2110-f96f-4119-85fe-ef7132dbf4bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "262e2110-f96f-4119-85fe-ef7132dbf4bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/73c0603b-9d92-4ffc-bbca-2af073174b31/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/262e2110-f96f-4119-85fe-ef7132dbf4bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/48abc62d-37cb-4240-9418-396edfed2e6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48abc62d-37cb-4240-9418-396edfed2e6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/7edcdc93-0f17-42e5-af3a-b59bb35b29a6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48abc62d-37cb-4240-9418-396edfed2e6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d00973d2-fcbf-4ae7-b68e-8d103d041458> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d00973d2-fcbf-4ae7-b68e-8d103d041458";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/7edcdc93-0f17-42e5-af3a-b59bb35b29a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d00973d2-fcbf-4ae7-b68e-8d103d041458>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f45f9b8-521b-419f-9117-5e69fa33fb74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f45f9b8-521b-419f-9117-5e69fa33fb74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/7edcdc93-0f17-42e5-af3a-b59bb35b29a6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f45f9b8-521b-419f-9117-5e69fa33fb74>.
+    
+<http://data.lblod.info/id/remote-data-objects/c83ddb23-5cf6-46cc-9f15-bcb35923c52c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c83ddb23-5cf6-46cc-9f15-bcb35923c52c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/ac9cd8f7-9edf-435c-b248-e79f1f6051c5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c83ddb23-5cf6-46cc-9f15-bcb35923c52c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e836a389-4cbe-4e3b-8a93-b029924da773> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e836a389-4cbe-4e3b-8a93-b029924da773";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/ac9cd8f7-9edf-435c-b248-e79f1f6051c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e836a389-4cbe-4e3b-8a93-b029924da773>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e723533-5b07-4ea2-9b0a-ed8e9baced84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e723533-5b07-4ea2-9b0a-ed8e9baced84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/ac9cd8f7-9edf-435c-b248-e79f1f6051c5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e723533-5b07-4ea2-9b0a-ed8e9baced84>.
+    
+<http://data.lblod.info/id/remote-data-objects/d579decb-7aaf-476f-b023-e6aa3fb60acc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d579decb-7aaf-476f-b023-e6aa3fb60acc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/d3a46514-2f98-4e14-be94-30e9c6eb74b5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d579decb-7aaf-476f-b023-e6aa3fb60acc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e6b6db8-33c2-4fce-a502-997cde92fc1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e6b6db8-33c2-4fce-a502-997cde92fc1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/d3a46514-2f98-4e14-be94-30e9c6eb74b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e6b6db8-33c2-4fce-a502-997cde92fc1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/389bebd6-0c56-4c85-a1a4-50d8710e4493> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "389bebd6-0c56-4c85-a1a4-50d8710e4493";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/d3a46514-2f98-4e14-be94-30e9c6eb74b5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/389bebd6-0c56-4c85-a1a4-50d8710e4493>.
+    
+<http://data.lblod.info/id/remote-data-objects/bac3be74-98bf-4014-a432-ce50f3c2e50f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bac3be74-98bf-4014-a432-ce50f3c2e50f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/d6426cdd-52a9-4e30-9d02-20e5f8667b22/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bac3be74-98bf-4014-a432-ce50f3c2e50f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8e09b4a-9db5-4443-8ab6-97cc27f706a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8e09b4a-9db5-4443-8ab6-97cc27f706a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/d6426cdd-52a9-4e30-9d02-20e5f8667b22/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8e09b4a-9db5-4443-8ab6-97cc27f706a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8f11ee0-86f8-4d4f-88b2-43401c26eae0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8f11ee0-86f8-4d4f-88b2-43401c26eae0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/d6426cdd-52a9-4e30-9d02-20e5f8667b22/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8f11ee0-86f8-4d4f-88b2-43401c26eae0>.
+    
+<http://data.lblod.info/id/remote-data-objects/fecdd907-d232-4679-83d6-1f84eac97a8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fecdd907-d232-4679-83d6-1f84eac97a8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/e6f02f1a-3801-4ba7-9299-d2ec54f4b05a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fecdd907-d232-4679-83d6-1f84eac97a8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a999505-bc7d-4420-bfb5-0469da0d8117> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a999505-bc7d-4420-bfb5-0469da0d8117";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/e6f02f1a-3801-4ba7-9299-d2ec54f4b05a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a999505-bc7d-4420-bfb5-0469da0d8117>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a048a8b-6143-4d2a-9b14-6ef258f46313> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a048a8b-6143-4d2a-9b14-6ef258f46313";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/e6f02f1a-3801-4ba7-9299-d2ec54f4b05a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a048a8b-6143-4d2a-9b14-6ef258f46313>.
+    
+<http://data.lblod.info/id/remote-data-objects/10afc20b-0c30-4eb6-a98e-c0819231dacb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10afc20b-0c30-4eb6-a98e-c0819231dacb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/e87fb2fa-e5e6-4930-af12-d370e428ab9e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10afc20b-0c30-4eb6-a98e-c0819231dacb>.
+    
+<http://data.lblod.info/id/remote-data-objects/495e585f-ffe1-4730-9e43-b2aa3dcac8a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "495e585f-ffe1-4730-9e43-b2aa3dcac8a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/e87fb2fa-e5e6-4930-af12-d370e428ab9e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/495e585f-ffe1-4730-9e43-b2aa3dcac8a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfffbff6-bdf3-40ee-8b00-226b615adb79> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfffbff6-bdf3-40ee-8b00-226b615adb79";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/rmw/e87fb2fa-e5e6-4930-af12-d370e428ab9e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfffbff6-bdf3-40ee-8b00-226b615adb79>.
+    
+<http://data.lblod.info/id/remote-data-objects/16fca9bc-2a1c-4ce4-96b2-a32b7ecba107> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16fca9bc-2a1c-4ce4-96b2-a32b7ecba107";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/Rvb/4e0e2480-f578-41be-acb6-1b36ebbf2967/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16fca9bc-2a1c-4ce4-96b2-a32b7ecba107>.
+    
+<http://data.lblod.info/id/remote-data-objects/c297a990-0303-4872-b108-c2952e4c7aa5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c297a990-0303-4872-b108-c2952e4c7aa5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/Rvb/57c4e34f-9c86-46c4-be58-27c77351a847/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c297a990-0303-4872-b108-c2952e4c7aa5>.
+    
+<http://data.lblod.info/id/remote-data-objects/60eb3546-22ef-49a0-a210-79ab1c318cfc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60eb3546-22ef-49a0-a210-79ab1c318cfc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/Rvb/5b061348-852b-460c-befa-4221618964f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60eb3546-22ef-49a0-a210-79ab1c318cfc>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fa708ab-e399-4d78-a5b1-1da8eb6a0884> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fa708ab-e399-4d78-a5b1-1da8eb6a0884";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/Rvb/5ec7f5cc-a349-4344-abe9-1a2ead3e9cac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fa708ab-e399-4d78-a5b1-1da8eb6a0884>.
+    
+<http://data.lblod.info/id/remote-data-objects/e74a02e4-5167-45a9-8734-03a8d7e09318> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e74a02e4-5167-45a9-8734-03a8d7e09318";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/Rvb/70404940-f2e6-4b9e-ae8f-c9b4bf0459af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e74a02e4-5167-45a9-8734-03a8d7e09318>.
+    
+<http://data.lblod.info/id/remote-data-objects/71bd0158-d9f1-46db-bb3f-8a5751f5b8df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71bd0158-d9f1-46db-bb3f-8a5751f5b8df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/Rvb/9157109c-61b6-41cb-b210-d49ac3236dab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71bd0158-d9f1-46db-bb3f-8a5751f5b8df>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe43942d-27ab-49c8-81ea-033ea50fce77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe43942d-27ab-49c8-81ea-033ea50fce77";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/Rvb/a7a3c5cf-1cf2-49dc-94e7-7daedf417049/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe43942d-27ab-49c8-81ea-033ea50fce77>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfd82254-4301-4bbe-976d-64f209572e85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfd82254-4301-4bbe-976d-64f209572e85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/Rvb/ad707c89-d84e-442c-b527-561b64807b9b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfd82254-4301-4bbe-976d-64f209572e85>.
+    
+<http://data.lblod.info/id/remote-data-objects/26a802b8-1102-45d4-8974-9138d8676c10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26a802b8-1102-45d4-8974-9138d8676c10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/Rvb/c2198c0d-4d46-441e-bc4e-730c507295d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26a802b8-1102-45d4-8974-9138d8676c10>.
+    
+<http://data.lblod.info/id/remote-data-objects/18c69ba5-e1b2-44ac-afe3-d35b8be092b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18c69ba5-e1b2-44ac-afe3-d35b8be092b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/Rvb/da31363b-ac7c-444d-a220-641d10f20efa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18c69ba5-e1b2-44ac-afe3-d35b8be092b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7772238e-c9a2-4e19-b4ae-0e43f6fa9f6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7772238e-c9a2-4e19-b4ae-0e43f6fa9f6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/Rvb/eecfbf30-325f-441a-b9b5-7fb287e89959/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7772238e-c9a2-4e19-b4ae-0e43f6fa9f6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/00a13432-ef08-44e4-b612-a3de18b1c442> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00a13432-ef08-44e4-b612-a3de18b1c442";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/0469db19-edc7-47a5-9635-aeb1d8fd7cf5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00a13432-ef08-44e4-b612-a3de18b1c442>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fb3d971-96ec-4b03-bb65-f481f0634410> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fb3d971-96ec-4b03-bb65-f481f0634410";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/060b8fda-bf1f-479c-8e6a-4b3bbd426d43/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fb3d971-96ec-4b03-bb65-f481f0634410>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed55984c-960e-4af5-83a3-a88a0f6d750e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed55984c-960e-4af5-83a3-a88a0f6d750e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/063f7b06-0f1d-4cc1-acbc-d69544293599/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed55984c-960e-4af5-83a3-a88a0f6d750e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c7e5081-b1cc-4c0d-878a-fe71b3449d39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c7e5081-b1cc-4c0d-878a-fe71b3449d39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/0b946e04-e40b-4cdb-9a62-6bd8d26f7eae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c7e5081-b1cc-4c0d-878a-fe71b3449d39>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c2994cc-469a-4045-9fb7-5e95c03ef34c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c2994cc-469a-4045-9fb7-5e95c03ef34c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/10a29c5d-5337-4b60-a7f8-815da35fc0da/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c2994cc-469a-4045-9fb7-5e95c03ef34c>.
+    
+<http://data.lblod.info/id/remote-data-objects/658f0dbe-30d2-420b-8700-f41d42e16eb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "658f0dbe-30d2-420b-8700-f41d42e16eb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/12ab2854-fdab-4756-80ee-da5f541540b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/658f0dbe-30d2-420b-8700-f41d42e16eb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdf3888a-c318-42f7-b5e3-28e59f995a65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdf3888a-c318-42f7-b5e3-28e59f995a65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/139dbef4-d5df-4f98-a46c-d4b8ba387795/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdf3888a-c318-42f7-b5e3-28e59f995a65>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3b67d21-8d33-4885-9983-61f9c736b5b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3b67d21-8d33-4885-9983-61f9c736b5b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/14679ec4-af71-443f-8d75-b2c438f62815/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:14.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/965203a7-a62c-4fcd-82aa-8ac4895c0855> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3b67d21-8d33-4885-9983-61f9c736b5b1>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201915-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201915-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201915-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201915-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/fc7c08f5-e505-4f49-86bb-26fe14e38e6e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fc7c08f5-e505-4f49-86bb-26fe14e38e6e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bb12471f-cc89-481b-8a87-6733891f7c36";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/463938f3-d998-45d7-96ec-365a8405f488> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "463938f3-d998-45d7-96ec-365a8405f488";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36>.
+
+  <http://redpencil.data.gift/id/task/994168cd-0dbc-4d6b-8543-d6aa31873b79> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "994168cd-0dbc-4d6b-8543-d6aa31873b79";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/fc7c08f5-e505-4f49-86bb-26fe14e38e6e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/463938f3-d998-45d7-96ec-365a8405f488>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/f0814354-e27e-4b12-a691-8bce0dbfdbb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0814354-e27e-4b12-a691-8bce0dbfdbb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/2a2fe32e-0f80-4a5e-aad1-af43c5c91c51/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0814354-e27e-4b12-a691-8bce0dbfdbb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b26d029-0fdf-486d-b3ba-cdc7ec9f2226> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b26d029-0fdf-486d-b3ba-cdc7ec9f2226";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/2fbbf751-e524-4c79-ba9c-cc9a42f7b6e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b26d029-0fdf-486d-b3ba-cdc7ec9f2226>.
+    
+<http://data.lblod.info/id/remote-data-objects/62c3dbb0-c5e8-4692-a041-8aec4439d093> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62c3dbb0-c5e8-4692-a041-8aec4439d093";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/3068a1f4-e2fb-4661-94fd-a04417a35970/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62c3dbb0-c5e8-4692-a041-8aec4439d093>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4d4d760-4c07-480e-8981-80b103d6547c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4d4d760-4c07-480e-8981-80b103d6547c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/3383afac-0e02-4796-a5f9-78a7a789a3b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4d4d760-4c07-480e-8981-80b103d6547c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7959921b-c7b0-46d8-b1ac-5e9bb6afd044> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7959921b-c7b0-46d8-b1ac-5e9bb6afd044";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/3564e6c2-98a3-46a2-848d-0d631bc807e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7959921b-c7b0-46d8-b1ac-5e9bb6afd044>.
+    
+<http://data.lblod.info/id/remote-data-objects/82f47f85-8c83-422c-b8af-397b84e968ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82f47f85-8c83-422c-b8af-397b84e968ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/39a0fa0a-35f3-47ad-97ab-fb6ffef2087c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82f47f85-8c83-422c-b8af-397b84e968ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/313c7b6b-c747-4672-b3b4-e0980061b789> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "313c7b6b-c747-4672-b3b4-e0980061b789";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/3a475e6c-6c00-4288-bcf2-27ed14ff6663/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/313c7b6b-c747-4672-b3b4-e0980061b789>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3c8009c-1597-435d-a307-ce95637be98d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3c8009c-1597-435d-a307-ce95637be98d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/3a6b961b-1f66-4b39-aab5-df5f73261d63/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3c8009c-1597-435d-a307-ce95637be98d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3f9778c-fd2c-4c56-ab25-a7628987887b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3f9778c-fd2c-4c56-ab25-a7628987887b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/3a942a0f-fdb0-4a35-8ba5-bd0001c65d40/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3f9778c-fd2c-4c56-ab25-a7628987887b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fe34146-b8c1-48d5-a6d7-68d778d221c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fe34146-b8c1-48d5-a6d7-68d778d221c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/3b50f01e-29bd-486b-98be-d6271b019018/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fe34146-b8c1-48d5-a6d7-68d778d221c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/88b2c352-c7ae-4b0a-8745-ecad8835a371> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88b2c352-c7ae-4b0a-8745-ecad8835a371";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/3d2e98b2-945a-454e-9ab7-c5b4f7557e2e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88b2c352-c7ae-4b0a-8745-ecad8835a371>.
+    
+<http://data.lblod.info/id/remote-data-objects/68a20fba-e516-4cd9-a13e-6522bbbc597b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68a20fba-e516-4cd9-a13e-6522bbbc597b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/42cfc458-e7d6-4010-b85d-ffd20d23152a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68a20fba-e516-4cd9-a13e-6522bbbc597b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5043b9e-2f72-41cb-97e1-f6534d3925a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5043b9e-2f72-41cb-97e1-f6534d3925a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/45fc0927-2903-405d-bc85-c05ea4d45067/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5043b9e-2f72-41cb-97e1-f6534d3925a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7e93039-e6b6-4c48-88d5-b64f107bec1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7e93039-e6b6-4c48-88d5-b64f107bec1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/4a00fa84-1dce-448e-96e3-2192df2b16da/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7e93039-e6b6-4c48-88d5-b64f107bec1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/591c8363-d6ac-4af3-b8ef-4f759787935c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "591c8363-d6ac-4af3-b8ef-4f759787935c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/4e8a9565-d295-4e6b-bb7d-85b5eb95ddca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/591c8363-d6ac-4af3-b8ef-4f759787935c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b16916bc-8c4e-4590-b5f9-11fbe5d38f06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b16916bc-8c4e-4590-b5f9-11fbe5d38f06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/505e615d-8d33-4e8c-8d67-891bdb8aefa0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b16916bc-8c4e-4590-b5f9-11fbe5d38f06>.
+    
+<http://data.lblod.info/id/remote-data-objects/296b5a1a-a5a3-4034-adb3-1192414e6abb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "296b5a1a-a5a3-4034-adb3-1192414e6abb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/52ae8a9d-e9ab-4073-bbaf-f718fc0b0f5c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/296b5a1a-a5a3-4034-adb3-1192414e6abb>.
+    
+<http://data.lblod.info/id/remote-data-objects/73cca0f0-292e-49d4-9453-ba1bd364d69e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73cca0f0-292e-49d4-9453-ba1bd364d69e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/53c81f2f-b476-445e-855f-5141eecaa6b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73cca0f0-292e-49d4-9453-ba1bd364d69e>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ea82da9-bec1-4c73-95e0-d62eb5501d5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ea82da9-bec1-4c73-95e0-d62eb5501d5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/5c80dc38-e6c3-4a6a-867f-2e75d7810485/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ea82da9-bec1-4c73-95e0-d62eb5501d5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1e5c14b-8b9c-4c4d-9b52-fda6089f781e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1e5c14b-8b9c-4c4d-9b52-fda6089f781e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/5d38a98b-6188-46e7-bef6-0c6707609196/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1e5c14b-8b9c-4c4d-9b52-fda6089f781e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c75f47fd-2e17-4262-b2e5-7701c53b876b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c75f47fd-2e17-4262-b2e5-7701c53b876b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/5d5bb498-6c81-45cb-95d0-32f919906786/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c75f47fd-2e17-4262-b2e5-7701c53b876b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f51e3469-211a-489e-a1fa-9cd8484b71c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f51e3469-211a-489e-a1fa-9cd8484b71c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/5d8e846a-a551-4e60-82b0-9d514e99ffe8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f51e3469-211a-489e-a1fa-9cd8484b71c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/08f52212-192a-4d33-ac5d-475424da127e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08f52212-192a-4d33-ac5d-475424da127e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/605bf436-95ee-4ea5-8b11-7b08a51371fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08f52212-192a-4d33-ac5d-475424da127e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a949bcf8-0119-4e8a-85a9-f9728b1f5cdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a949bcf8-0119-4e8a-85a9-f9728b1f5cdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/6277ef72-f232-48c4-8692-72ccbae36650/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a949bcf8-0119-4e8a-85a9-f9728b1f5cdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/40168971-4699-443c-bcf4-2d64cd4bcd62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40168971-4699-443c-bcf4-2d64cd4bcd62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/646ccdef-457d-4e05-897f-fe9299359c89/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40168971-4699-443c-bcf4-2d64cd4bcd62>.
+    
+<http://data.lblod.info/id/remote-data-objects/545ec0b9-efe4-4581-812a-c97a5c8a8835> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "545ec0b9-efe4-4581-812a-c97a5c8a8835";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/6550cadc-9d65-4939-99c2-390dc6242a04/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/545ec0b9-efe4-4581-812a-c97a5c8a8835>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b11e116-e380-41e3-a918-6c0d24e6901e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b11e116-e380-41e3-a918-6c0d24e6901e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/6b1114d4-1d50-41d6-83cb-6809d2d94074/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b11e116-e380-41e3-a918-6c0d24e6901e>.
+    
+<http://data.lblod.info/id/remote-data-objects/01f05978-1153-42e2-a8ae-8b5bcea818ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01f05978-1153-42e2-a8ae-8b5bcea818ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/6cfbf0ec-e98c-4087-811e-e04a5646bc3b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01f05978-1153-42e2-a8ae-8b5bcea818ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2bdb17b-3e03-4836-8433-20f6905293d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2bdb17b-3e03-4836-8433-20f6905293d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/6dacb21a-13ea-43fb-8519-1ffdad68a1d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2bdb17b-3e03-4836-8433-20f6905293d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f538281b-785c-464e-8fe5-88e5d137bfbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f538281b-785c-464e-8fe5-88e5d137bfbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/6ec68cba-c061-4439-b6e9-ed6dfd38fa31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f538281b-785c-464e-8fe5-88e5d137bfbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6412f86-a262-423f-b55b-48b03152271d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6412f86-a262-423f-b55b-48b03152271d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/6f33bcdc-9e7e-4d54-8681-1a7e6b93332b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6412f86-a262-423f-b55b-48b03152271d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d764140f-55db-42b6-bb71-2ed191be389f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d764140f-55db-42b6-bb71-2ed191be389f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/72bfc201-81a3-4260-8d40-9f404dd71949/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d764140f-55db-42b6-bb71-2ed191be389f>.
+    
+<http://data.lblod.info/id/remote-data-objects/894abba7-7b42-4681-94a4-ea5335e76ff8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "894abba7-7b42-4681-94a4-ea5335e76ff8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/757f1b5d-819c-42f3-a070-58a00e8c890f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/894abba7-7b42-4681-94a4-ea5335e76ff8>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1a71504-4287-415e-b310-68e3f9e78b28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1a71504-4287-415e-b310-68e3f9e78b28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/78c7d2c0-3b71-43cc-af1e-fa3a887a1747/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1a71504-4287-415e-b310-68e3f9e78b28>.
+    
+<http://data.lblod.info/id/remote-data-objects/85b82918-c1f5-4d5c-ad8c-2425973773e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85b82918-c1f5-4d5c-ad8c-2425973773e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/795a75ba-d792-4756-956e-d2370574fbcb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85b82918-c1f5-4d5c-ad8c-2425973773e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/819e8024-b13e-4be5-916a-50daeadf8639> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "819e8024-b13e-4be5-916a-50daeadf8639";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/7fc260bc-9f67-4867-8dfe-c24821475d4d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/819e8024-b13e-4be5-916a-50daeadf8639>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f08d555-6acb-46d4-983d-ef5cb849a5cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f08d555-6acb-46d4-983d-ef5cb849a5cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/8267b7ae-7e13-4f87-a8ca-a86ecbb02da5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f08d555-6acb-46d4-983d-ef5cb849a5cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/839174f7-16f8-41b9-9804-ed98c25cf79b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "839174f7-16f8-41b9-9804-ed98c25cf79b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/84d89621-4cd5-4dba-9f50-cd49d32bab30/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/839174f7-16f8-41b9-9804-ed98c25cf79b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5aed7bdf-cd49-4087-a0d9-d136089917da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5aed7bdf-cd49-4087-a0d9-d136089917da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/8601ef54-ccd0-41a1-8ba0-df263dc9be16/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5aed7bdf-cd49-4087-a0d9-d136089917da>.
+    
+<http://data.lblod.info/id/remote-data-objects/044ad394-c70a-4d1f-b0a5-daa45097f01d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "044ad394-c70a-4d1f-b0a5-daa45097f01d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/88c1ee96-d397-4066-a686-8922e32d21f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/044ad394-c70a-4d1f-b0a5-daa45097f01d>.
+    
+<http://data.lblod.info/id/remote-data-objects/60f0c8b4-85eb-45f6-8b5d-b9e6a2cf407a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60f0c8b4-85eb-45f6-8b5d-b9e6a2cf407a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/91710b88-ff8e-4b7c-969d-5be09e7583a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60f0c8b4-85eb-45f6-8b5d-b9e6a2cf407a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9db77b7-ef32-4dac-a07f-6240be66dcfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9db77b7-ef32-4dac-a07f-6240be66dcfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/93abe454-5fc8-4273-be60-8206856cd7e5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9db77b7-ef32-4dac-a07f-6240be66dcfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/67bf0cca-019e-41bb-8e92-4ecc2dc1bf12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67bf0cca-019e-41bb-8e92-4ecc2dc1bf12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/9600090b-d418-4537-b3e3-ab453317d4b4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67bf0cca-019e-41bb-8e92-4ecc2dc1bf12>.
+    
+<http://data.lblod.info/id/remote-data-objects/14a99018-5dfc-42be-a873-a13cc55b81e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14a99018-5dfc-42be-a873-a13cc55b81e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/981dac3f-6a2d-4c36-9343-51af75a6bcef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14a99018-5dfc-42be-a873-a13cc55b81e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/05ef480c-1bb7-4811-9461-8b02f5ef9d6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05ef480c-1bb7-4811-9461-8b02f5ef9d6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/994c08cd-741e-4e95-95b2-bb47531a2e1f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05ef480c-1bb7-4811-9461-8b02f5ef9d6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/dda567af-1abd-44a0-a662-b8006d895ea2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dda567af-1abd-44a0-a662-b8006d895ea2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/a060cbcf-d257-4b28-bffd-877238e4f052/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dda567af-1abd-44a0-a662-b8006d895ea2>.
+    
+<http://data.lblod.info/id/remote-data-objects/df3e7038-f364-4fcd-950a-b66cc5abd2cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df3e7038-f364-4fcd-950a-b66cc5abd2cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/ad063559-7716-4668-b54b-53d8a328800a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df3e7038-f364-4fcd-950a-b66cc5abd2cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e4952f8-4474-4b63-8cab-56afd9b0e3fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e4952f8-4474-4b63-8cab-56afd9b0e3fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/b16c01fc-aa71-4f06-9a28-bbb3b53937a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e4952f8-4474-4b63-8cab-56afd9b0e3fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/1da4b0a2-4080-498a-bfca-321e27818411> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1da4b0a2-4080-498a-bfca-321e27818411";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/b87ed6fb-7029-43bb-9fb2-8784905b693d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1da4b0a2-4080-498a-bfca-321e27818411>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef05c10b-d58b-4607-8359-85c02af9beea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef05c10b-d58b-4607-8359-85c02af9beea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/b9e54909-fc4c-49d2-8505-03429163b8c7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:15.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bb12471f-cc89-481b-8a87-6733891f7c36> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef05c10b-d58b-4607-8359-85c02af9beea>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201916-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201916-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201916-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201916-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2a0e5845-b25c-4832-b65b-e93991ab731e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2a0e5845-b25c-4832-b65b-e93991ab731e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2da62cff-9b7e-42a6-b27e-561b3d14a049";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/00ff0e31-f6b1-4740-ab6d-fed61972cbe4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "00ff0e31-f6b1-4740-ab6d-fed61972cbe4";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049>.
+
+  <http://redpencil.data.gift/id/task/b72f3be8-e09f-4ca2-aa96-d5395e450d24> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b72f3be8-e09f-4ca2-aa96-d5395e450d24";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2a0e5845-b25c-4832-b65b-e93991ab731e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/00ff0e31-f6b1-4740-ab6d-fed61972cbe4>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/b9f520db-49ec-4ce0-9196-0981100fc4b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9f520db-49ec-4ce0-9196-0981100fc4b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/bcfd092d-31d8-44d8-957f-196159a7bbc6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9f520db-49ec-4ce0-9196-0981100fc4b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3ac5c5b-4428-42ee-97da-0b47e571ec00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3ac5c5b-4428-42ee-97da-0b47e571ec00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/bf83feec-fbf5-42e4-9a7e-c20da439d134/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3ac5c5b-4428-42ee-97da-0b47e571ec00>.
+    
+<http://data.lblod.info/id/remote-data-objects/495c2946-cd7c-452f-8790-3951b7474eb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "495c2946-cd7c-452f-8790-3951b7474eb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/c01d5cf4-e40c-450e-9576-964280e039be/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/495c2946-cd7c-452f-8790-3951b7474eb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ae4b17b-3d5b-4aa2-9812-40f2f7227d7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ae4b17b-3d5b-4aa2-9812-40f2f7227d7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/cb4665c2-451f-4834-8c55-9bd53f95a91f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ae4b17b-3d5b-4aa2-9812-40f2f7227d7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d529d8cb-aa9a-4e9a-b68a-6970e3563ba3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d529d8cb-aa9a-4e9a-b68a-6970e3563ba3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/cf81036a-2dad-4c51-b83f-e725bb2e0782/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d529d8cb-aa9a-4e9a-b68a-6970e3563ba3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d2efc8f-1cfb-4e7e-9f92-3309facf795f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d2efc8f-1cfb-4e7e-9f92-3309facf795f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/da92d107-5deb-4054-b055-4fa221cddfd2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d2efc8f-1cfb-4e7e-9f92-3309facf795f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1539aa7-a967-475a-98cb-329aa2fd8311> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1539aa7-a967-475a-98cb-329aa2fd8311";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/e4c1b605-97ba-4762-8543-7242f426c77e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1539aa7-a967-475a-98cb-329aa2fd8311>.
+    
+<http://data.lblod.info/id/remote-data-objects/0992a719-dcaa-428e-af49-39b7e9a7b965> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0992a719-dcaa-428e-af49-39b7e9a7b965";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/e959ec9a-5ea7-4d11-81a4-f4144421f4aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0992a719-dcaa-428e-af49-39b7e9a7b965>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e3e158c-a339-4423-b6c7-b488c34a98b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e3e158c-a339-4423-b6c7-b488c34a98b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/eb12c7e2-4bd3-4072-be24-265dab72a8b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e3e158c-a339-4423-b6c7-b488c34a98b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e601e310-c84c-401c-8de3-f9d8bb6a8927> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e601e310-c84c-401c-8de3-f9d8bb6a8927";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/ec4eff17-be7b-4c7a-a4b4-bedd67cb445d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e601e310-c84c-401c-8de3-f9d8bb6a8927>.
+    
+<http://data.lblod.info/id/remote-data-objects/9790b3ed-635d-4d13-bedf-52fcf3af9b6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9790b3ed-635d-4d13-bedf-52fcf3af9b6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/f084ea74-a360-47b0-af16-8b73da6a9d27/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9790b3ed-635d-4d13-bedf-52fcf3af9b6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b364439f-2251-46ed-b648-e344df28b8bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b364439f-2251-46ed-b648-e344df28b8bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/f25e30d9-0606-4741-b974-6d22d46b5f1a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b364439f-2251-46ed-b648-e344df28b8bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/9427c835-0005-4a98-95e0-f05fecd9594a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9427c835-0005-4a98-95e0-f05fecd9594a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/sc/f9b51fda-0418-4116-83e6-fbed7d10e036/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9427c835-0005-4a98-95e0-f05fecd9594a>.
+    
+<http://data.lblod.info/id/remote-data-objects/00157496-c14f-4055-9c35-8086dcb922af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00157496-c14f-4055-9c35-8086dcb922af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/01f28f33-7f06-40f2-b78b-850e2161d236/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00157496-c14f-4055-9c35-8086dcb922af>.
+    
+<http://data.lblod.info/id/remote-data-objects/392f6935-a574-4b8a-b9da-052d0995b2b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "392f6935-a574-4b8a-b9da-052d0995b2b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/02dd1729-e63e-4162-83c2-be3b376802c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/392f6935-a574-4b8a-b9da-052d0995b2b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/251d49cd-944d-4cda-bb6b-a3a3847d304f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "251d49cd-944d-4cda-bb6b-a3a3847d304f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/03e4ff45-8c5e-4f34-80ad-3e28371ed062/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/251d49cd-944d-4cda-bb6b-a3a3847d304f>.
+    
+<http://data.lblod.info/id/remote-data-objects/aeccc0e1-f411-43a4-90e8-21cde9090223> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aeccc0e1-f411-43a4-90e8-21cde9090223";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/0628dc4c-ab12-4b08-b6ae-680cb975c8e9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aeccc0e1-f411-43a4-90e8-21cde9090223>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b286c9f-2843-4190-9058-58c520bb0788> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b286c9f-2843-4190-9058-58c520bb0788";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/09d19365-6888-48d9-8fd9-20529bcccef4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b286c9f-2843-4190-9058-58c520bb0788>.
+    
+<http://data.lblod.info/id/remote-data-objects/42877d3b-ec13-4200-8362-c8ce1eb70ea9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42877d3b-ec13-4200-8362-c8ce1eb70ea9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/09fbf65d-1928-4eb9-947f-1bd859b142e6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42877d3b-ec13-4200-8362-c8ce1eb70ea9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5dbf2cc5-7168-47a8-be98-f677b73fecd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5dbf2cc5-7168-47a8-be98-f677b73fecd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/0a74f290-a358-4db7-bca9-23853e087c62/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5dbf2cc5-7168-47a8-be98-f677b73fecd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/74e2593c-9c61-484a-8407-98a6ccedb29e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74e2593c-9c61-484a-8407-98a6ccedb29e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/0bfd8e2b-2434-4e2b-90bb-5c3510b70e3a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74e2593c-9c61-484a-8407-98a6ccedb29e>.
+    
+<http://data.lblod.info/id/remote-data-objects/50182b7a-2ef8-498b-b682-03adc50b2aa4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50182b7a-2ef8-498b-b682-03adc50b2aa4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/1023c5e5-16e3-4065-8257-426de4d8b52e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50182b7a-2ef8-498b-b682-03adc50b2aa4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f1e9fc4-0cd9-4e7b-9209-20caa0d5ca1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f1e9fc4-0cd9-4e7b-9209-20caa0d5ca1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/1808814e-54c1-4956-8e0a-704a4fda8abc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f1e9fc4-0cd9-4e7b-9209-20caa0d5ca1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d956ee7-8ace-4fb7-8512-e1f53dc93a9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d956ee7-8ace-4fb7-8512-e1f53dc93a9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/1aad05b8-82c5-4a9b-9166-927b0203be96/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d956ee7-8ace-4fb7-8512-e1f53dc93a9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d5fbb0d-b6ba-4ebc-8663-d65ee787df46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d5fbb0d-b6ba-4ebc-8663-d65ee787df46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/20594e8b-0270-4a85-9277-0dacd3297201/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d5fbb0d-b6ba-4ebc-8663-d65ee787df46>.
+    
+<http://data.lblod.info/id/remote-data-objects/eaf56f48-2b0c-44e5-93a9-072dc477168a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eaf56f48-2b0c-44e5-93a9-072dc477168a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/22e09738-466f-469f-bf0a-8d67f96663b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eaf56f48-2b0c-44e5-93a9-072dc477168a>.
+    
+<http://data.lblod.info/id/remote-data-objects/808e471b-4d9e-46d3-af55-13bd7fc304aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "808e471b-4d9e-46d3-af55-13bd7fc304aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/30156f00-39ba-450b-a385-857969e7b30f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/808e471b-4d9e-46d3-af55-13bd7fc304aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/55b9da2d-1127-4453-be94-c73d2004ea9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55b9da2d-1127-4453-be94-c73d2004ea9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/307de177-9da5-46e3-a172-7d338c4acd55/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55b9da2d-1127-4453-be94-c73d2004ea9b>.
+    
+<http://data.lblod.info/id/remote-data-objects/39692dac-9fbc-4174-9e69-f3841aa594d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39692dac-9fbc-4174-9e69-f3841aa594d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/32111c6a-ad8c-4073-8432-1f84dba84365/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39692dac-9fbc-4174-9e69-f3841aa594d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4297fdc3-7dbf-4817-b639-5190ed884a07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4297fdc3-7dbf-4817-b639-5190ed884a07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/39dedb4f-7fe6-41c7-80af-0a096241a3a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4297fdc3-7dbf-4817-b639-5190ed884a07>.
+    
+<http://data.lblod.info/id/remote-data-objects/17c9d49d-2e9c-40d4-a639-d84f09972bcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17c9d49d-2e9c-40d4-a639-d84f09972bcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/3cc7fd5f-2c11-4e17-b711-7c5d12e52683/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17c9d49d-2e9c-40d4-a639-d84f09972bcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/ace0ad0d-4460-4d22-b09e-49c7ade27eba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ace0ad0d-4460-4d22-b09e-49c7ade27eba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/3cd2b3e0-521f-47d6-afdf-2f561cd0a0ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ace0ad0d-4460-4d22-b09e-49c7ade27eba>.
+    
+<http://data.lblod.info/id/remote-data-objects/c469f3ca-165b-4838-ab45-61ab85f83267> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c469f3ca-165b-4838-ab45-61ab85f83267";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/405aaf2d-8673-4e9a-910f-20d26d38a4ed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c469f3ca-165b-4838-ab45-61ab85f83267>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b8fa640-32f4-4a67-9f37-f615374f825b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b8fa640-32f4-4a67-9f37-f615374f825b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/441c6647-37f7-437d-947c-7cbfc5535bd9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b8fa640-32f4-4a67-9f37-f615374f825b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c8d546a-3705-4180-be5b-129c08f4092a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c8d546a-3705-4180-be5b-129c08f4092a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/4e46ee15-12c0-4c21-8b92-52db8e299dfe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c8d546a-3705-4180-be5b-129c08f4092a>.
+    
+<http://data.lblod.info/id/remote-data-objects/798b0683-6782-4521-86e1-eefccd9950b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "798b0683-6782-4521-86e1-eefccd9950b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/55503e1d-09e9-46ce-9a3b-c3b8e25b8448/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/798b0683-6782-4521-86e1-eefccd9950b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9965e1e-d3ba-4f72-9d91-b9246ebfe336> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9965e1e-d3ba-4f72-9d91-b9246ebfe336";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/58c7d144-391a-4349-93a4-568f622f0533/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9965e1e-d3ba-4f72-9d91-b9246ebfe336>.
+    
+<http://data.lblod.info/id/remote-data-objects/484fb078-24c9-4f43-a963-80f387e628db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "484fb078-24c9-4f43-a963-80f387e628db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/5ace0070-5db4-438e-8041-2561a1c5f8b8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/484fb078-24c9-4f43-a963-80f387e628db>.
+    
+<http://data.lblod.info/id/remote-data-objects/a203f674-94c5-4977-a433-8f5ff204769d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a203f674-94c5-4977-a433-8f5ff204769d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/5da656ac-7ff1-4a78-92db-ed159faf62c7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a203f674-94c5-4977-a433-8f5ff204769d>.
+    
+<http://data.lblod.info/id/remote-data-objects/98da5225-312d-404f-87ba-95e2b02c2fd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98da5225-312d-404f-87ba-95e2b02c2fd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/6dd58a71-1f95-4d66-a69e-b0fbf14e288c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98da5225-312d-404f-87ba-95e2b02c2fd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba30eae7-f36f-446a-a989-d74c222fa281> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba30eae7-f36f-446a-a989-d74c222fa281";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/6f9ba1b3-53b9-449d-b84f-75d8c9a35ebe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba30eae7-f36f-446a-a989-d74c222fa281>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3b22adc-a3f6-4eea-bf92-1c984b690c76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3b22adc-a3f6-4eea-bf92-1c984b690c76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/717cdbb6-3990-47a0-bb50-73f846941343/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3b22adc-a3f6-4eea-bf92-1c984b690c76>.
+    
+<http://data.lblod.info/id/remote-data-objects/0da90fd6-e145-4e5b-a055-ba95879b0146> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0da90fd6-e145-4e5b-a055-ba95879b0146";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/7399b835-f744-4d8f-b7e3-c83d978cc38b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0da90fd6-e145-4e5b-a055-ba95879b0146>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbb820bb-549d-40ab-9148-2cde051fe054> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbb820bb-549d-40ab-9148-2cde051fe054";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/84ff9954-1de4-4ceb-a806-1abac240fc83/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbb820bb-549d-40ab-9148-2cde051fe054>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac27a517-6336-42c2-8529-ecc2ea2e49f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac27a517-6336-42c2-8529-ecc2ea2e49f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/85484b34-1c04-45dc-b5f0-7340e620cff8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac27a517-6336-42c2-8529-ecc2ea2e49f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8664239-549d-44f0-80da-5f00782837f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8664239-549d-44f0-80da-5f00782837f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/897289c3-dbea-4412-b8de-d45bbf30d90f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8664239-549d-44f0-80da-5f00782837f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c3c86c6-a66b-49f2-8072-38a412f6ec1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c3c86c6-a66b-49f2-8072-38a412f6ec1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/8b0245aa-0478-4093-82e0-e0c07eaddf95/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c3c86c6-a66b-49f2-8072-38a412f6ec1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/41a16f48-9611-4f4a-adf5-a0612d21a2b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41a16f48-9611-4f4a-adf5-a0612d21a2b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/8be9bf12-2bec-4360-9de0-ab39a66236c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41a16f48-9611-4f4a-adf5-a0612d21a2b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e60ffbd8-1aeb-4f74-a5ed-e5d600dc17e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e60ffbd8-1aeb-4f74-a5ed-e5d600dc17e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/8e45bd87-5c7e-446d-9872-974c9e6097c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e60ffbd8-1aeb-4f74-a5ed-e5d600dc17e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a90b4dd8-c6b9-42b5-9da2-d039da7b0af4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a90b4dd8-c6b9-42b5-9da2-d039da7b0af4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/8f042d37-1020-421f-85f0-3ad6f24e18ed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:16.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2da62cff-9b7e-42a6-b27e-561b3d14a049> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a90b4dd8-c6b9-42b5-9da2-d039da7b0af4>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201917-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201917-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201917-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201917-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/9c556fc2-d865-4c8c-a010-b005f661813d> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9c556fc2-d865-4c8c-a010-b005f661813d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a3a04c24-dc52-49cb-a19e-6bc213d05d77> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a3a04c24-dc52-49cb-a19e-6bc213d05d77";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee>.
+
+  <http://redpencil.data.gift/id/task/82cdde85-37bd-4d6e-b015-523c7b44955a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "82cdde85-37bd-4d6e-b015-523c7b44955a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/9c556fc2-d865-4c8c-a010-b005f661813d>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a3a04c24-dc52-49cb-a19e-6bc213d05d77>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e669469d-2f14-4389-a0ba-efb67bf3010e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e669469d-2f14-4389-a0ba-efb67bf3010e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/95bcd969-2a28-4a8f-af7f-bdf85ebf2aad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e669469d-2f14-4389-a0ba-efb67bf3010e>.
+    
+<http://data.lblod.info/id/remote-data-objects/25eed0dc-a449-41b8-a4d1-05fc56ee8c57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25eed0dc-a449-41b8-a4d1-05fc56ee8c57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/9b58c52f-ca1a-4a4d-94c9-90216ce70043/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25eed0dc-a449-41b8-a4d1-05fc56ee8c57>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ef5d67c-ff38-4d17-b92b-802466194a2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ef5d67c-ff38-4d17-b92b-802466194a2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/9fd123fb-44c2-4560-af6a-ec09684444fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ef5d67c-ff38-4d17-b92b-802466194a2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9a03213-ca1e-4738-8b3d-74198537bf38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9a03213-ca1e-4738-8b3d-74198537bf38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/a65f0077-b7af-4365-af67-9cb1e9e79a9d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9a03213-ca1e-4738-8b3d-74198537bf38>.
+    
+<http://data.lblod.info/id/remote-data-objects/f612ec61-8020-4eb5-a31a-d77615f521fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f612ec61-8020-4eb5-a31a-d77615f521fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/a8aba92b-48eb-4a52-b158-a4d31fed806f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f612ec61-8020-4eb5-a31a-d77615f521fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/0832ed27-0039-4bf2-aa1a-6d1e1a92c7f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0832ed27-0039-4bf2-aa1a-6d1e1a92c7f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/a8e63375-827b-4c16-bcf3-547136b8f877/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0832ed27-0039-4bf2-aa1a-6d1e1a92c7f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a20adc29-851d-4277-bf4d-45a03993c696> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a20adc29-851d-4277-bf4d-45a03993c696";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/add381b2-ae41-4537-bde8-7972bafcf984/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a20adc29-851d-4277-bf4d-45a03993c696>.
+    
+<http://data.lblod.info/id/remote-data-objects/845e2790-aee6-4c44-948b-47e128aa9a46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "845e2790-aee6-4c44-948b-47e128aa9a46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/b9370df9-b7ca-4bc5-bd82-6e7f2301e12a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/845e2790-aee6-4c44-948b-47e128aa9a46>.
+    
+<http://data.lblod.info/id/remote-data-objects/8878f460-1dbf-42c5-bb24-b1d5d168e939> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8878f460-1dbf-42c5-bb24-b1d5d168e939";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/badd1e0b-2a60-4b02-b3a1-34934570ac68/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8878f460-1dbf-42c5-bb24-b1d5d168e939>.
+    
+<http://data.lblod.info/id/remote-data-objects/4691354a-2ae0-42c2-818b-60b85df02ee3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4691354a-2ae0-42c2-818b-60b85df02ee3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/bec44fc5-f6c3-4146-84cb-b3005f21fea6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4691354a-2ae0-42c2-818b-60b85df02ee3>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1be399c-79d1-4b75-b276-97c040a36a64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1be399c-79d1-4b75-b276-97c040a36a64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/c0705801-4074-4781-8206-ba7919a331ca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1be399c-79d1-4b75-b276-97c040a36a64>.
+    
+<http://data.lblod.info/id/remote-data-objects/6950cf25-844d-4738-a341-236f3ebe1e4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6950cf25-844d-4738-a341-236f3ebe1e4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/c0e8247a-b495-4568-8042-5966921e48ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6950cf25-844d-4738-a341-236f3ebe1e4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f1871b8-c31b-414f-abfa-55d5e1ada979> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f1871b8-c31b-414f-abfa-55d5e1ada979";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/c227b387-59a2-4d7e-b36e-a58bf12b23c2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f1871b8-c31b-414f-abfa-55d5e1ada979>.
+    
+<http://data.lblod.info/id/remote-data-objects/12165916-8f70-4274-996f-db3f4dd65f7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12165916-8f70-4274-996f-db3f4dd65f7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/c36b4ea2-9996-42b0-ae92-c9e03b274b4b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12165916-8f70-4274-996f-db3f4dd65f7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac12aa83-54fb-481f-a7f2-ffaa21af24f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac12aa83-54fb-481f-a7f2-ffaa21af24f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/c6b0f231-dc64-4e91-b291-32c612ed1f2b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac12aa83-54fb-481f-a7f2-ffaa21af24f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0aeec94f-d7c7-4a72-afd8-ca3cf952aa62> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0aeec94f-d7c7-4a72-afd8-ca3cf952aa62";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/c9fc81a8-0b32-4b2c-9d05-b59de7c1a32b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0aeec94f-d7c7-4a72-afd8-ca3cf952aa62>.
+    
+<http://data.lblod.info/id/remote-data-objects/e76e3ebb-de49-4a79-9c4f-fef822b23f5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e76e3ebb-de49-4a79-9c4f-fef822b23f5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/d03edd1e-5a42-4162-91f5-ce43d381e2c0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e76e3ebb-de49-4a79-9c4f-fef822b23f5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7eb8227-d755-4e5a-99d8-75ca896027f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7eb8227-d755-4e5a-99d8-75ca896027f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/d7f5e8e3-98cd-4601-b5e4-4b3148d4f094/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7eb8227-d755-4e5a-99d8-75ca896027f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/40d15f1c-0369-4a8f-9e1e-9540140c5f3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40d15f1c-0369-4a8f-9e1e-9540140c5f3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/dd74fade-6bca-4036-868c-8b4e858ae9e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40d15f1c-0369-4a8f-9e1e-9540140c5f3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/96258ac8-bc4c-4c41-b50f-c52d4eecd00c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96258ac8-bc4c-4c41-b50f-c52d4eecd00c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/de788293-5d40-4a66-a2eb-507816db4d5c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96258ac8-bc4c-4c41-b50f-c52d4eecd00c>.
+    
+<http://data.lblod.info/id/remote-data-objects/55a0c14f-ad3e-4203-a7e4-fe1ba25b968c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55a0c14f-ad3e-4203-a7e4-fe1ba25b968c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/df6bc61c-914c-4566-9c80-d1153515fd9d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55a0c14f-ad3e-4203-a7e4-fe1ba25b968c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2faae98-35f4-41c8-82b6-003a6695d326> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2faae98-35f4-41c8-82b6-003a6695d326";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/e043fb2d-1cd3-4faa-b720-078c5d707187/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2faae98-35f4-41c8-82b6-003a6695d326>.
+    
+<http://data.lblod.info/id/remote-data-objects/932e308d-b232-4cf1-8c5d-1936e20b7048> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "932e308d-b232-4cf1-8c5d-1936e20b7048";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/e0abe17d-1c33-4499-ad45-0a9d5e039654/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/932e308d-b232-4cf1-8c5d-1936e20b7048>.
+    
+<http://data.lblod.info/id/remote-data-objects/d375d683-7866-49c7-93f2-d0449b770cd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d375d683-7866-49c7-93f2-d0449b770cd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/e1e5b961-97a1-4680-86fa-fb1ae7776bae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d375d683-7866-49c7-93f2-d0449b770cd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/55303410-4523-4d7e-a077-5ea550840b99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55303410-4523-4d7e-a077-5ea550840b99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/e5af7118-3b5d-4df2-be8b-6d9f969bb8dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55303410-4523-4d7e-a077-5ea550840b99>.
+    
+<http://data.lblod.info/id/remote-data-objects/09a91643-1285-4b2f-8f35-8df9047620d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09a91643-1285-4b2f-8f35-8df9047620d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/e8d2a236-c8a2-447f-a7e9-64aa0132acc5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09a91643-1285-4b2f-8f35-8df9047620d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/df5e1426-8cf0-4620-8c6a-ae8320bf0dc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df5e1426-8cf0-4620-8c6a-ae8320bf0dc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/e8de734c-c119-47ce-a763-770becf01077/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df5e1426-8cf0-4620-8c6a-ae8320bf0dc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5ea872c-88b2-47e9-b56b-1ecb1a2a8d6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5ea872c-88b2-47e9-b56b-1ecb1a2a8d6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/e985a3e5-d979-4488-b5c2-0d5603d0ac34/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5ea872c-88b2-47e9-b56b-1ecb1a2a8d6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fdfdfcc-cac8-4dab-ad36-c58106933c75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fdfdfcc-cac8-4dab-ad36-c58106933c75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/ed73716d-8155-4c45-95e4-f8fb7e6b16dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fdfdfcc-cac8-4dab-ad36-c58106933c75>.
+    
+<http://data.lblod.info/id/remote-data-objects/59e5f162-1523-4c31-ac4e-7e8e3c8230ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59e5f162-1523-4c31-ac4e-7e8e3c8230ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/f45ad0c8-7b54-4d7a-a9cc-284b418087e2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59e5f162-1523-4c31-ac4e-7e8e3c8230ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dcaedd0-2765-4d9d-93f7-9550b76fabd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dcaedd0-2765-4d9d-93f7-9550b76fabd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/fb9c9b38-cb65-4bd6-9ac0-d2d89a973a11/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dcaedd0-2765-4d9d-93f7-9550b76fabd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a15ebed4-d8b5-4650-9e95-5cc93c39ae75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a15ebed4-d8b5-4650-9e95-5cc93c39ae75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://roosdaal.meetingburger.net/vabu/fb9d58cd-dec7-4e79-ae68-f862fc72591b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a15ebed4-d8b5-4650-9e95-5cc93c39ae75>.
+    
+<http://data.lblod.info/id/remote-data-objects/14bf3571-3889-465a-8a50-16fa41501ebd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14bf3571-3889-465a-8a50-16fa41501ebd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/bb/0581bf7f-52b8-4855-bc5f-140a4d277cdd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14bf3571-3889-465a-8a50-16fa41501ebd>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc66a93f-f42c-4608-9d60-6d2463652ecb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc66a93f-f42c-4608-9d60-6d2463652ecb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/bb/154b187f-c3ef-4310-ae3c-dcf1cab945df/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc66a93f-f42c-4608-9d60-6d2463652ecb>.
+    
+<http://data.lblod.info/id/remote-data-objects/9280a2b9-c4a5-457e-a06a-c53ea1ec2bc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9280a2b9-c4a5-457e-a06a-c53ea1ec2bc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/bb/3db5ebbf-2663-4f6b-a86b-2871076160d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9280a2b9-c4a5-457e-a06a-c53ea1ec2bc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac83e191-a947-42fb-86bd-27cd06dd3b11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac83e191-a947-42fb-86bd-27cd06dd3b11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/bb/5335a338-abf2-4892-ba6a-a45f107ed412/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac83e191-a947-42fb-86bd-27cd06dd3b11>.
+    
+<http://data.lblod.info/id/remote-data-objects/7df4ad82-f526-4ef6-9f91-7626172b9041> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7df4ad82-f526-4ef6-9f91-7626172b9041";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/bb/6a760420-562e-4a42-8811-1b598e0358f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7df4ad82-f526-4ef6-9f91-7626172b9041>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7de5bd9-ae01-4465-92e4-275a541e91ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7de5bd9-ae01-4465-92e4-275a541e91ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/bb/76fd3c82-4a48-419c-b7f6-c9617079a0f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7de5bd9-ae01-4465-92e4-275a541e91ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ef811b0-82b0-4848-bda0-81cb85d89807> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ef811b0-82b0-4848-bda0-81cb85d89807";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/bb/9fea2614-1021-4c4c-aa3e-b3120f245da5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ef811b0-82b0-4848-bda0-81cb85d89807>.
+    
+<http://data.lblod.info/id/remote-data-objects/d54c81ed-0c4e-4e15-8d09-c6683369b112> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d54c81ed-0c4e-4e15-8d09-c6683369b112";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/bb/ceb72dbe-749c-4951-ab56-6a0d4c579a55/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d54c81ed-0c4e-4e15-8d09-c6683369b112>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ad9624d-de07-4904-a1f7-7957d5d6fa66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ad9624d-de07-4904-a1f7-7957d5d6fa66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/02df2c48-e6cf-4ee9-84e5-70951e9e2f43/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ad9624d-de07-4904-a1f7-7957d5d6fa66>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ae80a8a-0480-4e62-983d-1741c250e6e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ae80a8a-0480-4e62-983d-1741c250e6e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/03b4bad5-ebde-4bea-a275-1ba6d5e42b9f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ae80a8a-0480-4e62-983d-1741c250e6e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f562b2e-acb8-4cbd-a366-6ecafe1c6aa6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f562b2e-acb8-4cbd-a366-6ecafe1c6aa6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/06a9c45a-3391-4581-9bc9-11ba5b423b08/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f562b2e-acb8-4cbd-a366-6ecafe1c6aa6>.
+    
+<http://data.lblod.info/id/remote-data-objects/087a7fa0-77a3-4786-9524-5465df64b691> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "087a7fa0-77a3-4786-9524-5465df64b691";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/090f4937-b34e-45f0-b9e9-4d17701e6088/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/087a7fa0-77a3-4786-9524-5465df64b691>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cd27556-1450-4ffb-bc1f-6336d82d92ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cd27556-1450-4ffb-bc1f-6336d82d92ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/0e5e52e3-9cec-46e8-920a-eb761dcebe4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cd27556-1450-4ffb-bc1f-6336d82d92ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/d089c66e-88cd-4a55-a57c-e4033efd2027> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d089c66e-88cd-4a55-a57c-e4033efd2027";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/114b7ba3-c603-4f91-b9b9-bab1a15f006b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d089c66e-88cd-4a55-a57c-e4033efd2027>.
+    
+<http://data.lblod.info/id/remote-data-objects/d24ad75c-fb24-4e81-b388-881761c5bb04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d24ad75c-fb24-4e81-b388-881761c5bb04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/127cd182-0608-4874-82c5-5ac30aada3a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d24ad75c-fb24-4e81-b388-881761c5bb04>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc4e61ea-5f8d-40a1-a52d-0c5eea1d8165> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc4e61ea-5f8d-40a1-a52d-0c5eea1d8165";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/13e63c88-c6b8-437f-9ba1-34ec12e10ee9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc4e61ea-5f8d-40a1-a52d-0c5eea1d8165>.
+    
+<http://data.lblod.info/id/remote-data-objects/36b80a0b-a580-4756-8e70-e88bc86c8179> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36b80a0b-a580-4756-8e70-e88bc86c8179";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/183b8504-1450-46f7-b8bd-2cdba3ac74a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36b80a0b-a580-4756-8e70-e88bc86c8179>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bb59d0a-fd7e-4d60-bf91-73d79619193d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bb59d0a-fd7e-4d60-bf91-73d79619193d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/19aa39ce-d369-4ad3-ba5a-f99a8e246d1e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:17.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/71a6a2e2-c36e-41a0-ba1a-866d2cbed9ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bb59d0a-fd7e-4d60-bf91-73d79619193d>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201919-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201919-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201919-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201919-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/261028da-2fe8-4fd0-a77a-0cb7e9af28cc> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "261028da-2fe8-4fd0-a77a-0cb7e9af28cc";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9a3513c7-12a5-41d0-a67d-4f806f7303e9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c05e85a7-a1fe-4d89-a560-661cce763031> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c05e85a7-a1fe-4d89-a560-661cce763031";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9>.
+
+  <http://redpencil.data.gift/id/task/f0bd1c8a-61e1-434e-9afa-72c962b0ca30> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f0bd1c8a-61e1-434e-9afa-72c962b0ca30";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/261028da-2fe8-4fd0-a77a-0cb7e9af28cc>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c05e85a7-a1fe-4d89-a560-661cce763031>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/93429293-19ac-4290-aa28-5e80e7801480> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93429293-19ac-4290-aa28-5e80e7801480";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/19bb4a20-ae4f-4992-9b8b-ea5d80c9240f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93429293-19ac-4290-aa28-5e80e7801480>.
+    
+<http://data.lblod.info/id/remote-data-objects/30435133-ac8a-4fb4-85b1-13ad37f06cbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "30435133-ac8a-4fb4-85b1-13ad37f06cbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/1cfd7fa2-f9db-4500-b29c-329cb4e3a411/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/30435133-ac8a-4fb4-85b1-13ad37f06cbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/b163aa2c-59c1-4445-b691-06df8c041897> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b163aa2c-59c1-4445-b691-06df8c041897";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/2f7697d5-a0a7-4a19-be6b-ed06db35d9e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b163aa2c-59c1-4445-b691-06df8c041897>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3cc6284-27bb-413b-bd62-7c6c77961383> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3cc6284-27bb-413b-bd62-7c6c77961383";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/3304ff49-a45a-47e1-a26f-35180e3372a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3cc6284-27bb-413b-bd62-7c6c77961383>.
+    
+<http://data.lblod.info/id/remote-data-objects/0aab27a4-4d34-4103-99b0-9272391d9f59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0aab27a4-4d34-4103-99b0-9272391d9f59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/3a3a34d4-8b78-4697-868f-7bdb1a6d1ca7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0aab27a4-4d34-4103-99b0-9272391d9f59>.
+    
+<http://data.lblod.info/id/remote-data-objects/91a22ce3-1a93-4b18-ba1a-506a2ae87e08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91a22ce3-1a93-4b18-ba1a-506a2ae87e08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/3aa796d0-027b-424b-a4fd-7085debc5e07/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91a22ce3-1a93-4b18-ba1a-506a2ae87e08>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a049db3-b20e-44e1-a6e6-2f8359ae83b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a049db3-b20e-44e1-a6e6-2f8359ae83b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/3dfc60ba-72ee-4308-ae3f-a3c89412d989/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a049db3-b20e-44e1-a6e6-2f8359ae83b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3794298-b40d-436d-a995-0cea8fc4ac51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3794298-b40d-436d-a995-0cea8fc4ac51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/4519b51a-daae-4d06-bd40-60d73fabdddb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3794298-b40d-436d-a995-0cea8fc4ac51>.
+    
+<http://data.lblod.info/id/remote-data-objects/cda1253c-8e75-4977-b99d-e32b1dcc8598> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cda1253c-8e75-4977-b99d-e32b1dcc8598";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/45faf478-a669-4985-b832-0f62180e1e65/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cda1253c-8e75-4977-b99d-e32b1dcc8598>.
+    
+<http://data.lblod.info/id/remote-data-objects/69c8d4bb-9ff7-4db4-a958-fd545326e72f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69c8d4bb-9ff7-4db4-a958-fd545326e72f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/4ad28396-a283-4221-af65-afa95848bb89/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69c8d4bb-9ff7-4db4-a958-fd545326e72f>.
+    
+<http://data.lblod.info/id/remote-data-objects/81d607ca-1fb6-4335-a483-a7e0549117d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81d607ca-1fb6-4335-a483-a7e0549117d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/4ba145af-5086-4342-a2c9-221ca7def3f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81d607ca-1fb6-4335-a483-a7e0549117d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f0fe6fc-c906-4113-949e-fdccdec991fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f0fe6fc-c906-4113-949e-fdccdec991fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/53017916-e81e-4685-aa04-592bae24c619/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f0fe6fc-c906-4113-949e-fdccdec991fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/964091bc-e480-422c-a817-60455a072601> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "964091bc-e480-422c-a817-60455a072601";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/637f1591-2396-42de-8188-3442e2f468b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/964091bc-e480-422c-a817-60455a072601>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ffa0767-99af-4a83-be1a-8bfd93cd40eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ffa0767-99af-4a83-be1a-8bfd93cd40eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/63a440e1-4730-4a6f-8f29-1db78ff30f9d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ffa0767-99af-4a83-be1a-8bfd93cd40eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/1dabd608-5dfe-4f73-91b1-844d98c834d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1dabd608-5dfe-4f73-91b1-844d98c834d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/68d05a4a-44ef-421e-8a44-4df1789dca82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1dabd608-5dfe-4f73-91b1-844d98c834d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/2614534a-a7e6-4913-adc8-a97ead887875> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2614534a-a7e6-4913-adc8-a97ead887875";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/6ace3608-c967-4244-acea-723be057a425/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2614534a-a7e6-4913-adc8-a97ead887875>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdd0b082-45aa-42fa-a4dc-cbc616007a51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdd0b082-45aa-42fa-a4dc-cbc616007a51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/6c38671a-7efc-4fbd-828a-f36f55af56a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdd0b082-45aa-42fa-a4dc-cbc616007a51>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a4755dd-dfca-4078-99b4-7a4956e29ea2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a4755dd-dfca-4078-99b4-7a4956e29ea2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/6d7c2cd2-1265-4f79-9aa2-04129633d846/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a4755dd-dfca-4078-99b4-7a4956e29ea2>.
+    
+<http://data.lblod.info/id/remote-data-objects/367b6cbf-1cad-4f86-af7d-157a965564e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "367b6cbf-1cad-4f86-af7d-157a965564e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/6fd8f567-aee7-4761-95dc-0eccfc7ee7e9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/367b6cbf-1cad-4f86-af7d-157a965564e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e62b0d8-cd8c-4921-ac08-0f3c28f4d1b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e62b0d8-cd8c-4921-ac08-0f3c28f4d1b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/717c45da-1b3b-42c1-9d4e-d636e6bd1651/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e62b0d8-cd8c-4921-ac08-0f3c28f4d1b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/c23a6dce-9321-4ae7-9b4b-136fd8ed694d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c23a6dce-9321-4ae7-9b4b-136fd8ed694d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/7450cf6a-785f-46d1-83a1-a1f7e2f27c27/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c23a6dce-9321-4ae7-9b4b-136fd8ed694d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fd4e146-3616-4ac1-b3db-6c5c6648de1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fd4e146-3616-4ac1-b3db-6c5c6648de1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/75482e4f-37b9-4d28-88a7-f374fe6e0f62/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fd4e146-3616-4ac1-b3db-6c5c6648de1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/37479bca-fa44-46ae-8a03-046bef6f49a6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37479bca-fa44-46ae-8a03-046bef6f49a6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/7570e597-9c44-4e24-add6-ec0e6479159a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37479bca-fa44-46ae-8a03-046bef6f49a6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c145a1f7-baa9-40b0-9dc1-a1b5b3732916> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c145a1f7-baa9-40b0-9dc1-a1b5b3732916";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/7f6ad07f-80dc-47ba-add7-5dc906372e0c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c145a1f7-baa9-40b0-9dc1-a1b5b3732916>.
+    
+<http://data.lblod.info/id/remote-data-objects/e34182a9-6719-47d9-9442-3809c1bb9359> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e34182a9-6719-47d9-9442-3809c1bb9359";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/8022dc79-3a1c-4107-8970-fa6478554409/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e34182a9-6719-47d9-9442-3809c1bb9359>.
+    
+<http://data.lblod.info/id/remote-data-objects/8964ae93-04b4-4f94-ae54-a88d61900072> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8964ae93-04b4-4f94-ae54-a88d61900072";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/8045c9b6-5272-47da-af50-168310de649c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8964ae93-04b4-4f94-ae54-a88d61900072>.
+    
+<http://data.lblod.info/id/remote-data-objects/4872633d-4837-4f28-bab1-896e9fe52da3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4872633d-4837-4f28-bab1-896e9fe52da3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/81e5b4ce-2f27-476f-8f76-e71159f56d31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4872633d-4837-4f28-bab1-896e9fe52da3>.
+    
+<http://data.lblod.info/id/remote-data-objects/869bf7e6-872f-47ec-b0f4-f8e7a5618223> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "869bf7e6-872f-47ec-b0f4-f8e7a5618223";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/894d73ae-2450-4f63-9de2-407e692f2584/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/869bf7e6-872f-47ec-b0f4-f8e7a5618223>.
+    
+<http://data.lblod.info/id/remote-data-objects/05d591bd-45e4-43c8-9835-d208c195d679> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05d591bd-45e4-43c8-9835-d208c195d679";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/8ea4cf8e-6026-4cd3-ae5c-9654bd1b817e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05d591bd-45e4-43c8-9835-d208c195d679>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbf3f332-0dfa-414c-900a-d7d368eaad88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbf3f332-0dfa-414c-900a-d7d368eaad88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/9083e296-6a18-411c-96e5-d4aba4e39388/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbf3f332-0dfa-414c-900a-d7d368eaad88>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc8c7eda-e75d-4962-ba45-e3abe6688fa4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc8c7eda-e75d-4962-ba45-e3abe6688fa4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/94f212d0-6828-47d5-817e-f8c45a257581/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc8c7eda-e75d-4962-ba45-e3abe6688fa4>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6381fc6-b583-4469-8939-d7f15018c182> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6381fc6-b583-4469-8939-d7f15018c182";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/950191ab-c054-4e7e-8347-319c7d2db95d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6381fc6-b583-4469-8939-d7f15018c182>.
+    
+<http://data.lblod.info/id/remote-data-objects/013d013e-a0a5-447a-a106-3ebbc3e6dce3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "013d013e-a0a5-447a-a106-3ebbc3e6dce3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/990a92be-42bd-4e4e-83e3-58b4aabd939c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/013d013e-a0a5-447a-a106-3ebbc3e6dce3>.
+    
+<http://data.lblod.info/id/remote-data-objects/26075ef0-1ed0-442f-8c1d-e6f270eaecff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26075ef0-1ed0-442f-8c1d-e6f270eaecff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/9984b06f-4d71-4e10-8b97-71e0ac2fd8a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26075ef0-1ed0-442f-8c1d-e6f270eaecff>.
+    
+<http://data.lblod.info/id/remote-data-objects/a352a89f-e3a6-44b8-b5f4-9f3595b25b8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a352a89f-e3a6-44b8-b5f4-9f3595b25b8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/9c71db2b-87aa-448a-bcd8-b1d80885a9c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a352a89f-e3a6-44b8-b5f4-9f3595b25b8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/af453b86-a9b2-4f2e-8f12-a7696c69ea5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af453b86-a9b2-4f2e-8f12-a7696c69ea5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/9e026f34-f1ce-433c-9b4d-29c03f8dd334/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af453b86-a9b2-4f2e-8f12-a7696c69ea5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/539e70cd-e192-44fa-9c52-ec6cd2b98063> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "539e70cd-e192-44fa-9c52-ec6cd2b98063";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/a098e89b-5134-4fcf-8b5d-5c82310037d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/539e70cd-e192-44fa-9c52-ec6cd2b98063>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb2dcdf1-a498-4f6e-9dfa-708518afd657> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb2dcdf1-a498-4f6e-9dfa-708518afd657";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/af9ed948-ab3a-4de8-9064-c6ecb6104ca7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb2dcdf1-a498-4f6e-9dfa-708518afd657>.
+    
+<http://data.lblod.info/id/remote-data-objects/c96e803c-01a0-45ee-a7cf-9aeb1bd5df2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c96e803c-01a0-45ee-a7cf-9aeb1bd5df2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/b1b1c8ff-9d6b-4c8e-9b7b-90fff16aad4a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c96e803c-01a0-45ee-a7cf-9aeb1bd5df2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a94fc524-3676-4b26-927e-3f14fbfd094c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a94fc524-3676-4b26-927e-3f14fbfd094c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/b2152f9b-e3c0-4710-9640-8a4667f701d8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a94fc524-3676-4b26-927e-3f14fbfd094c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5e78384-2e54-4e79-b775-5b42a0198607> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5e78384-2e54-4e79-b775-5b42a0198607";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/b4f9ac0e-3fe1-45a4-8e43-45c11daed21d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5e78384-2e54-4e79-b775-5b42a0198607>.
+    
+<http://data.lblod.info/id/remote-data-objects/4634729c-f56f-456e-87da-d94eab4c9937> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4634729c-f56f-456e-87da-d94eab4c9937";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/c64fa6f3-92d0-48ba-91e4-c71653a3e87d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4634729c-f56f-456e-87da-d94eab4c9937>.
+    
+<http://data.lblod.info/id/remote-data-objects/23684a05-5f95-44c4-a4f9-0243df543d3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23684a05-5f95-44c4-a4f9-0243df543d3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/c8627794-62aa-484a-9982-beaab65edae0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23684a05-5f95-44c4-a4f9-0243df543d3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/11c18c7e-de00-4e85-a128-5eab51cb5ef7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11c18c7e-de00-4e85-a128-5eab51cb5ef7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/d2ec9a5e-4d96-4223-a4ec-275a528371a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11c18c7e-de00-4e85-a128-5eab51cb5ef7>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfd6d1c2-92f2-4d4a-8846-945eaf1956cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfd6d1c2-92f2-4d4a-8846-945eaf1956cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/d9f29585-545e-446a-ae9f-b6a181447648/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfd6d1c2-92f2-4d4a-8846-945eaf1956cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/490b1a74-ea5c-4e85-8261-e128ec360be1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "490b1a74-ea5c-4e85-8261-e128ec360be1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/db584b16-9f44-4a28-a4d1-9a8417e4d80b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/490b1a74-ea5c-4e85-8261-e128ec360be1>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ea08c9a-667d-4d9a-816a-3ab6aa9e34af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ea08c9a-667d-4d9a-816a-3ab6aa9e34af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/db59f87d-430f-43d2-81ec-4b3968f43df9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ea08c9a-667d-4d9a-816a-3ab6aa9e34af>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e86175f-34a8-4dc3-8b5d-5f44a77c3c78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e86175f-34a8-4dc3-8b5d-5f44a77c3c78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/ddb7ddad-237a-46b2-91ea-75326606b63d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e86175f-34a8-4dc3-8b5d-5f44a77c3c78>.
+    
+<http://data.lblod.info/id/remote-data-objects/76323167-68cd-4cb9-8533-213ea60d4673> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76323167-68cd-4cb9-8533-213ea60d4673";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/dff5a264-b85b-42af-87c1-5b20daeac8af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76323167-68cd-4cb9-8533-213ea60d4673>.
+    
+<http://data.lblod.info/id/remote-data-objects/15644a70-44d0-4a4a-be75-b97f73cdfc03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15644a70-44d0-4a4a-be75-b97f73cdfc03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/e299f22b-c5e6-4e91-871e-db4cc0a6d6bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:19.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9a3513c7-12a5-41d0-a67d-4f806f7303e9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15644a70-44d0-4a4a-be75-b97f73cdfc03>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201920-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201920-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201920-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201920-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/bc52943e-1477-42e5-87c6-5bc9c820e99a> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bc52943e-1477-42e5-87c6-5bc9c820e99a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "de7dbf1d-4973-43fe-acd1-d0bdaa60b364";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/cea49fe0-8957-4b76-aad4-6a898e8c4385> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cea49fe0-8957-4b76-aad4-6a898e8c4385";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364>.
+
+  <http://redpencil.data.gift/id/task/72ffa779-27b6-409b-9b67-05132fce3c6d> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "72ffa779-27b6-409b-9b67-05132fce3c6d";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/bc52943e-1477-42e5-87c6-5bc9c820e99a>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/cea49fe0-8957-4b76-aad4-6a898e8c4385>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/65e5ff47-adf3-4acc-96bd-080c961e4bd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65e5ff47-adf3-4acc-96bd-080c961e4bd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/eb9e442d-cc9d-4027-9558-7398a9a2c97d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65e5ff47-adf3-4acc-96bd-080c961e4bd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c44194f-9225-40f3-a1c2-7e0886637dfc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c44194f-9225-40f3-a1c2-7e0886637dfc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/ee79a874-449e-41ea-99b5-292517311f1d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c44194f-9225-40f3-a1c2-7e0886637dfc>.
+    
+<http://data.lblod.info/id/remote-data-objects/129987eb-c518-4ad3-998f-13e11d16b046> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "129987eb-c518-4ad3-998f-13e11d16b046";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/f6cdfe60-2b53-4c5c-9fe8-e5e89e5d2b18/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/129987eb-c518-4ad3-998f-13e11d16b046>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3293083-b5ba-4886-99c0-bec763efed06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3293083-b5ba-4886-99c0-bec763efed06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/cbs/fcccb8c1-c028-4abd-a4ca-251051b80ffd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3293083-b5ba-4886-99c0-bec763efed06>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdf6da9c-342b-4a59-b6c5-51529616a4be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdf6da9c-342b-4a59-b6c5-51529616a4be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/02fd6af1-315c-459a-8c7f-771f473bfcc3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdf6da9c-342b-4a59-b6c5-51529616a4be>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9d6729b-578e-461d-b9ee-ca5c864dbb6c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9d6729b-578e-461d-b9ee-ca5c864dbb6c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/02fd6af1-315c-459a-8c7f-771f473bfcc3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9d6729b-578e-461d-b9ee-ca5c864dbb6c>.
+    
+<http://data.lblod.info/id/remote-data-objects/749d7f82-c90a-4a07-8b84-19a4d04565c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "749d7f82-c90a-4a07-8b84-19a4d04565c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/02fd6af1-315c-459a-8c7f-771f473bfcc3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/749d7f82-c90a-4a07-8b84-19a4d04565c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce50036e-2105-4d79-9cde-16dfb5524fd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce50036e-2105-4d79-9cde-16dfb5524fd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/604905fa-d497-44ec-bb5c-60d18380757f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce50036e-2105-4d79-9cde-16dfb5524fd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/46baffc1-9546-4c51-b2e9-f61bbe473c4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46baffc1-9546-4c51-b2e9-f61bbe473c4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/604905fa-d497-44ec-bb5c-60d18380757f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46baffc1-9546-4c51-b2e9-f61bbe473c4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb6d2543-ae3d-4de6-a128-c9f30ec66d9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb6d2543-ae3d-4de6-a128-c9f30ec66d9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/604905fa-d497-44ec-bb5c-60d18380757f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb6d2543-ae3d-4de6-a128-c9f30ec66d9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c6867bd-eca0-4682-aeb3-b3e939495e51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c6867bd-eca0-4682-aeb3-b3e939495e51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/6134c31d-4ace-4f6d-b5a8-c2f213959ef6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c6867bd-eca0-4682-aeb3-b3e939495e51>.
+    
+<http://data.lblod.info/id/remote-data-objects/ac99fd7e-2228-4453-80f8-c1edce14535e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ac99fd7e-2228-4453-80f8-c1edce14535e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/6134c31d-4ace-4f6d-b5a8-c2f213959ef6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ac99fd7e-2228-4453-80f8-c1edce14535e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8c93c72-f0d7-4847-afbd-df809ae75898> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8c93c72-f0d7-4847-afbd-df809ae75898";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/6134c31d-4ace-4f6d-b5a8-c2f213959ef6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8c93c72-f0d7-4847-afbd-df809ae75898>.
+    
+<http://data.lblod.info/id/remote-data-objects/74b1fb2c-e46a-4fa6-a781-b6a23cbc28f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74b1fb2c-e46a-4fa6-a781-b6a23cbc28f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/648d86ba-c513-4eb9-a411-e8abaf046a55/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74b1fb2c-e46a-4fa6-a781-b6a23cbc28f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc067b7c-52ff-4ace-985b-e04b734989f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc067b7c-52ff-4ace-985b-e04b734989f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/648d86ba-c513-4eb9-a411-e8abaf046a55/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc067b7c-52ff-4ace-985b-e04b734989f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/f3a6667c-8d5e-42b7-b07a-eed57f92c6dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f3a6667c-8d5e-42b7-b07a-eed57f92c6dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/648d86ba-c513-4eb9-a411-e8abaf046a55/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f3a6667c-8d5e-42b7-b07a-eed57f92c6dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/9824467e-8c68-45ad-9290-5ca52407ba59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9824467e-8c68-45ad-9290-5ca52407ba59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/753ea2f7-0d56-48e4-b5bd-1a0954d2b5a8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9824467e-8c68-45ad-9290-5ca52407ba59>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4e60288-2af1-4793-857d-54db4cfea929> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4e60288-2af1-4793-857d-54db4cfea929";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/753ea2f7-0d56-48e4-b5bd-1a0954d2b5a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4e60288-2af1-4793-857d-54db4cfea929>.
+    
+<http://data.lblod.info/id/remote-data-objects/c36e071b-162f-4ae9-af4a-aff4e0e8e494> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c36e071b-162f-4ae9-af4a-aff4e0e8e494";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/859336dd-df88-40eb-b26e-b9ff12acc496/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c36e071b-162f-4ae9-af4a-aff4e0e8e494>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9b7e057-51c8-4890-af3a-63df7c5f376f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9b7e057-51c8-4890-af3a-63df7c5f376f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/859336dd-df88-40eb-b26e-b9ff12acc496/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9b7e057-51c8-4890-af3a-63df7c5f376f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6c12947-a0e9-46bd-90da-bb846456d74a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6c12947-a0e9-46bd-90da-bb846456d74a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/859336dd-df88-40eb-b26e-b9ff12acc496/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6c12947-a0e9-46bd-90da-bb846456d74a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bccd81d-8d4c-4505-91fa-068bb06ebdd6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bccd81d-8d4c-4505-91fa-068bb06ebdd6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/a436409d-4cee-4267-8c0b-0687f1c27ee9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bccd81d-8d4c-4505-91fa-068bb06ebdd6>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bb465d4-694e-4e57-9408-3aaef5c00c0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bb465d4-694e-4e57-9408-3aaef5c00c0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/a436409d-4cee-4267-8c0b-0687f1c27ee9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bb465d4-694e-4e57-9408-3aaef5c00c0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5492d60a-f8f1-4080-80a4-1115f9ea9ed3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5492d60a-f8f1-4080-80a4-1115f9ea9ed3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/a436409d-4cee-4267-8c0b-0687f1c27ee9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5492d60a-f8f1-4080-80a4-1115f9ea9ed3>.
+    
+<http://data.lblod.info/id/remote-data-objects/94a710b5-e2a5-43f2-9628-4d291143a98d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94a710b5-e2a5-43f2-9628-4d291143a98d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/b3217d3d-6138-4ba4-9065-3f504596e8d1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94a710b5-e2a5-43f2-9628-4d291143a98d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3364193f-6621-4e6f-a24b-8976ad0ef389> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3364193f-6621-4e6f-a24b-8976ad0ef389";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/b3217d3d-6138-4ba4-9065-3f504596e8d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3364193f-6621-4e6f-a24b-8976ad0ef389>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd26c8ba-29fc-4de1-9191-1eb5746b4f35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd26c8ba-29fc-4de1-9191-1eb5746b4f35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/b3217d3d-6138-4ba4-9065-3f504596e8d1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd26c8ba-29fc-4de1-9191-1eb5746b4f35>.
+    
+<http://data.lblod.info/id/remote-data-objects/131fb084-67c2-4d6d-857f-8623895baddc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "131fb084-67c2-4d6d-857f-8623895baddc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/c59934fb-730a-4ef5-9a35-7518ba1b5f84/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/131fb084-67c2-4d6d-857f-8623895baddc>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ddc2975-bf3a-443f-9351-019ff31a7ae2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ddc2975-bf3a-443f-9351-019ff31a7ae2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/c59934fb-730a-4ef5-9a35-7518ba1b5f84/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ddc2975-bf3a-443f-9351-019ff31a7ae2>.
+    
+<http://data.lblod.info/id/remote-data-objects/89f0efe8-f623-43ab-b68d-491ab40f4ea8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89f0efe8-f623-43ab-b68d-491ab40f4ea8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/c59934fb-730a-4ef5-9a35-7518ba1b5f84/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89f0efe8-f623-43ab-b68d-491ab40f4ea8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea95d4b5-eccf-4a51-b2cf-86ed39f44232> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea95d4b5-eccf-4a51-b2cf-86ed39f44232";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/d96ad0f4-edf8-4154-8027-7e73e12d0041/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea95d4b5-eccf-4a51-b2cf-86ed39f44232>.
+    
+<http://data.lblod.info/id/remote-data-objects/833014b2-6f68-488c-8834-6b32ce9393b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "833014b2-6f68-488c-8834-6b32ce9393b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/d96ad0f4-edf8-4154-8027-7e73e12d0041/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/833014b2-6f68-488c-8834-6b32ce9393b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/98fcb559-c2a2-478a-ad29-b7a06681f8ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98fcb559-c2a2-478a-ad29-b7a06681f8ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/d96ad0f4-edf8-4154-8027-7e73e12d0041/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98fcb559-c2a2-478a-ad29-b7a06681f8ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a35f77d-94df-4f05-af7d-72e9d5585e3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a35f77d-94df-4f05-af7d-72e9d5585e3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/e0fc6f5b-e62c-4190-a912-937a66b87f4b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a35f77d-94df-4f05-af7d-72e9d5585e3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/44bbb273-db23-4d5c-8c8d-384960bed4cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44bbb273-db23-4d5c-8c8d-384960bed4cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/e0fc6f5b-e62c-4190-a912-937a66b87f4b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44bbb273-db23-4d5c-8c8d-384960bed4cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f5546f2-c6fc-48fe-9e4b-83c1b3215d34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f5546f2-c6fc-48fe-9e4b-83c1b3215d34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/e0fc6f5b-e62c-4190-a912-937a66b87f4b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f5546f2-c6fc-48fe-9e4b-83c1b3215d34>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d4fdd9b-33dc-456c-958c-5f3b059e9966> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d4fdd9b-33dc-456c-958c-5f3b059e9966";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/e4ac89b6-60b7-4b9a-b06a-2f20c7056464/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d4fdd9b-33dc-456c-958c-5f3b059e9966>.
+    
+<http://data.lblod.info/id/remote-data-objects/369b4df9-71b7-425c-bb9a-d911bd53786d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "369b4df9-71b7-425c-bb9a-d911bd53786d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/e4ac89b6-60b7-4b9a-b06a-2f20c7056464/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/369b4df9-71b7-425c-bb9a-d911bd53786d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9961140e-c97f-4dab-8420-d89794384fa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9961140e-c97f-4dab-8420-d89794384fa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/e4ac89b6-60b7-4b9a-b06a-2f20c7056464/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9961140e-c97f-4dab-8420-d89794384fa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/3078a65b-3b6e-44d9-b95d-c5a0571320f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3078a65b-3b6e-44d9-b95d-c5a0571320f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/e97d2ab9-a384-41ea-90d7-18d4244fce25/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3078a65b-3b6e-44d9-b95d-c5a0571320f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b13b7b8-9ccc-44b6-9340-5844523511c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b13b7b8-9ccc-44b6-9340-5844523511c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/e97d2ab9-a384-41ea-90d7-18d4244fce25/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b13b7b8-9ccc-44b6-9340-5844523511c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/77b0bebe-df39-4084-bb87-21bea73fd08b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77b0bebe-df39-4084-bb87-21bea73fd08b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/e97d2ab9-a384-41ea-90d7-18d4244fce25/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77b0bebe-df39-4084-bb87-21bea73fd08b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a027e8d-8765-437d-8183-416af33289e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a027e8d-8765-437d-8183-416af33289e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/ea9f96fc-90a6-4e63-9b78-3bf53ddc7d6e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a027e8d-8765-437d-8183-416af33289e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/19090d99-698f-47dc-8a11-2b4c7e5c3053> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19090d99-698f-47dc-8a11-2b4c7e5c3053";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/ea9f96fc-90a6-4e63-9b78-3bf53ddc7d6e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19090d99-698f-47dc-8a11-2b4c7e5c3053>.
+    
+<http://data.lblod.info/id/remote-data-objects/881a6f12-2cc4-4b1c-8677-c8d9cd64f655> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "881a6f12-2cc4-4b1c-8677-c8d9cd64f655";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/ea9f96fc-90a6-4e63-9b78-3bf53ddc7d6e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/881a6f12-2cc4-4b1c-8677-c8d9cd64f655>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f288019-d08f-4d67-88c1-68eced29e6ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f288019-d08f-4d67-88c1-68eced29e6ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/ee8c5e15-6720-4e6d-a0d5-0b9bf0864068/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f288019-d08f-4d67-88c1-68eced29e6ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/48cc8652-0ada-4b4b-bb8c-fabc31208bef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48cc8652-0ada-4b4b-bb8c-fabc31208bef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/ee8c5e15-6720-4e6d-a0d5-0b9bf0864068/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48cc8652-0ada-4b4b-bb8c-fabc31208bef>.
+    
+<http://data.lblod.info/id/remote-data-objects/18495ca3-3f54-4724-93db-b8bdd73d33af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18495ca3-3f54-4724-93db-b8bdd73d33af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/ee8c5e15-6720-4e6d-a0d5-0b9bf0864068/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18495ca3-3f54-4724-93db-b8bdd73d33af>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bebf984-9b88-47b6-8e9b-ee9641a33ce5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bebf984-9b88-47b6-8e9b-ee9641a33ce5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/f27ee19e-c4f3-4b8d-bd45-178c65b219a0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bebf984-9b88-47b6-8e9b-ee9641a33ce5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d4a94e6-b9e5-4d52-bc55-c7398fd1c630> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d4a94e6-b9e5-4d52-bc55-c7398fd1c630";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/f27ee19e-c4f3-4b8d-bd45-178c65b219a0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:20.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/de7dbf1d-4973-43fe-acd1-d0bdaa60b364> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d4a94e6-b9e5-4d52-bc55-c7398fd1c630>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201921-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201921-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201921-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201921-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3623fc3d-d9a6-4b30-8b5f-78b10559c0a0> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3623fc3d-d9a6-4b30-8b5f-78b10559c0a0";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1bf6f4fc-e77e-4441-9044-dfe6b0b537fe";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/1c9465df-5f3e-455a-a4fd-b7f9a7f8e6b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1c9465df-5f3e-455a-a4fd-b7f9a7f8e6b4";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe>.
+
+  <http://redpencil.data.gift/id/task/5f01cca9-4b3d-40be-abaa-0bfdbfcf7c5b> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5f01cca9-4b3d-40be-abaa-0bfdbfcf7c5b";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3623fc3d-d9a6-4b30-8b5f-78b10559c0a0>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/1c9465df-5f3e-455a-a4fd-b7f9a7f8e6b4>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/52fbaa0f-114c-490a-a594-ea38e86ccfcc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52fbaa0f-114c-490a-a594-ea38e86ccfcc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/gr/f27ee19e-c4f3-4b8d-bd45-178c65b219a0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52fbaa0f-114c-490a-a594-ea38e86ccfcc>.
+    
+<http://data.lblod.info/id/remote-data-objects/14f106a0-5dd3-4523-be1a-331f85f53913> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14f106a0-5dd3-4523-be1a-331f85f53913";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/1b7dbc46-30a3-4a4c-9ff1-ba3dd0e4cc9c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14f106a0-5dd3-4523-be1a-331f85f53913>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfae575e-ac86-492d-9c59-938bfe8c0af0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfae575e-ac86-492d-9c59-938bfe8c0af0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/1b7dbc46-30a3-4a4c-9ff1-ba3dd0e4cc9c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfae575e-ac86-492d-9c59-938bfe8c0af0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1891d414-fa2f-4597-9971-a76781f09b7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1891d414-fa2f-4597-9971-a76781f09b7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/1b7dbc46-30a3-4a4c-9ff1-ba3dd0e4cc9c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1891d414-fa2f-4597-9971-a76781f09b7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6628bdc7-59cf-4b3d-a22b-0b53b262bea8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6628bdc7-59cf-4b3d-a22b-0b53b262bea8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/27040549-73db-4bb4-b7e7-0a730d1a4217/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6628bdc7-59cf-4b3d-a22b-0b53b262bea8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d64e126-b2a9-415f-a414-3353cd397624> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d64e126-b2a9-415f-a414-3353cd397624";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/27040549-73db-4bb4-b7e7-0a730d1a4217/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d64e126-b2a9-415f-a414-3353cd397624>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e74db5e-0d1f-4b24-af01-94f2195ef693> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e74db5e-0d1f-4b24-af01-94f2195ef693";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/27040549-73db-4bb4-b7e7-0a730d1a4217/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e74db5e-0d1f-4b24-af01-94f2195ef693>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e13b4b1-5c40-4d77-98bb-3f4940d326eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e13b4b1-5c40-4d77-98bb-3f4940d326eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/2814f4ec-ca07-444b-b6b8-11b79e51a9c4/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e13b4b1-5c40-4d77-98bb-3f4940d326eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb031aa6-e110-49a1-8a6f-fdd2db5b031a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb031aa6-e110-49a1-8a6f-fdd2db5b031a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/2814f4ec-ca07-444b-b6b8-11b79e51a9c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb031aa6-e110-49a1-8a6f-fdd2db5b031a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8f6b96f-6a84-49a6-8f23-45606e2d183b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8f6b96f-6a84-49a6-8f23-45606e2d183b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/2814f4ec-ca07-444b-b6b8-11b79e51a9c4/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8f6b96f-6a84-49a6-8f23-45606e2d183b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c08ff76-a78e-4349-ace8-79ff163da4f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c08ff76-a78e-4349-ace8-79ff163da4f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/30c21923-b428-47e6-950a-2dd56451bf40/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c08ff76-a78e-4349-ace8-79ff163da4f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e25b6294-f9d9-4698-a698-0496b489e1da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e25b6294-f9d9-4698-a698-0496b489e1da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/30c21923-b428-47e6-950a-2dd56451bf40/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e25b6294-f9d9-4698-a698-0496b489e1da>.
+    
+<http://data.lblod.info/id/remote-data-objects/8daedd2d-c24f-42ea-a2ca-9e0a60a7f295> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8daedd2d-c24f-42ea-a2ca-9e0a60a7f295";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/30c21923-b428-47e6-950a-2dd56451bf40/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8daedd2d-c24f-42ea-a2ca-9e0a60a7f295>.
+    
+<http://data.lblod.info/id/remote-data-objects/e73df251-6f2e-446b-9e8b-66ec9e74dcb6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e73df251-6f2e-446b-9e8b-66ec9e74dcb6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/3184e23c-9363-4c2d-bdf6-70b0bd5b3262/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e73df251-6f2e-446b-9e8b-66ec9e74dcb6>.
+    
+<http://data.lblod.info/id/remote-data-objects/3510c5b5-91ab-4f1f-89e5-a1c769d7e012> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3510c5b5-91ab-4f1f-89e5-a1c769d7e012";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/3184e23c-9363-4c2d-bdf6-70b0bd5b3262/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3510c5b5-91ab-4f1f-89e5-a1c769d7e012>.
+    
+<http://data.lblod.info/id/remote-data-objects/822dfaf7-4b97-4ca2-9f3b-187a8ab9bf86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "822dfaf7-4b97-4ca2-9f3b-187a8ab9bf86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/3184e23c-9363-4c2d-bdf6-70b0bd5b3262/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/822dfaf7-4b97-4ca2-9f3b-187a8ab9bf86>.
+    
+<http://data.lblod.info/id/remote-data-objects/de3c8f73-761e-4128-8106-e612981d0488> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de3c8f73-761e-4128-8106-e612981d0488";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/3a615ab3-c798-445e-95b7-e57de198db7b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de3c8f73-761e-4128-8106-e612981d0488>.
+    
+<http://data.lblod.info/id/remote-data-objects/094eea44-7428-4f6a-9295-826cc5187fde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "094eea44-7428-4f6a-9295-826cc5187fde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/3a615ab3-c798-445e-95b7-e57de198db7b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/094eea44-7428-4f6a-9295-826cc5187fde>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f01c784-fbf4-465f-9e93-93d33f4309f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f01c784-fbf4-465f-9e93-93d33f4309f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/452b40f3-cdd8-4b07-a99a-2b6584a8f129/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f01c784-fbf4-465f-9e93-93d33f4309f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9626edee-ba1d-404f-bd85-fa0984be2581> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9626edee-ba1d-404f-bd85-fa0984be2581";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/452b40f3-cdd8-4b07-a99a-2b6584a8f129/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9626edee-ba1d-404f-bd85-fa0984be2581>.
+    
+<http://data.lblod.info/id/remote-data-objects/c24a4c92-5277-4b0e-9041-4c00f24f9d2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c24a4c92-5277-4b0e-9041-4c00f24f9d2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/452b40f3-cdd8-4b07-a99a-2b6584a8f129/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c24a4c92-5277-4b0e-9041-4c00f24f9d2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f73ccd8-6373-41a9-bbb7-2f1fa00b6a03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f73ccd8-6373-41a9-bbb7-2f1fa00b6a03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/4bfbf027-3493-4dd9-a9dc-3f7b9e91215f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f73ccd8-6373-41a9-bbb7-2f1fa00b6a03>.
+    
+<http://data.lblod.info/id/remote-data-objects/296e7de7-fbb2-4f9a-b82c-d10d6cefc0fa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "296e7de7-fbb2-4f9a-b82c-d10d6cefc0fa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/4bfbf027-3493-4dd9-a9dc-3f7b9e91215f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/296e7de7-fbb2-4f9a-b82c-d10d6cefc0fa>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e265027-d72b-4daa-ad4e-439ac5b1472e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e265027-d72b-4daa-ad4e-439ac5b1472e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/4bfbf027-3493-4dd9-a9dc-3f7b9e91215f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e265027-d72b-4daa-ad4e-439ac5b1472e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e68dd212-6021-483a-906c-cdf78643be3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e68dd212-6021-483a-906c-cdf78643be3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/4c21f946-9a48-45b3-8b7a-3c884cbaaf7b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e68dd212-6021-483a-906c-cdf78643be3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed01ae9c-8f00-46e3-9457-25f5f3f29fdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed01ae9c-8f00-46e3-9457-25f5f3f29fdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/4c21f946-9a48-45b3-8b7a-3c884cbaaf7b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed01ae9c-8f00-46e3-9457-25f5f3f29fdf>.
+    
+<http://data.lblod.info/id/remote-data-objects/5df99999-f694-4099-94dc-13de2d16131e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5df99999-f694-4099-94dc-13de2d16131e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/4c21f946-9a48-45b3-8b7a-3c884cbaaf7b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5df99999-f694-4099-94dc-13de2d16131e>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf36c8f6-0300-43c5-8f3d-6906df001097> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf36c8f6-0300-43c5-8f3d-6906df001097";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/547c175a-7cdc-4525-8aec-d747a60b3433/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf36c8f6-0300-43c5-8f3d-6906df001097>.
+    
+<http://data.lblod.info/id/remote-data-objects/e19cf579-b6a4-495c-b09c-c15ad0abfc4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e19cf579-b6a4-495c-b09c-c15ad0abfc4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/547c175a-7cdc-4525-8aec-d747a60b3433/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e19cf579-b6a4-495c-b09c-c15ad0abfc4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/970cc54e-e6aa-44b2-8c3c-ad92d963aa4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "970cc54e-e6aa-44b2-8c3c-ad92d963aa4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/547c175a-7cdc-4525-8aec-d747a60b3433/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/970cc54e-e6aa-44b2-8c3c-ad92d963aa4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9810f3e8-e078-4a2e-b42d-a54603879160> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9810f3e8-e078-4a2e-b42d-a54603879160";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/65a13d8b-ccb4-4dfd-9da2-279dc9acedae/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9810f3e8-e078-4a2e-b42d-a54603879160>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6ff8b50-2e9d-4f98-b11f-68170ddad337> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6ff8b50-2e9d-4f98-b11f-68170ddad337";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/65a13d8b-ccb4-4dfd-9da2-279dc9acedae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6ff8b50-2e9d-4f98-b11f-68170ddad337>.
+    
+<http://data.lblod.info/id/remote-data-objects/72fdab2b-8189-49af-b430-35d9040bde43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72fdab2b-8189-49af-b430-35d9040bde43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/65a13d8b-ccb4-4dfd-9da2-279dc9acedae/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72fdab2b-8189-49af-b430-35d9040bde43>.
+    
+<http://data.lblod.info/id/remote-data-objects/25bc5587-6158-418b-aace-68042509d94b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25bc5587-6158-418b-aace-68042509d94b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/9567a256-d39a-40da-9085-37a9561b224e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25bc5587-6158-418b-aace-68042509d94b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca7c9178-2beb-4461-931e-f5737e746490> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca7c9178-2beb-4461-931e-f5737e746490";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/9567a256-d39a-40da-9085-37a9561b224e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca7c9178-2beb-4461-931e-f5737e746490>.
+    
+<http://data.lblod.info/id/remote-data-objects/83ac96b1-4b5d-47b1-a96d-5f35ccf523ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83ac96b1-4b5d-47b1-a96d-5f35ccf523ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/9567a256-d39a-40da-9085-37a9561b224e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83ac96b1-4b5d-47b1-a96d-5f35ccf523ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e726735-7f08-4c52-bdc5-920d9762d85f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e726735-7f08-4c52-bdc5-920d9762d85f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/aa5868fb-7817-494e-adc0-1423b50e67d7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e726735-7f08-4c52-bdc5-920d9762d85f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b61c0bcc-6da0-4242-a7e0-061d05bc06b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b61c0bcc-6da0-4242-a7e0-061d05bc06b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/aa5868fb-7817-494e-adc0-1423b50e67d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b61c0bcc-6da0-4242-a7e0-061d05bc06b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3257a13-c4a3-4dfd-b6df-861c50bed216> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3257a13-c4a3-4dfd-b6df-861c50bed216";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/aa5868fb-7817-494e-adc0-1423b50e67d7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3257a13-c4a3-4dfd-b6df-861c50bed216>.
+    
+<http://data.lblod.info/id/remote-data-objects/8eb4b49c-fb56-4af4-bc56-e8c02d852781> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8eb4b49c-fb56-4af4-bc56-e8c02d852781";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/b3202f08-5bf1-4d00-83ea-7d46c1e91c8c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8eb4b49c-fb56-4af4-bc56-e8c02d852781>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ffb7b0f-d036-41af-9c03-8f36d159b8cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ffb7b0f-d036-41af-9c03-8f36d159b8cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/b3202f08-5bf1-4d00-83ea-7d46c1e91c8c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ffb7b0f-d036-41af-9c03-8f36d159b8cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a9279d1-2caf-4b26-acec-e8c86cff33c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a9279d1-2caf-4b26-acec-e8c86cff33c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/b3202f08-5bf1-4d00-83ea-7d46c1e91c8c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a9279d1-2caf-4b26-acec-e8c86cff33c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0718006-0bf0-4872-a65e-fcec7e3cf94e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0718006-0bf0-4872-a65e-fcec7e3cf94e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/c2cc18b2-0ecf-4051-ae38-4c5e49304516/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0718006-0bf0-4872-a65e-fcec7e3cf94e>.
+    
+<http://data.lblod.info/id/remote-data-objects/64be1068-5f02-4d00-b7ff-818af1980195> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64be1068-5f02-4d00-b7ff-818af1980195";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/c2cc18b2-0ecf-4051-ae38-4c5e49304516/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64be1068-5f02-4d00-b7ff-818af1980195>.
+    
+<http://data.lblod.info/id/remote-data-objects/168fa035-8cd7-4944-a2f5-451db1e9807f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "168fa035-8cd7-4944-a2f5-451db1e9807f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/c2cc18b2-0ecf-4051-ae38-4c5e49304516/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/168fa035-8cd7-4944-a2f5-451db1e9807f>.
+    
+<http://data.lblod.info/id/remote-data-objects/34c5b9a3-d11f-4d3d-a134-a205bbbfcdb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34c5b9a3-d11f-4d3d-a134-a205bbbfcdb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/f03f58b6-aac3-48df-990e-55d127c8147a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34c5b9a3-d11f-4d3d-a134-a205bbbfcdb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed38888f-71b0-4824-a161-192c62973976> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed38888f-71b0-4824-a161-192c62973976";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/f03f58b6-aac3-48df-990e-55d127c8147a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed38888f-71b0-4824-a161-192c62973976>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c5b35e5-efed-40da-b0c8-0f791dffde28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c5b35e5-efed-40da-b0c8-0f791dffde28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/rmw/f03f58b6-aac3-48df-990e-55d127c8147a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c5b35e5-efed-40da-b0c8-0f791dffde28>.
+    
+<http://data.lblod.info/id/remote-data-objects/19fe52ff-dd9a-47b5-8b1a-696ae28c6390> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19fe52ff-dd9a-47b5-8b1a-696ae28c6390";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/01e9d652-65af-40ed-a098-67fed5671e43/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19fe52ff-dd9a-47b5-8b1a-696ae28c6390>.
+    
+<http://data.lblod.info/id/remote-data-objects/a062e330-9777-4e76-adc7-e46f0430c25e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a062e330-9777-4e76-adc7-e46f0430c25e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/037f324e-3e73-4b7c-aa0e-e9d9c9414d83/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:21.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1bf6f4fc-e77e-4441-9044-dfe6b0b537fe> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a062e330-9777-4e76-adc7-e46f0430c25e>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201922-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201922-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201922-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201922-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/1146be09-9479-4d3c-b2cf-8064bd85deb7> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1146be09-9479-4d3c-b2cf-8064bd85deb7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4138e6d4-5bd3-4162-a397-7d2e811da3ee";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f3767215-955b-42b9-a180-c17b421ab43d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f3767215-955b-42b9-a180-c17b421ab43d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee>.
+
+  <http://redpencil.data.gift/id/task/cae315b6-8574-4459-ad57-9b332483746e> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cae315b6-8574-4459-ad57-9b332483746e";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/1146be09-9479-4d3c-b2cf-8064bd85deb7>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f3767215-955b-42b9-a180-c17b421ab43d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/385f08e1-92d4-464a-a748-30cc775be956> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "385f08e1-92d4-464a-a748-30cc775be956";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/0a1cf75c-28a5-407e-9a2b-2bd470ed5e35/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/385f08e1-92d4-464a-a748-30cc775be956>.
+    
+<http://data.lblod.info/id/remote-data-objects/326c6a7a-6028-47e1-9c42-66510d6e7637> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "326c6a7a-6028-47e1-9c42-66510d6e7637";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/0a876f0f-693c-434a-b403-cbfe4c29ceed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/326c6a7a-6028-47e1-9c42-66510d6e7637>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f10a91b-5e72-4b3c-b40a-6be37cefa58a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f10a91b-5e72-4b3c-b40a-6be37cefa58a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/0fafd832-fbca-4b48-88cf-0d7a34c5b173/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f10a91b-5e72-4b3c-b40a-6be37cefa58a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8a56b76-34da-4368-81f3-d53b34e5c0fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8a56b76-34da-4368-81f3-d53b34e5c0fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/1f982cbb-cc69-4ace-8d71-dad753b0a73a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8a56b76-34da-4368-81f3-d53b34e5c0fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/56b04840-c303-445f-9af2-2edfda87fc81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56b04840-c303-445f-9af2-2edfda87fc81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/22104584-7545-4070-a6c6-e03ca1aff325/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56b04840-c303-445f-9af2-2edfda87fc81>.
+    
+<http://data.lblod.info/id/remote-data-objects/01299c87-7641-41ad-838c-25bf8c60f358> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01299c87-7641-41ad-838c-25bf8c60f358";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/22348082-e4c3-44d2-9b8d-0de5eb917fb4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01299c87-7641-41ad-838c-25bf8c60f358>.
+    
+<http://data.lblod.info/id/remote-data-objects/a28042b5-4780-4b4c-bdb3-b66e3f4e0781> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a28042b5-4780-4b4c-bdb3-b66e3f4e0781";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/23cc6876-3944-47d6-983e-e14470a045af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a28042b5-4780-4b4c-bdb3-b66e3f4e0781>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a883bf2-f77b-43d1-bfc5-afe699a5a3c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a883bf2-f77b-43d1-bfc5-afe699a5a3c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/255a65c7-a45f-42b5-8f20-71b6476a2d86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a883bf2-f77b-43d1-bfc5-afe699a5a3c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb0e3641-c129-44e8-9ebf-116180c2d50f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb0e3641-c129-44e8-9ebf-116180c2d50f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/2c5f28db-c567-44fb-98e8-2ef7bbd8fc12/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb0e3641-c129-44e8-9ebf-116180c2d50f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6eaff43a-80c4-44ab-acbd-823e38f1a4da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6eaff43a-80c4-44ab-acbd-823e38f1a4da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/32f398ff-11e0-4aa4-b181-694c951be023/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6eaff43a-80c4-44ab-acbd-823e38f1a4da>.
+    
+<http://data.lblod.info/id/remote-data-objects/41b82f3a-64ef-4dba-a11b-0d48f63004bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41b82f3a-64ef-4dba-a11b-0d48f63004bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/3330ed5f-3cf6-484e-bc8f-c775494d35c7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41b82f3a-64ef-4dba-a11b-0d48f63004bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba768cec-302a-4dba-9ccb-dd3179b95c7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba768cec-302a-4dba-9ccb-dd3179b95c7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/36881179-de9f-4d8b-83ef-b35a608fae01/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba768cec-302a-4dba-9ccb-dd3179b95c7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a5bd3be-384d-42ad-b5ca-c4388e5ce82e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a5bd3be-384d-42ad-b5ca-c4388e5ce82e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/405aa1fc-7cbc-40c0-bfd0-2cbe0fd6eed7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a5bd3be-384d-42ad-b5ca-c4388e5ce82e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1feb845-c7b8-4cf9-9e10-46bd2c1f1d1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1feb845-c7b8-4cf9-9e10-46bd2c1f1d1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/40c5fa0e-8386-4998-b91e-29d306329920/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1feb845-c7b8-4cf9-9e10-46bd2c1f1d1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c48c6b10-ec06-437e-91f4-88f0e5d4854d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c48c6b10-ec06-437e-91f4-88f0e5d4854d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/40d32180-688a-474d-b351-d0c3abc92a15/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c48c6b10-ec06-437e-91f4-88f0e5d4854d>.
+    
+<http://data.lblod.info/id/remote-data-objects/307f933f-42f0-453b-b50b-beed59477648> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "307f933f-42f0-453b-b50b-beed59477648";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/43078f1f-a6fd-4365-91f0-a00f3492644e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/307f933f-42f0-453b-b50b-beed59477648>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7b64db7-d503-4e32-97df-7f5a2ce5dae5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7b64db7-d503-4e32-97df-7f5a2ce5dae5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/463ca23a-907a-4299-bfb5-456bccb1026c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7b64db7-d503-4e32-97df-7f5a2ce5dae5>.
+    
+<http://data.lblod.info/id/remote-data-objects/863c76ce-4fce-483c-8edc-541bdb954ac6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "863c76ce-4fce-483c-8edc-541bdb954ac6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/499eee33-0ddf-427e-aed5-b60c652ff087/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/863c76ce-4fce-483c-8edc-541bdb954ac6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7bd9863-a20b-40aa-8455-d611876dd933> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7bd9863-a20b-40aa-8455-d611876dd933";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/4b6edcb2-5478-4b68-8107-f2e0b5ac04b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7bd9863-a20b-40aa-8455-d611876dd933>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f855d65-4842-4297-9d50-478da0e6acea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f855d65-4842-4297-9d50-478da0e6acea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/4c63db1f-ba60-462e-803d-b1df3ac20abd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f855d65-4842-4297-9d50-478da0e6acea>.
+    
+<http://data.lblod.info/id/remote-data-objects/72a70f51-4d00-4963-afab-030ce4d839f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72a70f51-4d00-4963-afab-030ce4d839f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/503ea967-3e2d-4349-9b1d-e2d4badd1635/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72a70f51-4d00-4963-afab-030ce4d839f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/850961be-7738-44e2-a843-54780e08cdcb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "850961be-7738-44e2-a843-54780e08cdcb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/56a34721-02e5-4bbd-89ac-85c5993efb57/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/850961be-7738-44e2-a843-54780e08cdcb>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ed6d0a3-6687-4a0e-8878-37e19284c8b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ed6d0a3-6687-4a0e-8878-37e19284c8b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/5a435950-bbfd-4b18-9327-4781e94f6890/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ed6d0a3-6687-4a0e-8878-37e19284c8b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a21f8f6-6cce-407e-b46a-c9bc368025c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a21f8f6-6cce-407e-b46a-c9bc368025c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/5c678d0d-ab82-4775-8c72-af447aa782f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a21f8f6-6cce-407e-b46a-c9bc368025c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/9335bdd2-f3fb-4104-a5f5-186871943563> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9335bdd2-f3fb-4104-a5f5-186871943563";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/5fd2004a-ec62-456f-8685-4ebaf24edfc4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9335bdd2-f3fb-4104-a5f5-186871943563>.
+    
+<http://data.lblod.info/id/remote-data-objects/12534b4b-ad74-4fe4-8bc8-1870b2cf254d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12534b4b-ad74-4fe4-8bc8-1870b2cf254d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/64f40300-6cce-4bd7-ace3-61c3a1fcf3ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12534b4b-ad74-4fe4-8bc8-1870b2cf254d>.
+    
+<http://data.lblod.info/id/remote-data-objects/683d265c-2b51-4ed1-8fef-bec4a8d55077> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "683d265c-2b51-4ed1-8fef-bec4a8d55077";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/6c205dea-a454-497f-a4be-56976a21612b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/683d265c-2b51-4ed1-8fef-bec4a8d55077>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed7efa25-0852-487e-8d77-9b0ff69ea0a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed7efa25-0852-487e-8d77-9b0ff69ea0a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/6d90d605-de6f-41fa-af1a-2d9abbbd1892/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed7efa25-0852-487e-8d77-9b0ff69ea0a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/15be8923-86e6-423b-864a-1adda0d85827> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15be8923-86e6-423b-864a-1adda0d85827";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/710a1041-2ad6-4467-bddb-90adefbaf623/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15be8923-86e6-423b-864a-1adda0d85827>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7ceefd6-fb97-4fe3-a506-a9b6a5b0ce10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7ceefd6-fb97-4fe3-a506-a9b6a5b0ce10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/7217f73c-f3dd-44eb-949f-344819cde943/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7ceefd6-fb97-4fe3-a506-a9b6a5b0ce10>.
+    
+<http://data.lblod.info/id/remote-data-objects/b58c6dbd-7691-4578-9dd8-67547e3c6093> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b58c6dbd-7691-4578-9dd8-67547e3c6093";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/73fbcffe-6645-4178-858c-542f5116ab8a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b58c6dbd-7691-4578-9dd8-67547e3c6093>.
+    
+<http://data.lblod.info/id/remote-data-objects/22164df3-5b2a-460b-b313-75c9307b5fd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22164df3-5b2a-460b-b313-75c9307b5fd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/7cbba624-2f16-4ccc-aa84-15dbcb8b0720/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22164df3-5b2a-460b-b313-75c9307b5fd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/efef003d-461a-421d-86ac-ee8e08b30d69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efef003d-461a-421d-86ac-ee8e08b30d69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/7eaae178-9c95-4b4a-a08f-290ee2492d3d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/efef003d-461a-421d-86ac-ee8e08b30d69>.
+    
+<http://data.lblod.info/id/remote-data-objects/c107933b-5d5f-45e8-9f19-35d9725d2ed6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c107933b-5d5f-45e8-9f19-35d9725d2ed6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/801d8ccd-39f0-4130-a792-3cb8480e4520/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c107933b-5d5f-45e8-9f19-35d9725d2ed6>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdb8f531-5772-4e04-818b-cf3ed4e02cdf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdb8f531-5772-4e04-818b-cf3ed4e02cdf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/813be96b-b3e2-45ee-83db-bf1f1b716028/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdb8f531-5772-4e04-818b-cf3ed4e02cdf>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e7efb31-554e-4a3c-b763-752d383baf5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e7efb31-554e-4a3c-b763-752d383baf5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/864db2c5-1658-4d2f-aefd-48ec9bc8c112/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e7efb31-554e-4a3c-b763-752d383baf5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b672cce6-38f3-48ed-bde5-63c3f8936a37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b672cce6-38f3-48ed-bde5-63c3f8936a37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/8774583e-3641-432c-ac4e-d626473bca8f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b672cce6-38f3-48ed-bde5-63c3f8936a37>.
+    
+<http://data.lblod.info/id/remote-data-objects/0be9db65-e27e-4a70-a2b2-1cefa2e3c139> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0be9db65-e27e-4a70-a2b2-1cefa2e3c139";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/8922fb8f-7405-4c0d-a336-194685301cee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0be9db65-e27e-4a70-a2b2-1cefa2e3c139>.
+    
+<http://data.lblod.info/id/remote-data-objects/21a275ac-3b99-4241-80b6-61edfdcf804f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21a275ac-3b99-4241-80b6-61edfdcf804f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/8b5344de-e972-4f18-b4fa-2d2430cd2731/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21a275ac-3b99-4241-80b6-61edfdcf804f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5017000a-6ec0-4adb-a3b4-398c7d2b56dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5017000a-6ec0-4adb-a3b4-398c7d2b56dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/8bc9813c-dd81-4d29-9a79-0aa8b9eabb96/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5017000a-6ec0-4adb-a3b4-398c7d2b56dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d757ea8d-c53b-4e62-8e74-d0ea10bab909> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d757ea8d-c53b-4e62-8e74-d0ea10bab909";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/8c7296c2-89b1-4922-9893-b3d2259bc398/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d757ea8d-c53b-4e62-8e74-d0ea10bab909>.
+    
+<http://data.lblod.info/id/remote-data-objects/35ef3def-9c64-4d80-a452-f0e1d0aa6a95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35ef3def-9c64-4d80-a452-f0e1d0aa6a95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/8cc7daa3-897e-4927-b212-2e12e464041f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35ef3def-9c64-4d80-a452-f0e1d0aa6a95>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0a72633-ee07-4e89-8b07-9a2da1c88ce2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0a72633-ee07-4e89-8b07-9a2da1c88ce2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/8e55aafe-b109-4ba3-996a-67800191b20c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0a72633-ee07-4e89-8b07-9a2da1c88ce2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2a1ed30-7d97-4da7-a871-e4933011a4c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2a1ed30-7d97-4da7-a871-e4933011a4c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/912cbaef-0344-46b7-89c6-c074465ffa3b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2a1ed30-7d97-4da7-a871-e4933011a4c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/338a874d-bc1d-4d26-92d7-cf7ed2b95412> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "338a874d-bc1d-4d26-92d7-cf7ed2b95412";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/9191700c-632c-479b-b4d7-97082a5e4352/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/338a874d-bc1d-4d26-92d7-cf7ed2b95412>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d2ef8b6-820a-48c7-98dd-93792ea37eca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d2ef8b6-820a-48c7-98dd-93792ea37eca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/9913df1e-5d4b-4f4f-82c8-ebae821e6764/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d2ef8b6-820a-48c7-98dd-93792ea37eca>.
+    
+<http://data.lblod.info/id/remote-data-objects/749ce2e3-0022-4896-8c3c-7a64c26447ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "749ce2e3-0022-4896-8c3c-7a64c26447ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/a67dfaa2-4400-498a-b421-81855144034d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/749ce2e3-0022-4896-8c3c-7a64c26447ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e9f26a0-14d6-49c2-8a3c-d7eed152f7fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e9f26a0-14d6-49c2-8a3c-d7eed152f7fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/b5060afe-7b22-4fd2-a75b-9e33af8242e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e9f26a0-14d6-49c2-8a3c-d7eed152f7fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dd8fea8-5fc3-4ad7-a3be-0b8223eab395> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dd8fea8-5fc3-4ad7-a3be-0b8223eab395";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/bcbefdb6-4ce7-4d30-81c1-9c8611310020/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dd8fea8-5fc3-4ad7-a3be-0b8223eab395>.
+    
+<http://data.lblod.info/id/remote-data-objects/abae095a-86a3-444d-ae81-da78ae3f34dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abae095a-86a3-444d-ae81-da78ae3f34dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/c9fc5f8a-8f9f-4bcb-a702-94c85e19100e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:22.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4138e6d4-5bd3-4162-a397-7d2e811da3ee> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abae095a-86a3-444d-ae81-da78ae3f34dc>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201924-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201924-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201924-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201924-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/6d88252a-6d6b-4aee-a25e-6367dc531ac6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6d88252a-6d6b-4aee-a25e-6367dc531ac6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d02c261c-90bf-46a8-b154-2f105f59c3d6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d125944a-94b4-4cd9-af4b-9eda02eb384f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d125944a-94b4-4cd9-af4b-9eda02eb384f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6>.
+
+  <http://redpencil.data.gift/id/task/0e8c11cc-e8fe-4767-821a-af1bbafae673> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0e8c11cc-e8fe-4767-821a-af1bbafae673";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/6d88252a-6d6b-4aee-a25e-6367dc531ac6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d125944a-94b4-4cd9-af4b-9eda02eb384f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4972bbbb-aad2-4bc6-a6ab-5c182bf791b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4972bbbb-aad2-4bc6-a6ab-5c182bf791b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/ca8496b5-40f3-4103-a60c-1e9ea159e424/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4972bbbb-aad2-4bc6-a6ab-5c182bf791b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/490bb45d-d020-4eda-9ac7-e7686f230c17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "490bb45d-d020-4eda-9ac7-e7686f230c17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/ccbf9220-89f0-444e-a22f-ea68a90a89d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/490bb45d-d020-4eda-9ac7-e7686f230c17>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e87837b-c482-4a49-b383-d1e57175f835> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e87837b-c482-4a49-b383-d1e57175f835";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/d3ee511a-61fb-4d59-a5a8-6a5a37c429e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e87837b-c482-4a49-b383-d1e57175f835>.
+    
+<http://data.lblod.info/id/remote-data-objects/a791c8bd-2878-4110-aa27-211e018275ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a791c8bd-2878-4110-aa27-211e018275ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/d407095e-e965-40d2-9bc0-ea0860b175d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a791c8bd-2878-4110-aa27-211e018275ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/6365b3ee-e4ff-4afe-ad51-6a2099ac1efa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6365b3ee-e4ff-4afe-ad51-6a2099ac1efa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/dd59c99a-882a-475e-952a-9014298f2c52/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6365b3ee-e4ff-4afe-ad51-6a2099ac1efa>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9eda1c0-8368-424f-aebf-17b4ec936cd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9eda1c0-8368-424f-aebf-17b4ec936cd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/e3f8c4ec-47d2-46db-bade-accecbe058f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9eda1c0-8368-424f-aebf-17b4ec936cd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/53d0abf5-baf4-477c-a039-dd8ac904032b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53d0abf5-baf4-477c-a039-dd8ac904032b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/e6c9b96e-4777-4c3d-a5df-89dd625d94c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53d0abf5-baf4-477c-a039-dd8ac904032b>.
+    
+<http://data.lblod.info/id/remote-data-objects/90008a4a-1334-455d-90b7-453156533ccd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90008a4a-1334-455d-90b7-453156533ccd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/e9929017-2f55-435e-9c79-0d117c0f653e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90008a4a-1334-455d-90b7-453156533ccd>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fb9e414-58db-4b97-aba6-c64668c57bfe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fb9e414-58db-4b97-aba6-c64668c57bfe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/ee204732-f23b-41c2-a7a6-00ec11b72dad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fb9e414-58db-4b97-aba6-c64668c57bfe>.
+    
+<http://data.lblod.info/id/remote-data-objects/76afded5-df04-4c90-b0ba-c61ad5b7db44> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76afded5-df04-4c90-b0ba-c61ad5b7db44";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/f852f8d0-a250-411c-9c0b-d9404366c9bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76afded5-df04-4c90-b0ba-c61ad5b7db44>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbca22ca-f79f-49a6-be28-5a7913ac02ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbca22ca-f79f-49a6-be28-5a7913ac02ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/f9b6e98d-af08-4308-aaa4-140b90e9ddbf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbca22ca-f79f-49a6-be28-5a7913ac02ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdbb1689-a100-4fc1-9586-c4733672cbfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdbb1689-a100-4fc1-9586-c4733672cbfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://rotselaar.meetingburger.net/vabu/f9e7d650-2f5e-4ffe-8878-809492f2d410/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdbb1689-a100-4fc1-9586-c4733672cbfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/767dfdb7-d195-4358-a87f-a943d28c7c8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "767dfdb7-d195-4358-a87f-a943d28c7c8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/agb-rvb/0e8105eb-07a7-4753-81bf-8ae7a2af1c73/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/767dfdb7-d195-4358-a87f-a943d28c7c8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/277c6e94-c435-4ed6-9b42-0f5d051f5b39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "277c6e94-c435-4ed6-9b42-0f5d051f5b39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/agb-rvb/4de84947-5dcb-41d4-a6b5-0a5a0e49ca8e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/277c6e94-c435-4ed6-9b42-0f5d051f5b39>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f32865c-d8c1-4d5d-8684-c7bd353ff035> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f32865c-d8c1-4d5d-8684-c7bd353ff035";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/agb-rvb/555d157a-7c58-44cb-a1db-6e375e04ee51/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f32865c-d8c1-4d5d-8684-c7bd353ff035>.
+    
+<http://data.lblod.info/id/remote-data-objects/192eaea6-26ce-4dbb-8de5-681c89cc7bf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "192eaea6-26ce-4dbb-8de5-681c89cc7bf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/agb-rvb/840b56d6-f52a-4fe9-ad45-17a1d04086fb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/192eaea6-26ce-4dbb-8de5-681c89cc7bf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/50b8cf19-3d3b-4dad-b792-053b77a96f0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50b8cf19-3d3b-4dad-b792-053b77a96f0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/agb-rvb/8c31bbb6-d28a-43c6-8ac9-71d6b6117cbe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50b8cf19-3d3b-4dad-b792-053b77a96f0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9321d758-62d4-499f-bb8a-d6be8a85b340> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9321d758-62d4-499f-bb8a-d6be8a85b340";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/agb-rvb/df058c46-18f7-49fb-9fae-80a8a104b951/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9321d758-62d4-499f-bb8a-d6be8a85b340>.
+    
+<http://data.lblod.info/id/remote-data-objects/b207c178-b6a9-48c1-b83c-ff53daef4c5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b207c178-b6a9-48c1-b83c-ff53daef4c5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/bb/28d30bc6-7bc2-4528-bdd6-585214f6bd92/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b207c178-b6a9-48c1-b83c-ff53daef4c5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8e84dfd-decf-4b6a-a179-3be67865b560> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8e84dfd-decf-4b6a-a179-3be67865b560";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/bb/311a3bbf-8904-493a-909b-2de2b9bf4a8b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8e84dfd-decf-4b6a-a179-3be67865b560>.
+    
+<http://data.lblod.info/id/remote-data-objects/9555cc79-2fb8-404a-9c02-78fa8e48ed51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9555cc79-2fb8-404a-9c02-78fa8e48ed51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/bb/37c68680-5a61-4b13-afe4-1e7f6a2140ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9555cc79-2fb8-404a-9c02-78fa8e48ed51>.
+    
+<http://data.lblod.info/id/remote-data-objects/285e9fcd-92d5-4f85-96ae-aa12090c177f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "285e9fcd-92d5-4f85-96ae-aa12090c177f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/bb/80dd95c9-5124-4bb9-b899-b0248a926302/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/285e9fcd-92d5-4f85-96ae-aa12090c177f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe7e070a-2c62-4e70-a800-b6b2c2789056> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe7e070a-2c62-4e70-a800-b6b2c2789056";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/bb/8e79f2a6-227f-4d7f-8c8d-2342df58a522/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe7e070a-2c62-4e70-a800-b6b2c2789056>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d236ba9-d738-49b9-9200-a8816ca845ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d236ba9-d738-49b9-9200-a8816ca845ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/bb/9850396c-799a-407d-96df-597a282126a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d236ba9-d738-49b9-9200-a8816ca845ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/38ef980d-893b-49cc-b3de-41ddfc37419f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38ef980d-893b-49cc-b3de-41ddfc37419f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/00311948-de1b-4d87-bcfd-b529f94427fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38ef980d-893b-49cc-b3de-41ddfc37419f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b0736b5-1875-47eb-b89a-f90a54015f12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b0736b5-1875-47eb-b89a-f90a54015f12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/003c0321-2120-42ff-809f-04493d580946/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b0736b5-1875-47eb-b89a-f90a54015f12>.
+    
+<http://data.lblod.info/id/remote-data-objects/f71714ec-c8b4-459b-91c3-d2323aa1565e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f71714ec-c8b4-459b-91c3-d2323aa1565e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/00974b38-10fc-4d5e-a574-8adc0b936a01/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f71714ec-c8b4-459b-91c3-d2323aa1565e>.
+    
+<http://data.lblod.info/id/remote-data-objects/385a22b6-0489-4d92-a9f1-eaa146f3d988> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "385a22b6-0489-4d92-a9f1-eaa146f3d988";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/00c51e02-608b-43c8-b1cd-fa0dcad33924/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/385a22b6-0489-4d92-a9f1-eaa146f3d988>.
+    
+<http://data.lblod.info/id/remote-data-objects/82914d2a-b46b-48a9-a6d3-7ae0b2df7546> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82914d2a-b46b-48a9-a6d3-7ae0b2df7546";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/0bdcd40a-b100-465b-a2fd-aca5aa49b36c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82914d2a-b46b-48a9-a6d3-7ae0b2df7546>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9a25b8d-39ea-4e4c-8ec7-7afed5e42bf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9a25b8d-39ea-4e4c-8ec7-7afed5e42bf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/1127c19c-edb5-48f1-ab8e-c73bfa5cb2b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9a25b8d-39ea-4e4c-8ec7-7afed5e42bf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/e80f6608-e7ef-47db-9586-bfb8501cb575> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e80f6608-e7ef-47db-9586-bfb8501cb575";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/1eb4606a-9a25-4e73-b274-5573ae9c7d25/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e80f6608-e7ef-47db-9586-bfb8501cb575>.
+    
+<http://data.lblod.info/id/remote-data-objects/2df26754-7219-4b35-b2a9-d7dc5fc83c91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2df26754-7219-4b35-b2a9-d7dc5fc83c91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/1fb4e0e5-a2c2-4912-9ed2-b830a2733a84/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2df26754-7219-4b35-b2a9-d7dc5fc83c91>.
+    
+<http://data.lblod.info/id/remote-data-objects/955addab-20cc-4ddb-88ca-21722cd86fdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "955addab-20cc-4ddb-88ca-21722cd86fdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/25405a8d-bdaf-4b18-b15a-698d7e27f898/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/955addab-20cc-4ddb-88ca-21722cd86fdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/13bf7de4-6cb7-425d-b5b1-aae1de8cdfb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13bf7de4-6cb7-425d-b5b1-aae1de8cdfb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/2692bf46-e65b-4af2-a231-ef6fee8a3126/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13bf7de4-6cb7-425d-b5b1-aae1de8cdfb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcc53ec1-d1bd-4ee8-a783-b5a184c4cc30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcc53ec1-d1bd-4ee8-a783-b5a184c4cc30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/32f2d449-c154-4c1b-a1c3-5ece365d17c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcc53ec1-d1bd-4ee8-a783-b5a184c4cc30>.
+    
+<http://data.lblod.info/id/remote-data-objects/3423c516-66e1-4c19-a009-e12d0950332a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3423c516-66e1-4c19-a009-e12d0950332a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/36d1e5f3-7adf-4e41-bb6c-594a4d5504bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3423c516-66e1-4c19-a009-e12d0950332a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a10e04e8-f8bc-4964-bd44-62859af1c0f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a10e04e8-f8bc-4964-bd44-62859af1c0f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/3a2e61d0-1655-4b60-8a8b-2f9f7a6075bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a10e04e8-f8bc-4964-bd44-62859af1c0f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/6408d9bd-d4b3-4949-844c-a0a7a9d598a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6408d9bd-d4b3-4949-844c-a0a7a9d598a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/405b3574-b7b0-4ed5-ab18-fdaa691ac725/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6408d9bd-d4b3-4949-844c-a0a7a9d598a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef38cf53-6da2-4eb5-94a4-3feea694e6a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef38cf53-6da2-4eb5-94a4-3feea694e6a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/5bb5691a-4fff-4947-9c5f-10fbeb99c16d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef38cf53-6da2-4eb5-94a4-3feea694e6a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6675d17-d140-410a-8a6e-5a666f0206e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6675d17-d140-410a-8a6e-5a666f0206e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/5c8d4dc7-abc0-4d52-af25-9b34debb75ee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6675d17-d140-410a-8a6e-5a666f0206e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/eab3b663-bb65-4d92-bff1-a4a3c11049bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eab3b663-bb65-4d92-bff1-a4a3c11049bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/6080c273-1457-47f4-b5be-d03c5edd60fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eab3b663-bb65-4d92-bff1-a4a3c11049bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a101916-7ec7-45f5-ab46-b0b32608c621> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a101916-7ec7-45f5-ab46-b0b32608c621";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/7503353a-c577-49e7-af9b-05756cb91aa6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a101916-7ec7-45f5-ab46-b0b32608c621>.
+    
+<http://data.lblod.info/id/remote-data-objects/29af1e3f-1c25-4477-a3cc-33659eeeb2b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29af1e3f-1c25-4477-a3cc-33659eeeb2b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/8165c3f9-cc4f-4d89-a2fc-1a7c6751a982/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29af1e3f-1c25-4477-a3cc-33659eeeb2b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ab4d757-7115-4a43-947a-d6e324f65669> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ab4d757-7115-4a43-947a-d6e324f65669";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/8881905a-589b-4929-a572-5c5adb917a12/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ab4d757-7115-4a43-947a-d6e324f65669>.
+    
+<http://data.lblod.info/id/remote-data-objects/105101a1-c57d-42af-bb10-155121ee8370> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "105101a1-c57d-42af-bb10-155121ee8370";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/893b437d-c3e9-4108-9332-917691ca8df0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/105101a1-c57d-42af-bb10-155121ee8370>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5ac7518-55cd-476d-8521-1255949b3a74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5ac7518-55cd-476d-8521-1255949b3a74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/8b89b503-4b30-4149-b2de-022f3489bfdf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5ac7518-55cd-476d-8521-1255949b3a74>.
+    
+<http://data.lblod.info/id/remote-data-objects/351eebe8-62a5-489a-9c31-8510f3e97c0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "351eebe8-62a5-489a-9c31-8510f3e97c0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/8d460121-cb94-4165-9f28-4b5e0f25f2e6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/351eebe8-62a5-489a-9c31-8510f3e97c0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/42185099-0cfa-4302-8263-f444682434a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42185099-0cfa-4302-8263-f444682434a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/8d5a1914-731a-4fb3-be98-19d24bd676d9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42185099-0cfa-4302-8263-f444682434a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9f4bec3-b6f9-499a-8f0e-a5f102ae8d80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9f4bec3-b6f9-499a-8f0e-a5f102ae8d80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/9aaffa45-3443-4204-a8e3-883701741116/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9f4bec3-b6f9-499a-8f0e-a5f102ae8d80>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e836c8a-7f93-4649-9178-2ca667dcb8da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e836c8a-7f93-4649-9178-2ca667dcb8da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/a014d85b-eb26-4efc-afea-b4fc0cb0fc30/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:24.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d02c261c-90bf-46a8-b154-2f105f59c3d6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e836c8a-7f93-4649-9178-2ca667dcb8da>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201925-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201925-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201925-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201925-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/9ca11ea0-64a1-4125-8634-008428ae5b3f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9ca11ea0-64a1-4125-8634-008428ae5b3f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "75790730-2afd-4915-9353-e79bc4aee3ab";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9b4aec43-9de6-4649-9ebf-a268111585d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9b4aec43-9de6-4649-9ebf-a268111585d4";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab>.
+
+  <http://redpencil.data.gift/id/task/8264e3e2-5b41-49a0-b72e-cb74e025c11e> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8264e3e2-5b41-49a0-b72e-cb74e025c11e";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/9ca11ea0-64a1-4125-8634-008428ae5b3f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9b4aec43-9de6-4649-9ebf-a268111585d4>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4fc4db1e-a898-4cb2-94bb-20a584e4df1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fc4db1e-a898-4cb2-94bb-20a584e4df1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/a88d0391-9d8a-4fae-9a4f-c77743f52cca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fc4db1e-a898-4cb2-94bb-20a584e4df1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fc9b998-e4ac-4f9a-b9c8-7c54218a50f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fc9b998-e4ac-4f9a-b9c8-7c54218a50f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/ad985d7f-8fa8-4982-b580-61deaaa224ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fc9b998-e4ac-4f9a-b9c8-7c54218a50f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfcce92e-6cdc-415d-82a9-ab45b2985e14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfcce92e-6cdc-415d-82a9-ab45b2985e14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/b1e22112-8037-4eb4-b0a9-10e684443197/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfcce92e-6cdc-415d-82a9-ab45b2985e14>.
+    
+<http://data.lblod.info/id/remote-data-objects/386f8bcc-b429-49bd-ba3e-c78d58421bab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "386f8bcc-b429-49bd-ba3e-c78d58421bab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/b2b1829c-e6d6-4909-9984-c1196b4f45e4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/386f8bcc-b429-49bd-ba3e-c78d58421bab>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a7ac227-c557-4336-921f-6237d48ddc25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a7ac227-c557-4336-921f-6237d48ddc25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/c0d5a6b8-82c5-47e8-bc00-0bd1c1530250/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a7ac227-c557-4336-921f-6237d48ddc25>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d4ec8b6-e652-45a1-821c-9a72ccc6e8b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d4ec8b6-e652-45a1-821c-9a72ccc6e8b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/c5d95067-d9cf-4227-afd5-b3e7f5d66524/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d4ec8b6-e652-45a1-821c-9a72ccc6e8b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e7f73b1-9760-41a7-bc0f-7c2709794995> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e7f73b1-9760-41a7-bc0f-7c2709794995";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/c97e5c97-03a6-4216-ad26-5d60ee5253f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e7f73b1-9760-41a7-bc0f-7c2709794995>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9130786-6513-4a6c-92eb-6e5870eb6654> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9130786-6513-4a6c-92eb-6e5870eb6654";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/cb36041d-5cc3-453f-b911-06c7e10d5244/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9130786-6513-4a6c-92eb-6e5870eb6654>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a840147-f893-4b55-9a85-aa7234c51129> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a840147-f893-4b55-9a85-aa7234c51129";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/cc9a0606-a47c-413c-a1cb-7a81e57054fd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a840147-f893-4b55-9a85-aa7234c51129>.
+    
+<http://data.lblod.info/id/remote-data-objects/883763df-d7c1-488f-ac6c-1ef1898d3209> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "883763df-d7c1-488f-ac6c-1ef1898d3209";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/d56d7d67-4546-43ac-b7ed-708a83a576be/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/883763df-d7c1-488f-ac6c-1ef1898d3209>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c4a6349-f7be-4dd4-98a2-c152110f1f6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c4a6349-f7be-4dd4-98a2-c152110f1f6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/d6652a30-ba44-4d15-833c-804f197e42a2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c4a6349-f7be-4dd4-98a2-c152110f1f6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd27df83-a278-4285-914b-b63d3a24e577> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd27df83-a278-4285-914b-b63d3a24e577";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/d761f5ca-2534-4107-b096-72e327605d44/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd27df83-a278-4285-914b-b63d3a24e577>.
+    
+<http://data.lblod.info/id/remote-data-objects/c57e0a49-805b-4a39-a060-b8e61e35aa31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c57e0a49-805b-4a39-a060-b8e61e35aa31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/e52f9abe-ca21-4d93-911d-b394016029da/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c57e0a49-805b-4a39-a060-b8e61e35aa31>.
+    
+<http://data.lblod.info/id/remote-data-objects/03da8c72-7127-4969-8cce-de7c15f41ab2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03da8c72-7127-4969-8cce-de7c15f41ab2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/e921ea0e-2126-4264-abb3-3d8e6ca66d79/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03da8c72-7127-4969-8cce-de7c15f41ab2>.
+    
+<http://data.lblod.info/id/remote-data-objects/51997a87-afb2-4a0e-9c53-59a7ea2414be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51997a87-afb2-4a0e-9c53-59a7ea2414be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/ef183d91-cfc1-4c28-ba1f-d9f99eb76bca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51997a87-afb2-4a0e-9c53-59a7ea2414be>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d8375d2-f5ca-45d4-88fb-312bb19103c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d8375d2-f5ca-45d4-88fb-312bb19103c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/f88e8819-fa6e-4acb-8ca5-304af363cd5a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d8375d2-f5ca-45d4-88fb-312bb19103c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/187cf440-f90a-4129-b041-ed30f194383c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "187cf440-f90a-4129-b041-ed30f194383c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/faf35083-c250-413e-8233-abac8bf40177/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/187cf440-f90a-4129-b041-ed30f194383c>.
+    
+<http://data.lblod.info/id/remote-data-objects/50b0e9f2-3abc-4f4e-a565-d99ebfc7c489> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50b0e9f2-3abc-4f4e-a565-d99ebfc7c489";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/fcbc085e-a7fa-449b-b645-3803d36a694b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50b0e9f2-3abc-4f4e-a565-d99ebfc7c489>.
+    
+<http://data.lblod.info/id/remote-data-objects/94b0c54d-295d-4e4d-84ac-9d27eb762bee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94b0c54d-295d-4e4d-84ac-9d27eb762bee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/cbs/fe1ae830-bd8c-4a60-8adf-0c9551f4acad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94b0c54d-295d-4e4d-84ac-9d27eb762bee>.
+    
+<http://data.lblod.info/id/remote-data-objects/80df2531-ea82-47f1-9936-f94d3542474f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80df2531-ea82-47f1-9936-f94d3542474f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/013190fb-3e0d-442a-9115-5e927f7baf04/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80df2531-ea82-47f1-9936-f94d3542474f>.
+    
+<http://data.lblod.info/id/remote-data-objects/acefe62d-da23-43fa-ae20-4bc4db9f2a2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acefe62d-da23-43fa-ae20-4bc4db9f2a2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/013190fb-3e0d-442a-9115-5e927f7baf04/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acefe62d-da23-43fa-ae20-4bc4db9f2a2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/29b970d6-fe3f-4aa8-87c3-10ad24981626> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29b970d6-fe3f-4aa8-87c3-10ad24981626";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/013190fb-3e0d-442a-9115-5e927f7baf04/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29b970d6-fe3f-4aa8-87c3-10ad24981626>.
+    
+<http://data.lblod.info/id/remote-data-objects/09112dc8-0e04-47f1-beba-826f0780634b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09112dc8-0e04-47f1-beba-826f0780634b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/15f0ca42-fca8-4021-95a5-fd98aa152336/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09112dc8-0e04-47f1-beba-826f0780634b>.
+    
+<http://data.lblod.info/id/remote-data-objects/744d1069-723a-4d0c-ab99-6ce3c20edade> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "744d1069-723a-4d0c-ab99-6ce3c20edade";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/15f0ca42-fca8-4021-95a5-fd98aa152336/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/744d1069-723a-4d0c-ab99-6ce3c20edade>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e7d6406-ba79-47f1-a021-ff67d12d919d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e7d6406-ba79-47f1-a021-ff67d12d919d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/15f0ca42-fca8-4021-95a5-fd98aa152336/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e7d6406-ba79-47f1-a021-ff67d12d919d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a83895da-664b-4cdf-b74e-3961c5665cf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a83895da-664b-4cdf-b74e-3961c5665cf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/36a8b907-c645-429b-abbb-dbd92e8deeae/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a83895da-664b-4cdf-b74e-3961c5665cf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/04263573-5c20-467c-b81a-28b33473d1d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04263573-5c20-467c-b81a-28b33473d1d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/36a8b907-c645-429b-abbb-dbd92e8deeae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04263573-5c20-467c-b81a-28b33473d1d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/13858fd2-7480-4de1-983a-6fdec5eba988> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13858fd2-7480-4de1-983a-6fdec5eba988";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/36a8b907-c645-429b-abbb-dbd92e8deeae/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13858fd2-7480-4de1-983a-6fdec5eba988>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c054523-017b-45cc-bf5f-e67626d2385f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c054523-017b-45cc-bf5f-e67626d2385f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/4de9e391-0707-47fc-a437-3335ba49485d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c054523-017b-45cc-bf5f-e67626d2385f>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa7e2c62-2a15-49b9-b74b-8ffc53c508d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa7e2c62-2a15-49b9-b74b-8ffc53c508d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/54b56fd9-434b-4df0-a6f2-9dad037f1f4b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa7e2c62-2a15-49b9-b74b-8ffc53c508d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/741ce9e9-9072-470f-b44e-f3295cc6778f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "741ce9e9-9072-470f-b44e-f3295cc6778f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/54b56fd9-434b-4df0-a6f2-9dad037f1f4b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/741ce9e9-9072-470f-b44e-f3295cc6778f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f904ede-6efc-4f6d-9ceb-e7562c1f302f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f904ede-6efc-4f6d-9ceb-e7562c1f302f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/54b56fd9-434b-4df0-a6f2-9dad037f1f4b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f904ede-6efc-4f6d-9ceb-e7562c1f302f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c65b8d57-faba-4aaa-a0a1-c250581bc0ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c65b8d57-faba-4aaa-a0a1-c250581bc0ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/6325674f-52e1-424d-ad01-7d15053eaf8c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c65b8d57-faba-4aaa-a0a1-c250581bc0ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccc873a9-9176-4b7f-8bd6-ca98ea72f0d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccc873a9-9176-4b7f-8bd6-ca98ea72f0d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/6325674f-52e1-424d-ad01-7d15053eaf8c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccc873a9-9176-4b7f-8bd6-ca98ea72f0d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce393306-bf8b-4c51-8ed5-8c0faa4c2ed6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce393306-bf8b-4c51-8ed5-8c0faa4c2ed6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/6325674f-52e1-424d-ad01-7d15053eaf8c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce393306-bf8b-4c51-8ed5-8c0faa4c2ed6>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc1c04ad-9c11-4d62-97f4-a01b74e9b5ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc1c04ad-9c11-4d62-97f4-a01b74e9b5ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/7ff88edf-66da-410d-aaf7-a2f355c4ba2d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc1c04ad-9c11-4d62-97f4-a01b74e9b5ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/c26a368d-4e4f-42b8-a662-ba639409d893> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c26a368d-4e4f-42b8-a662-ba639409d893";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/7ff88edf-66da-410d-aaf7-a2f355c4ba2d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c26a368d-4e4f-42b8-a662-ba639409d893>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b0c74e6-0fb8-475a-8139-39224f713831> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b0c74e6-0fb8-475a-8139-39224f713831";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/8743b1a4-3872-4319-b9a8-2ff0a1fef0b8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b0c74e6-0fb8-475a-8139-39224f713831>.
+    
+<http://data.lblod.info/id/remote-data-objects/d539d837-20f7-41f8-a662-cc7efdaa322b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d539d837-20f7-41f8-a662-cc7efdaa322b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/8743b1a4-3872-4319-b9a8-2ff0a1fef0b8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d539d837-20f7-41f8-a662-cc7efdaa322b>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb2240a4-eb69-402e-90db-2c3e5cdc3643> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb2240a4-eb69-402e-90db-2c3e5cdc3643";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/8743b1a4-3872-4319-b9a8-2ff0a1fef0b8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb2240a4-eb69-402e-90db-2c3e5cdc3643>.
+    
+<http://data.lblod.info/id/remote-data-objects/5abf6f2b-4b35-400c-a1f5-777717461483> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5abf6f2b-4b35-400c-a1f5-777717461483";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/abd48c5a-cb10-41bd-9c40-d47014d468c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5abf6f2b-4b35-400c-a1f5-777717461483>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe7970ab-02ec-4597-9c84-4a30a15fba2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe7970ab-02ec-4597-9c84-4a30a15fba2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/abd48c5a-cb10-41bd-9c40-d47014d468c8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe7970ab-02ec-4597-9c84-4a30a15fba2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8624a42-dddf-4e2d-af2f-61b1784b1d0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8624a42-dddf-4e2d-af2f-61b1784b1d0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/efc0229e-3297-48cb-a281-1c204212e63a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8624a42-dddf-4e2d-af2f-61b1784b1d0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d7c211c-6d2c-4da4-818c-e7da04ce5224> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d7c211c-6d2c-4da4-818c-e7da04ce5224";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/efc0229e-3297-48cb-a281-1c204212e63a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d7c211c-6d2c-4da4-818c-e7da04ce5224>.
+    
+<http://data.lblod.info/id/remote-data-objects/7905541a-f969-4c08-a52a-4c86646c2477> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7905541a-f969-4c08-a52a-4c86646c2477";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/efc0229e-3297-48cb-a281-1c204212e63a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7905541a-f969-4c08-a52a-4c86646c2477>.
+    
+<http://data.lblod.info/id/remote-data-objects/cca8de45-58c7-480b-8b02-d7b8c222db82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cca8de45-58c7-480b-8b02-d7b8c222db82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/f27cb935-275d-472f-bcaf-3dfb49bbafe8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cca8de45-58c7-480b-8b02-d7b8c222db82>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea1db0e6-79a4-4e39-875e-e46c35c7e380> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea1db0e6-79a4-4e39-875e-e46c35c7e380";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/f27cb935-275d-472f-bcaf-3dfb49bbafe8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea1db0e6-79a4-4e39-875e-e46c35c7e380>.
+    
+<http://data.lblod.info/id/remote-data-objects/81bed090-515c-40b0-a193-fb1636062800> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81bed090-515c-40b0-a193-fb1636062800";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/gr/f27cb935-275d-472f-bcaf-3dfb49bbafe8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81bed090-515c-40b0-a193-fb1636062800>.
+    
+<http://data.lblod.info/id/remote-data-objects/1077920a-468c-4fb5-8438-a9070b54e2f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1077920a-468c-4fb5-8438-a9070b54e2f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/0f6ece11-9797-483e-ad50-904f69ddc40b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1077920a-468c-4fb5-8438-a9070b54e2f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/86f323e3-9693-4822-beb7-396e8ab0e8be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86f323e3-9693-4822-beb7-396e8ab0e8be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/0f6ece11-9797-483e-ad50-904f69ddc40b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:25.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/75790730-2afd-4915-9353-e79bc4aee3ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86f323e3-9693-4822-beb7-396e8ab0e8be>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201926-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201926-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201926-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201926-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/0e43dd5a-9802-43ef-aaeb-73dc36b080c7> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0e43dd5a-9802-43ef-aaeb-73dc36b080c7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "59ae3a32-6f25-457b-b08b-74b3287e7864";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a797b051-40ba-4a21-a18b-99585e0d7180> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a797b051-40ba-4a21-a18b-99585e0d7180";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864>.
+
+  <http://redpencil.data.gift/id/task/068b7e41-b65c-438f-b64f-1a860ce9616c> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "068b7e41-b65c-438f-b64f-1a860ce9616c";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/0e43dd5a-9802-43ef-aaeb-73dc36b080c7>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a797b051-40ba-4a21-a18b-99585e0d7180>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/0a1cd82d-e16b-4912-9249-ecbe7c66cfa9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a1cd82d-e16b-4912-9249-ecbe7c66cfa9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/0f6ece11-9797-483e-ad50-904f69ddc40b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a1cd82d-e16b-4912-9249-ecbe7c66cfa9>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a1be0d1-1fb0-4bbd-bf63-bff8038b6c40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a1be0d1-1fb0-4bbd-bf63-bff8038b6c40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/36be8388-da87-46bf-8cc2-fa6a28a462fa/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a1be0d1-1fb0-4bbd-bf63-bff8038b6c40>.
+    
+<http://data.lblod.info/id/remote-data-objects/ceefb96a-c2ee-4860-b341-57a15ab8f238> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ceefb96a-c2ee-4860-b341-57a15ab8f238";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/36be8388-da87-46bf-8cc2-fa6a28a462fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ceefb96a-c2ee-4860-b341-57a15ab8f238>.
+    
+<http://data.lblod.info/id/remote-data-objects/6aaacc77-fbd1-43b4-8c02-8895cee99e39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6aaacc77-fbd1-43b4-8c02-8895cee99e39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/36be8388-da87-46bf-8cc2-fa6a28a462fa/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6aaacc77-fbd1-43b4-8c02-8895cee99e39>.
+    
+<http://data.lblod.info/id/remote-data-objects/45466a45-5fa7-4106-b395-886a4d2231e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45466a45-5fa7-4106-b395-886a4d2231e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/39acdcb0-a035-4d08-beea-d1631ae18902/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45466a45-5fa7-4106-b395-886a4d2231e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb270b9b-9b6b-4eb0-9bb9-0f2f29a52ef7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb270b9b-9b6b-4eb0-9bb9-0f2f29a52ef7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/39acdcb0-a035-4d08-beea-d1631ae18902/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb270b9b-9b6b-4eb0-9bb9-0f2f29a52ef7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea856073-75ca-4721-a174-149a8cf3d9ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea856073-75ca-4721-a174-149a8cf3d9ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/39acdcb0-a035-4d08-beea-d1631ae18902/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea856073-75ca-4721-a174-149a8cf3d9ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b3dab40-ce9b-409a-879d-611125c58dce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b3dab40-ce9b-409a-879d-611125c58dce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/59afad2d-198e-4b69-aeb9-bb9d0b2975d0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b3dab40-ce9b-409a-879d-611125c58dce>.
+    
+<http://data.lblod.info/id/remote-data-objects/79a92920-35ce-41ee-90a6-4de94625624a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79a92920-35ce-41ee-90a6-4de94625624a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/59afad2d-198e-4b69-aeb9-bb9d0b2975d0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79a92920-35ce-41ee-90a6-4de94625624a>.
+    
+<http://data.lblod.info/id/remote-data-objects/31c24758-71c5-40a9-99dd-a9a3b240bf07> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31c24758-71c5-40a9-99dd-a9a3b240bf07";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/59afad2d-198e-4b69-aeb9-bb9d0b2975d0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31c24758-71c5-40a9-99dd-a9a3b240bf07>.
+    
+<http://data.lblod.info/id/remote-data-objects/536ff278-e292-41fb-a02e-5055a2641504> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "536ff278-e292-41fb-a02e-5055a2641504";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/65733d6f-281a-41f8-96b0-2adb95fc1bbd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/536ff278-e292-41fb-a02e-5055a2641504>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6f1465b-885b-4047-bb62-4962e2328187> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6f1465b-885b-4047-bb62-4962e2328187";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/65733d6f-281a-41f8-96b0-2adb95fc1bbd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6f1465b-885b-4047-bb62-4962e2328187>.
+    
+<http://data.lblod.info/id/remote-data-objects/473cda9d-21e4-418a-a82b-ecee29edd0c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "473cda9d-21e4-418a-a82b-ecee29edd0c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/bbec1a9e-71c3-4dd4-abe6-f76ddcbea0c5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/473cda9d-21e4-418a-a82b-ecee29edd0c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/37f333d0-b1a7-40af-b40d-7c72986fb5df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37f333d0-b1a7-40af-b40d-7c72986fb5df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/bbec1a9e-71c3-4dd4-abe6-f76ddcbea0c5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37f333d0-b1a7-40af-b40d-7c72986fb5df>.
+    
+<http://data.lblod.info/id/remote-data-objects/ceaeed83-f6a5-44b3-b7c4-60b993272cd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ceaeed83-f6a5-44b3-b7c4-60b993272cd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/bbec1a9e-71c3-4dd4-abe6-f76ddcbea0c5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ceaeed83-f6a5-44b3-b7c4-60b993272cd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/21b0cc80-0f1a-4905-bcd4-d88293d13e88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21b0cc80-0f1a-4905-bcd4-d88293d13e88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/c5946a78-b582-4fca-b22f-c3e78667c337/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21b0cc80-0f1a-4905-bcd4-d88293d13e88>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a95f746-e52a-4dae-a600-0471751d5234> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a95f746-e52a-4dae-a600-0471751d5234";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/f88c185c-8d36-44c3-849a-a281ededa3aa/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a95f746-e52a-4dae-a600-0471751d5234>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4677d86-91eb-4d73-8896-843250f61283> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4677d86-91eb-4d73-8896-843250f61283";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/f88c185c-8d36-44c3-849a-a281ededa3aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4677d86-91eb-4d73-8896-843250f61283>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1a069e4-076a-47cf-aa45-d529d86e2e3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1a069e4-076a-47cf-aa45-d529d86e2e3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/ocmw-raad/f88c185c-8d36-44c3-849a-a281ededa3aa/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1a069e4-076a-47cf-aa45-d529d86e2e3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5112ce32-2eb6-46aa-9e51-737d167c7967> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5112ce32-2eb6-46aa-9e51-737d167c7967";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/09b6ada2-8854-49e9-a4bf-93f8ba396dd2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5112ce32-2eb6-46aa-9e51-737d167c7967>.
+    
+<http://data.lblod.info/id/remote-data-objects/83a77440-7dfd-47b4-9054-1f168ac6c419> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83a77440-7dfd-47b4-9054-1f168ac6c419";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/17d5ddc8-f0ff-4faa-b9bc-f45790d3f74a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83a77440-7dfd-47b4-9054-1f168ac6c419>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1d2d35a-57a6-463e-9769-e730ccd2216c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1d2d35a-57a6-463e-9769-e730ccd2216c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/1ce3a81c-d560-4a21-b7f6-d7b0b7ea5cea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1d2d35a-57a6-463e-9769-e730ccd2216c>.
+    
+<http://data.lblod.info/id/remote-data-objects/90b43ceb-c9b9-4fdc-a8c7-a92a58226f7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90b43ceb-c9b9-4fdc-a8c7-a92a58226f7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/2144ec07-b50f-4930-8bf8-c6ada9c0a822/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90b43ceb-c9b9-4fdc-a8c7-a92a58226f7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/96bdb432-1eef-4017-9c0c-e3ead285e282> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96bdb432-1eef-4017-9c0c-e3ead285e282";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/22c6ea68-8527-4669-bc5f-29ccb02a208a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96bdb432-1eef-4017-9c0c-e3ead285e282>.
+    
+<http://data.lblod.info/id/remote-data-objects/cade23a9-7e06-4137-a209-d81f74103b06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cade23a9-7e06-4137-a209-d81f74103b06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/28ffd037-6f39-4869-a19c-c9ef50435bb0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cade23a9-7e06-4137-a209-d81f74103b06>.
+    
+<http://data.lblod.info/id/remote-data-objects/575cf9e8-7d19-4a0e-88e5-8b19fea2045f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "575cf9e8-7d19-4a0e-88e5-8b19fea2045f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/3496750c-fe67-475e-9143-2bf277688167/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/575cf9e8-7d19-4a0e-88e5-8b19fea2045f>.
+    
+<http://data.lblod.info/id/remote-data-objects/7aafe2b6-6db6-485c-b2b1-fd4d8f479a02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7aafe2b6-6db6-485c-b2b1-fd4d8f479a02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/3615d440-7de4-4a1a-bd1e-544bcf00fb45/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7aafe2b6-6db6-485c-b2b1-fd4d8f479a02>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1ae1a5a-e43d-418b-acce-6517befa004b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1ae1a5a-e43d-418b-acce-6517befa004b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/37c3915c-6474-430c-afc9-dfbdc3fa45e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1ae1a5a-e43d-418b-acce-6517befa004b>.
+    
+<http://data.lblod.info/id/remote-data-objects/43d4d4bc-d07c-4433-ad0e-b126556e986d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43d4d4bc-d07c-4433-ad0e-b126556e986d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/38b88d02-c423-47b3-892d-0f9d772ae6b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43d4d4bc-d07c-4433-ad0e-b126556e986d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e03ee20-1040-4da0-b354-f0eaa1316196> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e03ee20-1040-4da0-b354-f0eaa1316196";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/3b6ad0bf-b72b-4a39-b538-ea61c8d37b0d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e03ee20-1040-4da0-b354-f0eaa1316196>.
+    
+<http://data.lblod.info/id/remote-data-objects/76a61661-8d24-4284-8b22-2ab07ad284c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "76a61661-8d24-4284-8b22-2ab07ad284c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/4c9fa8a4-4500-4011-9b62-270e30ec70d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/76a61661-8d24-4284-8b22-2ab07ad284c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e712f53-0f47-4540-abe4-60a7de869f61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e712f53-0f47-4540-abe4-60a7de869f61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/4e5f969e-f8ce-4984-b4f8-1eb5990f6243/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e712f53-0f47-4540-abe4-60a7de869f61>.
+    
+<http://data.lblod.info/id/remote-data-objects/7450b2e6-02d9-4781-a729-5d4c6b56c86c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7450b2e6-02d9-4781-a729-5d4c6b56c86c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/4fa3cdd7-2cb4-48b5-8ef4-fe68c740e26f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7450b2e6-02d9-4781-a729-5d4c6b56c86c>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c89737f-a3d2-43d2-b041-4c7012d6275f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c89737f-a3d2-43d2-b041-4c7012d6275f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/557892ef-c257-4c6e-aecb-8c4a7da85de6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c89737f-a3d2-43d2-b041-4c7012d6275f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b9b6040-3a96-404e-839b-e521163f99c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b9b6040-3a96-404e-839b-e521163f99c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/562d4880-2ba7-49cc-834c-8e23126065b8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b9b6040-3a96-404e-839b-e521163f99c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/20383008-3707-41ad-854f-6ead4179832b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20383008-3707-41ad-854f-6ead4179832b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/5729cfd1-2bd7-4b00-957d-2e383393cb4a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20383008-3707-41ad-854f-6ead4179832b>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd752e11-53a5-4c8f-bfed-0c19ebfcd8b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd752e11-53a5-4c8f-bfed-0c19ebfcd8b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/5771604d-8e43-4175-b4df-fa5a43fdde63/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd752e11-53a5-4c8f-bfed-0c19ebfcd8b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/5dd1aa85-1dd2-4163-9100-1fd6621406d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5dd1aa85-1dd2-4163-9100-1fd6621406d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/5789e4fc-83be-427e-97f0-6f10dd412320/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5dd1aa85-1dd2-4163-9100-1fd6621406d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/008fe385-911a-4c27-9730-0060ff34662c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "008fe385-911a-4c27-9730-0060ff34662c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/63091700-3e14-45f5-a29c-dcbbc4950c3e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/008fe385-911a-4c27-9730-0060ff34662c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee3ce5e6-7cc0-408d-9c7b-4ae03c46f220> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee3ce5e6-7cc0-408d-9c7b-4ae03c46f220";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/688f0776-3f64-4de0-91c0-bd01d1cdedd3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee3ce5e6-7cc0-408d-9c7b-4ae03c46f220>.
+    
+<http://data.lblod.info/id/remote-data-objects/d1c569a0-d9ef-4929-9d25-c2efadcd51ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1c569a0-d9ef-4929-9d25-c2efadcd51ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/7d44bad4-f31c-4621-8e6a-f0481828d1da/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d1c569a0-d9ef-4929-9d25-c2efadcd51ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/721702e6-280f-4310-b8a4-5cf707502c2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "721702e6-280f-4310-b8a4-5cf707502c2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/83196700-3c41-486d-b602-111a3118f11e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/721702e6-280f-4310-b8a4-5cf707502c2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/79616cca-b2f9-499a-bad7-8f57aaeab4eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79616cca-b2f9-499a-bad7-8f57aaeab4eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/88774854-bef4-4136-8c03-ba8c2fc0a6c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79616cca-b2f9-499a-bad7-8f57aaeab4eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/df499e85-29c9-41fd-a58f-4de97bc4b4c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df499e85-29c9-41fd-a58f-4de97bc4b4c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/9107ea13-8f08-4945-a751-98217914afb3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df499e85-29c9-41fd-a58f-4de97bc4b4c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/4febdb66-3571-4620-8af3-cd96132e2fe7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4febdb66-3571-4620-8af3-cd96132e2fe7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/97d810e9-a7ad-4293-8ca5-ebc396c80d81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4febdb66-3571-4620-8af3-cd96132e2fe7>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5f2e01a-2784-424d-822f-83f341d91823> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5f2e01a-2784-424d-822f-83f341d91823";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/9e63ece3-bc79-41f3-894b-3fc6f96229a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5f2e01a-2784-424d-822f-83f341d91823>.
+    
+<http://data.lblod.info/id/remote-data-objects/27bf1ed7-e60e-4a0b-ba31-db6e83c4b826> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27bf1ed7-e60e-4a0b-ba31-db6e83c4b826";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/a1fdf4f7-290b-43c2-8072-3bd086a38288/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27bf1ed7-e60e-4a0b-ba31-db6e83c4b826>.
+    
+<http://data.lblod.info/id/remote-data-objects/516356f0-fb2e-4460-8c1d-18b8b0a48af1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "516356f0-fb2e-4460-8c1d-18b8b0a48af1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/a36ef1ea-3c41-48ae-8bda-b4f415d9477b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/516356f0-fb2e-4460-8c1d-18b8b0a48af1>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbd19d9a-4d15-4a5d-99c0-110a5c113307> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbd19d9a-4d15-4a5d-99c0-110a5c113307";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/af259726-ae6a-4f81-bcaa-de848b37fedd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbd19d9a-4d15-4a5d-99c0-110a5c113307>.
+    
+<http://data.lblod.info/id/remote-data-objects/67759317-a7a6-44a8-a113-e3fd4a033285> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67759317-a7a6-44a8-a113-e3fd4a033285";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/b1433a28-b06e-471e-8f42-c9737b200ea8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:26.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/59ae3a32-6f25-457b-b08b-74b3287e7864> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67759317-a7a6-44a8-a113-e3fd4a033285>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201927-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201927-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201927-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201927-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/71c664f2-1572-4939-ae47-fcf383f29788> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "71c664f2-1572-4939-ae47-fcf383f29788";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "464bacc0-7ea6-404d-b3f1-02da4aa68816";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9d5a5efa-f63e-4635-bd69-a45fa4494de3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9d5a5efa-f63e-4635-bd69-a45fa4494de3";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816>.
+
+  <http://redpencil.data.gift/id/task/77810ca4-6cff-4338-b0af-ba3808c09e1a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "77810ca4-6cff-4338-b0af-ba3808c09e1a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/71c664f2-1572-4939-ae47-fcf383f29788>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9d5a5efa-f63e-4635-bd69-a45fa4494de3>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/79902208-bda8-4950-8f1e-0cc63275b04e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79902208-bda8-4950-8f1e-0cc63275b04e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/b75aa463-fc1c-444c-9241-4c9d0b793efb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79902208-bda8-4950-8f1e-0cc63275b04e>.
+    
+<http://data.lblod.info/id/remote-data-objects/258f1186-ed5c-43e1-acc7-9797c0a6f18e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "258f1186-ed5c-43e1-acc7-9797c0a6f18e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/c0b0d752-d145-4eef-934b-4905d5f9efce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/258f1186-ed5c-43e1-acc7-9797c0a6f18e>.
+    
+<http://data.lblod.info/id/remote-data-objects/038890e1-a4d7-4000-99ec-638ffef2a767> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "038890e1-a4d7-4000-99ec-638ffef2a767";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/c1acb4f9-26de-4c46-99cb-b6414bf663a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/038890e1-a4d7-4000-99ec-638ffef2a767>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b2d454a-21a3-482b-9c90-2cb03166aaa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b2d454a-21a3-482b-9c90-2cb03166aaa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/c32b1c78-5fdc-4c30-8f62-353fe01ab7d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b2d454a-21a3-482b-9c90-2cb03166aaa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/44989a69-198b-46a6-a898-18c1fe39dad5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44989a69-198b-46a6-a898-18c1fe39dad5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/cbe72ad6-2271-44d0-a999-61c0cce20761/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/44989a69-198b-46a6-a898-18c1fe39dad5>.
+    
+<http://data.lblod.info/id/remote-data-objects/92210aab-751f-4364-8e60-47edb6638962> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92210aab-751f-4364-8e60-47edb6638962";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/d3bd87bf-e294-4bfa-89e7-798bd8010924/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92210aab-751f-4364-8e60-47edb6638962>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c7d43cd-088d-44d2-8d21-1ccf80205c3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c7d43cd-088d-44d2-8d21-1ccf80205c3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/d4a999a7-2572-4049-8c93-4f4688f75085/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c7d43cd-088d-44d2-8d21-1ccf80205c3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9b96dd0-bf03-4b07-8d36-161b8fe2a221> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9b96dd0-bf03-4b07-8d36-161b8fe2a221";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/e3f72975-4cbb-406c-b7a7-4aa901dff696/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9b96dd0-bf03-4b07-8d36-161b8fe2a221>.
+    
+<http://data.lblod.info/id/remote-data-objects/96192daa-1647-46c6-81f8-aa1415c4f3db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96192daa-1647-46c6-81f8-aa1415c4f3db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schelle.meetingburger.net/vb/f77c81a2-f6c9-4a80-8c7e-98146a74ba77/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96192daa-1647-46c6-81f8-aa1415c4f3db>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab35e390-bf5c-4885-9f2b-755f439f2ea3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab35e390-bf5c-4885-9f2b-755f439f2ea3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/00e5937d-1327-4d60-9017-8d3ad861214a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab35e390-bf5c-4885-9f2b-755f439f2ea3>.
+    
+<http://data.lblod.info/id/remote-data-objects/57452478-3d46-4708-867a-e03585cda797> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57452478-3d46-4708-867a-e03585cda797";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/06e98192-8ef1-4e4c-b58e-a7e5b6f1bbca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57452478-3d46-4708-867a-e03585cda797>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbf6fc97-5b27-4d3c-933a-61d821295a18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbf6fc97-5b27-4d3c-933a-61d821295a18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/1308e198-f32b-4eda-938e-fe2a5b3aa379/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbf6fc97-5b27-4d3c-933a-61d821295a18>.
+    
+<http://data.lblod.info/id/remote-data-objects/68b81ae4-4ce1-4807-9938-4f8fe3d79cc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68b81ae4-4ce1-4807-9938-4f8fe3d79cc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/145f30ec-93d1-4885-92b7-9cfcc2fceb9b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68b81ae4-4ce1-4807-9938-4f8fe3d79cc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/b23edb93-bd69-4ab2-a855-5c71bfbf6961> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b23edb93-bd69-4ab2-a855-5c71bfbf6961";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/2209ce96-86f1-423d-b452-dd8e52cf927d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b23edb93-bd69-4ab2-a855-5c71bfbf6961>.
+    
+<http://data.lblod.info/id/remote-data-objects/1eca3738-caa6-4094-8707-fc731a368952> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1eca3738-caa6-4094-8707-fc731a368952";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/24c38e2e-d18d-4ad3-8dfe-fc39236c618a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1eca3738-caa6-4094-8707-fc731a368952>.
+    
+<http://data.lblod.info/id/remote-data-objects/464841fc-3f0f-4ac7-a9c4-3c50c0e67cc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "464841fc-3f0f-4ac7-a9c4-3c50c0e67cc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/292cacd8-799f-45c1-b541-7a07863cabe2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/464841fc-3f0f-4ac7-a9c4-3c50c0e67cc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce80cb66-561f-47b4-9e5c-a5172fe02af6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce80cb66-561f-47b4-9e5c-a5172fe02af6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/2e75de77-5b94-4585-b7b4-4d58dbe596fb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce80cb66-561f-47b4-9e5c-a5172fe02af6>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f4962f2-9dd7-4d53-ad98-697b2596809b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f4962f2-9dd7-4d53-ad98-697b2596809b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/342fdb1c-28f2-4c94-b11a-01769edd6aa6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f4962f2-9dd7-4d53-ad98-697b2596809b>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf0355fd-c02e-4703-a29f-af06bfb1f852> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf0355fd-c02e-4703-a29f-af06bfb1f852";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/39e99c85-85af-4532-8b7a-007cf028951c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf0355fd-c02e-4703-a29f-af06bfb1f852>.
+    
+<http://data.lblod.info/id/remote-data-objects/c222140a-7f20-45ec-8b3e-87d4f91be65e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c222140a-7f20-45ec-8b3e-87d4f91be65e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/3c21bbe9-58e7-4287-98fe-c0840d39b381/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c222140a-7f20-45ec-8b3e-87d4f91be65e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d880ace0-55f4-47a0-a389-d4b3098cd5d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d880ace0-55f4-47a0-a389-d4b3098cd5d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/4611e6be-177f-47a6-9bb3-06cfe91b7eed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d880ace0-55f4-47a0-a389-d4b3098cd5d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/2813d488-b8ca-4f3d-af93-a11e2b87e694> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2813d488-b8ca-4f3d-af93-a11e2b87e694";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/4fd6e982-266d-4d46-97c7-28a7229214a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2813d488-b8ca-4f3d-af93-a11e2b87e694>.
+    
+<http://data.lblod.info/id/remote-data-objects/72d2b397-4e29-43b0-af6e-ab66683125b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72d2b397-4e29-43b0-af6e-ab66683125b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/506c976a-8032-40b7-b6da-7c48df132ec8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72d2b397-4e29-43b0-af6e-ab66683125b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5f438d6-cb39-44b0-a19f-14a2b9796743> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5f438d6-cb39-44b0-a19f-14a2b9796743";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/53c0e279-23a7-480c-92a0-0f6ab9feeea6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5f438d6-cb39-44b0-a19f-14a2b9796743>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b66d0a6-f603-42d0-9016-9f1cd9fc5e4c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b66d0a6-f603-42d0-9016-9f1cd9fc5e4c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/59d0b816-844b-4671-aa1c-505d8277029f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b66d0a6-f603-42d0-9016-9f1cd9fc5e4c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3cf5fce-f1dd-4035-a1df-c812210cdae9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3cf5fce-f1dd-4035-a1df-c812210cdae9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/6ad6b5ac-26c0-4da9-9c9c-8f96cf0f3066/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3cf5fce-f1dd-4035-a1df-c812210cdae9>.
+    
+<http://data.lblod.info/id/remote-data-objects/6caf2916-ee53-4b79-849a-a758b696be4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6caf2916-ee53-4b79-849a-a758b696be4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/6ce01d24-ffe7-4296-8e4a-c4614126024c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6caf2916-ee53-4b79-849a-a758b696be4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f283a236-abc2-40be-b583-e20e317ee466> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f283a236-abc2-40be-b583-e20e317ee466";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/6f2d832f-1e18-4460-ba7c-cc728d1ab027/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f283a236-abc2-40be-b583-e20e317ee466>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a6ead4f-ec4b-4d08-a82f-917c2bdf37e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a6ead4f-ec4b-4d08-a82f-917c2bdf37e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/74518ec5-2964-404b-97a9-56218acaa2bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a6ead4f-ec4b-4d08-a82f-917c2bdf37e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d617f13-08ac-4bac-adbc-64cd018830bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d617f13-08ac-4bac-adbc-64cd018830bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/7b9a7e25-d245-46cc-a0ec-54f41df2c090/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d617f13-08ac-4bac-adbc-64cd018830bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/70b86e2e-b40a-4db9-bb6b-6dfe2eeff527> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70b86e2e-b40a-4db9-bb6b-6dfe2eeff527";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/7e875b08-d4c2-47a9-95ed-a90fd4cb5128/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70b86e2e-b40a-4db9-bb6b-6dfe2eeff527>.
+    
+<http://data.lblod.info/id/remote-data-objects/0209a6c7-9501-49cf-b160-db00758e9b0d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0209a6c7-9501-49cf-b160-db00758e9b0d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/8536973e-1738-4d84-bf16-bcb3f5b03298/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0209a6c7-9501-49cf-b160-db00758e9b0d>.
+    
+<http://data.lblod.info/id/remote-data-objects/293a0201-ce19-4981-9e39-3fb5f309990c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "293a0201-ce19-4981-9e39-3fb5f309990c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/91544fd9-23e2-4dbf-a228-988aafc477e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/293a0201-ce19-4981-9e39-3fb5f309990c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed868043-f7aa-4aac-ba26-62a03f1ebc19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed868043-f7aa-4aac-ba26-62a03f1ebc19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/95566280-556f-419b-92e9-6f8ee8c4650d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed868043-f7aa-4aac-ba26-62a03f1ebc19>.
+    
+<http://data.lblod.info/id/remote-data-objects/875b7c97-4f1e-49ea-af76-d671ab4ef606> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "875b7c97-4f1e-49ea-af76-d671ab4ef606";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/a035bf0f-b53f-453f-8dce-64d71c6935b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/875b7c97-4f1e-49ea-af76-d671ab4ef606>.
+    
+<http://data.lblod.info/id/remote-data-objects/eafdc835-4917-4e61-9fa7-a3c593f54f0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eafdc835-4917-4e61-9fa7-a3c593f54f0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/a5058c47-7a1a-4965-9509-97779daf3300/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eafdc835-4917-4e61-9fa7-a3c593f54f0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/53734502-ab86-4632-8b01-e336aff4336c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53734502-ab86-4632-8b01-e336aff4336c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/a64d4ab5-1a38-423d-99c9-a813f14579bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53734502-ab86-4632-8b01-e336aff4336c>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed713704-3102-4b1c-a6e2-092782ad88a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed713704-3102-4b1c-a6e2-092782ad88a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/a86fda70-cfc7-4482-9b27-5fa89ea4a11a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed713704-3102-4b1c-a6e2-092782ad88a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a9040a50-40c3-4caa-a62c-7f8b2f3d2bd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a9040a50-40c3-4caa-a62c-7f8b2f3d2bd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/b0729868-ce25-4629-bfad-fce1936f1b08/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a9040a50-40c3-4caa-a62c-7f8b2f3d2bd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/3eace2c8-87ad-40b9-b383-11bd86878086> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3eace2c8-87ad-40b9-b383-11bd86878086";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/b1a180ad-fe3f-435a-bf1d-221b91a2bb25/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3eace2c8-87ad-40b9-b383-11bd86878086>.
+    
+<http://data.lblod.info/id/remote-data-objects/8dd64749-5dee-491a-ad77-64abc5b4d70a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8dd64749-5dee-491a-ad77-64abc5b4d70a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/c4b4f041-a165-490a-884c-1f28418b73f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8dd64749-5dee-491a-ad77-64abc5b4d70a>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfbca1ab-60ed-40b5-a429-7d5892489f11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfbca1ab-60ed-40b5-a429-7d5892489f11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/c5f80e20-a7b1-4bad-8875-7b274a8324cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfbca1ab-60ed-40b5-a429-7d5892489f11>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f939027-c1a9-4abd-829e-854d7b7f5863> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f939027-c1a9-4abd-829e-854d7b7f5863";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/ca90d967-17e6-4d68-bd4b-4c37cc0ee0af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f939027-c1a9-4abd-829e-854d7b7f5863>.
+    
+<http://data.lblod.info/id/remote-data-objects/5827c84e-1038-476e-9f3f-96e860e38cc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5827c84e-1038-476e-9f3f-96e860e38cc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/d2453bf9-30d9-4426-8296-47a070be7aeb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5827c84e-1038-476e-9f3f-96e860e38cc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/5837f7f6-e3df-42e3-82dd-d90fd80da91c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5837f7f6-e3df-42e3-82dd-d90fd80da91c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/d46a9272-e7c5-4a94-8117-2626cba8d53d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5837f7f6-e3df-42e3-82dd-d90fd80da91c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a013ac6b-4bc0-4c44-a94c-aa74381f7b3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a013ac6b-4bc0-4c44-a94c-aa74381f7b3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/d6f0e55d-f690-4fdf-957a-3eda7d56b6b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a013ac6b-4bc0-4c44-a94c-aa74381f7b3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6cbb57af-7b06-465e-a77f-6e3b7c30a716> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6cbb57af-7b06-465e-a77f-6e3b7c30a716";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/d75e47c6-9d64-410e-a653-857f0ae37a2b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6cbb57af-7b06-465e-a77f-6e3b7c30a716>.
+    
+<http://data.lblod.info/id/remote-data-objects/07a0c44f-aa3d-4f6d-b6cb-02bb7ba7394c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07a0c44f-aa3d-4f6d-b6cb-02bb7ba7394c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/d8c7bc25-683a-48d3-b588-daf6fa9463d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07a0c44f-aa3d-4f6d-b6cb-02bb7ba7394c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2412a082-91c2-4655-abce-97c94775e79b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2412a082-91c2-4655-abce-97c94775e79b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/d90691fe-3b8f-438c-b1d2-20f9adaf6f2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2412a082-91c2-4655-abce-97c94775e79b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0da63de5-6362-4741-b5db-6bf1038f2181> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0da63de5-6362-4741-b5db-6bf1038f2181";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/dbdea0c1-9b29-4a78-bad1-80d36892ae9a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:27.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/464bacc0-7ea6-404d-b3f1-02da4aa68816> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0da63de5-6362-4741-b5db-6bf1038f2181>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201928-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201928-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201928-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201928-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c8b68e27-6b25-4505-8f4f-cdb424768f0c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c8b68e27-6b25-4505-8f4f-cdb424768f0c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "725fc154-44fc-4450-9951-e69a6876417f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c4f177d5-02a3-4438-bec5-5714cb6b17a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c4f177d5-02a3-4438-bec5-5714cb6b17a2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f>.
+
+  <http://redpencil.data.gift/id/task/f2723ee3-15e6-4790-81ad-14d75d132539> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f2723ee3-15e6-4790-81ad-14d75d132539";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c8b68e27-6b25-4505-8f4f-cdb424768f0c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c4f177d5-02a3-4438-bec5-5714cb6b17a2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/1b6a5068-4b0e-4c33-a259-86b7595446ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b6a5068-4b0e-4c33-a259-86b7595446ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/dd2f01bc-7416-4b97-aad7-a11674d977d9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b6a5068-4b0e-4c33-a259-86b7595446ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/a91dca8b-4b1c-43be-aa48-990b61c5f017> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a91dca8b-4b1c-43be-aa48-990b61c5f017";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/df3d8030-3792-436f-8e35-105ca417b047/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a91dca8b-4b1c-43be-aa48-990b61c5f017>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1139933-a32e-42e0-8afb-3dd7d4b29f0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1139933-a32e-42e0-8afb-3dd7d4b29f0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/e1b747ee-cf5d-4e98-9aae-b988225d94b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1139933-a32e-42e0-8afb-3dd7d4b29f0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2bd28a6-deba-4e8b-b5c1-90576e4d6fdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2bd28a6-deba-4e8b-b5c1-90576e4d6fdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/e395f4f7-a3ff-4d69-a42a-b47ecaad1310/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2bd28a6-deba-4e8b-b5c1-90576e4d6fdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a92353a-05ae-4887-a8d4-89e6070078dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a92353a-05ae-4887-a8d4-89e6070078dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/e9c4d809-24c2-4f25-878e-7592c252f58f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a92353a-05ae-4887-a8d4-89e6070078dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0d4c530-b592-4129-8b18-acbadc1735a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0d4c530-b592-4129-8b18-acbadc1735a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/ea2c11d3-35cb-4cd0-a25e-ed46921c71d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0d4c530-b592-4129-8b18-acbadc1735a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a70b0fd4-4e96-4dc9-8602-5e52c91e844e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a70b0fd4-4e96-4dc9-8602-5e52c91e844e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/ea841619-2177-42e1-aa67-8d69d04656e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a70b0fd4-4e96-4dc9-8602-5e52c91e844e>.
+    
+<http://data.lblod.info/id/remote-data-objects/5816073c-5cd3-40a3-8f52-f6e19a28e4e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5816073c-5cd3-40a3-8f52-f6e19a28e4e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/eea7af1a-12c0-493e-97af-a5edfab88c7c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5816073c-5cd3-40a3-8f52-f6e19a28e4e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffa3b0ca-7b6b-4e58-97c7-c79a70dd227a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffa3b0ca-7b6b-4e58-97c7-c79a70dd227a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/fc864ffd-2350-4dfe-b3f2-2b7d9a57097d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffa3b0ca-7b6b-4e58-97c7-c79a70dd227a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2b60d82-0a2d-4192-ac98-bfe6b3ae9c2e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2b60d82-0a2d-4192-ac98-bfe6b3ae9c2e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/bb/fec79685-c7c0-42a5-b9fb-76407359ef3e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2b60d82-0a2d-4192-ac98-bfe6b3ae9c2e>.
+    
+<http://data.lblod.info/id/remote-data-objects/885189c9-e049-44f7-bc14-2d0be15bc138> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "885189c9-e049-44f7-bc14-2d0be15bc138";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/00c146b6-c201-43c8-9456-a85fcaa1786c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/885189c9-e049-44f7-bc14-2d0be15bc138>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5a0c350-dca0-47ed-8201-6108203dc5b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5a0c350-dca0-47ed-8201-6108203dc5b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/06d72ffb-fc73-4c23-8b87-cdf228e078b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5a0c350-dca0-47ed-8201-6108203dc5b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdd9cb60-6434-44af-b807-bced2f349bc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdd9cb60-6434-44af-b807-bced2f349bc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/06dc5040-80e9-4ecf-9787-1c16a73793f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdd9cb60-6434-44af-b807-bced2f349bc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e610bd7b-3d92-4041-8557-9d24176c17fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e610bd7b-3d92-4041-8557-9d24176c17fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/0fb4937b-5476-42bb-8f4d-b11181780d00/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e610bd7b-3d92-4041-8557-9d24176c17fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb51ef0e-78ee-4e96-a5a0-434936d7c3b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb51ef0e-78ee-4e96-a5a0-434936d7c3b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/1090eed5-64e5-44c7-ac9d-a98c2a006ed3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb51ef0e-78ee-4e96-a5a0-434936d7c3b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a23000ef-babc-4960-9d96-e099d666df10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a23000ef-babc-4960-9d96-e099d666df10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/14289157-f953-4bf9-89af-478d483a5337/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a23000ef-babc-4960-9d96-e099d666df10>.
+    
+<http://data.lblod.info/id/remote-data-objects/8eaeb8ca-749d-4c1a-8421-9400f935a98c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8eaeb8ca-749d-4c1a-8421-9400f935a98c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/159af383-77fb-4c7a-b127-68021c73cba9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8eaeb8ca-749d-4c1a-8421-9400f935a98c>.
+    
+<http://data.lblod.info/id/remote-data-objects/902593c5-b118-42c5-b0f2-9b8d3dc630f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "902593c5-b118-42c5-b0f2-9b8d3dc630f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/1c9adba3-bec1-42f6-baff-7879348bc75f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/902593c5-b118-42c5-b0f2-9b8d3dc630f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4a3d93f-5301-4677-9a77-642fc963bf00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4a3d93f-5301-4677-9a77-642fc963bf00";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/2304c409-3826-48ea-8c4f-653ef43e6d49/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4a3d93f-5301-4677-9a77-642fc963bf00>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ff7ffa2-97a8-4fa9-8081-0cd0dd69be2d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ff7ffa2-97a8-4fa9-8081-0cd0dd69be2d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/270e8694-8de2-4c51-aafd-389b59d74171/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ff7ffa2-97a8-4fa9-8081-0cd0dd69be2d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f713e4db-e028-4e8d-a474-95adafd7c56b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f713e4db-e028-4e8d-a474-95adafd7c56b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/2fdf12e5-626b-44fb-9b63-1673b67cac3f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f713e4db-e028-4e8d-a474-95adafd7c56b>.
+    
+<http://data.lblod.info/id/remote-data-objects/705a21b6-f239-4bc6-87c0-9843979901bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "705a21b6-f239-4bc6-87c0-9843979901bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/305b4a91-ead5-49b3-b8dd-c4c7bcfec373/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/705a21b6-f239-4bc6-87c0-9843979901bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/b55045d2-c149-4efd-a5f1-856e49223312> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b55045d2-c149-4efd-a5f1-856e49223312";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/34187e4a-ccef-4db8-bb07-aa50be2ee11a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b55045d2-c149-4efd-a5f1-856e49223312>.
+    
+<http://data.lblod.info/id/remote-data-objects/feeac944-a3e6-400b-9cd0-74dba70c777b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "feeac944-a3e6-400b-9cd0-74dba70c777b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/3454af19-9792-4354-9d54-f8016798c0a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/feeac944-a3e6-400b-9cd0-74dba70c777b>.
+    
+<http://data.lblod.info/id/remote-data-objects/745b6f22-e5c9-41b4-8779-a3379586fbdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "745b6f22-e5c9-41b4-8779-a3379586fbdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/35b87e2c-95dc-4a6e-837c-cf972f2adc0e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/745b6f22-e5c9-41b4-8779-a3379586fbdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/58b2d875-7d02-46ad-aa3b-e8df07434b86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58b2d875-7d02-46ad-aa3b-e8df07434b86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/38bccb09-1e88-4486-98c0-4e6094bc6d48/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58b2d875-7d02-46ad-aa3b-e8df07434b86>.
+    
+<http://data.lblod.info/id/remote-data-objects/730aeedb-dbd1-48be-be8a-8231a52b4fd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "730aeedb-dbd1-48be-be8a-8231a52b4fd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/3c38c051-14e5-44d7-92e2-3d2b76a1c3f5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/730aeedb-dbd1-48be-be8a-8231a52b4fd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/24e9c58f-d307-4dc4-88f2-f7725c7e8cc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24e9c58f-d307-4dc4-88f2-f7725c7e8cc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/3cf0f669-8b5d-4c43-ab33-b6497ea11ea1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24e9c58f-d307-4dc4-88f2-f7725c7e8cc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb1108d0-48c0-46fe-b018-a39d7ea9cd6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb1108d0-48c0-46fe-b018-a39d7ea9cd6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/3d8082c9-9df5-4adc-b31c-d4ac9af19a7b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb1108d0-48c0-46fe-b018-a39d7ea9cd6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f412fc7-7bdd-4d75-bb50-3a52502068a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f412fc7-7bdd-4d75-bb50-3a52502068a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/3ec60e7e-d7b2-4cb5-b2df-bd069419f40a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f412fc7-7bdd-4d75-bb50-3a52502068a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c46e04e2-9f97-4a3d-89a1-3f3fcbc164e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c46e04e2-9f97-4a3d-89a1-3f3fcbc164e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/401a28c3-6455-4cb1-8c8b-0f0873c39073/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c46e04e2-9f97-4a3d-89a1-3f3fcbc164e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/63c64b1b-21ee-486a-8c52-1c3441f5cc14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63c64b1b-21ee-486a-8c52-1c3441f5cc14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/437b1de4-4596-46d4-b333-bcd00ee726d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63c64b1b-21ee-486a-8c52-1c3441f5cc14>.
+    
+<http://data.lblod.info/id/remote-data-objects/10b61383-1364-45a7-8486-f287ad3aa5b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10b61383-1364-45a7-8486-f287ad3aa5b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/43955366-f891-4796-9ec1-36beee05214c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10b61383-1364-45a7-8486-f287ad3aa5b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/6da46b16-040b-4923-9cd1-90181396182a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6da46b16-040b-4923-9cd1-90181396182a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/4495b79c-b343-43da-acaf-1fcb6cf3a905/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6da46b16-040b-4923-9cd1-90181396182a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca3caed6-b37e-4b5b-b74b-4b12b9ce9382> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca3caed6-b37e-4b5b-b74b-4b12b9ce9382";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/486b5d3e-60bb-4ec1-b8e0-a3ecee6bd90e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca3caed6-b37e-4b5b-b74b-4b12b9ce9382>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff30a94b-0986-4a81-8e06-3ca7c5249fd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff30a94b-0986-4a81-8e06-3ca7c5249fd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/4d8a3d4e-868d-4ae1-af99-dcf9dc92e463/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff30a94b-0986-4a81-8e06-3ca7c5249fd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/82467e0e-5b3e-4401-9e25-2bc1e79a24f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82467e0e-5b3e-4401-9e25-2bc1e79a24f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/51f16078-4390-46d6-b175-223996217ee6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82467e0e-5b3e-4401-9e25-2bc1e79a24f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1a9e33d-302b-436b-8b38-fe035333d983> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1a9e33d-302b-436b-8b38-fe035333d983";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/5541be07-5a55-4794-a328-aaca9d84c6a2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1a9e33d-302b-436b-8b38-fe035333d983>.
+    
+<http://data.lblod.info/id/remote-data-objects/1353865d-58ef-4b6e-8aaa-5dbe7c391375> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1353865d-58ef-4b6e-8aaa-5dbe7c391375";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/56e08b4f-71c9-4ff4-9aa8-666914514f89/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1353865d-58ef-4b6e-8aaa-5dbe7c391375>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5156546-d339-489e-85ed-1d0069881d7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5156546-d339-489e-85ed-1d0069881d7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/5978ba6e-24ff-4845-aba9-59aa184060d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5156546-d339-489e-85ed-1d0069881d7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a23c220b-d3fa-4dd5-9515-b916b276618a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a23c220b-d3fa-4dd5-9515-b916b276618a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/5c6cae5d-cfbc-41dd-b348-86952d128cb5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a23c220b-d3fa-4dd5-9515-b916b276618a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6cd9038-b3c8-4290-90a2-8d2d6e76306f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6cd9038-b3c8-4290-90a2-8d2d6e76306f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/61726ab6-c5e6-4616-9c62-2edb39b99b0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6cd9038-b3c8-4290-90a2-8d2d6e76306f>.
+    
+<http://data.lblod.info/id/remote-data-objects/102ee4f8-7b39-461d-ab29-29f465c54f12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "102ee4f8-7b39-461d-ab29-29f465c54f12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/666f1a6a-30e2-4225-81da-e87f42de26ba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/102ee4f8-7b39-461d-ab29-29f465c54f12>.
+    
+<http://data.lblod.info/id/remote-data-objects/daaf5218-5bbf-4a09-8988-29c53f7504b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "daaf5218-5bbf-4a09-8988-29c53f7504b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/698aa65c-44a5-4fe0-bf86-4698f7b6f947/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/daaf5218-5bbf-4a09-8988-29c53f7504b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/32bfa02f-c96d-4d87-8fff-b0dee449b992> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32bfa02f-c96d-4d87-8fff-b0dee449b992";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/72853d85-9ea1-48d8-a379-7e6feda09908/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32bfa02f-c96d-4d87-8fff-b0dee449b992>.
+    
+<http://data.lblod.info/id/remote-data-objects/2234796c-3c85-48ef-8108-d40fa5e51ebe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2234796c-3c85-48ef-8108-d40fa5e51ebe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/7655e2a7-ec98-4eb8-bc48-502e7982e731/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2234796c-3c85-48ef-8108-d40fa5e51ebe>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a276227-c367-44fb-b206-1b23edf2b00a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a276227-c367-44fb-b206-1b23edf2b00a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/798191b7-7f5c-4da1-9e56-c3eee3c151a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a276227-c367-44fb-b206-1b23edf2b00a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f457f60-3217-4073-b4d6-76f41677bbb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f457f60-3217-4073-b4d6-76f41677bbb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/820bd42b-6188-4260-a527-597871bb5fbb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f457f60-3217-4073-b4d6-76f41677bbb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf4cd609-d424-4e26-a513-9260121cae4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf4cd609-d424-4e26-a513-9260121cae4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/843f8b09-ca73-4e37-9c10-87f21b0e0e1f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf4cd609-d424-4e26-a513-9260121cae4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5511ba27-e9e6-43bc-8f8c-e4c19da82795> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5511ba27-e9e6-43bc-8f8c-e4c19da82795";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/84b09dcc-c947-4384-b2b3-a0cf065cb07f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:28.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/725fc154-44fc-4450-9951-e69a6876417f> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5511ba27-e9e6-43bc-8f8c-e4c19da82795>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201930-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201930-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201930-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201930-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/3a46dd9f-1e54-4a91-922e-63238b73a09d> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3a46dd9f-1e54-4a91-922e-63238b73a09d";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "918a56f7-564e-4ca7-8fdc-a050d932e63b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b9d2e99d-5e42-4735-8e2f-7799bea2bacf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b9d2e99d-5e42-4735-8e2f-7799bea2bacf";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b>.
+
+  <http://redpencil.data.gift/id/task/f86657ea-1d73-4c79-a13b-2ad97f5c1e11> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f86657ea-1d73-4c79-a13b-2ad97f5c1e11";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/3a46dd9f-1e54-4a91-922e-63238b73a09d>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b9d2e99d-5e42-4735-8e2f-7799bea2bacf>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/c60a5ddd-8ed4-41a6-8a6c-4d4886225528> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c60a5ddd-8ed4-41a6-8a6c-4d4886225528";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/89435cef-9900-4d02-ae7d-e42728a8bd2e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c60a5ddd-8ed4-41a6-8a6c-4d4886225528>.
+    
+<http://data.lblod.info/id/remote-data-objects/0506545a-9c0c-48ab-820b-44aeed5f85c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0506545a-9c0c-48ab-820b-44aeed5f85c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/8ca8162f-d677-4beb-943e-f96ebbb24d82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0506545a-9c0c-48ab-820b-44aeed5f85c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb2d4d3a-9f18-4715-8c26-a7aa330ce0c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb2d4d3a-9f18-4715-8c26-a7aa330ce0c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/9102cbde-8d68-475a-9dd4-d79e332298a9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb2d4d3a-9f18-4715-8c26-a7aa330ce0c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/8721c429-8b0c-4d7f-b6b8-14edacdbbb7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8721c429-8b0c-4d7f-b6b8-14edacdbbb7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/92499ab2-997e-4f60-8f72-2a09e3e97f10/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8721c429-8b0c-4d7f-b6b8-14edacdbbb7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7414b4de-e32a-4b19-92e7-fd2d62a1a74f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7414b4de-e32a-4b19-92e7-fd2d62a1a74f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/934ee4bd-de3e-41da-a350-31b9003151cc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7414b4de-e32a-4b19-92e7-fd2d62a1a74f>.
+    
+<http://data.lblod.info/id/remote-data-objects/32d33b3e-0de7-484b-ad1a-243dd0c439bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32d33b3e-0de7-484b-ad1a-243dd0c439bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/94067d31-e270-4e7f-bc04-cac3a5dd63de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32d33b3e-0de7-484b-ad1a-243dd0c439bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/65d1a768-f11c-4d00-902f-2ac00b63662a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65d1a768-f11c-4d00-902f-2ac00b63662a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/a197d1ff-6728-4dde-a10e-505d21fc1a3a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65d1a768-f11c-4d00-902f-2ac00b63662a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8207ccd2-3caa-4882-85b1-18862239b077> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8207ccd2-3caa-4882-85b1-18862239b077";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/a9d2001c-3201-4eb5-95f0-46f260638a8d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8207ccd2-3caa-4882-85b1-18862239b077>.
+    
+<http://data.lblod.info/id/remote-data-objects/841c9f8a-86be-4700-b3d9-94cd76c0d3e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "841c9f8a-86be-4700-b3d9-94cd76c0d3e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/b147e76b-c5ae-4690-9d3e-ea0e3feb05d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/841c9f8a-86be-4700-b3d9-94cd76c0d3e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b058766-08d2-4ff1-9575-7b278622938b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b058766-08d2-4ff1-9575-7b278622938b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/b1a5a02d-41b2-4916-a16e-dfc18f4ce8cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b058766-08d2-4ff1-9575-7b278622938b>.
+    
+<http://data.lblod.info/id/remote-data-objects/0515ea63-691c-4171-a60a-2812d6f08450> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0515ea63-691c-4171-a60a-2812d6f08450";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/b2f848ed-8804-416c-bc60-4f75bf55d16a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0515ea63-691c-4171-a60a-2812d6f08450>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7bbb3bb-67cd-4425-913f-2d8abc53b322> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7bbb3bb-67cd-4425-913f-2d8abc53b322";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/bd357189-e4b2-4046-b0d9-bfa3e48efc1b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7bbb3bb-67cd-4425-913f-2d8abc53b322>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cdae33d-45f1-4493-9d1f-e3e424c8c796> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cdae33d-45f1-4493-9d1f-e3e424c8c796";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/bfb04cdf-af2e-4add-acf0-a7441b76dc2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cdae33d-45f1-4493-9d1f-e3e424c8c796>.
+    
+<http://data.lblod.info/id/remote-data-objects/b82981e7-8830-41d3-888d-2abc3d8e054f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b82981e7-8830-41d3-888d-2abc3d8e054f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/c3ddd27c-140c-4c69-9388-321b40b0b7d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b82981e7-8830-41d3-888d-2abc3d8e054f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f171d36d-8429-413d-ad15-1c291b036fc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f171d36d-8429-413d-ad15-1c291b036fc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/d0681c5f-cb6d-4304-a730-b1a6eae3427d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f171d36d-8429-413d-ad15-1c291b036fc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ade68497-93cc-4127-8434-7132f4f84dba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ade68497-93cc-4127-8434-7132f4f84dba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/d57a00ab-075f-45e7-83da-bd71897486de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ade68497-93cc-4127-8434-7132f4f84dba>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce6e2226-9faa-4479-ad17-005c1486126d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce6e2226-9faa-4479-ad17-005c1486126d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/d8ac43d7-e567-4696-879b-8c96cbdfec2b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce6e2226-9faa-4479-ad17-005c1486126d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5eda1bce-1156-4d56-b391-c62f4b836984> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5eda1bce-1156-4d56-b391-c62f4b836984";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/df1fc037-f7e4-422f-98e8-2073fe2075ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5eda1bce-1156-4d56-b391-c62f4b836984>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7190166-6698-4698-8848-8d02dc188ad3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7190166-6698-4698-8848-8d02dc188ad3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/df27058b-916e-4859-9d37-8ced1a5873ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7190166-6698-4698-8848-8d02dc188ad3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d624bf32-6e02-43a0-84c6-0b10a34b483a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d624bf32-6e02-43a0-84c6-0b10a34b483a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/ea9f81b5-4719-4c77-89f2-ab20a218478d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d624bf32-6e02-43a0-84c6-0b10a34b483a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca9bf2fa-5453-4ca3-a42d-6a70f9c75abc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca9bf2fa-5453-4ca3-a42d-6a70f9c75abc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/f09f1ec3-b0a7-4f5f-9030-380955e272fb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca9bf2fa-5453-4ca3-a42d-6a70f9c75abc>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a554e0f-64c7-4a47-8dd4-3c460204e33a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a554e0f-64c7-4a47-8dd4-3c460204e33a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/f0f29e9f-e6e8-47ba-95bb-a0652d2b3d99/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a554e0f-64c7-4a47-8dd4-3c460204e33a>.
+    
+<http://data.lblod.info/id/remote-data-objects/425f4ae3-8e12-4eb7-bfdf-b729f4a4af87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "425f4ae3-8e12-4eb7-bfdf-b729f4a4af87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/f5a383cf-d386-4d7a-b9c7-744931a3bb28/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/425f4ae3-8e12-4eb7-bfdf-b729f4a4af87>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc42121e-a7cd-4718-bd8d-6e3bdc54f195> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc42121e-a7cd-4718-bd8d-6e3bdc54f195";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/f61da3ca-daa1-4310-84c7-e27e47a8868b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc42121e-a7cd-4718-bd8d-6e3bdc54f195>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7257939-50ed-4cac-8643-50fa2ba1fe17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7257939-50ed-4cac-8643-50fa2ba1fe17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/f80c7461-02c2-42e1-a697-031abf56f747/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7257939-50ed-4cac-8643-50fa2ba1fe17>.
+    
+<http://data.lblod.info/id/remote-data-objects/8cba021d-ec40-4c53-aaaa-9b296588357d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8cba021d-ec40-4c53-aaaa-9b296588357d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/cbs/fafe5833-b562-4e09-9535-834cb378bf99/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8cba021d-ec40-4c53-aaaa-9b296588357d>.
+    
+<http://data.lblod.info/id/remote-data-objects/be5e4990-8230-42b1-9b03-6b999c8bc481> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be5e4990-8230-42b1-9b03-6b999c8bc481";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/0c4ed502-7733-4419-aea1-cbd2b2e531bf/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be5e4990-8230-42b1-9b03-6b999c8bc481>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b202cd5-b6bc-4a2d-8f22-6a9ee531baef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b202cd5-b6bc-4a2d-8f22-6a9ee531baef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/0c4ed502-7733-4419-aea1-cbd2b2e531bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b202cd5-b6bc-4a2d-8f22-6a9ee531baef>.
+    
+<http://data.lblod.info/id/remote-data-objects/071a1753-55c4-48aa-8cd0-69e542f3028a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "071a1753-55c4-48aa-8cd0-69e542f3028a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/0c4ed502-7733-4419-aea1-cbd2b2e531bf/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/071a1753-55c4-48aa-8cd0-69e542f3028a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f91a5bf3-de54-4988-aabf-9fcb7519b291> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f91a5bf3-de54-4988-aabf-9fcb7519b291";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/22d48c77-9c62-4837-9680-639436eb718a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f91a5bf3-de54-4988-aabf-9fcb7519b291>.
+    
+<http://data.lblod.info/id/remote-data-objects/28df9be8-cb69-4257-b10f-a36979f3a3d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28df9be8-cb69-4257-b10f-a36979f3a3d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/22d48c77-9c62-4837-9680-639436eb718a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28df9be8-cb69-4257-b10f-a36979f3a3d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e3646c75-5388-4e1b-9279-7c7c32783db1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e3646c75-5388-4e1b-9279-7c7c32783db1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/22d48c77-9c62-4837-9680-639436eb718a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e3646c75-5388-4e1b-9279-7c7c32783db1>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5a036d0-ec0e-4605-a57b-6626ab25260f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5a036d0-ec0e-4605-a57b-6626ab25260f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/2a8fce23-37d2-49db-95ff-bca4be18549e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5a036d0-ec0e-4605-a57b-6626ab25260f>.
+    
+<http://data.lblod.info/id/remote-data-objects/964b017e-1703-4108-a6f3-918f1aee6a43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "964b017e-1703-4108-a6f3-918f1aee6a43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/2a8fce23-37d2-49db-95ff-bca4be18549e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/964b017e-1703-4108-a6f3-918f1aee6a43>.
+    
+<http://data.lblod.info/id/remote-data-objects/e95e4b4f-7e26-449c-924c-4e837dc62fce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e95e4b4f-7e26-449c-924c-4e837dc62fce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/2a8fce23-37d2-49db-95ff-bca4be18549e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e95e4b4f-7e26-449c-924c-4e837dc62fce>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dab6b82-cce3-42f9-bbe4-98160bff09ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dab6b82-cce3-42f9-bbe4-98160bff09ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/3b8cd934-2971-4303-bc46-3dc4c2313e02/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dab6b82-cce3-42f9-bbe4-98160bff09ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/a65ee471-eb38-46c1-aea0-06a472b6edf0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a65ee471-eb38-46c1-aea0-06a472b6edf0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/3b8cd934-2971-4303-bc46-3dc4c2313e02/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a65ee471-eb38-46c1-aea0-06a472b6edf0>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0eda642-7925-4d0f-8639-0b63c9fd41cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0eda642-7925-4d0f-8639-0b63c9fd41cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/3b8cd934-2971-4303-bc46-3dc4c2313e02/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0eda642-7925-4d0f-8639-0b63c9fd41cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6426253-3be2-4b6b-9d28-57fac538ad8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6426253-3be2-4b6b-9d28-57fac538ad8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/4efe1924-9e4b-4a15-b3a1-2d2805044060/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6426253-3be2-4b6b-9d28-57fac538ad8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4560f466-d80e-4b08-8c9b-8cf3d23e6db4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4560f466-d80e-4b08-8c9b-8cf3d23e6db4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/4efe1924-9e4b-4a15-b3a1-2d2805044060/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4560f466-d80e-4b08-8c9b-8cf3d23e6db4>.
+    
+<http://data.lblod.info/id/remote-data-objects/56526b8f-6adc-4f12-9ad2-6032034009e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "56526b8f-6adc-4f12-9ad2-6032034009e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/55bb4351-6182-4219-8efb-d2bd503ef4bd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/56526b8f-6adc-4f12-9ad2-6032034009e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c154f853-9bc0-403c-b48e-dbb5745be900> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c154f853-9bc0-403c-b48e-dbb5745be900";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/55bb4351-6182-4219-8efb-d2bd503ef4bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c154f853-9bc0-403c-b48e-dbb5745be900>.
+    
+<http://data.lblod.info/id/remote-data-objects/a61b5208-68f5-4064-829a-8b5abdbe14c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a61b5208-68f5-4064-829a-8b5abdbe14c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/55bb4351-6182-4219-8efb-d2bd503ef4bd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a61b5208-68f5-4064-829a-8b5abdbe14c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1506c7e-3caf-4fe3-9d55-b8709fa340f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1506c7e-3caf-4fe3-9d55-b8709fa340f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/74945b50-c9d1-4f37-8b70-148352889cc5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1506c7e-3caf-4fe3-9d55-b8709fa340f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2b3fd5b-d57c-41d5-ad46-24e8fe51d4e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2b3fd5b-d57c-41d5-ad46-24e8fe51d4e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/74945b50-c9d1-4f37-8b70-148352889cc5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2b3fd5b-d57c-41d5-ad46-24e8fe51d4e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7dcb1f49-e53a-4bd4-9a34-3c40377fc8cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7dcb1f49-e53a-4bd4-9a34-3c40377fc8cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/74945b50-c9d1-4f37-8b70-148352889cc5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7dcb1f49-e53a-4bd4-9a34-3c40377fc8cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/636690b6-73c8-44c8-9cef-6d69568c8861> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "636690b6-73c8-44c8-9cef-6d69568c8861";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/98ba8017-1584-4636-bbc8-ef9e58d0c950/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/636690b6-73c8-44c8-9cef-6d69568c8861>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c407d08-0981-4c30-99bf-6a0c5526be1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c407d08-0981-4c30-99bf-6a0c5526be1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/98ba8017-1584-4636-bbc8-ef9e58d0c950/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c407d08-0981-4c30-99bf-6a0c5526be1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c51ff5cc-44cd-4c6b-b81a-26024a77676f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c51ff5cc-44cd-4c6b-b81a-26024a77676f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/a00c43ae-b7ea-4ac7-9d36-058edc767f2a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c51ff5cc-44cd-4c6b-b81a-26024a77676f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b996a083-14c2-4a56-a7d2-6d0bf2729660> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b996a083-14c2-4a56-a7d2-6d0bf2729660";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/a00c43ae-b7ea-4ac7-9d36-058edc767f2a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:30.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/918a56f7-564e-4ca7-8fdc-a050d932e63b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b996a083-14c2-4a56-a7d2-6d0bf2729660>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201931-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201931-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201931-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201931-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/eed06c41-6b5e-4a42-8aea-68c3b0e69344> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "eed06c41-6b5e-4a42-8aea-68c3b0e69344";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "175b751b-051a-43fe-b554-e1bae1ea9924";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4a38b5df-e977-4758-9acd-d73307e938dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4a38b5df-e977-4758-9acd-d73307e938dd";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924>.
+
+  <http://redpencil.data.gift/id/task/ee83858a-f45a-47bf-a0a9-f394e211116f> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ee83858a-f45a-47bf-a0a9-f394e211116f";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/eed06c41-6b5e-4a42-8aea-68c3b0e69344>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4a38b5df-e977-4758-9acd-d73307e938dd>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/be11a081-65f6-4d4c-95fc-2c6a49d85906> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be11a081-65f6-4d4c-95fc-2c6a49d85906";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/a00c43ae-b7ea-4ac7-9d36-058edc767f2a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be11a081-65f6-4d4c-95fc-2c6a49d85906>.
+    
+<http://data.lblod.info/id/remote-data-objects/63c2e4f1-c03a-43a3-ae41-ff3b91f1a169> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63c2e4f1-c03a-43a3-ae41-ff3b91f1a169";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/aab269a7-f1ac-4cd2-9052-46ac36a3be7f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63c2e4f1-c03a-43a3-ae41-ff3b91f1a169>.
+    
+<http://data.lblod.info/id/remote-data-objects/40a54c53-0f1d-4a74-bef4-c8c2c3552f23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40a54c53-0f1d-4a74-bef4-c8c2c3552f23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/aab269a7-f1ac-4cd2-9052-46ac36a3be7f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40a54c53-0f1d-4a74-bef4-c8c2c3552f23>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a2bd3a4-c013-427e-8e49-b99c7d8bf48c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a2bd3a4-c013-427e-8e49-b99c7d8bf48c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/aab269a7-f1ac-4cd2-9052-46ac36a3be7f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a2bd3a4-c013-427e-8e49-b99c7d8bf48c>.
+    
+<http://data.lblod.info/id/remote-data-objects/393229d0-3b56-4e4f-91d2-8840250d93c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "393229d0-3b56-4e4f-91d2-8840250d93c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/abc9e2cf-b16b-4650-8a4d-fcf64f5a3e2a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/393229d0-3b56-4e4f-91d2-8840250d93c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6dc3e19-9c7a-4718-af8b-13a9e118d38a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6dc3e19-9c7a-4718-af8b-13a9e118d38a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/abc9e2cf-b16b-4650-8a4d-fcf64f5a3e2a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6dc3e19-9c7a-4718-af8b-13a9e118d38a>.
+    
+<http://data.lblod.info/id/remote-data-objects/01771b0c-3b89-4262-b443-0e72d13af78a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01771b0c-3b89-4262-b443-0e72d13af78a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/abc9e2cf-b16b-4650-8a4d-fcf64f5a3e2a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01771b0c-3b89-4262-b443-0e72d13af78a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e004dca0-2657-40e8-9870-a149d8271e13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e004dca0-2657-40e8-9870-a149d8271e13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/e2a57a31-04ff-40f6-9f63-7ff01ebd930c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e004dca0-2657-40e8-9870-a149d8271e13>.
+    
+<http://data.lblod.info/id/remote-data-objects/680b927c-4ddc-42a2-84f0-039a89cd26b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "680b927c-4ddc-42a2-84f0-039a89cd26b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/e2a57a31-04ff-40f6-9f63-7ff01ebd930c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/680b927c-4ddc-42a2-84f0-039a89cd26b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/af400c18-24b2-4161-b639-c2aefd41aeea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af400c18-24b2-4161-b639-c2aefd41aeea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/f0dfb168-c9fd-44e2-9d2e-7aff3cbe4028/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af400c18-24b2-4161-b639-c2aefd41aeea>.
+    
+<http://data.lblod.info/id/remote-data-objects/06e88a66-2802-4dc4-bf9b-ad8d0399ebd3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06e88a66-2802-4dc4-bf9b-ad8d0399ebd3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/f0dfb168-c9fd-44e2-9d2e-7aff3cbe4028/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06e88a66-2802-4dc4-bf9b-ad8d0399ebd3>.
+    
+<http://data.lblod.info/id/remote-data-objects/1e566289-66e6-4cff-958d-42452f35ff29> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1e566289-66e6-4cff-958d-42452f35ff29";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/f0dfb168-c9fd-44e2-9d2e-7aff3cbe4028/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1e566289-66e6-4cff-958d-42452f35ff29>.
+    
+<http://data.lblod.info/id/remote-data-objects/fef949fc-b355-4e7f-b4bc-654ab6165f1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fef949fc-b355-4e7f-b4bc-654ab6165f1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/f8d2a1c9-bf71-4118-a0a8-26c01b74daf0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fef949fc-b355-4e7f-b4bc-654ab6165f1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae94cc29-8d3d-4ca6-8569-36a322e79783> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae94cc29-8d3d-4ca6-8569-36a322e79783";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/f8d2a1c9-bf71-4118-a0a8-26c01b74daf0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae94cc29-8d3d-4ca6-8569-36a322e79783>.
+    
+<http://data.lblod.info/id/remote-data-objects/48fee7ca-b4b5-4be1-8ba6-12d764aced87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48fee7ca-b4b5-4be1-8ba6-12d764aced87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/f8d2a1c9-bf71-4118-a0a8-26c01b74daf0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48fee7ca-b4b5-4be1-8ba6-12d764aced87>.
+    
+<http://data.lblod.info/id/remote-data-objects/072ce435-38b0-4ddc-a54d-ba1a3345a0eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "072ce435-38b0-4ddc-a54d-ba1a3345a0eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/fd4a527d-133e-463b-b70b-520cf8924589/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/072ce435-38b0-4ddc-a54d-ba1a3345a0eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e28a985-91e4-4728-aaa9-eecb5d2957d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e28a985-91e4-4728-aaa9-eecb5d2957d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/fd4a527d-133e-463b-b70b-520cf8924589/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e28a985-91e4-4728-aaa9-eecb5d2957d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d8cb0bb-33a5-41fe-a86c-293d317a5f04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d8cb0bb-33a5-41fe-a86c-293d317a5f04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/gr/fd4a527d-133e-463b-b70b-520cf8924589/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d8cb0bb-33a5-41fe-a86c-293d317a5f04>.
+    
+<http://data.lblod.info/id/remote-data-objects/bec6eeec-d604-43fb-a9ad-ac8763617642> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bec6eeec-d604-43fb-a9ad-ac8763617642";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/06f826b0-5af9-465c-9197-cc79e4423f54/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bec6eeec-d604-43fb-a9ad-ac8763617642>.
+    
+<http://data.lblod.info/id/remote-data-objects/aefea8fb-0f6a-4e30-b8ba-29b1044ef8e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aefea8fb-0f6a-4e30-b8ba-29b1044ef8e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/06f826b0-5af9-465c-9197-cc79e4423f54/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aefea8fb-0f6a-4e30-b8ba-29b1044ef8e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6bd81f6-1ddf-451b-af24-edf605e5913b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6bd81f6-1ddf-451b-af24-edf605e5913b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/06f826b0-5af9-465c-9197-cc79e4423f54/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6bd81f6-1ddf-451b-af24-edf605e5913b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e072911-8df7-4492-8f1c-735b3eb32789> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e072911-8df7-4492-8f1c-735b3eb32789";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/21079e3a-25b1-431e-9e20-7ec017ab453e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e072911-8df7-4492-8f1c-735b3eb32789>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc036294-74d5-444b-9dd5-07ea26517e60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc036294-74d5-444b-9dd5-07ea26517e60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/21079e3a-25b1-431e-9e20-7ec017ab453e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc036294-74d5-444b-9dd5-07ea26517e60>.
+    
+<http://data.lblod.info/id/remote-data-objects/b08f0131-c1ec-44fe-bc17-0ad2b09db5d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b08f0131-c1ec-44fe-bc17-0ad2b09db5d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/21079e3a-25b1-431e-9e20-7ec017ab453e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b08f0131-c1ec-44fe-bc17-0ad2b09db5d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/fdb2c2ce-95d4-416b-a4c5-fffc91a51830> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdb2c2ce-95d4-416b-a4c5-fffc91a51830";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/23404a88-27cf-42c8-abd7-5dd9f48dbc0f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdb2c2ce-95d4-416b-a4c5-fffc91a51830>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e089c6a-30d7-4997-b9db-69da706a8984> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e089c6a-30d7-4997-b9db-69da706a8984";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/23404a88-27cf-42c8-abd7-5dd9f48dbc0f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e089c6a-30d7-4997-b9db-69da706a8984>.
+    
+<http://data.lblod.info/id/remote-data-objects/7876f8a4-6110-47ad-8bf3-e23d0939285d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7876f8a4-6110-47ad-8bf3-e23d0939285d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/23404a88-27cf-42c8-abd7-5dd9f48dbc0f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7876f8a4-6110-47ad-8bf3-e23d0939285d>.
+    
+<http://data.lblod.info/id/remote-data-objects/692d0141-069a-4346-953e-2d5b89a0c835> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "692d0141-069a-4346-953e-2d5b89a0c835";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/4b39ac34-766a-434e-95fc-b799ea4a5e84/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/692d0141-069a-4346-953e-2d5b89a0c835>.
+    
+<http://data.lblod.info/id/remote-data-objects/f162965c-42f5-41d1-9d66-296d67ca8025> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f162965c-42f5-41d1-9d66-296d67ca8025";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/4b39ac34-766a-434e-95fc-b799ea4a5e84/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f162965c-42f5-41d1-9d66-296d67ca8025>.
+    
+<http://data.lblod.info/id/remote-data-objects/409aea1a-78a1-4e4a-9a7c-3e9055d9f739> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "409aea1a-78a1-4e4a-9a7c-3e9055d9f739";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/4b39ac34-766a-434e-95fc-b799ea4a5e84/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/409aea1a-78a1-4e4a-9a7c-3e9055d9f739>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b90a287-584e-4784-ad31-f4925d52939f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b90a287-584e-4784-ad31-f4925d52939f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/631cc374-4617-4c41-8bf0-6a75c63d5b8b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b90a287-584e-4784-ad31-f4925d52939f>.
+    
+<http://data.lblod.info/id/remote-data-objects/74e8f2c7-ca00-45e9-b467-6817a104d7b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74e8f2c7-ca00-45e9-b467-6817a104d7b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/631cc374-4617-4c41-8bf0-6a75c63d5b8b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74e8f2c7-ca00-45e9-b467-6817a104d7b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6ded039-d775-4775-ad86-f3c1c82c6548> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6ded039-d775-4775-ad86-f3c1c82c6548";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/631cc374-4617-4c41-8bf0-6a75c63d5b8b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6ded039-d775-4775-ad86-f3c1c82c6548>.
+    
+<http://data.lblod.info/id/remote-data-objects/87e4cc4f-982b-4d0e-ba02-ad4051f4925f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87e4cc4f-982b-4d0e-ba02-ad4051f4925f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/7b44c735-52d5-47e8-a065-1160c072c9ce/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87e4cc4f-982b-4d0e-ba02-ad4051f4925f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e8b640e-b8bb-4b23-864b-c3f73cdcd8ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e8b640e-b8bb-4b23-864b-c3f73cdcd8ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/7b44c735-52d5-47e8-a065-1160c072c9ce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e8b640e-b8bb-4b23-864b-c3f73cdcd8ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d78798f-1330-45f5-9650-05fcf3cf1958> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d78798f-1330-45f5-9650-05fcf3cf1958";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/7b44c735-52d5-47e8-a065-1160c072c9ce/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d78798f-1330-45f5-9650-05fcf3cf1958>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd9ad3e8-9d09-439d-839a-6c1388db51cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd9ad3e8-9d09-439d-839a-6c1388db51cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/7b5b6172-716e-49cd-a3c2-062346fa209a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd9ad3e8-9d09-439d-839a-6c1388db51cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f8ceff4-c795-42f5-943f-7875b1531d88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f8ceff4-c795-42f5-943f-7875b1531d88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/7b5b6172-716e-49cd-a3c2-062346fa209a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f8ceff4-c795-42f5-943f-7875b1531d88>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e1c0019-7de8-4268-b22c-b5c53b1782c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e1c0019-7de8-4268-b22c-b5c53b1782c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/7b5b6172-716e-49cd-a3c2-062346fa209a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e1c0019-7de8-4268-b22c-b5c53b1782c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/22f02b87-aca3-44ea-b547-f6c38d3b6649> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22f02b87-aca3-44ea-b547-f6c38d3b6649";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/9252d2eb-1642-4a05-b268-b307fb9b7ab6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22f02b87-aca3-44ea-b547-f6c38d3b6649>.
+    
+<http://data.lblod.info/id/remote-data-objects/720cecbb-3568-4e79-8027-127f6de58983> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "720cecbb-3568-4e79-8027-127f6de58983";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/9252d2eb-1642-4a05-b268-b307fb9b7ab6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/720cecbb-3568-4e79-8027-127f6de58983>.
+    
+<http://data.lblod.info/id/remote-data-objects/b5a5957a-5674-4964-aa4c-77a54018fbfd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b5a5957a-5674-4964-aa4c-77a54018fbfd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/9252d2eb-1642-4a05-b268-b307fb9b7ab6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b5a5957a-5674-4964-aa4c-77a54018fbfd>.
+    
+<http://data.lblod.info/id/remote-data-objects/e12f1776-d6f7-408c-9db6-d0954cb418cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e12f1776-d6f7-408c-9db6-d0954cb418cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/ad86f39f-a2e7-4014-a0f9-6145875c5965/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e12f1776-d6f7-408c-9db6-d0954cb418cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d6afdba-c559-402f-9073-0e5a821bdbb4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d6afdba-c559-402f-9073-0e5a821bdbb4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/ad86f39f-a2e7-4014-a0f9-6145875c5965/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d6afdba-c559-402f-9073-0e5a821bdbb4>.
+    
+<http://data.lblod.info/id/remote-data-objects/463ff164-4bdc-40ef-abe4-b320d2799d7a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "463ff164-4bdc-40ef-abe4-b320d2799d7a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/ad86f39f-a2e7-4014-a0f9-6145875c5965/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/463ff164-4bdc-40ef-abe4-b320d2799d7a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3456d01-b467-478c-83b8-410876a76e9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3456d01-b467-478c-83b8-410876a76e9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/b32d0052-1c16-4ce5-ac27-9955ace0a8da/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3456d01-b467-478c-83b8-410876a76e9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b9dbf9e-01dd-43d7-ad1b-b359457525ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b9dbf9e-01dd-43d7-ad1b-b359457525ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/b32d0052-1c16-4ce5-ac27-9955ace0a8da/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b9dbf9e-01dd-43d7-ad1b-b359457525ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5faa438-77f7-4f76-9301-722c66dfb8b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5faa438-77f7-4f76-9301-722c66dfb8b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/b32d0052-1c16-4ce5-ac27-9955ace0a8da/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5faa438-77f7-4f76-9301-722c66dfb8b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cc90d61-595a-4af3-b60b-555a663a44e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cc90d61-595a-4af3-b60b-555a663a44e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/c16a04d9-89df-4f9b-b694-0b3bc796ed2c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cc90d61-595a-4af3-b60b-555a663a44e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/35cafdfb-d228-43e7-8285-58376cff0188> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35cafdfb-d228-43e7-8285-58376cff0188";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/c16a04d9-89df-4f9b-b694-0b3bc796ed2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:31.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/175b751b-051a-43fe-b554-e1bae1ea9924> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35cafdfb-d228-43e7-8285-58376cff0188>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201932-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201932-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201932-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201932-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/dcbdf0d8-daf2-4d71-8c0b-4cfa713c5ac7> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dcbdf0d8-daf2-4d71-8c0b-4cfa713c5ac7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9e36d7c0-a447-48f3-a736-c682eb96a4e7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/40e5843c-899e-4ef9-9dd4-4f9f10accd8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "40e5843c-899e-4ef9-9dd4-4f9f10accd8f";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7>.
+
+  <http://redpencil.data.gift/id/task/2648b181-2fbd-471d-8703-619f70c2cd4a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2648b181-2fbd-471d-8703-619f70c2cd4a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/dcbdf0d8-daf2-4d71-8c0b-4cfa713c5ac7>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/40e5843c-899e-4ef9-9dd4-4f9f10accd8f>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/cb1a29a1-d714-4d36-9a2d-0a6518b10600> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb1a29a1-d714-4d36-9a2d-0a6518b10600";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/c16a04d9-89df-4f9b-b694-0b3bc796ed2c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb1a29a1-d714-4d36-9a2d-0a6518b10600>.
+    
+<http://data.lblod.info/id/remote-data-objects/32ee7a25-90f5-4ace-9e4f-7c5056a146d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32ee7a25-90f5-4ace-9e4f-7c5056a146d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/c8069b59-0351-4372-bbff-1e3bf55458ef/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32ee7a25-90f5-4ace-9e4f-7c5056a146d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2a2110a-9745-4c36-96ab-c85ad95893d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2a2110a-9745-4c36-96ab-c85ad95893d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/c8069b59-0351-4372-bbff-1e3bf55458ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2a2110a-9745-4c36-96ab-c85ad95893d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/69cd21c1-5067-4bbd-9907-94df6567f712> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69cd21c1-5067-4bbd-9907-94df6567f712";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/c8069b59-0351-4372-bbff-1e3bf55458ef/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69cd21c1-5067-4bbd-9907-94df6567f712>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2253b28-c1a9-4e33-9c38-bc72d4b4d842> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2253b28-c1a9-4e33-9c38-bc72d4b4d842";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/d4ab6033-f9df-4fc4-b5d2-7e1e51d21107/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2253b28-c1a9-4e33-9c38-bc72d4b4d842>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c596a80-d7f5-4e3f-a341-0922710493fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c596a80-d7f5-4e3f-a341-0922710493fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/d4ab6033-f9df-4fc4-b5d2-7e1e51d21107/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c596a80-d7f5-4e3f-a341-0922710493fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddccdf7a-f9d6-4543-82a4-118a458d3f40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddccdf7a-f9d6-4543-82a4-118a458d3f40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/d4ab6033-f9df-4fc4-b5d2-7e1e51d21107/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddccdf7a-f9d6-4543-82a4-118a458d3f40>.
+    
+<http://data.lblod.info/id/remote-data-objects/3bef4f14-4a60-4612-9693-6c97d4739cec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3bef4f14-4a60-4612-9693-6c97d4739cec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/ec5c8ba6-7ed5-49e0-a038-cd629128036d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3bef4f14-4a60-4612-9693-6c97d4739cec>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce7e66d5-18f3-4514-9975-fc46d822becc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce7e66d5-18f3-4514-9975-fc46d822becc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/ec5c8ba6-7ed5-49e0-a038-cd629128036d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce7e66d5-18f3-4514-9975-fc46d822becc>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c4a4be7-1ff6-4415-9bdf-44a3a81be741> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c4a4be7-1ff6-4415-9bdf-44a3a81be741";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/ec5c8ba6-7ed5-49e0-a038-cd629128036d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c4a4be7-1ff6-4415-9bdf-44a3a81be741>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bad9a79-8f0f-4b09-9dc0-e0a40c358b81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bad9a79-8f0f-4b09-9dc0-e0a40c358b81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/fb1ed0b3-ff64-4c6c-9647-78c9fe2d29e5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bad9a79-8f0f-4b09-9dc0-e0a40c358b81>.
+    
+<http://data.lblod.info/id/remote-data-objects/7620a125-266c-45df-9f21-94f2a8aa3803> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7620a125-266c-45df-9f21-94f2a8aa3803";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/rmw/fb1ed0b3-ff64-4c6c-9647-78c9fe2d29e5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7620a125-266c-45df-9f21-94f2a8aa3803>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b8f157b-e0c6-4cfc-8c1c-30794521d752> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b8f157b-e0c6-4cfc-8c1c-30794521d752";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/0044014b-ed3e-470a-9b54-3af7bbfced1f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b8f157b-e0c6-4cfc-8c1c-30794521d752>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6eab8f8-1ae2-4dfb-837d-cabc9fbbe3fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6eab8f8-1ae2-4dfb-837d-cabc9fbbe3fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/09adae45-d1d3-4a9e-9d8c-b824a784e2ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6eab8f8-1ae2-4dfb-837d-cabc9fbbe3fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/c65f05e1-ffd6-427a-b516-7fecd48302ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c65f05e1-ffd6-427a-b516-7fecd48302ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/09fe4fbf-a633-4277-8818-87c8eee9d479/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c65f05e1-ffd6-427a-b516-7fecd48302ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae8fd1d3-eac7-4b85-8b61-a39ac320e7f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae8fd1d3-eac7-4b85-8b61-a39ac320e7f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/196170c8-de94-447b-b2f3-0dcf0116174a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae8fd1d3-eac7-4b85-8b61-a39ac320e7f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/69180ac3-4aa5-4bca-acd1-cd5073a4286e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69180ac3-4aa5-4bca-acd1-cd5073a4286e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/1adbbfc1-21b1-4ae5-8907-7b36e4d54693/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69180ac3-4aa5-4bca-acd1-cd5073a4286e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e277130a-005e-444d-944b-dbeeaedb3752> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e277130a-005e-444d-944b-dbeeaedb3752";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/1b924002-4d75-4a6c-b26b-dfd81a058a31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e277130a-005e-444d-944b-dbeeaedb3752>.
+    
+<http://data.lblod.info/id/remote-data-objects/52ef255f-4a33-4f65-9782-b463a6317516> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52ef255f-4a33-4f65-9782-b463a6317516";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/1fe1971d-ae96-4fb0-ac1e-9bd6921869c0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52ef255f-4a33-4f65-9782-b463a6317516>.
+    
+<http://data.lblod.info/id/remote-data-objects/4dd91a7f-e653-464b-bd20-9fa7e03fdef2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dd91a7f-e653-464b-bd20-9fa7e03fdef2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/22b59549-cfea-4084-9a6a-dcc59ec0fdb1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4dd91a7f-e653-464b-bd20-9fa7e03fdef2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a37bb141-1f3c-401a-95c3-26c479ef58c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a37bb141-1f3c-401a-95c3-26c479ef58c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/2482d447-8287-4c81-ad12-59ac1346d0d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a37bb141-1f3c-401a-95c3-26c479ef58c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/90656676-f37c-404b-b8df-1e783884cbb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90656676-f37c-404b-b8df-1e783884cbb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/29f5a803-d403-41c6-aa56-0334388131c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90656676-f37c-404b-b8df-1e783884cbb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2faa95c-3580-473a-9830-8b0d81b6122a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2faa95c-3580-473a-9830-8b0d81b6122a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/2b0bd8d0-a0ba-4e71-9691-a697e46dc2c2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2faa95c-3580-473a-9830-8b0d81b6122a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1f61c92-90a1-4ce5-8aff-ccd16520c3f8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1f61c92-90a1-4ce5-8aff-ccd16520c3f8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/344bb815-0c7b-4cc3-80c6-6705acf19739/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1f61c92-90a1-4ce5-8aff-ccd16520c3f8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8fed4e8b-24b7-4f57-a1cd-6d56a3a72fe2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fed4e8b-24b7-4f57-a1cd-6d56a3a72fe2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/371f3303-0cc7-49f1-9654-4f201f3522f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8fed4e8b-24b7-4f57-a1cd-6d56a3a72fe2>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6e51edc-02ab-421f-b47e-5447da799479> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6e51edc-02ab-421f-b47e-5447da799479";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/38022360-2fce-487d-948e-9fce7ba7277b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6e51edc-02ab-421f-b47e-5447da799479>.
+    
+<http://data.lblod.info/id/remote-data-objects/72e7c12b-99cf-486b-bc67-eadde6fa9572> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72e7c12b-99cf-486b-bc67-eadde6fa9572";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/39ad0aa5-f7ed-40ce-8a85-ff214fd9e36c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72e7c12b-99cf-486b-bc67-eadde6fa9572>.
+    
+<http://data.lblod.info/id/remote-data-objects/9bc9f0d3-8458-4147-8f80-66de67d6550f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9bc9f0d3-8458-4147-8f80-66de67d6550f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/3c916eab-21da-44e2-bf1a-e2275ee623cc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9bc9f0d3-8458-4147-8f80-66de67d6550f>.
+    
+<http://data.lblod.info/id/remote-data-objects/31b23aa9-81be-416b-81da-1a181f96efc5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31b23aa9-81be-416b-81da-1a181f96efc5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/3ebffd27-ceed-4dfa-bf7a-74303908713a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31b23aa9-81be-416b-81da-1a181f96efc5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0ce2e8e-0a7e-486e-9641-7ecdb517f25c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0ce2e8e-0a7e-486e-9641-7ecdb517f25c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/46198029-7ffa-4a1c-91fc-d7d4c85db5c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0ce2e8e-0a7e-486e-9641-7ecdb517f25c>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0dd04a3-ff00-490e-b76a-ec9b3a629268> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0dd04a3-ff00-490e-b76a-ec9b3a629268";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/4df8c5cb-3e0b-4997-9497-54475a38179c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0dd04a3-ff00-490e-b76a-ec9b3a629268>.
+    
+<http://data.lblod.info/id/remote-data-objects/ae459029-b24c-4d24-bfec-a947b27de3b0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae459029-b24c-4d24-bfec-a947b27de3b0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/500c2358-ccdb-4192-a7d7-bf15ababfbba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ae459029-b24c-4d24-bfec-a947b27de3b0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a6d656a-327b-490e-be56-81dcc8814261> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a6d656a-327b-490e-be56-81dcc8814261";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/55bd97c7-4300-4e72-8614-2de81263f88f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a6d656a-327b-490e-be56-81dcc8814261>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca9b7662-d384-4530-ae1b-4259aed409f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca9b7662-d384-4530-ae1b-4259aed409f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/569d5954-e37e-431a-ab4d-3308ba506709/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca9b7662-d384-4530-ae1b-4259aed409f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e61d4266-52f3-4ba6-b1ad-3cd0c02a22aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e61d4266-52f3-4ba6-b1ad-3cd0c02a22aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/594d7b34-632a-46ce-ad2f-071114c9ffd6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e61d4266-52f3-4ba6-b1ad-3cd0c02a22aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/00729cce-08b8-4c5a-9454-25b7a5e6160a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00729cce-08b8-4c5a-9454-25b7a5e6160a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/5a609b93-fc1f-46a0-a0f2-c4570ef38538/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00729cce-08b8-4c5a-9454-25b7a5e6160a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d15192fd-d31a-41f8-814d-a39046c66d84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d15192fd-d31a-41f8-814d-a39046c66d84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/655907e7-4a90-4b80-a387-bbc38e99fc75/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d15192fd-d31a-41f8-814d-a39046c66d84>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fc94ddb-e38c-4819-a858-e6c2de562c23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fc94ddb-e38c-4819-a858-e6c2de562c23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/6b386711-4bf5-4247-b9c2-9fbd191a7d9b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fc94ddb-e38c-4819-a858-e6c2de562c23>.
+    
+<http://data.lblod.info/id/remote-data-objects/05427810-0b74-48e1-9317-ca029d54de13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "05427810-0b74-48e1-9317-ca029d54de13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/6d6da024-56e1-4f98-b114-20355a84d492/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/05427810-0b74-48e1-9317-ca029d54de13>.
+    
+<http://data.lblod.info/id/remote-data-objects/29f064ae-8fe9-414a-8de3-85196ba9e99b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29f064ae-8fe9-414a-8de3-85196ba9e99b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/6eb816e3-c602-4d45-bed7-ec557a4555f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29f064ae-8fe9-414a-8de3-85196ba9e99b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9fd6245-de8a-481e-a7f0-18753645d01d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9fd6245-de8a-481e-a7f0-18753645d01d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/7334e81c-e54d-49f2-bbf3-d36796ed15c2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9fd6245-de8a-481e-a7f0-18753645d01d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1cd2dfa-d3ac-43b2-813d-a60abe43ef30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1cd2dfa-d3ac-43b2-813d-a60abe43ef30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/766bee9c-2b29-495c-ae47-b7d1e466484c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1cd2dfa-d3ac-43b2-813d-a60abe43ef30>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b6d43a1-1138-462a-9140-1f95b6cbedae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b6d43a1-1138-462a-9140-1f95b6cbedae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/7c798578-2152-425c-a06d-7e12317d11d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b6d43a1-1138-462a-9140-1f95b6cbedae>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d52eccd-1bb8-477c-bae9-82533e96a756> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d52eccd-1bb8-477c-bae9-82533e96a756";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/7c935dfb-82fd-4c26-bde7-80edc0fa60d8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d52eccd-1bb8-477c-bae9-82533e96a756>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bef580c-4f1b-4551-81a3-e8ba70cd1e09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bef580c-4f1b-4551-81a3-e8ba70cd1e09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/7e2b3f3d-6639-457f-b7f3-656c88b3b3ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bef580c-4f1b-4551-81a3-e8ba70cd1e09>.
+    
+<http://data.lblod.info/id/remote-data-objects/47172d21-f306-4f19-b59e-daf7e05a7d26> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47172d21-f306-4f19-b59e-daf7e05a7d26";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/8433ce98-8204-461a-b345-d288dd4e6cbe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47172d21-f306-4f19-b59e-daf7e05a7d26>.
+    
+<http://data.lblod.info/id/remote-data-objects/771317ba-6482-41a7-b1d6-82bba274dd65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "771317ba-6482-41a7-b1d6-82bba274dd65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/8701b4d3-6aa6-4ce5-ba8a-849c5b0520d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/771317ba-6482-41a7-b1d6-82bba274dd65>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3cbd692-02d1-4f69-ba8c-f4351404555c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3cbd692-02d1-4f69-ba8c-f4351404555c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/8a98dc3f-d5f5-4318-879f-724e6a250afc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3cbd692-02d1-4f69-ba8c-f4351404555c>.
+    
+<http://data.lblod.info/id/remote-data-objects/7126e697-72da-45fc-a2e7-6b48e1f6c548> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7126e697-72da-45fc-a2e7-6b48e1f6c548";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/8b50df45-db85-4020-b98f-37c588615f01/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7126e697-72da-45fc-a2e7-6b48e1f6c548>.
+    
+<http://data.lblod.info/id/remote-data-objects/5aa38e99-2585-4e1e-a471-3a53ff2d0ad6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5aa38e99-2585-4e1e-a471-3a53ff2d0ad6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/8f9964c4-3c04-4e7b-ba13-d622e70d81cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:32.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e36d7c0-a447-48f3-a736-c682eb96a4e7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5aa38e99-2585-4e1e-a471-3a53ff2d0ad6>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201933-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201933-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201933-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201933-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/85aca0d3-ab8a-4845-beff-124121263322> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "85aca0d3-ab8a-4845-beff-124121263322";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "aa3dbbf6-408b-4926-b5b0-38beadf6bb90";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/0873b89c-7b6f-4ff7-b33c-e51d52cebb48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0873b89c-7b6f-4ff7-b33c-e51d52cebb48";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90>.
+
+  <http://redpencil.data.gift/id/task/c1409b1b-2fdd-48df-8d06-6c201e8bf8e2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c1409b1b-2fdd-48df-8d06-6c201e8bf8e2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/85aca0d3-ab8a-4845-beff-124121263322>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/0873b89c-7b6f-4ff7-b33c-e51d52cebb48>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5ecb7c0a-f934-44dd-a05e-416b686f0428> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ecb7c0a-f934-44dd-a05e-416b686f0428";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/955b353d-00d8-4a01-9ec3-db6485ceaf35/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ecb7c0a-f934-44dd-a05e-416b686f0428>.
+    
+<http://data.lblod.info/id/remote-data-objects/03392064-d2b3-4b89-a19a-a677338ed18a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03392064-d2b3-4b89-a19a-a677338ed18a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/9900660a-9d69-4cfa-9326-8f501fb4399c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03392064-d2b3-4b89-a19a-a677338ed18a>.
+    
+<http://data.lblod.info/id/remote-data-objects/60b5dcd8-9723-481c-91cc-2144a4def128> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60b5dcd8-9723-481c-91cc-2144a4def128";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/a13f42f5-b144-4b8e-ac92-ddb281607585/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60b5dcd8-9723-481c-91cc-2144a4def128>.
+    
+<http://data.lblod.info/id/remote-data-objects/b80edd84-8640-403f-848d-f9f0abe196e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b80edd84-8640-403f-848d-f9f0abe196e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/a5e9b6f7-bf85-4b50-bfc1-5a64a7844c2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b80edd84-8640-403f-848d-f9f0abe196e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f63309f9-d318-4237-aa4f-370245db3319> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f63309f9-d318-4237-aa4f-370245db3319";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/a5f40490-3f8a-42c4-8cd6-ba206b42170d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f63309f9-d318-4237-aa4f-370245db3319>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa75e16c-af6a-4c60-946f-3c7dc2eae6b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa75e16c-af6a-4c60-946f-3c7dc2eae6b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/aa0d62f5-f32b-4e42-968e-082fe4fdc170/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa75e16c-af6a-4c60-946f-3c7dc2eae6b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba4b2286-8d0b-418e-8aa4-2d4cbed0f0b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba4b2286-8d0b-418e-8aa4-2d4cbed0f0b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/afd8e26d-5495-429f-af5e-ae1dd0150168/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba4b2286-8d0b-418e-8aa4-2d4cbed0f0b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/938b9161-a5b7-4522-b7fe-8101e2a1bfd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "938b9161-a5b7-4522-b7fe-8101e2a1bfd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/b1ad6248-928b-4e7a-b6e6-3392043c1f39/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/938b9161-a5b7-4522-b7fe-8101e2a1bfd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c40f98d-51fb-4879-981a-50b530cfb421> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c40f98d-51fb-4879-981a-50b530cfb421";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/b2a36fb9-aeff-4dd5-b2aa-4ee39d2366ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c40f98d-51fb-4879-981a-50b530cfb421>.
+    
+<http://data.lblod.info/id/remote-data-objects/8ff749d6-7dd9-4e52-94af-398a3de33bc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ff749d6-7dd9-4e52-94af-398a3de33bc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/b7d3c3d2-b000-4eab-b3d6-1a5ad22cd902/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8ff749d6-7dd9-4e52-94af-398a3de33bc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/aeeba511-3e56-4f81-9a3a-301d4f29c76f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aeeba511-3e56-4f81-9a3a-301d4f29c76f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/ba0b531d-4ede-4e46-864e-eea59f572e13/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aeeba511-3e56-4f81-9a3a-301d4f29c76f>.
+    
+<http://data.lblod.info/id/remote-data-objects/6027e0c7-dd59-4f9b-b21e-42551c76279e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6027e0c7-dd59-4f9b-b21e-42551c76279e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/bfb4e6b4-bd9e-4db7-9503-42f48bfbd052/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6027e0c7-dd59-4f9b-b21e-42551c76279e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f76321a-0c8e-4f5e-aaef-78796f0d9121> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f76321a-0c8e-4f5e-aaef-78796f0d9121";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/c03a62f6-2f2c-4e0b-9cac-22f4e9c7755a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f76321a-0c8e-4f5e-aaef-78796f0d9121>.
+    
+<http://data.lblod.info/id/remote-data-objects/11aa69a4-4709-45d6-9e5c-3d1083e704de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "11aa69a4-4709-45d6-9e5c-3d1083e704de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/c535c9c8-6b27-4ad2-8536-edcb9fb44b39/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/11aa69a4-4709-45d6-9e5c-3d1083e704de>.
+    
+<http://data.lblod.info/id/remote-data-objects/51928a88-d339-4519-b543-ef166faab316> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51928a88-d339-4519-b543-ef166faab316";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/c85d675c-8f99-4ded-962a-f011721613cc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51928a88-d339-4519-b543-ef166faab316>.
+    
+<http://data.lblod.info/id/remote-data-objects/16e5a0e2-9108-4e7d-99d6-09978e9f1c85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16e5a0e2-9108-4e7d-99d6-09978e9f1c85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/d1956f62-960e-4cb1-b512-619a7503594a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16e5a0e2-9108-4e7d-99d6-09978e9f1c85>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9646352-482e-46f1-89a6-0ec52f41aab2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9646352-482e-46f1-89a6-0ec52f41aab2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/d1bbf7fb-cf2a-4a10-a48d-95ea2f25c11e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9646352-482e-46f1-89a6-0ec52f41aab2>.
+    
+<http://data.lblod.info/id/remote-data-objects/435367e9-9cb8-4da8-9218-dc2ddd11e4b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "435367e9-9cb8-4da8-9218-dc2ddd11e4b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/d3d1325a-0f06-4320-8112-0129fe59d780/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/435367e9-9cb8-4da8-9218-dc2ddd11e4b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b11ec11-4571-4a37-9a49-4a7bcf52596e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b11ec11-4571-4a37-9a49-4a7bcf52596e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/d8144364-7883-4f8b-bb3f-6bfe5906860f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b11ec11-4571-4a37-9a49-4a7bcf52596e>.
+    
+<http://data.lblod.info/id/remote-data-objects/dafbada7-8e92-4a81-a5cf-6a5426aa61c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dafbada7-8e92-4a81-a5cf-6a5426aa61c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/d99c753b-a151-4acc-8e7d-e33320d57067/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dafbada7-8e92-4a81-a5cf-6a5426aa61c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c22a7f61-b6a3-4bf2-9ae1-a03ba8a9af52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c22a7f61-b6a3-4bf2-9ae1-a03ba8a9af52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/e063c878-1d85-4f96-a2ca-5205afbc074d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c22a7f61-b6a3-4bf2-9ae1-a03ba8a9af52>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ed49669-858e-46e2-a071-2102aff1e95d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ed49669-858e-46e2-a071-2102aff1e95d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/e37a3670-7b46-4ac8-8583-00f301feec32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ed49669-858e-46e2-a071-2102aff1e95d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b6d3e98-ffa9-4f73-81a5-8d53063d3a3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b6d3e98-ffa9-4f73-81a5-8d53063d3a3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/e7eb1561-cb8e-4f2f-8e4c-b31c075d5b19/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b6d3e98-ffa9-4f73-81a5-8d53063d3a3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/719d3b51-0b5d-4420-8b70-207c98be303d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "719d3b51-0b5d-4420-8b70-207c98be303d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/e7fad35c-c07a-4ff8-b3a9-c4324251ba46/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/719d3b51-0b5d-4420-8b70-207c98be303d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0f48a32-7ee7-4aca-a1f8-f95a0b352689> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0f48a32-7ee7-4aca-a1f8-f95a0b352689";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/e8053179-3b31-4005-9fc4-64cf72d77157/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0f48a32-7ee7-4aca-a1f8-f95a0b352689>.
+    
+<http://data.lblod.info/id/remote-data-objects/66df0eb4-85d1-44c5-aa13-102eb2dfc268> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66df0eb4-85d1-44c5-aa13-102eb2dfc268";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/f3efb3fe-dd01-41bb-adbf-33ff734b0d36/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66df0eb4-85d1-44c5-aa13-102eb2dfc268>.
+    
+<http://data.lblod.info/id/remote-data-objects/a93cab2e-940f-49ef-a84b-a86e3b53acce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a93cab2e-940f-49ef-a84b-a86e3b53acce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/f9c648c4-cb15-4585-bcca-ac570dba1c99/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a93cab2e-940f-49ef-a84b-a86e3b53acce>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f5cd5e8-033e-4ecb-862a-db554a8df445> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f5cd5e8-033e-4ecb-862a-db554a8df445";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schilde.meetingburger.net/vabu/fb8ce471-2a1e-448d-9ea1-98d0d400ea87/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f5cd5e8-033e-4ecb-862a-db554a8df445>.
+    
+<http://data.lblod.info/id/remote-data-objects/2238d52a-ddb9-4fae-83b7-3e58162717a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2238d52a-ddb9-4fae-83b7-3e58162717a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/014aedcf-93a0-4bc6-958f-450faa1ae7a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2238d52a-ddb9-4fae-83b7-3e58162717a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/29b18d38-b789-4a54-a81a-c54e45c6628f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29b18d38-b789-4a54-a81a-c54e45c6628f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/074be320-cc91-45b6-ae6f-4b6f9a4b53f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29b18d38-b789-4a54-a81a-c54e45c6628f>.
+    
+<http://data.lblod.info/id/remote-data-objects/22989dc8-3e86-4110-ad50-a4b65fc25243> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22989dc8-3e86-4110-ad50-a4b65fc25243";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/075f5eb3-cbfb-4985-bbcc-c8da531dd84f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22989dc8-3e86-4110-ad50-a4b65fc25243>.
+    
+<http://data.lblod.info/id/remote-data-objects/037a48a4-894d-4273-a898-b88cd513beae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "037a48a4-894d-4273-a898-b88cd513beae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/09373275-5d56-4f18-abfc-bca93fab1e17/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/037a48a4-894d-4273-a898-b88cd513beae>.
+    
+<http://data.lblod.info/id/remote-data-objects/9af182db-e4ab-4972-ad48-bfe41b89fcc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9af182db-e4ab-4972-ad48-bfe41b89fcc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/1423557f-e4ef-4ddf-a06f-b0e1ad7592d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9af182db-e4ab-4972-ad48-bfe41b89fcc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/5ff95f99-9385-4ea4-8a34-c564f89e5e56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ff95f99-9385-4ea4-8a34-c564f89e5e56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/14f6e4f1-717b-472e-8c8b-c7e1108b39a0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5ff95f99-9385-4ea4-8a34-c564f89e5e56>.
+    
+<http://data.lblod.info/id/remote-data-objects/9648ee4e-003b-4911-a5a6-490e99fd01c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9648ee4e-003b-4911-a5a6-490e99fd01c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/1926e2f4-cd1a-4c63-9fba-bf603f0a833f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9648ee4e-003b-4911-a5a6-490e99fd01c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ffc850bc-6c03-42db-97e7-3d52972c2c17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ffc850bc-6c03-42db-97e7-3d52972c2c17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/1af0d27c-6fcc-43aa-91c1-f09f1c1f6cf5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ffc850bc-6c03-42db-97e7-3d52972c2c17>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a3a9087-32b6-4f0e-8129-86562e89f9a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a3a9087-32b6-4f0e-8129-86562e89f9a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/22a42086-050a-4def-a3f2-dcd27bf2fc4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a3a9087-32b6-4f0e-8129-86562e89f9a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/107103d6-4b34-41d6-b94e-611c7bf7b327> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "107103d6-4b34-41d6-b94e-611c7bf7b327";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/22a47009-ac94-4db6-9fda-c60f5fa272ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/107103d6-4b34-41d6-b94e-611c7bf7b327>.
+    
+<http://data.lblod.info/id/remote-data-objects/93eb1d31-ae28-48b2-8c2f-2dafeafa601a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93eb1d31-ae28-48b2-8c2f-2dafeafa601a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/22f8a485-addb-48bc-9b50-a442f7b82c32/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/93eb1d31-ae28-48b2-8c2f-2dafeafa601a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c98c0c36-6762-4687-a1da-fa5aab8b58e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c98c0c36-6762-4687-a1da-fa5aab8b58e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/25977bf9-eeb3-4556-9f9c-e6a374ce6d57/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c98c0c36-6762-4687-a1da-fa5aab8b58e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a12db255-8459-4d90-8fb1-47fab0e194bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a12db255-8459-4d90-8fb1-47fab0e194bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/300f0e4d-23f6-4e5e-a4a8-a110479f2c82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a12db255-8459-4d90-8fb1-47fab0e194bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb98ea23-6c5b-41f3-894e-602e3451d1e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb98ea23-6c5b-41f3-894e-602e3451d1e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/3af5e3eb-e848-4464-b287-9ca73ff21ba8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb98ea23-6c5b-41f3-894e-602e3451d1e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/5438ba10-dcbd-43f9-96a3-26355eb3f619> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5438ba10-dcbd-43f9-96a3-26355eb3f619";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/3f29aae0-6355-4027-8db6-ceac77e50007/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5438ba10-dcbd-43f9-96a3-26355eb3f619>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c41883d-9bb2-487c-826c-ad9d1b8f7415> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c41883d-9bb2-487c-826c-ad9d1b8f7415";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/3f3b4869-a971-4bc2-ac54-9be38ccd1941/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c41883d-9bb2-487c-826c-ad9d1b8f7415>.
+    
+<http://data.lblod.info/id/remote-data-objects/4176b842-9312-49cf-9275-c84420014f5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4176b842-9312-49cf-9275-c84420014f5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/40c63bfa-70af-4a36-9a0c-48b911898a9b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4176b842-9312-49cf-9275-c84420014f5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/53c648f9-120e-4465-b36e-59ebd6b727c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53c648f9-120e-4465-b36e-59ebd6b727c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/47fb5f57-f6d3-40a4-8a77-f3507e70343a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53c648f9-120e-4465-b36e-59ebd6b727c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/26994f1f-9339-4f2c-99da-c8429203d28b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26994f1f-9339-4f2c-99da-c8429203d28b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/4c015369-a529-4e87-8969-087ed40a5e35/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26994f1f-9339-4f2c-99da-c8429203d28b>.
+    
+<http://data.lblod.info/id/remote-data-objects/547d2fbf-66ba-4e21-9ef9-4135b4746b2a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "547d2fbf-66ba-4e21-9ef9-4135b4746b2a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/4df84979-32ac-4d09-a28e-af6fbd61ba04/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/547d2fbf-66ba-4e21-9ef9-4135b4746b2a>.
+    
+<http://data.lblod.info/id/remote-data-objects/aedcedae-f1fa-40a1-9811-d1f3769aeab5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aedcedae-f1fa-40a1-9811-d1f3769aeab5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/538ebbd8-d49d-4ff9-a04c-f58c113ae968/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aedcedae-f1fa-40a1-9811-d1f3769aeab5>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0c1ee8d-835c-4a74-b53f-9e7288536a9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0c1ee8d-835c-4a74-b53f-9e7288536a9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/54269446-c35f-44b1-b965-605cb7c3e76f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:33.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa3dbbf6-408b-4926-b5b0-38beadf6bb90> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0c1ee8d-835c-4a74-b53f-9e7288536a9b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201935-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201935-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201935-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201935-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/121bd503-fbd6-49c7-8109-c9620b7c07c7> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "121bd503-fbd6-49c7-8109-c9620b7c07c7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1774f23a-a6c9-4e66-b4a1-e845606f3e29";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a8addce4-ebf2-45ca-b46b-55182ecbd0cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a8addce4-ebf2-45ca-b46b-55182ecbd0cf";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29>.
+
+  <http://redpencil.data.gift/id/task/3c580ae4-541e-469e-948b-6d45148ededc> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3c580ae4-541e-469e-948b-6d45148ededc";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/121bd503-fbd6-49c7-8109-c9620b7c07c7>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a8addce4-ebf2-45ca-b46b-55182ecbd0cf>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/0ad7206c-7fc6-423c-ad01-8a7dafc3a3dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ad7206c-7fc6-423c-ad01-8a7dafc3a3dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/5e1789a1-8056-490d-ae5d-f077be54c5dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ad7206c-7fc6-423c-ad01-8a7dafc3a3dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/a22eb081-62e7-46dd-94cb-3773fa23c7d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a22eb081-62e7-46dd-94cb-3773fa23c7d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/652e6869-6543-4f90-8d27-b1171665d868/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a22eb081-62e7-46dd-94cb-3773fa23c7d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/633930ab-fa67-4206-b61d-d3f6ec9ac50f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "633930ab-fa67-4206-b61d-d3f6ec9ac50f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/66ab411c-8fb9-4a16-b5af-f9f2fd2acfb7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/633930ab-fa67-4206-b61d-d3f6ec9ac50f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b43370d2-c420-4499-9d08-a48dfd7120c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b43370d2-c420-4499-9d08-a48dfd7120c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/66e403ef-e43f-4351-999b-9cbd9c363063/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b43370d2-c420-4499-9d08-a48dfd7120c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/707e53dd-f1b0-4b1f-9e4d-c4bd127f6c57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "707e53dd-f1b0-4b1f-9e4d-c4bd127f6c57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/69faf2cc-a39b-4eb9-ad30-c7137b4d1fb2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/707e53dd-f1b0-4b1f-9e4d-c4bd127f6c57>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ff687c6-1fd6-436d-b3eb-7401621109b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ff687c6-1fd6-436d-b3eb-7401621109b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/6ea35ba3-e4ec-4ec8-83d0-683d2003eb68/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ff687c6-1fd6-436d-b3eb-7401621109b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/caa2d970-cebe-4501-bb38-4f9601760000> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "caa2d970-cebe-4501-bb38-4f9601760000";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/73031940-afb7-40fe-b4c3-a09fa30c6b40/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/caa2d970-cebe-4501-bb38-4f9601760000>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ef6594a-028b-4ab6-b337-39599d732df3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ef6594a-028b-4ab6-b337-39599d732df3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/74ea6ad6-6148-47f7-af5e-df1ba165c20f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ef6594a-028b-4ab6-b337-39599d732df3>.
+    
+<http://data.lblod.info/id/remote-data-objects/becbe1b6-f371-4d7a-a2a8-d567deb4b54f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "becbe1b6-f371-4d7a-a2a8-d567deb4b54f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/85d5f79b-c5df-4589-a322-9be53c4d50c2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/becbe1b6-f371-4d7a-a2a8-d567deb4b54f>.
+    
+<http://data.lblod.info/id/remote-data-objects/b53dacc3-b73e-427d-9e88-9a5787d6cd74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b53dacc3-b73e-427d-9e88-9a5787d6cd74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/870a7dce-3af6-4be1-80bb-452309b87c17/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b53dacc3-b73e-427d-9e88-9a5787d6cd74>.
+    
+<http://data.lblod.info/id/remote-data-objects/702515f6-88cd-40c7-941c-9ac68a1cfabe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "702515f6-88cd-40c7-941c-9ac68a1cfabe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/88212f64-5d62-4383-bef3-c29a32730cb3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/702515f6-88cd-40c7-941c-9ac68a1cfabe>.
+    
+<http://data.lblod.info/id/remote-data-objects/50895759-2e74-4cb3-b6eb-a2a9df2317bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50895759-2e74-4cb3-b6eb-a2a9df2317bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/8a822ab5-0124-4d8c-b07c-f38635896995/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50895759-2e74-4cb3-b6eb-a2a9df2317bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/af4afb5a-d2db-4a81-a40d-48c719c5e133> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af4afb5a-d2db-4a81-a40d-48c719c5e133";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/8c68aa3b-7efc-40fe-a8ee-6a3d2be6bf89/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/af4afb5a-d2db-4a81-a40d-48c719c5e133>.
+    
+<http://data.lblod.info/id/remote-data-objects/9f3cafc1-1e89-486c-b0e3-e3c0eae9f095> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f3cafc1-1e89-486c-b0e3-e3c0eae9f095";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/8ef43615-56a3-49d1-aa2f-26e583e99045/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9f3cafc1-1e89-486c-b0e3-e3c0eae9f095>.
+    
+<http://data.lblod.info/id/remote-data-objects/67e8ebc3-410b-4393-83e8-dd2b1a870ada> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67e8ebc3-410b-4393-83e8-dd2b1a870ada";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/97bf8f98-3f11-4dc2-afbb-9fee971aa197/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67e8ebc3-410b-4393-83e8-dd2b1a870ada>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5662bf9-4909-473e-a3b7-6063262331fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5662bf9-4909-473e-a3b7-6063262331fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/99bb5a35-869d-4808-91a9-3f28afc2d5e3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5662bf9-4909-473e-a3b7-6063262331fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b288e78-024c-4dd9-b0b8-912f51e76ea9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b288e78-024c-4dd9-b0b8-912f51e76ea9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/a158d298-e2d3-4fb3-94db-2c2b7373d4bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b288e78-024c-4dd9-b0b8-912f51e76ea9>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbb0fe88-0e14-4c4e-ac46-461682309d02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbb0fe88-0e14-4c4e-ac46-461682309d02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/a2053b96-1a9e-488a-b0fd-2dba60fdbd3c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbb0fe88-0e14-4c4e-ac46-461682309d02>.
+    
+<http://data.lblod.info/id/remote-data-objects/d015e0fa-718b-4f7b-857f-b397c69b7bc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d015e0fa-718b-4f7b-857f-b397c69b7bc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/a456bef5-ba55-4f8b-8413-9815e91daa6c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d015e0fa-718b-4f7b-857f-b397c69b7bc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/38b67ec2-44fa-45d4-b17b-9f4f523ddf3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38b67ec2-44fa-45d4-b17b-9f4f523ddf3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/a49383df-40d8-434f-a35c-4624f73eef9b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38b67ec2-44fa-45d4-b17b-9f4f523ddf3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbf1b966-78f9-4ec8-b479-3bf215a3707e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbf1b966-78f9-4ec8-b479-3bf215a3707e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/a92e39b6-4f24-4f8c-872d-81cd5c3a183b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbf1b966-78f9-4ec8-b479-3bf215a3707e>.
+    
+<http://data.lblod.info/id/remote-data-objects/f999c933-ea68-4718-92c1-0e0d9690984b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f999c933-ea68-4718-92c1-0e0d9690984b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/aa273e01-20c1-4973-a06f-c8dda546e3c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f999c933-ea68-4718-92c1-0e0d9690984b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ca61d45-6f99-4fae-844f-43327eeda6f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ca61d45-6f99-4fae-844f-43327eeda6f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/ab9527fb-df5f-4fe6-a5e6-018bb2326a25/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ca61d45-6f99-4fae-844f-43327eeda6f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/a90a8542-601e-458b-abf1-beaff490d73b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a90a8542-601e-458b-abf1-beaff490d73b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/ac733386-d5e1-4053-a3e6-68ed899f4f0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a90a8542-601e-458b-abf1-beaff490d73b>.
+    
+<http://data.lblod.info/id/remote-data-objects/184c5d35-d83c-4633-b84b-a81f108af2a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "184c5d35-d83c-4633-b84b-a81f108af2a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/b434c3e9-1426-4991-82a7-99d144e27949/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/184c5d35-d83c-4633-b84b-a81f108af2a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/d58028cd-421e-4990-b4bb-277c6dfbf9b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d58028cd-421e-4990-b4bb-277c6dfbf9b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/b7e5dc98-3b29-49cc-8957-23e0942a01a0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d58028cd-421e-4990-b4bb-277c6dfbf9b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/78c04eab-c6ae-41ee-ad40-2d96f8cb7759> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78c04eab-c6ae-41ee-ad40-2d96f8cb7759";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/b844559c-47b6-4b59-9c55-70aba0b07995/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78c04eab-c6ae-41ee-ad40-2d96f8cb7759>.
+    
+<http://data.lblod.info/id/remote-data-objects/15f5bb50-d1c8-4f4c-9871-5a47fd6f342d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15f5bb50-d1c8-4f4c-9871-5a47fd6f342d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/bf1b6602-42c2-4158-b8ee-b8cd26f7f5d8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15f5bb50-d1c8-4f4c-9871-5a47fd6f342d>.
+    
+<http://data.lblod.info/id/remote-data-objects/91a7b998-73a5-4946-be5f-848184ef6685> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91a7b998-73a5-4946-be5f-848184ef6685";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/c09a9c1f-e2d6-4900-87eb-6761f217d911/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/91a7b998-73a5-4946-be5f-848184ef6685>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f17be77-2a90-458c-94e6-a7dd4fcce361> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f17be77-2a90-458c-94e6-a7dd4fcce361";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/c10a6c61-4ad8-444c-9a3f-8bbe830fb996/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f17be77-2a90-458c-94e6-a7dd4fcce361>.
+    
+<http://data.lblod.info/id/remote-data-objects/656e25cf-3cd5-480c-859e-c45cf019819c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "656e25cf-3cd5-480c-859e-c45cf019819c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/cc0f7293-8f0e-4af6-9645-a2bb04343ea4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/656e25cf-3cd5-480c-859e-c45cf019819c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5af17845-4869-409e-a81f-df27e735b9d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5af17845-4869-409e-a81f-df27e735b9d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/cd2f2cf7-1877-4ca8-8679-77d24131ab5d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5af17845-4869-409e-a81f-df27e735b9d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/aff65a6a-63d4-4fe1-89c0-731b346e515a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aff65a6a-63d4-4fe1-89c0-731b346e515a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/d0964171-71d1-4b6f-a7e4-c2aa64e845d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aff65a6a-63d4-4fe1-89c0-731b346e515a>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cad04b5-3c49-47d1-9197-251ec7488c20> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cad04b5-3c49-47d1-9197-251ec7488c20";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/d3275f09-47f8-443e-848a-00bebf461aa1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cad04b5-3c49-47d1-9197-251ec7488c20>.
+    
+<http://data.lblod.info/id/remote-data-objects/820d756b-0c83-4319-8e13-a35300e05ccf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "820d756b-0c83-4319-8e13-a35300e05ccf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/d658d2c0-6d1d-490a-9a72-61f80826d076/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/820d756b-0c83-4319-8e13-a35300e05ccf>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7b68765-bc29-42fe-b647-51ca755a2c16> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7b68765-bc29-42fe-b647-51ca755a2c16";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/dc3000ab-9f68-4215-9cd4-15188940bf43/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7b68765-bc29-42fe-b647-51ca755a2c16>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc12b9ef-07ca-4a17-bf16-441011791310> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc12b9ef-07ca-4a17-bf16-441011791310";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/dc65c4ff-738f-43eb-8b35-c57c31d51778/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc12b9ef-07ca-4a17-bf16-441011791310>.
+    
+<http://data.lblod.info/id/remote-data-objects/982ea47d-b7ff-4112-9a36-e6ad7c664d98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "982ea47d-b7ff-4112-9a36-e6ad7c664d98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/e1176d65-3271-4dd0-83ed-240b3d7cd84e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/982ea47d-b7ff-4112-9a36-e6ad7c664d98>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c588f77-46aa-4c00-9a01-35014e36d8d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c588f77-46aa-4c00-9a01-35014e36d8d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/e1bce050-9b9c-46ba-974f-ea295fdfd5e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c588f77-46aa-4c00-9a01-35014e36d8d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/f0135054-25a5-4029-856a-a9a13f2e882e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0135054-25a5-4029-856a-a9a13f2e882e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/e48ec10f-1051-4575-bb19-544d14362808/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f0135054-25a5-4029-856a-a9a13f2e882e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e1b0a858-c530-4336-80d9-11c24b4f047e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e1b0a858-c530-4336-80d9-11c24b4f047e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/e77d04af-01c0-4cd6-a7ba-2eac1e09d3a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e1b0a858-c530-4336-80d9-11c24b4f047e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ab6844a-4173-4f5e-910f-d97512b0877e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ab6844a-4173-4f5e-910f-d97512b0877e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/ec8b8a75-82a5-42f8-9370-20f2a93a9c34/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ab6844a-4173-4f5e-910f-d97512b0877e>.
+    
+<http://data.lblod.info/id/remote-data-objects/551fbd8f-1cfb-42c0-bf59-4f3d74560f86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "551fbd8f-1cfb-42c0-bf59-4f3d74560f86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/efa44d0e-08cd-4db9-9644-2b6e5cc13e99/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/551fbd8f-1cfb-42c0-bf59-4f3d74560f86>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a662f5a-fdbf-4064-ae34-6366cc59b2a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a662f5a-fdbf-4064-ae34-6366cc59b2a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/f15ceb0a-731b-4de1-96d0-da4860adb562/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a662f5a-fdbf-4064-ae34-6366cc59b2a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/84a66637-1049-40d1-8d18-0d072fa6ea15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84a66637-1049-40d1-8d18-0d072fa6ea15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/f1e4999d-c237-49c4-9da8-e354089706a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84a66637-1049-40d1-8d18-0d072fa6ea15>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c3cf30a-54dd-4b50-9925-9ec56bf09912> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c3cf30a-54dd-4b50-9925-9ec56bf09912";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/f5c9fbdf-a370-47c8-8dc9-7cab8d786c59/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c3cf30a-54dd-4b50-9925-9ec56bf09912>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ff09675-87e3-4bfd-a567-30b9c53f1a67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ff09675-87e3-4bfd-a567-30b9c53f1a67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/cbs/fff16ecc-d17d-4e93-9450-5d20208f7b3e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ff09675-87e3-4bfd-a567-30b9c53f1a67>.
+    
+<http://data.lblod.info/id/remote-data-objects/445335a9-cef0-47b0-b6cf-544573d170cb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "445335a9-cef0-47b0-b6cf-544573d170cb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/0b77bf2d-4afd-43a1-b58a-29db9f747108/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/445335a9-cef0-47b0-b6cf-544573d170cb>.
+    
+<http://data.lblod.info/id/remote-data-objects/1edd1066-7fee-475b-88b0-3836e02e0455> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1edd1066-7fee-475b-88b0-3836e02e0455";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/0b77bf2d-4afd-43a1-b58a-29db9f747108/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1edd1066-7fee-475b-88b0-3836e02e0455>.
+    
+<http://data.lblod.info/id/remote-data-objects/d926233d-63ba-4cc6-a68f-f8bc92c60fda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d926233d-63ba-4cc6-a68f-f8bc92c60fda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/0b77bf2d-4afd-43a1-b58a-29db9f747108/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:35.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1774f23a-a6c9-4e66-b4a1-e845606f3e29> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d926233d-63ba-4cc6-a68f-f8bc92c60fda>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201936-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201936-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201936-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201936-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/eb58b1e3-6919-47b1-a7ab-cfdbfac81969> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "eb58b1e3-6919-47b1-a7ab-cfdbfac81969";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "03244643-75d3-455c-9401-35da5694dc5e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/fc773a0c-d0b0-4c2f-a1a1-2aa011e1b36c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fc773a0c-d0b0-4c2f-a1a1-2aa011e1b36c";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e>.
+
+  <http://redpencil.data.gift/id/task/d55ee6c6-ae6a-4186-90ec-646442f0a367> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d55ee6c6-ae6a-4186-90ec-646442f0a367";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/eb58b1e3-6919-47b1-a7ab-cfdbfac81969>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/fc773a0c-d0b0-4c2f-a1a1-2aa011e1b36c>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/d4a782da-0fb5-4a69-886a-6d2b814fe8a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4a782da-0fb5-4a69-886a-6d2b814fe8a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/1c80910c-3938-4884-80a9-e130fafe4f72/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4a782da-0fb5-4a69-886a-6d2b814fe8a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd68b4a8-798f-4e74-b414-3ae662785085> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd68b4a8-798f-4e74-b414-3ae662785085";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/1c80910c-3938-4884-80a9-e130fafe4f72/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd68b4a8-798f-4e74-b414-3ae662785085>.
+    
+<http://data.lblod.info/id/remote-data-objects/71f12471-b9c8-455f-925f-8af782d41eb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71f12471-b9c8-455f-925f-8af782d41eb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/1f0af8a2-e900-4162-bf33-7e56954fe57e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71f12471-b9c8-455f-925f-8af782d41eb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/2295e7ff-b6a7-4b03-93be-d5ad10032844> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2295e7ff-b6a7-4b03-93be-d5ad10032844";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/1f0af8a2-e900-4162-bf33-7e56954fe57e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2295e7ff-b6a7-4b03-93be-d5ad10032844>.
+    
+<http://data.lblod.info/id/remote-data-objects/98fa6eb3-2735-452c-8747-ffcfc3cdd174> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98fa6eb3-2735-452c-8747-ffcfc3cdd174";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/1f0af8a2-e900-4162-bf33-7e56954fe57e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98fa6eb3-2735-452c-8747-ffcfc3cdd174>.
+    
+<http://data.lblod.info/id/remote-data-objects/aca7cedf-0d07-434d-af10-df1203bed841> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aca7cedf-0d07-434d-af10-df1203bed841";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/3fc011d4-0cb4-4f39-9a7b-6607caffc3a3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aca7cedf-0d07-434d-af10-df1203bed841>.
+    
+<http://data.lblod.info/id/remote-data-objects/b357fb1c-abd5-4740-96bd-be1422552406> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b357fb1c-abd5-4740-96bd-be1422552406";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/3fc011d4-0cb4-4f39-9a7b-6607caffc3a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b357fb1c-abd5-4740-96bd-be1422552406>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa7c6a56-6aa3-4ee1-80c2-f27dd0ac5be5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa7c6a56-6aa3-4ee1-80c2-f27dd0ac5be5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/3fc011d4-0cb4-4f39-9a7b-6607caffc3a3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa7c6a56-6aa3-4ee1-80c2-f27dd0ac5be5>.
+    
+<http://data.lblod.info/id/remote-data-objects/aca88980-ca38-477f-81c3-611631b713e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aca88980-ca38-477f-81c3-611631b713e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/4e242eee-705f-4d27-9f4a-5ac4c592879a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aca88980-ca38-477f-81c3-611631b713e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b394cfdf-bf11-4f34-b4e0-9d7345f591c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b394cfdf-bf11-4f34-b4e0-9d7345f591c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/4e242eee-705f-4d27-9f4a-5ac4c592879a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b394cfdf-bf11-4f34-b4e0-9d7345f591c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b24f8960-894f-4ecc-b207-ceb36b7c0190> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b24f8960-894f-4ecc-b207-ceb36b7c0190";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/4e242eee-705f-4d27-9f4a-5ac4c592879a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b24f8960-894f-4ecc-b207-ceb36b7c0190>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2f67a23-7240-481e-9aae-8a5083771ee2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2f67a23-7240-481e-9aae-8a5083771ee2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/6ddb103c-6c92-460c-b10e-b001c775aaf3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2f67a23-7240-481e-9aae-8a5083771ee2>.
+    
+<http://data.lblod.info/id/remote-data-objects/31092ae9-fa0c-4068-9ef8-ffd5c8294581> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31092ae9-fa0c-4068-9ef8-ffd5c8294581";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/6ddb103c-6c92-460c-b10e-b001c775aaf3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/31092ae9-fa0c-4068-9ef8-ffd5c8294581>.
+    
+<http://data.lblod.info/id/remote-data-objects/b1993c24-053f-40bc-8180-eab07b93fc48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b1993c24-053f-40bc-8180-eab07b93fc48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/6ddb103c-6c92-460c-b10e-b001c775aaf3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b1993c24-053f-40bc-8180-eab07b93fc48>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbdbfb9e-37f5-4880-8829-585ba7371e8e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbdbfb9e-37f5-4880-8829-585ba7371e8e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/6f552501-7a42-4038-ad86-916205edc40d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbdbfb9e-37f5-4880-8829-585ba7371e8e>.
+    
+<http://data.lblod.info/id/remote-data-objects/091ff4a7-c79f-4050-8514-6befd2cb0a81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "091ff4a7-c79f-4050-8514-6befd2cb0a81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/6f552501-7a42-4038-ad86-916205edc40d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/091ff4a7-c79f-4050-8514-6befd2cb0a81>.
+    
+<http://data.lblod.info/id/remote-data-objects/a04cae04-3570-4ed3-9d41-bc95d46ac6cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a04cae04-3570-4ed3-9d41-bc95d46ac6cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/6f552501-7a42-4038-ad86-916205edc40d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a04cae04-3570-4ed3-9d41-bc95d46ac6cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c205868-7856-426d-a4e4-d5531fe2db43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c205868-7856-426d-a4e4-d5531fe2db43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/74f49a3a-34b3-4f9e-a2c7-b8258f9d8ba2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c205868-7856-426d-a4e4-d5531fe2db43>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e2f1c80-829e-4306-89e7-65c829962498> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e2f1c80-829e-4306-89e7-65c829962498";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/74f49a3a-34b3-4f9e-a2c7-b8258f9d8ba2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e2f1c80-829e-4306-89e7-65c829962498>.
+    
+<http://data.lblod.info/id/remote-data-objects/b424d3fc-74b4-4688-a7f6-8a36b5120e47> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b424d3fc-74b4-4688-a7f6-8a36b5120e47";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/74f49a3a-34b3-4f9e-a2c7-b8258f9d8ba2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b424d3fc-74b4-4688-a7f6-8a36b5120e47>.
+    
+<http://data.lblod.info/id/remote-data-objects/22f70846-ef92-4cc2-81a5-97efabbde864> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22f70846-ef92-4cc2-81a5-97efabbde864";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/777eaf04-66ef-49b5-8db7-8a9470c267f0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22f70846-ef92-4cc2-81a5-97efabbde864>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d20b92a-1183-40bf-8137-75328e466c19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d20b92a-1183-40bf-8137-75328e466c19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/777eaf04-66ef-49b5-8db7-8a9470c267f0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d20b92a-1183-40bf-8137-75328e466c19>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ee346e8-cd93-49ac-87e8-f81273ede41e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ee346e8-cd93-49ac-87e8-f81273ede41e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/777eaf04-66ef-49b5-8db7-8a9470c267f0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ee346e8-cd93-49ac-87e8-f81273ede41e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7544cde2-420c-4178-8d27-0ef798e9aa81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7544cde2-420c-4178-8d27-0ef798e9aa81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/8ae9d6e1-e22d-402c-b8bc-8614e14c1ffc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7544cde2-420c-4178-8d27-0ef798e9aa81>.
+    
+<http://data.lblod.info/id/remote-data-objects/33e4cfe0-3f8b-4c37-b2d0-11cb8eea0081> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33e4cfe0-3f8b-4c37-b2d0-11cb8eea0081";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/8ae9d6e1-e22d-402c-b8bc-8614e14c1ffc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33e4cfe0-3f8b-4c37-b2d0-11cb8eea0081>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c394a2a-a3ca-4eba-abf5-b38c98d2a5e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c394a2a-a3ca-4eba-abf5-b38c98d2a5e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/8ae9d6e1-e22d-402c-b8bc-8614e14c1ffc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c394a2a-a3ca-4eba-abf5-b38c98d2a5e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/df070b89-f351-46f5-a204-665800d75dc7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df070b89-f351-46f5-a204-665800d75dc7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/a83c81e7-6b27-475d-b5eb-d95cfe2994d5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df070b89-f351-46f5-a204-665800d75dc7>.
+    
+<http://data.lblod.info/id/remote-data-objects/106b15aa-2d8d-4c72-9939-691e978fdaa3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "106b15aa-2d8d-4c72-9939-691e978fdaa3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/a83c81e7-6b27-475d-b5eb-d95cfe2994d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/106b15aa-2d8d-4c72-9939-691e978fdaa3>.
+    
+<http://data.lblod.info/id/remote-data-objects/12ebf1d4-561b-4302-af69-05f71289cc91> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12ebf1d4-561b-4302-af69-05f71289cc91";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/a83c81e7-6b27-475d-b5eb-d95cfe2994d5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12ebf1d4-561b-4302-af69-05f71289cc91>.
+    
+<http://data.lblod.info/id/remote-data-objects/c456f6b8-e299-42c0-92cc-9162738cc725> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c456f6b8-e299-42c0-92cc-9162738cc725";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/b0429ee3-726d-4403-aaad-d414329df8ab/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c456f6b8-e299-42c0-92cc-9162738cc725>.
+    
+<http://data.lblod.info/id/remote-data-objects/9945b1f1-d180-4e83-bb39-9820ba968e11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9945b1f1-d180-4e83-bb39-9820ba968e11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/b0429ee3-726d-4403-aaad-d414329df8ab/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9945b1f1-d180-4e83-bb39-9820ba968e11>.
+    
+<http://data.lblod.info/id/remote-data-objects/784c5388-5524-481e-8f4c-629fcf5accd8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "784c5388-5524-481e-8f4c-629fcf5accd8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/b0429ee3-726d-4403-aaad-d414329df8ab/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/784c5388-5524-481e-8f4c-629fcf5accd8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1cbafef-68ea-4b9d-91ea-473c64c46692> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1cbafef-68ea-4b9d-91ea-473c64c46692";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/d61783b3-6644-4cf9-9c09-e2c005472588/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1cbafef-68ea-4b9d-91ea-473c64c46692>.
+    
+<http://data.lblod.info/id/remote-data-objects/60864bd2-46bd-4975-b171-ebecd719889b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60864bd2-46bd-4975-b171-ebecd719889b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/d61783b3-6644-4cf9-9c09-e2c005472588/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/60864bd2-46bd-4975-b171-ebecd719889b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ef33fde-05a7-4959-bb15-30f97c599f06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ef33fde-05a7-4959-bb15-30f97c599f06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/d61783b3-6644-4cf9-9c09-e2c005472588/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ef33fde-05a7-4959-bb15-30f97c599f06>.
+    
+<http://data.lblod.info/id/remote-data-objects/395d9801-d6f5-4af4-96c2-b40db1f8df86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "395d9801-d6f5-4af4-96c2-b40db1f8df86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/ee579d03-b860-49cb-86d3-cf435495e466/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/395d9801-d6f5-4af4-96c2-b40db1f8df86>.
+    
+<http://data.lblod.info/id/remote-data-objects/9dd09574-b28e-4f69-8756-9a04b5748850> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dd09574-b28e-4f69-8756-9a04b5748850";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/ee579d03-b860-49cb-86d3-cf435495e466/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9dd09574-b28e-4f69-8756-9a04b5748850>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5a4cf0d-0cce-4831-9732-de7debe5f89f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5a4cf0d-0cce-4831-9732-de7debe5f89f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/ee579d03-b860-49cb-86d3-cf435495e466/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5a4cf0d-0cce-4831-9732-de7debe5f89f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a4c1d52-ce33-4501-a6b9-98e300bb0961> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a4c1d52-ce33-4501-a6b9-98e300bb0961";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/f6995ca2-7967-41f9-960b-2ef7f58c6531/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a4c1d52-ce33-4501-a6b9-98e300bb0961>.
+    
+<http://data.lblod.info/id/remote-data-objects/bfcd4581-bbd0-48de-8460-132c4d3c8554> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfcd4581-bbd0-48de-8460-132c4d3c8554";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/f6995ca2-7967-41f9-960b-2ef7f58c6531/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bfcd4581-bbd0-48de-8460-132c4d3c8554>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd539c1c-099e-4a2a-a88e-ee7769304f5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd539c1c-099e-4a2a-a88e-ee7769304f5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/gr/f6995ca2-7967-41f9-960b-2ef7f58c6531/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd539c1c-099e-4a2a-a88e-ee7769304f5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8c8f3e58-e92e-4c78-8a19-2b002abdecb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c8f3e58-e92e-4c78-8a19-2b002abdecb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/03362852-ff10-4c06-a8b2-64be9dab72bd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8c8f3e58-e92e-4c78-8a19-2b002abdecb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d3d37d2-5c19-4d3d-b1a8-cfd2e110fa24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d3d37d2-5c19-4d3d-b1a8-cfd2e110fa24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/03362852-ff10-4c06-a8b2-64be9dab72bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d3d37d2-5c19-4d3d-b1a8-cfd2e110fa24>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d32eb3f-a150-40af-816f-5922b14aae1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d32eb3f-a150-40af-816f-5922b14aae1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/03362852-ff10-4c06-a8b2-64be9dab72bd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d32eb3f-a150-40af-816f-5922b14aae1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc18a3f3-fabe-4284-9fc9-ed6976585ae6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc18a3f3-fabe-4284-9fc9-ed6976585ae6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/15c9245f-f2a1-4ec5-b7e8-85fa3c89062c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc18a3f3-fabe-4284-9fc9-ed6976585ae6>.
+    
+<http://data.lblod.info/id/remote-data-objects/518a7344-54e4-4dd4-91f5-6cbf67eb3632> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "518a7344-54e4-4dd4-91f5-6cbf67eb3632";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/15c9245f-f2a1-4ec5-b7e8-85fa3c89062c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/518a7344-54e4-4dd4-91f5-6cbf67eb3632>.
+    
+<http://data.lblod.info/id/remote-data-objects/846a5091-b075-40d6-bab4-7f03a0c53552> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "846a5091-b075-40d6-bab4-7f03a0c53552";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/15c9245f-f2a1-4ec5-b7e8-85fa3c89062c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/846a5091-b075-40d6-bab4-7f03a0c53552>.
+    
+<http://data.lblod.info/id/remote-data-objects/be2f41bb-b936-40af-afc0-81f19793005a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be2f41bb-b936-40af-afc0-81f19793005a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/27fd4ad4-3bf8-493d-8c9f-91a0f34b99b5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be2f41bb-b936-40af-afc0-81f19793005a>.
+    
+<http://data.lblod.info/id/remote-data-objects/78f77f25-65bb-4dd9-a9ba-00cd4bf87164> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78f77f25-65bb-4dd9-a9ba-00cd4bf87164";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/27fd4ad4-3bf8-493d-8c9f-91a0f34b99b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78f77f25-65bb-4dd9-a9ba-00cd4bf87164>.
+    
+<http://data.lblod.info/id/remote-data-objects/f04764fb-0eeb-4896-b17e-fa341f2e77e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f04764fb-0eeb-4896-b17e-fa341f2e77e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/27fd4ad4-3bf8-493d-8c9f-91a0f34b99b5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:36.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/03244643-75d3-455c-9401-35da5694dc5e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f04764fb-0eeb-4896-b17e-fa341f2e77e8>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201937-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201937-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201937-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201937-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/13b55f2b-df51-41fe-bc4b-fd4c10ce968e> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "13b55f2b-df51-41fe-bc4b-fd4c10ce968e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "086c1b61-7f70-4210-be39-ef10eecd2127";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/5531bc0d-079e-4b9c-b7a8-486e41690827> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "5531bc0d-079e-4b9c-b7a8-486e41690827";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127>.
+
+  <http://redpencil.data.gift/id/task/f0df9fb5-c96b-4a25-81f4-1583d95c44a3> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f0df9fb5-c96b-4a25-81f4-1583d95c44a3";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/13b55f2b-df51-41fe-bc4b-fd4c10ce968e>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/5531bc0d-079e-4b9c-b7a8-486e41690827>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5b640dd4-3568-44e8-9faa-446fdd3df8d4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b640dd4-3568-44e8-9faa-446fdd3df8d4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/32113bb0-7692-4d2a-a5e6-ba2573e9700f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b640dd4-3568-44e8-9faa-446fdd3df8d4>.
+    
+<http://data.lblod.info/id/remote-data-objects/33048508-5ea4-4487-9d3b-56b7ebb8c63f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33048508-5ea4-4487-9d3b-56b7ebb8c63f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/32113bb0-7692-4d2a-a5e6-ba2573e9700f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33048508-5ea4-4487-9d3b-56b7ebb8c63f>.
+    
+<http://data.lblod.info/id/remote-data-objects/96575713-eab3-426b-9383-1b876d91cc05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96575713-eab3-426b-9383-1b876d91cc05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/32113bb0-7692-4d2a-a5e6-ba2573e9700f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96575713-eab3-426b-9383-1b876d91cc05>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f778d6b-dfb7-48b0-b9f6-1e4cecc4d656> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f778d6b-dfb7-48b0-b9f6-1e4cecc4d656";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/34f26006-d97d-4a13-838e-f9b41a48d756/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f778d6b-dfb7-48b0-b9f6-1e4cecc4d656>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ea47391-8c83-497a-8fc2-2b585e961e0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ea47391-8c83-497a-8fc2-2b585e961e0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/34f26006-d97d-4a13-838e-f9b41a48d756/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ea47391-8c83-497a-8fc2-2b585e961e0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c0a35c3-59ea-46c8-a230-59b16c48d74b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c0a35c3-59ea-46c8-a230-59b16c48d74b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/34f26006-d97d-4a13-838e-f9b41a48d756/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c0a35c3-59ea-46c8-a230-59b16c48d74b>.
+    
+<http://data.lblod.info/id/remote-data-objects/edb5327c-88f7-48ab-a707-5c35ac33884b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edb5327c-88f7-48ab-a707-5c35ac33884b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/37a08b57-249f-491a-8da3-4eed156d2d44/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edb5327c-88f7-48ab-a707-5c35ac33884b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2efb171-ff1a-43dc-a910-cd86d1e593df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2efb171-ff1a-43dc-a910-cd86d1e593df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/37a08b57-249f-491a-8da3-4eed156d2d44/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2efb171-ff1a-43dc-a910-cd86d1e593df>.
+    
+<http://data.lblod.info/id/remote-data-objects/6def42c8-6eb8-4a24-9f77-24d8e7291c5d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6def42c8-6eb8-4a24-9f77-24d8e7291c5d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/37a08b57-249f-491a-8da3-4eed156d2d44/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6def42c8-6eb8-4a24-9f77-24d8e7291c5d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b94359ba-ba08-4184-87fd-3dcbb0214d93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b94359ba-ba08-4184-87fd-3dcbb0214d93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/4c16dd62-3194-4e03-9f10-db97f4536afb/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b94359ba-ba08-4184-87fd-3dcbb0214d93>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c0b177a-e496-4a3c-b224-165f408a49b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c0b177a-e496-4a3c-b224-165f408a49b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/4c16dd62-3194-4e03-9f10-db97f4536afb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c0b177a-e496-4a3c-b224-165f408a49b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/595b773d-81c1-4f85-bf31-4c858b48a8cf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "595b773d-81c1-4f85-bf31-4c858b48a8cf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/4c16dd62-3194-4e03-9f10-db97f4536afb/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/595b773d-81c1-4f85-bf31-4c858b48a8cf>.
+    
+<http://data.lblod.info/id/remote-data-objects/fac8101f-ba7b-464f-8d3c-70388790e640> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fac8101f-ba7b-464f-8d3c-70388790e640";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/54f6e192-a663-4f29-b2d1-ea79e4d76762/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fac8101f-ba7b-464f-8d3c-70388790e640>.
+    
+<http://data.lblod.info/id/remote-data-objects/f74f126d-e070-4a05-a23f-ceb05e57321d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f74f126d-e070-4a05-a23f-ceb05e57321d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/54f6e192-a663-4f29-b2d1-ea79e4d76762/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f74f126d-e070-4a05-a23f-ceb05e57321d>.
+    
+<http://data.lblod.info/id/remote-data-objects/875be48b-1b22-4892-a1cb-8dd23831e55b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "875be48b-1b22-4892-a1cb-8dd23831e55b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/54f6e192-a663-4f29-b2d1-ea79e4d76762/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/875be48b-1b22-4892-a1cb-8dd23831e55b>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b0d519e-513a-4496-bf14-e70962b2a46f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b0d519e-513a-4496-bf14-e70962b2a46f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/75a80ad5-73cf-46f9-8739-8f5f2995030d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b0d519e-513a-4496-bf14-e70962b2a46f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e15011f-bbea-425a-afb0-83ae358f665f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e15011f-bbea-425a-afb0-83ae358f665f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/75a80ad5-73cf-46f9-8739-8f5f2995030d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e15011f-bbea-425a-afb0-83ae358f665f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f760829-b6f9-42d6-b8b5-9380f9f0ebfa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f760829-b6f9-42d6-b8b5-9380f9f0ebfa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/77577207-829c-4832-ae23-36fb8b129912/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f760829-b6f9-42d6-b8b5-9380f9f0ebfa>.
+    
+<http://data.lblod.info/id/remote-data-objects/71fbecd2-d9ce-4b11-a15d-47f6d685b15c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71fbecd2-d9ce-4b11-a15d-47f6d685b15c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/77577207-829c-4832-ae23-36fb8b129912/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71fbecd2-d9ce-4b11-a15d-47f6d685b15c>.
+    
+<http://data.lblod.info/id/remote-data-objects/406a924b-a7a9-42b3-9ea4-c14ff23ce13f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "406a924b-a7a9-42b3-9ea4-c14ff23ce13f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/77577207-829c-4832-ae23-36fb8b129912/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/406a924b-a7a9-42b3-9ea4-c14ff23ce13f>.
+    
+<http://data.lblod.info/id/remote-data-objects/72299e42-9304-4bb5-980a-15edeac10db0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72299e42-9304-4bb5-980a-15edeac10db0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/99e7661f-557c-4fdb-9404-b3e66f1de948/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72299e42-9304-4bb5-980a-15edeac10db0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e54eb7c5-8b49-44bb-93ef-259b785626d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e54eb7c5-8b49-44bb-93ef-259b785626d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/99e7661f-557c-4fdb-9404-b3e66f1de948/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e54eb7c5-8b49-44bb-93ef-259b785626d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2232a3bd-91bd-4f16-8bd6-a896cb2be8ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2232a3bd-91bd-4f16-8bd6-a896cb2be8ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/99e7661f-557c-4fdb-9404-b3e66f1de948/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2232a3bd-91bd-4f16-8bd6-a896cb2be8ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/9844a64e-4ed8-4cfa-ad50-bf6cb73d55d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9844a64e-4ed8-4cfa-ad50-bf6cb73d55d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/a97f5522-aa40-493d-b610-e1d2b976aef8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9844a64e-4ed8-4cfa-ad50-bf6cb73d55d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/baa5b16b-c7a6-45fd-8fd1-032b71b034f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "baa5b16b-c7a6-45fd-8fd1-032b71b034f0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/a97f5522-aa40-493d-b610-e1d2b976aef8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/baa5b16b-c7a6-45fd-8fd1-032b71b034f0>.
+    
+<http://data.lblod.info/id/remote-data-objects/c16e60b3-ba49-4a1c-9497-abe9e46e5f81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c16e60b3-ba49-4a1c-9497-abe9e46e5f81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/a97f5522-aa40-493d-b610-e1d2b976aef8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c16e60b3-ba49-4a1c-9497-abe9e46e5f81>.
+    
+<http://data.lblod.info/id/remote-data-objects/598092bb-5d95-43af-be8f-7e6d8d946306> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "598092bb-5d95-43af-be8f-7e6d8d946306";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/aed3a184-d772-47cd-8652-a0c49c53f181/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/598092bb-5d95-43af-be8f-7e6d8d946306>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7570fc2-2372-486f-ab7a-1fd7a3bab93d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7570fc2-2372-486f-ab7a-1fd7a3bab93d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/aed3a184-d772-47cd-8652-a0c49c53f181/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7570fc2-2372-486f-ab7a-1fd7a3bab93d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c69848a9-0721-47c9-adb6-00602249e4a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c69848a9-0721-47c9-adb6-00602249e4a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/aed3a184-d772-47cd-8652-a0c49c53f181/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c69848a9-0721-47c9-adb6-00602249e4a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f4d7405-3f08-4746-8b42-949a70a435af> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f4d7405-3f08-4746-8b42-949a70a435af";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/af77a3ef-0eec-492e-8855-89108f02cc85/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f4d7405-3f08-4746-8b42-949a70a435af>.
+    
+<http://data.lblod.info/id/remote-data-objects/db50cb1e-2ac7-4b45-9d26-bdbf7cda72e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db50cb1e-2ac7-4b45-9d26-bdbf7cda72e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/af77a3ef-0eec-492e-8855-89108f02cc85/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db50cb1e-2ac7-4b45-9d26-bdbf7cda72e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/7fa40614-c919-426d-8677-af0beb666981> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7fa40614-c919-426d-8677-af0beb666981";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/af77a3ef-0eec-492e-8855-89108f02cc85/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7fa40614-c919-426d-8677-af0beb666981>.
+    
+<http://data.lblod.info/id/remote-data-objects/18eb8404-668c-4609-934c-e0ce2032a5b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18eb8404-668c-4609-934c-e0ce2032a5b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/dc138f6e-76ab-4787-a292-6a7da536f364/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18eb8404-668c-4609-934c-e0ce2032a5b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2e7de0e-66b5-4b0b-a530-d75508dac934> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2e7de0e-66b5-4b0b-a530-d75508dac934";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/dc138f6e-76ab-4787-a292-6a7da536f364/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2e7de0e-66b5-4b0b-a530-d75508dac934>.
+    
+<http://data.lblod.info/id/remote-data-objects/df261cf5-fe55-42e8-a095-dc118b452f17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df261cf5-fe55-42e8-a095-dc118b452f17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/rmw/dc138f6e-76ab-4787-a292-6a7da536f364/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df261cf5-fe55-42e8-a095-dc118b452f17>.
+    
+<http://data.lblod.info/id/remote-data-objects/7470675f-3498-4f47-8413-ab4c94709582> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7470675f-3498-4f47-8413-ab4c94709582";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/050a9f94-9832-4550-852f-df318de842f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7470675f-3498-4f47-8413-ab4c94709582>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cb7ad45-d868-48e7-b0f1-53ed087daf65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cb7ad45-d868-48e7-b0f1-53ed087daf65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/07a175a6-9b7a-48e6-9d0b-4857771dfac4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cb7ad45-d868-48e7-b0f1-53ed087daf65>.
+    
+<http://data.lblod.info/id/remote-data-objects/a099cd5c-6ffe-43ac-8ca0-d3f26b5ae21c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a099cd5c-6ffe-43ac-8ca0-d3f26b5ae21c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/0c0a59fb-8232-4e91-a82b-d0b5eb04d761/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a099cd5c-6ffe-43ac-8ca0-d3f26b5ae21c>.
+    
+<http://data.lblod.info/id/remote-data-objects/08730a36-429d-4a81-ad77-41192cae2133> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08730a36-429d-4a81-ad77-41192cae2133";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/13a0e1c4-fff0-473a-8e57-55b781ced8c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08730a36-429d-4a81-ad77-41192cae2133>.
+    
+<http://data.lblod.info/id/remote-data-objects/da0204c9-8a03-464e-96df-1d7b9935f0ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da0204c9-8a03-464e-96df-1d7b9935f0ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/1eb33d67-6a73-46d7-8843-3f078298053e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da0204c9-8a03-464e-96df-1d7b9935f0ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/50c7b9d7-a443-42e6-a787-377dab0254fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50c7b9d7-a443-42e6-a787-377dab0254fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/2990800e-f7dd-4619-bb12-173e3f6878cc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50c7b9d7-a443-42e6-a787-377dab0254fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb743943-9cad-4a8c-83b0-b1d0053fab45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb743943-9cad-4a8c-83b0-b1d0053fab45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/2f08c93d-d8c2-4d0e-8c6d-845ea7e880b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb743943-9cad-4a8c-83b0-b1d0053fab45>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfa17533-183b-4880-ae17-ef05727f1032> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfa17533-183b-4880-ae17-ef05727f1032";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/32085188-2eb2-44e5-a1ba-78834189c1de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfa17533-183b-4880-ae17-ef05727f1032>.
+    
+<http://data.lblod.info/id/remote-data-objects/863f5733-ded8-470b-8da8-2243f3f20fb8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "863f5733-ded8-470b-8da8-2243f3f20fb8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/346375e1-bfbd-42ea-9ed0-c1caa009d769/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/863f5733-ded8-470b-8da8-2243f3f20fb8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3530a29c-5da2-48b7-9ab7-d33d0addf313> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3530a29c-5da2-48b7-9ab7-d33d0addf313";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/370d3cea-439c-4c06-b845-338042624ce0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3530a29c-5da2-48b7-9ab7-d33d0addf313>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e24914c-5a22-44f1-bab2-e6c406a339db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e24914c-5a22-44f1-bab2-e6c406a339db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/380d7057-1420-452e-9982-b79415c3c2c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e24914c-5a22-44f1-bab2-e6c406a339db>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed423b63-8e4c-4968-af49-a21d4a7ff72f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed423b63-8e4c-4968-af49-a21d4a7ff72f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/38fb4bf6-849c-40ac-9dac-d41d6c127ccb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed423b63-8e4c-4968-af49-a21d4a7ff72f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a3ff287-6971-4c72-9ca3-80a8d0b95837> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a3ff287-6971-4c72-9ca3-80a8d0b95837";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/395520f6-f793-4ad9-b852-6f20877620f5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a3ff287-6971-4c72-9ca3-80a8d0b95837>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccfff027-0b4e-4024-a333-3043459448e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccfff027-0b4e-4024-a333-3043459448e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/3b322696-a849-42bd-99e4-fc44a9ca72a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccfff027-0b4e-4024-a333-3043459448e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/194deca4-b1b5-4d72-a281-c8aa5d649f98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "194deca4-b1b5-4d72-a281-c8aa5d649f98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/42068c14-1255-4e7f-9ce8-f7dcc49cfcb9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:37.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/086c1b61-7f70-4210-be39-ef10eecd2127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/194deca4-b1b5-4d72-a281-c8aa5d649f98>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201938-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201938-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201938-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201938-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c2958384-6640-4756-bfe9-3e45b5a1e6ff> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c2958384-6640-4756-bfe9-3e45b5a1e6ff";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ad47b685-d98a-40d0-bc39-127fa290dfae";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/df8b4880-7600-4f6c-a07d-ed084ceef027> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "df8b4880-7600-4f6c-a07d-ed084ceef027";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae>.
+
+  <http://redpencil.data.gift/id/task/be8c43ae-a29e-4ccc-a9db-5f9e5014c7df> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "be8c43ae-a29e-4ccc-a9db-5f9e5014c7df";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c2958384-6640-4756-bfe9-3e45b5a1e6ff>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/df8b4880-7600-4f6c-a07d-ed084ceef027>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/a2c15cf3-d853-417d-9110-d3a5cc4b679d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2c15cf3-d853-417d-9110-d3a5cc4b679d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/4361c143-876c-402c-935c-11de66bfaae4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2c15cf3-d853-417d-9110-d3a5cc4b679d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1353fa6-c72b-4790-afb0-e76a7aa1453a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1353fa6-c72b-4790-afb0-e76a7aa1453a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/437b34bf-b9c2-4d30-973c-399bfba63a9f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1353fa6-c72b-4790-afb0-e76a7aa1453a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4405b8ba-431f-424b-b4e8-c3734cce6177> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4405b8ba-431f-424b-b4e8-c3734cce6177";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/47065581-4d15-42fe-921c-acbba23cb673/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4405b8ba-431f-424b-b4e8-c3734cce6177>.
+    
+<http://data.lblod.info/id/remote-data-objects/48c81152-629a-4782-824a-1aaba50c3a2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48c81152-629a-4782-824a-1aaba50c3a2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/4e5798e2-90c5-4e53-b04d-dbb727de572b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48c81152-629a-4782-824a-1aaba50c3a2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e52a2c03-aeb6-4eea-9cbf-7d6aa35fc755> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e52a2c03-aeb6-4eea-9cbf-7d6aa35fc755";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/50670b1e-19e8-4cf8-8186-4c83f5a91572/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e52a2c03-aeb6-4eea-9cbf-7d6aa35fc755>.
+    
+<http://data.lblod.info/id/remote-data-objects/41f762b5-067e-4331-a857-ff9ebf26e7d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41f762b5-067e-4331-a857-ff9ebf26e7d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/5668c79b-9e46-4acc-895c-0696348ae2c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41f762b5-067e-4331-a857-ff9ebf26e7d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a6ca021-81b0-477e-b6e7-381862c4d77d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a6ca021-81b0-477e-b6e7-381862c4d77d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/5cec890b-a57f-4e6f-8b6b-ad4ee08186a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a6ca021-81b0-477e-b6e7-381862c4d77d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5da78097-b006-4161-be87-c699375dc9c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5da78097-b006-4161-be87-c699375dc9c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/641ba323-ea16-4ad4-b572-4492f855c461/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5da78097-b006-4161-be87-c699375dc9c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e56815c-74a6-4f12-9431-b6bc07fa58a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e56815c-74a6-4f12-9431-b6bc07fa58a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/6e33c50d-dc49-4e9a-a821-e5c5652db43a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e56815c-74a6-4f12-9431-b6bc07fa58a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/7144b215-d628-4f91-947a-2499d3e7ae80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7144b215-d628-4f91-947a-2499d3e7ae80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/765f1b88-f827-4458-b7cb-22ee04dfd38f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7144b215-d628-4f91-947a-2499d3e7ae80>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6397085-03a2-4e0c-a52d-90dfe4c08bbf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6397085-03a2-4e0c-a52d-90dfe4c08bbf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/77ee8e9f-f282-44e8-a314-1d9fa055e59f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6397085-03a2-4e0c-a52d-90dfe4c08bbf>.
+    
+<http://data.lblod.info/id/remote-data-objects/d28dab84-9e6c-496f-8947-924d784f1c1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d28dab84-9e6c-496f-8947-924d784f1c1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/7aad766e-6a6f-4fa2-953e-336548294f96/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d28dab84-9e6c-496f-8947-924d784f1c1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8372628-cada-46f5-a187-13988815ca3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8372628-cada-46f5-a187-13988815ca3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/7ae18dc4-c3b2-4f3b-9223-6494cf7990cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8372628-cada-46f5-a187-13988815ca3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/26f040b4-bd44-403c-82b4-748b677dad92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26f040b4-bd44-403c-82b4-748b677dad92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/7f10970b-51d4-462d-ab19-da22766ffc8e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26f040b4-bd44-403c-82b4-748b677dad92>.
+    
+<http://data.lblod.info/id/remote-data-objects/f28ae9f5-5ea1-4378-a9ad-605c9e7e3042> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f28ae9f5-5ea1-4378-a9ad-605c9e7e3042";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/80996e2d-a4a2-4f74-b21c-24aa6b92d7f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f28ae9f5-5ea1-4378-a9ad-605c9e7e3042>.
+    
+<http://data.lblod.info/id/remote-data-objects/c56ecf35-9cbe-43a9-8250-e09cb9065c68> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c56ecf35-9cbe-43a9-8250-e09cb9065c68";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/822b9a54-530a-4394-a0a5-5f77276e1a7b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c56ecf35-9cbe-43a9-8250-e09cb9065c68>.
+    
+<http://data.lblod.info/id/remote-data-objects/479547c3-dfc8-4478-9898-fe799772c8b4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "479547c3-dfc8-4478-9898-fe799772c8b4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/82c47e35-706b-48a1-8016-b3657fb31e7c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/479547c3-dfc8-4478-9898-fe799772c8b4>.
+    
+<http://data.lblod.info/id/remote-data-objects/365f0226-6fac-49d1-8604-85f485abd173> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "365f0226-6fac-49d1-8604-85f485abd173";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/85591fad-783b-4cd7-8684-d6fdef2e1a49/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/365f0226-6fac-49d1-8604-85f485abd173>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f640030-a1fa-4065-ba8d-4e6c18502935> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f640030-a1fa-4065-ba8d-4e6c18502935";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/8bad668d-47bd-4e17-987b-aa594d2de2b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f640030-a1fa-4065-ba8d-4e6c18502935>.
+    
+<http://data.lblod.info/id/remote-data-objects/1711606b-70c9-431e-b4f8-e7d7108f55ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1711606b-70c9-431e-b4f8-e7d7108f55ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/9a096ba1-bdee-4226-8074-2a1c8345d46a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1711606b-70c9-431e-b4f8-e7d7108f55ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/689f1941-843b-4ff0-a860-0951f03eaee7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "689f1941-843b-4ff0-a860-0951f03eaee7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/9d5f650e-e181-45e1-abce-85f1aa905d58/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/689f1941-843b-4ff0-a860-0951f03eaee7>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b8fe6c0-d070-4360-be38-a85bf8dd71e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b8fe6c0-d070-4360-be38-a85bf8dd71e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/9d941683-0f04-4499-a9d0-c810a053cfa0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b8fe6c0-d070-4360-be38-a85bf8dd71e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/a94ed5e7-f3d0-44b7-9a7b-bef15d85ce8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a94ed5e7-f3d0-44b7-9a7b-bef15d85ce8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/9e1d780d-984a-4580-8fa0-c26099e0982a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a94ed5e7-f3d0-44b7-9a7b-bef15d85ce8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2c4f544-b107-4780-b107-cc35e22bddd2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2c4f544-b107-4780-b107-cc35e22bddd2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/a3d09c1e-97e1-4391-995a-4068491b13f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2c4f544-b107-4780-b107-cc35e22bddd2>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba6a25e2-b89f-4d37-b0d4-a9d084e4bfaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba6a25e2-b89f-4d37-b0d4-a9d084e4bfaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/a454b05c-3313-4d30-bf01-04992ec9e2a0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba6a25e2-b89f-4d37-b0d4-a9d084e4bfaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/15d1fe81-4d77-4e21-af3e-eb3e7d0c70ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15d1fe81-4d77-4e21-af3e-eb3e7d0c70ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/a66dea2c-f934-4803-9a66-9b2d4fbd3c2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/15d1fe81-4d77-4e21-af3e-eb3e7d0c70ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/b50d1597-0ca6-452b-890a-f06f20ea69a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b50d1597-0ca6-452b-890a-f06f20ea69a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/accf0911-6d15-49f7-849a-35a08aed100d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b50d1597-0ca6-452b-890a-f06f20ea69a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2e2517f-5c58-4458-93b3-cfe9532fc29b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2e2517f-5c58-4458-93b3-cfe9532fc29b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/af97985f-a3cf-4f16-a12a-ac2d10f8c4d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2e2517f-5c58-4458-93b3-cfe9532fc29b>.
+    
+<http://data.lblod.info/id/remote-data-objects/16a51f24-b0fb-4c75-aaf2-00d67bbccf8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16a51f24-b0fb-4c75-aaf2-00d67bbccf8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/b336abf7-56a5-4776-a64f-d4d5b4a26d6e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16a51f24-b0fb-4c75-aaf2-00d67bbccf8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/12423895-cb79-4552-b1c5-0e87145d9e7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12423895-cb79-4552-b1c5-0e87145d9e7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/b4382a46-16f1-4f4a-aae6-9314b39cd976/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12423895-cb79-4552-b1c5-0e87145d9e7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd5c2ce5-af98-43b3-9833-f107c08df2a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd5c2ce5-af98-43b3-9833-f107c08df2a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/b6395d4e-f784-4136-a0ad-d7015f207659/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd5c2ce5-af98-43b3-9833-f107c08df2a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f1575d6-7c9c-4bd8-a9d8-48ba634b4a10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f1575d6-7c9c-4bd8-a9d8-48ba634b4a10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/b6ac6c59-1488-4ac2-8261-95be6bbce10e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f1575d6-7c9c-4bd8-a9d8-48ba634b4a10>.
+    
+<http://data.lblod.info/id/remote-data-objects/b51ea295-1000-4a5d-a032-c0a7ba191bb7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b51ea295-1000-4a5d-a032-c0a7ba191bb7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/b96a322d-6675-4b9a-a25d-a1bd108a3a51/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b51ea295-1000-4a5d-a032-c0a7ba191bb7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7663b232-fa9e-4fd9-90be-20d925ade35e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7663b232-fa9e-4fd9-90be-20d925ade35e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/b9c322b6-66dc-4d72-a3d3-009e62c126f5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7663b232-fa9e-4fd9-90be-20d925ade35e>.
+    
+<http://data.lblod.info/id/remote-data-objects/bea021f0-968c-455d-9f5c-1ea4d213423d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bea021f0-968c-455d-9f5c-1ea4d213423d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/c8c2222e-b8fe-4f23-8e0a-6c5f391e38c2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bea021f0-968c-455d-9f5c-1ea4d213423d>.
+    
+<http://data.lblod.info/id/remote-data-objects/063e2a89-cea3-4a48-b271-773c1d49ac64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "063e2a89-cea3-4a48-b271-773c1d49ac64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/c945de9c-25a6-4bdf-b0d5-8d92bbfc5753/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/063e2a89-cea3-4a48-b271-773c1d49ac64>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2ea9abf-421c-4fc8-a358-caf6141d26dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2ea9abf-421c-4fc8-a358-caf6141d26dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/cac08814-16db-4a8d-ba7e-875aeef401b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2ea9abf-421c-4fc8-a358-caf6141d26dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2569f28-75c5-4f52-8521-401a80538c88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2569f28-75c5-4f52-8521-401a80538c88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/cf571b7c-0a79-49ee-8546-c302bf1e3e4c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2569f28-75c5-4f52-8521-401a80538c88>.
+    
+<http://data.lblod.info/id/remote-data-objects/950fd12c-cd4a-4fa6-a258-cf9541fff526> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "950fd12c-cd4a-4fa6-a258-cf9541fff526";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/d004928e-d2e4-49c7-9ad3-62f9e8736e7f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/950fd12c-cd4a-4fa6-a258-cf9541fff526>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd2059f3-aeed-4e45-8675-a1e02b42c816> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd2059f3-aeed-4e45-8675-a1e02b42c816";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/d85ea24a-f808-4954-ab57-6516760bb1d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd2059f3-aeed-4e45-8675-a1e02b42c816>.
+    
+<http://data.lblod.info/id/remote-data-objects/db0cf428-e259-4fda-a9fd-1aa423f6d966> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db0cf428-e259-4fda-a9fd-1aa423f6d966";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/db5d35f1-b603-428f-8220-60928fbee183/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db0cf428-e259-4fda-a9fd-1aa423f6d966>.
+    
+<http://data.lblod.info/id/remote-data-objects/9baed0c2-db5d-4f26-acd4-f8ec4d792ab6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9baed0c2-db5d-4f26-acd4-f8ec4d792ab6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/db6b0724-4f8b-4bef-85a4-2e929b9eaf5c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9baed0c2-db5d-4f26-acd4-f8ec4d792ab6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a9264eb-5242-4b52-a21a-f1e977acf1a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a9264eb-5242-4b52-a21a-f1e977acf1a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/e3c4608f-3a3f-4775-8016-39dce8f3e9b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a9264eb-5242-4b52-a21a-f1e977acf1a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/d13d4148-c4fd-465e-a01f-f2670d94fdb9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d13d4148-c4fd-465e-a01f-f2670d94fdb9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/e6cfbf2a-0330-4d27-821e-535929c5a6ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d13d4148-c4fd-465e-a01f-f2670d94fdb9>.
+    
+<http://data.lblod.info/id/remote-data-objects/13324aca-08f7-4545-b42a-d5ae8f9f9ff0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13324aca-08f7-4545-b42a-d5ae8f9f9ff0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/e6f1d855-a2f4-44e3-a009-ff222538e4a4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13324aca-08f7-4545-b42a-d5ae8f9f9ff0>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ae9a238-bedf-45ba-9f13-c595116de7a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ae9a238-bedf-45ba-9f13-c595116de7a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/e936c908-7701-4abd-b302-d9c08867f20b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ae9a238-bedf-45ba-9f13-c595116de7a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/156185fd-71ed-4ca6-b8e6-b3d6c478005b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "156185fd-71ed-4ca6-b8e6-b3d6c478005b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/e9dc14f1-5323-4f42-b750-035c1468d198/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/156185fd-71ed-4ca6-b8e6-b3d6c478005b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d1ba2b9-88c0-4ed7-8e5c-b3707748ae0c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d1ba2b9-88c0-4ed7-8e5c-b3707748ae0c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/ebe9a94d-545c-42ba-8d5d-c19b02e8b2f0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d1ba2b9-88c0-4ed7-8e5c-b3707748ae0c>.
+    
+<http://data.lblod.info/id/remote-data-objects/da7d47c4-9162-4526-8738-3b5abaf35afd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da7d47c4-9162-4526-8738-3b5abaf35afd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/f0662adc-5af8-4184-817d-f3919d71931a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da7d47c4-9162-4526-8738-3b5abaf35afd>.
+    
+<http://data.lblod.info/id/remote-data-objects/748cb16d-fa59-40b9-85f9-206f434061ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "748cb16d-fa59-40b9-85f9-206f434061ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/f137aa2c-c675-4c16-adac-a5b0b3804076/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:38.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ad47b685-d98a-40d0-bc39-127fa290dfae> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/748cb16d-fa59-40b9-85f9-206f434061ac>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201940-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201940-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201940-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201940-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/cf9784c2-1a41-4fbf-a70e-9d3f92ecd242> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cf9784c2-1a41-4fbf-a70e-9d3f92ecd242";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d0d107a3-c855-4fcf-9297-0cebce8b96ab";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/8be2cc07-8b38-4138-96a1-702ad0967605> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8be2cc07-8b38-4138-96a1-702ad0967605";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab>.
+
+  <http://redpencil.data.gift/id/task/2d60f5a4-86dd-4c79-9196-8df66390c7f8> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2d60f5a4-86dd-4c79-9196-8df66390c7f8";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/cf9784c2-1a41-4fbf-a70e-9d3f92ecd242>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/8be2cc07-8b38-4138-96a1-702ad0967605>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e7a3ac66-3289-4702-9166-83d00a26772c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7a3ac66-3289-4702-9166-83d00a26772c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/f5828841-56f2-49c8-87fe-4f8ccd94789d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7a3ac66-3289-4702-9166-83d00a26772c>.
+    
+<http://data.lblod.info/id/remote-data-objects/67b47b7b-a6dc-4fa7-b51e-6f4e4c552ff0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67b47b7b-a6dc-4fa7-b51e-6f4e4c552ff0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/f7f5d790-21b3-4e41-bcc3-6b903e4c1935/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67b47b7b-a6dc-4fa7-b51e-6f4e4c552ff0>.
+    
+<http://data.lblod.info/id/remote-data-objects/07732310-1ca3-4663-8c79-4c8e12bb9e17> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "07732310-1ca3-4663-8c79-4c8e12bb9e17";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/f94b39fd-9079-4f0d-9c43-c91f77d4e79a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/07732310-1ca3-4663-8c79-4c8e12bb9e17>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b4b9a22-475d-4c67-9a6f-4056ce9558d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b4b9a22-475d-4c67-9a6f-4056ce9558d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://schoten.meetingburger.net/vabu/f99eaa55-2f5e-44d1-bb9c-4d2aee23e4fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b4b9a22-475d-4c67-9a6f-4056ce9558d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0dd015d-c25c-4a8b-9cc3-094394edd74b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0dd015d-c25c-4a8b-9cc3-094394edd74b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/burgemeesterbesluiten/253338f0-e472-4cfb-8b54-132620c96ca4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0dd015d-c25c-4a8b-9cc3-094394edd74b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ca852135-45b8-4082-9d68-ae8736624219> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca852135-45b8-4082-9d68-ae8736624219";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/burgemeesterbesluiten/2af1660e-7ef6-4bd2-91aa-69a40772dc03/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ca852135-45b8-4082-9d68-ae8736624219>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9d6c1ed-73be-44d0-91b7-6c5a99ee31d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9d6c1ed-73be-44d0-91b7-6c5a99ee31d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/burgemeesterbesluiten/5df86183-664a-4e40-bf50-b606bad45331/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9d6c1ed-73be-44d0-91b7-6c5a99ee31d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/90705a89-ed1d-4aa4-aed3-6e442137e83f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90705a89-ed1d-4aa4-aed3-6e442137e83f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/burgemeesterbesluiten/75d0acca-01a8-42f1-a7f7-04634f61489a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90705a89-ed1d-4aa4-aed3-6e442137e83f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a95880de-2929-4e37-83ef-ff2dbd36153f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a95880de-2929-4e37-83ef-ff2dbd36153f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/burgemeesterbesluiten/7d15d15a-b298-4ae0-be62-013ce02bf041/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a95880de-2929-4e37-83ef-ff2dbd36153f>.
+    
+<http://data.lblod.info/id/remote-data-objects/41211598-a3e9-4e46-87f1-8b097ec4656c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41211598-a3e9-4e46-87f1-8b097ec4656c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/burgemeesterbesluiten/92971d86-cb94-4d81-9968-2f07edc3dc8e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41211598-a3e9-4e46-87f1-8b097ec4656c>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb42810f-a3bb-4be1-a9b4-99c1902739fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb42810f-a3bb-4be1-a9b4-99c1902739fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/burgemeesterbesluiten/a0bdfd57-7591-41c6-bdfd-912c02f8db53/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb42810f-a3bb-4be1-a9b4-99c1902739fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f77c7b3f-c48f-4e48-9d70-a2540840f76f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f77c7b3f-c48f-4e48-9d70-a2540840f76f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/burgemeesterbesluiten/a7592d98-b5ab-4d7e-9b4e-34aca797ab8a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f77c7b3f-c48f-4e48-9d70-a2540840f76f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e3bea5b-37f1-4091-9fc5-f1aadb5cdbad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e3bea5b-37f1-4091-9fc5-f1aadb5cdbad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/burgemeesterbesluiten/aba67b89-56b1-4b90-a964-b4c26f6e32d8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e3bea5b-37f1-4091-9fc5-f1aadb5cdbad>.
+    
+<http://data.lblod.info/id/remote-data-objects/90b471e0-86f0-496d-8db4-37612fb6760d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90b471e0-86f0-496d-8db4-37612fb6760d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/burgemeesterbesluiten/b20beca1-b36a-4b2d-aa83-3df380249bfd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90b471e0-86f0-496d-8db4-37612fb6760d>.
+    
+<http://data.lblod.info/id/remote-data-objects/066f80ab-4c4e-402c-aa42-893b7ea368d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "066f80ab-4c4e-402c-aa42-893b7ea368d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/burgemeesterbesluiten/b8717761-8bac-43e6-a6cd-0200cce51efb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/066f80ab-4c4e-402c-aa42-893b7ea368d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/67f0df2c-bc0b-4146-a05e-02e9bd6caf0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67f0df2c-bc0b-4146-a05e-02e9bd6caf0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/burgemeesterbesluiten/cd0caab8-20db-463b-9733-a9d505d3f752/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67f0df2c-bc0b-4146-a05e-02e9bd6caf0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b6d6398-9caf-4b3b-b09a-8436a807b5a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b6d6398-9caf-4b3b-b09a-8436a807b5a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/burgemeesterbesluiten/d52bd969-982b-4f6a-a60e-74eed62bf816/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b6d6398-9caf-4b3b-b09a-8436a807b5a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/807192e9-bd15-47d2-8c37-b647844391c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "807192e9-bd15-47d2-8c37-b647844391c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/burgemeesterbesluiten/ddc11129-df32-4858-9e26-f10f0c60b5a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/807192e9-bd15-47d2-8c37-b647844391c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d32a272-d21c-4486-942d-2c59550f0861> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d32a272-d21c-4486-942d-2c59550f0861";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/burgemeesterbesluiten/e4d64c08-e6d2-4b13-86ed-b0278ce89bd1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d32a272-d21c-4486-942d-2c59550f0861>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c059988-eba0-4fe7-b6ab-ba305cb38613> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c059988-eba0-4fe7-b6ab-ba305cb38613";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/079d3481-5283-4070-a021-82411716a339/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c059988-eba0-4fe7-b6ab-ba305cb38613>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a52945a-c954-4397-8c48-55cbcfe4aad2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a52945a-c954-4397-8c48-55cbcfe4aad2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/0c44c46d-109a-42cd-920d-57283fa1f330/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a52945a-c954-4397-8c48-55cbcfe4aad2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b27c4a3-161e-4a18-aa14-b076302998a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b27c4a3-161e-4a18-aa14-b076302998a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/0f056cdd-f0c0-4694-b91d-baf5425f7d36/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b27c4a3-161e-4a18-aa14-b076302998a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/85403c16-6301-4d34-9a2e-ac9401c2973d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "85403c16-6301-4d34-9a2e-ac9401c2973d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/1062e902-2563-44f8-8cfe-35289e1213ce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/85403c16-6301-4d34-9a2e-ac9401c2973d>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdd1c5e8-d33c-4676-a767-de623a58d681> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdd1c5e8-d33c-4676-a767-de623a58d681";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/1796aea9-0b84-4e75-a58b-393334209f0a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdd1c5e8-d33c-4676-a767-de623a58d681>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b36128a-6b18-40ed-9ae6-87d6ef2ebf71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b36128a-6b18-40ed-9ae6-87d6ef2ebf71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/1cd86fa0-6cc7-476a-bcb4-056bf103dba6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b36128a-6b18-40ed-9ae6-87d6ef2ebf71>.
+    
+<http://data.lblod.info/id/remote-data-objects/42376dcb-5969-4a59-9959-eda8419cc189> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42376dcb-5969-4a59-9959-eda8419cc189";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/1d35e714-e5aa-4f7e-ac56-c22ac1865143/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42376dcb-5969-4a59-9959-eda8419cc189>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec95d5b6-9acd-4dce-902b-6e3234293ee6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec95d5b6-9acd-4dce-902b-6e3234293ee6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/28be3840-88b0-4fde-abae-2f6c8412be87/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec95d5b6-9acd-4dce-902b-6e3234293ee6>.
+    
+<http://data.lblod.info/id/remote-data-objects/398a94c5-fb61-4476-b585-72a3896a2328> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "398a94c5-fb61-4476-b585-72a3896a2328";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/296bb8c2-c489-47f9-91b7-6bd4d9d83071/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/398a94c5-fb61-4476-b585-72a3896a2328>.
+    
+<http://data.lblod.info/id/remote-data-objects/141a8338-a771-4a68-951f-131ac18e095b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "141a8338-a771-4a68-951f-131ac18e095b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/2988f368-72dc-4dd9-803f-732d554aadfb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/141a8338-a771-4a68-951f-131ac18e095b>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ecda6d1-31fb-40ee-8053-e351f84d44f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ecda6d1-31fb-40ee-8053-e351f84d44f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/2e6aba0d-d506-472e-b80b-9c000dbfea68/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ecda6d1-31fb-40ee-8053-e351f84d44f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/1083a80c-d214-415d-9f74-8b89aed2305f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1083a80c-d214-415d-9f74-8b89aed2305f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/30437502-f79c-42a6-9917-ccbad22287d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1083a80c-d214-415d-9f74-8b89aed2305f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c588c037-b21d-4902-9e82-0c4a9460e6fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c588c037-b21d-4902-9e82-0c4a9460e6fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/34aa90d9-8f03-437e-aa50-3c557e27cfd3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c588c037-b21d-4902-9e82-0c4a9460e6fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d89e385-be5f-42d3-b766-5e4dede43768> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d89e385-be5f-42d3-b766-5e4dede43768";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/36b5f914-1eb5-4882-b532-f5aae472946e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d89e385-be5f-42d3-b766-5e4dede43768>.
+    
+<http://data.lblod.info/id/remote-data-objects/597a277b-29a7-486f-b21e-b2cce255d6e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "597a277b-29a7-486f-b21e-b2cce255d6e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/3b3fcfe9-c1cb-4315-b78f-e2c0f3395872/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/597a277b-29a7-486f-b21e-b2cce255d6e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/639c448f-4727-4991-b96e-40adf0ae8a30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "639c448f-4727-4991-b96e-40adf0ae8a30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/3d214963-eeba-42e2-a125-b60c04754d28/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/639c448f-4727-4991-b96e-40adf0ae8a30>.
+    
+<http://data.lblod.info/id/remote-data-objects/e124add9-2abc-4cc5-8c37-efd05fd6fb8c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e124add9-2abc-4cc5-8c37-efd05fd6fb8c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/45d800b9-41c6-4e94-bcde-1917c43bd802/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e124add9-2abc-4cc5-8c37-efd05fd6fb8c>.
+    
+<http://data.lblod.info/id/remote-data-objects/906df5a3-76cf-4ae4-bad5-67a904ab7920> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "906df5a3-76cf-4ae4-bad5-67a904ab7920";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/49f6f2b0-3408-4a94-93b4-91c5cfb28308/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/906df5a3-76cf-4ae4-bad5-67a904ab7920>.
+    
+<http://data.lblod.info/id/remote-data-objects/aad25710-08b8-4ecc-8cdb-b49f33aa5545> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aad25710-08b8-4ecc-8cdb-b49f33aa5545";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/4ada6097-ba14-4f79-950f-13bc7fef5160/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aad25710-08b8-4ecc-8cdb-b49f33aa5545>.
+    
+<http://data.lblod.info/id/remote-data-objects/d14c7288-3716-4bbc-afa1-a1f65991eb5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d14c7288-3716-4bbc-afa1-a1f65991eb5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/5e9cfe50-acbb-4747-86d8-f5ba68465a8d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d14c7288-3716-4bbc-afa1-a1f65991eb5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7f7ccf8-b21e-4537-8ff1-ef288ba7b7a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7f7ccf8-b21e-4537-8ff1-ef288ba7b7a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/6157ae81-8041-46a6-87aa-aa27c8913c3d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7f7ccf8-b21e-4537-8ff1-ef288ba7b7a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f5cd0f5-f4d5-46dd-8590-00f741e4798d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f5cd0f5-f4d5-46dd-8590-00f741e4798d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/64bf11d1-d629-4df7-9781-28bf23ca7b59/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f5cd0f5-f4d5-46dd-8590-00f741e4798d>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fa8c8a4-9816-48f8-992b-e419ae97ea27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fa8c8a4-9816-48f8-992b-e419ae97ea27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/65e5c948-1604-4fe2-8de0-5fcfb4a75d7c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fa8c8a4-9816-48f8-992b-e419ae97ea27>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce1a43f2-4a71-42d4-a5fb-f0297483e299> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce1a43f2-4a71-42d4-a5fb-f0297483e299";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/66c62630-0af5-4acd-9f16-b1c30daacc7f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce1a43f2-4a71-42d4-a5fb-f0297483e299>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b417401-26f4-487a-bbb9-0ab30ccc799e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b417401-26f4-487a-bbb9-0ab30ccc799e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/6b2e780d-4223-4ec3-a58c-ed8bf37a7f18/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b417401-26f4-487a-bbb9-0ab30ccc799e>.
+    
+<http://data.lblod.info/id/remote-data-objects/88b47bc7-a211-4b61-8722-de7dd01c6229> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88b47bc7-a211-4b61-8722-de7dd01c6229";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/7235a46e-1b5b-4f24-a8b1-98a552750b74/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88b47bc7-a211-4b61-8722-de7dd01c6229>.
+    
+<http://data.lblod.info/id/remote-data-objects/99c3a7dd-9ce4-44e0-9ce7-92885ebcc2db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99c3a7dd-9ce4-44e0-9ce7-92885ebcc2db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/779d78b9-1877-4135-a82f-52b84649984a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99c3a7dd-9ce4-44e0-9ce7-92885ebcc2db>.
+    
+<http://data.lblod.info/id/remote-data-objects/8d38d0b2-07de-467b-87fb-6c0929af58ac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d38d0b2-07de-467b-87fb-6c0929af58ac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/77e5d7a0-9ad7-492f-8a19-e63470c5d93e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8d38d0b2-07de-467b-87fb-6c0929af58ac>.
+    
+<http://data.lblod.info/id/remote-data-objects/27e68391-3213-47a0-baa2-d54f257e471e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27e68391-3213-47a0-baa2-d54f257e471e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/77f2dbdb-a4db-4987-9955-85d08a657261/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27e68391-3213-47a0-baa2-d54f257e471e>.
+    
+<http://data.lblod.info/id/remote-data-objects/70e84387-e140-43be-97d7-c80c2925e117> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70e84387-e140-43be-97d7-c80c2925e117";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/798ccf8e-b3a6-42cf-bd66-dd7fff6f3578/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70e84387-e140-43be-97d7-c80c2925e117>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cdf4fba-a874-4078-beb5-9c8d4752b865> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cdf4fba-a874-4078-beb5-9c8d4752b865";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/7b950111-8a84-452c-8be7-02114a483e60/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:40.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/d0d107a3-c855-4fcf-9297-0cebce8b96ab> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cdf4fba-a874-4078-beb5-9c8d4752b865>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201941-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201941-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201941-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201941-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/6fd3913a-553c-4e85-9186-7a49ea9be6ce> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6fd3913a-553c-4e85-9186-7a49ea9be6ce";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "171d3a30-4040-4162-81ca-b7a6bb728c58";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9e9cd6a9-6516-4da5-a65c-e67c9092cf21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9e9cd6a9-6516-4da5-a65c-e67c9092cf21";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58>.
+
+  <http://redpencil.data.gift/id/task/53c8e496-695e-4745-978f-5d76c951667b> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "53c8e496-695e-4745-978f-5d76c951667b";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/6fd3913a-553c-4e85-9186-7a49ea9be6ce>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9e9cd6a9-6516-4da5-a65c-e67c9092cf21>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7ca0ef83-4a44-4f59-9a97-aa5681a2aa96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ca0ef83-4a44-4f59-9a97-aa5681a2aa96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/7eb225fd-35db-4274-933e-61be0ed3eab8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ca0ef83-4a44-4f59-9a97-aa5681a2aa96>.
+    
+<http://data.lblod.info/id/remote-data-objects/794f1374-fe61-4e63-ade9-b153cc5eea87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "794f1374-fe61-4e63-ade9-b153cc5eea87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/84b52c42-2698-4cfc-bb8a-e20bf913501d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/794f1374-fe61-4e63-ade9-b153cc5eea87>.
+    
+<http://data.lblod.info/id/remote-data-objects/6db8d416-46db-4e93-8713-48522cc3cafe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6db8d416-46db-4e93-8713-48522cc3cafe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/8b8c2905-35ab-429a-91d4-9e057da4abba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6db8d416-46db-4e93-8713-48522cc3cafe>.
+    
+<http://data.lblod.info/id/remote-data-objects/33953510-7e2b-40f2-bbd7-07e5af5d38ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33953510-7e2b-40f2-bbd7-07e5af5d38ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/8d28f688-d776-4176-9b49-dfff9f74ac81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33953510-7e2b-40f2-bbd7-07e5af5d38ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/4875426e-6442-4728-8e7d-63a381f2a77f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4875426e-6442-4728-8e7d-63a381f2a77f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/8e4a0c20-1426-439b-95a8-490364ea0abd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4875426e-6442-4728-8e7d-63a381f2a77f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c66c859e-42d0-4030-9715-386483f335ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c66c859e-42d0-4030-9715-386483f335ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/91369051-3251-45a2-adbe-14064f518979/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c66c859e-42d0-4030-9715-386483f335ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7ffb57d-232d-41cd-91dd-adf0f16de12b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7ffb57d-232d-41cd-91dd-adf0f16de12b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/94bfd36d-61f6-47af-a5ef-64bb9576d82a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7ffb57d-232d-41cd-91dd-adf0f16de12b>.
+    
+<http://data.lblod.info/id/remote-data-objects/04c01423-dde9-4375-ab8f-6c077650e659> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04c01423-dde9-4375-ab8f-6c077650e659";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/9785a6f1-04df-444f-8c92-f3f41a889751/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04c01423-dde9-4375-ab8f-6c077650e659>.
+    
+<http://data.lblod.info/id/remote-data-objects/0351638c-b34c-4207-b4c0-e864b2d54987> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0351638c-b34c-4207-b4c0-e864b2d54987";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/a0e94293-0901-4f09-9cb4-5d4d2ba09870/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0351638c-b34c-4207-b4c0-e864b2d54987>.
+    
+<http://data.lblod.info/id/remote-data-objects/71c541cc-0436-4df5-b887-fb3fe0b7903f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71c541cc-0436-4df5-b887-fb3fe0b7903f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/ad092354-8066-4219-b150-0133a2f5d20a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71c541cc-0436-4df5-b887-fb3fe0b7903f>.
+    
+<http://data.lblod.info/id/remote-data-objects/33b5ae7d-9b20-4038-a132-03a14ad3a748> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33b5ae7d-9b20-4038-a132-03a14ad3a748";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/b033d964-e5a3-431e-b2ed-403040fc859e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33b5ae7d-9b20-4038-a132-03a14ad3a748>.
+    
+<http://data.lblod.info/id/remote-data-objects/64fd5028-a5fc-4883-88c8-6ba42674de9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64fd5028-a5fc-4883-88c8-6ba42674de9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/b6bd8d7d-d8ca-4d08-a877-5db65109a294/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64fd5028-a5fc-4883-88c8-6ba42674de9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/71b884a5-b2a6-4f53-a8f8-f92b5d78ee45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71b884a5-b2a6-4f53-a8f8-f92b5d78ee45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/b8541785-cafa-419b-ae53-15169bd79700/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71b884a5-b2a6-4f53-a8f8-f92b5d78ee45>.
+    
+<http://data.lblod.info/id/remote-data-objects/1da39caa-c069-4cfa-bddf-8940acc6fa3c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1da39caa-c069-4cfa-bddf-8940acc6fa3c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/b991a799-789a-4ffd-b110-a088a6f7c588/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1da39caa-c069-4cfa-bddf-8940acc6fa3c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e757574-7937-4291-a8bc-dafad3a152dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e757574-7937-4291-a8bc-dafad3a152dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/be5916dc-6613-4ad1-8f1e-0fdc38d6acf8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e757574-7937-4291-a8bc-dafad3a152dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/a39858ec-b7f1-4a4a-b111-8da754b6ef43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a39858ec-b7f1-4a4a-b111-8da754b6ef43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/c17e8bf0-205e-4e04-b941-370b76b174b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a39858ec-b7f1-4a4a-b111-8da754b6ef43>.
+    
+<http://data.lblod.info/id/remote-data-objects/f57e53f9-3179-4aad-850e-8342a41cfd6f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f57e53f9-3179-4aad-850e-8342a41cfd6f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/ceab5488-d115-4a41-b4d2-3d2a24b3425c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f57e53f9-3179-4aad-850e-8342a41cfd6f>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e451f0f-ed74-4b0f-8b22-4cc8eb2a22e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e451f0f-ed74-4b0f-8b22-4cc8eb2a22e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/d1fe289d-752f-4c46-8dc0-981e15187b86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e451f0f-ed74-4b0f-8b22-4cc8eb2a22e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/92000a6f-cae3-44fd-bb1c-58dd5f93a158> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92000a6f-cae3-44fd-bb1c-58dd5f93a158";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/d8a951f8-575a-43e7-b663-96c7651ef3ca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92000a6f-cae3-44fd-bb1c-58dd5f93a158>.
+    
+<http://data.lblod.info/id/remote-data-objects/469c5ce4-c96b-418a-8a29-e521731bcdf7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "469c5ce4-c96b-418a-8a29-e521731bcdf7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/da336da8-c9e9-4238-bf71-c043705d8ae1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/469c5ce4-c96b-418a-8a29-e521731bcdf7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0dfa120-f640-4c87-90ac-631f5f581e43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0dfa120-f640-4c87-90ac-631f5f581e43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/db852fda-b130-4da3-bae9-5ba28000625e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0dfa120-f640-4c87-90ac-631f5f581e43>.
+    
+<http://data.lblod.info/id/remote-data-objects/dab29777-7eba-49c5-a218-bc76f18e363a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dab29777-7eba-49c5-a218-bc76f18e363a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/df6a57ce-3861-4eee-97f3-4fa0dadd5e42/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dab29777-7eba-49c5-a218-bc76f18e363a>.
+    
+<http://data.lblod.info/id/remote-data-objects/366c6e4d-935e-4cd4-ae68-d09867f19b80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "366c6e4d-935e-4cd4-ae68-d09867f19b80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/df7fecd4-6aca-4807-a348-108a3d223ea2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/366c6e4d-935e-4cd4-ae68-d09867f19b80>.
+    
+<http://data.lblod.info/id/remote-data-objects/c231556a-021e-45cf-a2e1-062f76db17f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c231556a-021e-45cf-a2e1-062f76db17f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/e44d02c9-a0e1-49bb-b52f-b1dfb0d77220/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c231556a-021e-45cf-a2e1-062f76db17f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/34c2b707-bf6b-4c5a-a09b-09f4d9d8fa80> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34c2b707-bf6b-4c5a-a09b-09f4d9d8fa80";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/e50cbb54-9fc0-48b2-b93c-4c877a5f3483/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34c2b707-bf6b-4c5a-a09b-09f4d9d8fa80>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cfce13c-3275-485f-8afd-d6f8e5681810> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cfce13c-3275-485f-8afd-d6f8e5681810";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/e8b14b11-107b-4bcd-a4d6-43156442eb06/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cfce13c-3275-485f-8afd-d6f8e5681810>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b30fa71-0cb1-4094-8f29-50cb704bb1e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b30fa71-0cb1-4094-8f29-50cb704bb1e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/e8ccf148-68ec-40c5-80af-33b73a262f40/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b30fa71-0cb1-4094-8f29-50cb704bb1e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f8446b5-3623-47e6-b031-26ab1bafa44e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f8446b5-3623-47e6-b031-26ab1bafa44e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/e9a3590f-9e92-4a37-bf7a-f822da26727f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f8446b5-3623-47e6-b031-26ab1bafa44e>.
+    
+<http://data.lblod.info/id/remote-data-objects/eae9238e-360b-467e-9701-eb12ed765e9c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eae9238e-360b-467e-9701-eb12ed765e9c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/ee1d0f0f-7fcd-4725-b5a8-ce8c839bd577/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eae9238e-360b-467e-9701-eb12ed765e9c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2beed470-6a78-4f5e-ac01-02b5d7a0ee3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2beed470-6a78-4f5e-ac01-02b5d7a0ee3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/ef902eb9-b36c-499e-b9a2-d9e94cc23906/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2beed470-6a78-4f5e-ac01-02b5d7a0ee3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f78e65fa-157b-49db-9f9c-8acb570cccf6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f78e65fa-157b-49db-9f9c-8acb570cccf6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/f5b22532-b96c-483e-8953-3068ff613211/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f78e65fa-157b-49db-9f9c-8acb570cccf6>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b4a5916-5c34-4638-948b-dbe517958ad2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b4a5916-5c34-4638-948b-dbe517958ad2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/f8583244-ac84-4680-9c2d-7008c810f276/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b4a5916-5c34-4638-948b-dbe517958ad2>.
+    
+<http://data.lblod.info/id/remote-data-objects/9cbd94d6-c842-445f-aaaf-874395e2c1b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cbd94d6-c842-445f-aaaf-874395e2c1b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/fa219c57-a06b-4098-a261-6a9a334e9003/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9cbd94d6-c842-445f-aaaf-874395e2c1b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/29e784f9-93da-447f-b31e-1bcc87e9bbdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29e784f9-93da-447f-b31e-1bcc87e9bbdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/fa4fb07a-8e0d-4371-82d8-f3647c715096/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29e784f9-93da-447f-b31e-1bcc87e9bbdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d91b417d-d47a-4e86-b2fd-98d8173af932> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d91b417d-d47a-4e86-b2fd-98d8173af932";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/fab08042-e2f8-498d-a0f1-110e1952db57/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d91b417d-d47a-4e86-b2fd-98d8173af932>.
+    
+<http://data.lblod.info/id/remote-data-objects/94188d16-d9d5-4574-a048-84542afdacf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94188d16-d9d5-4574-a048-84542afdacf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/fc3289ad-2252-4abb-a40a-ace0d0372962/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94188d16-d9d5-4574-a048-84542afdacf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/040e6fd2-82c0-46db-b654-5b93d51aeb93> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "040e6fd2-82c0-46db-b654-5b93d51aeb93";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/cbs/feb80a77-0336-4355-bcb7-3103cea135fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/040e6fd2-82c0-46db-b654-5b93d51aeb93>.
+    
+<http://data.lblod.info/id/remote-data-objects/649f22b1-1c23-4fa2-92c2-acfb75411799> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "649f22b1-1c23-4fa2-92c2-acfb75411799";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/05f05f4b-9e02-4ffc-99c2-bcf86f010e53/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/649f22b1-1c23-4fa2-92c2-acfb75411799>.
+    
+<http://data.lblod.info/id/remote-data-objects/16a1c5c3-b7c2-4def-b162-0f04b792571b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16a1c5c3-b7c2-4def-b162-0f04b792571b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/05f05f4b-9e02-4ffc-99c2-bcf86f010e53/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16a1c5c3-b7c2-4def-b162-0f04b792571b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8e312ac7-d51e-4edd-aa93-1f444eb7f861> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e312ac7-d51e-4edd-aa93-1f444eb7f861";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/05f05f4b-9e02-4ffc-99c2-bcf86f010e53/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8e312ac7-d51e-4edd-aa93-1f444eb7f861>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f602f67-4e52-4884-8d88-3b140993ed57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f602f67-4e52-4884-8d88-3b140993ed57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/1b08e6d7-5296-46b2-a08a-d14caaa83b50/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f602f67-4e52-4884-8d88-3b140993ed57>.
+    
+<http://data.lblod.info/id/remote-data-objects/89226135-4cd3-45db-be3e-2ff17ea31da0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89226135-4cd3-45db-be3e-2ff17ea31da0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/1b08e6d7-5296-46b2-a08a-d14caaa83b50/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89226135-4cd3-45db-be3e-2ff17ea31da0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a82d349b-a7d9-4505-9dec-e003a138194a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a82d349b-a7d9-4505-9dec-e003a138194a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/1b08e6d7-5296-46b2-a08a-d14caaa83b50/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a82d349b-a7d9-4505-9dec-e003a138194a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cf95c26-2a92-43d2-b9d0-c6d4ea470eac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cf95c26-2a92-43d2-b9d0-c6d4ea470eac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/1bb0a749-3731-4479-8899-12a7de261a5c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cf95c26-2a92-43d2-b9d0-c6d4ea470eac>.
+    
+<http://data.lblod.info/id/remote-data-objects/0efa9774-f1a6-40ed-8277-6eabedad8d24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0efa9774-f1a6-40ed-8277-6eabedad8d24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/1bb0a749-3731-4479-8899-12a7de261a5c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0efa9774-f1a6-40ed-8277-6eabedad8d24>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb45d56f-585b-43be-bdd4-0de4d139821c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb45d56f-585b-43be-bdd4-0de4d139821c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/1bb0a749-3731-4479-8899-12a7de261a5c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb45d56f-585b-43be-bdd4-0de4d139821c>.
+    
+<http://data.lblod.info/id/remote-data-objects/657e863d-75c5-45c7-b101-ad96bd7aaf8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "657e863d-75c5-45c7-b101-ad96bd7aaf8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/1c50dda1-0bfb-41eb-b48f-db1ab9c8352b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/657e863d-75c5-45c7-b101-ad96bd7aaf8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/eba899c7-6f42-46bb-8168-3cb7998ff3b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eba899c7-6f42-46bb-8168-3cb7998ff3b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/1c50dda1-0bfb-41eb-b48f-db1ab9c8352b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eba899c7-6f42-46bb-8168-3cb7998ff3b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/b8a8ff29-e8c7-4b09-bbbb-bb6599bdd4c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8a8ff29-e8c7-4b09-bbbb-bb6599bdd4c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/1c50dda1-0bfb-41eb-b48f-db1ab9c8352b/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b8a8ff29-e8c7-4b09-bbbb-bb6599bdd4c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/16b894bb-5168-44a8-8915-f95a30809e9b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16b894bb-5168-44a8-8915-f95a30809e9b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/245a963a-f5a1-432e-a653-30380e9ede8c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:41.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/171d3a30-4040-4162-81ca-b7a6bb728c58> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16b894bb-5168-44a8-8915-f95a30809e9b>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201942-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201942-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201942-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201942-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/4b17f648-ab23-441d-81d5-8969b41e5ed7> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4b17f648-ab23-441d-81d5-8969b41e5ed7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bbce6d66-ceac-49fe-a998-1103d6d74d6e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/9aa35f9d-7463-4f2e-82e9-67f31d922b97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9aa35f9d-7463-4f2e-82e9-67f31d922b97";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e>.
+
+  <http://redpencil.data.gift/id/task/866b0d70-6597-4748-82ba-03f1d10e0379> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "866b0d70-6597-4748-82ba-03f1d10e0379";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/4b17f648-ab23-441d-81d5-8969b41e5ed7>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/9aa35f9d-7463-4f2e-82e9-67f31d922b97>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/7da49dc4-cd59-42e7-a4b7-a84ad7921187> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7da49dc4-cd59-42e7-a4b7-a84ad7921187";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/245a963a-f5a1-432e-a653-30380e9ede8c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7da49dc4-cd59-42e7-a4b7-a84ad7921187>.
+    
+<http://data.lblod.info/id/remote-data-objects/812d1f99-fbce-4ca8-b567-fbe8ef6c7319> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "812d1f99-fbce-4ca8-b567-fbe8ef6c7319";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/245a963a-f5a1-432e-a653-30380e9ede8c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/812d1f99-fbce-4ca8-b567-fbe8ef6c7319>.
+    
+<http://data.lblod.info/id/remote-data-objects/858da11a-4b73-46a4-8fff-40d47dad469a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "858da11a-4b73-46a4-8fff-40d47dad469a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/52ac2bc8-65d1-4020-bcd5-ca5ec920caf8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/858da11a-4b73-46a4-8fff-40d47dad469a>.
+    
+<http://data.lblod.info/id/remote-data-objects/81a6d673-00a5-4114-bed7-3ebc219a1783> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81a6d673-00a5-4114-bed7-3ebc219a1783";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/52ac2bc8-65d1-4020-bcd5-ca5ec920caf8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81a6d673-00a5-4114-bed7-3ebc219a1783>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc3bb4be-5acc-43ee-99d6-b4f62729cfc0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc3bb4be-5acc-43ee-99d6-b4f62729cfc0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/52ac2bc8-65d1-4020-bcd5-ca5ec920caf8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc3bb4be-5acc-43ee-99d6-b4f62729cfc0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed8c8b67-b179-45ff-a0e8-31ca5102baac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed8c8b67-b179-45ff-a0e8-31ca5102baac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/6d92f15d-a07c-44ab-a13c-806596093621/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed8c8b67-b179-45ff-a0e8-31ca5102baac>.
+    
+<http://data.lblod.info/id/remote-data-objects/29c1173a-52ec-47a1-aca2-2fcd8efbb4ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29c1173a-52ec-47a1-aca2-2fcd8efbb4ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/6d92f15d-a07c-44ab-a13c-806596093621/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29c1173a-52ec-47a1-aca2-2fcd8efbb4ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/a72e09cf-c348-4d95-9f7f-4e4ecb1382b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a72e09cf-c348-4d95-9f7f-4e4ecb1382b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/6d92f15d-a07c-44ab-a13c-806596093621/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a72e09cf-c348-4d95-9f7f-4e4ecb1382b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cb2bee8-ba5c-45dc-b5c8-ecbc647c400e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cb2bee8-ba5c-45dc-b5c8-ecbc647c400e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/845cdbdc-da80-41dc-a0be-af0455e9b50e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cb2bee8-ba5c-45dc-b5c8-ecbc647c400e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7dd9aed-e60f-4619-b0c5-0edecba7e61f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7dd9aed-e60f-4619-b0c5-0edecba7e61f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/845cdbdc-da80-41dc-a0be-af0455e9b50e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7dd9aed-e60f-4619-b0c5-0edecba7e61f>.
+    
+<http://data.lblod.info/id/remote-data-objects/99a87533-1928-4247-8316-689da49f0185> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "99a87533-1928-4247-8316-689da49f0185";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/845cdbdc-da80-41dc-a0be-af0455e9b50e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/99a87533-1928-4247-8316-689da49f0185>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c419ca4-2dd9-4251-94df-dabff725934b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c419ca4-2dd9-4251-94df-dabff725934b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/8a20fbe3-23eb-49a5-a3cc-0210dc373a8a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c419ca4-2dd9-4251-94df-dabff725934b>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9217685-4c1a-469a-a271-0f3ff338cb19> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9217685-4c1a-469a-a271-0f3ff338cb19";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/8a20fbe3-23eb-49a5-a3cc-0210dc373a8a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9217685-4c1a-469a-a271-0f3ff338cb19>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6522d09-392d-4c1b-bf8e-d56833d37a3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6522d09-392d-4c1b-bf8e-d56833d37a3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/8e63192d-c74e-44c5-9b25-7cb3dad8f8d3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6522d09-392d-4c1b-bf8e-d56833d37a3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/81efc282-b375-4a3a-8245-2a75aec2a02d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81efc282-b375-4a3a-8245-2a75aec2a02d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/8e63192d-c74e-44c5-9b25-7cb3dad8f8d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81efc282-b375-4a3a-8245-2a75aec2a02d>.
+    
+<http://data.lblod.info/id/remote-data-objects/281c4e82-52d1-4a34-b26a-55ef99fece15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "281c4e82-52d1-4a34-b26a-55ef99fece15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/8e63192d-c74e-44c5-9b25-7cb3dad8f8d3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/281c4e82-52d1-4a34-b26a-55ef99fece15>.
+    
+<http://data.lblod.info/id/remote-data-objects/14c64e6b-1134-48d6-b403-428ba91d1e5a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14c64e6b-1134-48d6-b403-428ba91d1e5a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/9f5416b3-d0cb-48e3-9c9d-0b28103b11b6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14c64e6b-1134-48d6-b403-428ba91d1e5a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f16847af-958b-4b34-927a-072681c332a8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f16847af-958b-4b34-927a-072681c332a8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/9f5416b3-d0cb-48e3-9c9d-0b28103b11b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f16847af-958b-4b34-927a-072681c332a8>.
+    
+<http://data.lblod.info/id/remote-data-objects/f375c9e0-7fab-4e19-a6dd-b47d2aec47b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f375c9e0-7fab-4e19-a6dd-b47d2aec47b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/9f5416b3-d0cb-48e3-9c9d-0b28103b11b6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f375c9e0-7fab-4e19-a6dd-b47d2aec47b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb9a011c-f2d2-45c2-83d9-b746354a1250> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb9a011c-f2d2-45c2-83d9-b746354a1250";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/a2c3fd00-1d6f-4bd4-92e3-f74d19a12a30/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb9a011c-f2d2-45c2-83d9-b746354a1250>.
+    
+<http://data.lblod.info/id/remote-data-objects/398066ab-469c-42d1-9f44-3f71167405f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "398066ab-469c-42d1-9f44-3f71167405f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/a2c3fd00-1d6f-4bd4-92e3-f74d19a12a30/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/398066ab-469c-42d1-9f44-3f71167405f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd932ad4-c4f8-4f47-a3ee-132d52b2f0f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd932ad4-c4f8-4f47-a3ee-132d52b2f0f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/a2c3fd00-1d6f-4bd4-92e3-f74d19a12a30/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd932ad4-c4f8-4f47-a3ee-132d52b2f0f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/14806456-cf5f-4876-9e22-1145e2fc179b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14806456-cf5f-4876-9e22-1145e2fc179b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/ab6cb4e4-b4b3-4483-a903-147ddfe84053/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/14806456-cf5f-4876-9e22-1145e2fc179b>.
+    
+<http://data.lblod.info/id/remote-data-objects/65fabbd7-7bce-4d68-91e1-a97d9379ee7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65fabbd7-7bce-4d68-91e1-a97d9379ee7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/ab6cb4e4-b4b3-4483-a903-147ddfe84053/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65fabbd7-7bce-4d68-91e1-a97d9379ee7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/de85bea4-28c2-4c70-b21a-e7151c563127> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de85bea4-28c2-4c70-b21a-e7151c563127";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/ab6cb4e4-b4b3-4483-a903-147ddfe84053/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de85bea4-28c2-4c70-b21a-e7151c563127>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3674619-4b9c-4df8-ad11-fd0a06fa1003> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3674619-4b9c-4df8-ad11-fd0a06fa1003";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/c48b6943-4298-41bf-b943-a4f8dcea4216/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3674619-4b9c-4df8-ad11-fd0a06fa1003>.
+    
+<http://data.lblod.info/id/remote-data-objects/95db3f2e-bf4e-4b51-9158-e5ca08bb86b2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95db3f2e-bf4e-4b51-9158-e5ca08bb86b2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/c48b6943-4298-41bf-b943-a4f8dcea4216/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95db3f2e-bf4e-4b51-9158-e5ca08bb86b2>.
+    
+<http://data.lblod.info/id/remote-data-objects/47b9c0fb-95f6-46f3-9d2e-11d15d1b45cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47b9c0fb-95f6-46f3-9d2e-11d15d1b45cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/c48b6943-4298-41bf-b943-a4f8dcea4216/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47b9c0fb-95f6-46f3-9d2e-11d15d1b45cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/78ffe48b-b43b-4e95-9210-b81b48d029a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78ffe48b-b43b-4e95-9210-b81b48d029a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/e22ad0cc-858e-4072-8000-05205c8e4c66/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78ffe48b-b43b-4e95-9210-b81b48d029a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb26faf5-a0ea-42a3-98ea-53db25979e1b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb26faf5-a0ea-42a3-98ea-53db25979e1b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/e22ad0cc-858e-4072-8000-05205c8e4c66/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb26faf5-a0ea-42a3-98ea-53db25979e1b>.
+    
+<http://data.lblod.info/id/remote-data-objects/09ca83e4-fba8-47be-b1fc-d7c736a45b39> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09ca83e4-fba8-47be-b1fc-d7c736a45b39";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/GR/e22ad0cc-858e-4072-8000-05205c8e4c66/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09ca83e4-fba8-47be-b1fc-d7c736a45b39>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f6eb070-95a8-4002-a23c-c17490171d27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f6eb070-95a8-4002-a23c-c17490171d27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/021be3d1-3a27-4456-adab-ef24c5b5bab0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f6eb070-95a8-4002-a23c-c17490171d27>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f4cd299-f9a8-4283-8458-28c387709a5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f4cd299-f9a8-4283-8458-28c387709a5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/021be3d1-3a27-4456-adab-ef24c5b5bab0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f4cd299-f9a8-4283-8458-28c387709a5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/24fee142-2280-46d2-9a1b-40e45fd56338> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24fee142-2280-46d2-9a1b-40e45fd56338";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/021be3d1-3a27-4456-adab-ef24c5b5bab0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24fee142-2280-46d2-9a1b-40e45fd56338>.
+    
+<http://data.lblod.info/id/remote-data-objects/4562b6e9-86d1-4ad4-bdb3-c3b01bcf231f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4562b6e9-86d1-4ad4-bdb3-c3b01bcf231f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/1d308fd7-37a5-4e17-acb8-30ceba1457e0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4562b6e9-86d1-4ad4-bdb3-c3b01bcf231f>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcb2654d-c29f-4b5e-b6e4-f95b169e3f01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcb2654d-c29f-4b5e-b6e4-f95b169e3f01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/1d308fd7-37a5-4e17-acb8-30ceba1457e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcb2654d-c29f-4b5e-b6e4-f95b169e3f01>.
+    
+<http://data.lblod.info/id/remote-data-objects/022c27e2-5212-4930-8a8e-aa21f072102e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "022c27e2-5212-4930-8a8e-aa21f072102e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/4b40d33d-cc43-4f64-87ab-920516b50c40/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/022c27e2-5212-4930-8a8e-aa21f072102e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3571943-35e9-4da1-b240-28184df486e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3571943-35e9-4da1-b240-28184df486e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/4b40d33d-cc43-4f64-87ab-920516b50c40/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3571943-35e9-4da1-b240-28184df486e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a5f19c0-9ff6-4dbd-b742-1a225bfdd67b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a5f19c0-9ff6-4dbd-b742-1a225bfdd67b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/4b40d33d-cc43-4f64-87ab-920516b50c40/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a5f19c0-9ff6-4dbd-b742-1a225bfdd67b>.
+    
+<http://data.lblod.info/id/remote-data-objects/610a5c09-e36e-4ad0-9929-9fb70555ac21> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "610a5c09-e36e-4ad0-9929-9fb70555ac21";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/58f11484-0b4f-4bcf-bd36-78166d04f246/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/610a5c09-e36e-4ad0-9929-9fb70555ac21>.
+    
+<http://data.lblod.info/id/remote-data-objects/733e4db9-1f60-44fd-bb0e-73723023861c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "733e4db9-1f60-44fd-bb0e-73723023861c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/58f11484-0b4f-4bcf-bd36-78166d04f246/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/733e4db9-1f60-44fd-bb0e-73723023861c>.
+    
+<http://data.lblod.info/id/remote-data-objects/bde01de8-e41d-4480-bcdf-a7ef98ad815c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bde01de8-e41d-4480-bcdf-a7ef98ad815c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/58f11484-0b4f-4bcf-bd36-78166d04f246/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bde01de8-e41d-4480-bcdf-a7ef98ad815c>.
+    
+<http://data.lblod.info/id/remote-data-objects/20e3bc08-d3d5-40c7-a43c-dab1b9426d5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20e3bc08-d3d5-40c7-a43c-dab1b9426d5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/598e9867-d1f2-4f17-aaaf-db98cd9db915/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20e3bc08-d3d5-40c7-a43c-dab1b9426d5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f5eda59-47e4-408c-b5d9-28831445fe48> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f5eda59-47e4-408c-b5d9-28831445fe48";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/598e9867-d1f2-4f17-aaaf-db98cd9db915/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f5eda59-47e4-408c-b5d9-28831445fe48>.
+    
+<http://data.lblod.info/id/remote-data-objects/b21d97f1-2349-455a-8a2b-f2f84b42c07d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b21d97f1-2349-455a-8a2b-f2f84b42c07d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/598e9867-d1f2-4f17-aaaf-db98cd9db915/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b21d97f1-2349-455a-8a2b-f2f84b42c07d>.
+    
+<http://data.lblod.info/id/remote-data-objects/039f6aef-0273-42ef-b488-5fbe03cd2b9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "039f6aef-0273-42ef-b488-5fbe03cd2b9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/5d89a807-526d-4178-8bab-3c82dd405bce/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/039f6aef-0273-42ef-b488-5fbe03cd2b9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/ba6f8709-71df-42f6-994d-a3a7f805dee6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba6f8709-71df-42f6-994d-a3a7f805dee6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/5d89a807-526d-4178-8bab-3c82dd405bce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ba6f8709-71df-42f6-994d-a3a7f805dee6>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e73bf3c-028c-4547-a88d-6f4276f06063> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e73bf3c-028c-4547-a88d-6f4276f06063";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/5d89a807-526d-4178-8bab-3c82dd405bce/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e73bf3c-028c-4547-a88d-6f4276f06063>.
+    
+<http://data.lblod.info/id/remote-data-objects/4056e898-bc5b-49a6-b430-2b10b033b5bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4056e898-bc5b-49a6-b430-2b10b033b5bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/75359246-6f74-4fc9-ae49-f0f25ab2da37/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4056e898-bc5b-49a6-b430-2b10b033b5bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8dc4efe-eddb-4734-a7be-761e26f621e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8dc4efe-eddb-4734-a7be-761e26f621e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/75359246-6f74-4fc9-ae49-f0f25ab2da37/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:42.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bbce6d66-ceac-49fe-a998-1103d6d74d6e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8dc4efe-eddb-4734-a7be-761e26f621e8>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201943-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201943-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201943-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201943-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c7137002-68ac-4bde-ace2-4ff09bcdc8f9> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c7137002-68ac-4bde-ace2-4ff09bcdc8f9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c74296cd-6dfe-4547-80af-4e0c1d218cf9";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/41cb41e1-9cb4-46d7-b95b-577963b8ce00> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "41cb41e1-9cb4-46d7-b95b-577963b8ce00";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9>.
+
+  <http://redpencil.data.gift/id/task/2c9453fc-e016-4d1c-ad3f-b23224b5e0d6> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2c9453fc-e016-4d1c-ad3f-b23224b5e0d6";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c7137002-68ac-4bde-ace2-4ff09bcdc8f9>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/41cb41e1-9cb4-46d7-b95b-577963b8ce00>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/0126c0dc-356e-4058-8246-356bf63e2a94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0126c0dc-356e-4058-8246-356bf63e2a94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/75359246-6f74-4fc9-ae49-f0f25ab2da37/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0126c0dc-356e-4058-8246-356bf63e2a94>.
+    
+<http://data.lblod.info/id/remote-data-objects/ef96c636-fd4a-4bef-83dd-3cba18e05968> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef96c636-fd4a-4bef-83dd-3cba18e05968";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/80c1a95a-9d9f-4fbe-9e00-6c9f9de95392/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ef96c636-fd4a-4bef-83dd-3cba18e05968>.
+    
+<http://data.lblod.info/id/remote-data-objects/b57de3d1-c824-4060-984c-1b5b3cf42206> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b57de3d1-c824-4060-984c-1b5b3cf42206";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/80c1a95a-9d9f-4fbe-9e00-6c9f9de95392/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b57de3d1-c824-4060-984c-1b5b3cf42206>.
+    
+<http://data.lblod.info/id/remote-data-objects/4cafb3b0-f497-44a4-8a4d-70104d0680f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4cafb3b0-f497-44a4-8a4d-70104d0680f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/80c1a95a-9d9f-4fbe-9e00-6c9f9de95392/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4cafb3b0-f497-44a4-8a4d-70104d0680f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9d3e238-a105-4d04-b834-11e1f0747263> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9d3e238-a105-4d04-b834-11e1f0747263";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/8e588d33-5465-497c-868b-9992d11cbfb8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9d3e238-a105-4d04-b834-11e1f0747263>.
+    
+<http://data.lblod.info/id/remote-data-objects/437ff7e5-6117-4181-b954-d9e0a2cfbeda> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "437ff7e5-6117-4181-b954-d9e0a2cfbeda";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/8e588d33-5465-497c-868b-9992d11cbfb8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/437ff7e5-6117-4181-b954-d9e0a2cfbeda>.
+    
+<http://data.lblod.info/id/remote-data-objects/2fb76670-3e04-4479-820c-a2115ab7e8c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fb76670-3e04-4479-820c-a2115ab7e8c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/8e588d33-5465-497c-868b-9992d11cbfb8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2fb76670-3e04-4479-820c-a2115ab7e8c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/a828d5a3-29ae-4410-a40b-e697d2b19917> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a828d5a3-29ae-4410-a40b-e697d2b19917";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/a9fded11-6a89-4e2a-ad22-9a01f7718910/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a828d5a3-29ae-4410-a40b-e697d2b19917>.
+    
+<http://data.lblod.info/id/remote-data-objects/18a580bd-6fcc-4ff4-8ffd-cb5f868ffb7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18a580bd-6fcc-4ff4-8ffd-cb5f868ffb7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/a9fded11-6a89-4e2a-ad22-9a01f7718910/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18a580bd-6fcc-4ff4-8ffd-cb5f868ffb7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/2df34eac-1e56-4724-ad99-31ff8f969490> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2df34eac-1e56-4724-ad99-31ff8f969490";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/a9fded11-6a89-4e2a-ad22-9a01f7718910/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2df34eac-1e56-4724-ad99-31ff8f969490>.
+    
+<http://data.lblod.info/id/remote-data-objects/c127dba4-d96f-4806-806e-2848de7e1022> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c127dba4-d96f-4806-806e-2848de7e1022";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/bf9b63a8-9ff6-4fad-a87c-f0351025683e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c127dba4-d96f-4806-806e-2848de7e1022>.
+    
+<http://data.lblod.info/id/remote-data-objects/86f578c9-3c8e-4680-a7cb-04e3b5dcc224> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86f578c9-3c8e-4680-a7cb-04e3b5dcc224";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/bf9b63a8-9ff6-4fad-a87c-f0351025683e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86f578c9-3c8e-4680-a7cb-04e3b5dcc224>.
+    
+<http://data.lblod.info/id/remote-data-objects/533f8c07-bc2d-40e9-a511-3cb9f5f7456f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "533f8c07-bc2d-40e9-a511-3cb9f5f7456f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/bf9b63a8-9ff6-4fad-a87c-f0351025683e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/533f8c07-bc2d-40e9-a511-3cb9f5f7456f>.
+    
+<http://data.lblod.info/id/remote-data-objects/32fcb0b3-c364-4328-b937-bbd8176ddfe2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "32fcb0b3-c364-4328-b937-bbd8176ddfe2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/c60e1ac5-49f6-42c8-aed8-33f27f09bcd1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/32fcb0b3-c364-4328-b937-bbd8176ddfe2>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e423ce7-ca9b-478b-a55a-05e4eafe5a9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e423ce7-ca9b-478b-a55a-05e4eafe5a9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/c60e1ac5-49f6-42c8-aed8-33f27f09bcd1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e423ce7-ca9b-478b-a55a-05e4eafe5a9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/973b4c30-b891-40d8-9830-5aa0d36f5478> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "973b4c30-b891-40d8-9830-5aa0d36f5478";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/c60e1ac5-49f6-42c8-aed8-33f27f09bcd1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/973b4c30-b891-40d8-9830-5aa0d36f5478>.
+    
+<http://data.lblod.info/id/remote-data-objects/18130abc-5712-4671-8f87-b4019cbf3dd9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18130abc-5712-4671-8f87-b4019cbf3dd9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/e130e3b5-1044-4bf4-93a1-848d23b1f55d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18130abc-5712-4671-8f87-b4019cbf3dd9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c5b0e41-1024-4951-8f37-8e0f27f1561e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c5b0e41-1024-4951-8f37-8e0f27f1561e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/e130e3b5-1044-4bf4-93a1-848d23b1f55d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c5b0e41-1024-4951-8f37-8e0f27f1561e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5fbac5a-961a-436c-863c-a028892a47f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5fbac5a-961a-436c-863c-a028892a47f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/e130e3b5-1044-4bf4-93a1-848d23b1f55d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5fbac5a-961a-436c-863c-a028892a47f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e9caa4e-6a15-475a-ac22-f4f18196facf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e9caa4e-6a15-475a-ac22-f4f18196facf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/e558d6d9-1a80-4a30-aad5-43db3f486ea2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e9caa4e-6a15-475a-ac22-f4f18196facf>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5b705c9-f985-4f97-903c-dd86db8115f1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5b705c9-f985-4f97-903c-dd86db8115f1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/e558d6d9-1a80-4a30-aad5-43db3f486ea2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5b705c9-f985-4f97-903c-dd86db8115f1>.
+    
+<http://data.lblod.info/id/remote-data-objects/b36fa1c0-12ad-4550-a7ba-6db17480f20e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b36fa1c0-12ad-4550-a7ba-6db17480f20e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/e558d6d9-1a80-4a30-aad5-43db3f486ea2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b36fa1c0-12ad-4550-a7ba-6db17480f20e>.
+    
+<http://data.lblod.info/id/remote-data-objects/27e0b077-80f6-48d3-bad3-df928b290986> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27e0b077-80f6-48d3-bad3-df928b290986";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/eed415dd-00ad-452c-886b-f6333f2610dc/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27e0b077-80f6-48d3-bad3-df928b290986>.
+    
+<http://data.lblod.info/id/remote-data-objects/1b02d660-f020-470f-83fa-0bfd5a1031dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1b02d660-f020-470f-83fa-0bfd5a1031dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/eed415dd-00ad-452c-886b-f6333f2610dc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1b02d660-f020-470f-83fa-0bfd5a1031dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/09a0441b-c9b1-43b5-a3d9-c9d0d258759d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09a0441b-c9b1-43b5-a3d9-c9d0d258759d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/RMW/eed415dd-00ad-452c-886b-f6333f2610dc/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09a0441b-c9b1-43b5-a3d9-c9d0d258759d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8350c14-60b1-41d5-942d-eb0961f7de51> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8350c14-60b1-41d5-942d-eb0961f7de51";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/0124d1ef-6e6f-4102-95cb-265b624c5165/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8350c14-60b1-41d5-942d-eb0961f7de51>.
+    
+<http://data.lblod.info/id/remote-data-objects/87100c25-b759-4dbb-b364-14276f2810a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87100c25-b759-4dbb-b364-14276f2810a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/015b3207-c823-4fd7-91eb-b262fa8cd0fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/87100c25-b759-4dbb-b364-14276f2810a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe8af0ea-c325-4c60-a340-60cf8744d351> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe8af0ea-c325-4c60-a340-60cf8744d351";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/047e8e65-d57f-4ed8-b5bd-f535c18cbdff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe8af0ea-c325-4c60-a340-60cf8744d351>.
+    
+<http://data.lblod.info/id/remote-data-objects/21157237-02eb-4447-87c1-f519f7d9a679> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21157237-02eb-4447-87c1-f519f7d9a679";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/05ed669c-f56b-4db1-850e-64c10490f532/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21157237-02eb-4447-87c1-f519f7d9a679>.
+    
+<http://data.lblod.info/id/remote-data-objects/6a81af8f-ff0d-4cbb-9b1c-91a9e56156fe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a81af8f-ff0d-4cbb-9b1c-91a9e56156fe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/0664d839-e272-421b-8a97-05128d336cdd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6a81af8f-ff0d-4cbb-9b1c-91a9e56156fe>.
+    
+<http://data.lblod.info/id/remote-data-objects/025e89a6-7a51-4707-a5d1-74b4c651d1a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "025e89a6-7a51-4707-a5d1-74b4c651d1a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/08736ecf-2d77-4451-a30c-caef76b4d143/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/025e89a6-7a51-4707-a5d1-74b4c651d1a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c034fbca-4f55-42b5-94a2-d05d685fe3a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c034fbca-4f55-42b5-94a2-d05d685fe3a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/0f18233c-07e7-4a27-ad44-cb8316802dea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c034fbca-4f55-42b5-94a2-d05d685fe3a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8caeee90-e2e3-404f-94df-7466afea337a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8caeee90-e2e3-404f-94df-7466afea337a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/15fef607-db36-4e1c-afe2-3abc67b81140/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8caeee90-e2e3-404f-94df-7466afea337a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7381295-a433-444a-a8e4-2b53c0f2ff23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7381295-a433-444a-a8e4-2b53c0f2ff23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/1ac320cb-004e-4c88-817c-0a327887518e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7381295-a433-444a-a8e4-2b53c0f2ff23>.
+    
+<http://data.lblod.info/id/remote-data-objects/78d60ad3-704b-4bea-9510-9c5571f8be0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78d60ad3-704b-4bea-9510-9c5571f8be0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/1c366653-1798-40a1-9bc4-0952f99c895a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78d60ad3-704b-4bea-9510-9c5571f8be0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4e7efb5-6156-4bb9-9655-5d90ca7bc3bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4e7efb5-6156-4bb9-9655-5d90ca7bc3bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/2150a80d-85a4-412f-8a43-0021e3474835/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4e7efb5-6156-4bb9-9655-5d90ca7bc3bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/19dd8327-c31d-48f8-9be8-960535b40687> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19dd8327-c31d-48f8-9be8-960535b40687";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/2d442e25-b4eb-4056-b59b-cc34da13a2c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19dd8327-c31d-48f8-9be8-960535b40687>.
+    
+<http://data.lblod.info/id/remote-data-objects/db4823ba-2d3e-467a-b5c5-56846febef60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db4823ba-2d3e-467a-b5c5-56846febef60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/2ecf4731-de4e-4413-9b47-e1f4fc932d1f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db4823ba-2d3e-467a-b5c5-56846febef60>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c182dcb-f3a6-4efa-8882-78695e607fe3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c182dcb-f3a6-4efa-8882-78695e607fe3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/308adcf3-2204-4465-90ae-ea0408b5c13e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c182dcb-f3a6-4efa-8882-78695e607fe3>.
+    
+<http://data.lblod.info/id/remote-data-objects/fea13c53-eb09-4f95-81a3-d5f1ce13160e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fea13c53-eb09-4f95-81a3-d5f1ce13160e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/3684ab1a-9c25-4e28-baea-c6c35a05ebd5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fea13c53-eb09-4f95-81a3-d5f1ce13160e>.
+    
+<http://data.lblod.info/id/remote-data-objects/867f27de-3853-4e22-b7cf-e982d09cc747> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "867f27de-3853-4e22-b7cf-e982d09cc747";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/37cf1c4b-a811-4529-a44b-0fcb1f3e532b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/867f27de-3853-4e22-b7cf-e982d09cc747>.
+    
+<http://data.lblod.info/id/remote-data-objects/6df3881f-5fd2-4179-9c6a-3aacfae66d45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6df3881f-5fd2-4179-9c6a-3aacfae66d45";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/3f7aeafa-196f-480e-a310-6163bd58015a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6df3881f-5fd2-4179-9c6a-3aacfae66d45>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a220cc8-805a-4bbe-a414-b6ab550e7d6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a220cc8-805a-4bbe-a414-b6ab550e7d6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/4022e51a-2084-4be9-90df-d9cf0667f54e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a220cc8-805a-4bbe-a414-b6ab550e7d6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2fdeb9c-8377-4e71-9a32-caa9e1acac8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2fdeb9c-8377-4e71-9a32-caa9e1acac8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/47e597f4-45c0-45cc-946b-fbab85ac2418/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2fdeb9c-8377-4e71-9a32-caa9e1acac8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b140b1a-dbc1-4887-88b8-92a5c4645534> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b140b1a-dbc1-4887-88b8-92a5c4645534";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/48ad40e4-6eb4-4473-9469-23661e9de573/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b140b1a-dbc1-4887-88b8-92a5c4645534>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ff74292-5aee-4e2d-b9ed-e6798599edc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ff74292-5aee-4e2d-b9ed-e6798599edc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/4ad70c05-b2a3-4e1d-a057-db748d11bc8e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ff74292-5aee-4e2d-b9ed-e6798599edc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/58e2783a-2c8a-4e0d-9515-a922ec76a94b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58e2783a-2c8a-4e0d-9515-a922ec76a94b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/4ba0de94-ee62-4910-b19b-b3fe782d40da/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58e2783a-2c8a-4e0d-9515-a922ec76a94b>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce560c35-e4ca-4f00-ada0-764d7897fcdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce560c35-e4ca-4f00-ada0-764d7897fcdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/5001b75e-c442-4e8f-9ca0-225a609ec249/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce560c35-e4ca-4f00-ada0-764d7897fcdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/8a0567df-8f2d-4970-b664-f52435574941> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a0567df-8f2d-4970-b664-f52435574941";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/516e4012-b016-42d1-93d3-da7dbca89446/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8a0567df-8f2d-4970-b664-f52435574941>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a08aac4-1797-4568-9f5b-fd7d3fe6d741> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a08aac4-1797-4568-9f5b-fd7d3fe6d741";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/645ac875-a74f-4fe8-aa75-24ed1ec03c04/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:43.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/c74296cd-6dfe-4547-80af-4e0c1d218cf9> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a08aac4-1797-4568-9f5b-fd7d3fe6d741>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201944-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201944-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201944-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201944-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/fa1fe763-1c70-4baa-a657-531f37627a75> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fa1fe763-1c70-4baa-a657-531f37627a75";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "24764c47-d65f-4ac4-a7fb-26f1a10cfd98";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/449d959b-81e2-4de6-a9b8-b0b46206e643> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "449d959b-81e2-4de6-a9b8-b0b46206e643";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98>.
+
+  <http://redpencil.data.gift/id/task/cdfb17c9-5da1-4564-8a55-15806dde8522> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "cdfb17c9-5da1-4564-8a55-15806dde8522";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/fa1fe763-1c70-4baa-a657-531f37627a75>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/449d959b-81e2-4de6-a9b8-b0b46206e643>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/3b8ad1e0-004b-43fd-8f89-24c16c3ff668> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b8ad1e0-004b-43fd-8f89-24c16c3ff668";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/670c02c7-2b6f-43d8-82de-e49518f7d2c3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b8ad1e0-004b-43fd-8f89-24c16c3ff668>.
+    
+<http://data.lblod.info/id/remote-data-objects/320758af-afcc-4489-8f1e-dec084d6a7a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "320758af-afcc-4489-8f1e-dec084d6a7a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/6ac01c94-8cd4-41a1-aad3-481cbc02d72a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/320758af-afcc-4489-8f1e-dec084d6a7a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/40178a1d-aabb-45fc-abe9-5394f92fa492> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40178a1d-aabb-45fc-abe9-5394f92fa492";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/6e237a7f-53ef-4167-ba95-98eddfb15cec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40178a1d-aabb-45fc-abe9-5394f92fa492>.
+    
+<http://data.lblod.info/id/remote-data-objects/45687cc9-ebed-4090-93b2-58caf35decf3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "45687cc9-ebed-4090-93b2-58caf35decf3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/7573f0ea-c7c1-46e1-9f8b-d18b38545196/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/45687cc9-ebed-4090-93b2-58caf35decf3>.
+    
+<http://data.lblod.info/id/remote-data-objects/83ac4ced-2582-47d0-9023-fd7b633efc18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83ac4ced-2582-47d0-9023-fd7b633efc18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/7703651d-102a-4c56-a693-237e3e5ebcee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83ac4ced-2582-47d0-9023-fd7b633efc18>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7a9bb64-d368-4fab-bf34-9ebf36f9c093> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7a9bb64-d368-4fab-bf34-9ebf36f9c093";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/78d91d66-9348-41f3-8537-1a9fcc42848a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7a9bb64-d368-4fab-bf34-9ebf36f9c093>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ce0d047-74ca-40d0-bf7c-fa97e73cd81b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ce0d047-74ca-40d0-bf7c-fa97e73cd81b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/79d308c1-3a4b-41de-897a-54ed4f8c1f42/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ce0d047-74ca-40d0-bf7c-fa97e73cd81b>.
+    
+<http://data.lblod.info/id/remote-data-objects/8edd8654-a2f7-4bfd-ba4c-4b80b30abbd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8edd8654-a2f7-4bfd-ba4c-4b80b30abbd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/7cef7f73-0646-428c-a63f-8cf55043070c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8edd8654-a2f7-4bfd-ba4c-4b80b30abbd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/1cd2d94d-95f7-48c1-bb78-d9862fd00613> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1cd2d94d-95f7-48c1-bb78-d9862fd00613";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/8229095d-1d81-4b75-a866-6ab9e0f4d4d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1cd2d94d-95f7-48c1-bb78-d9862fd00613>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa2c012c-48b1-47cc-8ea2-ed7422d4ca4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa2c012c-48b1-47cc-8ea2-ed7422d4ca4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/8aea7ed1-aae3-4fca-a4a2-bbde64093aff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa2c012c-48b1-47cc-8ea2-ed7422d4ca4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/1920102b-07c0-4093-9d62-a4efbc1ad020> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1920102b-07c0-4093-9d62-a4efbc1ad020";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/8efae7d6-1838-4b27-a46a-18acc6a79977/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1920102b-07c0-4093-9d62-a4efbc1ad020>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb89520c-de1d-425a-aa5a-56ef25284b95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb89520c-de1d-425a-aa5a-56ef25284b95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/935f3c41-22ec-4a41-9d26-a72058f0c386/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb89520c-de1d-425a-aa5a-56ef25284b95>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d9e1b51-ed30-4ff8-b86f-fec6ab657ee9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d9e1b51-ed30-4ff8-b86f-fec6ab657ee9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/939353b4-2faf-4dac-a2d4-6e5653d7a18f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d9e1b51-ed30-4ff8-b86f-fec6ab657ee9>.
+    
+<http://data.lblod.info/id/remote-data-objects/8505ec64-af82-41e3-a29c-eed7814b7934> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8505ec64-af82-41e3-a29c-eed7814b7934";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/93c6ddb2-76c7-49b2-9b23-4a289aff5125/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8505ec64-af82-41e3-a29c-eed7814b7934>.
+    
+<http://data.lblod.info/id/remote-data-objects/458c78aa-efc7-4302-9a92-58b43d35ff3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "458c78aa-efc7-4302-9a92-58b43d35ff3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/940072f0-62c0-42b7-869f-94d6c23f6871/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/458c78aa-efc7-4302-9a92-58b43d35ff3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/42a1df95-4958-4b18-810e-1bc9311ff6f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42a1df95-4958-4b18-810e-1bc9311ff6f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/9608ac02-5eb1-47cd-a5d4-d1f3bb916c72/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42a1df95-4958-4b18-810e-1bc9311ff6f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8b680e1-7686-49a5-af6e-6be8641f5553> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8b680e1-7686-49a5-af6e-6be8641f5553";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/9ceafcda-f26b-461c-aa45-20f1a6de9483/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8b680e1-7686-49a5-af6e-6be8641f5553>.
+    
+<http://data.lblod.info/id/remote-data-objects/1a3d93f6-8015-4cfe-b4f1-8f7c4aa0dfaa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a3d93f6-8015-4cfe-b4f1-8f7c4aa0dfaa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/9dd8d3a6-ed26-4dbd-9817-31fb8a8068c7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1a3d93f6-8015-4cfe-b4f1-8f7c4aa0dfaa>.
+    
+<http://data.lblod.info/id/remote-data-objects/09dcab66-0271-4553-9815-ba37e5afda4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09dcab66-0271-4553-9815-ba37e5afda4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/a1c0ca0f-8ab3-4785-834f-bdf5f843586a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09dcab66-0271-4553-9815-ba37e5afda4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/517f099f-e387-41f0-873a-e8e541543e9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "517f099f-e387-41f0-873a-e8e541543e9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/a2c2a9f1-1ec8-4532-9264-9be202fa2754/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/517f099f-e387-41f0-873a-e8e541543e9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/f46aa3fe-af60-4c0e-8fe1-25b141af9c28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f46aa3fe-af60-4c0e-8fe1-25b141af9c28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/a5397f59-6863-49fd-810d-a9d95d20b316/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f46aa3fe-af60-4c0e-8fe1-25b141af9c28>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd0204e5-2ab6-4209-b1bf-9c6f58aa44d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd0204e5-2ab6-4209-b1bf-9c6f58aa44d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/b0bff8f4-517a-42a8-b83b-68551cb3bc6d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd0204e5-2ab6-4209-b1bf-9c6f58aa44d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/47529a2b-a12c-4499-b372-72e729924496> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47529a2b-a12c-4499-b372-72e729924496";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/b5824ac0-095c-4fab-a41b-7ae4d3f57f54/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47529a2b-a12c-4499-b372-72e729924496>.
+    
+<http://data.lblod.info/id/remote-data-objects/3749c0be-1c96-4ee6-b9a3-c2bc7eedf1d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3749c0be-1c96-4ee6-b9a3-c2bc7eedf1d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/b81ee4f2-2fc1-44d1-9151-cffc832879f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3749c0be-1c96-4ee6-b9a3-c2bc7eedf1d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/675c15f5-018e-4860-a4b8-cc221687367d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "675c15f5-018e-4860-a4b8-cc221687367d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/bf693f59-3804-4a02-8303-d3c366152ceb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/675c15f5-018e-4860-a4b8-cc221687367d>.
+    
+<http://data.lblod.info/id/remote-data-objects/03b7802f-0d18-4b7f-ba1b-0307050c25c0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03b7802f-0d18-4b7f-ba1b-0307050c25c0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/bfac96e3-a54a-445d-9e40-1a33061e9ee6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03b7802f-0d18-4b7f-ba1b-0307050c25c0>.
+    
+<http://data.lblod.info/id/remote-data-objects/b85adcd7-0581-4e57-ae0b-2d8709d5dd75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b85adcd7-0581-4e57-ae0b-2d8709d5dd75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/bfc1496e-9f8f-4913-859c-c49017a153b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b85adcd7-0581-4e57-ae0b-2d8709d5dd75>.
+    
+<http://data.lblod.info/id/remote-data-objects/745a5b8e-5c26-4eb9-a9b0-33d18b0a224b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "745a5b8e-5c26-4eb9-a9b0-33d18b0a224b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/c17f1ddc-dbb5-40d9-854d-33024bacf1d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/745a5b8e-5c26-4eb9-a9b0-33d18b0a224b>.
+    
+<http://data.lblod.info/id/remote-data-objects/64aac0e2-5661-448d-9924-4b2ba0bd73fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64aac0e2-5661-448d-9924-4b2ba0bd73fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/c94bb3e1-593b-4aa7-8b44-12b0579d7275/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64aac0e2-5661-448d-9924-4b2ba0bd73fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/4db84788-a7e8-4201-bdff-b3bef96e06c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4db84788-a7e8-4201-bdff-b3bef96e06c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/d3d03588-2d0d-419e-adb2-5b61ad5557bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4db84788-a7e8-4201-bdff-b3bef96e06c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8cb9004-3f41-4a3d-93c4-00ee862899a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8cb9004-3f41-4a3d-93c4-00ee862899a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/d66fa431-c565-42db-aa32-a20ec074af54/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8cb9004-3f41-4a3d-93c4-00ee862899a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0108304-7d66-4fe6-84a3-3431a7642d02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0108304-7d66-4fe6-84a3-3431a7642d02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/d90f89d8-9967-41c1-a70a-b746bee17875/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0108304-7d66-4fe6-84a3-3431a7642d02>.
+    
+<http://data.lblod.info/id/remote-data-objects/edd4bcd7-90b4-465f-ab1e-c91f74407844> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "edd4bcd7-90b4-465f-ab1e-c91f74407844";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/e4aa70cb-c95f-4b24-9f63-10c5430a6101/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/edd4bcd7-90b4-465f-ab1e-c91f74407844>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd3d3772-8ff6-48a9-bf8d-6503c598a85e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd3d3772-8ff6-48a9-bf8d-6503c598a85e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/e94adc29-d555-4b13-8f47-a5ef099abd37/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd3d3772-8ff6-48a9-bf8d-6503c598a85e>.
+    
+<http://data.lblod.info/id/remote-data-objects/3844656f-1aa0-4512-8f09-baecf7d30000> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3844656f-1aa0-4512-8f09-baecf7d30000";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/edc6f32c-37cc-4799-bf79-246f99385bba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3844656f-1aa0-4512-8f09-baecf7d30000>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cb7899d-ab22-4c9b-bd3b-df66c48df526> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cb7899d-ab22-4c9b-bd3b-df66c48df526";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/ef7664e2-f9e8-48e3-8fbb-365711b0e2ef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cb7899d-ab22-4c9b-bd3b-df66c48df526>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ee75a8d-f6e6-40d1-b7f3-488bf9e9231d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ee75a8d-f6e6-40d1-b7f3-488bf9e9231d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/f68bf59c-ae68-412b-8156-bad87fae9e2e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ee75a8d-f6e6-40d1-b7f3-488bf9e9231d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bda911eb-f272-482a-b693-42c8d8cf11e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bda911eb-f272-482a-b693-42c8d8cf11e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/f6f0f768-fb0a-4737-8fe6-bdc9f385df8d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bda911eb-f272-482a-b693-42c8d8cf11e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ec60b36-71fc-44e3-9faf-9c0d777e6b9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ec60b36-71fc-44e3-9faf-9c0d777e6b9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/f96bb479-9618-47f0-bc45-8ede4642c868/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ec60b36-71fc-44e3-9faf-9c0d777e6b9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/1901b45f-a0c9-44bd-8840-ea50a5f836c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1901b45f-a0c9-44bd-8840-ea50a5f836c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/fb6b3c18-6de9-45c1-976c-f47656ad2603/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1901b45f-a0c9-44bd-8840-ea50a5f836c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5fbf0505-2184-4a6b-8740-bbcc0eb4274c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fbf0505-2184-4a6b-8740-bbcc0eb4274c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/fc5917ec-919b-4ee0-b8cc-dfc785630983/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5fbf0505-2184-4a6b-8740-bbcc0eb4274c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b5f56bb-7b03-46da-885e-0302b5c40e78> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b5f56bb-7b03-46da-885e-0302b5c40e78";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/fc90c56d-f01c-4259-a222-da2e056a9347/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b5f56bb-7b03-46da-885e-0302b5c40e78>.
+    
+<http://data.lblod.info/id/remote-data-objects/6083f2d3-45fe-4fd4-b57f-6181f6817f83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6083f2d3-45fe-4fd4-b57f-6181f6817f83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tielt-winge.meetingburger.net/VB/ff39bc37-85c3-4f74-8290-ae467ab6270b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6083f2d3-45fe-4fd4-b57f-6181f6817f83>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8b572f9-c88f-460e-9779-6af6df35ef87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8b572f9-c88f-460e-9779-6af6df35ef87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/burg/32dcb98d-7fe5-4a6b-8f13-ec059b0c4442/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8b572f9-c88f-460e-9779-6af6df35ef87>.
+    
+<http://data.lblod.info/id/remote-data-objects/579be815-6a46-4c27-b5d2-a087ecde6f7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "579be815-6a46-4c27-b5d2-a087ecde6f7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/burg/41b533f1-b6e4-4795-8499-cd636a44a1bb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/579be815-6a46-4c27-b5d2-a087ecde6f7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbcfe26d-dfd8-4032-bd6c-80038dc8e70d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbcfe26d-dfd8-4032-bd6c-80038dc8e70d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/burg/52c23adc-8159-4b57-8f2c-1cd4a52d4e7b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbcfe26d-dfd8-4032-bd6c-80038dc8e70d>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb79778d-5947-459c-bd62-a912287a5a09> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb79778d-5947-459c-bd62-a912287a5a09";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/burg/6400f040-a0cd-49fd-abae-237f37a9ea17/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb79778d-5947-459c-bd62-a912287a5a09>.
+    
+<http://data.lblod.info/id/remote-data-objects/0be56240-0797-4cec-923c-54ba7f5fd8ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0be56240-0797-4cec-923c-54ba7f5fd8ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/burg/81ad0771-c9a3-494e-8ffb-c1e85f080eea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0be56240-0797-4cec-923c-54ba7f5fd8ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bd871db-53c8-4e61-90d7-d23bd9576fcd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bd871db-53c8-4e61-90d7-d23bd9576fcd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/burg/b9c4adf4-a4d3-481f-b509-f980905901d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bd871db-53c8-4e61-90d7-d23bd9576fcd>.
+    
+<http://data.lblod.info/id/remote-data-objects/115fb0fd-477b-42ea-81bb-8f64f6bb4081> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "115fb0fd-477b-42ea-81bb-8f64f6bb4081";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/burg/c091b3c8-0617-4c96-b9ff-93795f6dd18e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:44.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/24764c47-d65f-4ac4-a7fb-26f1a10cfd98> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/115fb0fd-477b-42ea-81bb-8f64f6bb4081>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201946-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201946-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201946-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201946-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/b5dcd1b6-74d6-4dc7-82d1-aa22fc9befda> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b5dcd1b6-74d6-4dc7-82d1-aa22fc9befda";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/933319ac-739b-42a2-b0b7-e981c4d74906> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "933319ac-739b-42a2-b0b7-e981c4d74906";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e>.
+
+  <http://redpencil.data.gift/id/task/7bacc593-5103-4d80-8ec8-386d81281954> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7bacc593-5103-4d80-8ec8-386d81281954";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/b5dcd1b6-74d6-4dc7-82d1-aa22fc9befda>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/933319ac-739b-42a2-b0b7-e981c4d74906>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5b5356f5-e391-44f1-9171-798cf5426b90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b5356f5-e391-44f1-9171-798cf5426b90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/burg/cd2bbf63-72c6-474a-ae66-b03698704846/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b5356f5-e391-44f1-9171-798cf5426b90>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6902e03-38cf-4b9f-a64d-b6e76081cb27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6902e03-38cf-4b9f-a64d-b6e76081cb27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/burg/d666d95d-80b9-4e76-9626-2dcab276a62a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6902e03-38cf-4b9f-a64d-b6e76081cb27>.
+    
+<http://data.lblod.info/id/remote-data-objects/6eacadc7-b8d4-4277-a12a-fe3c4e25c46a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6eacadc7-b8d4-4277-a12a-fe3c4e25c46a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/burg/d94991f8-346b-4f90-904c-70be380bdb42/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6eacadc7-b8d4-4277-a12a-fe3c4e25c46a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ec1b9d3-e3bb-4c34-bf63-eb5ac9e8ca28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ec1b9d3-e3bb-4c34-bf63-eb5ac9e8ca28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/burg/eee7bf39-cab4-468f-8229-16212cd95dba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ec1b9d3-e3bb-4c34-bf63-eb5ac9e8ca28>.
+    
+<http://data.lblod.info/id/remote-data-objects/665baba5-721f-44b6-8529-8158af061816> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "665baba5-721f-44b6-8529-8158af061816";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/burg/f2db4b3a-1524-4e8c-99b4-f03f080cd392/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/665baba5-721f-44b6-8529-8158af061816>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2ee7876-a568-46fa-8b60-57eabf87ffeb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2ee7876-a568-46fa-8b60-57eabf87ffeb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/03905f27-225f-4c71-b2c6-51490cb6d37a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2ee7876-a568-46fa-8b60-57eabf87ffeb>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ea30c09-ebb5-4d8b-8b51-99557907cec4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ea30c09-ebb5-4d8b-8b51-99557907cec4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/0869e7e5-8b81-41c0-a5e0-6157faf47929/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ea30c09-ebb5-4d8b-8b51-99557907cec4>.
+    
+<http://data.lblod.info/id/remote-data-objects/da522c7b-066a-49aa-aa05-4775cb4d0232> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da522c7b-066a-49aa-aa05-4775cb4d0232";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/09cd51c5-915d-402f-b60f-6b7103421197/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da522c7b-066a-49aa-aa05-4775cb4d0232>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9d8cd38-989c-443d-8175-306123f21a53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9d8cd38-989c-443d-8175-306123f21a53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/0aa10916-9d4d-4f2f-b729-d6907a1e0254/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9d8cd38-989c-443d-8175-306123f21a53>.
+    
+<http://data.lblod.info/id/remote-data-objects/3d587e7b-18d1-43d9-9192-4d6b7279ae94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3d587e7b-18d1-43d9-9192-4d6b7279ae94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/0ab9ddb9-bf13-4d09-a09e-4e7a49cb1791/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3d587e7b-18d1-43d9-9192-4d6b7279ae94>.
+    
+<http://data.lblod.info/id/remote-data-objects/f858a3cb-dd55-49a1-8fb8-43c322246c9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f858a3cb-dd55-49a1-8fb8-43c322246c9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/0c9d58db-35b4-4e50-b1e0-b299f06dfbba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f858a3cb-dd55-49a1-8fb8-43c322246c9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/a27cce7e-bc3f-46c9-8649-deb272a66a14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a27cce7e-bc3f-46c9-8649-deb272a66a14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/1047d972-62a9-4d46-907f-034dd64d5f82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a27cce7e-bc3f-46c9-8649-deb272a66a14>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f0752b1-4421-4aaa-a78b-5382a7e805c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f0752b1-4421-4aaa-a78b-5382a7e805c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/12881184-cb05-4cf7-9ac3-51e969de7e92/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f0752b1-4421-4aaa-a78b-5382a7e805c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/84fa7352-4a39-4be7-b857-d03dda22b35c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84fa7352-4a39-4be7-b857-d03dda22b35c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/129503e1-f3cf-4743-9cf6-99dfdc5892cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/84fa7352-4a39-4be7-b857-d03dda22b35c>.
+    
+<http://data.lblod.info/id/remote-data-objects/351b00a4-5da6-4dda-b547-047720965813> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "351b00a4-5da6-4dda-b547-047720965813";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/145da599-aa38-4d52-8455-842ee245265b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/351b00a4-5da6-4dda-b547-047720965813>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e9b81c8-04a6-489e-b62e-ed05894a5d75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e9b81c8-04a6-489e-b62e-ed05894a5d75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/1d109b40-f60c-4dfd-851d-a6e31969861d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e9b81c8-04a6-489e-b62e-ed05894a5d75>.
+    
+<http://data.lblod.info/id/remote-data-objects/23f60801-b50c-4ca0-8e0f-6a58ce6832db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23f60801-b50c-4ca0-8e0f-6a58ce6832db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/1d877eb6-4138-4e39-a47c-c67bdcb6f391/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23f60801-b50c-4ca0-8e0f-6a58ce6832db>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c221c47-a714-4c04-91a8-9f53920b24f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c221c47-a714-4c04-91a8-9f53920b24f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/1dd34527-d42b-407e-843b-dd8f0fdf7c00/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c221c47-a714-4c04-91a8-9f53920b24f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd45ea60-9b78-4a99-89df-11297cffed42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd45ea60-9b78-4a99-89df-11297cffed42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/1f3653e7-7b53-42ca-81e7-ed7803433bee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd45ea60-9b78-4a99-89df-11297cffed42>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7f42cc9-377f-4c60-b3a4-6246bf9e086b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7f42cc9-377f-4c60-b3a4-6246bf9e086b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/23b239c8-7606-4411-b82d-98dd2561ad39/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7f42cc9-377f-4c60-b3a4-6246bf9e086b>.
+    
+<http://data.lblod.info/id/remote-data-objects/24b53fde-bb8b-4b01-b3ee-d306ab43d548> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24b53fde-bb8b-4b01-b3ee-d306ab43d548";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/24f98f67-c828-4c7d-a329-94546a375d90/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24b53fde-bb8b-4b01-b3ee-d306ab43d548>.
+    
+<http://data.lblod.info/id/remote-data-objects/628bc50f-9bd3-4c1c-9e93-1c791f62b2e8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "628bc50f-9bd3-4c1c-9e93-1c791f62b2e8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/29c40f90-098a-4325-a701-ff30abc7b7f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/628bc50f-9bd3-4c1c-9e93-1c791f62b2e8>.
+    
+<http://data.lblod.info/id/remote-data-objects/304c80db-bdc0-4b9e-ab74-d19b4dfbc58a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "304c80db-bdc0-4b9e-ab74-d19b4dfbc58a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/29d1aa29-ce98-41ed-a4a8-d5d9d9b5dc15/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/304c80db-bdc0-4b9e-ab74-d19b4dfbc58a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0c3102e-d214-4d21-8c6f-35e10c37c204> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0c3102e-d214-4d21-8c6f-35e10c37c204";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/328c8b59-1c38-4049-8fb1-ccc58e082c37/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0c3102e-d214-4d21-8c6f-35e10c37c204>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ccf7d4b-ba55-4744-9df0-bf19b3935ce7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ccf7d4b-ba55-4744-9df0-bf19b3935ce7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/3add7c71-a938-4a19-9ec5-6cc986185ecd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ccf7d4b-ba55-4744-9df0-bf19b3935ce7>.
+    
+<http://data.lblod.info/id/remote-data-objects/2b39c9a5-bd45-404d-bbe8-043601fa358a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b39c9a5-bd45-404d-bbe8-043601fa358a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/44c58e8e-eead-4c56-b131-d618c2b88cc2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2b39c9a5-bd45-404d-bbe8-043601fa358a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2337feaa-7270-47d3-a8cf-d5046dccb038> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2337feaa-7270-47d3-a8cf-d5046dccb038";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/4f87999a-1b5f-42d4-9c24-66b857400a30/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2337feaa-7270-47d3-a8cf-d5046dccb038>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9c67818-4b13-4199-b432-f77d949f9699> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9c67818-4b13-4199-b432-f77d949f9699";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/56a23146-a26a-43bc-a1af-b1ad96b75c4b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9c67818-4b13-4199-b432-f77d949f9699>.
+    
+<http://data.lblod.info/id/remote-data-objects/22b6d32e-b613-4aae-a267-b476b6a55718> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "22b6d32e-b613-4aae-a267-b476b6a55718";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/5b0e53ab-a448-4e94-9aad-98bc758f20b6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/22b6d32e-b613-4aae-a267-b476b6a55718>.
+    
+<http://data.lblod.info/id/remote-data-objects/048a9996-03d6-4a11-b946-2443bee5d0de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "048a9996-03d6-4a11-b946-2443bee5d0de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/5bc44538-5309-4edb-84fc-c282959547e6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/048a9996-03d6-4a11-b946-2443bee5d0de>.
+    
+<http://data.lblod.info/id/remote-data-objects/f57ec370-dbd8-43fa-a12f-55af22e5f630> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f57ec370-dbd8-43fa-a12f-55af22e5f630";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/5bff5ca5-dccf-485f-b237-57d84675aae2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f57ec370-dbd8-43fa-a12f-55af22e5f630>.
+    
+<http://data.lblod.info/id/remote-data-objects/3cd99cd7-eb8b-44c2-99eb-16a0c2b9f46d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3cd99cd7-eb8b-44c2-99eb-16a0c2b9f46d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/6002bd21-d754-47e5-93e9-05ec80aaeda4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3cd99cd7-eb8b-44c2-99eb-16a0c2b9f46d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c69bf435-ad69-48c7-9051-a17f01651ab1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c69bf435-ad69-48c7-9051-a17f01651ab1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/60f3542f-a016-4f7c-8816-4609eb3565a2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c69bf435-ad69-48c7-9051-a17f01651ab1>.
+    
+<http://data.lblod.info/id/remote-data-objects/1159294e-ad7c-4aa9-9ec2-9d0445c52c0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1159294e-ad7c-4aa9-9ec2-9d0445c52c0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/624c8517-b9ec-4255-9eae-745bb8b98e24/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1159294e-ad7c-4aa9-9ec2-9d0445c52c0b>.
+    
+<http://data.lblod.info/id/remote-data-objects/94da88df-cb20-4ffe-b056-37730cf03ace> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94da88df-cb20-4ffe-b056-37730cf03ace";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/642cdf5f-2d74-43e7-bb79-a291cb71ab98/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94da88df-cb20-4ffe-b056-37730cf03ace>.
+    
+<http://data.lblod.info/id/remote-data-objects/a85bc253-235b-4a15-857c-9eec9b609b08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a85bc253-235b-4a15-857c-9eec9b609b08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/70f24cb2-feba-4a81-b7c2-7eecf75a7de3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a85bc253-235b-4a15-857c-9eec9b609b08>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b5443b4-4c61-458a-a5d2-24f42626029b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b5443b4-4c61-458a-a5d2-24f42626029b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/711bd316-dae6-4954-87f6-11e31685058d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b5443b4-4c61-458a-a5d2-24f42626029b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b42bff7a-e788-452f-ab46-c31fc3655577> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b42bff7a-e788-452f-ab46-c31fc3655577";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/7379a91b-307c-4d91-84dd-47d8e4f16b1a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b42bff7a-e788-452f-ab46-c31fc3655577>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8dadfbe-7bff-4465-a5d5-26d536cfa29a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8dadfbe-7bff-4465-a5d5-26d536cfa29a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/7baef2d3-fcf9-48b6-9172-42d12a220604/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8dadfbe-7bff-4465-a5d5-26d536cfa29a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b33624f5-1181-4548-9458-38d1f2fe4ebb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b33624f5-1181-4548-9458-38d1f2fe4ebb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/7c1a96ca-e4c7-4106-be39-e8af782981b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b33624f5-1181-4548-9458-38d1f2fe4ebb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0b78126-60a7-4108-93c5-615451655abf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0b78126-60a7-4108-93c5-615451655abf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/82a6cb16-212b-4123-9f02-e4d41853c957/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0b78126-60a7-4108-93c5-615451655abf>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d19813e-3f71-4282-a7e2-2a9f0fc5cac9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d19813e-3f71-4282-a7e2-2a9f0fc5cac9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/865e8dde-df76-487c-b0cc-57e5bae975f3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d19813e-3f71-4282-a7e2-2a9f0fc5cac9>.
+    
+<http://data.lblod.info/id/remote-data-objects/aa5f7d3d-6209-47f7-a4ae-a748f56c126a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa5f7d3d-6209-47f7-a4ae-a748f56c126a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/87dc227d-17f7-48c9-a399-fd1e80d3c84f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/aa5f7d3d-6209-47f7-a4ae-a748f56c126a>.
+    
+<http://data.lblod.info/id/remote-data-objects/37a84e27-8b3e-401e-b3c1-1fda64550ea5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37a84e27-8b3e-401e-b3c1-1fda64550ea5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/8896b588-43f4-4f21-812a-a37a796357cf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37a84e27-8b3e-401e-b3c1-1fda64550ea5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5185c96d-6ba5-41d5-a551-c9117eb3e69e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5185c96d-6ba5-41d5-a551-c9117eb3e69e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/8c6394a5-b208-4887-adba-9b2db5b50047/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5185c96d-6ba5-41d5-a551-c9117eb3e69e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d788b789-2ec8-48fb-8b93-81160c6cc886> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d788b789-2ec8-48fb-8b93-81160c6cc886";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/8e095c32-497a-4d42-9c71-21a4c2f0ed0c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d788b789-2ec8-48fb-8b93-81160c6cc886>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4259049-19f3-405f-98b6-cd4f0cc4ec25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4259049-19f3-405f-98b6-cd4f0cc4ec25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/988ee83f-c970-4b69-9276-bee71ebd199e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4259049-19f3-405f-98b6-cd4f0cc4ec25>.
+    
+<http://data.lblod.info/id/remote-data-objects/b220a307-0dc4-4bcb-b4c8-aac9bcafb696> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b220a307-0dc4-4bcb-b4c8-aac9bcafb696";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/99af53f2-1852-4154-8858-849dbd81f8f8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b220a307-0dc4-4bcb-b4c8-aac9bcafb696>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab017504-19fa-4b57-81c3-7edb309ec57e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab017504-19fa-4b57-81c3-7edb309ec57e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/9b4c2112-c26a-4c71-9fcc-8715315c0797/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab017504-19fa-4b57-81c3-7edb309ec57e>.
+    
+<http://data.lblod.info/id/remote-data-objects/dab08079-3840-4cea-bb77-a4900b959161> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dab08079-3840-4cea-bb77-a4900b959161";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/9c958b8f-d996-4e77-91c4-fa64b08b4364/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:46.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/4dd288fd-193f-4c3e-9b6a-7f8e7e499c9e> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dab08079-3840-4cea-bb77-a4900b959161>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201947-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201947-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201947-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201947-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d40db799-7e7d-452c-a101-61cd1389f88c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d40db799-7e7d-452c-a101-61cd1389f88c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ccda0cd1-3971-4b08-a5bd-a1061c39583a";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/d7eebc5c-eb36-4916-aa7e-4f4b3f57c2f0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d7eebc5c-eb36-4916-aa7e-4f4b3f57c2f0";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a>.
+
+  <http://redpencil.data.gift/id/task/67f5d387-25cf-4e5c-9d62-8eddfe720526> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "67f5d387-25cf-4e5c-9d62-8eddfe720526";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d40db799-7e7d-452c-a101-61cd1389f88c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/d7eebc5c-eb36-4916-aa7e-4f4b3f57c2f0>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/6d56c508-1cc5-45e6-a85a-c2e3d1bc4caa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d56c508-1cc5-45e6-a85a-c2e3d1bc4caa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/9da56267-681e-4575-920c-ccd403a9ed85/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d56c508-1cc5-45e6-a85a-c2e3d1bc4caa>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e873604-32ab-4af0-b525-dfc4da26c7b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e873604-32ab-4af0-b525-dfc4da26c7b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/9e33f85a-80c5-4b41-812d-0f3e9c874719/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e873604-32ab-4af0-b525-dfc4da26c7b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/66d8f9c4-1875-4173-b25c-4af86f2302f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66d8f9c4-1875-4173-b25c-4af86f2302f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/a300ed8e-86a1-4cd7-a332-b45135be735c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66d8f9c4-1875-4173-b25c-4af86f2302f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/66446b2e-2185-42e8-a8bb-94db737451e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66446b2e-2185-42e8-a8bb-94db737451e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/b4bf15cc-09ad-42f7-9335-e444b0b84582/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66446b2e-2185-42e8-a8bb-94db737451e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a632184-3aea-46d4-bd9e-3477bb750830> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a632184-3aea-46d4-bd9e-3477bb750830";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/b68625a6-8f27-4b6e-a3ac-a820b5784659/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a632184-3aea-46d4-bd9e-3477bb750830>.
+    
+<http://data.lblod.info/id/remote-data-objects/03eab97d-7b4f-469d-831b-9c6faf17e5de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03eab97d-7b4f-469d-831b-9c6faf17e5de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/bb07d3ea-9c32-4989-a10d-2d09ab9ff371/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03eab97d-7b4f-469d-831b-9c6faf17e5de>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdfcb84b-ff0c-489a-a40a-4b0cea846756> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdfcb84b-ff0c-489a-a40a-4b0cea846756";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/bff2b3f7-1681-4f74-bb0d-6390d17efdf5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdfcb84b-ff0c-489a-a40a-4b0cea846756>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b98908d-1592-48c7-b117-d6e459f88fd6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b98908d-1592-48c7-b117-d6e459f88fd6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/c13cd3f3-f8b9-4436-bca0-5b0b8d5ef2ca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b98908d-1592-48c7-b117-d6e459f88fd6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c04ba12e-5bc9-4500-b497-b8766addadd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c04ba12e-5bc9-4500-b497-b8766addadd5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/c3311e16-0fbb-4b54-83ad-72b575f0396d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c04ba12e-5bc9-4500-b497-b8766addadd5>.
+    
+<http://data.lblod.info/id/remote-data-objects/bbec8a46-deb7-4d29-878e-a3d143934d96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bbec8a46-deb7-4d29-878e-a3d143934d96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/c9b3dae0-a031-4f4e-9dc7-19a4de959247/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bbec8a46-deb7-4d29-878e-a3d143934d96>.
+    
+<http://data.lblod.info/id/remote-data-objects/1120dda3-b3c1-4389-92d0-455a5cde158e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1120dda3-b3c1-4389-92d0-455a5cde158e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/cae1bbcc-fddd-4c68-8894-2076f343d07e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1120dda3-b3c1-4389-92d0-455a5cde158e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8b9e586-8202-4c1c-a8dd-66fa448101aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8b9e586-8202-4c1c-a8dd-66fa448101aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/cbede3c5-511d-4ab6-94fc-cb02b85b7572/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8b9e586-8202-4c1c-a8dd-66fa448101aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/a47f40ec-5640-47c0-932d-c7640aba4de5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a47f40ec-5640-47c0-932d-c7640aba4de5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/d4abc3fa-3210-41a3-a6ab-36b096940cc4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a47f40ec-5640-47c0-932d-c7640aba4de5>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc5f5c16-ddb2-464a-b351-0bca22c7301a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc5f5c16-ddb2-464a-b351-0bca22c7301a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/d9b7a327-9a5f-4e9b-a3bd-5c5b69c413b3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc5f5c16-ddb2-464a-b351-0bca22c7301a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c4b0a51-df32-4f88-9ff9-80ce6947ab53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c4b0a51-df32-4f88-9ff9-80ce6947ab53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/de2eb4d5-236b-4561-8a53-68a33d4fb23b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c4b0a51-df32-4f88-9ff9-80ce6947ab53>.
+    
+<http://data.lblod.info/id/remote-data-objects/98d3885d-a483-46be-8b0e-db86141c3b35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98d3885d-a483-46be-8b0e-db86141c3b35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/e0f1f8ac-9906-4e43-8156-f1eb9a7ad2ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98d3885d-a483-46be-8b0e-db86141c3b35>.
+    
+<http://data.lblod.info/id/remote-data-objects/bcc42d60-b426-4042-b8bc-d985b0c7170c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bcc42d60-b426-4042-b8bc-d985b0c7170c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/e21ad307-79f8-4cae-94e7-5d2d900a6cf8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bcc42d60-b426-4042-b8bc-d985b0c7170c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d15b67fe-e587-4ebb-b06e-099f5fa32eb5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d15b67fe-e587-4ebb-b06e-099f5fa32eb5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/e3c97c9d-5ff6-4855-9ab6-a5b9ebc2752d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d15b67fe-e587-4ebb-b06e-099f5fa32eb5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c7aa3293-15f5-4780-8883-70fed0979c88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c7aa3293-15f5-4780-8883-70fed0979c88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/e42021bf-a7ee-48bb-b374-b778e7337043/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c7aa3293-15f5-4780-8883-70fed0979c88>.
+    
+<http://data.lblod.info/id/remote-data-objects/78c87420-272e-4247-b59c-a687b2da43e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78c87420-272e-4247-b59c-a687b2da43e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/e59772f9-2425-49d7-81f2-3e7c08f6d918/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78c87420-272e-4247-b59c-a687b2da43e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a06ccd5c-5a1b-448b-89ff-30cb29ec8837> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a06ccd5c-5a1b-448b-89ff-30cb29ec8837";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/eebca1f9-c0f2-4f92-8785-b106f0e25b20/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a06ccd5c-5a1b-448b-89ff-30cb29ec8837>.
+    
+<http://data.lblod.info/id/remote-data-objects/59479cd3-8964-4aa4-82d6-5c9d46a47cdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59479cd3-8964-4aa4-82d6-5c9d46a47cdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/f56c3e0a-3e2c-4953-9055-e36716bd85c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59479cd3-8964-4aa4-82d6-5c9d46a47cdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/c559ddba-b94b-41a1-901c-c3be929633e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c559ddba-b94b-41a1-901c-c3be929633e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/f5bfa4b3-15aa-4234-80da-ec3f408b0a1a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c559ddba-b94b-41a1-901c-c3be929633e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/763b377a-6c46-4908-8348-74d75e3cd3ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "763b377a-6c46-4908-8348-74d75e3cd3ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/fbfbbc09-e6d1-4b3b-ad00-89359cd4c452/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/763b377a-6c46-4908-8348-74d75e3cd3ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/f1d4fa4f-9fbb-4e07-afab-6aed77f6f5ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1d4fa4f-9fbb-4e07-afab-6aed77f6f5ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/cbs/fce56b0d-8e0b-40c6-bd97-a4c29ae88e2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f1d4fa4f-9fbb-4e07-afab-6aed77f6f5ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d87f8ed-962d-4f23-9db2-967ec3a06cc9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d87f8ed-962d-4f23-9db2-967ec3a06cc9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/022fe7fb-2bbb-4fa1-adef-f76bbd891aca/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d87f8ed-962d-4f23-9db2-967ec3a06cc9>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f3ab8db-c9ed-42e6-8428-2b626b3ff155> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f3ab8db-c9ed-42e6-8428-2b626b3ff155";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/022fe7fb-2bbb-4fa1-adef-f76bbd891aca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f3ab8db-c9ed-42e6-8428-2b626b3ff155>.
+    
+<http://data.lblod.info/id/remote-data-objects/042b59f6-9665-47d9-a425-d3ee1b086d76> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "042b59f6-9665-47d9-a425-d3ee1b086d76";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/022fe7fb-2bbb-4fa1-adef-f76bbd891aca/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/042b59f6-9665-47d9-a425-d3ee1b086d76>.
+    
+<http://data.lblod.info/id/remote-data-objects/69100c32-7419-4796-80bc-019c80330852> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69100c32-7419-4796-80bc-019c80330852";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/046f78cc-ebd7-414b-a44b-d79b1879db49/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69100c32-7419-4796-80bc-019c80330852>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff81a3cd-c5c2-40c2-9b34-0da4909b9221> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff81a3cd-c5c2-40c2-9b34-0da4909b9221";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/046f78cc-ebd7-414b-a44b-d79b1879db49/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff81a3cd-c5c2-40c2-9b34-0da4909b9221>.
+    
+<http://data.lblod.info/id/remote-data-objects/40e64619-ef9e-4096-acef-4aeb21115df1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40e64619-ef9e-4096-acef-4aeb21115df1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/046f78cc-ebd7-414b-a44b-d79b1879db49/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40e64619-ef9e-4096-acef-4aeb21115df1>.
+    
+<http://data.lblod.info/id/remote-data-objects/95509312-6fd7-4ab9-85a8-521af8057ad7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95509312-6fd7-4ab9-85a8-521af8057ad7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/352ee972-4e19-4310-b55d-51c8d75d2c56/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95509312-6fd7-4ab9-85a8-521af8057ad7>.
+    
+<http://data.lblod.info/id/remote-data-objects/405d1d3e-9445-4fd7-beba-158465af1744> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "405d1d3e-9445-4fd7-beba-158465af1744";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/352ee972-4e19-4310-b55d-51c8d75d2c56/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/405d1d3e-9445-4fd7-beba-158465af1744>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6828043-93fb-46fc-b388-874605a7646b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6828043-93fb-46fc-b388-874605a7646b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/352ee972-4e19-4310-b55d-51c8d75d2c56/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6828043-93fb-46fc-b388-874605a7646b>.
+    
+<http://data.lblod.info/id/remote-data-objects/a00d918d-5901-4f47-8bbb-2250a65d37bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a00d918d-5901-4f47-8bbb-2250a65d37bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/39b9ccd8-8ce4-4883-ba3b-426dacb6874a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a00d918d-5901-4f47-8bbb-2250a65d37bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/24761eda-0133-4cdf-9ac0-2765fa13c628> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "24761eda-0133-4cdf-9ac0-2765fa13c628";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/39b9ccd8-8ce4-4883-ba3b-426dacb6874a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/24761eda-0133-4cdf-9ac0-2765fa13c628>.
+    
+<http://data.lblod.info/id/remote-data-objects/a593290b-2e44-467b-9463-ff62e3d86825> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a593290b-2e44-467b-9463-ff62e3d86825";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/39b9ccd8-8ce4-4883-ba3b-426dacb6874a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a593290b-2e44-467b-9463-ff62e3d86825>.
+    
+<http://data.lblod.info/id/remote-data-objects/50b52593-3ba4-4cc5-a9c1-2d5f1a33a62a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50b52593-3ba4-4cc5-a9c1-2d5f1a33a62a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/538ae6b9-8e08-4dee-8bd6-a90bf53250f6/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50b52593-3ba4-4cc5-a9c1-2d5f1a33a62a>.
+    
+<http://data.lblod.info/id/remote-data-objects/77ebadd9-870c-4920-83e7-a3ed8973774d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77ebadd9-870c-4920-83e7-a3ed8973774d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/538ae6b9-8e08-4dee-8bd6-a90bf53250f6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77ebadd9-870c-4920-83e7-a3ed8973774d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2c8248f-d95a-41cd-ab39-1106e60be89d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2c8248f-d95a-41cd-ab39-1106e60be89d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/538ae6b9-8e08-4dee-8bd6-a90bf53250f6/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2c8248f-d95a-41cd-ab39-1106e60be89d>.
+    
+<http://data.lblod.info/id/remote-data-objects/96d8c6b6-1eda-4d0a-907b-7d55b4145904> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "96d8c6b6-1eda-4d0a-907b-7d55b4145904";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/610e2f5a-0961-46bb-be52-07023f9a4a91/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/96d8c6b6-1eda-4d0a-907b-7d55b4145904>.
+    
+<http://data.lblod.info/id/remote-data-objects/a91c9920-24ae-4f82-bc93-e583adaa828e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a91c9920-24ae-4f82-bc93-e583adaa828e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/610e2f5a-0961-46bb-be52-07023f9a4a91/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a91c9920-24ae-4f82-bc93-e583adaa828e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4fa64e36-bfff-41c5-90bc-c8e6ab187ec6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fa64e36-bfff-41c5-90bc-c8e6ab187ec6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/76dd8f5f-c17e-46ae-ac99-3894fcb703c9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4fa64e36-bfff-41c5-90bc-c8e6ab187ec6>.
+    
+<http://data.lblod.info/id/remote-data-objects/16b52a7b-c05f-4caa-86af-b14e48b1ed24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16b52a7b-c05f-4caa-86af-b14e48b1ed24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/76dd8f5f-c17e-46ae-ac99-3894fcb703c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16b52a7b-c05f-4caa-86af-b14e48b1ed24>.
+    
+<http://data.lblod.info/id/remote-data-objects/e42472ad-4617-418c-ab0c-4a1fc225665f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e42472ad-4617-418c-ab0c-4a1fc225665f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/76dd8f5f-c17e-46ae-ac99-3894fcb703c9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e42472ad-4617-418c-ab0c-4a1fc225665f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8450a801-c7a4-4445-a161-e847ad7f571d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8450a801-c7a4-4445-a161-e847ad7f571d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/78d252fd-4368-4aef-a268-e182a213c7fa/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8450a801-c7a4-4445-a161-e847ad7f571d>.
+    
+<http://data.lblod.info/id/remote-data-objects/dba4b2e1-92e0-490f-98c2-c44e7f46f70e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dba4b2e1-92e0-490f-98c2-c44e7f46f70e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/78d252fd-4368-4aef-a268-e182a213c7fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dba4b2e1-92e0-490f-98c2-c44e7f46f70e>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdd27ceb-42ad-4a57-a45b-70dc6aaef399> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdd27ceb-42ad-4a57-a45b-70dc6aaef399";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/78d252fd-4368-4aef-a268-e182a213c7fa/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdd27ceb-42ad-4a57-a45b-70dc6aaef399>.
+    
+<http://data.lblod.info/id/remote-data-objects/927686c3-e1fb-4d60-9db8-65a1bd6deea5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "927686c3-e1fb-4d60-9db8-65a1bd6deea5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/8046cbc5-cc2e-409d-a1e9-05c3796fe24c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/927686c3-e1fb-4d60-9db8-65a1bd6deea5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3ed82f1-8c5d-4d08-9689-29773ee1cd11> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3ed82f1-8c5d-4d08-9689-29773ee1cd11";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/8046cbc5-cc2e-409d-a1e9-05c3796fe24c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:47.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ccda0cd1-3971-4b08-a5bd-a1061c39583a> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3ed82f1-8c5d-4d08-9689-29773ee1cd11>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201948-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201948-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201948-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201948-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/db41a2ad-b75b-4d50-8197-5adf4d73fa05> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "db41a2ad-b75b-4d50-8197-5adf4d73fa05";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6d522046-8b9a-41d4-912a-b81d2b54e439";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/ec397936-2076-4f16-a27c-21771fe5acd5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ec397936-2076-4f16-a27c-21771fe5acd5";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439>.
+
+  <http://redpencil.data.gift/id/task/c5b2c00c-639d-467f-b852-29cbe53e3c07> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c5b2c00c-639d-467f-b852-29cbe53e3c07";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/db41a2ad-b75b-4d50-8197-5adf4d73fa05>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/ec397936-2076-4f16-a27c-21771fe5acd5>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/50b97d7a-5cc9-430f-a5bc-d8456a74c045> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50b97d7a-5cc9-430f-a5bc-d8456a74c045";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/8046cbc5-cc2e-409d-a1e9-05c3796fe24c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50b97d7a-5cc9-430f-a5bc-d8456a74c045>.
+    
+<http://data.lblod.info/id/remote-data-objects/f49f6c04-09bb-4954-b008-fae9133c5eb2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f49f6c04-09bb-4954-b008-fae9133c5eb2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/957172cc-1296-490f-9c00-4364552614d1/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f49f6c04-09bb-4954-b008-fae9133c5eb2>.
+    
+<http://data.lblod.info/id/remote-data-objects/913402cf-17d9-4d26-8c4a-dbb39f710261> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "913402cf-17d9-4d26-8c4a-dbb39f710261";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/957172cc-1296-490f-9c00-4364552614d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/913402cf-17d9-4d26-8c4a-dbb39f710261>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed563a7d-2a8a-4f1a-835a-be8b898a8147> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed563a7d-2a8a-4f1a-835a-be8b898a8147";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/957172cc-1296-490f-9c00-4364552614d1/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed563a7d-2a8a-4f1a-835a-be8b898a8147>.
+    
+<http://data.lblod.info/id/remote-data-objects/3fa254e9-f726-4e86-9b3b-5563cad5bce5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3fa254e9-f726-4e86-9b3b-5563cad5bce5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/9da21c91-43da-4bf4-b27c-dd2692863982/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3fa254e9-f726-4e86-9b3b-5563cad5bce5>.
+    
+<http://data.lblod.info/id/remote-data-objects/d10f90a2-f8a1-4fc4-a760-b68f330b07c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d10f90a2-f8a1-4fc4-a760-b68f330b07c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/9da21c91-43da-4bf4-b27c-dd2692863982/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d10f90a2-f8a1-4fc4-a760-b68f330b07c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/09641469-c67e-47ad-97ac-444eb8417086> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09641469-c67e-47ad-97ac-444eb8417086";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/9da21c91-43da-4bf4-b27c-dd2692863982/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/09641469-c67e-47ad-97ac-444eb8417086>.
+    
+<http://data.lblod.info/id/remote-data-objects/acae7916-0a32-467e-8103-432cc79e6c70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acae7916-0a32-467e-8103-432cc79e6c70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/ad33d368-65f9-4503-b07d-ccd79da0f40c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acae7916-0a32-467e-8103-432cc79e6c70>.
+    
+<http://data.lblod.info/id/remote-data-objects/623f06d7-11b8-4aaf-a289-b7ad69135440> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "623f06d7-11b8-4aaf-a289-b7ad69135440";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/ad33d368-65f9-4503-b07d-ccd79da0f40c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/623f06d7-11b8-4aaf-a289-b7ad69135440>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bba0972-1c04-4bb8-9e21-4520ad99ab6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bba0972-1c04-4bb8-9e21-4520ad99ab6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/ad33d368-65f9-4503-b07d-ccd79da0f40c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bba0972-1c04-4bb8-9e21-4520ad99ab6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/c34f7f17-d436-4cdd-88d1-9d293a9071e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c34f7f17-d436-4cdd-88d1-9d293a9071e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/b13254cc-a992-4ef0-a69a-dbfd2ebca74a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c34f7f17-d436-4cdd-88d1-9d293a9071e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/06cfe47f-afe0-46cf-9e23-d884ec3299f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06cfe47f-afe0-46cf-9e23-d884ec3299f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/b13254cc-a992-4ef0-a69a-dbfd2ebca74a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/06cfe47f-afe0-46cf-9e23-d884ec3299f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/7d60e293-6cc1-40b8-adc2-0e36d784991f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d60e293-6cc1-40b8-adc2-0e36d784991f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/b13254cc-a992-4ef0-a69a-dbfd2ebca74a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7d60e293-6cc1-40b8-adc2-0e36d784991f>.
+    
+<http://data.lblod.info/id/remote-data-objects/39c22097-f27f-4f6a-8b23-e1d55ba5946e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39c22097-f27f-4f6a-8b23-e1d55ba5946e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/b781a369-dbca-4244-9d57-39796d66c9a8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39c22097-f27f-4f6a-8b23-e1d55ba5946e>.
+    
+<http://data.lblod.info/id/remote-data-objects/237d37e7-3b1b-42ee-b741-719b8adce4fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "237d37e7-3b1b-42ee-b741-719b8adce4fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/b781a369-dbca-4244-9d57-39796d66c9a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/237d37e7-3b1b-42ee-b741-719b8adce4fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/75d33419-4173-42f8-b3c7-171a6afcf895> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75d33419-4173-42f8-b3c7-171a6afcf895";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/b781a369-dbca-4244-9d57-39796d66c9a8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75d33419-4173-42f8-b3c7-171a6afcf895>.
+    
+<http://data.lblod.info/id/remote-data-objects/6218d603-fd85-48c1-8c53-8130ad81353c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6218d603-fd85-48c1-8c53-8130ad81353c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/c9aa77cf-dc88-4484-8f1e-98863b81637c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6218d603-fd85-48c1-8c53-8130ad81353c>.
+    
+<http://data.lblod.info/id/remote-data-objects/eac39e1e-a74a-4631-91d3-f640fbc56412> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eac39e1e-a74a-4631-91d3-f640fbc56412";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/c9aa77cf-dc88-4484-8f1e-98863b81637c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eac39e1e-a74a-4631-91d3-f640fbc56412>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c0e9405-efc6-4ee5-8717-4c16b25d720e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c0e9405-efc6-4ee5-8717-4c16b25d720e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/c9aa77cf-dc88-4484-8f1e-98863b81637c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c0e9405-efc6-4ee5-8717-4c16b25d720e>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b2dca27-799e-435f-be61-f92478e39a5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b2dca27-799e-435f-be61-f92478e39a5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/e58cbad0-5319-4cf9-8627-80745a939c79/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b2dca27-799e-435f-be61-f92478e39a5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9acebe5b-4c4d-492b-82ab-c26d53a50c9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9acebe5b-4c4d-492b-82ab-c26d53a50c9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/e58cbad0-5319-4cf9-8627-80745a939c79/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9acebe5b-4c4d-492b-82ab-c26d53a50c9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/36605bdb-fca2-4663-9439-1c3ef3a27465> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36605bdb-fca2-4663-9439-1c3ef3a27465";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/gr/e58cbad0-5319-4cf9-8627-80745a939c79/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36605bdb-fca2-4663-9439-1c3ef3a27465>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9d2600e-b9c8-4181-84b7-43b010682add> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9d2600e-b9c8-4181-84b7-43b010682add";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/0240220c-387e-485a-950f-3605a8394ac0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9d2600e-b9c8-4181-84b7-43b010682add>.
+    
+<http://data.lblod.info/id/remote-data-objects/e90a89fd-1cb0-45df-a972-a9000380a057> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e90a89fd-1cb0-45df-a972-a9000380a057";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/0240220c-387e-485a-950f-3605a8394ac0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e90a89fd-1cb0-45df-a972-a9000380a057>.
+    
+<http://data.lblod.info/id/remote-data-objects/77160912-7566-4fc9-8ed8-b03b321586d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77160912-7566-4fc9-8ed8-b03b321586d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/0240220c-387e-485a-950f-3605a8394ac0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77160912-7566-4fc9-8ed8-b03b321586d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/7f52d2f1-38f0-42bb-b913-cd8f89555466> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f52d2f1-38f0-42bb-b913-cd8f89555466";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/0de6a32c-123b-4cd3-bfa0-590aa1b50ddb/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7f52d2f1-38f0-42bb-b913-cd8f89555466>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4573da8-8198-4257-86bf-4e8228937f2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4573da8-8198-4257-86bf-4e8228937f2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/0de6a32c-123b-4cd3-bfa0-590aa1b50ddb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4573da8-8198-4257-86bf-4e8228937f2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2272abe6-9e8f-4468-92fd-7e6bfa5d0d4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2272abe6-9e8f-4468-92fd-7e6bfa5d0d4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/0de6a32c-123b-4cd3-bfa0-590aa1b50ddb/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2272abe6-9e8f-4468-92fd-7e6bfa5d0d4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/69b6cc62-2e0a-44fe-bae9-7394a5eb3325> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69b6cc62-2e0a-44fe-bae9-7394a5eb3325";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/1a36965e-100d-48e2-a12f-d9097f86b567/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69b6cc62-2e0a-44fe-bae9-7394a5eb3325>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e7d7b5b-a9b0-4aa6-a6c1-e79522bd1695> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e7d7b5b-a9b0-4aa6-a6c1-e79522bd1695";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/1a36965e-100d-48e2-a12f-d9097f86b567/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e7d7b5b-a9b0-4aa6-a6c1-e79522bd1695>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea36bcde-ea83-443e-9865-f22db1839502> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea36bcde-ea83-443e-9865-f22db1839502";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/1a36965e-100d-48e2-a12f-d9097f86b567/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea36bcde-ea83-443e-9865-f22db1839502>.
+    
+<http://data.lblod.info/id/remote-data-objects/fca7b927-8e44-4838-b049-4463dcc40639> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fca7b927-8e44-4838-b049-4463dcc40639";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/1a4e00ee-d887-4e28-8a11-a621b55396dd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fca7b927-8e44-4838-b049-4463dcc40639>.
+    
+<http://data.lblod.info/id/remote-data-objects/4a313a9a-ca38-4e36-b29b-794a5dee4202> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a313a9a-ca38-4e36-b29b-794a5dee4202";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/1a4e00ee-d887-4e28-8a11-a621b55396dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4a313a9a-ca38-4e36-b29b-794a5dee4202>.
+    
+<http://data.lblod.info/id/remote-data-objects/1bc4ef10-b4cc-4327-871d-3df2856ce979> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1bc4ef10-b4cc-4327-871d-3df2856ce979";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/1a4e00ee-d887-4e28-8a11-a621b55396dd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1bc4ef10-b4cc-4327-871d-3df2856ce979>.
+    
+<http://data.lblod.info/id/remote-data-objects/2de2194c-4b3b-4be6-ae34-2fe35ae1570c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2de2194c-4b3b-4be6-ae34-2fe35ae1570c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/245f0943-d9ed-43bf-9bbc-a0e69fd11790/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2de2194c-4b3b-4be6-ae34-2fe35ae1570c>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb7c9ede-1bb1-4318-89a9-efacd218ce46> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb7c9ede-1bb1-4318-89a9-efacd218ce46";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/245f0943-d9ed-43bf-9bbc-a0e69fd11790/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb7c9ede-1bb1-4318-89a9-efacd218ce46>.
+    
+<http://data.lblod.info/id/remote-data-objects/d502fbc7-c194-4208-b03b-d8386d28b414> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d502fbc7-c194-4208-b03b-d8386d28b414";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/245f0943-d9ed-43bf-9bbc-a0e69fd11790/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d502fbc7-c194-4208-b03b-d8386d28b414>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd68266c-1d3c-4116-a4fd-54a4a958a3f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd68266c-1d3c-4116-a4fd-54a4a958a3f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/27f527e1-f88e-4631-ba35-cdb2d3c47002/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd68266c-1d3c-4116-a4fd-54a4a958a3f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/c17258ed-a890-4ab6-8c39-b66a8f7e1a4d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c17258ed-a890-4ab6-8c39-b66a8f7e1a4d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/27f527e1-f88e-4631-ba35-cdb2d3c47002/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c17258ed-a890-4ab6-8c39-b66a8f7e1a4d>.
+    
+<http://data.lblod.info/id/remote-data-objects/98757c32-1963-4ba9-bb74-a340dddd7dea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "98757c32-1963-4ba9-bb74-a340dddd7dea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/27f527e1-f88e-4631-ba35-cdb2d3c47002/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/98757c32-1963-4ba9-bb74-a340dddd7dea>.
+    
+<http://data.lblod.info/id/remote-data-objects/6e669d7a-39d1-45df-9d7f-498332ac47f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6e669d7a-39d1-45df-9d7f-498332ac47f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/29d67e41-c147-4337-9043-913a2d01a4c9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6e669d7a-39d1-45df-9d7f-498332ac47f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ced12493-a92f-4664-ae7a-461a4a37d137> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ced12493-a92f-4664-ae7a-461a4a37d137";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/29d67e41-c147-4337-9043-913a2d01a4c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ced12493-a92f-4664-ae7a-461a4a37d137>.
+    
+<http://data.lblod.info/id/remote-data-objects/74007630-7ca4-4778-a514-84d069c83fdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74007630-7ca4-4778-a514-84d069c83fdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/29d67e41-c147-4337-9043-913a2d01a4c9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/74007630-7ca4-4778-a514-84d069c83fdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/53fa4cf2-1b2e-48d8-b475-4321f78c7de7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53fa4cf2-1b2e-48d8-b475-4321f78c7de7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/39cac297-4799-48f3-994a-f7f5a835594d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53fa4cf2-1b2e-48d8-b475-4321f78c7de7>.
+    
+<http://data.lblod.info/id/remote-data-objects/68098959-048c-4a1d-8fab-07ce2accc6b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68098959-048c-4a1d-8fab-07ce2accc6b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/39cac297-4799-48f3-994a-f7f5a835594d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68098959-048c-4a1d-8fab-07ce2accc6b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/cebf253a-0a63-4e5d-82f0-d7a018af6c2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cebf253a-0a63-4e5d-82f0-d7a018af6c2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/39cac297-4799-48f3-994a-f7f5a835594d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cebf253a-0a63-4e5d-82f0-d7a018af6c2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/a143f66b-b39e-432c-b076-2e13f84e4b99> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a143f66b-b39e-432c-b076-2e13f84e4b99";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/61914d36-ca88-4bb0-8b20-1579ba8fc26f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a143f66b-b39e-432c-b076-2e13f84e4b99>.
+    
+<http://data.lblod.info/id/remote-data-objects/86f93bc7-343c-4d04-9b5f-3104caa931d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86f93bc7-343c-4d04-9b5f-3104caa931d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/61914d36-ca88-4bb0-8b20-1579ba8fc26f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86f93bc7-343c-4d04-9b5f-3104caa931d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0ab99abc-6681-49a6-a38a-ab03f34cfb9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ab99abc-6681-49a6-a38a-ab03f34cfb9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/aa1943df-c304-42c7-9f8d-9f733026d542/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0ab99abc-6681-49a6-a38a-ab03f34cfb9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/38c12681-1c5c-46d3-aaee-b34ebad78ca0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38c12681-1c5c-46d3-aaee-b34ebad78ca0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/aa1943df-c304-42c7-9f8d-9f733026d542/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:48.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/6d522046-8b9a-41d4-912a-b81d2b54e439> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38c12681-1c5c-46d3-aaee-b34ebad78ca0>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201949-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201949-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201949-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201949-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/742a4545-dcdb-42f4-a8ef-f80bc67640a6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "742a4545-dcdb-42f4-a8ef-f80bc67640a6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1ae72262-be53-4a61-9f4c-2c13d0192336";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/015f9b45-5f36-45c0-9a9e-dea921e77ec2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "015f9b45-5f36-45c0-9a9e-dea921e77ec2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336>.
+
+  <http://redpencil.data.gift/id/task/ced426d6-21ce-4555-bc4e-07e199e2151a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ced426d6-21ce-4555-bc4e-07e199e2151a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/742a4545-dcdb-42f4-a8ef-f80bc67640a6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/015f9b45-5f36-45c0-9a9e-dea921e77ec2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/92eab587-dd8f-4cd7-8104-c99fd68f32b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "92eab587-dd8f-4cd7-8104-c99fd68f32b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/af378fc3-13a9-402d-81bf-9a6f6b224196/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/92eab587-dd8f-4cd7-8104-c99fd68f32b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/555450d7-b183-4ed6-9e32-4b2ca78b0066> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "555450d7-b183-4ed6-9e32-4b2ca78b0066";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/af378fc3-13a9-402d-81bf-9a6f6b224196/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/555450d7-b183-4ed6-9e32-4b2ca78b0066>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2fdd84e-f51e-4ad5-b7a2-9b5044d4660e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2fdd84e-f51e-4ad5-b7a2-9b5044d4660e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/af378fc3-13a9-402d-81bf-9a6f6b224196/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2fdd84e-f51e-4ad5-b7a2-9b5044d4660e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2c1bb01b-ce2b-40d9-ab70-bb37bdcb34d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2c1bb01b-ce2b-40d9-ab70-bb37bdcb34d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/d516dce8-6f61-43b5-b4a9-fdbab0463b59/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2c1bb01b-ce2b-40d9-ab70-bb37bdcb34d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd44d056-9745-4148-96d1-0b309f1db0db> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd44d056-9745-4148-96d1-0b309f1db0db";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/d516dce8-6f61-43b5-b4a9-fdbab0463b59/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd44d056-9745-4148-96d1-0b309f1db0db>.
+    
+<http://data.lblod.info/id/remote-data-objects/cbdfe6f8-a566-4713-9c15-1d7e38b3cf74> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cbdfe6f8-a566-4713-9c15-1d7e38b3cf74";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/d516dce8-6f61-43b5-b4a9-fdbab0463b59/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cbdfe6f8-a566-4713-9c15-1d7e38b3cf74>.
+    
+<http://data.lblod.info/id/remote-data-objects/01cc6924-7a09-47aa-8fd1-f037198cfda2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01cc6924-7a09-47aa-8fd1-f037198cfda2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/f110d5eb-32ef-48e7-9254-222be6313e88/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/01cc6924-7a09-47aa-8fd1-f037198cfda2>.
+    
+<http://data.lblod.info/id/remote-data-objects/4680cd29-a176-4632-8a40-f1f944804e64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4680cd29-a176-4632-8a40-f1f944804e64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/f110d5eb-32ef-48e7-9254-222be6313e88/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4680cd29-a176-4632-8a40-f1f944804e64>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b68c262-3ade-40ad-89c4-dc6a2f5a380a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b68c262-3ade-40ad-89c4-dc6a2f5a380a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/f110d5eb-32ef-48e7-9254-222be6313e88/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b68c262-3ade-40ad-89c4-dc6a2f5a380a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc450b92-f0b1-4cc6-80dc-9d6b0648f51a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc450b92-f0b1-4cc6-80dc-9d6b0648f51a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/fe89ae34-8a4e-4a1e-90aa-c32da860e516/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc450b92-f0b1-4cc6-80dc-9d6b0648f51a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c12c557d-19fd-4822-b880-0bd1f31858e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c12c557d-19fd-4822-b880-0bd1f31858e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/fe89ae34-8a4e-4a1e-90aa-c32da860e516/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c12c557d-19fd-4822-b880-0bd1f31858e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/740ba29a-2ccb-49ff-956d-36bbae45d011> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "740ba29a-2ccb-49ff-956d-36bbae45d011";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/rmw/fe89ae34-8a4e-4a1e-90aa-c32da860e516/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/740ba29a-2ccb-49ff-956d-36bbae45d011>.
+    
+<http://data.lblod.info/id/remote-data-objects/280f775d-4e63-417a-a819-ff649d214701> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "280f775d-4e63-417a-a819-ff649d214701";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/011199b0-f21e-472d-b9c1-b174e5b8617a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/280f775d-4e63-417a-a819-ff649d214701>.
+    
+<http://data.lblod.info/id/remote-data-objects/b80db43b-719e-4296-b791-9a1daff3c72b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b80db43b-719e-4296-b791-9a1daff3c72b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/0c5daaa3-0eb0-427b-a16d-97e0dc76798f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b80db43b-719e-4296-b791-9a1daff3c72b>.
+    
+<http://data.lblod.info/id/remote-data-objects/6714dfa0-af20-464f-8578-f74174d91b5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6714dfa0-af20-464f-8578-f74174d91b5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/0fffc747-1371-4d83-8ef1-62b78403088b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6714dfa0-af20-464f-8578-f74174d91b5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e356564-3bc1-43c1-9f48-fb37e155d4bf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e356564-3bc1-43c1-9f48-fb37e155d4bf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/1cdfe362-a17d-41a9-a085-bff1db284aeb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e356564-3bc1-43c1-9f48-fb37e155d4bf>.
+    
+<http://data.lblod.info/id/remote-data-objects/e86f6350-aa95-4078-9896-0234e4cc7727> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e86f6350-aa95-4078-9896-0234e4cc7727";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/1e45d9b6-6ac2-43cf-8c69-a4e76979491f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e86f6350-aa95-4078-9896-0234e4cc7727>.
+    
+<http://data.lblod.info/id/remote-data-objects/28af41e7-329c-42ba-8e18-4a4cde4973eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28af41e7-329c-42ba-8e18-4a4cde4973eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/245db8fa-647d-4a6f-9773-ac4ab7d4aefb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28af41e7-329c-42ba-8e18-4a4cde4973eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/00e26e25-4825-4a00-87c9-9366a8066c85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00e26e25-4825-4a00-87c9-9366a8066c85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/2cf4d052-c76f-419d-a17c-b736e2b70f25/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00e26e25-4825-4a00-87c9-9366a8066c85>.
+    
+<http://data.lblod.info/id/remote-data-objects/37cc411d-9eb4-4a0c-b5bc-ddc14a6c1bc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37cc411d-9eb4-4a0c-b5bc-ddc14a6c1bc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/331c9e54-e4ad-4f96-9727-44059c14bd90/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37cc411d-9eb4-4a0c-b5bc-ddc14a6c1bc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab02ed9e-4f3e-4c4f-985d-ffa09354ec9a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab02ed9e-4f3e-4c4f-985d-ffa09354ec9a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/422e1a1d-4e97-43c5-ab26-18432f581904/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab02ed9e-4f3e-4c4f-985d-ffa09354ec9a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b91562f8-8534-41e7-b401-1d41a1a72ac8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b91562f8-8534-41e7-b401-1d41a1a72ac8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/495dc2e5-3581-4716-9e7d-6dcbc97258cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b91562f8-8534-41e7-b401-1d41a1a72ac8>.
+    
+<http://data.lblod.info/id/remote-data-objects/27d7e458-1517-40a3-b235-5d00c406d8fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27d7e458-1517-40a3-b235-5d00c406d8fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/55a99a76-1a75-4813-b927-b128a725a48b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27d7e458-1517-40a3-b235-5d00c406d8fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/48673e37-cc5c-407c-9340-355fe5917d15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48673e37-cc5c-407c-9340-355fe5917d15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/5684d406-396d-4d63-b76b-10de3997b5ba/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48673e37-cc5c-407c-9340-355fe5917d15>.
+    
+<http://data.lblod.info/id/remote-data-objects/bb8dbe98-fb79-4c00-8481-7ba9d3dbeee3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bb8dbe98-fb79-4c00-8481-7ba9d3dbeee3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/63e001b3-2e13-44ed-8806-b127d7077ca6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bb8dbe98-fb79-4c00-8481-7ba9d3dbeee3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2de7547c-4eaf-41ab-a280-e732fc142200> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2de7547c-4eaf-41ab-a280-e732fc142200";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/658e553b-a973-4a85-8918-44da5a9d69f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2de7547c-4eaf-41ab-a280-e732fc142200>.
+    
+<http://data.lblod.info/id/remote-data-objects/b71bcffc-407f-4bae-a747-fe147eb135c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b71bcffc-407f-4bae-a747-fe147eb135c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/692f5c6c-69c0-475f-bd3d-4bca35ed2032/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b71bcffc-407f-4bae-a747-fe147eb135c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0936ef69-2664-426a-ad1e-cc20a6ad33c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0936ef69-2664-426a-ad1e-cc20a6ad33c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/6c12ba79-1be1-4358-b136-8f3fea3d38a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0936ef69-2664-426a-ad1e-cc20a6ad33c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/c8ca65f6-61a7-4412-9751-ff582e972e2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8ca65f6-61a7-4412-9751-ff582e972e2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/6ca89b7e-fcd6-4107-bb4b-26c2ca862d0a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c8ca65f6-61a7-4412-9751-ff582e972e2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f496bb2-fe33-4ea1-be0e-f9254611e1b8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f496bb2-fe33-4ea1-be0e-f9254611e1b8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/715aeff9-591d-4ade-897d-3b143e8202a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f496bb2-fe33-4ea1-be0e-f9254611e1b8>.
+    
+<http://data.lblod.info/id/remote-data-objects/9930d239-ae26-4fde-8dd6-79c5ef2eb63e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9930d239-ae26-4fde-8dd6-79c5ef2eb63e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/7b94592c-0d59-4965-a94d-4517e92e61a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9930d239-ae26-4fde-8dd6-79c5ef2eb63e>.
+    
+<http://data.lblod.info/id/remote-data-objects/acc87c7e-837c-4ba9-8279-ec20fc9b80c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acc87c7e-837c-4ba9-8279-ec20fc9b80c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/7fe43441-cf0c-4e0b-a201-703c066c3a13/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acc87c7e-837c-4ba9-8279-ec20fc9b80c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/4db68f52-deb7-4a58-8d28-bc65e4c00885> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4db68f52-deb7-4a58-8d28-bc65e4c00885";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/80e3a02e-ae9c-4e4c-ac25-57f107da9b89/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4db68f52-deb7-4a58-8d28-bc65e4c00885>.
+    
+<http://data.lblod.info/id/remote-data-objects/7ad5f61d-15bd-487a-81f8-9a91b92ff445> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ad5f61d-15bd-487a-81f8-9a91b92ff445";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/84a41d2b-e85b-4452-b9ce-a5f01881bfef/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7ad5f61d-15bd-487a-81f8-9a91b92ff445>.
+    
+<http://data.lblod.info/id/remote-data-objects/be396ea8-8b2e-4e59-9081-d6ee1997b024> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be396ea8-8b2e-4e59-9081-d6ee1997b024";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/8a8b5b27-1ca2-4d44-844b-4be23eb267db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be396ea8-8b2e-4e59-9081-d6ee1997b024>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3f6e12b-f42e-48d6-9442-a433a1041bd7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3f6e12b-f42e-48d6-9442-a433a1041bd7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/8f52767f-b35f-4947-9c3e-8627f053e83d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3f6e12b-f42e-48d6-9442-a433a1041bd7>.
+    
+<http://data.lblod.info/id/remote-data-objects/022b2d7b-9a6e-4219-bf1e-4bef03cf4d53> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "022b2d7b-9a6e-4219-bf1e-4bef03cf4d53";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/9b5435b3-73e8-4121-afbd-c9b38cdaf166/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/022b2d7b-9a6e-4219-bf1e-4bef03cf4d53>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee225ce6-1275-49b8-8390-f5160ae2daa7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee225ce6-1275-49b8-8390-f5160ae2daa7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/a5be6006-4ebe-435c-a65b-aaf026c69b0e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee225ce6-1275-49b8-8390-f5160ae2daa7>.
+    
+<http://data.lblod.info/id/remote-data-objects/65fd4cb2-d8f4-4ff9-b34f-24d6990b9f88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65fd4cb2-d8f4-4ff9-b34f-24d6990b9f88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/a66ebc76-43e0-4532-8ca7-188841f40fc2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65fd4cb2-d8f4-4ff9-b34f-24d6990b9f88>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0b06c81-5670-439c-8052-0395b6d4f08a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0b06c81-5670-439c-8052-0395b6d4f08a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/a860d459-d58e-4860-a57b-4dbf1b3f9e4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0b06c81-5670-439c-8052-0395b6d4f08a>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0c2e66e-9052-4bfa-bd64-3e36763aec1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0c2e66e-9052-4bfa-bd64-3e36763aec1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/a8ecf0c3-256b-449f-8c34-86e09877e54f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0c2e66e-9052-4bfa-bd64-3e36763aec1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/e854a0df-0c47-4eea-af74-d498fab9d366> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e854a0df-0c47-4eea-af74-d498fab9d366";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/a9fa8b13-0527-4688-9024-fd1832c107c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e854a0df-0c47-4eea-af74-d498fab9d366>.
+    
+<http://data.lblod.info/id/remote-data-objects/116876a4-25b3-4e3a-91c9-ef7ed7a9dbdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "116876a4-25b3-4e3a-91c9-ef7ed7a9dbdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/ab63c4eb-2589-4e1a-84c8-474873d0f5ee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/116876a4-25b3-4e3a-91c9-ef7ed7a9dbdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/c69058d6-ba92-4538-b3c4-f99553be88c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c69058d6-ba92-4538-b3c4-f99553be88c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/ae59014f-0ef2-40d4-8999-f0d0004582cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c69058d6-ba92-4538-b3c4-f99553be88c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/0729c4b9-e645-4f49-85a1-d7d19c78f2a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0729c4b9-e645-4f49-85a1-d7d19c78f2a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/afed327b-2309-4f3d-a148-22a1bc84293e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0729c4b9-e645-4f49-85a1-d7d19c78f2a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/065834fc-f417-4a97-9236-b880d023c9fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "065834fc-f417-4a97-9236-b880d023c9fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/b55a8ea2-fd75-464a-a499-ed06664de91a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/065834fc-f417-4a97-9236-b880d023c9fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/f2c365c1-651f-4311-8f67-8db0c8787042> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f2c365c1-651f-4311-8f67-8db0c8787042";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/bc563aac-1a7c-474e-be43-2f9d2c4ffde9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f2c365c1-651f-4311-8f67-8db0c8787042>.
+    
+<http://data.lblod.info/id/remote-data-objects/de116920-ea23-4458-98ab-594853bfbbf2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "de116920-ea23-4458-98ab-594853bfbbf2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/be80ce78-41e1-41b7-b7ae-649a84c4af8b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/de116920-ea23-4458-98ab-594853bfbbf2>.
+    
+<http://data.lblod.info/id/remote-data-objects/ccd38477-fb6f-4a16-a6f4-01461ba19ce3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ccd38477-fb6f-4a16-a6f4-01461ba19ce3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/c2fe3457-d9ae-44e6-872f-1c302fddb1a8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ccd38477-fb6f-4a16-a6f4-01461ba19ce3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2f15db4-4476-4e53-b95a-e923530449e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2f15db4-4476-4e53-b95a-e923530449e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/dd77212a-97d6-4af8-9dc9-f80276c3bd9c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:49.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/1ae72262-be53-4a61-9f4c-2c13d0192336> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2f15db4-4476-4e53-b95a-e923530449e6>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201951-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201951-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201951-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201951-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c0a158e8-0120-46dd-bb35-fa9936690d76> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c0a158e8-0120-46dd-bb35-fa9936690d76";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9729a376-2fb6-4a3e-af5d-f80caa3c77f8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a9d79b76-291a-459f-9ade-83075bd9f563> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a9d79b76-291a-459f-9ade-83075bd9f563";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8>.
+
+  <http://redpencil.data.gift/id/task/3d711df6-f416-4023-8412-3d963f69d2d4> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "3d711df6-f416-4023-8412-3d963f69d2d4";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c0a158e8-0120-46dd-bb35-fa9936690d76>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a9d79b76-291a-459f-9ade-83075bd9f563>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/fdf5b118-e13b-46bf-815c-188b71a52de5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fdf5b118-e13b-46bf-815c-188b71a52de5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/dfe14654-034e-4dc4-b3a9-1bd90f8423e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fdf5b118-e13b-46bf-815c-188b71a52de5>.
+    
+<http://data.lblod.info/id/remote-data-objects/3360f5f4-d5a7-4967-a073-282b5450bb33> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3360f5f4-d5a7-4967-a073-282b5450bb33";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/e3c9f08f-d30c-4128-9fc5-5f7959b229c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3360f5f4-d5a7-4967-a073-282b5450bb33>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcb99ecb-cf42-4f80-af90-63a00c528d7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcb99ecb-cf42-4f80-af90-63a00c528d7d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/e8fde400-8f43-4564-9d90-bfba5e5727a6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcb99ecb-cf42-4f80-af90-63a00c528d7d>.
+    
+<http://data.lblod.info/id/remote-data-objects/7649babd-51bf-4f1f-a592-20c56b7986be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7649babd-51bf-4f1f-a592-20c56b7986be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/ea724522-c5bf-418c-88b5-e9598b2f5bd2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7649babd-51bf-4f1f-a592-20c56b7986be>.
+    
+<http://data.lblod.info/id/remote-data-objects/8bec2b0e-4452-4b62-8821-bf6a7a1b124a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8bec2b0e-4452-4b62-8821-bf6a7a1b124a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://tremelo.meetingburger.net/VB/f464c75d-28e4-41ec-b703-901d26150a8f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8bec2b0e-4452-4b62-8821-bf6a7a1b124a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5f2ed28-b704-4d40-8c5e-6b2c13cf25eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5f2ed28-b704-4d40-8c5e-6b2c13cf25eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/bb/61c96e20-2003-437a-b8fa-285ebcca2560/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5f2ed28-b704-4d40-8c5e-6b2c13cf25eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa72b83f-94a3-41a5-8199-777c4e31c222> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa72b83f-94a3-41a5-8199-777c4e31c222";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/bb/6658b10e-581b-4e49-852d-384e0bc22f31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa72b83f-94a3-41a5-8199-777c4e31c222>.
+    
+<http://data.lblod.info/id/remote-data-objects/51344c56-e22a-47aa-9556-5c0883728f50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51344c56-e22a-47aa-9556-5c0883728f50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/bb/84473af3-e649-433d-a0e0-8e3bb38df703/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51344c56-e22a-47aa-9556-5c0883728f50>.
+    
+<http://data.lblod.info/id/remote-data-objects/bdf1d237-45a6-4982-8600-7b1e8451a5f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bdf1d237-45a6-4982-8600-7b1e8451a5f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/bb/d145c828-1fa2-4f0c-ad67-193baa4c5a78/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bdf1d237-45a6-4982-8600-7b1e8451a5f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/479e2ecf-e244-4642-bc78-6a31a4a82903> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "479e2ecf-e244-4642-bc78-6a31a4a82903";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/bb/ed7497d3-ff4b-47f1-849f-4b4e27d42724/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/479e2ecf-e244-4642-bc78-6a31a4a82903>.
+    
+<http://data.lblod.info/id/remote-data-objects/f13244c1-0159-4d47-bda1-4b2488729941> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f13244c1-0159-4d47-bda1-4b2488729941";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/bb/f66ca695-921f-4302-b1ee-f4c94dff03c9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f13244c1-0159-4d47-bda1-4b2488729941>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0870fa1-2107-4680-a1bc-e30845bec16f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0870fa1-2107-4680-a1bc-e30845bec16f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/bb/f7059f10-5c44-4c03-9068-8793d6dcf3b1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0870fa1-2107-4680-a1bc-e30845bec16f>.
+    
+<http://data.lblod.info/id/remote-data-objects/83a7ef11-c20e-4a24-905b-909846ca3c50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83a7ef11-c20e-4a24-905b-909846ca3c50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/0058591d-bd82-4197-9769-cf7ab065279b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83a7ef11-c20e-4a24-905b-909846ca3c50>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd7b4c92-70e4-4446-96ac-f9e266abcc94> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd7b4c92-70e4-4446-96ac-f9e266abcc94";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/005a19e9-a8d9-42d2-b5cc-9b26a4b37876/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd7b4c92-70e4-4446-96ac-f9e266abcc94>.
+    
+<http://data.lblod.info/id/remote-data-objects/53111459-5b73-4ded-915b-2257d0fc1220> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "53111459-5b73-4ded-915b-2257d0fc1220";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/0373f342-c0d8-4dd2-a237-a13ed23a27d5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/53111459-5b73-4ded-915b-2257d0fc1220>.
+    
+<http://data.lblod.info/id/remote-data-objects/994024c1-ece7-40a8-9e1e-d753cdb7f5f6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "994024c1-ece7-40a8-9e1e-d753cdb7f5f6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/06823cea-5c08-4b25-8e0d-acadcd6f665b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/994024c1-ece7-40a8-9e1e-d753cdb7f5f6>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5de654f-5cee-46ce-ab9c-741ca270ba37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5de654f-5cee-46ce-ab9c-741ca270ba37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/06da301a-8c90-4e2d-9b3f-8a3f27b83047/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5de654f-5cee-46ce-ab9c-741ca270ba37>.
+    
+<http://data.lblod.info/id/remote-data-objects/25dced4c-e5e0-431b-882a-5aebbc5eff3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25dced4c-e5e0-431b-882a-5aebbc5eff3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/0db142ad-a6ba-4812-8199-7921ce4ba7c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25dced4c-e5e0-431b-882a-5aebbc5eff3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/04b4533c-aabc-4890-a732-57453806c919> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04b4533c-aabc-4890-a732-57453806c919";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/0fc66fef-6911-440a-8f27-ce2e8288e014/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/04b4533c-aabc-4890-a732-57453806c919>.
+    
+<http://data.lblod.info/id/remote-data-objects/03604f14-2462-40ed-8b42-8df4d583884f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03604f14-2462-40ed-8b42-8df4d583884f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/14558c35-16a6-4b2d-bf2f-85b9108e2461/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03604f14-2462-40ed-8b42-8df4d583884f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5734549-fe78-4da2-a100-f844f7d69843> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5734549-fe78-4da2-a100-f844f7d69843";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/18fb4ab9-2ed2-4fa9-88b6-88f60a58eaf6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5734549-fe78-4da2-a100-f844f7d69843>.
+    
+<http://data.lblod.info/id/remote-data-objects/37f4a2d4-1164-46e0-ab07-e00a409b8bf7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37f4a2d4-1164-46e0-ab07-e00a409b8bf7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/1bd2a4fc-a969-4e01-85a3-5dd99d5294ec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37f4a2d4-1164-46e0-ab07-e00a409b8bf7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e918c477-0a83-4da2-a1cb-339d6910b964> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e918c477-0a83-4da2-a1cb-339d6910b964";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/20d94124-3cac-48b8-9c6f-f70cfb616975/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e918c477-0a83-4da2-a1cb-339d6910b964>.
+    
+<http://data.lblod.info/id/remote-data-objects/72cf1538-48eb-40c6-a241-e2cbb456f45e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72cf1538-48eb-40c6-a241-e2cbb456f45e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/250e4784-4e86-464c-bbaf-9727d738981b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72cf1538-48eb-40c6-a241-e2cbb456f45e>.
+    
+<http://data.lblod.info/id/remote-data-objects/053e4f65-56ab-4a6a-8027-322594c74cc4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "053e4f65-56ab-4a6a-8027-322594c74cc4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/27e39528-2725-49dc-9cf5-74ab2563cfce/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/053e4f65-56ab-4a6a-8027-322594c74cc4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8f39f46-073b-4a8e-9fc1-cb88876b113c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8f39f46-073b-4a8e-9fc1-cb88876b113c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/2aaa89fa-6826-46fe-a331-932aaa544eb2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8f39f46-073b-4a8e-9fc1-cb88876b113c>.
+    
+<http://data.lblod.info/id/remote-data-objects/62bb05db-3415-4dea-97b9-0772caa69192> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62bb05db-3415-4dea-97b9-0772caa69192";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/32cabe39-f329-44d5-9bcb-6909823c99e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62bb05db-3415-4dea-97b9-0772caa69192>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1f24342-f99b-4a6a-b60f-03725c8ea752> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1f24342-f99b-4a6a-b60f-03725c8ea752";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/340628c9-ca47-4950-b38e-18308655602d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1f24342-f99b-4a6a-b60f-03725c8ea752>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ddc3aa3-8c8e-4efb-9579-9791093241b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ddc3aa3-8c8e-4efb-9579-9791093241b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/3907c564-9007-444f-9d10-976fecb5a415/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ddc3aa3-8c8e-4efb-9579-9791093241b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e53f410-5d67-4ec1-99d9-e7bd8dd5735b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e53f410-5d67-4ec1-99d9-e7bd8dd5735b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/3acb215a-2aa2-4a3f-a40c-7f8350061bea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e53f410-5d67-4ec1-99d9-e7bd8dd5735b>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfd33003-cf6e-4133-9966-aa71c89fab12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfd33003-cf6e-4133-9966-aa71c89fab12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/3c3ff270-d35e-45ff-87f1-19631f0af313/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfd33003-cf6e-4133-9966-aa71c89fab12>.
+    
+<http://data.lblod.info/id/remote-data-objects/38f0b271-1f2b-4c02-81de-b70779ceb487> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38f0b271-1f2b-4c02-81de-b70779ceb487";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/4334f72e-02b3-491a-b61c-68f3921f0715/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38f0b271-1f2b-4c02-81de-b70779ceb487>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c6897c4-b1fe-4e21-a3f5-dde01e6e2c8a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c6897c4-b1fe-4e21-a3f5-dde01e6e2c8a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/43cc6623-ebff-465f-851b-af2aad577001/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c6897c4-b1fe-4e21-a3f5-dde01e6e2c8a>.
+    
+<http://data.lblod.info/id/remote-data-objects/49c7920f-d8b4-42cd-ae31-d549452def14> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49c7920f-d8b4-42cd-ae31-d549452def14";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/516f8791-4b22-4644-b2df-649a22cdd2bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49c7920f-d8b4-42cd-ae31-d549452def14>.
+    
+<http://data.lblod.info/id/remote-data-objects/d5955aaa-ef2d-47a7-8129-090d25cbaddf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5955aaa-ef2d-47a7-8129-090d25cbaddf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/5256a6ad-8976-44ec-b1c4-13c755ec4bea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d5955aaa-ef2d-47a7-8129-090d25cbaddf>.
+    
+<http://data.lblod.info/id/remote-data-objects/b30097c0-34e7-4ac4-86c6-215b3d795f0a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b30097c0-34e7-4ac4-86c6-215b3d795f0a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/52d6e381-cf5f-4059-b744-ae50e5977965/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b30097c0-34e7-4ac4-86c6-215b3d795f0a>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f1b10b1-792b-468f-9e98-414ddf42dbf8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f1b10b1-792b-468f-9e98-414ddf42dbf8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/560d6a71-ab82-492f-a7ba-f10d1ae0ca3a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f1b10b1-792b-468f-9e98-414ddf42dbf8>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b7ff549-e1a6-4c56-9986-d29b5b4f00ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b7ff549-e1a6-4c56-9986-d29b5b4f00ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/5ae15831-655d-4ee7-ad86-9f6e59aa716c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b7ff549-e1a6-4c56-9986-d29b5b4f00ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/3394edd1-5c69-4d8d-a2a4-ad22e8b74cb0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3394edd1-5c69-4d8d-a2a4-ad22e8b74cb0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/5da7f762-eb4e-45f1-9bfc-97116e71b66c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3394edd1-5c69-4d8d-a2a4-ad22e8b74cb0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ac9d6f8-be3c-4947-8705-6a33d6668426> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ac9d6f8-be3c-4947-8705-6a33d6668426";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/5f96c095-f791-4d21-9bee-ef15973be434/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ac9d6f8-be3c-4947-8705-6a33d6668426>.
+    
+<http://data.lblod.info/id/remote-data-objects/5df6139c-dee6-4319-b9a5-31c106b7e1aa> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5df6139c-dee6-4319-b9a5-31c106b7e1aa";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/662594cb-7a25-48f0-ac87-65f877fa9cd0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5df6139c-dee6-4319-b9a5-31c106b7e1aa>.
+    
+<http://data.lblod.info/id/remote-data-objects/28807027-8318-4526-9918-74098ffdd754> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28807027-8318-4526-9918-74098ffdd754";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/6a165f8d-7c4e-4758-8ef9-1b193383008e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28807027-8318-4526-9918-74098ffdd754>.
+    
+<http://data.lblod.info/id/remote-data-objects/29792307-ab03-4066-be0d-57e9629ba804> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29792307-ab03-4066-be0d-57e9629ba804";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/6beb9f1b-612c-43f6-9089-24820105c189/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29792307-ab03-4066-be0d-57e9629ba804>.
+    
+<http://data.lblod.info/id/remote-data-objects/38c31adf-28d2-46c4-8776-8ff202564b3d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38c31adf-28d2-46c4-8776-8ff202564b3d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/6c93b58f-0202-4b03-ab99-46661ef10030/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38c31adf-28d2-46c4-8776-8ff202564b3d>.
+    
+<http://data.lblod.info/id/remote-data-objects/43eaad1f-ebf0-4f62-b10a-29bb50ee2b56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43eaad1f-ebf0-4f62-b10a-29bb50ee2b56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/6d041092-aaec-4b76-a733-6ff289880860/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43eaad1f-ebf0-4f62-b10a-29bb50ee2b56>.
+    
+<http://data.lblod.info/id/remote-data-objects/f9f3005a-ccd5-4f39-8960-75e526dbbf27> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f9f3005a-ccd5-4f39-8960-75e526dbbf27";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/6de84e31-a04e-4238-ada7-babaabb049e2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f9f3005a-ccd5-4f39-8960-75e526dbbf27>.
+    
+<http://data.lblod.info/id/remote-data-objects/5560e83e-89eb-464e-a0a7-60d0f8852d2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5560e83e-89eb-464e-a0a7-60d0f8852d2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/7092c40c-e11c-4786-9870-f207b04f6db0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5560e83e-89eb-464e-a0a7-60d0f8852d2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/17120e3f-2e31-4350-aeda-d6041e857ef2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17120e3f-2e31-4350-aeda-d6041e857ef2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/70ce6363-76fc-4697-abe9-43ed74b86f03/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17120e3f-2e31-4350-aeda-d6041e857ef2>.
+    
+<http://data.lblod.info/id/remote-data-objects/36818e51-f8b1-4b4b-a67a-1e6de4e22035> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "36818e51-f8b1-4b4b-a67a-1e6de4e22035";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/7169a7b7-b32a-46d9-bed4-e7c84fc814c2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/36818e51-f8b1-4b4b-a67a-1e6de4e22035>.
+    
+<http://data.lblod.info/id/remote-data-objects/35b1bf1b-f233-47fe-8a2e-1afa0e3d2779> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35b1bf1b-f233-47fe-8a2e-1afa0e3d2779";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/7e821832-ca29-43fa-b1e3-b8819b87adbb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:51.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9729a376-2fb6-4a3e-af5d-f80caa3c77f8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35b1bf1b-f233-47fe-8a2e-1afa0e3d2779>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201952-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201952-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201952-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201952-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/30c6215e-5cc7-447a-b165-c449e8355918> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "30c6215e-5cc7-447a-b165-c449e8355918";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ea75d959-6a9d-46c2-b630-fd2223d37fb7";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/a724bd4d-74de-4e78-a968-47cf3f7bddea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a724bd4d-74de-4e78-a968-47cf3f7bddea";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7>.
+
+  <http://redpencil.data.gift/id/task/58e31a7b-4a1e-4e54-9d97-7fe639365081> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "58e31a7b-4a1e-4e54-9d97-7fe639365081";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/30c6215e-5cc7-447a-b165-c449e8355918>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/a724bd4d-74de-4e78-a968-47cf3f7bddea>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/2f707bf1-177e-4f0a-8f8d-fc3d7064e58c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f707bf1-177e-4f0a-8f8d-fc3d7064e58c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/7ecb5bb0-2f41-488a-845a-c91ed8fbf50e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f707bf1-177e-4f0a-8f8d-fc3d7064e58c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f18cf442-e578-4f73-ab87-08d17027d412> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f18cf442-e578-4f73-ab87-08d17027d412";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/81792438-1182-48d1-9e6f-85ec4fa27f76/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f18cf442-e578-4f73-ab87-08d17027d412>.
+    
+<http://data.lblod.info/id/remote-data-objects/a231a152-a916-437e-ba40-895065382e75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a231a152-a916-437e-ba40-895065382e75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/8638215e-faf0-45ed-b514-1b4409307cbf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a231a152-a916-437e-ba40-895065382e75>.
+    
+<http://data.lblod.info/id/remote-data-objects/116214f4-be50-49dc-9de9-f02ab8f61bdb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "116214f4-be50-49dc-9de9-f02ab8f61bdb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/89473e09-e9de-49c4-9c6f-7d8af9755782/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/116214f4-be50-49dc-9de9-f02ab8f61bdb>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd4aac36-d98a-44be-922b-56d64af592fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd4aac36-d98a-44be-922b-56d64af592fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/8f114a68-0ca0-4b63-bcb9-bc12ec22ad2b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd4aac36-d98a-44be-922b-56d64af592fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb15e73e-fbbe-454d-8a3a-38e4098d827c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb15e73e-fbbe-454d-8a3a-38e4098d827c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/8f584b57-23d4-4da8-acde-8a650321cd5e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb15e73e-fbbe-454d-8a3a-38e4098d827c>.
+    
+<http://data.lblod.info/id/remote-data-objects/877aafef-474e-4b9c-b3e5-6a68e3da364f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "877aafef-474e-4b9c-b3e5-6a68e3da364f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/93de00fe-48e6-44b9-a825-723dc1ebf980/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/877aafef-474e-4b9c-b3e5-6a68e3da364f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee0212f6-0377-4c1c-bde0-eea79ce7b5e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee0212f6-0377-4c1c-bde0-eea79ce7b5e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/972d6041-debd-4fe3-93ee-8ca512ffb5f2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee0212f6-0377-4c1c-bde0-eea79ce7b5e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/016705a0-2e9c-4618-90e9-d18b42849b4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "016705a0-2e9c-4618-90e9-d18b42849b4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/9fbd2826-55c3-4d5e-8975-794d7a25798d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/016705a0-2e9c-4618-90e9-d18b42849b4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/234810db-2de2-4b36-9e34-e00f3562e8d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "234810db-2de2-4b36-9e34-e00f3562e8d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/a3f9598a-ce16-43b3-8e78-b8f0b2f9039d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/234810db-2de2-4b36-9e34-e00f3562e8d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/2cd089f7-1470-453f-a9e5-9e6925b77314> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2cd089f7-1470-453f-a9e5-9e6925b77314";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/a58d0c88-fd8f-4bdb-b63e-d96ff5871b4e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2cd089f7-1470-453f-a9e5-9e6925b77314>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2a2a3c2-b2fd-472f-bfb0-9060f569886e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2a2a3c2-b2fd-472f-bfb0-9060f569886e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/a85ca9e1-46bf-4e2e-9306-5c02fbf01654/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2a2a3c2-b2fd-472f-bfb0-9060f569886e>.
+    
+<http://data.lblod.info/id/remote-data-objects/6f287b77-67ec-4e23-91b7-c28703d6e585> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6f287b77-67ec-4e23-91b7-c28703d6e585";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/ad3cb2c9-6660-41ba-883a-5d162ffedaa6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6f287b77-67ec-4e23-91b7-c28703d6e585>.
+    
+<http://data.lblod.info/id/remote-data-objects/797496bc-1de1-436f-825a-9347b0436626> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "797496bc-1de1-436f-825a-9347b0436626";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/b4f9d40d-e3d6-4d91-93a4-089c3d80ed27/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/797496bc-1de1-436f-825a-9347b0436626>.
+    
+<http://data.lblod.info/id/remote-data-objects/fcbbadb4-ddf0-41b8-b0f0-a14551336b96> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcbbadb4-ddf0-41b8-b0f0-a14551336b96";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/b670f019-f89a-4234-8269-215483047263/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fcbbadb4-ddf0-41b8-b0f0-a14551336b96>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea46b01d-a97b-41c7-a9d8-bf1699b813c4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea46b01d-a97b-41c7-a9d8-bf1699b813c4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/ba812c8a-c7dc-4420-901d-d16bc62060f9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea46b01d-a97b-41c7-a9d8-bf1699b813c4>.
+    
+<http://data.lblod.info/id/remote-data-objects/293c951e-27f3-49aa-b266-2926f1dbdb31> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "293c951e-27f3-49aa-b266-2926f1dbdb31";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/c1e0529f-7e94-4634-bae3-bddf7883c11a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/293c951e-27f3-49aa-b266-2926f1dbdb31>.
+    
+<http://data.lblod.info/id/remote-data-objects/7940ce00-58b1-403f-b664-bc0b7facde5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7940ce00-58b1-403f-b664-bc0b7facde5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/c233406c-da7e-41a8-ac27-aaa086f99a6c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7940ce00-58b1-403f-b664-bc0b7facde5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/42242bef-d9bb-491d-85b4-9736d9a0c23e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42242bef-d9bb-491d-85b4-9736d9a0c23e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/c2d2d550-4f81-4a17-a5b5-e8d7486abdcd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42242bef-d9bb-491d-85b4-9736d9a0c23e>.
+    
+<http://data.lblod.info/id/remote-data-objects/7c4033cb-b812-48dd-b99b-a6dfc724e6a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c4033cb-b812-48dd-b99b-a6dfc724e6a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/c38a09c8-4f27-421c-8470-f080d276451a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7c4033cb-b812-48dd-b99b-a6dfc724e6a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/3ab19e38-d53b-45de-87d2-9ec9a0e98c7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3ab19e38-d53b-45de-87d2-9ec9a0e98c7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/c908025c-bc32-469a-8039-359d375b3ba4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3ab19e38-d53b-45de-87d2-9ec9a0e98c7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d9904d47-f3e9-49f8-ba77-ca744bd5dabc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d9904d47-f3e9-49f8-ba77-ca744bd5dabc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/ca015520-994d-4ff8-abc5-387c99f73f64/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d9904d47-f3e9-49f8-ba77-ca744bd5dabc>.
+    
+<http://data.lblod.info/id/remote-data-objects/52691b62-7337-49be-b1d8-53f2f28e1b1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "52691b62-7337-49be-b1d8-53f2f28e1b1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/ca9628eb-d44f-4c77-9bba-c591e531914e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/52691b62-7337-49be-b1d8-53f2f28e1b1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/b2fc61fe-e09e-43e7-b426-94b23f117e4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b2fc61fe-e09e-43e7-b426-94b23f117e4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/cc0e9d77-c0ca-4394-8129-783a3d47bf79/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b2fc61fe-e09e-43e7-b426-94b23f117e4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f67ad664-13ee-464d-824c-cfa56efdea69> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f67ad664-13ee-464d-824c-cfa56efdea69";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/cd38aa5b-cb2d-467d-a3ed-2e11ad8fc992/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f67ad664-13ee-464d-824c-cfa56efdea69>.
+    
+<http://data.lblod.info/id/remote-data-objects/d283cbf6-cff1-439e-b960-5fd3d35f1b8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d283cbf6-cff1-439e-b960-5fd3d35f1b8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/d4e3948f-a765-4ac9-a968-a610deb687a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d283cbf6-cff1-439e-b960-5fd3d35f1b8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/318c30c5-4187-469e-88a9-4f547cff87e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "318c30c5-4187-469e-88a9-4f547cff87e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/d7338a21-51e4-4820-9cd5-34bcd485af56/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/318c30c5-4187-469e-88a9-4f547cff87e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/f675ded3-9059-45a5-98ee-0b6ad18aa2e7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f675ded3-9059-45a5-98ee-0b6ad18aa2e7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/d9292f99-ebf6-4efa-8657-d83f2c831b88/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f675ded3-9059-45a5-98ee-0b6ad18aa2e7>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce1b7d07-f756-4880-8631-827d65cd13f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce1b7d07-f756-4880-8631-827d65cd13f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/dd1fc99a-8267-46e1-85f2-46ae60d630fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce1b7d07-f756-4880-8631-827d65cd13f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/eeda2bfd-ff17-4e57-8d24-cc621cef8c28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eeda2bfd-ff17-4e57-8d24-cc621cef8c28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/f27e5b4f-4600-4414-aba7-8daf1854e40c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eeda2bfd-ff17-4e57-8d24-cc621cef8c28>.
+    
+<http://data.lblod.info/id/remote-data-objects/7360907a-4a28-480b-a7c0-8f4f9c99bd52> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7360907a-4a28-480b-a7c0-8f4f9c99bd52";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/f7698caf-8b86-4494-b808-ad67e2fdb2bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7360907a-4a28-480b-a7c0-8f4f9c99bd52>.
+    
+<http://data.lblod.info/id/remote-data-objects/26899120-cfa2-4183-8685-3b6ba81adb71> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26899120-cfa2-4183-8685-3b6ba81adb71";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/cbs/f9afd7ff-466b-47ce-af7e-4821d648245d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26899120-cfa2-4183-8685-3b6ba81adb71>.
+    
+<http://data.lblod.info/id/remote-data-objects/627817a5-04ee-4ad4-9065-37d9a7311f08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "627817a5-04ee-4ad4-9065-37d9a7311f08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/0ae32057-2d01-462c-b3f9-0cd482584602/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/627817a5-04ee-4ad4-9065-37d9a7311f08>.
+    
+<http://data.lblod.info/id/remote-data-objects/fef0494f-3c39-4243-bf9a-83bd8d79df7b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fef0494f-3c39-4243-bf9a-83bd8d79df7b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/0ae32057-2d01-462c-b3f9-0cd482584602/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fef0494f-3c39-4243-bf9a-83bd8d79df7b>.
+    
+<http://data.lblod.info/id/remote-data-objects/336bb5b9-a37a-4146-8643-67a6208592e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "336bb5b9-a37a-4146-8643-67a6208592e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/0ae32057-2d01-462c-b3f9-0cd482584602/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/336bb5b9-a37a-4146-8643-67a6208592e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/68d7e732-92f2-465b-be40-79bd21d65fc2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68d7e732-92f2-465b-be40-79bd21d65fc2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/17d14e37-9d05-418c-9e86-ff8d874c3886/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68d7e732-92f2-465b-be40-79bd21d65fc2>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b74dc2e-7e6f-4e88-bcfa-b4c14462f636> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b74dc2e-7e6f-4e88-bcfa-b4c14462f636";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/17d14e37-9d05-418c-9e86-ff8d874c3886/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b74dc2e-7e6f-4e88-bcfa-b4c14462f636>.
+    
+<http://data.lblod.info/id/remote-data-objects/12d07177-f101-4f95-8c95-f8c3bcb13a36> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12d07177-f101-4f95-8c95-f8c3bcb13a36";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/17d14e37-9d05-418c-9e86-ff8d874c3886/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/12d07177-f101-4f95-8c95-f8c3bcb13a36>.
+    
+<http://data.lblod.info/id/remote-data-objects/95c1c0a7-97e7-48e9-8c73-7790c87a915a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95c1c0a7-97e7-48e9-8c73-7790c87a915a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/1ee6febe-f67a-4e51-90b9-2ed7e459b1db/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95c1c0a7-97e7-48e9-8c73-7790c87a915a>.
+    
+<http://data.lblod.info/id/remote-data-objects/40ad2625-02ea-4203-8869-bd6fc7f76be0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40ad2625-02ea-4203-8869-bd6fc7f76be0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/1ee6febe-f67a-4e51-90b9-2ed7e459b1db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40ad2625-02ea-4203-8869-bd6fc7f76be0>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f146b85-c7bd-4770-ade2-eebdfcd49715> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f146b85-c7bd-4770-ade2-eebdfcd49715";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/1ee6febe-f67a-4e51-90b9-2ed7e459b1db/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f146b85-c7bd-4770-ade2-eebdfcd49715>.
+    
+<http://data.lblod.info/id/remote-data-objects/88265754-28af-4395-96be-06791813893d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88265754-28af-4395-96be-06791813893d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/1f7d2a8d-233c-4556-b0ee-a22547c18770/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/88265754-28af-4395-96be-06791813893d>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3528588-4f3d-497e-b060-ff0690b18782> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3528588-4f3d-497e-b060-ff0690b18782";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/1f7d2a8d-233c-4556-b0ee-a22547c18770/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3528588-4f3d-497e-b060-ff0690b18782>.
+    
+<http://data.lblod.info/id/remote-data-objects/a6d07831-09ce-4a01-a10f-706a558b9889> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6d07831-09ce-4a01-a10f-706a558b9889";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/1f7d2a8d-233c-4556-b0ee-a22547c18770/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a6d07831-09ce-4a01-a10f-706a558b9889>.
+    
+<http://data.lblod.info/id/remote-data-objects/2bd737e5-82ef-47f1-957f-1d3f10ce083c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2bd737e5-82ef-47f1-957f-1d3f10ce083c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/30c0e002-f109-4fb0-9541-52d52f3cc7eb/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2bd737e5-82ef-47f1-957f-1d3f10ce083c>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0fec040-c60c-44e4-96d4-c93968fd76ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0fec040-c60c-44e4-96d4-c93968fd76ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/30c0e002-f109-4fb0-9541-52d52f3cc7eb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0fec040-c60c-44e4-96d4-c93968fd76ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/3b2d2306-0a05-47ec-b700-0067204d6854> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3b2d2306-0a05-47ec-b700-0067204d6854";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/30c0e002-f109-4fb0-9541-52d52f3cc7eb/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3b2d2306-0a05-47ec-b700-0067204d6854>.
+    
+<http://data.lblod.info/id/remote-data-objects/d24c88c1-6597-4ba7-9f11-2efbf0e3f915> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d24c88c1-6597-4ba7-9f11-2efbf0e3f915";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/477ee1ab-d433-479e-8069-4d2c27d91554/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d24c88c1-6597-4ba7-9f11-2efbf0e3f915>.
+    
+<http://data.lblod.info/id/remote-data-objects/0493a9d4-f436-4710-8b4a-30b22fd26290> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0493a9d4-f436-4710-8b4a-30b22fd26290";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/477ee1ab-d433-479e-8069-4d2c27d91554/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0493a9d4-f436-4710-8b4a-30b22fd26290>.
+    
+<http://data.lblod.info/id/remote-data-objects/893082d6-3c47-4eef-879c-c538eb202bfe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "893082d6-3c47-4eef-879c-c538eb202bfe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/477ee1ab-d433-479e-8069-4d2c27d91554/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:52.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea75d959-6a9d-46c2-b630-fd2223d37fb7> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/893082d6-3c47-4eef-879c-c538eb202bfe>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201953-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201953-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201953-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201953-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/f45408a6-2463-44f7-805f-19dbdd3e72b8> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f45408a6-2463-44f7-805f-19dbdd3e72b8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "bf24f047-c28b-47f8-b022-026c49acd24b";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/571649cc-ed01-425b-adee-1d0ba11044bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "571649cc-ed01-425b-adee-1d0ba11044bc";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b>.
+
+  <http://redpencil.data.gift/id/task/45babe5c-9d47-4424-88fc-d103629697fd> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "45babe5c-9d47-4424-88fc-d103629697fd";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/f45408a6-2463-44f7-805f-19dbdd3e72b8>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/571649cc-ed01-425b-adee-1d0ba11044bc>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/e4bdd655-6003-4616-876d-42898104fa72> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4bdd655-6003-4616-876d-42898104fa72";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/7c59f9f7-333d-4b44-b938-62b022ff3be7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4bdd655-6003-4616-876d-42898104fa72>.
+    
+<http://data.lblod.info/id/remote-data-objects/f34e50c8-ef29-4d40-9a6b-1ee72ab7b669> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f34e50c8-ef29-4d40-9a6b-1ee72ab7b669";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/7c59f9f7-333d-4b44-b938-62b022ff3be7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f34e50c8-ef29-4d40-9a6b-1ee72ab7b669>.
+    
+<http://data.lblod.info/id/remote-data-objects/68b69653-f2f3-406b-b2e4-55bd5850cff4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68b69653-f2f3-406b-b2e4-55bd5850cff4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/7c59f9f7-333d-4b44-b938-62b022ff3be7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68b69653-f2f3-406b-b2e4-55bd5850cff4>.
+    
+<http://data.lblod.info/id/remote-data-objects/75f8456a-8017-4b32-bccd-23a244b828b3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75f8456a-8017-4b32-bccd-23a244b828b3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/9ccdc64a-8124-4369-9c98-adf33da15f3f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75f8456a-8017-4b32-bccd-23a244b828b3>.
+    
+<http://data.lblod.info/id/remote-data-objects/e068667a-19b5-427b-ba5a-996bb7db7d64> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e068667a-19b5-427b-ba5a-996bb7db7d64";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/9ccdc64a-8124-4369-9c98-adf33da15f3f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e068667a-19b5-427b-ba5a-996bb7db7d64>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed637480-a92d-419d-877f-4a3bd3be136e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed637480-a92d-419d-877f-4a3bd3be136e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/9ccdc64a-8124-4369-9c98-adf33da15f3f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed637480-a92d-419d-877f-4a3bd3be136e>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ccc7a16-494a-43d2-8739-92a7f3a8ef1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ccc7a16-494a-43d2-8739-92a7f3a8ef1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/ba16f0a6-9841-490a-80c0-c03bd9fba7e5/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ccc7a16-494a-43d2-8739-92a7f3a8ef1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7032b145-9bd4-4e3a-8319-8914f381d7ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7032b145-9bd4-4e3a-8319-8914f381d7ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/ba16f0a6-9841-490a-80c0-c03bd9fba7e5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7032b145-9bd4-4e3a-8319-8914f381d7ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/e942d96a-ac27-4b68-b36b-b8b84568b1ff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e942d96a-ac27-4b68-b36b-b8b84568b1ff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/ba16f0a6-9841-490a-80c0-c03bd9fba7e5/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e942d96a-ac27-4b68-b36b-b8b84568b1ff>.
+    
+<http://data.lblod.info/id/remote-data-objects/97c8f97e-d32f-49d5-bcb0-19d7c0e31325> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "97c8f97e-d32f-49d5-bcb0-19d7c0e31325";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/c6fb4dcc-47bb-4dc8-ac24-0b3acef6a71d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/97c8f97e-d32f-49d5-bcb0-19d7c0e31325>.
+    
+<http://data.lblod.info/id/remote-data-objects/f165ef40-80ff-460e-a5e1-5ab75b6a7ffb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f165ef40-80ff-460e-a5e1-5ab75b6a7ffb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/c6fb4dcc-47bb-4dc8-ac24-0b3acef6a71d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f165ef40-80ff-460e-a5e1-5ab75b6a7ffb>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7951755-1845-4d07-bd75-c13b79653a75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7951755-1845-4d07-bd75-c13b79653a75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/c6fb4dcc-47bb-4dc8-ac24-0b3acef6a71d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7951755-1845-4d07-bd75-c13b79653a75>.
+    
+<http://data.lblod.info/id/remote-data-objects/46d54a61-f87d-492d-a970-ea2164b2761f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46d54a61-f87d-492d-a970-ea2164b2761f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/c9c9d718-e670-4370-8347-c665a45bbf2b/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46d54a61-f87d-492d-a970-ea2164b2761f>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee1188d6-604f-485d-99de-0a031caf1d15> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee1188d6-604f-485d-99de-0a031caf1d15";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/c9c9d718-e670-4370-8347-c665a45bbf2b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee1188d6-604f-485d-99de-0a031caf1d15>.
+    
+<http://data.lblod.info/id/remote-data-objects/89ce804f-e5c3-406a-92d3-398bf710b3c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89ce804f-e5c3-406a-92d3-398bf710b3c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/ce833463-489d-42f3-99e9-0b6c3882078c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89ce804f-e5c3-406a-92d3-398bf710b3c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/c525da4c-f8d3-4a63-a06a-d5d03b701e12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c525da4c-f8d3-4a63-a06a-d5d03b701e12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/ce833463-489d-42f3-99e9-0b6c3882078c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c525da4c-f8d3-4a63-a06a-d5d03b701e12>.
+    
+<http://data.lblod.info/id/remote-data-objects/e34a9e7c-b7d5-43cc-9973-6597630c0df4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e34a9e7c-b7d5-43cc-9973-6597630c0df4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/ce833463-489d-42f3-99e9-0b6c3882078c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e34a9e7c-b7d5-43cc-9973-6597630c0df4>.
+    
+<http://data.lblod.info/id/remote-data-objects/d948bbff-528f-475e-84b2-d5b8fe3ef134> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d948bbff-528f-475e-84b2-d5b8fe3ef134";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/cfe73aa7-48c0-463b-b063-9e878f58d0b8/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d948bbff-528f-475e-84b2-d5b8fe3ef134>.
+    
+<http://data.lblod.info/id/remote-data-objects/d196f432-6015-427c-82ef-47afbdc2f22c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d196f432-6015-427c-82ef-47afbdc2f22c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/cfe73aa7-48c0-463b-b063-9e878f58d0b8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d196f432-6015-427c-82ef-47afbdc2f22c>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcabb845-7aa2-42ab-9b10-88e55e07ca75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcabb845-7aa2-42ab-9b10-88e55e07ca75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/cfe73aa7-48c0-463b-b063-9e878f58d0b8/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcabb845-7aa2-42ab-9b10-88e55e07ca75>.
+    
+<http://data.lblod.info/id/remote-data-objects/70b14081-549c-478c-aaa1-37c3fc047cfb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70b14081-549c-478c-aaa1-37c3fc047cfb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/e6f996c8-edca-4784-8c4c-4575cbf04639/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/70b14081-549c-478c-aaa1-37c3fc047cfb>.
+    
+<http://data.lblod.info/id/remote-data-objects/683bfe52-c9d3-4e7d-bf27-a2d3ca6f0636> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "683bfe52-c9d3-4e7d-bf27-a2d3ca6f0636";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/e6f996c8-edca-4784-8c4c-4575cbf04639/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/683bfe52-c9d3-4e7d-bf27-a2d3ca6f0636>.
+    
+<http://data.lblod.info/id/remote-data-objects/a0a4f0b3-598a-472c-b1b9-e2a4268ac7e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a0a4f0b3-598a-472c-b1b9-e2a4268ac7e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/e6f996c8-edca-4784-8c4c-4575cbf04639/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a0a4f0b3-598a-472c-b1b9-e2a4268ac7e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/199f4e8b-a506-4f90-9bc3-0bcf4ba178a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "199f4e8b-a506-4f90-9bc3-0bcf4ba178a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/eafb3b58-48af-4ab1-a1dc-535165638ca9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/199f4e8b-a506-4f90-9bc3-0bcf4ba178a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/eeeb287e-6394-4247-a7ed-515f316cacce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eeeb287e-6394-4247-a7ed-515f316cacce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/eafb3b58-48af-4ab1-a1dc-535165638ca9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eeeb287e-6394-4247-a7ed-515f316cacce>.
+    
+<http://data.lblod.info/id/remote-data-objects/25abab4c-3d7e-49c6-b5ce-a1f87c90b358> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25abab4c-3d7e-49c6-b5ce-a1f87c90b358";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/eafb3b58-48af-4ab1-a1dc-535165638ca9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/25abab4c-3d7e-49c6-b5ce-a1f87c90b358>.
+    
+<http://data.lblod.info/id/remote-data-objects/4475b76a-7cee-49a8-b175-2b0002376799> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4475b76a-7cee-49a8-b175-2b0002376799";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/fd684bcb-95fb-4362-833e-ac0fee07a190/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4475b76a-7cee-49a8-b175-2b0002376799>.
+    
+<http://data.lblod.info/id/remote-data-objects/eadeb598-b45c-4ce9-9e0d-36f4c167f78c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eadeb598-b45c-4ce9-9e0d-36f4c167f78c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/fd684bcb-95fb-4362-833e-ac0fee07a190/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eadeb598-b45c-4ce9-9e0d-36f4c167f78c>.
+    
+<http://data.lblod.info/id/remote-data-objects/61ecf31b-b393-4ae4-85cb-e1a337ef91d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61ecf31b-b393-4ae4-85cb-e1a337ef91d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/gr/fd684bcb-95fb-4362-833e-ac0fee07a190/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61ecf31b-b393-4ae4-85cb-e1a337ef91d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/307f5582-4635-4567-ab3b-88774a88f456> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "307f5582-4635-4567-ab3b-88774a88f456";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/05631247-e6ca-4604-b2f4-81589e097cbb/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/307f5582-4635-4567-ab3b-88774a88f456>.
+    
+<http://data.lblod.info/id/remote-data-objects/89909a7a-4279-40df-9521-cdd683b6221d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89909a7a-4279-40df-9521-cdd683b6221d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/05631247-e6ca-4604-b2f4-81589e097cbb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89909a7a-4279-40df-9521-cdd683b6221d>.
+    
+<http://data.lblod.info/id/remote-data-objects/ee126d1d-2c2e-415c-8b4d-a7de12eea634> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ee126d1d-2c2e-415c-8b4d-a7de12eea634";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/05631247-e6ca-4604-b2f4-81589e097cbb/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ee126d1d-2c2e-415c-8b4d-a7de12eea634>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8fd09b0-f984-4a3a-8a66-f401a0be38a2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8fd09b0-f984-4a3a-8a66-f401a0be38a2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/0a48b215-8333-4846-948f-8e8a81bbb223/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8fd09b0-f984-4a3a-8a66-f401a0be38a2>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d9c1e02-ad99-4426-98db-06d090305c61> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d9c1e02-ad99-4426-98db-06d090305c61";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/0a48b215-8333-4846-948f-8e8a81bbb223/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d9c1e02-ad99-4426-98db-06d090305c61>.
+    
+<http://data.lblod.info/id/remote-data-objects/6b54833c-7c6c-4956-b4bc-34a50504dda0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6b54833c-7c6c-4956-b4bc-34a50504dda0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/0a48b215-8333-4846-948f-8e8a81bbb223/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6b54833c-7c6c-4956-b4bc-34a50504dda0>.
+    
+<http://data.lblod.info/id/remote-data-objects/9169afec-b133-436d-8e4f-21bfa33c91d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9169afec-b133-436d-8e4f-21bfa33c91d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/11a088ce-01df-46fd-aa36-72b3a24d3a53/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9169afec-b133-436d-8e4f-21bfa33c91d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/94ca4b67-92e1-42f0-bf32-0703c57ebf9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94ca4b67-92e1-42f0-bf32-0703c57ebf9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/11a088ce-01df-46fd-aa36-72b3a24d3a53/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94ca4b67-92e1-42f0-bf32-0703c57ebf9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9da1b962-9080-438f-8ed7-e6b7916dfee8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9da1b962-9080-438f-8ed7-e6b7916dfee8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/11a088ce-01df-46fd-aa36-72b3a24d3a53/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9da1b962-9080-438f-8ed7-e6b7916dfee8>.
+    
+<http://data.lblod.info/id/remote-data-objects/6817541f-3a7b-41aa-83c9-18945a65a459> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6817541f-3a7b-41aa-83c9-18945a65a459";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/157b2d81-0ba0-420a-b14c-c692152b066a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6817541f-3a7b-41aa-83c9-18945a65a459>.
+    
+<http://data.lblod.info/id/remote-data-objects/e6a076a1-04fd-42a3-8adc-4ee04e06f46f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6a076a1-04fd-42a3-8adc-4ee04e06f46f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/157b2d81-0ba0-420a-b14c-c692152b066a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e6a076a1-04fd-42a3-8adc-4ee04e06f46f>.
+    
+<http://data.lblod.info/id/remote-data-objects/35f8120c-fc10-4e85-a58b-a7eae48c8196> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35f8120c-fc10-4e85-a58b-a7eae48c8196";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/157b2d81-0ba0-420a-b14c-c692152b066a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35f8120c-fc10-4e85-a58b-a7eae48c8196>.
+    
+<http://data.lblod.info/id/remote-data-objects/77a73d00-d5d2-4609-9f89-ac38d346f576> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77a73d00-d5d2-4609-9f89-ac38d346f576";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/1a75674d-a9ce-4a82-904b-9ae51c1acd37/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77a73d00-d5d2-4609-9f89-ac38d346f576>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa77336c-8e22-410e-8b52-3f1668ae3680> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa77336c-8e22-410e-8b52-3f1668ae3680";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/1a75674d-a9ce-4a82-904b-9ae51c1acd37/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa77336c-8e22-410e-8b52-3f1668ae3680>.
+    
+<http://data.lblod.info/id/remote-data-objects/f87423bf-55ee-4372-8700-f5b6e8a3f203> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f87423bf-55ee-4372-8700-f5b6e8a3f203";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/1a75674d-a9ce-4a82-904b-9ae51c1acd37/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f87423bf-55ee-4372-8700-f5b6e8a3f203>.
+    
+<http://data.lblod.info/id/remote-data-objects/ed071535-8502-46fd-9a7f-b1076f968504> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed071535-8502-46fd-9a7f-b1076f968504";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/349b0795-c0b3-4f46-b0a4-013e881a9bbf/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ed071535-8502-46fd-9a7f-b1076f968504>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c408e04-4ac1-4418-9f00-968700b42dbb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c408e04-4ac1-4418-9f00-968700b42dbb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/349b0795-c0b3-4f46-b0a4-013e881a9bbf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c408e04-4ac1-4418-9f00-968700b42dbb>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fb8ba47-5cee-41a1-97c1-93eb891291be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fb8ba47-5cee-41a1-97c1-93eb891291be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/349b0795-c0b3-4f46-b0a4-013e881a9bbf/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fb8ba47-5cee-41a1-97c1-93eb891291be>.
+    
+<http://data.lblod.info/id/remote-data-objects/021004b7-62d5-4225-80a8-1eac147bd092> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "021004b7-62d5-4225-80a8-1eac147bd092";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/56dd61c8-d84e-406e-aa25-397f58a93e96/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/021004b7-62d5-4225-80a8-1eac147bd092>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a467222-df8b-457a-9bc0-6ac7eaf7a9c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a467222-df8b-457a-9bc0-6ac7eaf7a9c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/56dd61c8-d84e-406e-aa25-397f58a93e96/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a467222-df8b-457a-9bc0-6ac7eaf7a9c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/deff84a3-dea1-41fa-9015-e2028a83266c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "deff84a3-dea1-41fa-9015-e2028a83266c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/7af26550-fbd7-4923-8cfc-e1d901837297/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:53.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/bf24f047-c28b-47f8-b022-026c49acd24b> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/deff84a3-dea1-41fa-9015-e2028a83266c>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201954-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201954-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201954-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201954-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/c232b1e8-b76d-42bd-bed2-3bdc034a91e1> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c232b1e8-b76d-42bd-bed2-3bdc034a91e1";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "dbb7c85f-4d0f-450e-b969-300f3f4e1489";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/f4eeb13b-5965-43a7-86ba-7c1c7d7d8ded> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f4eeb13b-5965-43a7-86ba-7c1c7d7d8ded";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489>.
+
+  <http://redpencil.data.gift/id/task/9eabc222-6bd2-418b-ae12-6bfdfd574500> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9eabc222-6bd2-418b-ae12-6bfdfd574500";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/c232b1e8-b76d-42bd-bed2-3bdc034a91e1>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/f4eeb13b-5965-43a7-86ba-7c1c7d7d8ded>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/49634c0b-065a-4b58-b657-79a057afe4bd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49634c0b-065a-4b58-b657-79a057afe4bd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/7af26550-fbd7-4923-8cfc-e1d901837297/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49634c0b-065a-4b58-b657-79a057afe4bd>.
+    
+<http://data.lblod.info/id/remote-data-objects/38e6f214-8dd6-4973-88f2-399123da337c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "38e6f214-8dd6-4973-88f2-399123da337c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/7af26550-fbd7-4923-8cfc-e1d901837297/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/38e6f214-8dd6-4973-88f2-399123da337c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5f5f388a-957a-4548-9584-321d967ff627> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5f5f388a-957a-4548-9584-321d967ff627";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/91447dbe-7233-461e-86c5-49bce08d8a89/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5f5f388a-957a-4548-9584-321d967ff627>.
+    
+<http://data.lblod.info/id/remote-data-objects/1eb580c1-d3d1-4723-9d9e-f0751dee3263> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1eb580c1-d3d1-4723-9d9e-f0751dee3263";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/91447dbe-7233-461e-86c5-49bce08d8a89/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1eb580c1-d3d1-4723-9d9e-f0751dee3263>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e0cc321-03a5-46c2-8ded-36ef191c68cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e0cc321-03a5-46c2-8ded-36ef191c68cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/91447dbe-7233-461e-86c5-49bce08d8a89/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e0cc321-03a5-46c2-8ded-36ef191c68cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/be89d303-3f81-4e96-b99d-0703c2544f01> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be89d303-3f81-4e96-b99d-0703c2544f01";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/ae341acb-7dd2-4c90-b2b3-f1fcc07e425e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be89d303-3f81-4e96-b99d-0703c2544f01>.
+    
+<http://data.lblod.info/id/remote-data-objects/7a83527b-a1eb-4494-8ecf-b628466491f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a83527b-a1eb-4494-8ecf-b628466491f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/ae341acb-7dd2-4c90-b2b3-f1fcc07e425e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7a83527b-a1eb-4494-8ecf-b628466491f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c62a8ba-f473-4a17-a216-98dc6541624d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c62a8ba-f473-4a17-a216-98dc6541624d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/ae341acb-7dd2-4c90-b2b3-f1fcc07e425e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c62a8ba-f473-4a17-a216-98dc6541624d>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ed971da-6f63-424a-bafe-7562b69411b1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ed971da-6f63-424a-bafe-7562b69411b1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/b5c4ff60-3e9d-4b53-b63c-c74a8fb1417d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ed971da-6f63-424a-bafe-7562b69411b1>.
+    
+<http://data.lblod.info/id/remote-data-objects/57857521-c2af-45eb-8b91-a44588015642> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57857521-c2af-45eb-8b91-a44588015642";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/b5c4ff60-3e9d-4b53-b63c-c74a8fb1417d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57857521-c2af-45eb-8b91-a44588015642>.
+    
+<http://data.lblod.info/id/remote-data-objects/46aad283-8c41-49aa-8cb8-5a40ca9ccc49> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "46aad283-8c41-49aa-8cb8-5a40ca9ccc49";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/b5c4ff60-3e9d-4b53-b63c-c74a8fb1417d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/46aad283-8c41-49aa-8cb8-5a40ca9ccc49>.
+    
+<http://data.lblod.info/id/remote-data-objects/8dfe07a6-4d5a-48f1-a524-d5a6a405153d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8dfe07a6-4d5a-48f1-a524-d5a6a405153d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/b94b5516-f570-42ac-9c04-ab9448ffaf57/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8dfe07a6-4d5a-48f1-a524-d5a6a405153d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e367b67a-887a-4ec8-951b-ec7a50fa7700> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e367b67a-887a-4ec8-951b-ec7a50fa7700";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/b94b5516-f570-42ac-9c04-ab9448ffaf57/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e367b67a-887a-4ec8-951b-ec7a50fa7700>.
+    
+<http://data.lblod.info/id/remote-data-objects/42732ef0-f3a1-4244-ab0f-cdab10e2de40> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "42732ef0-f3a1-4244-ab0f-cdab10e2de40";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/b94b5516-f570-42ac-9c04-ab9448ffaf57/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/42732ef0-f3a1-4244-ab0f-cdab10e2de40>.
+    
+<http://data.lblod.info/id/remote-data-objects/b69aa4a7-dd0d-4139-9cc3-403422da5bd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b69aa4a7-dd0d-4139-9cc3-403422da5bd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/cdf445ed-2e24-44e2-85b5-a62656bd28bf/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b69aa4a7-dd0d-4139-9cc3-403422da5bd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/2039db6e-9302-492b-8114-fe01e0da3be1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2039db6e-9302-492b-8114-fe01e0da3be1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/cdf445ed-2e24-44e2-85b5-a62656bd28bf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2039db6e-9302-492b-8114-fe01e0da3be1>.
+    
+<http://data.lblod.info/id/remote-data-objects/72761d6d-72fb-4ffc-a2c1-0dd1384c3014> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "72761d6d-72fb-4ffc-a2c1-0dd1384c3014";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/cdf445ed-2e24-44e2-85b5-a62656bd28bf/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/72761d6d-72fb-4ffc-a2c1-0dd1384c3014>.
+    
+<http://data.lblod.info/id/remote-data-objects/d94b781a-83cb-4b56-8e2a-26fbf539dc1f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d94b781a-83cb-4b56-8e2a-26fbf539dc1f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/d8d419dd-4558-47f1-8085-7f6efacf8471/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d94b781a-83cb-4b56-8e2a-26fbf539dc1f>.
+    
+<http://data.lblod.info/id/remote-data-objects/9b076219-0ecf-4011-b9a8-d2afbff8a9c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9b076219-0ecf-4011-b9a8-d2afbff8a9c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/d8d419dd-4558-47f1-8085-7f6efacf8471/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9b076219-0ecf-4011-b9a8-d2afbff8a9c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e7fc058c-8ba2-4c96-a079-7c9b4910a07f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7fc058c-8ba2-4c96-a079-7c9b4910a07f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/rmw/d8d419dd-4558-47f1-8085-7f6efacf8471/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e7fc058c-8ba2-4c96-a079-7c9b4910a07f>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5277eea-8062-416c-aaed-3dcbd37ed26b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5277eea-8062-416c-aaed-3dcbd37ed26b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/04740de6-1bb9-47cd-b5ca-695308fab38f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5277eea-8062-416c-aaed-3dcbd37ed26b>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc297046-4f92-4451-8a4c-9334ba278b7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc297046-4f92-4451-8a4c-9334ba278b7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/0a9c41a3-7667-4f16-be7a-a98e200a27fc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc297046-4f92-4451-8a4c-9334ba278b7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/86238bc9-ec71-4ebe-8f8d-20e237b69997> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86238bc9-ec71-4ebe-8f8d-20e237b69997";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/0edd3d5b-b92d-4e81-98ea-b49881d4f7e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86238bc9-ec71-4ebe-8f8d-20e237b69997>.
+    
+<http://data.lblod.info/id/remote-data-objects/c184d47f-1f6f-491f-b305-6b9fbb5d26d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c184d47f-1f6f-491f-b305-6b9fbb5d26d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/18ac1a40-7874-46f2-a8e1-5496f21c013b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c184d47f-1f6f-491f-b305-6b9fbb5d26d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/0203c348-0130-4146-9a1c-9b3fca2f5de0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0203c348-0130-4146-9a1c-9b3fca2f5de0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/1ef6574f-00e6-4938-9707-f72bc240f898/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0203c348-0130-4146-9a1c-9b3fca2f5de0>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4cff174-1d0c-4dcf-8e7d-8a30c940d4ec> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4cff174-1d0c-4dcf-8e7d-8a30c940d4ec";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/23710fc5-3286-4611-876d-fcab78d0aaec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4cff174-1d0c-4dcf-8e7d-8a30c940d4ec>.
+    
+<http://data.lblod.info/id/remote-data-objects/0be6541d-1247-41a4-9942-d4f20ea88c43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0be6541d-1247-41a4-9942-d4f20ea88c43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/2a05edc0-8cb5-4e68-8eb4-079f62797748/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0be6541d-1247-41a4-9942-d4f20ea88c43>.
+    
+<http://data.lblod.info/id/remote-data-objects/7486a6bf-e92c-4e22-b640-2a57f15e721a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7486a6bf-e92c-4e22-b640-2a57f15e721a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/2d3e897b-908f-4d65-90d3-9d413cc8dcb2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7486a6bf-e92c-4e22-b640-2a57f15e721a>.
+    
+<http://data.lblod.info/id/remote-data-objects/acd09c2e-016a-40f9-b2cf-d27615168db3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "acd09c2e-016a-40f9-b2cf-d27615168db3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/2ef3ebd7-6fbb-48e8-a208-ed74430db275/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/acd09c2e-016a-40f9-b2cf-d27615168db3>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a09872f-f1ac-4971-ac7b-3ceca3fcf62f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a09872f-f1ac-4971-ac7b-3ceca3fcf62f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/3b2ecbc5-ac42-4fe2-b5fc-c0cb426360e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a09872f-f1ac-4971-ac7b-3ceca3fcf62f>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c931cb4-9d13-486d-9897-65187c58a95d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c931cb4-9d13-486d-9897-65187c58a95d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/3fc6c7a0-33cf-4029-8b2e-19baf8df3f09/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c931cb4-9d13-486d-9897-65187c58a95d>.
+    
+<http://data.lblod.info/id/remote-data-objects/9a07ba59-9fef-4e66-a42f-d06847dbf4f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a07ba59-9fef-4e66-a42f-d06847dbf4f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/42268ff9-6945-45e5-a7ed-b4647231d16f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9a07ba59-9fef-4e66-a42f-d06847dbf4f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc36e9f6-614b-457e-86cf-997b5e7e344a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc36e9f6-614b-457e-86cf-997b5e7e344a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/4245a068-9e58-4dd4-873f-c283d145ca60/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc36e9f6-614b-457e-86cf-997b5e7e344a>.
+    
+<http://data.lblod.info/id/remote-data-objects/86e24e33-259c-499f-a0f8-46f0df9cffdd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86e24e33-259c-499f-a0f8-46f0df9cffdd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/424995e7-56f3-477c-949e-b82d6694c0aa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86e24e33-259c-499f-a0f8-46f0df9cffdd>.
+    
+<http://data.lblod.info/id/remote-data-objects/57914284-b217-428b-a602-0e038c442aa8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57914284-b217-428b-a602-0e038c442aa8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/495e5707-1fa0-49fe-9115-e26363aa8f7b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57914284-b217-428b-a602-0e038c442aa8>.
+    
+<http://data.lblod.info/id/remote-data-objects/508f3ff3-84cb-4057-864a-ed01cfc25d13> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "508f3ff3-84cb-4057-864a-ed01cfc25d13";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/4a4324b5-d91d-40df-8590-670ac9f9dac7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/508f3ff3-84cb-4057-864a-ed01cfc25d13>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd0a9d7b-65a0-42bd-b97d-58822c42ac9e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd0a9d7b-65a0-42bd-b97d-58822c42ac9e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/53e9674b-e5f9-43c8-8996-bc0c9665be70/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd0a9d7b-65a0-42bd-b97d-58822c42ac9e>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd666bf2-c122-4a54-8f37-757a581e816f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd666bf2-c122-4a54-8f37-757a581e816f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/5452670f-714c-4438-84cf-f5d978825adf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd666bf2-c122-4a54-8f37-757a581e816f>.
+    
+<http://data.lblod.info/id/remote-data-objects/03cf9cef-9973-426c-a34a-747f157efd5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03cf9cef-9973-426c-a34a-747f157efd5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/555b934e-22ca-4654-8797-471200ac0405/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03cf9cef-9973-426c-a34a-747f157efd5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5d7eb2f3-1169-4f14-9edf-7eb768f7fb81> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d7eb2f3-1169-4f14-9edf-7eb768f7fb81";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/5aafd630-2327-4be9-a2b9-a24656b5f16d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5d7eb2f3-1169-4f14-9edf-7eb768f7fb81>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ee36a9d-2ca9-4cae-8865-5a082544a822> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ee36a9d-2ca9-4cae-8865-5a082544a822";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/6441a4f5-dc0f-4274-930f-795ca7a8f687/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ee36a9d-2ca9-4cae-8865-5a082544a822>.
+    
+<http://data.lblod.info/id/remote-data-objects/ab111847-db69-4be3-903d-8b7f5d5e82f2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ab111847-db69-4be3-903d-8b7f5d5e82f2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/64b2ee05-4e80-4a2d-b0b6-83f093b6f1e1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ab111847-db69-4be3-903d-8b7f5d5e82f2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d53b4ba1-ac2b-4714-ba90-9843f8b9ec0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d53b4ba1-ac2b-4714-ba90-9843f8b9ec0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/6663d96b-4c4b-4b40-ac63-9c9b0701610f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d53b4ba1-ac2b-4714-ba90-9843f8b9ec0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8062623c-3dfc-46eb-b3ac-0fde7c32f16d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8062623c-3dfc-46eb-b3ac-0fde7c32f16d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/71182c79-8e8e-4030-a9e0-33efce9e7145/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8062623c-3dfc-46eb-b3ac-0fde7c32f16d>.
+    
+<http://data.lblod.info/id/remote-data-objects/fafed8c1-1b3c-480a-aec5-5694eb04f518> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fafed8c1-1b3c-480a-aec5-5694eb04f518";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/80d71330-4650-4476-a00e-b4b936cbb3c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fafed8c1-1b3c-480a-aec5-5694eb04f518>.
+    
+<http://data.lblod.info/id/remote-data-objects/65528150-236d-4a7d-9983-41ec7bc3fa03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65528150-236d-4a7d-9983-41ec7bc3fa03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/83f85355-55d8-4ae5-8ce1-350ebdbdc3da/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65528150-236d-4a7d-9983-41ec7bc3fa03>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc569258-2c19-4bc0-b29a-de74ce2f5908> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc569258-2c19-4bc0-b29a-de74ce2f5908";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/842737f1-4fa6-4b9c-ae9e-8a8c8842facc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc569258-2c19-4bc0-b29a-de74ce2f5908>.
+    
+<http://data.lblod.info/id/remote-data-objects/7bf650ce-fff3-4ebc-8d42-af55051216b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bf650ce-fff3-4ebc-8d42-af55051216b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/854f5d27-8e22-4771-881c-065d644ebed1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7bf650ce-fff3-4ebc-8d42-af55051216b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/cae2d8d4-1998-40a9-a479-c2491ea05fd1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cae2d8d4-1998-40a9-a479-c2491ea05fd1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/86e91581-3df8-44f2-b587-89a36a46ffb6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cae2d8d4-1998-40a9-a479-c2491ea05fd1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e0f1e636-2f7c-48dd-8aea-95c0918439df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0f1e636-2f7c-48dd-8aea-95c0918439df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/8924fbef-4aa2-4be4-9cec-8b43e9d436f4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:54.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/dbb7c85f-4d0f-450e-b969-300f3f4e1489> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e0f1e636-2f7c-48dd-8aea-95c0918439df>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201956-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201956-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201956-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201956-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/df3d3fd7-1442-4fe2-8d15-932663fb2a5f> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "df3d3fd7-1442-4fe2-8d15-932663fb2a5f";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "622f8ce6-1af5-463d-9f19-b420166505b6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/2ec026a8-037e-4acd-ab6a-350f14ec92dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2ec026a8-037e-4acd-ab6a-350f14ec92dd";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6>.
+
+  <http://redpencil.data.gift/id/task/6aed4621-d9a4-466e-b622-1fc21416af62> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "6aed4621-d9a4-466e-b622-1fc21416af62";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/df3d3fd7-1442-4fe2-8d15-932663fb2a5f>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/2ec026a8-037e-4acd-ab6a-350f14ec92dd>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/df769515-6769-466d-8a96-a1e4776bb89c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df769515-6769-466d-8a96-a1e4776bb89c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/8acc9fbc-52fc-4ac2-8100-2dc54435629a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df769515-6769-466d-8a96-a1e4776bb89c>.
+    
+<http://data.lblod.info/id/remote-data-objects/6103dc08-578a-4853-b532-e9fb96d4e85a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6103dc08-578a-4853-b532-e9fb96d4e85a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/967bb925-ba17-4646-8c2a-221f1b268282/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6103dc08-578a-4853-b532-e9fb96d4e85a>.
+    
+<http://data.lblod.info/id/remote-data-objects/273ebc8b-c2a8-4bb1-b031-b87ff6317a90> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "273ebc8b-c2a8-4bb1-b031-b87ff6317a90";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/993ad8f1-16ca-40a3-9913-d4c3797ab116/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/273ebc8b-c2a8-4bb1-b031-b87ff6317a90>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7a28e78-7d1e-4215-b5cc-d420e3ce48e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7a28e78-7d1e-4215-b5cc-d420e3ce48e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/9a3afa47-7ddb-47c3-b53c-70837c2d8763/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7a28e78-7d1e-4215-b5cc-d420e3ce48e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6b7c793-25c1-4614-bf7a-31d2c5913358> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6b7c793-25c1-4614-bf7a-31d2c5913358";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/9c722cfa-02c9-4907-b1fe-bc59831bffe7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6b7c793-25c1-4614-bf7a-31d2c5913358>.
+    
+<http://data.lblod.info/id/remote-data-objects/5dfd8a23-089e-4035-9316-6b6cb64d92ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5dfd8a23-089e-4035-9316-6b6cb64d92ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/9c9df637-e14d-41e6-9b05-4a5ed30a4152/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5dfd8a23-089e-4035-9316-6b6cb64d92ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/79687a19-02aa-48a1-b329-60cf12f5742c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79687a19-02aa-48a1-b329-60cf12f5742c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/a2e33063-3c0e-46a6-a46f-6e3c2bf49e37/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79687a19-02aa-48a1-b329-60cf12f5742c>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4a36daa-b87e-4326-bc13-8724232db39b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4a36daa-b87e-4326-bc13-8724232db39b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/a2ea223d-8f97-48c5-b990-4e061f06b88a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4a36daa-b87e-4326-bc13-8724232db39b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f8fa780d-d426-4961-9562-4ef148474b84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f8fa780d-d426-4961-9562-4ef148474b84";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/a4d6945f-df25-455e-9477-92d5e7a4721b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f8fa780d-d426-4961-9562-4ef148474b84>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4c27a0b-d17c-4c7c-af62-fc9e4e00734f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4c27a0b-d17c-4c7c-af62-fc9e4e00734f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/a5b0f5ac-7da3-423e-afb5-499d7ffc0c2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4c27a0b-d17c-4c7c-af62-fc9e4e00734f>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f76b020-63ff-4318-9d35-5db699f81367> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f76b020-63ff-4318-9d35-5db699f81367";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/a5f223fe-f9e6-4718-8f47-7172d3a4bfb6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f76b020-63ff-4318-9d35-5db699f81367>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c4363a2-719a-42b0-824a-5edefa9a45a5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c4363a2-719a-42b0-824a-5edefa9a45a5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/ac9684a8-2088-470a-a8d5-778889988f54/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c4363a2-719a-42b0-824a-5edefa9a45a5>.
+    
+<http://data.lblod.info/id/remote-data-objects/7caca299-62f4-43fa-925e-c0053148d468> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7caca299-62f4-43fa-925e-c0053148d468";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/ad335eaf-7911-4883-9011-a529fb32ee95/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7caca299-62f4-43fa-925e-c0053148d468>.
+    
+<http://data.lblod.info/id/remote-data-objects/83ef0547-3320-43f0-8212-803b3193281b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83ef0547-3320-43f0-8212-803b3193281b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/adba2ea0-4a0c-4b6c-9fec-e07577d7e128/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83ef0547-3320-43f0-8212-803b3193281b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5664d45e-fad6-4b44-a110-586bf89e43d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5664d45e-fad6-4b44-a110-586bf89e43d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/b1770d1f-979c-48df-ad94-d6df8bc21ebd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5664d45e-fad6-4b44-a110-586bf89e43d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd901f58-ff6e-49f2-8402-654fc6fc21da> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd901f58-ff6e-49f2-8402-654fc6fc21da";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/b3de0c28-a0c3-4173-9261-318f2063c43c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd901f58-ff6e-49f2-8402-654fc6fc21da>.
+    
+<http://data.lblod.info/id/remote-data-objects/4305c995-bdde-481a-8f39-ef0267d34186> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4305c995-bdde-481a-8f39-ef0267d34186";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/b4d1117e-3a61-4f00-98e4-931e39f60d1d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4305c995-bdde-481a-8f39-ef0267d34186>.
+    
+<http://data.lblod.info/id/remote-data-objects/6dab3336-f390-4016-9549-f6e8310a1129> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6dab3336-f390-4016-9549-f6e8310a1129";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/b5d448be-459b-4d14-b4ef-17c4f58b0ed3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6dab3336-f390-4016-9549-f6e8310a1129>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e21f297-28ee-471b-93cc-0a317b5ca5dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e21f297-28ee-471b-93cc-0a317b5ca5dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/b759ce2a-d242-4f18-a6cd-90f7fed2c130/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e21f297-28ee-471b-93cc-0a317b5ca5dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/0015ffb7-e6e9-4389-a2fc-6328d279f1d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0015ffb7-e6e9-4389-a2fc-6328d279f1d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/b8d83395-89cc-4876-b352-2d8bc5bb6ad9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0015ffb7-e6e9-4389-a2fc-6328d279f1d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2eed285-920a-41e7-8f6e-dfcbb551f278> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2eed285-920a-41e7-8f6e-dfcbb551f278";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/bd1a2fcb-1d4f-4f06-8643-1893bb881c6b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2eed285-920a-41e7-8f6e-dfcbb551f278>.
+    
+<http://data.lblod.info/id/remote-data-objects/64b8361e-f6a4-4dfb-a716-6294ead96ca9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64b8361e-f6a4-4dfb-a716-6294ead96ca9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/bd2b19fd-6768-41f2-b963-dc65a8fec7ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/64b8361e-f6a4-4dfb-a716-6294ead96ca9>.
+    
+<http://data.lblod.info/id/remote-data-objects/50d729e7-eee8-4570-a4d5-d4f4e0879209> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50d729e7-eee8-4570-a4d5-d4f4e0879209";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/befdc84e-84c7-46e5-8451-e09664bb2b83/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50d729e7-eee8-4570-a4d5-d4f4e0879209>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1d8e891-45e0-4a8b-863d-dfe95f115ef0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1d8e891-45e0-4a8b-863d-dfe95f115ef0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/c45e98cc-e886-48eb-852b-13f43700067a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1d8e891-45e0-4a8b-863d-dfe95f115ef0>.
+    
+<http://data.lblod.info/id/remote-data-objects/39155276-6e48-47a5-b3aa-0e0c1a8164c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39155276-6e48-47a5-b3aa-0e0c1a8164c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/ca827ce3-bdf3-465e-89ac-58b9a0188265/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/39155276-6e48-47a5-b3aa-0e0c1a8164c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8ddc913-8ec1-4cfd-8da5-426efe5a17a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8ddc913-8ec1-4cfd-8da5-426efe5a17a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/cbb3ecef-a256-4043-9e0f-95bcd7818917/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8ddc913-8ec1-4cfd-8da5-426efe5a17a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/bc1c5aef-1032-414f-ac38-2f49afa03b8b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bc1c5aef-1032-414f-ac38-2f49afa03b8b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/ce7537c6-669d-4188-a996-ccee1b4008ff/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bc1c5aef-1032-414f-ac38-2f49afa03b8b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1dde200a-461d-44be-9b17-0a38304102e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1dde200a-461d-44be-9b17-0a38304102e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/cf2e55b1-bad7-4c8b-848a-2fa07ace624c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1dde200a-461d-44be-9b17-0a38304102e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c0e63131-5c47-4592-a885-dbf74805fb4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0e63131-5c47-4592-a885-dbf74805fb4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/d0b6b382-46ac-436f-acdb-1185373b9840/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c0e63131-5c47-4592-a885-dbf74805fb4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/abb401dc-669b-445f-87be-105d41713be9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "abb401dc-669b-445f-87be-105d41713be9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/d408c8f6-845e-407c-9b2f-3b160ff1b3d9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/abb401dc-669b-445f-87be-105d41713be9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9f704b5-9a0e-453a-814e-6021902c8b4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9f704b5-9a0e-453a-814e-6021902c8b4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/d9e52b77-1508-47eb-895f-5421cf74631e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9f704b5-9a0e-453a-814e-6021902c8b4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/86499b0d-b55d-42ac-9ac9-decb951bb6df> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86499b0d-b55d-42ac-9ac9-decb951bb6df";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/dcc078bb-5d9a-4e31-bb83-432f2daebaca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86499b0d-b55d-42ac-9ac9-decb951bb6df>.
+    
+<http://data.lblod.info/id/remote-data-objects/0579fb6a-c73a-421c-987c-9edf42cbc443> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0579fb6a-c73a-421c-987c-9edf42cbc443";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/de2c3970-671d-48e1-873e-b0f2e3ce5540/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0579fb6a-c73a-421c-987c-9edf42cbc443>.
+    
+<http://data.lblod.info/id/remote-data-objects/b82d235f-551b-40fb-b0d7-30029994cd9f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b82d235f-551b-40fb-b0d7-30029994cd9f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/e4600a81-3466-428b-93d4-6d8572f63516/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b82d235f-551b-40fb-b0d7-30029994cd9f>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cee6ebb-31fa-45ba-9217-d9957efe4d5e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cee6ebb-31fa-45ba-9217-d9957efe4d5e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/e927a0b1-d766-429e-a4ab-5a49ce49125d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cee6ebb-31fa-45ba-9217-d9957efe4d5e>.
+    
+<http://data.lblod.info/id/remote-data-objects/9440401e-458c-4f63-b3e1-78e574d6555d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9440401e-458c-4f63-b3e1-78e574d6555d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/f53bccf4-e58a-4c99-b9b3-962ee7186956/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9440401e-458c-4f63-b3e1-78e574d6555d>.
+    
+<http://data.lblod.info/id/remote-data-objects/186685f4-98fe-4c58-baf5-ea33cd747c92> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "186685f4-98fe-4c58-baf5-ea33cd747c92";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/f94890b9-bb0a-4986-99c8-ba80453ba8cb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/186685f4-98fe-4c58-baf5-ea33cd747c92>.
+    
+<http://data.lblod.info/id/remote-data-objects/693855ac-7435-418f-8959-6f16e286f959> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "693855ac-7435-418f-8959-6f16e286f959";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wellen.meetingburger.net/vabu/fabcf476-735d-4cae-9113-75a334e91d78/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/693855ac-7435-418f-8959-6f16e286f959>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f399224-1566-430f-8734-fc5b0e1fe869> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f399224-1566-430f-8734-fc5b0e1fe869";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/058dd10d-acc0-460c-bcd5-479165366bea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f399224-1566-430f-8734-fc5b0e1fe869>.
+    
+<http://data.lblod.info/id/remote-data-objects/b9f15bf4-3934-49e0-a6af-ce8f414ac8fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b9f15bf4-3934-49e0-a6af-ce8f414ac8fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/09841ded-cc87-47cd-8859-bccd21c2f880/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b9f15bf4-3934-49e0-a6af-ce8f414ac8fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/266e505e-b965-4d13-aa4a-6f09c559af70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "266e505e-b965-4d13-aa4a-6f09c559af70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/113c0f3c-b4ca-475e-84ba-43482ec49df4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/266e505e-b965-4d13-aa4a-6f09c559af70>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4904ab9-e209-4bfe-96d3-ec6411c9f4bc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4904ab9-e209-4bfe-96d3-ec6411c9f4bc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/12fea516-af72-412d-b2dc-2b32288ab4d1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4904ab9-e209-4bfe-96d3-ec6411c9f4bc>.
+    
+<http://data.lblod.info/id/remote-data-objects/407bae7b-9e6a-4f73-8dbf-70458c5cd1d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "407bae7b-9e6a-4f73-8dbf-70458c5cd1d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/1ab38c6a-78a1-4853-8e0b-b714295e0c1b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/407bae7b-9e6a-4f73-8dbf-70458c5cd1d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/093f830a-ae18-4f48-a046-71be3669fab9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "093f830a-ae18-4f48-a046-71be3669fab9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/1b04f0a9-fd7b-40fa-80df-6157c6e42f47/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/093f830a-ae18-4f48-a046-71be3669fab9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a4730e7c-8cc6-4fc3-bb4c-af08d375d827> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a4730e7c-8cc6-4fc3-bb4c-af08d375d827";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/2a5ecfdb-3717-4567-98cd-1f5c7bb67769/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a4730e7c-8cc6-4fc3-bb4c-af08d375d827>.
+    
+<http://data.lblod.info/id/remote-data-objects/1fdb3b8f-42de-4227-be99-65e0cdb48cac> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1fdb3b8f-42de-4227-be99-65e0cdb48cac";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/2fd4fde2-59ef-4ba3-be40-8b1ab92e0d9a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1fdb3b8f-42de-4227-be99-65e0cdb48cac>.
+    
+<http://data.lblod.info/id/remote-data-objects/21e63c38-6f15-4dd9-9882-9ddd72b1f6d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21e63c38-6f15-4dd9-9882-9ddd72b1f6d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/33101ca9-b43c-4dff-9c46-8a3a5d14dab7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21e63c38-6f15-4dd9-9882-9ddd72b1f6d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d3b0986-0435-4679-a3fd-5be40c4e2036> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d3b0986-0435-4679-a3fd-5be40c4e2036";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/349c9f50-9697-4172-9492-85603cb14b9e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d3b0986-0435-4679-a3fd-5be40c4e2036>.
+    
+<http://data.lblod.info/id/remote-data-objects/5dfab50d-5321-4835-90b8-4b3c0d9480bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5dfab50d-5321-4835-90b8-4b3c0d9480bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/388c891e-64b1-4422-9389-951cf04fdc00/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5dfab50d-5321-4835-90b8-4b3c0d9480bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/116f721f-aa26-42e5-9b56-f552c58da840> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "116f721f-aa26-42e5-9b56-f552c58da840";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/39445783-9798-49d2-bee2-63a95ff5ecca/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:56.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/622f8ce6-1af5-463d-9f19-b420166505b6> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/116f721f-aa26-42e5-9b56-f552c58da840>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201957-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201957-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201957-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201957-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/390f791e-cb30-4829-8190-08332b9f8344> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "390f791e-cb30-4829-8190-08332b9f8344";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "91bc008f-27c3-45c3-80d1-980d45646c46";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/8f901f85-0b9e-41f6-a441-d98cfe294035> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8f901f85-0b9e-41f6-a441-d98cfe294035";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46>.
+
+  <http://redpencil.data.gift/id/task/c5d0b533-f573-4846-8b4a-e7a958c7b26f> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c5d0b533-f573-4846-8b4a-e7a958c7b26f";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/390f791e-cb30-4829-8190-08332b9f8344>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/8f901f85-0b9e-41f6-a441-d98cfe294035>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/2ccfba2f-2993-4892-b5db-aa9eefec15f3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ccfba2f-2993-4892-b5db-aa9eefec15f3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/3a17a43d-0f2f-4dcd-8258-97b38e48dec1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ccfba2f-2993-4892-b5db-aa9eefec15f3>.
+    
+<http://data.lblod.info/id/remote-data-objects/29df1088-6328-4923-9a96-acd1c62d15c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "29df1088-6328-4923-9a96-acd1c62d15c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/3af8d17f-38e4-4a4e-b96d-d3f669daff86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/29df1088-6328-4923-9a96-acd1c62d15c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf7cc6ff-9778-4e20-ab18-016407aea507> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf7cc6ff-9778-4e20-ab18-016407aea507";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/3d25b189-22b1-47a0-935d-42d54d66182c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf7cc6ff-9778-4e20-ab18-016407aea507>.
+    
+<http://data.lblod.info/id/remote-data-objects/c28b995b-365d-4ee1-a289-2d7dd64f43bb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c28b995b-365d-4ee1-a289-2d7dd64f43bb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/3e1fc6b5-b274-4c4a-a176-8a777537ab22/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c28b995b-365d-4ee1-a289-2d7dd64f43bb>.
+    
+<http://data.lblod.info/id/remote-data-objects/bf13feeb-d1b5-4a92-b919-8ce189754d70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf13feeb-d1b5-4a92-b919-8ce189754d70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/44639351-1986-4a05-a4e3-ec7b7df17ffb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bf13feeb-d1b5-4a92-b919-8ce189754d70>.
+    
+<http://data.lblod.info/id/remote-data-objects/2f0af172-59fc-4dce-99cf-34dc7472c4c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2f0af172-59fc-4dce-99cf-34dc7472c4c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/475b2d74-196f-4921-bfef-2b9e54eda7b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2f0af172-59fc-4dce-99cf-34dc7472c4c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/19c806e2-2f56-4414-b803-f77d627015c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "19c806e2-2f56-4414-b803-f77d627015c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/476c80af-5362-4fd4-8a4a-0a6da621fb22/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/19c806e2-2f56-4414-b803-f77d627015c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/4d26e5fb-1f6d-4a9e-9a06-f72f570d3175> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4d26e5fb-1f6d-4a9e-9a06-f72f570d3175";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/4a5c62d2-ec81-4f25-8a34-670f8ec417f0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4d26e5fb-1f6d-4a9e-9a06-f72f570d3175>.
+    
+<http://data.lblod.info/id/remote-data-objects/59836f31-34a8-4bf8-9451-54d4db45766a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59836f31-34a8-4bf8-9451-54d4db45766a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/4f77244d-cfc0-4560-9666-1b2171420365/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59836f31-34a8-4bf8-9451-54d4db45766a>.
+    
+<http://data.lblod.info/id/remote-data-objects/00408484-2243-4c1e-b1fc-66b841a4452d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "00408484-2243-4c1e-b1fc-66b841a4452d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/579ba1dc-60a5-4891-ae67-a8778ee2c72d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/00408484-2243-4c1e-b1fc-66b841a4452d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b537c708-b856-4b61-bf90-6a335c5ab335> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b537c708-b856-4b61-bf90-6a335c5ab335";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/5c727ccc-3962-4229-acf8-187d77c5ee6b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b537c708-b856-4b61-bf90-6a335c5ab335>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb716f18-4568-489c-9c80-d75d24ba22d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb716f18-4568-489c-9c80-d75d24ba22d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/671ac81d-82fe-4b6f-a45d-12dc016123c0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb716f18-4568-489c-9c80-d75d24ba22d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e9be4e27-9d0c-4026-ad49-65428f4466d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9be4e27-9d0c-4026-ad49-65428f4466d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/68414237-f89e-4ae1-99fa-35a737c7bc2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e9be4e27-9d0c-4026-ad49-65428f4466d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e9db0d3-e052-431c-bb7f-8931f4824f6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e9db0d3-e052-431c-bb7f-8931f4824f6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/6943bc9d-90cb-42be-bc45-7c91663462f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e9db0d3-e052-431c-bb7f-8931f4824f6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/d49d02c6-1e4d-4ca9-b250-6209c516f299> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d49d02c6-1e4d-4ca9-b250-6209c516f299";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/71e284b4-3d15-47bf-92f9-582263fcdc81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d49d02c6-1e4d-4ca9-b250-6209c516f299>.
+    
+<http://data.lblod.info/id/remote-data-objects/db244c82-8b52-4eb3-9aea-7888aae7385a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db244c82-8b52-4eb3-9aea-7888aae7385a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/7294f48e-7f78-48c3-91e6-b40b346b5bd1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db244c82-8b52-4eb3-9aea-7888aae7385a>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5382f48-901e-4820-bf7b-b7ec71c202c8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5382f48-901e-4820-bf7b-b7ec71c202c8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/75b7d393-ffb0-4e41-8a22-8551586a9f31/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5382f48-901e-4820-bf7b-b7ec71c202c8>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f420b09-a72a-4c0d-8005-6aea88cd2297> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f420b09-a72a-4c0d-8005-6aea88cd2297";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/772bc46a-0e7a-4e5d-9c7f-13c5e29ea4b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f420b09-a72a-4c0d-8005-6aea88cd2297>.
+    
+<http://data.lblod.info/id/remote-data-objects/6158a7ba-f750-4645-acb3-6f3d14d55175> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6158a7ba-f750-4645-acb3-6f3d14d55175";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/7987cb67-e9b3-41ff-aa83-e30bc0646c56/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6158a7ba-f750-4645-acb3-6f3d14d55175>.
+    
+<http://data.lblod.info/id/remote-data-objects/baeae90c-b068-42a0-b638-5d4b84945562> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "baeae90c-b068-42a0-b638-5d4b84945562";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/7b5804da-2c4e-47bf-b457-5d247ed2751a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/baeae90c-b068-42a0-b638-5d4b84945562>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e349c88-9ece-403d-8b0a-5a2ac9874351> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e349c88-9ece-403d-8b0a-5a2ac9874351";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/7e829366-8f0f-4492-9369-8d7ab4951ef1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e349c88-9ece-403d-8b0a-5a2ac9874351>.
+    
+<http://data.lblod.info/id/remote-data-objects/eadcc295-7979-4ba7-b02a-ebae0309281d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eadcc295-7979-4ba7-b02a-ebae0309281d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/8170e932-cb79-49de-9347-46e76d918de0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eadcc295-7979-4ba7-b02a-ebae0309281d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8a46260-207f-4cf5-bf62-9352e3965a35> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8a46260-207f-4cf5-bf62-9352e3965a35";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/81cbf50d-a954-4814-8942-94a2ae70cfc9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8a46260-207f-4cf5-bf62-9352e3965a35>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a2b5ad4-cca5-434a-851f-6fa296dba04a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a2b5ad4-cca5-434a-851f-6fa296dba04a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/83dc8aa5-86d9-4d24-9c8b-4fa280f58091/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a2b5ad4-cca5-434a-851f-6fa296dba04a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fa7ab4c4-fa71-44e7-adc1-df75b9ce3de8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa7ab4c4-fa71-44e7-adc1-df75b9ce3de8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/84eac546-23ff-410e-b3ae-86556f10839a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fa7ab4c4-fa71-44e7-adc1-df75b9ce3de8>.
+    
+<http://data.lblod.info/id/remote-data-objects/4c81a3db-b86a-4bf5-ad8b-261fa0a9e1d1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c81a3db-b86a-4bf5-ad8b-261fa0a9e1d1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/8cca8cf7-489a-4e7e-88c9-f4454738761c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4c81a3db-b86a-4bf5-ad8b-261fa0a9e1d1>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b2d7fd6-ee73-40f7-a086-672c273f70f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b2d7fd6-ee73-40f7-a086-672c273f70f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/8d154d03-873b-4fa9-a6c4-1657466a89d7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b2d7fd6-ee73-40f7-a086-672c273f70f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/e84fffd2-72f5-4e4a-84ed-c586fed328c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e84fffd2-72f5-4e4a-84ed-c586fed328c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/8d383b0e-7755-48c6-a93f-7b8395e2c8b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e84fffd2-72f5-4e4a-84ed-c586fed328c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/66d31711-cebb-4cab-a6a9-487959fd2f95> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66d31711-cebb-4cab-a6a9-487959fd2f95";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/8e733e8d-b1d6-423a-8071-f3d1df9d549c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66d31711-cebb-4cab-a6a9-487959fd2f95>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ac66365-1997-4f47-ae3d-f3a31101b5fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ac66365-1997-4f47-ae3d-f3a31101b5fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/8eb1ef17-50cf-480f-8257-eb4c60235d05/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ac66365-1997-4f47-ae3d-f3a31101b5fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/c4674d07-e219-4a80-b511-d4d3714abb75> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4674d07-e219-4a80-b511-d4d3714abb75";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/96784f24-92cd-41d0-a4a8-6a8d3a2748ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c4674d07-e219-4a80-b511-d4d3714abb75>.
+    
+<http://data.lblod.info/id/remote-data-objects/40449b95-2413-487c-8097-423dbf0efdbc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40449b95-2413-487c-8097-423dbf0efdbc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/96b031c6-ede5-43a1-81f2-a24668020743/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40449b95-2413-487c-8097-423dbf0efdbc>.
+    
+<http://data.lblod.info/id/remote-data-objects/9ff0a704-c3ee-4e6a-99f5-b77371298fce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ff0a704-c3ee-4e6a-99f5-b77371298fce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/97d4072d-2e39-4bbf-b278-60617f2509c8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9ff0a704-c3ee-4e6a-99f5-b77371298fce>.
+    
+<http://data.lblod.info/id/remote-data-objects/a827c7b9-4ff1-466b-a549-4cc556a5a984> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a827c7b9-4ff1-466b-a549-4cc556a5a984";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/9a7a5055-3940-4e52-8017-67895eb64237/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a827c7b9-4ff1-466b-a549-4cc556a5a984>.
+    
+<http://data.lblod.info/id/remote-data-objects/c055586e-8ab3-4d34-ba56-cf7fb44f2d54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c055586e-8ab3-4d34-ba56-cf7fb44f2d54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/9fa5037c-b840-49dc-885d-dba724a8e8fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c055586e-8ab3-4d34-ba56-cf7fb44f2d54>.
+    
+<http://data.lblod.info/id/remote-data-objects/803199bc-3e2b-43c7-b3cd-dcfb996ccb60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "803199bc-3e2b-43c7-b3cd-dcfb996ccb60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/a3853c11-c142-4865-9330-99cb12d0d950/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/803199bc-3e2b-43c7-b3cd-dcfb996ccb60>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4740bdf-0408-4120-b865-ac1b561ef34b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4740bdf-0408-4120-b865-ac1b561ef34b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/aa732331-c56c-44b3-bced-5a74472df485/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4740bdf-0408-4120-b865-ac1b561ef34b>.
+    
+<http://data.lblod.info/id/remote-data-objects/e8288dd7-8374-4880-9ad9-c8b1a6a20c02> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e8288dd7-8374-4880-9ad9-c8b1a6a20c02";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/ac173798-7c61-43fd-aaca-33c43386673f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e8288dd7-8374-4880-9ad9-c8b1a6a20c02>.
+    
+<http://data.lblod.info/id/remote-data-objects/a2373349-6787-496e-af84-aa9f2e415831> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a2373349-6787-496e-af84-aa9f2e415831";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/afe5cbc4-e993-4929-8716-7502b29e82ae/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a2373349-6787-496e-af84-aa9f2e415831>.
+    
+<http://data.lblod.info/id/remote-data-objects/65f7bf10-d161-4ced-9f72-de61e83ab235> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65f7bf10-d161-4ced-9f72-de61e83ab235";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/b0093910-01c1-4746-b698-6c0ea9bb1105/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/65f7bf10-d161-4ced-9f72-de61e83ab235>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f757a92-1e11-4d8a-a20d-3c97236b2838> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f757a92-1e11-4d8a-a20d-3c97236b2838";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/b00dbf47-4b81-4393-8362-d88c843ce8b9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f757a92-1e11-4d8a-a20d-3c97236b2838>.
+    
+<http://data.lblod.info/id/remote-data-objects/dbdf15a7-4f11-4c2b-a274-38f65b38107b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dbdf15a7-4f11-4c2b-a274-38f65b38107b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/b28abae2-1f75-4078-afe2-64b245d68680/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dbdf15a7-4f11-4c2b-a274-38f65b38107b>.
+    
+<http://data.lblod.info/id/remote-data-objects/9685d5b5-8427-4b6f-98ac-7349e5b7c191> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9685d5b5-8427-4b6f-98ac-7349e5b7c191";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/b2af6985-1a1d-4b6b-b8c0-29d3a771bb2f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9685d5b5-8427-4b6f-98ac-7349e5b7c191>.
+    
+<http://data.lblod.info/id/remote-data-objects/a86e1b1e-83a7-4312-ab30-9aeec6ffa15c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a86e1b1e-83a7-4312-ab30-9aeec6ffa15c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/b4e02e7c-32a6-4ceb-b0af-dfec50c34384/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a86e1b1e-83a7-4312-ab30-9aeec6ffa15c>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a49d990-3b5f-4ab0-84b7-15646cc9570b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a49d990-3b5f-4ab0-84b7-15646cc9570b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/b5cf7e27-311d-489f-b840-2f1fb23f222e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a49d990-3b5f-4ab0-84b7-15646cc9570b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1d7dfc81-e4f5-45c2-b6ae-17fd061c6ee6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1d7dfc81-e4f5-45c2-b6ae-17fd061c6ee6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/b62b4ee8-5e99-48c8-8578-b3bb8e74abf0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1d7dfc81-e4f5-45c2-b6ae-17fd061c6ee6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d1390d9-9cc1-4d23-a1b7-306c82749798> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d1390d9-9cc1-4d23-a1b7-306c82749798";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/b6c462db-8b80-4b47-aad7-e05d2008edaf/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d1390d9-9cc1-4d23-a1b7-306c82749798>.
+    
+<http://data.lblod.info/id/remote-data-objects/c6eb6ed9-22e8-40cf-8e67-5262f21c50f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6eb6ed9-22e8-40cf-8e67-5262f21c50f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/c4df68b3-2549-4487-b5fa-e9db5621d517/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c6eb6ed9-22e8-40cf-8e67-5262f21c50f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f454c15-aa8b-495e-ba26-9e627140b932> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f454c15-aa8b-495e-ba26-9e627140b932";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/c8bb4f73-bd85-40a4-89f7-d935ce5830bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f454c15-aa8b-495e-ba26-9e627140b932>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8682ad5-514f-4250-bd22-9064aa977445> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8682ad5-514f-4250-bd22-9064aa977445";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/d236a7a7-c179-4e76-b63f-fabd82063bf1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:57.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/91bc008f-27c3-45c3-80d1-980d45646c46> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8682ad5-514f-4250-bd22-9064aa977445>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201958-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201958-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201958-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201958-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/2f0506be-d1e7-4dd1-9f04-648341d13781> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2f0506be-d1e7-4dd1-9f04-648341d13781";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "19c08452-195a-49d4-bf56-3c340a37dfc3";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4b4e32a2-c7fc-4efc-977f-d3e397440c45> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4b4e32a2-c7fc-4efc-977f-d3e397440c45";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3>.
+
+  <http://redpencil.data.gift/id/task/e5a28f91-d935-4851-a464-795615aa9cb0> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e5a28f91-d935-4851-a464-795615aa9cb0";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/2f0506be-d1e7-4dd1-9f04-648341d13781>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4b4e32a2-c7fc-4efc-977f-d3e397440c45>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5230da7e-2899-4b77-8b2c-4354c3673c88> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5230da7e-2899-4b77-8b2c-4354c3673c88";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/d44ea316-9b5a-4939-8814-dbdc7150f228/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5230da7e-2899-4b77-8b2c-4354c3673c88>.
+    
+<http://data.lblod.info/id/remote-data-objects/e69fda57-f1a1-4c00-85e4-f9f2db400b12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e69fda57-f1a1-4c00-85e4-f9f2db400b12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/d86705fc-f753-42d1-a278-f2c09f4e9428/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e69fda57-f1a1-4c00-85e4-f9f2db400b12>.
+    
+<http://data.lblod.info/id/remote-data-objects/0f7ac3be-9409-439d-95b9-abbb286adb06> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0f7ac3be-9409-439d-95b9-abbb286adb06";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/de593ab9-f2f0-4d54-a055-fff46f080b62/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0f7ac3be-9409-439d-95b9-abbb286adb06>.
+    
+<http://data.lblod.info/id/remote-data-objects/b6a1360b-510b-43a2-bb8d-0e9ca6e93b56> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6a1360b-510b-43a2-bb8d-0e9ca6e93b56";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/df2795e0-617e-4218-8019-5309b6aad2fa/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b6a1360b-510b-43a2-bb8d-0e9ca6e93b56>.
+    
+<http://data.lblod.info/id/remote-data-objects/9469f238-c374-403f-8873-e381693bf864> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9469f238-c374-403f-8873-e381693bf864";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/ec066760-23ce-4484-97dd-b657a8ffe1ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9469f238-c374-403f-8873-e381693bf864>.
+    
+<http://data.lblod.info/id/remote-data-objects/41000fb9-3140-4873-b0b3-691841695c66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "41000fb9-3140-4873-b0b3-691841695c66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/ee8a97fe-a61e-4868-abdd-b521f47e9e87/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/41000fb9-3140-4873-b0b3-691841695c66>.
+    
+<http://data.lblod.info/id/remote-data-objects/83699bde-1a75-4b79-bf3b-2519aeb808e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83699bde-1a75-4b79-bf3b-2519aeb808e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/f9064e1f-9335-4716-aaab-bdda7da6f367/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83699bde-1a75-4b79-bf3b-2519aeb808e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/797bec95-d0bc-4088-82f9-6288dd35c941> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "797bec95-d0bc-4088-82f9-6288dd35c941";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/cbs/fc6d0290-a12f-430e-9f30-07c54fbc1836/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/797bec95-d0bc-4088-82f9-6288dd35c941>.
+    
+<http://data.lblod.info/id/remote-data-objects/c55f2de2-86d2-4e79-a0f2-f4405db85e05> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c55f2de2-86d2-4e79-a0f2-f4405db85e05";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/1c047571-690c-4147-b6b9-4070e67623e7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c55f2de2-86d2-4e79-a0f2-f4405db85e05>.
+    
+<http://data.lblod.info/id/remote-data-objects/23a80f86-66dd-41fb-b542-5a6eb18a43ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "23a80f86-66dd-41fb-b542-5a6eb18a43ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/1c047571-690c-4147-b6b9-4070e67623e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/23a80f86-66dd-41fb-b542-5a6eb18a43ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/d2d06091-cb02-4909-8967-296a9fb5cdd0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2d06091-cb02-4909-8967-296a9fb5cdd0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/1c047571-690c-4147-b6b9-4070e67623e7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d2d06091-cb02-4909-8967-296a9fb5cdd0>.
+    
+<http://data.lblod.info/id/remote-data-objects/51acccc1-bf42-40dc-9a6e-734602c7ecf9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "51acccc1-bf42-40dc-9a6e-734602c7ecf9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/3b43f807-6422-4794-87fe-e21c7d9017af/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/51acccc1-bf42-40dc-9a6e-734602c7ecf9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c3c43ec5-cd66-4f5d-99fc-18546449c99b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c3c43ec5-cd66-4f5d-99fc-18546449c99b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/3b43f807-6422-4794-87fe-e21c7d9017af/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c3c43ec5-cd66-4f5d-99fc-18546449c99b>.
+    
+<http://data.lblod.info/id/remote-data-objects/016f7e56-9f39-48f7-9c97-e6b05f2387cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "016f7e56-9f39-48f7-9c97-e6b05f2387cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/3b43f807-6422-4794-87fe-e21c7d9017af/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/016f7e56-9f39-48f7-9c97-e6b05f2387cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f2bd341-e0c9-4203-930f-16805bd1be25> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f2bd341-e0c9-4203-930f-16805bd1be25";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/3bef9d86-8fdc-41a6-b124-37240de731cd/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f2bd341-e0c9-4203-930f-16805bd1be25>.
+    
+<http://data.lblod.info/id/remote-data-objects/8f9de257-8d8d-4ceb-b8e8-7b7628daafad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f9de257-8d8d-4ceb-b8e8-7b7628daafad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/3bef9d86-8fdc-41a6-b124-37240de731cd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8f9de257-8d8d-4ceb-b8e8-7b7628daafad>.
+    
+<http://data.lblod.info/id/remote-data-objects/47fdaa1c-c359-4867-a92c-6128bf3f8f65> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "47fdaa1c-c359-4867-a92c-6128bf3f8f65";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/3bef9d86-8fdc-41a6-b124-37240de731cd/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/47fdaa1c-c359-4867-a92c-6128bf3f8f65>.
+    
+<http://data.lblod.info/id/remote-data-objects/845e1a4c-3ff9-4ef6-8c52-474945da74b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "845e1a4c-3ff9-4ef6-8c52-474945da74b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/5e9e5f78-e75c-404f-81d0-cb5c4d173c70/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/845e1a4c-3ff9-4ef6-8c52-474945da74b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/e2a86586-00cb-4746-a240-9ae4a993c902> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2a86586-00cb-4746-a240-9ae4a993c902";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/5e9e5f78-e75c-404f-81d0-cb5c4d173c70/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e2a86586-00cb-4746-a240-9ae4a993c902>.
+    
+<http://data.lblod.info/id/remote-data-objects/9c42595b-1c57-4fbc-b7b7-ea4cbd66c50e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9c42595b-1c57-4fbc-b7b7-ea4cbd66c50e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/5e9e5f78-e75c-404f-81d0-cb5c4d173c70/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9c42595b-1c57-4fbc-b7b7-ea4cbd66c50e>.
+    
+<http://data.lblod.info/id/remote-data-objects/68a81460-ef46-40cf-9e45-2fb2935b5014> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68a81460-ef46-40cf-9e45-2fb2935b5014";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/72ef39ba-e3f2-48e2-8697-d3796aacb067/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/68a81460-ef46-40cf-9e45-2fb2935b5014>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd4cf3ea-38aa-4d1d-85ce-5b32e8356a42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd4cf3ea-38aa-4d1d-85ce-5b32e8356a42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/72ef39ba-e3f2-48e2-8697-d3796aacb067/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd4cf3ea-38aa-4d1d-85ce-5b32e8356a42>.
+    
+<http://data.lblod.info/id/remote-data-objects/f11762bf-2910-4b0e-9a80-4c9f6a7ebda9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f11762bf-2910-4b0e-9a80-4c9f6a7ebda9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/820c43dc-5c60-40e1-a2e8-40df082c41de/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f11762bf-2910-4b0e-9a80-4c9f6a7ebda9>.
+    
+<http://data.lblod.info/id/remote-data-objects/49fa5625-3381-49df-bf1c-e9266a136c85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49fa5625-3381-49df-bf1c-e9266a136c85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/820c43dc-5c60-40e1-a2e8-40df082c41de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49fa5625-3381-49df-bf1c-e9266a136c85>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d70b361-b912-42ee-9adb-3f9401251c1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d70b361-b912-42ee-9adb-3f9401251c1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/8edc0462-ecd5-4a76-acac-49e0790f495d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d70b361-b912-42ee-9adb-3f9401251c1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/2070dab4-f9ac-474c-8b3b-68c04b1c5311> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2070dab4-f9ac-474c-8b3b-68c04b1c5311";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/8edc0462-ecd5-4a76-acac-49e0790f495d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2070dab4-f9ac-474c-8b3b-68c04b1c5311>.
+    
+<http://data.lblod.info/id/remote-data-objects/7e65f594-a281-4c03-9a99-950a59f3039f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7e65f594-a281-4c03-9a99-950a59f3039f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/9ae53915-c346-4403-9f2e-f2248671f75c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7e65f594-a281-4c03-9a99-950a59f3039f>.
+    
+<http://data.lblod.info/id/remote-data-objects/79343ae9-c458-49dd-aa81-d60fec3b1462> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79343ae9-c458-49dd-aa81-d60fec3b1462";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/9ae53915-c346-4403-9f2e-f2248671f75c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79343ae9-c458-49dd-aa81-d60fec3b1462>.
+    
+<http://data.lblod.info/id/remote-data-objects/f61941f1-76e4-4a56-9625-1b57a4e52307> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f61941f1-76e4-4a56-9625-1b57a4e52307";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/9ae53915-c346-4403-9f2e-f2248671f75c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f61941f1-76e4-4a56-9625-1b57a4e52307>.
+    
+<http://data.lblod.info/id/remote-data-objects/b3416310-651f-4ece-a5d5-0391c128e5c5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b3416310-651f-4ece-a5d5-0391c128e5c5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/9b6f5979-2009-4dce-8152-ca03aa9e7de0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b3416310-651f-4ece-a5d5-0391c128e5c5>.
+    
+<http://data.lblod.info/id/remote-data-objects/94f386a4-b8f5-459b-9829-99c462e3e8d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94f386a4-b8f5-459b-9829-99c462e3e8d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/9b6f5979-2009-4dce-8152-ca03aa9e7de0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94f386a4-b8f5-459b-9829-99c462e3e8d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/155e59ee-cdbd-4443-8fb9-640f53512d3f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "155e59ee-cdbd-4443-8fb9-640f53512d3f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/9b6f5979-2009-4dce-8152-ca03aa9e7de0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/155e59ee-cdbd-4443-8fb9-640f53512d3f>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd1d71fc-9b08-4b9c-ba3f-0cb994654e22> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd1d71fc-9b08-4b9c-ba3f-0cb994654e22";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/a7a5d032-b6a2-4563-9e4f-e09ba26aeb0e/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd1d71fc-9b08-4b9c-ba3f-0cb994654e22>.
+    
+<http://data.lblod.info/id/remote-data-objects/48f21599-3570-4f31-8953-b3fa3333f0ca> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "48f21599-3570-4f31-8953-b3fa3333f0ca";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/a7a5d032-b6a2-4563-9e4f-e09ba26aeb0e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/48f21599-3570-4f31-8953-b3fa3333f0ca>.
+    
+<http://data.lblod.info/id/remote-data-objects/417c7e6d-8800-4164-a148-fc7261d3b92f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "417c7e6d-8800-4164-a148-fc7261d3b92f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/a7a5d032-b6a2-4563-9e4f-e09ba26aeb0e/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/417c7e6d-8800-4164-a148-fc7261d3b92f>.
+    
+<http://data.lblod.info/id/remote-data-objects/66ca4155-9b46-46dd-8d34-f7a072dc63c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "66ca4155-9b46-46dd-8d34-f7a072dc63c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/ac0c4d9b-3786-43cb-a233-f572c5ab6e55/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/66ca4155-9b46-46dd-8d34-f7a072dc63c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/4da4d0d0-af31-42f9-893e-deb472ad4e03> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4da4d0d0-af31-42f9-893e-deb472ad4e03";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/ac0c4d9b-3786-43cb-a233-f572c5ab6e55/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4da4d0d0-af31-42f9-893e-deb472ad4e03>.
+    
+<http://data.lblod.info/id/remote-data-objects/f5f0adc3-56de-4ab6-ad87-6366e172fd1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5f0adc3-56de-4ab6-ad87-6366e172fd1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/ac0c4d9b-3786-43cb-a233-f572c5ab6e55/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f5f0adc3-56de-4ab6-ad87-6366e172fd1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/69b7f62d-2bc1-4c0d-8b2a-fc14cf8d87a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "69b7f62d-2bc1-4c0d-8b2a-fc14cf8d87a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/d23523d6-6d0a-44ec-b738-4a49bef5c522/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/69b7f62d-2bc1-4c0d-8b2a-fc14cf8d87a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/1f3e3fc0-b592-455e-aed3-958493e580c9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1f3e3fc0-b592-455e-aed3-958493e580c9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/d23523d6-6d0a-44ec-b738-4a49bef5c522/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1f3e3fc0-b592-455e-aed3-958493e580c9>.
+    
+<http://data.lblod.info/id/remote-data-objects/61f09202-7234-4878-98b4-9240bb72b212> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61f09202-7234-4878-98b4-9240bb72b212";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/d5e4cba9-97e3-495e-9fee-8c5835f2a897/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61f09202-7234-4878-98b4-9240bb72b212>.
+    
+<http://data.lblod.info/id/remote-data-objects/6541c12c-c78e-4151-b887-3ad53b2cbad9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6541c12c-c78e-4151-b887-3ad53b2cbad9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/d5e4cba9-97e3-495e-9fee-8c5835f2a897/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6541c12c-c78e-4151-b887-3ad53b2cbad9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a70e8302-84ab-4351-8a60-60f1c756cbce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a70e8302-84ab-4351-8a60-60f1c756cbce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/d5e4cba9-97e3-495e-9fee-8c5835f2a897/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a70e8302-84ab-4351-8a60-60f1c756cbce>.
+    
+<http://data.lblod.info/id/remote-data-objects/0e8a58cb-2066-45c4-866d-c3787a32d81d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e8a58cb-2066-45c4-866d-c3787a32d81d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/dfa2da99-c9c5-4b85-beb6-dc3f9ed1d237/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0e8a58cb-2066-45c4-866d-c3787a32d81d>.
+    
+<http://data.lblod.info/id/remote-data-objects/61d6649c-3365-43b6-933d-bc67c8bf817f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61d6649c-3365-43b6-933d-bc67c8bf817f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/dfa2da99-c9c5-4b85-beb6-dc3f9ed1d237/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/61d6649c-3365-43b6-933d-bc67c8bf817f>.
+    
+<http://data.lblod.info/id/remote-data-objects/67c5cc60-fae2-4874-88d1-ad84ea164478> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "67c5cc60-fae2-4874-88d1-ad84ea164478";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/dfa2da99-c9c5-4b85-beb6-dc3f9ed1d237/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/67c5cc60-fae2-4874-88d1-ad84ea164478>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec01807d-e7bb-402f-b026-a4a8ca7dbf0f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec01807d-e7bb-402f-b026-a4a8ca7dbf0f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/fba43e15-6a58-4b6d-a121-36dc38ef0008/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec01807d-e7bb-402f-b026-a4a8ca7dbf0f>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f333463-bca4-48fe-8630-309c407301d5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f333463-bca4-48fe-8630-309c407301d5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/fba43e15-6a58-4b6d-a121-36dc38ef0008/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f333463-bca4-48fe-8630-309c407301d5>.
+    
+<http://data.lblod.info/id/remote-data-objects/c5545549-43ed-4044-977e-fd6b14cbeb50> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c5545549-43ed-4044-977e-fd6b14cbeb50";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wezembeek-oppem.meetingburger.net/gr/fba43e15-6a58-4b6d-a121-36dc38ef0008/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c5545549-43ed-4044-977e-fd6b14cbeb50>.
+    
+<http://data.lblod.info/id/remote-data-objects/df04266c-e4b4-4115-96c3-5071bea318be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df04266c-e4b4-4115-96c3-5071bea318be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/00d6946c-946a-4d2e-aa40-4c2bba3bbd4f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:58.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/19c08452-195a-49d4-bf56-3c340a37dfc3> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df04266c-e4b4-4115-96c3-5071bea318be>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201959-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201959-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201959-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118201959-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/ff507feb-b697-4177-8219-9ab0018f2685> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ff507feb-b697-4177-8219-9ab0018f2685";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "9e39fe5c-08b0-4ede-aa10-4421ab5f664c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/1e9e02bb-e641-494e-8315-7ae76301514d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1e9e02bb-e641-494e-8315-7ae76301514d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c>.
+
+  <http://redpencil.data.gift/id/task/59b54471-a7c1-4da5-bd08-e50482f1ad0a> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "59b54471-a7c1-4da5-bd08-e50482f1ad0a";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/ff507feb-b697-4177-8219-9ab0018f2685>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/1e9e02bb-e641-494e-8315-7ae76301514d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/fb4ef253-2011-4d16-ae2a-2d78cbdb5a3e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb4ef253-2011-4d16-ae2a-2d78cbdb5a3e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/0165d504-241d-458c-ab57-f2229f5a9b5e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb4ef253-2011-4d16-ae2a-2d78cbdb5a3e>.
+    
+<http://data.lblod.info/id/remote-data-objects/be0bfd2e-d1f9-4873-b8c4-fbdd9c9be246> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be0bfd2e-d1f9-4873-b8c4-fbdd9c9be246";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/029f1b5d-97e4-4654-a73a-089a994b0c49/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be0bfd2e-d1f9-4873-b8c4-fbdd9c9be246>.
+    
+<http://data.lblod.info/id/remote-data-objects/f608b04f-6434-4aaa-9179-8ea67b8dcbfc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f608b04f-6434-4aaa-9179-8ea67b8dcbfc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/02e9cf7f-3fc8-4938-a56d-d07b73bbe910/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f608b04f-6434-4aaa-9179-8ea67b8dcbfc>.
+    
+<http://data.lblod.info/id/remote-data-objects/d6f78d58-80a8-4725-a9a1-2f6005f1c56f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d6f78d58-80a8-4725-a9a1-2f6005f1c56f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/033d0f8c-90a8-461c-aafd-0dedebbbae1f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d6f78d58-80a8-4725-a9a1-2f6005f1c56f>.
+    
+<http://data.lblod.info/id/remote-data-objects/16db03ba-c583-476f-a42b-a33edcbac07e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16db03ba-c583-476f-a42b-a33edcbac07e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/04501d30-0736-4ef5-81f1-ef5ad3d49d37/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16db03ba-c583-476f-a42b-a33edcbac07e>.
+    
+<http://data.lblod.info/id/remote-data-objects/86adc0a5-0f81-4b3f-accc-f751258188b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86adc0a5-0f81-4b3f-accc-f751258188b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/08ecb971-ec1a-4d1e-8449-2b4b5bb4132a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/86adc0a5-0f81-4b3f-accc-f751258188b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/101f91e1-e5c3-4d2c-904a-dc8f89b8c37f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "101f91e1-e5c3-4d2c-904a-dc8f89b8c37f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/0b1b9c21-9665-47d6-992c-6519a7c199d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/101f91e1-e5c3-4d2c-904a-dc8f89b8c37f>.
+    
+<http://data.lblod.info/id/remote-data-objects/d7d6b75e-a13d-48c2-b284-1600776d0358> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7d6b75e-a13d-48c2-b284-1600776d0358";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/0dd29970-8874-4f34-87b3-36551c4b2f92/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d7d6b75e-a13d-48c2-b284-1600776d0358>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf5cce67-6cbc-47f6-ba39-dfeb6e7fa3d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf5cce67-6cbc-47f6-ba39-dfeb6e7fa3d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/0e9b7e6b-103d-46a6-9210-560c2593ef51/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf5cce67-6cbc-47f6-ba39-dfeb6e7fa3d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9d764a0-d118-4eb4-a38a-23326aa1866b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9d764a0-d118-4eb4-a38a-23326aa1866b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/0ff5a531-ceb4-434f-8d07-d40f4725d92a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9d764a0-d118-4eb4-a38a-23326aa1866b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5bc112d1-cbfc-4e59-a370-7fa68931c1ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bc112d1-cbfc-4e59-a370-7fa68931c1ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/13ea9172-47da-4e04-8e45-0ef9a57e917e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5bc112d1-cbfc-4e59-a370-7fa68931c1ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/81f0d6d6-cf79-4888-89fc-41c9a55c1865> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81f0d6d6-cf79-4888-89fc-41c9a55c1865";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/18f22853-4f91-4ccc-87f5-b2f9c186f443/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81f0d6d6-cf79-4888-89fc-41c9a55c1865>.
+    
+<http://data.lblod.info/id/remote-data-objects/743b1f24-c629-4605-bd35-80b3660a8dd6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "743b1f24-c629-4605-bd35-80b3660a8dd6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/19401f33-0e52-41b1-8707-b7f3ff29c2de/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/743b1f24-c629-4605-bd35-80b3660a8dd6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b89c1003-47f7-4adb-a7a9-19bcab6659c6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b89c1003-47f7-4adb-a7a9-19bcab6659c6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/2063ea05-a6cd-482d-8883-eca5d87534e0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b89c1003-47f7-4adb-a7a9-19bcab6659c6>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc6c7c7b-a557-4222-b3f6-94a9fb819d38> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc6c7c7b-a557-4222-b3f6-94a9fb819d38";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/20b4f532-c379-42e3-a1af-72d3c8b712b5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc6c7c7b-a557-4222-b3f6-94a9fb819d38>.
+    
+<http://data.lblod.info/id/remote-data-objects/dc23104d-8128-4b7f-8daa-ccec47d32f08> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc23104d-8128-4b7f-8daa-ccec47d32f08";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/267f195d-98f3-4e1d-ad35-c3b9e0e12355/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dc23104d-8128-4b7f-8daa-ccec47d32f08>.
+    
+<http://data.lblod.info/id/remote-data-objects/43edb142-8f9f-4ca1-b249-3e937382df87> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43edb142-8f9f-4ca1-b249-3e937382df87";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/26a0c559-8571-46f8-9c81-b8c15df3200d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43edb142-8f9f-4ca1-b249-3e937382df87>.
+    
+<http://data.lblod.info/id/remote-data-objects/506a4cd0-45e3-443a-9e84-78c4defaa888> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "506a4cd0-45e3-443a-9e84-78c4defaa888";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/273ecb49-f7e8-4e38-a187-18b5dd94eb85/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/506a4cd0-45e3-443a-9e84-78c4defaa888>.
+    
+<http://data.lblod.info/id/remote-data-objects/8997dc71-c616-4d85-872e-95ab1d93403c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8997dc71-c616-4d85-872e-95ab1d93403c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/291667bf-16fe-49fc-b4e2-d090ffc5cb70/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8997dc71-c616-4d85-872e-95ab1d93403c>.
+    
+<http://data.lblod.info/id/remote-data-objects/d0907e6f-5f68-4bfc-9399-f66350e6ab04> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d0907e6f-5f68-4bfc-9399-f66350e6ab04";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/2e04232c-0250-4ea7-8e73-20dd52235b26/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d0907e6f-5f68-4bfc-9399-f66350e6ab04>.
+    
+<http://data.lblod.info/id/remote-data-objects/d53e809a-9c74-464a-ab6e-0f82da3dc157> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d53e809a-9c74-464a-ab6e-0f82da3dc157";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/33649abf-5832-4a87-a74b-160a90570944/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d53e809a-9c74-464a-ab6e-0f82da3dc157>.
+    
+<http://data.lblod.info/id/remote-data-objects/9522ce0e-c7ac-40da-9ad8-a583a48a9c70> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9522ce0e-c7ac-40da-9ad8-a583a48a9c70";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/39547ab9-cc27-483b-abbd-0e7b524f1826/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9522ce0e-c7ac-40da-9ad8-a583a48a9c70>.
+    
+<http://data.lblod.info/id/remote-data-objects/0437c867-d647-4c67-a068-28fff8f78080> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0437c867-d647-4c67-a068-28fff8f78080";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/3e1d37f6-54ef-43d3-9a6d-62f6eafdb3d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0437c867-d647-4c67-a068-28fff8f78080>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc5b7503-7bcf-4ead-b6c2-30fb62390b7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc5b7503-7bcf-4ead-b6c2-30fb62390b7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/42d292a8-0191-4380-ad05-b3f8298a9cf1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc5b7503-7bcf-4ead-b6c2-30fb62390b7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/0a4c2af7-cac9-4c72-9d7e-9189718fc940> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0a4c2af7-cac9-4c72-9d7e-9189718fc940";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/49393c04-84ff-41e8-bcd4-9ba4052866be/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0a4c2af7-cac9-4c72-9d7e-9189718fc940>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ee1829d-3da2-4871-89b8-fb47ffe80c8d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ee1829d-3da2-4871-89b8-fb47ffe80c8d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/5b69c8bb-6b49-40d8-8be4-027ad10eeb91/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ee1829d-3da2-4871-89b8-fb47ffe80c8d>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c456577-3d29-4b52-a0d1-5c9053330e57> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c456577-3d29-4b52-a0d1-5c9053330e57";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/5dfb4745-bd73-44ea-a58e-069e9d56f169/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c456577-3d29-4b52-a0d1-5c9053330e57>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b9376b3-9414-4c63-8b09-42999a68bac3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b9376b3-9414-4c63-8b09-42999a68bac3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/64ebd1e4-124f-459c-9045-5740afa30590/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b9376b3-9414-4c63-8b09-42999a68bac3>.
+    
+<http://data.lblod.info/id/remote-data-objects/0b6e53ee-6500-4cc3-807e-cc5d5328d6b9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b6e53ee-6500-4cc3-807e-cc5d5328d6b9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/6e565466-9d12-49b1-b771-3c1acad6d09e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0b6e53ee-6500-4cc3-807e-cc5d5328d6b9>.
+    
+<http://data.lblod.info/id/remote-data-objects/eb7bd1d7-bdb6-4d46-9ab6-564ac802ebc1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb7bd1d7-bdb6-4d46-9ab6-564ac802ebc1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/6f0f44a7-46e6-45c1-bf48-15842577bfa4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eb7bd1d7-bdb6-4d46-9ab6-564ac802ebc1>.
+    
+<http://data.lblod.info/id/remote-data-objects/10320990-c514-4e48-bdfe-6181660b71e6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "10320990-c514-4e48-bdfe-6181660b71e6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/70e6a8fa-70eb-4b6e-8296-bc71043c23bc/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/10320990-c514-4e48-bdfe-6181660b71e6>.
+    
+<http://data.lblod.info/id/remote-data-objects/091aabe3-8a93-4ede-8a42-d28652ebc5f9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "091aabe3-8a93-4ede-8a42-d28652ebc5f9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/735e8478-4e2b-4395-80a8-2e1e27a2e63e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/091aabe3-8a93-4ede-8a42-d28652ebc5f9>.
+    
+<http://data.lblod.info/id/remote-data-objects/a3b5458d-6a30-4d6a-856f-b3d921cea13f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3b5458d-6a30-4d6a-856f-b3d921cea13f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/7c19129b-5ea3-442d-9b4c-6881dc046a98/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a3b5458d-6a30-4d6a-856f-b3d921cea13f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb97d199-8e53-46dc-bae4-e0e76ca5acde> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb97d199-8e53-46dc-bae4-e0e76ca5acde";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/7cd111fe-b53c-48e6-b07c-9357be725385/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb97d199-8e53-46dc-bae4-e0e76ca5acde>.
+    
+<http://data.lblod.info/id/remote-data-objects/28fefa60-ddc1-405e-8146-a0770b9f3240> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28fefa60-ddc1-405e-8146-a0770b9f3240";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/831b6d70-116c-485d-bd53-fece6dcdde41/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/28fefa60-ddc1-405e-8146-a0770b9f3240>.
+    
+<http://data.lblod.info/id/remote-data-objects/b34ae9e6-3f50-49e4-a32c-9061714387d2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b34ae9e6-3f50-49e4-a32c-9061714387d2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/84326452-86d8-4925-9953-0b1f966738d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b34ae9e6-3f50-49e4-a32c-9061714387d2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d8dbda8c-7e08-4c26-9fdc-a656ffaf51ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8dbda8c-7e08-4c26-9fdc-a656ffaf51ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/8729f653-41e5-48d9-8da2-1f072e40b308/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d8dbda8c-7e08-4c26-9fdc-a656ffaf51ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc1c5cb7-39a2-4e28-9cf5-68dcbe7127c1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc1c5cb7-39a2-4e28-9cf5-68dcbe7127c1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/88a491f2-2458-46b1-8dac-1e8c9ed596ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc1c5cb7-39a2-4e28-9cf5-68dcbe7127c1>.
+    
+<http://data.lblod.info/id/remote-data-objects/e5a778e5-5d73-44ec-abd0-7d31e29685a0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e5a778e5-5d73-44ec-abd0-7d31e29685a0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/8b5dc8f2-5b3a-4670-9450-3655a2db050b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e5a778e5-5d73-44ec-abd0-7d31e29685a0>.
+    
+<http://data.lblod.info/id/remote-data-objects/171df962-09e1-4980-be16-20c377a4e52b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "171df962-09e1-4980-be16-20c377a4e52b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/8d141088-581b-494b-8063-1d351a0c483e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/171df962-09e1-4980-be16-20c377a4e52b>.
+    
+<http://data.lblod.info/id/remote-data-objects/79639fed-e3d3-4f27-b4d1-379510f40b5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79639fed-e3d3-4f27-b4d1-379510f40b5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/90e3298d-8421-4d8c-998e-96db25687761/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/79639fed-e3d3-4f27-b4d1-379510f40b5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a2d294a-7a59-4d3c-ab8d-80556ddf45fb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a2d294a-7a59-4d3c-ab8d-80556ddf45fb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/979b61d0-d432-46b1-aa5d-03791bcd8315/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a2d294a-7a59-4d3c-ab8d-80556ddf45fb>.
+    
+<http://data.lblod.info/id/remote-data-objects/a012db1e-b886-48b4-b387-eb992b511410> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a012db1e-b886-48b4-b387-eb992b511410";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/9ac14046-da5b-4e38-ae58-0cb53841e7f8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a012db1e-b886-48b4-b387-eb992b511410>.
+    
+<http://data.lblod.info/id/remote-data-objects/cd238b0f-2939-4a24-b51e-2bc6cacd6366> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd238b0f-2939-4a24-b51e-2bc6cacd6366";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/ac5e03a2-3096-4c1a-a671-373b8a433a0a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cd238b0f-2939-4a24-b51e-2bc6cacd6366>.
+    
+<http://data.lblod.info/id/remote-data-objects/0d0b782f-ebe7-449c-bb57-af5b3d6076ad> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0d0b782f-ebe7-449c-bb57-af5b3d6076ad";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/ad32990a-dbd2-4cd5-aa0d-c94cb72153e4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0d0b782f-ebe7-449c-bb57-af5b3d6076ad>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7aa7041-0aac-4938-bd67-e7b4411431c3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7aa7041-0aac-4938-bd67-e7b4411431c3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/afbb075a-356c-4c36-8bf0-8319c81f4fed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7aa7041-0aac-4938-bd67-e7b4411431c3>.
+    
+<http://data.lblod.info/id/remote-data-objects/78073b00-b296-47ff-aca1-46094cf2f69c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78073b00-b296-47ff-aca1-46094cf2f69c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/b2817c88-6550-4ef2-977e-93cb816dbbec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/78073b00-b296-47ff-aca1-46094cf2f69c>.
+    
+<http://data.lblod.info/id/remote-data-objects/f44cee94-16c8-48b0-94e9-f3f135e46e4e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f44cee94-16c8-48b0-94e9-f3f135e46e4e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/b52a91ee-bf9a-4869-b808-7f785f8567d3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f44cee94-16c8-48b0-94e9-f3f135e46e4e>.
+    
+<http://data.lblod.info/id/remote-data-objects/75f75f4a-f04c-4d20-8f4b-eb9c9da33b85> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "75f75f4a-f04c-4d20-8f4b-eb9c9da33b85";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/b5799c5a-1676-400a-9740-998939f9801d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/75f75f4a-f04c-4d20-8f4b-eb9c9da33b85>.
+    
+<http://data.lblod.info/id/remote-data-objects/7122f30f-904e-46cc-8d76-4c655b9e7eed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7122f30f-904e-46cc-8d76-4c655b9e7eed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/bc0a82d4-90e7-4178-8838-85207c1c70a3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:19:59.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/9e39fe5c-08b0-4ede-aa10-4421ab5f664c> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7122f30f-904e-46cc-8d76-4c655b9e7eed>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202000-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202000-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202000-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202000-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/d9ae27fb-818a-45f6-a6d4-aa18799990a6> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d9ae27fb-818a-45f6-a6d4-aa18799990a6";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2f5e5ce2-2716-4399-96f7-a2b96cc07bd2";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/99a7647b-9572-4663-9146-5b7b8ea3eef2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "99a7647b-9572-4663-9146-5b7b8ea3eef2";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2>.
+
+  <http://redpencil.data.gift/id/task/79f77972-cec2-4e25-9a26-44a92e1436bc> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "79f77972-cec2-4e25-9a26-44a92e1436bc";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/d9ae27fb-818a-45f6-a6d4-aa18799990a6>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/99a7647b-9572-4663-9146-5b7b8ea3eef2>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/276769f8-324d-4f60-a9aa-ce5aa673f773> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "276769f8-324d-4f60-a9aa-ce5aa673f773";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/c2dbc919-0ff4-48f9-9d83-49f8365ad955/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/276769f8-324d-4f60-a9aa-ce5aa673f773>.
+    
+<http://data.lblod.info/id/remote-data-objects/5c5d66f5-7684-4fef-805b-541ad9b3e1f5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5c5d66f5-7684-4fef-805b-541ad9b3e1f5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/c3645ef8-0575-4460-b47b-0ba8dc28cb4b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5c5d66f5-7684-4fef-805b-541ad9b3e1f5>.
+    
+<http://data.lblod.info/id/remote-data-objects/95ab021b-88a9-4234-94c5-bea48b84943b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "95ab021b-88a9-4234-94c5-bea48b84943b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/c3d3ef01-457d-4bb1-b2a4-da41fd145d82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/95ab021b-88a9-4234-94c5-bea48b84943b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b86755ad-1147-4fe2-b82a-859755334ec8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b86755ad-1147-4fe2-b82a-859755334ec8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/c6658363-7057-4ff1-93c9-f03153eac8c4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b86755ad-1147-4fe2-b82a-859755334ec8>.
+    
+<http://data.lblod.info/id/remote-data-objects/5915d703-382c-41dc-8ea4-c869fc3ce8d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5915d703-382c-41dc-8ea4-c869fc3ce8d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/c814e445-c3fc-4fc6-8f61-47b79d885644/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5915d703-382c-41dc-8ea4-c869fc3ce8d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e819e67-a305-419f-ae22-03fd445b84a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e819e67-a305-419f-ae22-03fd445b84a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/cc93bf39-f62e-4a0a-9345-dcff8966b43a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e819e67-a305-419f-ae22-03fd445b84a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/9e71f823-1d0a-4377-9a33-a3d7adaab5d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9e71f823-1d0a-4377-9a33-a3d7adaab5d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/d28f7395-0d4d-4e18-af6a-6af41e744dbe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9e71f823-1d0a-4377-9a33-a3d7adaab5d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/4f26db2c-54b4-402b-a82a-1b5a75fadf23> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4f26db2c-54b4-402b-a82a-1b5a75fadf23";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/d7334695-0f9a-472f-b812-5e5dd045a0ee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4f26db2c-54b4-402b-a82a-1b5a75fadf23>.
+    
+<http://data.lblod.info/id/remote-data-objects/c360ce0c-1dc3-4e95-8500-e16e0167622a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c360ce0c-1dc3-4e95-8500-e16e0167622a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/dbb72059-4f30-46d7-8a4a-b453e96407a1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c360ce0c-1dc3-4e95-8500-e16e0167622a>.
+    
+<http://data.lblod.info/id/remote-data-objects/4ad9fc8e-a4bc-4ed4-8d9c-a51bb441fa6d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ad9fc8e-a4bc-4ed4-8d9c-a51bb441fa6d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/e1fc6a47-d2dd-4a59-86ec-67fa1aaecd64/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4ad9fc8e-a4bc-4ed4-8d9c-a51bb441fa6d>.
+    
+<http://data.lblod.info/id/remote-data-objects/dfe28042-2dc1-4c7f-8a0e-769f99910925> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfe28042-2dc1-4c7f-8a0e-769f99910925";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/e3e5edd6-8182-48fe-ac47-efee6ec8ad13/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dfe28042-2dc1-4c7f-8a0e-769f99910925>.
+    
+<http://data.lblod.info/id/remote-data-objects/5af86c42-43f8-4d07-a82f-ebadcbe5eb66> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5af86c42-43f8-4d07-a82f-ebadcbe5eb66";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/eb691e75-fd7b-4434-bd39-e5b55121dea1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5af86c42-43f8-4d07-a82f-ebadcbe5eb66>.
+    
+<http://data.lblod.info/id/remote-data-objects/a5c56a64-84f6-4e4f-9568-bdf97e4db5cc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a5c56a64-84f6-4e4f-9568-bdf97e4db5cc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/f4fa14a9-65a3-401e-98df-94af39be51bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a5c56a64-84f6-4e4f-9568-bdf97e4db5cc>.
+    
+<http://data.lblod.info/id/remote-data-objects/da2000aa-0c9e-4b60-adcd-c3153344c05e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "da2000aa-0c9e-4b60-adcd-c3153344c05e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/f6ccd789-ec14-4a68-bbf4-230710e4aa82/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/da2000aa-0c9e-4b60-adcd-c3153344c05e>.
+    
+<http://data.lblod.info/id/remote-data-objects/d71c3c25-7769-4f1c-be08-610f098ff8c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d71c3c25-7769-4f1c-be08-610f098ff8c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/f822382e-aa48-4b5a-bc62-1a985408054a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d71c3c25-7769-4f1c-be08-610f098ff8c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/db1fb1c2-2826-4c12-adb1-b89e8284be43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "db1fb1c2-2826-4c12-adb1-b89e8284be43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/fe288ab9-0a94-4608-8afe-429d5789432c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/db1fb1c2-2826-4c12-adb1-b89e8284be43>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ed5ec6b-7cb1-4a16-b02c-1d01eb3da839> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ed5ec6b-7cb1-4a16-b02c-1d01eb3da839";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/bb/ffc3427e-230b-4a05-9b5a-ca8991c3bf86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ed5ec6b-7cb1-4a16-b02c-1d01eb3da839>.
+    
+<http://data.lblod.info/id/remote-data-objects/d3cdeef3-c0ac-41d6-8259-7ff847546f12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d3cdeef3-c0ac-41d6-8259-7ff847546f12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/144c66ba-4a9d-4ef1-8348-b321a8eee3ed/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d3cdeef3-c0ac-41d6-8259-7ff847546f12>.
+    
+<http://data.lblod.info/id/remote-data-objects/f7b4f266-02fe-423e-9cf7-fe6210fbbcfe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7b4f266-02fe-423e-9cf7-fe6210fbbcfe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/144c66ba-4a9d-4ef1-8348-b321a8eee3ed/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f7b4f266-02fe-423e-9cf7-fe6210fbbcfe>.
+    
+<http://data.lblod.info/id/remote-data-objects/e900e7ec-e3b1-460f-b38d-cf8ba618a507> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e900e7ec-e3b1-460f-b38d-cf8ba618a507";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/144c66ba-4a9d-4ef1-8348-b321a8eee3ed/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e900e7ec-e3b1-460f-b38d-cf8ba618a507>.
+    
+<http://data.lblod.info/id/remote-data-objects/fde9075c-649f-4ea2-beb0-677f7cc2d457> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fde9075c-649f-4ea2-beb0-677f7cc2d457";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/16240dec-7e0d-4098-8532-56ec9dcf7673/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fde9075c-649f-4ea2-beb0-677f7cc2d457>.
+    
+<http://data.lblod.info/id/remote-data-objects/b76d68e0-e2b2-45af-8dc9-ddb364ee8905> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b76d68e0-e2b2-45af-8dc9-ddb364ee8905";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/16240dec-7e0d-4098-8532-56ec9dcf7673/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b76d68e0-e2b2-45af-8dc9-ddb364ee8905>.
+    
+<http://data.lblod.info/id/remote-data-objects/7b12e6dc-ad16-4e55-ac47-a260187674be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7b12e6dc-ad16-4e55-ac47-a260187674be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/16240dec-7e0d-4098-8532-56ec9dcf7673/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7b12e6dc-ad16-4e55-ac47-a260187674be>.
+    
+<http://data.lblod.info/id/remote-data-objects/08085ef4-ba9a-457d-85c9-4ce60caa7668> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "08085ef4-ba9a-457d-85c9-4ce60caa7668";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/1d6f4903-03f1-44d1-92ed-765c7131c32d/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/08085ef4-ba9a-457d-85c9-4ce60caa7668>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ea4b7d2-f487-4be2-9b4b-167c5721d18f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ea4b7d2-f487-4be2-9b4b-167c5721d18f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/1d6f4903-03f1-44d1-92ed-765c7131c32d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ea4b7d2-f487-4be2-9b4b-167c5721d18f>.
+    
+<http://data.lblod.info/id/remote-data-objects/eac254ff-4d18-4308-a2c7-cc78297c3ae6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eac254ff-4d18-4308-a2c7-cc78297c3ae6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/1d6f4903-03f1-44d1-92ed-765c7131c32d/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eac254ff-4d18-4308-a2c7-cc78297c3ae6>.
+    
+<http://data.lblod.info/id/remote-data-objects/2a9e5ef8-2bf8-447d-beab-48bfd1079ae8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a9e5ef8-2bf8-447d-beab-48bfd1079ae8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/2befbadb-00fb-4049-ad76-6dc078af7be7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2a9e5ef8-2bf8-447d-beab-48bfd1079ae8>.
+    
+<http://data.lblod.info/id/remote-data-objects/55931634-8f5f-460e-9245-3733aa01ee1a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "55931634-8f5f-460e-9245-3733aa01ee1a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/2befbadb-00fb-4049-ad76-6dc078af7be7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/55931634-8f5f-460e-9245-3733aa01ee1a>.
+    
+<http://data.lblod.info/id/remote-data-objects/8b76bdf1-601f-458a-b189-98acd61dac6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b76bdf1-601f-458a-b189-98acd61dac6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/2befbadb-00fb-4049-ad76-6dc078af7be7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/8b76bdf1-601f-458a-b189-98acd61dac6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd946ed4-462d-470f-84f0-3e89d27aaa6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd946ed4-462d-470f-84f0-3e89d27aaa6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/3228a05f-57ab-46bc-bc55-4d0ea98c0de0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd946ed4-462d-470f-84f0-3e89d27aaa6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5b9e8e03-f34a-4f51-a85c-68d49187f869> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5b9e8e03-f34a-4f51-a85c-68d49187f869";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/3228a05f-57ab-46bc-bc55-4d0ea98c0de0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5b9e8e03-f34a-4f51-a85c-68d49187f869>.
+    
+<http://data.lblod.info/id/remote-data-objects/0c0542eb-97d7-4fa7-9479-09004a7a1286> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0c0542eb-97d7-4fa7-9479-09004a7a1286";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/4b956e77-6f8e-40f6-b0b2-1a418e4bb6b7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0c0542eb-97d7-4fa7-9479-09004a7a1286>.
+    
+<http://data.lblod.info/id/remote-data-objects/3c59db85-b84b-4ca4-8c5e-46313e768b2f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c59db85-b84b-4ca4-8c5e-46313e768b2f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/4b956e77-6f8e-40f6-b0b2-1a418e4bb6b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3c59db85-b84b-4ca4-8c5e-46313e768b2f>.
+    
+<http://data.lblod.info/id/remote-data-objects/90b1bfc1-60c9-4441-9973-7a9b5fa4a88f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90b1bfc1-60c9-4441-9973-7a9b5fa4a88f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/4b956e77-6f8e-40f6-b0b2-1a418e4bb6b7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/90b1bfc1-60c9-4441-9973-7a9b5fa4a88f>.
+    
+<http://data.lblod.info/id/remote-data-objects/768f53dd-455a-4bb9-a11c-ab138c1e1e18> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "768f53dd-455a-4bb9-a11c-ab138c1e1e18";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/7026b482-98dc-42e4-845a-2026fdcbd250/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/768f53dd-455a-4bb9-a11c-ab138c1e1e18>.
+    
+<http://data.lblod.info/id/remote-data-objects/0eb8c000-0987-4f1a-89b3-cf36f31ae062> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0eb8c000-0987-4f1a-89b3-cf36f31ae062";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/7026b482-98dc-42e4-845a-2026fdcbd250/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0eb8c000-0987-4f1a-89b3-cf36f31ae062>.
+    
+<http://data.lblod.info/id/remote-data-objects/df999db4-e195-42b2-87b8-794022fedc3a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df999db4-e195-42b2-87b8-794022fedc3a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/7026b482-98dc-42e4-845a-2026fdcbd250/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df999db4-e195-42b2-87b8-794022fedc3a>.
+    
+<http://data.lblod.info/id/remote-data-objects/277dc607-e2bc-4182-b8d9-73a5341ae2fc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "277dc607-e2bc-4182-b8d9-73a5341ae2fc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/73b1677c-948b-4d1c-a835-4a8b9bcf76a7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/277dc607-e2bc-4182-b8d9-73a5341ae2fc>.
+    
+<http://data.lblod.info/id/remote-data-objects/135e7c2d-33d8-4774-b94a-5956ab4f2e86> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "135e7c2d-33d8-4774-b94a-5956ab4f2e86";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/73b1677c-948b-4d1c-a835-4a8b9bcf76a7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/135e7c2d-33d8-4774-b94a-5956ab4f2e86>.
+    
+<http://data.lblod.info/id/remote-data-objects/eba5f5cd-1ed8-4a6f-b104-faf02fb495ae> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eba5f5cd-1ed8-4a6f-b104-faf02fb495ae";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/73b1677c-948b-4d1c-a835-4a8b9bcf76a7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eba5f5cd-1ed8-4a6f-b104-faf02fb495ae>.
+    
+<http://data.lblod.info/id/remote-data-objects/a69fb15c-1c4c-4307-8e6b-f93054b6ad1e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a69fb15c-1c4c-4307-8e6b-f93054b6ad1e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/75c10791-fc2b-46b4-88c1-52860b257881/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a69fb15c-1c4c-4307-8e6b-f93054b6ad1e>.
+    
+<http://data.lblod.info/id/remote-data-objects/13d16a9e-53f3-49a6-a56c-76daec96a1cd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13d16a9e-53f3-49a6-a56c-76daec96a1cd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/75c10791-fc2b-46b4-88c1-52860b257881/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/13d16a9e-53f3-49a6-a56c-76daec96a1cd>.
+    
+<http://data.lblod.info/id/remote-data-objects/df67c96b-32a7-4c3a-b87c-acb874053ef6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df67c96b-32a7-4c3a-b87c-acb874053ef6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/75c10791-fc2b-46b4-88c1-52860b257881/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/df67c96b-32a7-4c3a-b87c-acb874053ef6>.
+    
+<http://data.lblod.info/id/remote-data-objects/b90057d9-0fb0-4a09-aafb-b55c57f49571> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b90057d9-0fb0-4a09-aafb-b55c57f49571";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/b3abd5d6-3092-4af1-a13e-563b65e40ed3/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b90057d9-0fb0-4a09-aafb-b55c57f49571>.
+    
+<http://data.lblod.info/id/remote-data-objects/6970a5bb-53ff-4ba0-a633-f080441ff4be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6970a5bb-53ff-4ba0-a633-f080441ff4be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/b3abd5d6-3092-4af1-a13e-563b65e40ed3/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6970a5bb-53ff-4ba0-a633-f080441ff4be>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec3c06f9-1401-4290-b442-b053d249b633> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec3c06f9-1401-4290-b442-b053d249b633";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/b3abd5d6-3092-4af1-a13e-563b65e40ed3/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec3c06f9-1401-4290-b442-b053d249b633>.
+    
+<http://data.lblod.info/id/remote-data-objects/fb092c22-69c2-460a-bc16-c869e7300a8f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fb092c22-69c2-460a-bc16-c869e7300a8f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/be6286d8-257d-4259-9293-abf2a218b640/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fb092c22-69c2-460a-bc16-c869e7300a8f>.
+    
+<http://data.lblod.info/id/remote-data-objects/fc58fc72-b22b-46bb-9b33-0e8caa728d5f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fc58fc72-b22b-46bb-9b33-0e8caa728d5f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/be6286d8-257d-4259-9293-abf2a218b640/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fc58fc72-b22b-46bb-9b33-0e8caa728d5f>.
+    
+<http://data.lblod.info/id/remote-data-objects/49843197-d5a8-437e-b19b-84497b483305> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49843197-d5a8-437e-b19b-84497b483305";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/be6286d8-257d-4259-9293-abf2a218b640/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49843197-d5a8-437e-b19b-84497b483305>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbaf1aa1-d206-4c3d-b83e-b0f3d2f7e8f7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbaf1aa1-d206-4c3d-b83e-b0f3d2f7e8f7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/c4cd775d-b051-4bb2-bb8a-56382af15be9/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/2f5e5ce2-2716-4399-96f7-a2b96cc07bd2> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbaf1aa1-d206-4c3d-b83e-b0f3d2f7e8f7>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202002-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202002-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202002-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202002-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/a9a846e0-e99f-4330-88af-1fe16eaa9199> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a9a846e0-e99f-4330-88af-1fe16eaa9199";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "166cc13d-1f9b-446c-a04b-8d814b9bc127";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/0ef0bcab-a93e-4848-b9bf-87a11de7f976> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0ef0bcab-a93e-4848-b9bf-87a11de7f976";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127>.
+
+  <http://redpencil.data.gift/id/task/f409a934-ab3e-4a75-bcc1-23fe5d580750> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "f409a934-ab3e-4a75-bcc1-23fe5d580750";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/a9a846e0-e99f-4330-88af-1fe16eaa9199>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/0ef0bcab-a93e-4848-b9bf-87a11de7f976>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/4248b1ce-4bf4-4d19-b440-37f1e1144f1c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4248b1ce-4bf4-4d19-b440-37f1e1144f1c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/c4cd775d-b051-4bb2-bb8a-56382af15be9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4248b1ce-4bf4-4d19-b440-37f1e1144f1c>.
+    
+<http://data.lblod.info/id/remote-data-objects/593eec22-0a10-4db3-820a-9445db98173c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "593eec22-0a10-4db3-820a-9445db98173c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/c4cd775d-b051-4bb2-bb8a-56382af15be9/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/593eec22-0a10-4db3-820a-9445db98173c>.
+    
+<http://data.lblod.info/id/remote-data-objects/9988b302-3d00-4473-b85a-f7b13a803fd4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9988b302-3d00-4473-b85a-f7b13a803fd4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/ce54d4b6-5768-4b64-beb8-37271d0764d2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9988b302-3d00-4473-b85a-f7b13a803fd4>.
+    
+<http://data.lblod.info/id/remote-data-objects/a892a6bc-2a61-419c-96d2-5d05fcd0c5b7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a892a6bc-2a61-419c-96d2-5d05fcd0c5b7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/ce54d4b6-5768-4b64-beb8-37271d0764d2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a892a6bc-2a61-419c-96d2-5d05fcd0c5b7>.
+    
+<http://data.lblod.info/id/remote-data-objects/4bfcf33a-0897-4b08-8b49-f127b0dfb110> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bfcf33a-0897-4b08-8b49-f127b0dfb110";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/ce54d4b6-5768-4b64-beb8-37271d0764d2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4bfcf33a-0897-4b08-8b49-f127b0dfb110>.
+    
+<http://data.lblod.info/id/remote-data-objects/c75ab1f9-9bf4-4fe9-93db-6bb96324d8ed> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c75ab1f9-9bf4-4fe9-93db-6bb96324d8ed";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/dea1ff5f-2018-46e4-a48d-88c6e134e756/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c75ab1f9-9bf4-4fe9-93db-6bb96324d8ed>.
+    
+<http://data.lblod.info/id/remote-data-objects/e4ae0929-9a86-471a-80b0-0488947d64ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4ae0929-9a86-471a-80b0-0488947d64ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/dea1ff5f-2018-46e4-a48d-88c6e134e756/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e4ae0929-9a86-471a-80b0-0488947d64ea>.
+    
+<http://data.lblod.info/id/remote-data-objects/378a53b1-6f27-4007-ac01-76d7fbf2685e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "378a53b1-6f27-4007-ac01-76d7fbf2685e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/dea1ff5f-2018-46e4-a48d-88c6e134e756/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/378a53b1-6f27-4007-ac01-76d7fbf2685e>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8df01c9-8af1-48dd-8500-df6c4e5e5112> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8df01c9-8af1-48dd-8500-df6c4e5e5112";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/f78de52c-c79e-41ec-b300-43bb0e1a21b7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8df01c9-8af1-48dd-8500-df6c4e5e5112>.
+    
+<http://data.lblod.info/id/remote-data-objects/7012d426-c9e6-4d01-81c7-db8a1694750d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7012d426-c9e6-4d01-81c7-db8a1694750d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/f78de52c-c79e-41ec-b300-43bb0e1a21b7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7012d426-c9e6-4d01-81c7-db8a1694750d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b03ca57b-08e7-45a9-9f97-398a17f6a12d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b03ca57b-08e7-45a9-9f97-398a17f6a12d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/gr/f78de52c-c79e-41ec-b300-43bb0e1a21b7/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b03ca57b-08e7-45a9-9f97-398a17f6a12d>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc14f646-cc2d-46da-8e4b-db7f317a429d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc14f646-cc2d-46da-8e4b-db7f317a429d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/029ebba2-8b74-4330-8e53-3aa593d86a81/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc14f646-cc2d-46da-8e4b-db7f317a429d>.
+    
+<http://data.lblod.info/id/remote-data-objects/b89b2921-1c6a-4135-9d03-1404150ab120> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b89b2921-1c6a-4135-9d03-1404150ab120";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/029ebba2-8b74-4330-8e53-3aa593d86a81/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b89b2921-1c6a-4135-9d03-1404150ab120>.
+    
+<http://data.lblod.info/id/remote-data-objects/35a9ce2b-bfd8-441e-8252-9589e70401c2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35a9ce2b-bfd8-441e-8252-9589e70401c2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/029ebba2-8b74-4330-8e53-3aa593d86a81/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/35a9ce2b-bfd8-441e-8252-9589e70401c2>.
+    
+<http://data.lblod.info/id/remote-data-objects/d521906a-8769-42cb-a84c-cd08d0e89c98> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d521906a-8769-42cb-a84c-cd08d0e89c98";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/0f5f0992-1db9-4343-a4c5-a542b92b3de7/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d521906a-8769-42cb-a84c-cd08d0e89c98>.
+    
+<http://data.lblod.info/id/remote-data-objects/e76a1929-d87c-4544-a6f9-9e8ee37e71ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e76a1929-d87c-4544-a6f9-9e8ee37e71ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/0f5f0992-1db9-4343-a4c5-a542b92b3de7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e76a1929-d87c-4544-a6f9-9e8ee37e71ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/17310df9-d966-4432-8b5b-1aadbcf821d6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "17310df9-d966-4432-8b5b-1aadbcf821d6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/26c61e12-bf89-44a5-8b5c-ae1e76ae657f/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/17310df9-d966-4432-8b5b-1aadbcf821d6>.
+    
+<http://data.lblod.info/id/remote-data-objects/3a7b8856-e98d-41ea-88ac-fefae6c76968> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a7b8856-e98d-41ea-88ac-fefae6c76968";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/26c61e12-bf89-44a5-8b5c-ae1e76ae657f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3a7b8856-e98d-41ea-88ac-fefae6c76968>.
+    
+<http://data.lblod.info/id/remote-data-objects/b0acdc07-3cc8-4bc2-9667-46a002483fc8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0acdc07-3cc8-4bc2-9667-46a002483fc8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/26c61e12-bf89-44a5-8b5c-ae1e76ae657f/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b0acdc07-3cc8-4bc2-9667-46a002483fc8>.
+    
+<http://data.lblod.info/id/remote-data-objects/befa16a2-328b-415c-96f1-041362ca162b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "befa16a2-328b-415c-96f1-041362ca162b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/28c06d18-a845-4b51-8f82-f404bc6f8f9c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/befa16a2-328b-415c-96f1-041362ca162b>.
+    
+<http://data.lblod.info/id/remote-data-objects/21b518f6-ba89-4c91-a5dd-bd1d1cd53108> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "21b518f6-ba89-4c91-a5dd-bd1d1cd53108";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/28c06d18-a845-4b51-8f82-f404bc6f8f9c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/21b518f6-ba89-4c91-a5dd-bd1d1cd53108>.
+    
+<http://data.lblod.info/id/remote-data-objects/6842e2f3-d635-4fed-854e-2b44ce02097b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6842e2f3-d635-4fed-854e-2b44ce02097b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/28c06d18-a845-4b51-8f82-f404bc6f8f9c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6842e2f3-d635-4fed-854e-2b44ce02097b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5064ed32-f537-4019-85b6-21a9f05ebbe4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5064ed32-f537-4019-85b6-21a9f05ebbe4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/3403f644-1c60-4059-b8ed-d711f69005c0/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5064ed32-f537-4019-85b6-21a9f05ebbe4>.
+    
+<http://data.lblod.info/id/remote-data-objects/49ca2616-d815-41b1-9474-8b4a03c91b28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49ca2616-d815-41b1-9474-8b4a03c91b28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/3403f644-1c60-4059-b8ed-d711f69005c0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/49ca2616-d815-41b1-9474-8b4a03c91b28>.
+    
+<http://data.lblod.info/id/remote-data-objects/83cbe16d-9495-4166-aae7-6ffed06aa461> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83cbe16d-9495-4166-aae7-6ffed06aa461";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/3403f644-1c60-4059-b8ed-d711f69005c0/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83cbe16d-9495-4166-aae7-6ffed06aa461>.
+    
+<http://data.lblod.info/id/remote-data-objects/9731bed8-6675-4a96-b7b4-42bce4f7b3d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9731bed8-6675-4a96-b7b4-42bce4f7b3d3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/4f048073-d978-481c-94e7-c7eec3fa7917/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9731bed8-6675-4a96-b7b4-42bce4f7b3d3>.
+    
+<http://data.lblod.info/id/remote-data-objects/174cfa3a-caa1-42a7-bb11-b8b3a9c84312> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "174cfa3a-caa1-42a7-bb11-b8b3a9c84312";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/4f048073-d978-481c-94e7-c7eec3fa7917/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/174cfa3a-caa1-42a7-bb11-b8b3a9c84312>.
+    
+<http://data.lblod.info/id/remote-data-objects/40b959f8-9382-4f7b-baed-66c28f27fc7c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40b959f8-9382-4f7b-baed-66c28f27fc7c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/4f048073-d978-481c-94e7-c7eec3fa7917/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/40b959f8-9382-4f7b-baed-66c28f27fc7c>.
+    
+<http://data.lblod.info/id/remote-data-objects/513d21a9-fc62-478c-948f-e716010513d7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "513d21a9-fc62-478c-948f-e716010513d7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/58f832f6-b369-4fd4-801e-0da64311915c/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/513d21a9-fc62-478c-948f-e716010513d7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6d76188a-f226-42d1-b031-71222e722b83> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6d76188a-f226-42d1-b031-71222e722b83";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/58f832f6-b369-4fd4-801e-0da64311915c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6d76188a-f226-42d1-b031-71222e722b83>.
+    
+<http://data.lblod.info/id/remote-data-objects/2934d071-b301-4843-837d-22e3d386ac28> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2934d071-b301-4843-837d-22e3d386ac28";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/58f832f6-b369-4fd4-801e-0da64311915c/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2934d071-b301-4843-837d-22e3d386ac28>.
+    
+<http://data.lblod.info/id/remote-data-objects/77c25293-a989-48f2-97ce-24834385c8e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77c25293-a989-48f2-97ce-24834385c8e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/5e5868b4-f5e2-46ba-b2ad-cfee21defc19/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/77c25293-a989-48f2-97ce-24834385c8e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/a8e183db-eecc-4c16-ac34-e324cc6ea044> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8e183db-eecc-4c16-ac34-e324cc6ea044";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/5e5868b4-f5e2-46ba-b2ad-cfee21defc19/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a8e183db-eecc-4c16-ac34-e324cc6ea044>.
+    
+<http://data.lblod.info/id/remote-data-objects/649e5b2a-e9d2-43d8-8cf8-810e94419ccc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "649e5b2a-e9d2-43d8-8cf8-810e94419ccc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/5e5868b4-f5e2-46ba-b2ad-cfee21defc19/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/649e5b2a-e9d2-43d8-8cf8-810e94419ccc>.
+    
+<http://data.lblod.info/id/remote-data-objects/774c4f0d-2d3f-4cf1-b59f-470777154b4b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "774c4f0d-2d3f-4cf1-b59f-470777154b4b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/884cf5f9-4a1b-41a3-a070-0119262185b2/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/774c4f0d-2d3f-4cf1-b59f-470777154b4b>.
+    
+<http://data.lblod.info/id/remote-data-objects/f293c49f-a509-49d4-8e0d-e5122defca42> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f293c49f-a509-49d4-8e0d-e5122defca42";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/884cf5f9-4a1b-41a3-a070-0119262185b2/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f293c49f-a509-49d4-8e0d-e5122defca42>.
+    
+<http://data.lblod.info/id/remote-data-objects/9d030829-882d-4575-8bac-8a60202033eb> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9d030829-882d-4575-8bac-8a60202033eb";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/884cf5f9-4a1b-41a3-a070-0119262185b2/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9d030829-882d-4575-8bac-8a60202033eb>.
+    
+<http://data.lblod.info/id/remote-data-objects/26d8b2f0-5a52-4264-bc08-14df850075fd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26d8b2f0-5a52-4264-bc08-14df850075fd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/91f8fa24-e567-4222-9ed2-c572b53b5b11/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26d8b2f0-5a52-4264-bc08-14df850075fd>.
+    
+<http://data.lblod.info/id/remote-data-objects/73494fe5-cb7d-4c6e-8354-26cf432aaba9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "73494fe5-cb7d-4c6e-8354-26cf432aaba9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/91f8fa24-e567-4222-9ed2-c572b53b5b11/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/73494fe5-cb7d-4c6e-8354-26cf432aaba9>.
+    
+<http://data.lblod.info/id/remote-data-objects/cb8afcb2-9b35-432c-ae07-41f4643c1d37> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb8afcb2-9b35-432c-ae07-41f4643c1d37";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/91f8fa24-e567-4222-9ed2-c572b53b5b11/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cb8afcb2-9b35-432c-ae07-41f4643c1d37>.
+    
+<http://data.lblod.info/id/remote-data-objects/e11c0f5d-55eb-48ac-b48e-c58dd169c289> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e11c0f5d-55eb-48ac-b48e-c58dd169c289";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/a3570734-53d7-45c6-bf0d-2610bd046e5a/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e11c0f5d-55eb-48ac-b48e-c58dd169c289>.
+    
+<http://data.lblod.info/id/remote-data-objects/d50fab52-b65f-4083-b6c1-22af3e040279> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d50fab52-b65f-4083-b6c1-22af3e040279";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/a3570734-53d7-45c6-bf0d-2610bd046e5a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d50fab52-b65f-4083-b6c1-22af3e040279>.
+    
+<http://data.lblod.info/id/remote-data-objects/16db7147-a711-4720-aca2-08c7e7992ccf> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16db7147-a711-4720-aca2-08c7e7992ccf";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/a3570734-53d7-45c6-bf0d-2610bd046e5a/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/16db7147-a711-4720-aca2-08c7e7992ccf>.
+    
+<http://data.lblod.info/id/remote-data-objects/ddad65e7-f0b1-443b-a4fc-8f1dbe22d018> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ddad65e7-f0b1-443b-a4fc-8f1dbe22d018";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/babb67d6-4810-447d-87b3-ab378f8f0f57/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ddad65e7-f0b1-443b-a4fc-8f1dbe22d018>.
+    
+<http://data.lblod.info/id/remote-data-objects/80250c4f-78de-4b1e-bb15-05c2e0f8764e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80250c4f-78de-4b1e-bb15-05c2e0f8764e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/babb67d6-4810-447d-87b3-ab378f8f0f57/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/80250c4f-78de-4b1e-bb15-05c2e0f8764e>.
+    
+<http://data.lblod.info/id/remote-data-objects/c51a02ff-6b2f-4cd3-95fd-b9cf74f8a963> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c51a02ff-6b2f-4cd3-95fd-b9cf74f8a963";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/babb67d6-4810-447d-87b3-ab378f8f0f57/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c51a02ff-6b2f-4cd3-95fd-b9cf74f8a963>.
+    
+<http://data.lblod.info/id/remote-data-objects/be946beb-e155-40d3-930d-1036d93137a4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be946beb-e155-40d3-930d-1036d93137a4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/be272cba-b565-4ef2-ad2b-adec55357549/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/be946beb-e155-40d3-930d-1036d93137a4>.
+    
+<http://data.lblod.info/id/remote-data-objects/27095c36-19e8-4988-8b63-2bdea4198b4a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27095c36-19e8-4988-8b63-2bdea4198b4a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/be272cba-b565-4ef2-ad2b-adec55357549/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27095c36-19e8-4988-8b63-2bdea4198b4a>.
+    
+<http://data.lblod.info/id/remote-data-objects/7beac627-4992-4825-a26b-61e2f6e8ff67> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7beac627-4992-4825-a26b-61e2f6e8ff67";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/be272cba-b565-4ef2-ad2b-adec55357549/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7beac627-4992-4825-a26b-61e2f6e8ff67>.
+    
+<http://data.lblod.info/id/remote-data-objects/c9a1b814-bde1-47c6-923f-5ff019d246ea> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9a1b814-bde1-47c6-923f-5ff019d246ea";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/c3bc0ea8-2ef0-4b5f-b1bd-0a6bf0e20559/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:02.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/166cc13d-1f9b-446c-a04b-8d814b9bc127> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c9a1b814-bde1-47c6-923f-5ff019d246ea>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202003-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202003-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202003-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202003-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/37a6c5f2-7808-4d40-ad31-61fda4e3201c> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "37a6c5f2-7808-4d40-ad31-61fda4e3201c";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e451391a-c884-4d3f-8647-ded9a93c1373";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/4477c391-5e25-4b1f-a364-9fd63d0e5e84> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "4477c391-5e25-4b1f-a364-9fd63d0e5e84";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373>.
+
+  <http://redpencil.data.gift/id/task/03d53929-3d54-4a74-bf68-1ec5eaf6e7f9> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "03d53929-3d54-4a74-bf68-1ec5eaf6e7f9";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/37a6c5f2-7808-4d40-ad31-61fda4e3201c>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/4477c391-5e25-4b1f-a364-9fd63d0e5e84>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/050bbd35-0f54-43d6-986b-e59be80b45a3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "050bbd35-0f54-43d6-986b-e59be80b45a3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/c3bc0ea8-2ef0-4b5f-b1bd-0a6bf0e20559/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/050bbd35-0f54-43d6-986b-e59be80b45a3>.
+    
+<http://data.lblod.info/id/remote-data-objects/b867a29d-8e00-4ddc-9986-10ce9950f610> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b867a29d-8e00-4ddc-9986-10ce9950f610";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/c3bc0ea8-2ef0-4b5f-b1bd-0a6bf0e20559/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b867a29d-8e00-4ddc-9986-10ce9950f610>.
+    
+<http://data.lblod.info/id/remote-data-objects/fe26ef47-03ec-42a0-a868-15ca8594ccb1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe26ef47-03ec-42a0-a868-15ca8594ccb1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/d204e8f7-70d9-4aa4-88d9-a05d6d3c5289/agenda>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fe26ef47-03ec-42a0-a868-15ca8594ccb1>.
+    
+<http://data.lblod.info/id/remote-data-objects/719885de-d8c3-4049-882b-d87e22f128f4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "719885de-d8c3-4049-882b-d87e22f128f4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/d204e8f7-70d9-4aa4-88d9-a05d6d3c5289/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/719885de-d8c3-4049-882b-d87e22f128f4>.
+    
+<http://data.lblod.info/id/remote-data-objects/0cede9ed-c734-464a-8173-6fb36bbaa0e2> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0cede9ed-c734-464a-8173-6fb36bbaa0e2";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/rmw/d204e8f7-70d9-4aa4-88d9-a05d6d3c5289/notulen>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0cede9ed-c734-464a-8173-6fb36bbaa0e2>.
+    
+<http://data.lblod.info/id/remote-data-objects/5cb5253e-4d6d-477f-be0f-e4b79d0da7ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5cb5253e-4d6d-477f-be0f-e4b79d0da7ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/09e8211b-ef65-463c-9d24-87ac1760e075/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5cb5253e-4d6d-477f-be0f-e4b79d0da7ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/cdb43652-11b0-43ff-b713-a4141f7cf42b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cdb43652-11b0-43ff-b713-a4141f7cf42b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/0bb6722f-dfad-49b1-9784-2aa5845496ac/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cdb43652-11b0-43ff-b713-a4141f7cf42b>.
+    
+<http://data.lblod.info/id/remote-data-objects/5e14d9fd-69dd-4321-9c8d-81ed774061ab> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e14d9fd-69dd-4321-9c8d-81ed774061ab";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/0d0c7a67-3974-467f-800b-9c63dd89f172/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5e14d9fd-69dd-4321-9c8d-81ed774061ab>.
+    
+<http://data.lblod.info/id/remote-data-objects/6c522781-2775-449f-aa54-cbce2d6cab2c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6c522781-2775-449f-aa54-cbce2d6cab2c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/0eee9eb2-99f9-4cc9-aff8-eddc7f5abd14/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6c522781-2775-449f-aa54-cbce2d6cab2c>.
+    
+<http://data.lblod.info/id/remote-data-objects/5aeb9151-b7c2-4538-989c-0b7d78464992> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5aeb9151-b7c2-4538-989c-0b7d78464992";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/1231de09-b468-4efe-a234-48762f634a06/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5aeb9151-b7c2-4538-989c-0b7d78464992>.
+    
+<http://data.lblod.info/id/remote-data-objects/005e06ab-7863-43fd-acc1-a75644313bb3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "005e06ab-7863-43fd-acc1-a75644313bb3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/1f5ecc2d-62da-47c1-98ee-9c0bd488cde5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/005e06ab-7863-43fd-acc1-a75644313bb3>.
+    
+<http://data.lblod.info/id/remote-data-objects/599a6528-bbf6-4b4d-8f51-acf036f19967> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "599a6528-bbf6-4b4d-8f51-acf036f19967";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/210cdf98-4bbb-40ef-a67c-0f87eb6c853d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/599a6528-bbf6-4b4d-8f51-acf036f19967>.
+    
+<http://data.lblod.info/id/remote-data-objects/b7aef3b9-8213-4350-902d-ff99740d476d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7aef3b9-8213-4350-902d-ff99740d476d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/245e6422-93d5-4b39-bb04-9a461d62b1ee/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b7aef3b9-8213-4350-902d-ff99740d476d>.
+    
+<http://data.lblod.info/id/remote-data-objects/e36ce1c2-6059-470f-b173-7262d8c5c52a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e36ce1c2-6059-470f-b173-7262d8c5c52a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/297f10df-21e7-4139-9907-11a320459585/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e36ce1c2-6059-470f-b173-7262d8c5c52a>.
+    
+<http://data.lblod.info/id/remote-data-objects/007485c6-8016-483a-888d-b87f7924f75e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "007485c6-8016-483a-888d-b87f7924f75e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/2a6feec9-fa88-4654-9254-6f787d60347a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/007485c6-8016-483a-888d-b87f7924f75e>.
+    
+<http://data.lblod.info/id/remote-data-objects/82fdc0d9-74e2-42fa-83b4-01524983b23e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82fdc0d9-74e2-42fa-83b4-01524983b23e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/2c784e17-bb1b-4ce7-a3db-484f22cf8bc6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82fdc0d9-74e2-42fa-83b4-01524983b23e>.
+    
+<http://data.lblod.info/id/remote-data-objects/2ea8c951-b884-4c2a-8ac6-21d57947dc6a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ea8c951-b884-4c2a-8ac6-21d57947dc6a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/361efffb-90b4-4504-8521-5883bce72b6c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2ea8c951-b884-4c2a-8ac6-21d57947dc6a>.
+    
+<http://data.lblod.info/id/remote-data-objects/331223db-d5ed-4d93-a187-62c5a442cf97> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "331223db-d5ed-4d93-a187-62c5a442cf97";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/3c684c1e-7cd7-441f-b36c-833f86bfed8d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/331223db-d5ed-4d93-a187-62c5a442cf97>.
+    
+<http://data.lblod.info/id/remote-data-objects/4e88ebdd-2239-4122-8d1d-f60d02d9fbe5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4e88ebdd-2239-4122-8d1d-f60d02d9fbe5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/3ffed0f6-31db-44ba-bc3f-d66c5540f25a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4e88ebdd-2239-4122-8d1d-f60d02d9fbe5>.
+    
+<http://data.lblod.info/id/remote-data-objects/3e433953-411e-4083-bbef-75e257fb31de> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3e433953-411e-4083-bbef-75e257fb31de";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/429ab3ee-a6c5-496f-9466-965823972480/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3e433953-411e-4083-bbef-75e257fb31de>.
+    
+<http://data.lblod.info/id/remote-data-objects/63844019-2ec6-4f28-86fd-1ce106774a82> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "63844019-2ec6-4f28-86fd-1ce106774a82";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/429e057b-11fd-4f66-9acc-a041eff18e2a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/63844019-2ec6-4f28-86fd-1ce106774a82>.
+    
+<http://data.lblod.info/id/remote-data-objects/dd7d2139-b2c4-4c68-abc8-7d1c5f9f79e4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd7d2139-b2c4-4c68-abc8-7d1c5f9f79e4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/44875686-73f4-45e2-8a8f-56db351e9770/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dd7d2139-b2c4-4c68-abc8-7d1c5f9f79e4>.
+    
+<http://data.lblod.info/id/remote-data-objects/e740d50e-074e-49dc-bed9-5cf465099ae3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e740d50e-074e-49dc-bed9-5cf465099ae3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/45362010-f2b4-4040-bccd-ddd803ca0482/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e740d50e-074e-49dc-bed9-5cf465099ae3>.
+    
+<http://data.lblod.info/id/remote-data-objects/34adb11e-4cf7-490d-9533-0d710cefd753> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34adb11e-4cf7-490d-9533-0d710cefd753";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/4c11200d-b871-4fcc-893a-3a381afd477a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/34adb11e-4cf7-490d-9533-0d710cefd753>.
+    
+<http://data.lblod.info/id/remote-data-objects/402465f1-052b-4b9b-9a2f-26d55cc78594> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "402465f1-052b-4b9b-9a2f-26d55cc78594";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/4c5b86db-5702-4363-a19e-635406653148/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/402465f1-052b-4b9b-9a2f-26d55cc78594>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f4a3cc8-2e01-4f65-be76-9df4c60b1724> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f4a3cc8-2e01-4f65-be76-9df4c60b1724";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/4d606ef2-521b-46cb-be0d-31cab7143828/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f4a3cc8-2e01-4f65-be76-9df4c60b1724>.
+    
+<http://data.lblod.info/id/remote-data-objects/cfab09ec-8292-4618-b4e1-4ec0471cd4e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cfab09ec-8292-4618-b4e1-4ec0471cd4e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/4eaa64e4-3a9e-417c-a205-b0f57789f581/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cfab09ec-8292-4618-b4e1-4ec0471cd4e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/81016c95-b8d7-41db-a481-4e8765891398> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81016c95-b8d7-41db-a481-4e8765891398";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/58789ae0-20f3-4e92-b8b8-efbe7fd663fe/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/81016c95-b8d7-41db-a481-4e8765891398>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cc9f693-c765-4cbf-b197-d5c046ba8e34> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cc9f693-c765-4cbf-b197-d5c046ba8e34";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/59b30f07-59c7-428c-9531-52fe23cdb356/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cc9f693-c765-4cbf-b197-d5c046ba8e34>.
+    
+<http://data.lblod.info/id/remote-data-objects/a73051e9-886c-46cf-a7ba-6fa8136f5b6e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a73051e9-886c-46cf-a7ba-6fa8136f5b6e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/5a68c025-f326-40e5-8779-023859521d72/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a73051e9-886c-46cf-a7ba-6fa8136f5b6e>.
+    
+<http://data.lblod.info/id/remote-data-objects/820d553d-0e3f-4361-8459-d32107a72ed7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "820d553d-0e3f-4361-8459-d32107a72ed7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/5ff08ddb-b2e0-4ba1-b919-3e0db56966c1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/820d553d-0e3f-4361-8459-d32107a72ed7>.
+    
+<http://data.lblod.info/id/remote-data-objects/6ba2ea0e-684c-47da-a0d3-c8154aa775a1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6ba2ea0e-684c-47da-a0d3-c8154aa775a1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/65d205e6-27b7-4758-812c-c2cd8b6f6c39/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/6ba2ea0e-684c-47da-a0d3-c8154aa775a1>.
+    
+<http://data.lblod.info/id/remote-data-objects/71f18d9c-acfe-4f19-8a39-bed2efa5a689> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71f18d9c-acfe-4f19-8a39-bed2efa5a689";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/69d2bace-4616-4795-b0d3-469cddb154fb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71f18d9c-acfe-4f19-8a39-bed2efa5a689>.
+    
+<http://data.lblod.info/id/remote-data-objects/e820c759-176e-4559-805c-2af226ea78ba> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e820c759-176e-4559-805c-2af226ea78ba";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/6da9416f-a75a-4958-b9c3-a264f64c3f85/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e820c759-176e-4559-805c-2af226ea78ba>.
+    
+<http://data.lblod.info/id/remote-data-objects/82e76697-b40c-4616-b597-4418abda6173> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "82e76697-b40c-4616-b597-4418abda6173";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/73d9af10-4289-4909-b065-6d40b2b65f4f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/82e76697-b40c-4616-b597-4418abda6173>.
+    
+<http://data.lblod.info/id/remote-data-objects/013de543-fff8-4bb1-b066-53d52a64785f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "013de543-fff8-4bb1-b066-53d52a64785f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/74d8abfa-e10a-430f-9db4-8ecdb0d826bd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/013de543-fff8-4bb1-b066-53d52a64785f>.
+    
+<http://data.lblod.info/id/remote-data-objects/f666796a-efcf-4f79-a02d-f3fcc5f2e2dc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f666796a-efcf-4f79-a02d-f3fcc5f2e2dc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/76a17cb8-6624-4d37-a2b8-2804bb8e4e80/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f666796a-efcf-4f79-a02d-f3fcc5f2e2dc>.
+    
+<http://data.lblod.info/id/remote-data-objects/734ffe27-e674-4013-b7cc-8457d9975805> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "734ffe27-e674-4013-b7cc-8457d9975805";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/7aab0578-4f12-4fb6-98d2-65b02af29aeb/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/734ffe27-e674-4013-b7cc-8457d9975805>.
+    
+<http://data.lblod.info/id/remote-data-objects/018a39dc-7960-43d9-9317-e3b31aeaea4f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "018a39dc-7960-43d9-9317-e3b31aeaea4f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/80f9a1e9-1c4b-4abf-b1fc-1997e4bac04a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/018a39dc-7960-43d9-9317-e3b31aeaea4f>.
+    
+<http://data.lblod.info/id/remote-data-objects/419a120c-8375-4ab2-ad9c-2d10ccc89999> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "419a120c-8375-4ab2-ad9c-2d10ccc89999";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/8b912546-b956-4ac1-ba38-03f199645d2c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/419a120c-8375-4ab2-ad9c-2d10ccc89999>.
+    
+<http://data.lblod.info/id/remote-data-objects/94c5cc75-1f41-4aa1-8ef9-190ec1693167> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94c5cc75-1f41-4aa1-8ef9-190ec1693167";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/99c9a781-1462-4c60-a54c-1b2d4de56a8a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94c5cc75-1f41-4aa1-8ef9-190ec1693167>.
+    
+<http://data.lblod.info/id/remote-data-objects/83c82ef0-a9a4-4185-8b8c-a3f3519c7f9d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83c82ef0-a9a4-4185-8b8c-a3f3519c7f9d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/9b8fb73c-193f-472d-9f14-544df98b8e30/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83c82ef0-a9a4-4185-8b8c-a3f3519c7f9d>.
+    
+<http://data.lblod.info/id/remote-data-objects/0397f8d7-9a0d-4952-b3e4-9b1e1d6e3f12> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0397f8d7-9a0d-4952-b3e4-9b1e1d6e3f12";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/a296b028-0d9c-49b8-9547-969f04bcaa77/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/0397f8d7-9a0d-4952-b3e4-9b1e1d6e3f12>.
+    
+<http://data.lblod.info/id/remote-data-objects/b319042f-08a9-4422-85c7-b7f3f74af7dd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b319042f-08a9-4422-85c7-b7f3f74af7dd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/a88f4c72-7762-4cac-a230-a80dfb8a9246/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b319042f-08a9-4422-85c7-b7f3f74af7dd>.
+    
+<http://data.lblod.info/id/remote-data-objects/4de0470c-fa25-40a9-8b49-c5c4cb6d1f6b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4de0470c-fa25-40a9-8b49-c5c4cb6d1f6b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/aa5fa018-bb66-4e6b-977b-363fd25fbc7e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4de0470c-fa25-40a9-8b49-c5c4cb6d1f6b>.
+    
+<http://data.lblod.info/id/remote-data-objects/27933653-790d-4109-a814-f29614c6bbe6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27933653-790d-4109-a814-f29614c6bbe6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/ad1f2920-ebb3-4722-94e1-0b4700dfbbc7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/27933653-790d-4109-a814-f29614c6bbe6>.
+    
+<http://data.lblod.info/id/remote-data-objects/62a0c6cc-5149-403f-b6c0-b232da37d8c7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62a0c6cc-5149-403f-b6c0-b232da37d8c7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/aeaf3f5a-f280-45af-a422-b8b5733eb9e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/62a0c6cc-5149-403f-b6c0-b232da37d8c7>.
+    
+<http://data.lblod.info/id/remote-data-objects/b487f4cc-d526-4636-809f-9ad6e4b7e089> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b487f4cc-d526-4636-809f-9ad6e4b7e089";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/cd6ded2e-b83b-467e-937f-08814a7d9849/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b487f4cc-d526-4636-809f-9ad6e4b7e089>.
+    
+<http://data.lblod.info/id/remote-data-objects/9aa210aa-abe7-44df-9b83-f62fed32b468> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9aa210aa-abe7-44df-9b83-f62fed32b468";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/d07b65b5-dfac-452c-8f32-c80566981457/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/9aa210aa-abe7-44df-9b83-f62fed32b468>.
+    
+<http://data.lblod.info/id/remote-data-objects/3f64055d-ee23-47ea-97b7-91e0525f3b10> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3f64055d-ee23-47ea-97b7-91e0525f3b10";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/d11bd102-584a-4f9a-ac12-9e60051e7744/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:03.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/e451391a-c884-4d3f-8647-ded9a93c1373> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/3f64055d-ee23-47ea-97b7-91e0525f3b10>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202004-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202004-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202004-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202004-create-harvesting-jobs.ttl
@@ -1,0 +1,576 @@
+<http://redpencil.data.gift/id/job/fab1f0a4-6218-4778-a809-2a2117a2aa49> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "fab1f0a4-6218-4778-a809-2a2117a2aa49";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "ea63ed8b-edd0-41d0-b3bc-40909c7580b8";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/b15e8e33-3ee8-4b73-b9e8-ad053088ff7d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b15e8e33-3ee8-4b73-b9e8-ad053088ff7d";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8>.
+
+  <http://redpencil.data.gift/id/task/a7a0f918-9b03-4035-a2b6-07fdce8076dd> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a7a0f918-9b03-4035-a2b6-07fdce8076dd";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/fab1f0a4-6218-4778-a809-2a2117a2aa49>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/b15e8e33-3ee8-4b73-b9e8-ad053088ff7d>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/43c51a56-6eff-44fc-9929-0c6afc04dbf4> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "43c51a56-6eff-44fc-9929-0c6afc04dbf4";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/d28feb68-f6f9-4f7e-b6eb-76720b114d7c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/43c51a56-6eff-44fc-9929-0c6afc04dbf4>.
+    
+<http://data.lblod.info/id/remote-data-objects/ec4343f9-9291-4207-94ff-a77868e13fc6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec4343f9-9291-4207-94ff-a77868e13fc6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/d30c5338-f467-44a4-a915-cefaffbb5e26/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ec4343f9-9291-4207-94ff-a77868e13fc6>.
+    
+<http://data.lblod.info/id/remote-data-objects/ff6268b2-1ccb-4bf9-9cc0-ad1ae9305ecc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff6268b2-1ccb-4bf9-9cc0-ad1ae9305ecc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/d3c43be0-2a23-4440-b2e9-42dd5219e618/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ff6268b2-1ccb-4bf9-9cc0-ad1ae9305ecc>.
+    
+<http://data.lblod.info/id/remote-data-objects/b83b78a0-2161-43a3-b093-df2eba819901> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b83b78a0-2161-43a3-b093-df2eba819901";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/d4aa3dcd-33f3-4607-8422-cb62c870a44f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b83b78a0-2161-43a3-b093-df2eba819901>.
+    
+<http://data.lblod.info/id/remote-data-objects/fbd21864-5c47-42c9-ae5e-20042e2c8cdc> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fbd21864-5c47-42c9-ae5e-20042e2c8cdc";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/d5525b57-ecd7-4a74-a102-1cb59263e909/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fbd21864-5c47-42c9-ae5e-20042e2c8cdc>.
+    
+<http://data.lblod.info/id/remote-data-objects/57679e05-d0df-4c91-91eb-a8172ece56ce> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "57679e05-d0df-4c91-91eb-a8172ece56ce";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/d57080a2-9c08-4313-8fb8-f6de2606f6e7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/57679e05-d0df-4c91-91eb-a8172ece56ce>.
+    
+<http://data.lblod.info/id/remote-data-objects/193d7216-44a0-4dea-8dc5-3c89e90755a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "193d7216-44a0-4dea-8dc5-3c89e90755a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/d93fb13e-9935-48be-9d1e-1109dcfcd513/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/193d7216-44a0-4dea-8dc5-3c89e90755a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/50724430-7166-46c2-b9dc-7c14c59f9335> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50724430-7166-46c2-b9dc-7c14c59f9335";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/db1e6e00-ed62-48bb-a656-6705130ba7dd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/50724430-7166-46c2-b9dc-7c14c59f9335>.
+    
+<http://data.lblod.info/id/remote-data-objects/c1e844c5-56a7-48f6-8aff-ca81439288e1> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c1e844c5-56a7-48f6-8aff-ca81439288e1";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/db83ee85-3fc2-468c-a95d-556fd684082c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c1e844c5-56a7-48f6-8aff-ca81439288e1>.
+    
+<http://data.lblod.info/id/remote-data-objects/59ccaec3-d60d-4edb-b6a4-bd06ed5564ef> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "59ccaec3-d60d-4edb-b6a4-bd06ed5564ef";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/dcfa2822-9709-4ea1-a5de-fb1637ba06c6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/59ccaec3-d60d-4edb-b6a4-bd06ed5564ef>.
+    
+<http://data.lblod.info/id/remote-data-objects/58923c1e-ac44-4ae8-a40d-15e273ff5ac9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58923c1e-ac44-4ae8-a40d-15e273ff5ac9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/df4a5a85-2be4-43e1-81a6-302abec391ea/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/58923c1e-ac44-4ae8-a40d-15e273ff5ac9>.
+    
+<http://data.lblod.info/id/remote-data-objects/d842525d-1295-4a66-b56d-60ac1a83d64a> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d842525d-1295-4a66-b56d-60ac1a83d64a";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/e9e16143-01fe-4231-8f50-2bff8559e076/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d842525d-1295-4a66-b56d-60ac1a83d64a>.
+    
+<http://data.lblod.info/id/remote-data-objects/f4007ca4-d015-4c06-acbb-c2c8f852ad5c> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f4007ca4-d015-4c06-acbb-c2c8f852ad5c";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/ec9ac6fe-1e10-4ecb-90e3-e0594dafcf86/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f4007ca4-d015-4c06-acbb-c2c8f852ad5c>.
+    
+<http://data.lblod.info/id/remote-data-objects/cc3f29e9-aaab-4285-97a9-1e3645162728> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc3f29e9-aaab-4285-97a9-1e3645162728";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/sc/f2227a24-f8b3-4e32-b00e-e92592d49fa9/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cc3f29e9-aaab-4285-97a9-1e3645162728>.
+    
+<http://data.lblod.info/id/remote-data-objects/cf3ad66d-6f4e-4fbe-beba-601685d3215b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cf3ad66d-6f4e-4fbe-beba-601685d3215b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/007600d3-ae1a-48b8-8a0a-7e9090ce7239/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/cf3ad66d-6f4e-4fbe-beba-601685d3215b>.
+    
+<http://data.lblod.info/id/remote-data-objects/342180ce-66b8-47db-99c0-2ae471026fbe> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "342180ce-66b8-47db-99c0-2ae471026fbe";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/07bc7f9f-c6e0-4201-941b-36a17c1d796f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/342180ce-66b8-47db-99c0-2ae471026fbe>.
+    
+<http://data.lblod.info/id/remote-data-objects/a1921816-6699-48f9-a285-2e2db08dc6be> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1921816-6699-48f9-a285-2e2db08dc6be";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/097acc47-a1fb-4678-9740-c86d0f60469e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a1921816-6699-48f9-a285-2e2db08dc6be>.
+    
+<http://data.lblod.info/id/remote-data-objects/b33c42b4-9c49-4069-a316-0e3dc24cf1d9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b33c42b4-9c49-4069-a316-0e3dc24cf1d9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/0c1f01f6-caa9-4dde-ac24-0464c60e642f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b33c42b4-9c49-4069-a316-0e3dc24cf1d9>.
+    
+<http://data.lblod.info/id/remote-data-objects/20eadd37-c465-4869-a530-d45a086e39a7> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "20eadd37-c465-4869-a530-d45a086e39a7";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/0deac96d-78de-43c4-8797-66a8b6541066/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/20eadd37-c465-4869-a530-d45a086e39a7>.
+    
+<http://data.lblod.info/id/remote-data-objects/145c48f9-6bba-46e7-8a55-20d941742f30> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "145c48f9-6bba-46e7-8a55-20d941742f30";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/1255c7ac-5824-4084-963c-2e60a7ae2ea5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/145c48f9-6bba-46e7-8a55-20d941742f30>.
+    
+<http://data.lblod.info/id/remote-data-objects/eaa54913-dc27-4eaa-a9ca-dbdbd66f07d8> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eaa54913-dc27-4eaa-a9ca-dbdbd66f07d8";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/19461f4f-c8ee-4133-8bec-12dc414d9e0b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/eaa54913-dc27-4eaa-a9ca-dbdbd66f07d8>.
+    
+<http://data.lblod.info/id/remote-data-objects/630cdf64-ee92-49e5-a2a6-8632845f6686> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "630cdf64-ee92-49e5-a2a6-8632845f6686";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/19508f23-641d-46a4-9118-5ec8056c5031/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/630cdf64-ee92-49e5-a2a6-8632845f6686>.
+    
+<http://data.lblod.info/id/remote-data-objects/89f90e73-f715-406b-9bd3-4fa0730b60d0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "89f90e73-f715-406b-9bd3-4fa0730b60d0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/1d169870-1e3d-4613-88e5-bfcfcf333e63/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/89f90e73-f715-406b-9bd3-4fa0730b60d0>.
+    
+<http://data.lblod.info/id/remote-data-objects/dcf772fb-5a78-4dd3-83e0-74223c7dd350> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcf772fb-5a78-4dd3-83e0-74223c7dd350";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/24921d62-d98d-4a5a-8df7-de2b3527d7f7/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/dcf772fb-5a78-4dd3-83e0-74223c7dd350>.
+    
+<http://data.lblod.info/id/remote-data-objects/03a72d2b-5b60-49b3-bf9a-a860ff4193e3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03a72d2b-5b60-49b3-bf9a-a860ff4193e3";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/26b92890-28b1-47f5-873a-8a49311ca819/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/03a72d2b-5b60-49b3-bf9a-a860ff4193e3>.
+    
+<http://data.lblod.info/id/remote-data-objects/71e42ab4-f324-4883-ba8c-344c3c80ceff> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71e42ab4-f324-4883-ba8c-344c3c80ceff";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/28be8683-cf3b-4a37-8391-19bcc662fff4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/71e42ab4-f324-4883-ba8c-344c3c80ceff>.
+    
+<http://data.lblod.info/id/remote-data-objects/867b721f-ead3-4af8-a2d1-22bcf3dca0e5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "867b721f-ead3-4af8-a2d1-22bcf3dca0e5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/2ebdfcd5-efc3-45d0-b98f-f503b682a828/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/867b721f-ead3-4af8-a2d1-22bcf3dca0e5>.
+    
+<http://data.lblod.info/id/remote-data-objects/511fa024-749c-4336-85eb-929149f14b7e> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "511fa024-749c-4336-85eb-929149f14b7e";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/3454bb6a-cfe9-42bc-b1aa-19d0d445476d/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/511fa024-749c-4336-85eb-929149f14b7e>.
+    
+<http://data.lblod.info/id/remote-data-objects/37e4b940-e114-4aee-a0dc-7c15fbf40d54> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37e4b940-e114-4aee-a0dc-7c15fbf40d54";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/40cdbbc3-741b-4f15-987a-3cf98befe945/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/37e4b940-e114-4aee-a0dc-7c15fbf40d54>.
+    
+<http://data.lblod.info/id/remote-data-objects/26425d8b-68a1-4111-9566-328bd70465b5> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "26425d8b-68a1-4111-9566-328bd70465b5";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/4598ba65-4cf0-4730-8b72-63f32b4bb81b/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/26425d8b-68a1-4111-9566-328bd70465b5>.
+    
+<http://data.lblod.info/id/remote-data-objects/94ed10b4-02cc-43c8-8dfe-820dc79f3469> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94ed10b4-02cc-43c8-8dfe-820dc79f3469";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/4602feb6-f457-4b6f-821d-e68dd8b8f1d4/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/94ed10b4-02cc-43c8-8dfe-820dc79f3469>.
+    
+<http://data.lblod.info/id/remote-data-objects/5a52e663-2ec3-48ad-8ceb-bde90da37365> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5a52e663-2ec3-48ad-8ceb-bde90da37365";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/51109259-2f0d-47d6-9c78-9680fba2a5f1/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5a52e663-2ec3-48ad-8ceb-bde90da37365>.
+    
+<http://data.lblod.info/id/remote-data-objects/4b952e63-1dde-41bd-8bee-9fa61ebfd731> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4b952e63-1dde-41bd-8bee-9fa61ebfd731";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/5514eab6-1d6c-4770-91f0-3f3c055405e8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/4b952e63-1dde-41bd-8bee-9fa61ebfd731>.
+    
+<http://data.lblod.info/id/remote-data-objects/f6809b09-aa2d-48e9-bbda-6ae7c03e6476> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f6809b09-aa2d-48e9-bbda-6ae7c03e6476";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/5525b993-30f8-45ef-b4e9-d258462aee7e/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/f6809b09-aa2d-48e9-bbda-6ae7c03e6476>.
+    
+<http://data.lblod.info/id/remote-data-objects/1c339ffb-a73c-4703-bbf8-303c6c0f15a9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1c339ffb-a73c-4703-bbf8-303c6c0f15a9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/6f6614f3-4d2f-436a-956e-f87b610835ad/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1c339ffb-a73c-4703-bbf8-303c6c0f15a9>.
+    
+<http://data.lblod.info/id/remote-data-objects/fd3f9e4b-5466-48e6-a9eb-ad5dc42a10e9> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd3f9e4b-5466-48e6-a9eb-ad5dc42a10e9";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/6fe51d5c-3dba-493b-b010-27e536317326/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fd3f9e4b-5466-48e6-a9eb-ad5dc42a10e9>.
+    
+<http://data.lblod.info/id/remote-data-objects/ecacbc3c-bd8f-407e-a480-e89fa1954dbd> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ecacbc3c-bd8f-407e-a480-e89fa1954dbd";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/7ba7f9b3-35b5-4ddc-b6d9-f0666669a8db/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ecacbc3c-bd8f-407e-a480-e89fa1954dbd>.
+    
+<http://data.lblod.info/id/remote-data-objects/2d5ccf82-2212-47d5-bbec-e59275614b1d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2d5ccf82-2212-47d5-bbec-e59275614b1d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/7bdb5eee-7c3d-41e3-8d65-058ea4ed36e5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2d5ccf82-2212-47d5-bbec-e59275614b1d>.
+    
+<http://data.lblod.info/id/remote-data-objects/33632334-65ee-46f5-8b64-47456fc6e34f> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "33632334-65ee-46f5-8b64-47456fc6e34f";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/7d61f628-f366-4c2f-9570-cf758f901742/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/33632334-65ee-46f5-8b64-47456fc6e34f>.
+    
+<http://data.lblod.info/id/remote-data-objects/2486c51b-b625-4257-a3ab-09e08e2245b6> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2486c51b-b625-4257-a3ab-09e08e2245b6";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/7ecf5979-119c-4dc8-a0a8-459ff64e3e95/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2486c51b-b625-4257-a3ab-09e08e2245b6>.
+    
+<http://data.lblod.info/id/remote-data-objects/e386631b-773b-4822-bcb4-bb6eeb79c026> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e386631b-773b-4822-bcb4-bb6eeb79c026";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/7f4a5649-9c9c-47dd-9a6e-d79bf74d106f/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/e386631b-773b-4822-bcb4-bb6eeb79c026>.
+    
+<http://data.lblod.info/id/remote-data-objects/638b207a-0f19-4119-8997-56e74af984ee> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "638b207a-0f19-4119-8997-56e74af984ee";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/814be897-2bd8-4a16-a0f7-588bf081e7c0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/638b207a-0f19-4119-8997-56e74af984ee>.
+    
+<http://data.lblod.info/id/remote-data-objects/ce7ea041-1329-4b7c-a6e8-484e92d4802d> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce7ea041-1329-4b7c-a6e8-484e92d4802d";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/8604e26b-9f3c-4a9c-8e4b-cd5335f4841a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ce7ea041-1329-4b7c-a6e8-484e92d4802d>.
+    
+<http://data.lblod.info/id/remote-data-objects/d4ce196f-67d2-468a-8ea3-fa3a984efe59> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d4ce196f-67d2-468a-8ea3-fa3a984efe59";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/8a07719a-1552-4f17-9589-4e41f5b58eec/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/d4ce196f-67d2-468a-8ea3-fa3a984efe59>.
+    
+<http://data.lblod.info/id/remote-data-objects/bd0f6b3f-8406-49e0-a9c0-582caec30f24> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bd0f6b3f-8406-49e0-a9c0-582caec30f24";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/9155a2c4-06c3-4e52-bfe0-00ea0f062a38/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/bd0f6b3f-8406-49e0-a9c0-582caec30f24>.
+    
+<http://data.lblod.info/id/remote-data-objects/1927d2dd-ac79-43bf-8b04-f567a179534b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1927d2dd-ac79-43bf-8b04-f567a179534b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/9e2292f5-19b7-48d5-a5cd-4be4f855f56c/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1927d2dd-ac79-43bf-8b04-f567a179534b>.
+    
+<http://data.lblod.info/id/remote-data-objects/1ebacf72-27c8-4006-9a14-8552aae6aa5b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1ebacf72-27c8-4006-9a14-8552aae6aa5b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/9f1ed935-f755-4def-97be-3306a5c50e44/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/1ebacf72-27c8-4006-9a14-8552aae6aa5b>.
+    
+<http://data.lblod.info/id/remote-data-objects/b4cf9fdf-25f7-46d6-bd31-1ecfaffeb044> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b4cf9fdf-25f7-46d6-bd31-1ecfaffeb044";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/a11736cb-f681-41bb-9b05-e48bde79d798/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/b4cf9fdf-25f7-46d6-bd31-1ecfaffeb044>.
+    
+<http://data.lblod.info/id/remote-data-objects/83cad6a5-f04b-418f-a8d5-77bae409e071> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83cad6a5-f04b-418f-a8d5-77bae409e071";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/a67bf797-9c2f-44d1-bc0b-19ce8e00ba49/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/83cad6a5-f04b-418f-a8d5-77bae409e071>.
+    
+<http://data.lblod.info/id/remote-data-objects/743214fe-8943-4c6e-b2a0-2c303d75adf0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "743214fe-8943-4c6e-b2a0-2c303d75adf0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/a827033c-5f5e-4a6c-aa74-be0ae65be6d6/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:04.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/ea63ed8b-edd0-41d0-b3bc-40909c7580b8> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/743214fe-8943-4c6e-b2a0-2c303d75adf0>.
+    

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202005-create-harvesting-jobs.graph
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202005-create-harvesting-jobs.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202005-create-harvesting-jobs.ttl
+++ b/config/migrations/2022/20221118200000-harvest-cevi-and-remmicom/20221118202005-create-harvesting-jobs.ttl
@@ -1,0 +1,114 @@
+<http://redpencil.data.gift/id/job/e5ff5747-a57c-4357-824a-d426298734ef> a <http://vocab.deri.ie/cogs#Job>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "e5ff5747-a57c-4357-824a-d426298734ef";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/busy>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/lblodHarvestAndPublish>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa4b7d98-4c8b-4fd3-a7c8-148fa5edbe63> a <http://lblod.data.gift/vocabularies/harvesting/HarvestingCollection>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "aa4b7d98-4c8b-4fd3-a7c8-148fa5edbe63";
+    <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://redpencil.data.gift/id/dataContainers/c01f2d4f-a72d-4963-89ca-912fd07d01d3> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c01f2d4f-a72d-4963-89ca-912fd07d01d3";
+    <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> <http://data.lblod.info/id/harvesting-collection/aa4b7d98-4c8b-4fd3-a7c8-148fa5edbe63>.
+
+  <http://redpencil.data.gift/id/task/2c6c9cfc-68fb-4da9-bad1-1e7074e71ec2> a <http://redpencil.data.gift/vocabularies/tasks/Task> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2c6c9cfc-68fb-4da9-bad1-1e7074e71ec2";
+    <http://purl.org/dc/terms/isPartOf> <http://redpencil.data.gift/id/job/e5ff5747-a57c-4357-824a-d426298734ef>;
+    <http://purl.org/dc/terms/created> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://purl.org/dc/terms/modified> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <http://www.w3.org/ns/adms#status> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>;
+    <http://redpencil.data.gift/vocabularies/tasks/index> "0";
+    <http://redpencil.data.gift/vocabularies/tasks/inputContainer> <http://redpencil.data.gift/id/dataContainers/c01f2d4f-a72d-4963-89ca-912fd07d01d3>;
+    <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/collecting>.
+  
+<http://data.lblod.info/id/remote-data-objects/5574c8ca-e5a5-4296-a113-24bbea3c8716> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5574c8ca-e5a5-4296-a113-24bbea3c8716";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/aba3a587-8eef-4fd6-a10c-efb8d4834a58/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa4b7d98-4c8b-4fd3-a7c8-148fa5edbe63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/5574c8ca-e5a5-4296-a113-24bbea3c8716>.
+    
+<http://data.lblod.info/id/remote-data-objects/fecde89e-7f2f-45f3-a5fe-8caa18887059> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fecde89e-7f2f-45f3-a5fe-8caa18887059";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/acfe5cd7-ccd3-479e-add9-bc1727a4b095/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa4b7d98-4c8b-4fd3-a7c8-148fa5edbe63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/fecde89e-7f2f-45f3-a5fe-8caa18887059>.
+    
+<http://data.lblod.info/id/remote-data-objects/18df13b9-f8f5-42b3-bd73-7cb395d2bc60> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18df13b9-f8f5-42b3-bd73-7cb395d2bc60";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/b30183db-e9c5-413d-9fa5-0dfe9b7be96a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa4b7d98-4c8b-4fd3-a7c8-148fa5edbe63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/18df13b9-f8f5-42b3-bd73-7cb395d2bc60>.
+    
+<http://data.lblod.info/id/remote-data-objects/2e16cbcd-51aa-4228-bf84-7b34db10b969> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e16cbcd-51aa-4228-bf84-7b34db10b969";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/bb1435ed-4c21-4b23-9a6b-5df925ad2cb5/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa4b7d98-4c8b-4fd3-a7c8-148fa5edbe63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/2e16cbcd-51aa-4228-bf84-7b34db10b969>.
+    
+<http://data.lblod.info/id/remote-data-objects/7cfa32ca-a513-4385-9ee7-6b78f2a25559> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7cfa32ca-a513-4385-9ee7-6b78f2a25559";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/cd227638-62f8-4977-87d0-7d8b796540e8/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa4b7d98-4c8b-4fd3-a7c8-148fa5edbe63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/7cfa32ca-a513-4385-9ee7-6b78f2a25559>.
+    
+<http://data.lblod.info/id/remote-data-objects/a7a42f4d-5d20-4f06-b1e4-7bdc27e5e8e0> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a7a42f4d-5d20-4f06-b1e4-7bdc27e5e8e0";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/e03fbf87-0cab-4580-9da2-4eee82c0e1b0/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa4b7d98-4c8b-4fd3-a7c8-148fa5edbe63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/a7a42f4d-5d20-4f06-b1e4-7bdc27e5e8e0>.
+    
+<http://data.lblod.info/id/remote-data-objects/ea9971e9-5d8c-4d4d-8f40-22cd8ca1bf43> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ea9971e9-5d8c-4d4d-8f40-22cd8ca1bf43";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/ecd29822-6fe7-42ca-8d5c-54e680f4c72a/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa4b7d98-4c8b-4fd3-a7c8-148fa5edbe63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/ea9971e9-5d8c-4d4d-8f40-22cd8ca1bf43>.
+    
+<http://data.lblod.info/id/remote-data-objects/c2a7c53b-3d97-469c-b645-5d517b308c0b> a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject>,<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c2a7c53b-3d97-469c-b645-5d517b308c0b";
+  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://wommelgem.meetingburger.net/vabu/fbe44090-99b5-4b49-8c4f-b5ba66b63bfd/besluitenlijst>;
+  <http://www.w3.org/ns/adms#status> <http://lblod.data.gift/file-download-statuses/ready-to-be-collected>;
+  <http://redpencil.data.gift/vocabularies/http/requestHeader> <http://data.lblod.info/request-headers/accept/text/html>;
+  <http://purl.org/dc/terms/created> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/modified> "2022-11-18T20:20:05.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+  <http://purl.org/dc/terms/creator> <http://lblod.data.gift/services/migrations>.
+
+  <http://data.lblod.info/id/harvesting-collection/aa4b7d98-4c8b-4fd3-a7c8-148fa5edbe63> <http://purl.org/dc/terms/hasPart> <http://data.lblod.info/id/remote-data-objects/c2a7c53b-3d97-469c-b645-5d517b308c0b>.
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
     restart: always
     logging: *default-logging
   harvest-collector:
-    image: lblod/harvest-collector-service:0.6.2
+    image: lblod/harvest-collector-service:0.7.0
     volumes:
       - ./data/files:/share
     labels:


### PR DESCRIPTION
Relates to OP-1860
To be tested with https://github.com/lblod/harvest-collector-service/pull/12

Adds tasks to harvest the +/- 25 000 URLs of meetings from Cevi and Remmicom.

I tested locally with tasks having 100 URLs running every 5 minutes and it completed smoothly in a day.
I decided, for QA, to go with tasks that contain 50 URLs. We execute one task every 5 minutes. It should take approximately 2 days to complete. Having 5 minutes between each small task leaves room to process other tasks that will arrive to the collector, via scheduled jobs for example.

